### PR TITLE
[crypto] Change DST to Namespace

### DIFF
--- a/p2p/src/actors/tracker/actor.rs
+++ b/p2p/src/actors/tracker/actor.rs
@@ -22,7 +22,7 @@ use std::{
 use tokio::sync::mpsc;
 use tracing::{debug, trace};
 
-const DST: &[u8] = b"_COMMONWARE_P2P_IP_";
+const NAMESPACE: &[u8] = b"_COMMONWARE_P2P_IP_";
 
 struct PeerSet {
     index: u64,
@@ -154,7 +154,7 @@ impl<C: Crypto> Actor<C> {
             .expect("Failed to get current time")
             .as_secs();
         let (socket_bytes, payload_bytes) = socket_peer_payload(&cfg.address, current_time);
-        let ip_signature = cfg.crypto.sign(DST, &payload_bytes);
+        let ip_signature = cfg.crypto.sign(NAMESPACE, &payload_bytes);
         let ip_signature = wire::Peer {
             socket: socket_bytes,
             timestamp: current_time,
@@ -386,7 +386,7 @@ impl<C: Crypto> Actor<C> {
 
             // If any signature is invalid, disconnect from the peer
             let payload = wire_peer_payload(&peer);
-            if !C::verify(DST, &payload, public_key, &signature.signature) {
+            if !C::verify(NAMESPACE, &payload, public_key, &signature.signature) {
                 return Err(Error::InvalidSignature);
             }
 
@@ -695,7 +695,7 @@ mod tests {
         // Provide peer address
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
         let (socket_bytes, payload_bytes) = socket_peer_payload(&socket, 0);
-        let ip_signature = peer1_signer.sign(DST, &payload_bytes);
+        let ip_signature = peer1_signer.sign(NAMESPACE, &payload_bytes);
         let peers = wire::Peers {
             peers: vec![wire::Peer {
                 socket: socket_bytes,

--- a/p2p/src/connection/handshake.rs
+++ b/p2p/src/connection/handshake.rs
@@ -11,7 +11,7 @@ use tokio::time;
 use tokio_util::codec::Framed;
 use tokio_util::codec::LengthDelimitedCodec;
 
-const DST: &[u8] = b"_COMMONWARE_P2P_HANDSHAKE_";
+const NAMESPACE: &[u8] = b"_COMMONWARE_P2P_HANDSHAKE_";
 
 pub async fn create_handshake<C: Crypto>(
     crypto: &mut C,
@@ -22,7 +22,7 @@ pub async fn create_handshake<C: Crypto>(
     let mut payload = Vec::new();
     payload.extend_from_slice(&recipient_public_key);
     payload.extend_from_slice(ephemeral_public_key.as_bytes());
-    let signature = crypto.sign(DST, &payload);
+    let signature = crypto.sign(NAMESPACE, &payload);
 
     // Send handshake
     Ok(wire::Message {
@@ -85,7 +85,7 @@ impl Handshake {
         payload.extend_from_slice(&handshake.ephemeral_public_key);
 
         // Verify signature
-        if !C::verify(DST, &payload, &public_key, &signature.signature) {
+        if !C::verify(NAMESPACE, &payload, &public_key, &signature.signature) {
             return Err(Error::InvalidSignature);
         }
 

--- a/p2p/src/crypto/ed25519.rs
+++ b/p2p/src/crypto/ed25519.rs
@@ -28,9 +28,9 @@ impl Ed25519 {
         }
     }
 
-    fn payload(dst: &[u8], message: &[u8]) -> Vec<u8> {
-        let mut payload = Vec::with_capacity(dst.len() + message.len());
-        payload.extend_from_slice(dst);
+    fn payload(namespace: &[u8], message: &[u8]) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(namespace.len() + message.len());
+        payload.extend_from_slice(namespace);
         payload.extend_from_slice(message);
         payload
     }
@@ -41,8 +41,8 @@ impl crypto::Crypto for Ed25519 {
         self.verifier.clone()
     }
 
-    fn sign(&mut self, dst: &[u8], message: &[u8]) -> crypto::Signature {
-        let payload = Self::payload(dst, message);
+    fn sign(&mut self, namespace: &[u8], message: &[u8]) -> crypto::Signature {
+        let payload = Self::payload(namespace, message);
         self.signer.sign(&payload).to_bytes().to_vec().into()
     }
 
@@ -55,7 +55,7 @@ impl crypto::Crypto for Ed25519 {
     }
 
     fn verify(
-        dst: &[u8],
+        namespace: &[u8],
         message: &[u8],
         public_key: &crypto::PublicKey,
         signature: &crypto::Signature,
@@ -73,7 +73,7 @@ impl crypto::Crypto for Ed25519 {
             Err(_) => return false,
         };
         let signature = Signature::from(signature);
-        let payload = Self::payload(dst, message);
+        let payload = Self::payload(namespace, message);
         public_key.verify(&signature, &payload).is_ok()
     }
 }

--- a/p2p/src/crypto/mod.rs
+++ b/p2p/src/crypto/mod.rs
@@ -11,19 +11,22 @@ pub type PublicKey = Bytes;
 pub type Signature = Bytes;
 
 /// Cryptographic operations required by commonware-p2p.
-///
-/// # Warning
-///
-/// Although data provided to this implementation to be signed are expected to be
-/// unique to commonware-p2p, it is strongly recommended to prefix any payloads
-/// with a unique identifier (dst) to prevent replay attacks.
 pub trait Crypto: Send + Sync + Clone + 'static {
     /// Returns the public key of the signer.
     fn me(&self) -> PublicKey;
-    /// Sign the given data (usually an IP).
-    fn sign(&mut self, dst: &[u8], data: &[u8]) -> Signature;
+
     /// Verify that a public key is well-formatted.
     fn validate(public_key: &PublicKey) -> bool;
+
+    /// Sign the given data.
+    ///
+    /// To protect against replay attacks, it is required to provide a namespace
+    /// to prefix any data. This ensures that a signature meant for one context cannot be used
+    /// unexpectedly in another (i.e. signing a message on the network layer can't accidentally
+    /// spend funds on the execution layer).
+    fn sign(&mut self, namespace: &[u8], data: &[u8]) -> Signature;
+
     /// Check that a signature is valid for the given data and public key.
-    fn verify(dst: &[u8], data: &[u8], public_key: &PublicKey, signature: &Signature) -> bool;
+    fn verify(namespace: &[u8], data: &[u8], public_key: &PublicKey, signature: &Signature)
+        -> bool;
 }


### PR DESCRIPTION
## Changes
* To avoid confusion (`dst` has a specific meaning in some cryptographic schemes), `dst` has been renamed to `namespace` for `Crypto` users.