### PR TITLE
[crypto] Expose `utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "bytes",
  "ed25519-consensus",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.2"
+version = "0.0.3"
 license = "MIT OR Apache-2.0"
 description = "Cryptographic primitives tailored for distributed systems running in byzantine environments."
 readme = "README.md"

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -2,7 +2,7 @@
 
 use bytes::Bytes;
 
-mod utils;
+pub mod utils;
 
 pub mod ed25519;
 

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -2,9 +2,8 @@
 
 use bytes::Bytes;
 
-pub mod utils;
-
 pub mod ed25519;
+pub mod utils;
 
 /// Byte array representing an arbitrary public key.
 pub type PublicKey = Bytes;

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/commonwarexyz/monorepo"
 documentation = "https://docs.rs/commonware-chat"
 
 [dependencies]
-commonware-cryptography = { version = "0.0.2", path = "../../cryptography" }
+commonware-cryptography = { version = "0.0.3", path = "../../cryptography" }
 commonware-p2p = { version = "0.0.11", path = "../../p2p" } 
 tokio = { version = "1", features = ["full"] }
 clap = "4"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/commonwarexyz/monorepo"
 documentation = "https://docs.rs/commonware-p2p"
 
 [dependencies]
-commonware-cryptography = { version = "0.0.2", path = "../cryptography" }
+commonware-cryptography = { version = "0.0.3", path = "../cryptography" }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 futures = "0.3"


### PR DESCRIPTION
## Changes
* Expose `utils::payload` to make it easier to write external `cryptography::Scheme` implementations.