### PR TITLE
[p2p] Add `#[derive(Clone)]` to Sender

### DIFF
--- a/p2p/src/channels.rs
+++ b/p2p/src/channels.rs
@@ -14,6 +14,7 @@ pub type Receiver = mpsc::Receiver<Message>;
 
 /// Sender is the mechanism used to send arbitrary bytes to
 /// a set of recipients over a pre-defined channel.
+#[derive(Clone)]
 pub struct Sender {
     channel: u32,
     messenger: Messenger,


### PR DESCRIPTION
## Changes
* Make it possible for a client of the SDK to spawn multiple senders over the same channel