### PR TITLE
[examples/chat] Bump Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "chrono",
  "clap",

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.9"
+version = "0.0.10"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-p2p."
 readme = "README.md"


### PR DESCRIPTION
## Changes
* Release a new version of `chat` that uses #32 