### PR TITLE
[cargo] Create Workspace Dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "chrono",
  "clap",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bitvec",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,6 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "commonware-cryptography",
- "ed25519-consensus",
  "futures",
  "governor",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,8 @@ members = [
     "examples/chat",
 ]
 resolver = "2"
+
+[workspace.dependencies]
+commonware-cryptography = { version = "0.0.3", path = "cryptography" }
+commonware-p2p = { version = "0.0.12", path = "p2p" }
+bytes = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ resolver = "2"
 [workspace.dependencies]
 commonware-cryptography = { version = "0.0.3", path = "cryptography" }
 commonware-p2p = { version = "0.0.12", path = "p2p" }
-bytes = "1"
+bytes = "1.7.1"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/commonwarexyz/monorepo"
 documentation = "https://docs.rs/commonware-cryptography"
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 ed25519-consensus = "2.1.0"
 sha2 = "0.10"
 rand = "0.8"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/commonwarexyz/monorepo"
 documentation = "https://docs.rs/commonware-chat"
 
 [dependencies]
-commonware-cryptography = { version = "0.0.3", path = "../../cryptography" }
-commonware-p2p = { version = "0.0.12", path = "../../p2p" } 
+commonware-cryptography = { workspace = true }
+commonware-p2p = { workspace = true } 
 tokio = { version = "1", features = ["full"] }
 clap = "4"
 chrono = "0.4"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.12"
+version = "0.0.13"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/commonware-chat"
 
 [dependencies]
 commonware-cryptography = { version = "0.0.3", path = "../../cryptography" }
-commonware-p2p = { version = "0.0.11", path = "../../p2p" } 
+commonware-p2p = { version = "0.0.12", path = "../../p2p" } 
 tokio = { version = "1", features = ["full"] }
 clap = "4"
 chrono = "0.4"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -11,25 +11,24 @@ repository = "https://github.com/commonwarexyz/monorepo"
 documentation = "https://docs.rs/commonware-p2p"
 
 [dependencies]
-commonware-cryptography = { version = "0.0.3", path = "../cryptography" }
+commonware-cryptography = { workspace = true }
+bytes = { workspace = true } 
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 futures = "0.3"
-bytes = "1"
 governor = "0.6"
 x25519-dalek = { version = "2", features = ["getrandom"] }
 chacha20poly1305 = "0.10"
 prost = "0.12"
 sha2 = "0.10"
 hex = "0.4"
-ed25519-consensus = "2.1.0"
 tracing = "0.1"
 bitvec = "1"
 prometheus-client = "0.22"
 rand = "0.8"
 
 [dev-dependencies]
-tokio-test = { version = "0.4" }
+tokio-test = "0.4"
 
 [build-dependencies]
 prost-build = "0.12"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.11"
+version = "0.0.12"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"


### PR DESCRIPTION
## Changes
* Release a new version of `p2p` to ensure `Scheme` is the same version for people that import both `crytpography` and `p2p`.