### PR TITLE
[p2p/crypto] Rename `data` to `message`

### DIFF
--- a/p2p/src/crypto/ed25519.rs
+++ b/p2p/src/crypto/ed25519.rs
@@ -4,7 +4,7 @@
 //! set of validation rules for Ed25519 signatures (which is necessary for
 //! stability in a consensus context).
 
-use crate::crypto;
+use crate::crypto::{self, utils::payload};
 use ed25519_consensus::{Signature, SigningKey, VerificationKey};
 use sha2::{Digest, Sha256};
 
@@ -27,13 +27,6 @@ impl Ed25519 {
             verifier: verifier.to_bytes().to_vec().into(),
         }
     }
-
-    fn payload(namespace: &[u8], message: &[u8]) -> Vec<u8> {
-        let mut payload = Vec::with_capacity(namespace.len() + message.len());
-        payload.extend_from_slice(namespace);
-        payload.extend_from_slice(message);
-        payload
-    }
 }
 
 impl crypto::Crypto for Ed25519 {
@@ -42,7 +35,7 @@ impl crypto::Crypto for Ed25519 {
     }
 
     fn sign(&mut self, namespace: &[u8], message: &[u8]) -> crypto::Signature {
-        let payload = Self::payload(namespace, message);
+        let payload = payload(namespace, message);
         self.signer.sign(&payload).to_bytes().to_vec().into()
     }
 
@@ -73,7 +66,7 @@ impl crypto::Crypto for Ed25519 {
             Err(_) => return false,
         };
         let signature = Signature::from(signature);
-        let payload = Self::payload(namespace, message);
+        let payload = payload(namespace, message);
         public_key.verify(&signature, &payload).is_ok()
     }
 }

--- a/p2p/src/crypto/mod.rs
+++ b/p2p/src/crypto/mod.rs
@@ -4,6 +4,7 @@
 use bytes::Bytes;
 
 pub mod ed25519;
+pub mod utils;
 
 /// Byte array representing an arbitrary public key.
 pub type PublicKey = Bytes;
@@ -18,15 +19,28 @@ pub trait Crypto: Send + Sync + Clone + 'static {
     /// Verify that a public key is well-formatted.
     fn validate(public_key: &PublicKey) -> bool;
 
-    /// Sign the given data.
+    /// Sign the given message.
+    ///
+    /// The message should not be hashed prior to calling this function. If a particular
+    /// scheme requires a payload to be hashed before it is signed, it will be done internally.
     ///
     /// To protect against replay attacks, it is required to provide a namespace
-    /// to prefix any data. This ensures that a signature meant for one context cannot be used
+    /// to prefix any message. This ensures that a signature meant for one context cannot be used
     /// unexpectedly in another (i.e. signing a message on the network layer can't accidentally
     /// spend funds on the execution layer).
-    fn sign(&mut self, namespace: &[u8], data: &[u8]) -> Signature;
+    fn sign(&mut self, namespace: &[u8], message: &[u8]) -> Signature;
 
-    /// Check that a signature is valid for the given data and public key.
-    fn verify(namespace: &[u8], data: &[u8], public_key: &PublicKey, signature: &Signature)
-        -> bool;
+    /// Check that a signature is valid for the given message and public key.
+    ///
+    /// The message should not be hashed prior to calling this function. If a particular
+    /// scheme requires a payload to be hashed before it is signed, it will be done internally.
+    ///
+    /// Because namespace is prepended to message before signing, the namespace provided here must
+    /// match the namespace provided during signing.
+    fn verify(
+        namespace: &[u8],
+        message: &[u8],
+        public_key: &PublicKey,
+        signature: &Signature,
+    ) -> bool;
 }

--- a/p2p/src/crypto/utils.rs
+++ b/p2p/src/crypto/utils.rs
@@ -1,0 +1,7 @@
+/// Concatenates the namespace and message into a single payload for signing.
+pub fn payload(namespace: &[u8], message: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(namespace.len() + message.len());
+    payload.extend_from_slice(namespace);
+    payload.extend_from_slice(message);
+    payload
+}


### PR DESCRIPTION
## Changes
* Change name of provided `data` for signing to `message`
* Clarify that `message` should not be hashed prior to invocation