### PR TITLE
[p2p] add config to allow setting TCP_NODELAY on TcpStreams 

### DIFF
--- a/p2p/src/actors/dialer.rs
+++ b/p2p/src/actors/dialer.rs
@@ -106,8 +106,10 @@ impl<C: Crypto> Actor<C> {
             "dialed peer"
         );
 
-        // Disable Nagle delay.
-        _ = connection.set_nodelay(true);
+        // Set TCP_NODELAY
+        if let Err(e) = connection.set_nodelay(config.tcp_nodelay) {
+            debug!(peer = hex::encode(&peer), error = ?e, "failed to set TCP_NODELAY")
+        }
 
         // Upgrade connection
         let stream = match Stream::upgrade_dialer(config, connection, peer.clone()).await {

--- a/p2p/src/actors/dialer.rs
+++ b/p2p/src/actors/dialer.rs
@@ -106,6 +106,9 @@ impl<C: Crypto> Actor<C> {
             "dialed peer"
         );
 
+        // Disable Nagle delay.
+        _ = connection.set_nodelay(true);
+
         // Upgrade connection
         let stream = match Stream::upgrade_dialer(config, connection, peer.clone()).await {
             Ok(stream) => stream,

--- a/p2p/src/actors/dialer.rs
+++ b/p2p/src/actors/dialer.rs
@@ -107,8 +107,10 @@ impl<C: Crypto> Actor<C> {
         );
 
         // Set TCP_NODELAY
-        if let Err(e) = connection.set_nodelay(config.tcp_nodelay) {
-            debug!(peer = hex::encode(&peer), error = ?e, "failed to set TCP_NODELAY")
+        if let Some(nodelay) = config.tcp_nodelay {
+            if let Err(e) = connection.set_nodelay(nodelay) {
+                debug!(peer = hex::encode(&peer), error = ?e, "failed to set TCP_NODELAY")
+            }
         }
 
         // Upgrade connection

--- a/p2p/src/actors/listener.rs
+++ b/p2p/src/actors/listener.rs
@@ -110,8 +110,10 @@ impl<C: Crypto> Actor<C> {
             debug!(ip = ?address.ip(), port = ?address.port(), "accepted incoming connection");
 
             // Set TCP_NODELAY
-            if let Err(e) = stream.set_nodelay(self.connection.tcp_nodelay) {
-                debug!(ip = ?address.ip(), port = ?address.port(), error = ?e, "failed to set TCP_NODELAY")
+            if let Some(nodelay) = self.connection.tcp_nodelay {
+                if let Err(e) = stream.set_nodelay(nodelay) {
+                    debug!(ip = ?address.ip(), port = ?address.port(), error = ?e, "failed to set TCP_NODELAY")
+                }
             }
 
             // Spawn a new handshaker to upgrade connection

--- a/p2p/src/actors/listener.rs
+++ b/p2p/src/actors/listener.rs
@@ -109,8 +109,10 @@ impl<C: Crypto> Actor<C> {
             };
             debug!(ip = ?address.ip(), port = ?address.port(), "accepted incoming connection");
 
-            // Disable Nagle delay.
-            _ = stream.set_nodelay(true);
+            // Set TCP_NODELAY
+            if let Err(e) = stream.set_nodelay(self.connection.tcp_nodelay) {
+                debug!(ip = ?address.ip(), port = ?address.port(), error = ?e, "failed to set TCP_NODELAY")
+            }
 
             // Spawn a new handshaker to upgrade connection
             tokio::spawn(Self::handshake(

--- a/p2p/src/actors/listener.rs
+++ b/p2p/src/actors/listener.rs
@@ -109,6 +109,9 @@ impl<C: Crypto> Actor<C> {
             };
             debug!(ip = ?address.ip(), port = ?address.port(), "accepted incoming connection");
 
+            // Disable Nagle delay.
+            _ = stream.set_nodelay(true);
+
             // Spawn a new handshaker to upgrade connection
             tokio::spawn(Self::handshake(
                 self.connection.clone(),

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -63,6 +63,9 @@ pub struct Config<C: Crypto> {
     /// Duration after which to close the connection if a message cannot be written.
     pub write_timeout: Duration,
 
+    /// Whether or not to disable Nagle's algorithm
+    pub tcp_nodelay: bool,
+
     /// Quota for connection attempts per peer (incoming or outgoing).
     pub allowed_connection_rate_per_peer: Quota,
 
@@ -118,6 +121,7 @@ impl<C: Crypto> Config<C> {
             handshake_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(60),
             write_timeout: Duration::from_secs(30),
+            tcp_nodelay: true,
             allowed_connection_rate_per_peer: Quota::per_minute(NonZeroU32::new(1).unwrap()),
             allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(256).unwrap()),
             dial_frequency: Duration::from_secs(60),

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -63,7 +63,13 @@ pub struct Config<C: Crypto> {
     /// Duration after which to close the connection if a message cannot be written.
     pub write_timeout: Duration,
 
-    /// Whether or not to disable Nagle's algorithm
+    /// Whether or not to disable Nagle's algorithm.
+    ///
+    /// The algorithm combines a series of small network packets into a single packet
+    /// before sending to reduce overhead of sending multiple small packets which might not
+    /// be efficient on slow, congested networks. However, to do so the algorithm introduces
+    /// a slight delay as it waits to accumulate more data. Latency-sensitive networks should
+    /// consider disabling it to send the packets as soon as possible to reduce latency.
     pub tcp_nodelay: bool,
 
     /// Quota for connection attempts per peer (incoming or outgoing).
@@ -121,7 +127,7 @@ impl<C: Crypto> Config<C> {
             handshake_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(60),
             write_timeout: Duration::from_secs(30),
-            tcp_nodelay: true,
+            tcp_nodelay: false,
             allowed_connection_rate_per_peer: Quota::per_minute(NonZeroU32::new(1).unwrap()),
             allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(256).unwrap()),
             dial_frequency: Duration::from_secs(60),

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -70,7 +70,10 @@ pub struct Config<C: Crypto> {
     /// be efficient on slow, congested networks. However, to do so the algorithm introduces
     /// a slight delay as it waits to accumulate more data. Latency-sensitive networks should
     /// consider disabling it to send the packets as soon as possible to reduce latency.
-    pub tcp_nodelay: bool,
+    ///
+    /// Note: Make sure that your compile target has and allows this configuration otherwise
+    /// panics or unexpected behaviours are possible.
+    pub tcp_nodelay: Option<bool>,
 
     /// Quota for connection attempts per peer (incoming or outgoing).
     pub allowed_connection_rate_per_peer: Quota,
@@ -127,7 +130,7 @@ impl<C: Crypto> Config<C> {
             handshake_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(60),
             write_timeout: Duration::from_secs(30),
-            tcp_nodelay: false,
+            tcp_nodelay: None,
             allowed_connection_rate_per_peer: Quota::per_minute(NonZeroU32::new(1).unwrap()),
             allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(256).unwrap()),
             dial_frequency: Duration::from_secs(60),

--- a/p2p/src/connection/mod.rs
+++ b/p2p/src/connection/mod.rs
@@ -19,7 +19,7 @@ pub struct Config<C: Crypto> {
     pub handshake_timeout: Duration,
     pub read_timeout: Duration,
     pub write_timeout: Duration,
-    pub tcp_nodelay: bool,
+    pub tcp_nodelay: Option<bool>,
 }
 
 #[derive(Debug)]

--- a/p2p/src/connection/mod.rs
+++ b/p2p/src/connection/mod.rs
@@ -19,6 +19,7 @@ pub struct Config<C: Crypto> {
     pub handshake_timeout: Duration,
     pub read_timeout: Duration,
     pub write_timeout: Duration,
+    pub tcp_nodelay: bool,
 }
 
 #[derive(Debug)]

--- a/p2p/src/network.rs
+++ b/p2p/src/network.rs
@@ -113,6 +113,7 @@ impl<C: Crypto> Network<C> {
             handshake_timeout: self.cfg.handshake_timeout,
             read_timeout: self.cfg.read_timeout,
             write_timeout: self.cfg.write_timeout,
+            tcp_nodelay: self.cfg.tcp_nodelay,
         };
         let listener = listener::Actor::new(listener::Config {
             port: self.cfg.address.port(),


### PR DESCRIPTION
TCP_NODELAY is not on by default in contrary to Golang, so wanted to open a pr for it :) 