### PR TITLE
[p2p] Reduce read timeout on `Config::aggressive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "chrono",
  "clap",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bitvec",
  "bytes",

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.10"
+version = "0.0.11"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-p2p."
 readme = "README.md"
@@ -11,7 +11,7 @@ repository = "https://github.com/commonwarexyz/monorepo"
 documentation = "https://docs.rs/commonware-chat"
 
 [dependencies]
-commonware-p2p = { version = "0.0.9", path = "../../p2p" } 
+commonware-p2p = { version = "0.0.10", path = "../../p2p" } 
 tokio = { version = "1", features = ["full"] }
 clap = "4"
 chrono = "0.4"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.9"
+version = "0.0.10"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -170,8 +170,8 @@ impl<C: Crypto> Config<C> {
             mailbox_size: 1_000,
             max_frame_length: 1024 * 1024, // 1 MB
             handshake_timeout: Duration::from_secs(5),
-            read_timeout: Duration::from_secs(60),
-            write_timeout: Duration::from_secs(30),
+            read_timeout: Duration::from_secs(10), // should be greater than gossip_bit_vec_frequency
+            write_timeout: Duration::from_secs(10),
             tcp_nodelay: None,
             allowed_connection_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
             allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(256).unwrap()),


### PR DESCRIPTION
## Changes
* Reduce the time it takes for a peer to terminate a connection