### PR TITLE
[p2p] Add self to `PeerSet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "chrono",
  "clap",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bitvec",
  "bytes",

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.8"
+version = "0.0.9"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-p2p."
 readme = "README.md"
@@ -11,7 +11,7 @@ repository = "https://github.com/commonwarexyz/monorepo"
 documentation = "https://docs.rs/commonware-chat"
 
 [dependencies]
-commonware-p2p = { version = "0.0.7", path = "../../p2p" } 
+commonware-p2p = { version = "0.0.8", path = "../../p2p" } 
 tokio = { version = "1", features = ["full"] }
 clap = "4"
 chrono = "0.4"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.7"
+version = "0.0.8"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/p2p/src/actors/tracker/actor.rs
+++ b/p2p/src/actors/tracker/actor.rs
@@ -281,6 +281,11 @@ impl<C: Crypto> Actor<C> {
                 self.peers.insert(peer.clone(), AddressCount::new());
             }
         }
+
+        // Add self
+        set.found(self.crypto.me());
+
+        // Update bit vector now that we have changed it
         set.update_msg();
 
         // Remove oldest entries if necessary

--- a/p2p/src/actors/tracker/actor.rs
+++ b/p2p/src/actors/tracker/actor.rs
@@ -659,7 +659,8 @@ mod tests {
     #[tokio::test]
     async fn test_bit_vec() {
         // Create actor
-        let cfg = test_config(ed25519::insecure_signer(0), Vec::new());
+        let peer0 = ed25519::insecure_signer(0);
+        let cfg = test_config(peer0.clone(), Vec::new());
         let (actor, mailbox, oracle) = Actor::new(cfg);
 
         // Run actor in background
@@ -681,7 +682,10 @@ mod tests {
 
         // Register some peers
         oracle
-            .register(0, vec![peer1.clone(), peer2.clone(), peer3.clone()])
+            .register(
+                0,
+                vec![peer0.me(), peer1.clone(), peer2.clone(), peer3.clone()],
+            )
             .await;
 
         // Request bit vector
@@ -693,8 +697,12 @@ mod tests {
         };
         assert!(bit_vec.index == 0);
         let bits: BitVec<u8, Lsb0> = BitVec::from_vec(bit_vec.bits);
-        for bit in bits.iter() {
-            assert!(!*bit);
+        for (idx, bit) in bits.iter().enumerate() {
+            if idx == 3 {
+                assert!(*bit);
+            } else {
+                assert!(!*bit);
+            }
         }
 
         // Provide peer address
@@ -723,8 +731,9 @@ mod tests {
         assert!(bit_vec.index == 0);
         let bits: BitVec<u8, Lsb0> = BitVec::from_vec(bit_vec.bits);
         for (idx, bit) in bits.iter().enumerate() {
-            if idx == 1 {
+            if idx == 1 || idx == 3 {
                 // peer1 is the second peer in the bit vector (sorted by public key)
+                // peer3 is us
                 assert!(*bit);
             } else {
                 assert!(!*bit);
@@ -748,7 +757,7 @@ mod tests {
             match bit_vec.index {
                 0 => {
                     for (idx, bit) in bits.iter().enumerate() {
-                        if idx == 1 {
+                        if idx == 1 || idx == 3 {
                             assert!(*bit);
                         } else {
                             assert!(!*bit);


### PR DESCRIPTION
## Changes
* When creating a new `PeerSet`, make sure to include ourself (otherwise, we'll request our peer record...which throws an error).