### PR TITLE
[p2p] Support Connections With Multiple Sets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,12 +168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,7 +342,7 @@ version = "0.0.6"
 dependencies = [
  "chrono",
  "clap",
- "commonware-p2p 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "commonware-p2p",
  "crossterm 0.22.1",
  "governor",
  "hex",
@@ -362,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "bitvec",
  "bytes",
@@ -384,30 +378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "commonware-p2p"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3791dde397b145b297dc4a309d89494b44e4aace01eca5c9ea177145f223d4"
-dependencies = [
- "bitvec",
- "bytes",
- "chacha20poly1305",
- "ed25519-dalek",
- "futures",
- "governor",
- "hex",
- "prometheus-client",
- "prost",
- "prost-build",
- "rand",
- "sha2 0.10.8",
- "tokio",
- "tokio-util",
- "tracing",
- "x25519-dalek",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,12 +389,6 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation-sys"
@@ -508,7 +472,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -553,16 +516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,16 +541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
 name = "ed25519-consensus"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,20 +552,6 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.8",
- "subtle",
  "zeroize",
 ]
 
@@ -1186,16 +1115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,15 +1521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,16 +1552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "chrono",
  "clap",

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.6"
+version = "0.0.7"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-p2p."
 readme = "README.md"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://commonware.xyz"
 repository = "https://github.com/commonwarexyz/monorepo"
 
 [dependencies]
-commonware-p2p = "0.0.5" 
+commonware-p2p = { version = "0.0.6", path = "../../p2p" } 
 tokio = { version = "1", features = ["full"] }
 clap = "4"
 chrono = "0.4"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.5"
+version = "0.0.6"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/p2p/src/actors/tracker/actor.rs
+++ b/p2p/src/actors/tracker/actor.rs
@@ -406,11 +406,11 @@ impl<C: Crypto> Actor<C> {
 
             // Attempt to update peer record
             if self.handle_peer(
-                peer,
-                Address::Network(Signature {
+                public_key,
+                Signature {
                     addr: address,
                     peer: peer.clone(),
-                }),
+                },
             ) {
                 debug!(peer = hex::encode(public_key), "updated peer record");
                 updated = true;

--- a/p2p/src/actors/tracker/actor.rs
+++ b/p2p/src/actors/tracker/actor.rs
@@ -341,14 +341,14 @@ impl<C: Crypto> Actor<C> {
         reserved
     }
 
-    fn handle_peer(&mut self, peer: PublicKey, address: Signature) -> bool {
+    fn handle_peer(&mut self, peer: &PublicKey, address: Signature) -> bool {
         // Check if peer is authorized
         if !self.allowed(&peer) {
             return false;
         }
 
         // Update peer address
-        let record = self.peers.get_mut(&peer).unwrap();
+        let record = self.peers.get_mut(peer).unwrap();
         if !record.update(address) {
             return false;
         }
@@ -532,7 +532,6 @@ impl<C: Crypto> Actor<C> {
                         Some(set) => set,
                         None => {
                             debug!("no peer sets available");
-                            peer.kill().await;
                             continue;
                         }
                     };

--- a/p2p/src/actors/tracker/actor.rs
+++ b/p2p/src/actors/tracker/actor.rs
@@ -603,7 +603,7 @@ mod tests {
             bootstrappers,
             allow_private_ips: true,
             mailbox_size: 32,
-            tracked_peer_sets: 32,
+            tracked_peer_sets: 2,
             allowed_connection_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
             peer_gossip_max_count: 32,
         }

--- a/p2p/src/actors/tracker/actor.rs
+++ b/p2p/src/actors/tracker/actor.rs
@@ -31,8 +31,8 @@ pub struct Actor<C: Crypto> {
 
     sender: mpsc::Sender<Message>,
     receiver: mpsc::Receiver<Message>,
-    peers: HashMap<PublicKey, Address>,
-    sets: BTreeMap<u64, BTreeSet<PublicKey>>,
+    peers: HashMap<PublicKey, (Address, usize)>,
+    sets: BTreeMap<u64, (HashMap<PublicKey, usize>, BitVec<u8, Lsb0>)>,
     connections_rate_limiter: DefaultKeyedRateLimiter<PublicKey>,
     connections: HashSet<PublicKey>,
 
@@ -41,7 +41,6 @@ pub struct Actor<C: Crypto> {
     rate_limited_connections: Family<metrics::Peer, Counter>,
 
     ip_signature: wire::Peer,
-    bit_vec: Option<wire::BitVec>,
 }
 
 impl<C: Crypto> Actor<C> {

--- a/p2p/src/actors/tracker/actor.rs
+++ b/p2p/src/actors/tracker/actor.rs
@@ -5,9 +5,7 @@ pub use super::{
 };
 use crate::{
     crypto::{Crypto, PublicKey},
-    ip,
-    metrics::{self, Peer},
-    wire,
+    ip, metrics, wire,
 };
 use bitvec::prelude::*;
 use governor::DefaultKeyedRateLimiter;
@@ -349,7 +347,12 @@ impl<C: Crypto> Actor<C> {
 
         // Update peer address
         let record = self.peers.get_mut(peer).unwrap();
-        if !record.update(address) {
+        if !record.update(address.clone()) {
+            trace!(
+                peer = hex::encode(peer),
+                wire = address.peer.timestamp,
+                "stored peer newer"
+            );
             return false;
         }
 

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -87,7 +87,14 @@ pub struct Config<C: Crypto> {
     /// Quota for peers to dial.
     pub dial_rate: Quota,
 
-    /// Number of peer sets to keep in memory for handling peer requests.
+    /// Number of peer sets to track.
+    ///
+    /// We will attempt to maintain connections to peers stored
+    /// across all peer sets, not just the most recent. This allows
+    /// us to continue serving requests to peers that have recently
+    /// been evicted and/or to communicate with peers in a future
+    /// set (if we, for example, are trying to do a reshare of a threshold
+    /// key).
     pub tracked_peer_sets: usize,
 
     /// Frequency we gossip about known peers.
@@ -135,7 +142,7 @@ impl<C: Crypto> Config<C> {
             allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(256).unwrap()),
             dial_frequency: Duration::from_secs(60),
             dial_rate: Quota::per_second(NonZeroU32::new(30).unwrap()),
-            tracked_peer_sets: 32,
+            tracked_peer_sets: 4,
             gossip_bit_vec_frequency: Duration::from_secs(50),
             allowed_bit_vec_rate: Quota::per_second(NonZeroU32::new(2).unwrap()),
             peer_gossip_max_count: 32,


### PR DESCRIPTION
## Changes
* Avoid regeneration of bit vector each time a peer address is discovered
* Maintain connections with all peers in tracked sets
* Gossip bit vectors from all tracked sets
* Migrate logic from actor to new structures
* Remove unnecessary async function definitions