### PR TITLE
[cryptography] Implement BLS12-381 DKG, Resharing, Scheme, and Threshold Signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +174,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +231,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +265,12 @@ name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
@@ -290,6 +329,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -359,10 +425,16 @@ dependencies = [
 name = "commonware-cryptography"
 version = "0.0.3"
 dependencies = [
+ "blst",
  "bytes",
+ "criterion",
  "ed25519-consensus",
+ "proptest",
+ "prost-build",
  "rand",
+ "rayon",
  "sha2 0.10.8",
+ "zeroize",
 ]
 
 [[package]]
@@ -417,6 +489,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +589,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -607,6 +740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +874,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "governor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +897,16 @@ dependencies = [
  "rand",
  "smallvec",
  "spinning_top",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -775,6 +930,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -834,10 +995,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -883,6 +1064,12 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
@@ -961,7 +1148,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1020,6 +1207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
 ]
 
 [[package]]
@@ -1036,6 +1234,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opaque-debug"
@@ -1126,6 +1330,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "plotters"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1423,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -1262,6 +1514,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1601,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1418,10 +1705,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1682,6 +1990,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +2151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +2212,25 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1965,6 +2317,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -32,24 +32,24 @@ portable = ["blst/portable"]
 [[bench]]
 name="dkg_recovery"
 harness = false
-path = "bls12381/benches/dkg_recovery.rs"
+path = "src/bls12381/benches/dkg_recovery.rs"
 
 [[bench]]
 name="reshare_recovery"
 harness = false
-path = "bls12381/benches/reshare_recovery.rs"
+path = "src/bls12381/benches/reshare_recovery.rs"
 
 [[bench]]
 name="signature_generation"
 harness = false
-path = "bls12381/benches/signature_generation.rs"
+path = "src/bls12381/benches/signature_generation.rs"
 
 [[bench]]
 name="signature_aggregation"
 harness = false
-path = "bls12381/benches/signature_aggregation.rs"
+path = "src/bls12381/benches/signature_aggregation.rs"
 
 [[bench]]
 name="signature_verification"
 harness = false
-path = "bls12381/benches/signature_verification.rs"
+path = "src/bls12381/benches/signature_verification.rs"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -15,3 +15,41 @@ bytes = { workspace = true }
 ed25519-consensus = "2.1.0"
 sha2 = "0.10"
 rand = "0.8"
+blst = { version = "0.3.13", features = ["no-threads"] }
+zeroize = "1.5.7"
+rayon = "1.10"
+
+[dev-dependencies]
+proptest = "1"
+criterion = "0.5.1"
+
+[build-dependencies]
+prost-build = "0.12"
+
+[features]
+portable = ["blst/portable"]
+
+[[bench]]
+name="dkg_recovery"
+harness = false
+path = "bls12381/benches/dkg_recovery.rs"
+
+[[bench]]
+name="reshare_recovery"
+harness = false
+path = "bls12381/benches/reshare_recovery.rs"
+
+[[bench]]
+name="signature_generation"
+harness = false
+path = "bls12381/benches/signature_generation.rs"
+
+[[bench]]
+name="signature_aggregation"
+harness = false
+path = "bls12381/benches/signature_aggregation.rs"
+
+[[bench]]
+name="signature_verification"
+harness = false
+path = "bls12381/benches/signature_verification.rs"

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -1,8 +1,7 @@
-use commonware_cryptography::{ed25519::insecure_signer, Scheme};
+use commonware_cryptography::{bls12381::dkg, ed25519::insecure_signer, Scheme};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use std::collections::HashMap;
 use std::hint::black_box;
-use vrf::bls12381::dkg;
 
 fn benchmark_dkg_recovery(c: &mut Criterion) {
     let concurrency = 1; // only used in recovery during reshare

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -1,0 +1,84 @@
+use commonware_cryptography::{ed25519::insecure_signer, Scheme};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::collections::HashMap;
+use std::hint::black_box;
+use vrf::bls12381::dkg;
+
+fn benchmark_dkg_recovery(c: &mut Criterion) {
+    let concurrency = 1; // only used in recovery during reshare
+    for &n in &[5, 10, 20, 50, 100, 250, 500] {
+        let t = dkg::utils::threshold(n).unwrap();
+        c.bench_function(&format!("conc={} n={} t={}", concurrency, n, t), |b| {
+            b.iter_batched(
+                || {
+                    // Create contributors
+                    let mut contributors = (0..n)
+                        .map(|i| insecure_signer(i as u16).me())
+                        .collect::<Vec<_>>();
+                    contributors.sort();
+
+                    // Create shares
+                    let mut contributor = None;
+                    let mut commitments = HashMap::new();
+                    for i in 0..n {
+                        let me = contributors[i as usize].clone();
+                        let p0 = dkg::contributor::P0::new(
+                            me,
+                            t,
+                            None,
+                            contributors.clone(),
+                            contributors.clone(),
+                            concurrency,
+                        );
+                        let (p1, commitment, shares) = p0.finalize();
+                        if i == 0 {
+                            contributor = p1;
+                        }
+                        commitments.insert(i, (commitment, shares));
+                    }
+                    let mut contributor = contributor.unwrap();
+
+                    // Distribute commitments
+                    for i in 0..n {
+                        // Get recipient share
+                        let (commitment, _) = commitments.get(&i).unwrap();
+                        let commitment = commitment.clone();
+
+                        // Send share to contributor
+                        let dealer = contributors[i as usize].clone();
+                        contributor.commitment(dealer, commitment).unwrap();
+                    }
+
+                    // Convert to p1
+                    let mut contributor = contributor.finalize().unwrap();
+
+                    // Distribute shares
+                    for i in 0..n {
+                        // Get recipient share
+                        let (_, shares) = commitments.get(&i).unwrap();
+                        let share = shares[0];
+
+                        // Send share to contributor
+                        let dealer = contributors[i as usize].clone();
+                        contributor.share(dealer, share).unwrap();
+                    }
+
+                    // Finalize
+                    let commitments = (0..n).collect::<Vec<_>>();
+                    (contributor, commitments)
+                },
+                |(contributor, commitments)| {
+                    black_box(contributor.finalize(commitments).unwrap());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_dkg_recovery
+}
+criterion_main!(benches);

--- a/cryptography/src/bls12381/benches/reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/reshare_recovery.rs
@@ -1,0 +1,169 @@
+use commonware_cryptography::{ed25519::insecure_signer, Scheme};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::collections::HashMap;
+use std::hint::black_box;
+use vrf::bls12381::{dkg, primitives::poly};
+
+fn benchmark_reshare_recovery(c: &mut Criterion) {
+    for &n in &[5, 10, 20, 50, 100, 250, 500] {
+        // Perform DKG
+        //
+        // We do this once outside of the benchmark to reduce the overhead
+        // of each sample (which can be large as `n` grows).
+
+        // Create contributors
+        let mut contributors = (0..n)
+            .map(|i| insecure_signer(i as u16).me())
+            .collect::<Vec<_>>();
+        contributors.sort();
+
+        // Create shares
+        let t = dkg::utils::threshold(n).unwrap();
+        let mut contributor_shares = HashMap::new();
+        let mut commitments = Vec::new();
+        for i in 0..n {
+            let me = contributors[i as usize].clone();
+            let p0 = dkg::contributor::P0::new(
+                me,
+                t,
+                None,
+                contributors.clone(),
+                contributors.clone(),
+                1,
+            );
+            let (p1, commitment, shares) = p0.finalize();
+            contributor_shares.insert(i, (commitment.clone(), shares, p1.unwrap()));
+            commitments.push(commitment);
+        }
+
+        // Distribute commitments
+        for i in 0..n {
+            let dealer = contributors[i as usize].clone();
+            for j in 0..n {
+                // Get recipient share
+                let (commitment, _, _) = contributor_shares.get(&i).unwrap();
+                let commitment = commitment.clone();
+
+                // Send share to recipient
+                let (_, _, ref mut recipient) = contributor_shares.get_mut(&j).unwrap();
+                recipient.commitment(dealer.clone(), commitment).unwrap();
+            }
+        }
+
+        // Convert to p2
+        let mut p2 = HashMap::new();
+        for i in 0..n {
+            let (_, shares, contributor) = contributor_shares.remove(&i).unwrap();
+            let contributor = contributor.finalize().unwrap();
+            p2.insert(i, (shares, contributor));
+        }
+        let mut contributor_shares = p2;
+
+        // Distribute shares
+        for i in 0..n {
+            let dealer = contributors[i as usize].clone();
+            for j in 0..n {
+                // Get recipient share
+                let (shares, _) = contributor_shares.get(&i).unwrap();
+                let share = shares[j as usize];
+
+                // Send share to recipient
+                let (_, recipient) = contributor_shares.get_mut(&j).unwrap();
+                recipient.share(dealer.clone(), share).unwrap();
+            }
+        }
+
+        // Finalize
+        let included_commitments = (0..n).collect::<Vec<_>>();
+        let commitments = commitments[0..n as usize].to_vec();
+        let mut group: Option<poly::Public> = None;
+        let mut outputs = Vec::new();
+        for i in 0..n {
+            let (_, contributor) = contributor_shares.remove(&i).unwrap();
+            let output = contributor
+                .finalize(included_commitments.clone())
+                .expect("unable to finalize");
+            assert_eq!(output.commitments, commitments);
+            match &group {
+                Some(group) => {
+                    assert_eq!(output.public, *group);
+                }
+                None => {
+                    group = Some(output.public.clone());
+                }
+            }
+            outputs.push(output);
+        }
+
+        for &concurrency in &[1, 2, 4, 8] {
+            c.bench_function(&format!("conc={} n={} t={}", concurrency, n, t), |b| {
+                b.iter_batched(
+                    || {
+                        // Create reshare
+                        let group = group.clone().unwrap();
+                        let mut contributor = None;
+                        let mut commitments = HashMap::new();
+                        for i in 0..n {
+                            let me = contributors[i as usize].clone();
+                            let share = outputs[i as usize].share;
+                            let p0 = dkg::contributor::P0::new(
+                                me,
+                                t,
+                                Some((group.clone(), share)),
+                                contributors.clone(),
+                                contributors.clone(),
+                                concurrency,
+                            );
+                            let (p1, commitment, shares) = p0.finalize();
+                            if i == 0 {
+                                contributor = p1;
+                            }
+                            commitments.insert(i, (commitment, shares));
+                        }
+                        let mut contributor = contributor.unwrap();
+
+                        // Distribute commitments
+                        for i in 0..n {
+                            // Get recipient share
+                            let (commitment, _) = commitments.get(&i).unwrap();
+                            let commitment = commitment.clone();
+
+                            // Send share to contributor
+                            let dealer = contributors[i as usize].clone();
+                            contributor.commitment(dealer, commitment).unwrap();
+                        }
+
+                        // Convert to p2
+                        let mut contributor = contributor.finalize().unwrap();
+
+                        // Distribute shares
+                        for i in 0..n {
+                            // Get recipient share
+                            let (_, shares) = commitments.get(&i).unwrap();
+                            let share = shares[0];
+
+                            // Send share to contributor
+                            let dealer = contributors[i as usize].clone();
+                            contributor.share(dealer, share).unwrap();
+                        }
+
+                        // Finalize
+                        let commitments = (0..n).collect::<Vec<_>>();
+                        (contributor, commitments)
+                    },
+                    |(contributor, commitments)| {
+                        black_box(contributor.finalize(commitments).unwrap());
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
+        }
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_reshare_recovery
+}
+criterion_main!(benches);

--- a/cryptography/src/bls12381/benches/reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/reshare_recovery.rs
@@ -1,8 +1,11 @@
-use commonware_cryptography::{ed25519::insecure_signer, Scheme};
+use commonware_cryptography::{
+    bls12381::{dkg, primitives::poly},
+    ed25519::insecure_signer,
+    Scheme,
+};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use std::collections::HashMap;
 use std::hint::black_box;
-use vrf::bls12381::{dkg, primitives::poly};
 
 fn benchmark_reshare_recovery(c: &mut Criterion) {
     for &n in &[5, 10, 20, 50, 100, 250, 500] {

--- a/cryptography/src/bls12381/benches/signature_aggregation.rs
+++ b/cryptography/src/bls12381/benches/signature_aggregation.rs
@@ -1,0 +1,28 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::hint::black_box;
+use vrf::bls12381::{dkg, primitives};
+
+fn benchmark_signature_aggregation(c: &mut Criterion) {
+    let msg = b"hello";
+    for &n in &[5, 10, 20, 50, 100, 250, 500] {
+        let t = dkg::utils::threshold(n).unwrap();
+        c.bench_function(&format!("n={} t={}", n, t), |b| {
+            b.iter_batched(
+                || {
+                    let (_, shares) = dkg::ops::generate_shares(None, n, t);
+                    shares
+                        .iter()
+                        .map(|s| primitives::ops::partial_sign(s, &msg[..]))
+                        .collect::<Vec<_>>()
+                },
+                |partials| {
+                    black_box(primitives::ops::aggregate(t, partials).unwrap());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, benchmark_signature_aggregation);
+criterion_main!(benches);

--- a/cryptography/src/bls12381/benches/signature_aggregation.rs
+++ b/cryptography/src/bls12381/benches/signature_aggregation.rs
@@ -1,6 +1,6 @@
+use commonware_cryptography::bls12381::{dkg, primitives};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use std::hint::black_box;
-use vrf::bls12381::{dkg, primitives};
 
 fn benchmark_signature_aggregation(c: &mut Criterion) {
     let msg = b"hello";

--- a/cryptography/src/bls12381/benches/signature_generation.rs
+++ b/cryptography/src/bls12381/benches/signature_generation.rs
@@ -1,0 +1,24 @@
+use commonware_cryptography::Scheme;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::hint::black_box;
+use vrf::bls12381::scheme::Bls12381;
+
+fn benchmark_signature_generation(c: &mut Criterion) {
+    let namespace = b"namespace";
+    let msg = b"hello";
+    c.bench_function(
+        &format!("ns_len={} msg_len={}", namespace.len(), msg.len()),
+        |b| {
+            b.iter_batched(
+                Bls12381::new,
+                |mut signer| {
+                    black_box(signer.sign(namespace, msg));
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
+criterion_group!(benches, benchmark_signature_generation);
+criterion_main!(benches);

--- a/cryptography/src/bls12381/benches/signature_generation.rs
+++ b/cryptography/src/bls12381/benches/signature_generation.rs
@@ -1,7 +1,6 @@
-use commonware_cryptography::Scheme;
+use commonware_cryptography::{bls12381::scheme::Bls12381, Scheme};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use std::hint::black_box;
-use vrf::bls12381::scheme::Bls12381;
 
 fn benchmark_signature_generation(c: &mut Criterion) {
     let namespace = b"namespace";

--- a/cryptography/src/bls12381/benches/signature_verification.rs
+++ b/cryptography/src/bls12381/benches/signature_verification.rs
@@ -1,7 +1,6 @@
-use commonware_cryptography::Scheme;
+use commonware_cryptography::{bls12381::scheme::Bls12381, Scheme};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use std::hint::black_box;
-use vrf::bls12381::scheme::Bls12381;
 
 fn benchmark_signature_verification(c: &mut Criterion) {
     let namespace = b"namespace";

--- a/cryptography/src/bls12381/benches/signature_verification.rs
+++ b/cryptography/src/bls12381/benches/signature_verification.rs
@@ -1,0 +1,28 @@
+use commonware_cryptography::Scheme;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::hint::black_box;
+use vrf::bls12381::scheme::Bls12381;
+
+fn benchmark_signature_verification(c: &mut Criterion) {
+    let namespace = b"namespace";
+    let msg = b"hello";
+    c.bench_function(
+        &format!("ns_len={} msg_len={}", namespace.len(), msg.len()),
+        |b| {
+            b.iter_batched(
+                || {
+                    let mut signer = Bls12381::new();
+                    let signature = signer.sign(namespace, msg);
+                    (signer, signature)
+                },
+                |(signer, signature)| {
+                    black_box(Bls12381::verify(namespace, msg, &signer.me(), &signature));
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
+criterion_group!(benches, benchmark_signature_verification);
+criterion_main!(benches);

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -1,0 +1,607 @@
+//! Orchestrator of the DKG/Resharing procedure.
+//!
+//! In practice, this will often be implemented by a consensus mechanism but
+//! can be run as a trusted, standalone binary.
+//!
+//! # Duplicate/Unnecessary Information
+//!
+//! Duplicate/unnecessary information will error but not disqualify (to avoid including
+//! junk in a block), only invalid or missing information qualifies as an attributable
+//! fault (otherwise may occur by accident).
+
+use super::utils;
+use crate::bls12381::{
+    dkg::{ops, Error},
+    primitives::{group::Share, poly},
+};
+use crate::PublicKey;
+use std::collections::{HashMap, HashSet};
+
+/// Gather commitments from all contributors.
+pub struct P0 {
+    threshold: u32,
+    previous: Option<poly::Public>,
+    concurrency: usize,
+
+    dealers: Vec<PublicKey>,
+    dealers_ordered: HashMap<PublicKey, u32>,
+
+    recipients: Vec<PublicKey>,
+    recipients_ordered: HashMap<PublicKey, u32>,
+
+    commitments: HashMap<PublicKey, poly::Public>,
+    disqualified: HashSet<PublicKey>,
+}
+
+impl P0 {
+    /// Create a new abiter for a DKG/Resharing procedure.
+    pub fn new(
+        threshold: u32,
+        previous: Option<poly::Public>,
+        mut dealers: Vec<PublicKey>,
+        mut recipients: Vec<PublicKey>,
+        concurrency: usize,
+    ) -> Self {
+        dealers.sort();
+        let dealers_ordered = dealers
+            .iter()
+            .enumerate()
+            .map(|(i, pk)| (pk.clone(), i as u32))
+            .collect();
+        recipients.sort();
+        let recipients_ordered = recipients
+            .iter()
+            .enumerate()
+            .map(|(i, pk)| (pk.clone(), i as u32))
+            .collect();
+        dealers.sort();
+        Self {
+            threshold,
+            previous,
+            concurrency,
+            dealers,
+            dealers_ordered,
+            recipients,
+            recipients_ordered,
+            commitments: HashMap::new(),
+            disqualified: HashSet::new(),
+        }
+    }
+
+    /// Required number of commitments to continue procedure.
+    pub fn required(&self) -> u32 {
+        match &self.previous {
+            Some(previous) => previous.required(),
+            None => self.threshold,
+        }
+    }
+
+    /// Disqualify a contributor from the DKG for external reason (i.e. sending invalid messages).
+    pub fn disqualify(&mut self, contributor: PublicKey) {
+        self.disqualified.insert(contributor);
+    }
+
+    /// Verify and track a commitment from a dealer.
+    pub fn commitment(&mut self, dealer: PublicKey, commitment: poly::Public) -> Result<(), Error> {
+        // Check if contributor is disqualified
+        if self.disqualified.contains(&dealer) {
+            return Err(Error::ContributorDisqualified);
+        }
+
+        // Find the index of the contributor
+        let idx = match self.dealers_ordered.get(&dealer) {
+            Some(idx) => *idx,
+            None => return Err(Error::ContirbutorInvalid),
+        };
+
+        // Check if commitment already exists
+        if self.commitments.contains_key(&dealer) {
+            return Err(Error::DuplicateCommitment);
+        }
+
+        // Verify the commitment is valid
+        match ops::verify_commitment(self.previous.as_ref(), idx, &commitment, self.threshold) {
+            Ok(()) => {
+                self.commitments.insert(dealer, commitment);
+            }
+            Err(e) => {
+                self.disqualified.insert(dealer);
+                return Err(e);
+            }
+        }
+        Ok(())
+    }
+
+    /// If there exist at least `required()` commitments, proceed to `P1`.
+    pub fn finalize(mut self) -> (Option<P1>, HashSet<PublicKey>) {
+        // Disqualify any contributors who did not submit a commitment
+        for contributor in self.dealers.iter() {
+            if !self.commitments.contains_key(contributor) {
+                self.disqualified.insert(contributor.clone());
+            }
+        }
+
+        // Ensure we have enough commitments to proceed
+        if self.commitments.len() < self.required() as usize {
+            return (None, self.disqualified);
+        }
+
+        // Allow the arbiter to proceed
+        (
+            Some(P1 {
+                threshold: self.threshold,
+                previous: self.previous,
+                concurrency: self.concurrency,
+                dealers: self.dealers,
+                dealers_ordered: self.dealers_ordered,
+                recipients: self.recipients,
+                recipients_ordered: self.recipients_ordered,
+                commitments: self.commitments,
+                disqualified: self.disqualified.clone(),
+                acks: HashMap::new(),
+            }),
+            self.disqualified,
+        )
+    }
+}
+
+/// Collect acknowledgements and complaints from all recipients.
+pub struct P1 {
+    threshold: u32,
+    previous: Option<poly::Public>,
+    concurrency: usize,
+
+    dealers: Vec<PublicKey>,
+    dealers_ordered: HashMap<PublicKey, u32>,
+
+    recipients: Vec<PublicKey>,
+    recipients_ordered: HashMap<PublicKey, u32>,
+
+    commitments: HashMap<PublicKey, poly::Public>,
+    disqualified: HashSet<PublicKey>,
+
+    acks: HashMap<u32, HashSet<u32>>,
+}
+
+/// Alias for a commitment from a dealer.
+pub type Commitment = (u32, PublicKey, poly::Public);
+
+/// Alias for a request for a missing share from a dealer
+/// for a recipient.
+pub type Request = (u32, u32);
+
+impl P1 {
+    /// Required number of commitments to continue procedure.
+    pub fn required(&self) -> u32 {
+        match &self.previous {
+            Some(previous) => previous.required(),
+            None => self.threshold,
+        }
+    }
+
+    /// Disqualify a contributor from the DKG for external reason (i.e. sending invalid messages).
+    pub fn disqualify(&mut self, contributor: PublicKey) {
+        self.disqualified.insert(contributor);
+    }
+
+    /// Get the public key of a dealer.
+    pub fn dealer(&self, dealer: u32) -> Option<PublicKey> {
+        self.dealers.get(dealer as usize).cloned()
+    }
+
+    /// Return all tracked commitments.
+    pub fn commitments(&self) -> Vec<Commitment> {
+        self.commitments
+            .iter()
+            .filter_map(|(contributor, commitment)| {
+                if self.disqualified.contains(contributor) {
+                    return None;
+                }
+
+                let idx = self.dealers_ordered.get(contributor).unwrap();
+                Some((*idx, contributor.clone(), commitment.clone()))
+            })
+            .collect()
+    }
+
+    /// Verify and track an acknowledgement from a recipient for a dealer.
+    pub fn ack(&mut self, recipient: PublicKey, dealer: u32) -> Result<(), Error> {
+        // Check if contributor is disqualified
+        if self.disqualified.contains(&recipient) {
+            return Err(Error::ContributorDisqualified);
+        }
+
+        // Find the index of the recipient
+        let idx = match self.recipients_ordered.get(&recipient) {
+            Some(idx) => *idx,
+            None => return Err(Error::ContirbutorInvalid),
+        };
+
+        {
+            // Get dealer that submitted commitment
+            let dealer = self
+                .dealers
+                .get(dealer as usize)
+                .ok_or(Error::DealerInvalid)?;
+
+            // Check if commitment is still valid
+            if self.disqualified.contains(dealer) | !self.commitments.contains_key(dealer) {
+                // We don't disqualify the submitter here as this could have happened
+                // without their knowledge.
+                return Err(Error::CommitmentDisqualified);
+            }
+
+            // Ensure we aren't sending a self-ack
+            if recipient == *dealer {
+                self.disqualified.insert(recipient);
+                return Err(Error::SelfAck);
+            }
+        }
+
+        // Store ack
+        let entry = self.acks.entry(dealer).or_default();
+        if entry.contains(&idx) {
+            Err(Error::DuplicateAck)
+        } else {
+            entry.insert(idx);
+            Ok(())
+        }
+    }
+
+    /// Verify a complaint from a recipient for a dealer.
+    ///
+    /// If a complaint is valid, the dealer is disqualified. If a
+    /// complaint is invalid, the recipient is disqualified.
+    pub fn complaint(
+        &mut self,
+        recipient: PublicKey,
+        dealer: u32,
+        share: &Share,
+    ) -> Result<(), Error> {
+        // Check if contributor is disqualified
+        if self.disqualified.contains(&recipient) {
+            return Err(Error::ContributorDisqualified);
+        }
+
+        // Find the index of the contributor
+        let idx = match self.recipients_ordered.get(&recipient) {
+            Some(idx) => *idx,
+            None => return Err(Error::ContirbutorInvalid),
+        };
+
+        // Find the dealer that submitted the commitment
+        let dealer_key = self
+            .dealers
+            .get(dealer as usize)
+            .ok_or(Error::DealerInvalid)?;
+
+        if dealer_key == &recipient {
+            return Err(Error::SelfComplaint);
+        }
+
+        // Check if commitment is still valid
+        if self.disqualified.contains(dealer_key) | !self.commitments.contains_key(dealer_key) {
+            // We don't disqualify the submitter here as this could have happened
+            // without their knowledge.
+            return Err(Error::CommitmentDisqualified);
+        }
+
+        // Verify complaint
+        let commitment = self.commitments.get(dealer_key).unwrap();
+        match ops::verify_share(
+            self.previous.as_ref(),
+            dealer,
+            commitment,
+            self.threshold,
+            idx,
+            share,
+        ) {
+            Ok(_) => {
+                // Submitting a useless complaint is a disqualifying offense
+                self.disqualified.insert(recipient);
+                Err(Error::ComplaintInvalid)
+            }
+            Err(_) => {
+                // Disqualify the dealer
+                self.disqualified.insert(dealer_key.clone());
+                Ok(())
+            }
+        }
+    }
+
+    /// Request missing dealings.
+    fn requests(&self) -> (HashMap<u32, HashSet<u32>>, Vec<Request>) {
+        // Compute missing shares
+        let mut missing_dealings = HashMap::new(); // dealer -> {recipient}
+        let mut required_reveals = HashMap::new(); // recipient -> {dealer}
+        for (dealer, acks) in self.acks.iter() {
+            for (recipient, recipient_bytes) in self.recipients.iter().enumerate() {
+                // Skip any recipients that are disqualified or have already acked
+                let dealer_bytes = self.dealers[*dealer as usize].clone();
+                if *recipient_bytes == dealer_bytes {
+                    continue;
+                }
+                if self.disqualified.contains(recipient_bytes) {
+                    continue;
+                }
+                let recipient = recipient as u32;
+                if acks.contains(&recipient) {
+                    continue;
+                }
+
+                // Add dealer -> recipient to tracker
+                let entry = missing_dealings.entry(*dealer).or_insert_with(HashSet::new);
+                entry.insert(recipient);
+                let entry = required_reveals
+                    .entry(recipient)
+                    .or_insert_with(HashSet::new);
+                entry.insert(*dealer);
+            }
+        }
+
+        // Do not request reveals for recipients with more than `max_reveals` missing shares
+        let max_reveals = utils::max_reveals(self.threshold);
+        for (recipient, dealers) in required_reveals.iter() {
+            if dealers.len() <= max_reveals as usize {
+                continue;
+            }
+
+            // Remove recipient from missing dealings
+            for dealer in dealers.iter() {
+                if let Some(recipients) = missing_dealings.get_mut(dealer) {
+                    recipients.remove(recipient);
+                }
+            }
+
+            // We do not disqualify dealers that would otherwise need to distribute
+            // shares because a particular recipient may just be refusing to participate.
+        }
+
+        // Construct required reveals
+        let mut reveals = Vec::new();
+        for (dealer, recipients) in missing_dealings.iter() {
+            for recipient in recipients.iter() {
+                reveals.push((*dealer, *recipient));
+            }
+        }
+        (missing_dealings, reveals)
+    }
+
+    /// If there exist at least `threshold - 1` acks each for `required()` dealers, proceed to `P2`.
+    pub fn finalize(mut self) -> (Option<(P2, Vec<Request>)>, HashSet<PublicKey>) {
+        // Remove acks of disqualified recipients
+        for acks in self.acks.values_mut() {
+            for disqualified in self.disqualified.iter() {
+                if let Some(idx) = self.recipients_ordered.get(disqualified) {
+                    acks.remove(idx);
+                }
+
+                // If we can't find the recipient, it is probably a disqualified dealer.
+            }
+        }
+
+        // Disqualify any commitments without at least `self.threshold` acks
+        for dealer in self.commitments.keys() {
+            let idx = self.dealers_ordered.get(dealer).unwrap();
+            let acks = match self.acks.get(idx) {
+                Some(acks) => acks.len(),
+                None => 0,
+            };
+
+            // Check against `self.threshold - 1` because we don't send an
+            // ack for ourselves.
+            if acks < (self.threshold - 1) as usize {
+                self.disqualified.insert(dealer.clone());
+            }
+        }
+
+        // Remove disqualified commitments
+        for disqualified in self.disqualified.iter() {
+            self.commitments.remove(disqualified);
+            self.acks
+                .remove(self.dealers_ordered.get(disqualified).unwrap());
+        }
+
+        // If there are not `self.required()` dealings with at least `self.required()` acks,
+        // we cannot proceed.
+        if self.acks.len() < self.required() as usize {
+            return (None, self.disqualified);
+        }
+
+        // Allow the arbiter to proceed
+        let (missing_dealings, requests) = self.requests();
+        (
+            Some((
+                P2 {
+                    threshold: self.threshold,
+                    previous: self.previous,
+                    concurrency: self.concurrency,
+                    dealers: self.dealers,
+                    dealers_ordered: self.dealers_ordered,
+                    commitments: self.commitments,
+                    disqualified: self.disqualified.clone(),
+                    acks: self.acks,
+                    missing_dealings,
+                    resolutions: HashMap::new(),
+                },
+                requests,
+            )),
+            self.disqualified,
+        )
+    }
+}
+
+/// Output of the DKG/Resharing procedure.
+#[derive(Clone)]
+pub struct Output {
+    pub public: poly::Public,
+    pub commitments: Vec<u32>,
+    pub resolutions: HashMap<(u32, u32), Share>,
+}
+
+/// Collect missing shares (if any) and recover the public polynomial.
+pub struct P2 {
+    threshold: u32,
+    previous: Option<poly::Public>,
+    concurrency: usize,
+
+    dealers: Vec<PublicKey>,
+    dealers_ordered: HashMap<PublicKey, u32>,
+
+    commitments: HashMap<PublicKey, poly::Public>,
+    disqualified: HashSet<PublicKey>,
+
+    acks: HashMap<u32, HashSet<u32>>,
+
+    missing_dealings: HashMap<u32, HashSet<u32>>,
+    resolutions: HashMap<(u32, u32), Share>,
+}
+
+impl P2 {
+    /// Required number of commitments to continue procedure.
+    pub fn required(&self) -> u32 {
+        match &self.previous {
+            Some(previous) => previous.required(),
+            None => self.threshold,
+        }
+    }
+
+    /// Disqualify a contributor from the DKG for external reason (i.e. sending invalid messages).
+    pub fn disqualify(&mut self, contributor: PublicKey) {
+        self.disqualified.insert(contributor);
+    }
+
+    /// Get the ID of a dealer.
+    pub fn dealer(&self, dealer: &PublicKey) -> Option<u32> {
+        self.dealers_ordered.get(dealer).cloned()
+    }
+
+    /// Return all tracked commitments.
+    pub fn commitments(&self) -> Vec<Commitment> {
+        self.commitments
+            .iter()
+            .filter_map(|(contributor, commitment)| {
+                if self.disqualified.contains(contributor) {
+                    return None;
+                }
+
+                let idx = self.dealers_ordered.get(contributor).unwrap();
+                Some((*idx, contributor.clone(), commitment.clone()))
+            })
+            .collect()
+    }
+
+    /// Verify and track a forced resolution from a dealer.
+    pub fn reveal(&mut self, dealer: PublicKey, share: Share) -> Result<(), Error> {
+        // Check if contributor is disqualified
+        if self.disqualified.contains(&dealer) {
+            return Err(Error::ContributorDisqualified);
+        }
+
+        // Find the index of the contributor
+        let idx = match self.dealers_ordered.get(&dealer) {
+            Some(idx) => *idx,
+            None => return Err(Error::ContirbutorInvalid),
+        };
+
+        // Check if commitment is still valid
+        if self.disqualified.contains(&dealer) | !self.commitments.contains_key(&dealer) {
+            // We don't disqualify the submitter here as this could have happened
+            // without their knowledge.
+            return Err(Error::CommitmentDisqualified);
+        }
+
+        // Verify share
+        let commitment = self.commitments.get(&dealer).unwrap();
+        if let Err(e) = ops::verify_share(
+            self.previous.as_ref(),
+            idx,
+            commitment,
+            self.threshold,
+            share.index,
+            &share,
+        ) {
+            // Disqualify the dealer
+            self.disqualified.insert(dealer);
+            return Err(e);
+        }
+
+        // Store that resolution was successful
+        let missing = match self.missing_dealings.get_mut(&idx) {
+            Some(missing) => missing,
+            None => {
+                return Err(Error::UnexpectedReveal);
+            }
+        };
+        if missing.remove(&share.index) {
+            self.resolutions.insert((idx, share.index), share);
+            Ok(())
+        } else {
+            Err(Error::UnexpectedReveal)
+        }
+    }
+
+    /// If there exist at least `threshold` resolutions for `required()` dealers, recover
+    /// the group public polynomial.
+    pub fn finalize(mut self) -> (Result<Output, Error>, HashSet<PublicKey>) {
+        // Remove any dealers that did not distribute all required shares (may not be `n`)
+        for (dealer, recipients) in &self.missing_dealings {
+            if recipients.is_empty() {
+                continue;
+            }
+            self.disqualified
+                .insert(self.dealers[*dealer as usize].clone());
+        }
+
+        // Remove any disqualified dealers
+        for disqualified in self.disqualified.iter() {
+            self.commitments.remove(disqualified);
+            self.acks
+                .remove(self.dealers_ordered.get(disqualified).unwrap());
+        }
+
+        // Determine if we have enough resolutions
+        let required = self.required();
+        if self.acks.len() < required as usize {
+            return (Err(Error::InsufficientDealings), self.disqualified);
+        }
+
+        // Recover group
+        let public = match self.previous {
+            Some(previous) => {
+                let commitments = self
+                    .commitments
+                    .iter()
+                    .map(|(contributor, commitment)| {
+                        let idx = self.dealers_ordered.get(contributor).unwrap();
+                        (*idx, commitment.clone())
+                    })
+                    .collect();
+                match ops::recover_public(&previous, commitments, self.threshold, self.concurrency)
+                {
+                    Ok(public) => public,
+                    Err(e) => return (Err(e), self.disqualified),
+                }
+            }
+            None => {
+                let commitments = self.commitments.values().cloned().collect();
+                match ops::construct_public(commitments, required) {
+                    Ok(public) => public,
+                    Err(e) => return (Err(e), self.disqualified),
+                }
+            }
+        };
+
+        // Generate output
+        let output = Output {
+            public,
+            commitments: self
+                .commitments
+                .keys()
+                .map(|contributor| *self.dealers_ordered.get(contributor).unwrap())
+                .collect(),
+            resolutions: self.resolutions,
+        };
+        (Ok(output), self.disqualified)
+    }
+}

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -1,13 +1,19 @@
 //! Orchestrator of the DKG/Resharing procedure.
 //!
 //! In practice, this will often be implemented by a consensus mechanism but
-//! can be run as a trusted, standalone binary.
+//! can be run as a trusted, standalone binary (see <https://docs.rs/commonware-vrf>).
 //!
 //! # Duplicate/Unnecessary Information
 //!
 //! Duplicate/unnecessary information will error but not disqualify (to avoid including
 //! junk in a block), only invalid or missing information qualifies as an attributable
 //! fault (otherwise may occur by accident).
+//!
+//! # Warning
+//!
+//! It is up to the developer to authorize interaction with the arbiter. This is purposely
+//! not provided by the Arbiter because this authorization function is highly dependent on
+//! the context in which the contributor is being used.
 
 use super::utils;
 use crate::bls12381::{

--- a/cryptography/src/bls12381/dkg/contributor.rs
+++ b/cryptography/src/bls12381/dkg/contributor.rs
@@ -1,0 +1,455 @@
+//! Participants in a DKG/Resharing procedure that hold a share of the secret.
+//!
+//! # Tracking Invalidity
+//!
+//! Unlike the arbiter, the contributor does not track invalidity and requires
+//! the arbiter to notify it of such things. This prevents the case where
+//! a malicious contributor disqualifies itself on one contributor before
+//! said contributors can inform the arbiter of the issue. This could prevent
+//! an honest contributor from recognizing a commitment as valid (that all other
+//! contributors have agreed upon).
+
+use crate::bls12381::{
+    dkg::{ops, Error},
+    primitives::{
+        group::{self, Element, Share},
+        poly::{self, Eval},
+    },
+};
+use crate::PublicKey;
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+/// Output of a DKG/Resharing procedure.
+#[derive(Clone)]
+pub struct Output {
+    pub public: poly::Public,
+    pub commitments: Vec<poly::Public>,
+    pub share: Share,
+}
+
+/// Generate shares and a commitment (optional).
+pub struct P0 {
+    me: PublicKey,
+    threshold: u32,
+    previous: Option<(poly::Public, Share)>,
+    concurrency: usize,
+
+    dealers_ordered: HashMap<PublicKey, u32>,
+    recipients: Vec<PublicKey>,
+    recipients_ordered: HashMap<PublicKey, u32>,
+}
+
+impl P0 {
+    /// Create a new dealer for a DKG/Resharing procedure (optional).
+    ///
+    /// If `me` is not in `dealers`, this will panic.
+    pub fn new(
+        me: PublicKey,
+        threshold: u32,
+        previous: Option<(poly::Public, Share)>,
+        mut dealers: Vec<PublicKey>,
+        mut recipients: Vec<PublicKey>,
+        concurrency: usize,
+    ) -> Self {
+        dealers.sort();
+        let dealers_ordered = dealers
+            .iter()
+            .enumerate()
+            .map(|(i, pk)| (pk.clone(), i as u32))
+            .collect::<HashMap<_, _>>();
+        if !dealers_ordered.contains_key(&me) {
+            panic!("me must be in dealers");
+        }
+        recipients.sort();
+        let recipients_ordered = recipients
+            .iter()
+            .enumerate()
+            .map(|(i, pk)| (pk.clone(), i as u32))
+            .collect();
+        Self {
+            me,
+            threshold,
+            previous,
+            concurrency,
+            dealers_ordered,
+            recipients,
+            recipients_ordered,
+        }
+    }
+
+    /// Construct commitment, shares, and optionally `P1` (if the dealer
+    /// is also a recipient).
+    pub fn finalize(self) -> (Option<P1>, poly::Public, Vec<Share>) {
+        // Generate shares and commitment
+        let (public, share) = match self.previous {
+            Some((public, share)) => (Some(public), Some(share)),
+            None => (None, None),
+        };
+        let (commitment, shares) =
+            ops::generate_shares(share, self.recipients.len() as u32, self.threshold);
+
+        // Proceed to next phase
+        let p1 = if self.recipients_ordered.contains_key(&self.me) {
+            // We manually construct P1 to avoid resorting the dealers/recipients
+            Some(P1 {
+                me: self.me,
+                threshold: self.threshold,
+                previous: public,
+                concurrency: self.concurrency,
+                dealers_ordered: self.dealers_ordered,
+                recipients_ordered: self.recipients_ordered,
+                commitments: HashMap::new(),
+                valid: BTreeMap::new(),
+            })
+        } else {
+            None
+        };
+        (p1, commitment, shares)
+    }
+}
+
+/// Track commitments distributed by dealers.
+pub struct P1 {
+    me: PublicKey,
+    threshold: u32,
+    previous: Option<poly::Public>,
+    concurrency: usize,
+
+    dealers_ordered: HashMap<PublicKey, u32>,
+    recipients_ordered: HashMap<PublicKey, u32>,
+
+    commitments: HashMap<PublicKey, poly::Public>,
+
+    valid: BTreeMap<u32, (poly::Public, Share)>,
+}
+
+impl P1 {
+    /// Create a new contributor for a DKG/Resharing procedure.
+    pub fn new(
+        me: PublicKey,
+        threshold: u32,
+        previous: Option<poly::Public>,
+        mut dealers: Vec<PublicKey>,
+        mut recipients: Vec<PublicKey>,
+        concurrency: usize,
+    ) -> Self {
+        dealers.sort();
+        let dealers_ordered = dealers
+            .iter()
+            .enumerate()
+            .map(|(i, pk)| (pk.clone(), i as u32))
+            .collect();
+        recipients.sort();
+        let recipients_ordered = recipients
+            .iter()
+            .enumerate()
+            .map(|(i, pk)| (pk.clone(), i as u32))
+            .collect();
+        Self {
+            me,
+            threshold,
+            previous,
+            concurrency,
+            dealers_ordered,
+            recipients_ordered,
+            commitments: HashMap::new(),
+            valid: BTreeMap::new(),
+        }
+    }
+
+    /// Required number of commitments to continue procedure.
+    pub fn required(&self) -> u32 {
+        match &self.previous {
+            Some(previous) => previous.required(),
+            None => self.threshold,
+        }
+    }
+
+    /// Verify and track a commitment from a dealer.
+    pub fn commitment(&mut self, dealer: PublicKey, commitment: poly::Public) -> Result<(), Error> {
+        // Ensure contributor is valid
+        let idx = match self.dealers_ordered.get(&dealer) {
+            Some(contributor) => *contributor,
+            None => return Err(Error::DealerInvalid),
+        };
+
+        // Verify that commitment is valid
+        ops::verify_commitment(self.previous.as_ref(), idx, &commitment, self.threshold)?;
+
+        // Store commitment
+        self.commitments.insert(dealer, commitment);
+        Ok(())
+    }
+
+    /// Return whether a commitment has been received from a dealer.
+    pub fn has(&self, dealer: PublicKey) -> bool {
+        self.commitments.contains_key(&dealer)
+    }
+
+    /// Return the count of tracked commitments.
+    pub fn count(&self) -> usize {
+        self.commitments.len()
+    }
+
+    /// If there exist at least `required()` commitments, proceed to `P2`.
+    pub fn finalize(self) -> Option<P2> {
+        // Ensure there are enough commitments to proceed
+        if self.commitments.len() < self.required() as usize {
+            return None;
+        }
+
+        // Proceed to next phase
+        Some(P2 {
+            me: self.me,
+            threshold: self.threshold,
+            previous: self.previous,
+            concurrency: self.concurrency,
+            dealers_ordered: self.dealers_ordered,
+            recipients_ordered: self.recipients_ordered,
+            commitments: self.commitments,
+            valid: self.valid,
+        })
+    }
+}
+
+/// Track shares distributed by dealers.
+pub struct P2 {
+    me: PublicKey,
+    threshold: u32,
+    previous: Option<poly::Public>,
+    concurrency: usize,
+
+    dealers_ordered: HashMap<PublicKey, u32>,
+    recipients_ordered: HashMap<PublicKey, u32>,
+
+    commitments: HashMap<PublicKey, poly::Public>,
+
+    valid: BTreeMap<u32, (poly::Public, Share)>,
+}
+
+impl P2 {
+    /// Required number of commitments to continue procedure.
+    pub fn required(&self) -> u32 {
+        match &self.previous {
+            Some(previous) => previous.required(),
+            None => self.threshold,
+        }
+    }
+
+    /// Verify and track a share from a dealer.
+    pub fn share(&mut self, dealer: PublicKey, share: Share) -> Result<(), Error> {
+        // Ensure contributor is valid
+        let idx = match self.dealers_ordered.get(&dealer) {
+            Some(contributor) => *contributor,
+            None => return Err(Error::DealerInvalid),
+        };
+
+        // Ensure share is for us
+        if share.index != self.recipients_ordered[&self.me] {
+            return Err(Error::MisdirectedShare);
+        }
+
+        // Verify that share is valid
+        let commitment = match self.commitments.get(&dealer) {
+            Some(commitment) => commitment.clone(),
+            None => return Err(Error::MissingCommitment),
+        };
+        ops::verify_share(
+            self.previous.as_ref(),
+            idx,
+            &commitment,
+            self.threshold,
+            share.index,
+            &share,
+        )?;
+
+        // Store share for later use
+        //
+        // If we receive multiple shares from the same dealer, we will
+        // only keep the last.
+        self.valid.insert(idx, (commitment, share));
+        Ok(())
+    }
+
+    /// If we are tracking shares for all provided `commitments`, recover
+    /// the new group public polynomial and our share.
+    pub fn finalize(mut self, commitments: Vec<u32>) -> Result<Output, Error> {
+        // Ensure we have all required shares
+        for dealer in &commitments {
+            if !self.valid.contains_key(dealer) {
+                return Err(Error::MissingShare);
+            }
+        }
+
+        // Remove all valid not in commitments
+        let commitments: HashSet<_> = commitments.into_iter().collect();
+        for dealer in self.valid.keys().cloned().collect::<Vec<_>>() {
+            if !commitments.contains(&dealer) {
+                self.valid.remove(&dealer);
+            }
+        }
+
+        // Ensure we have enough shares to construct a secret
+        let required = self.required();
+        let shares = self.valid.len();
+        if shares < required as usize {
+            return Err(Error::InsufficientDealings);
+        }
+
+        // Construct secret
+        let mut public = poly::Public::zero();
+        let mut t_commitments = Vec::new();
+        let mut secret = group::Private::zero();
+        match self.previous {
+            None => {
+                // Add all valid commitments/shares
+                for share in self.valid.values() {
+                    public.add(&share.0);
+                    t_commitments.push(share.0.clone());
+                    secret.add(&share.1.private);
+                }
+            }
+            Some(previous) => {
+                // Recover public via interpolation
+                //
+                // While it is tempting to remove this work (given we only need the secret
+                // to generate a threshold signature), this polynomial is required to verify
+                // dealings of future resharings.
+                let commitments: BTreeMap<u32, poly::Public> = self
+                    .valid
+                    .iter()
+                    .take(required as usize)
+                    .map(|(dealer, (commitment, _))| (*dealer, commitment.clone()))
+                    .collect();
+                t_commitments = commitments.values().cloned().collect();
+                public =
+                    ops::recover_public(&previous, commitments, self.threshold, self.concurrency)?;
+
+                // Recover share via interpolation
+                let shares = self
+                    .valid
+                    .into_iter()
+                    .take(required as usize)
+                    .map(|(dealer, (_, share))| Eval {
+                        index: dealer,
+                        value: share.private,
+                    })
+                    .collect::<Vec<_>>();
+                secret = match poly::Private::recover(required, shares) {
+                    Ok(share) => share,
+                    Err(_) => return Err(Error::ShareInterpolationFailed),
+                };
+            }
+        }
+
+        // Return the public polynomial and share
+        Ok(Output {
+            public,
+            commitments: t_commitments,
+            share: Share {
+                index: self.recipients_ordered[&self.me],
+                private: secret,
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ed25519::insecure_signer, Scheme};
+    use std::collections::HashMap;
+
+    fn create_and_verify_shares(n: u32, t: u32, dealers: u32, concurrency: usize) {
+        // Create contributors
+        let mut contributors = (0..n)
+            .map(|i| insecure_signer(i as u16).me())
+            .collect::<Vec<_>>();
+        contributors.sort();
+
+        // Create shares
+        let mut contributor_shares = HashMap::new();
+        let mut commitments = Vec::new();
+        for i in 0..n {
+            let me = contributors[i as usize].clone();
+            let contributor = P0::new(
+                me,
+                t,
+                None,
+                contributors.clone(),
+                contributors.clone(),
+                concurrency,
+            );
+            let (contributor, public, shares) = contributor.finalize();
+            contributor_shares.insert(i, (public.clone(), shares, contributor.unwrap()));
+            commitments.push(public);
+        }
+
+        // Distribute commitments
+        for i in 0..dealers {
+            let dealer = contributors[i as usize].clone();
+            for j in 0..n {
+                // Get recipient share
+                let (commitment, _, _) = contributor_shares.get(&i).unwrap();
+                let commitment = commitment.clone();
+
+                // Send share to recipient
+                let (_, _, ref mut recipient) = contributor_shares.get_mut(&j).unwrap();
+                recipient.commitment(dealer.clone(), commitment).unwrap();
+            }
+        }
+
+        // Convert to p2
+        let mut p2 = HashMap::new();
+        for i in 0..n {
+            let (_, shares, contributor) = contributor_shares.remove(&i).unwrap();
+            let contributor = contributor.finalize().unwrap();
+            p2.insert(i, (shares, contributor));
+        }
+        let mut contributor_shares = p2;
+
+        // Distribute shares
+        for i in 0..dealers {
+            let dealer = contributors[i as usize].clone();
+            for j in 0..n {
+                // Get recipient share
+                let (shares, _) = contributor_shares.get(&i).unwrap();
+                let share = shares[j as usize];
+
+                // Send share to recipient
+                let (_, recipient) = contributor_shares.get_mut(&j).unwrap();
+                recipient.share(dealer.clone(), share).unwrap();
+            }
+        }
+
+        // Finalize
+        let included_commitments = (0..dealers).collect::<Vec<_>>();
+        let commitments = commitments[0..dealers as usize].to_vec();
+        let mut group: Option<poly::Public> = None;
+        for i in 0..n {
+            let (_, contributor) = contributor_shares.remove(&i).unwrap();
+            let output = contributor
+                .finalize(included_commitments.clone())
+                .expect("unable to finalize");
+            assert_eq!(output.commitments, commitments);
+            match &group {
+                Some(group) => {
+                    assert_eq!(output.public, *group);
+                }
+                None => {
+                    group = Some(output.public);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_simple_dkg() {
+        create_and_verify_shares(5, 3, 5, 4);
+    }
+
+    #[test]
+    fn test_large_dkg() {
+        create_and_verify_shares(100, 67, 80, 4);
+    }
+}

--- a/cryptography/src/bls12381/dkg/contributor.rs
+++ b/cryptography/src/bls12381/dkg/contributor.rs
@@ -8,6 +8,12 @@
 //! said contributors can inform the arbiter of the issue. This could prevent
 //! an honest contributor from recognizing a commitment as valid (that all other
 //! contributors have agreed upon).
+//!
+//! # Warning
+//!
+//! It is up to the developer to authorize interaction with the contributor. This is purposely
+//! not provided by the contributor because this authorization function is highly dependent on
+//! the context in which the contributor is being used.
 
 use crate::bls12381::{
     dkg::{ops, Error},

--- a/cryptography/src/bls12381/dkg/mod.rs
+++ b/cryptography/src/bls12381/dkg/mod.rs
@@ -1,0 +1,750 @@
+//! Distributed Key Generation (DKG) and Resharing protocol for the BLS12-381 curve.
+//!
+//! This crate implements a Distributed Key Generation (DKG) and Resharing protocol
+//! for the BLS12-381 curve. Unlike many other constructions, this scheme only requires
+//! participants to publicly post shares during a "forced reveal" (when a given dealer
+//! does not distribute a share required for a party to recover their secret). Outside of this
+//! reveal, all shares are communicated directly between a dealer and recipient over an
+//! encrypted channel (which can be instantiated with <https://docs.rs/commonware-p2p>).
+//!
+//! The DKG is based on the "Joint-Feldman" construction from "Secure Distributed Key
+//! Generation for Discrete-Log Based Cryptosystems" (GJKR99) and resharing is based
+//! on the construction provided in "Redistributing secret shares to new access structures
+//! and its applications" (Desmedt97).
+//!
+//! # Protocol
+//!
+//! The protocol has two types of participants: the arbiter and contributors. The arbiter
+//! serves as an orchestrator that collects commitments, acks, complaints, and reveals from
+//! contributors and replicates them to other contributors. The arbiter can be implemented as
+//! a standalone process or by some consensus protocol. Contributors are the participants
+//! that deal shares and commitments to other contributors in the protocol.
+//!
+//! Because the target use case for this protocol is a blockchain, the protocol is designed
+//! to maintain a `2f + 1` threshold over `3f + 1` participants across any reshare (including reshares
+//! with a changing contributor set) where `2f + 1` contributors are online and honest (although
+//! the threshold can be arbitrarily configured). To achieve this, the protocol sacrifices
+//! responsiveness and instead relies on "timeouts" that all online and honest contributors
+//! are expected to communicate within. To provide a "feeling" of responsiveness, the protocol
+//! can be implemented with block height-based timeouts over an optimistically responsive protocol.
+//!
+//! Whether or not the protocol succeeds in a given round (i.e. `2f + 1` participants are not
+//! online and honest), all contributors that do not adhere to the protocol will be identified
+//! and returned. If the protocol succeeds, the contributions of any contributors that did not
+//! adhere to the protocol are excluded (and still returned). It is expected that the set of
+//! contributors would punish/exclude "bad" contributors prior to a future round.
+//!
+//! ## Arbiter
+//!
+//! ### [Phase 0] Step 0: Collect Commitments
+//!
+//! In the first phase, the arbiter collects randomly generated commitments from all contributors.
+//! If the arbiter is instantiated with a polynomial (from a previous DKG/Reshare), it will enforce all
+//! generated commitments are consistent with said polynomial. The arbiter, lastly, enforces that the
+//! degree of each commitment is `threshold - 1`.
+//!
+//! Any contributors that do not submit a commitment before the timeout or submit an invalid commitment
+//! are disqualified.
+//!
+//! If there are not at least `threshold` valid commitments (or `previous.degree + 1` commitments in
+//! resharing), the arbiter will abort the protocol.
+//!
+//! ### [Phase 0] Step 1: Distribute Valid Commitments
+//!
+//! After the Phase 0 timeout, the arbiter sends all valid commitments to all qualified contributors (this
+//! can be implemented as a read operation on a blockchain and does not actually need to be a network message).
+//!
+//! ### [Phase 1] Step 2: Collect Acks and Complaints
+//!
+//! After distributing valid commitments, the arbiter will listen for acks and complaints from qualified
+//! contributors. An "ack" is a message indicating that a given contributor has received a valid
+//! share from a dealer (does not include encrypted or plaintext share material). A "complaint" is a
+//! signed share from a given dealer that is invalid (signing is external to this implementation).
+//! If the complaint is valid, the dealer that sent it is disqualified. If the complaint is invalid
+//! (it is a valid share), the recipient is disqualified. Because all shares must be signed by the contributor
+//! that generates them and this signature is over the plaintext share, there is no need to have a
+//! "justification" phase where said contributor must "defend" itself.
+//!
+//! Any commitments without at least `threshold - 1` acks (dealers don't need to ack their own
+//! commitment) are disqualified. Contributors that are missing more than (threshold - 1)/2 shares
+//! (on commitments with at least `threshold - 1` acks) are disqualified (revealing this many shares
+//! could allow an adversary to reconstruct the secret).
+//!
+//! If there are not at least `threshold` valid commitments (or `previous.degree + 1` commitments in
+//! resharing), the arbiter will abort the protocol.
+//!
+//! ### [Phase 1] Step 3 (Optional): Request Reveals
+//!
+//! After the Phase 1 timeout, the arbiter will send a request to contributors of any commitments with
+//! at least `threshold - 1` acks for qualified contributors that have not yet sent an ack for
+//! said commitment.
+//!
+//! If there are no such requests, the arbiter will proceed directly to step 5 (without waiting for
+//! a timeout).
+//!
+//! If there are such requests, the arbiter will proceed to step 4.
+//!
+//! ### [Phase 2] Step 4 (Optional): Collect Reveals
+//!
+//! Collect reveals that match any requests from Step 3. If a valid reveal for a commitment
+//! is not sent before the timeout or the reveal is invalid, the arbiter will disqualify the commitment.
+//!
+//! ### [Phase 2] Step 5: Finalize Commitments and Distribute Reveals
+//!
+//! After Step 2 (or 4), the arbiter will forward all commitments with at least `threshold - 1` acks to
+//! all qualified contributors (and any accompanying reveals). The arbtier will then recover the
+//! new group polynomial using all valid commitments, if a DKG, or the first `threshold` commitments
+//! (sorted by participant identity), if a reshare.
+//!
+//! ## Contributor
+//!
+//! ### [Phase 0] Step 0 (Optional): Generate Shares and Commitment
+//!
+//! If a contributor is joining a pre-existing group (and is not a dealer), it proceeds to Step 2.
+//!
+//! Otherwise, it generates shares and a commitment. If it is a DKG, the commitment is a random polynomial
+//! with degree of `threshold - 1`. If it is a reshare, the commitment must be consistent with the previous
+//! group polynomial. The contributor generates the shares and commitment for Step 1 and sends the commitment
+//! to the arbiter.
+//!
+//! ### [Phase 0] Step 1 (Optional): Distribute Shares
+//!
+//! After receiving qualified commitments from the arbiter, the contributor (if qualified) will distribute
+//! shares to all other contributors (ordered by participant identity).
+//!
+//! ### [Phase 1] Step 2: Submit Acks/Complaints
+//!
+//! After receiving a share from a qualified contributor, the contributor will send an "ack" to the
+//! arbiter if the share is valid (confirmed against commitment) or a "complaint" if the share is invalid.
+//!
+//! The contributor will not send an "ack" for its own share (if it is a qualified contributor).
+//!
+//! ### [Phase 2] Step 3 (Optional): Respond to Reveal Requests
+//!
+//! If a contributor receives a "request" from the arbiter to reveal a share, it will do so. Even
+//! if it knows it sent said share to said contributor, it is possible that this contributor is malicious
+//! and chose not to "ack" it (this should not be a penalty for the contributor that must reveal).
+//!
+//! ### [Phase 2] Step 4 (Optional): Collect Reveals, Recover Group Polynomial, and Derive Share
+//!
+//! If the round is successful, the arbiter will forward the valid commitments and any reveals required
+//! to construct shares for the new group polynomial (which shares the same constant term if it is a
+//! reshare). Like above, the contributor will recover the group polynomial. Unlike above, the
+//! contributor will also recover its new share of the secret (rather than just adding all shares together).
+//!
+//! # Example
+//!
+//! For a complete example of how to instantiate this crate, checkout [commonware-vrf](https://docs.rs/commonware-vrf).
+
+pub mod arbiter;
+pub mod contributor;
+pub mod ops;
+pub mod utils;
+
+#[derive(Debug)]
+pub enum Error {
+    UnexpectedPolynomial,
+    CommitmentWrongDegree,
+    MisdirectedShare,
+    ShareWrongCommitment,
+    InsufficientDealings,
+    ReshareMismatch,
+    ShareInterpolationFailed,
+    PublicKeyInterpolationFailed,
+    DealerInvalid,
+    MissingShare,
+    CommitmentDisqualified,
+    ContributorDisqualified,
+    ContirbutorInvalid,
+    ComplaintInvalid,
+    UnexpectedReveal,
+    MissingCommitment,
+    SelfAck,
+    SelfComplaint,
+    DuplicateCommitment,
+    DuplicateAck,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::UnexpectedPolynomial => write!(f, "unexpected polynomial"),
+            Error::CommitmentWrongDegree => write!(f, "commitment has wrong degree"),
+            Error::MisdirectedShare => write!(f, "misdirected share"),
+            Error::ShareWrongCommitment => write!(f, "share does not on commitment"),
+            Error::InsufficientDealings => write!(f, "insufficient dealings"),
+            Error::ReshareMismatch => write!(f, "reshare mismatch"),
+            Error::ShareInterpolationFailed => write!(f, "share interpolation failed"),
+            Error::PublicKeyInterpolationFailed => write!(f, "public key interpolation failed"),
+            Error::DealerInvalid => write!(f, "dealer is invalid"),
+            Error::MissingShare => write!(f, "missing share"),
+            Error::CommitmentDisqualified => write!(f, "commitment disqualified"),
+            Error::ContributorDisqualified => write!(f, "contributor disqualified"),
+            Error::ContirbutorInvalid => write!(f, "contributor is invalid"),
+            Error::ComplaintInvalid => write!(f, "complaint is invalid"),
+            Error::UnexpectedReveal => write!(f, "unexpected reveal"),
+            Error::MissingCommitment => write!(f, "missing commitment"),
+            Error::SelfAck => write!(f, "self ack"),
+            Error::SelfComplaint => write!(f, "self complaint"),
+            Error::DuplicateCommitment => write!(f, "duplicate commitment"),
+            Error::DuplicateAck => write!(f, "duplicate ack"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bls12381::dkg::{arbiter, contributor};
+    use crate::bls12381::primitives::group::Private;
+    use crate::{ed25519::insecure_signer, Scheme};
+    use std::collections::HashMap;
+
+    fn run_dkg_and_reshare(
+        n_0: u32,
+        t_0: u32,
+        dealers_0: u32,
+        n_1: u32,
+        t_1: u32,
+        dealers_1: u32,
+        concurrency: usize,
+    ) {
+        // Create contributors (must be in sorted order)
+        let mut contributors = Vec::new();
+        for i in 0..n_0 {
+            let signer = insecure_signer(i as u16).me();
+            contributors.push(signer);
+        }
+        contributors.sort();
+
+        // Create shares
+        let mut contributor_shares = HashMap::new();
+        let mut contributor_cons = HashMap::new();
+        for con in &contributors {
+            let me = con.clone();
+            let p0 = contributor::P0::new(
+                me,
+                t_0,
+                None,
+                contributors.clone(),
+                contributors.clone(),
+                concurrency,
+            );
+            let (p1, public, shares) = p0.finalize();
+            contributor_shares.insert(con.clone(), (public, shares));
+            contributor_cons.insert(con.clone(), p1.unwrap());
+        }
+
+        // Inform arbiter of commitments
+        let mut arb = arbiter::P0::new(
+            t_0,
+            None,
+            contributors.clone(),
+            contributors.clone(),
+            concurrency,
+        );
+        for contributor in contributors.iter().take(dealers_0 as usize) {
+            let (public, _) = contributor_shares.get(contributor).unwrap();
+            arb.commitment(contributor.clone(), public.clone()).unwrap();
+        }
+        let (result, disqualified) = arb.finalize();
+
+        // Verify disqualifications
+        assert_eq!(disqualified.len(), (n_0 - dealers_0) as usize);
+        for contributor in contributors.iter().skip(dealers_0 as usize) {
+            assert!(disqualified.contains(contributor));
+        }
+        let mut arb = result.unwrap();
+
+        // Send select commitments to contributors
+        for (_, dealer, commitment) in arb.commitments().iter() {
+            for contributor in contributors.iter() {
+                contributor_cons
+                    .get_mut(contributor)
+                    .unwrap()
+                    .commitment(dealer.clone(), commitment.clone())
+                    .unwrap();
+            }
+        }
+
+        // Finalze contributor P1
+        let mut p2 = HashMap::new();
+        for contributor in contributors.iter() {
+            let output = contributor_cons
+                .remove(contributor)
+                .unwrap()
+                .finalize()
+                .unwrap();
+            p2.insert(contributor.clone(), output);
+        }
+        let mut contributor_cons = p2;
+
+        // Distribute shares to contributors and send acks to arbiter
+        for (dealer, dealer_key, _) in arb.commitments().iter() {
+            for (idx, recipient) in contributors.iter().enumerate() {
+                let (_, shares) = contributor_shares.get(dealer_key).unwrap().clone();
+                let share = shares[idx];
+                contributor_cons
+                    .get_mut(recipient)
+                    .unwrap()
+                    .share(dealer_key.clone(), share)
+                    .unwrap();
+
+                // Skip ack for self
+                if dealer_key == recipient {
+                    continue;
+                }
+
+                // Ensure ack fails if not commitment
+                let result = arb.ack(recipient.clone(), *dealer);
+                if idx < dealers_0 as usize {
+                    result.unwrap();
+                } else {
+                    // Should fail if never sent a commitment
+                    result.unwrap_err();
+                }
+            }
+        }
+
+        // Finalize arb P1
+        let (result, disqualified) = arb.finalize();
+
+        // Verify disqualifications (unchanged)
+        assert_eq!(disqualified.len(), (n_0 - dealers_0) as usize);
+        for contributor in contributors.iter().skip(dealers_0 as usize) {
+            assert!(disqualified.contains(contributor));
+        }
+        let (arb, requests) = result.unwrap();
+
+        // Verify no missing shares
+        //
+        // If shares were missing, we'd need to ask for them!
+        assert!(requests.is_empty());
+
+        // Recover public key on arbiter
+        let (result, disqualified) = arb.finalize();
+        assert!(disqualified.len() == (n_0 - dealers_0) as usize);
+        for contributor in contributors.iter().skip(dealers_0 as usize) {
+            assert!(disqualified.contains(contributor));
+        }
+        let output = result.unwrap();
+
+        // Distribute final commitments to contributors and recover public key
+        let mut results = HashMap::new();
+        for contributor in contributors.iter() {
+            let result = contributor_cons
+                .remove(contributor)
+                .unwrap()
+                .finalize(output.commitments.clone())
+                .unwrap();
+            assert_eq!(result.public, output.public);
+            results.insert(contributor.clone(), result);
+        }
+
+        // Create reshare dealers
+        let reshare_dealers = contributors.clone();
+
+        // Create reshare recipients (assume no overlap)
+        let mut reshare_recipients = Vec::new();
+        for i in 0..n_1 {
+            let recipient = insecure_signer((i + n_0) as u16).me();
+            reshare_recipients.push(recipient);
+        }
+        reshare_recipients.sort();
+
+        let mut reshare_contributor_shares = HashMap::new();
+        for contributor in contributors.iter() {
+            let output = results.get(contributor).unwrap();
+            let p0 = contributor::P0::new(
+                contributor.clone(),
+                t_1,
+                Some((output.public.clone(), output.share)),
+                reshare_dealers.clone(),
+                reshare_recipients.clone(),
+                concurrency,
+            );
+            let (p1, public, shares) = p0.finalize();
+            assert!(p1.is_none());
+            reshare_contributor_shares.insert(contributor.clone(), (public, shares));
+        }
+
+        let mut reshare_contributor_cons = HashMap::new();
+        for con in &reshare_recipients {
+            let p1 = contributor::P1::new(
+                con.clone(),
+                t_1,
+                Some(output.public.clone()),
+                reshare_dealers.clone(),
+                reshare_recipients.clone(),
+                concurrency,
+            );
+            reshare_contributor_cons.insert(con.clone(), p1);
+        }
+
+        // Inform arbiter of commitments
+        let mut arb = arbiter::P0::new(
+            t_1,
+            Some(output.public.clone()),
+            reshare_dealers.clone(),
+            reshare_recipients.clone(),
+            concurrency,
+        );
+        for con in reshare_dealers.iter().take(dealers_1 as usize) {
+            let (public, _) = reshare_contributor_shares.get(con).unwrap();
+            arb.commitment(con.clone(), public.clone()).unwrap();
+        }
+        let (result, disqualified) = arb.finalize();
+
+        // Verify disqualifications
+        assert_eq!(disqualified.len(), (n_0 - dealers_1) as usize);
+        for contributor in reshare_dealers.iter().skip(dealers_1 as usize) {
+            assert!(disqualified.contains(contributor));
+        }
+        let mut arb = result.unwrap();
+
+        // Send select commitments to recipients
+        for (_, dealer, commitment) in arb.commitments().iter() {
+            for contributor in reshare_recipients.iter() {
+                reshare_contributor_cons
+                    .get_mut(contributor)
+                    .unwrap()
+                    .commitment(dealer.clone(), commitment.clone())
+                    .unwrap();
+            }
+        }
+
+        // Finalize contributor P0
+        let mut p2 = HashMap::new();
+        for contributor in reshare_recipients.iter() {
+            let output = reshare_contributor_cons
+                .remove(contributor)
+                .unwrap()
+                .finalize()
+                .unwrap();
+            p2.insert(contributor.clone(), output);
+        }
+        let mut reshare_contributor_cons = p2;
+
+        // Distribute shares to contributors and send acks to arbiter
+        for (dealer, dealer_key, _) in arb.commitments().iter() {
+            for (idx, recipient) in reshare_recipients.iter().enumerate() {
+                let (_, shares) = reshare_contributor_shares.get(dealer_key).unwrap().clone();
+                reshare_contributor_cons
+                    .get_mut(recipient)
+                    .unwrap()
+                    .share(dealer_key.clone(), shares[idx])
+                    .unwrap();
+
+                // Skip ack for self
+                if dealer_key == recipient {
+                    continue;
+                }
+
+                arb.ack(recipient.clone(), *dealer).unwrap();
+            }
+        }
+
+        // Finalize arb p1
+        let (result, disqualified) = arb.finalize();
+
+        // Verify disqualifications (unchanged)
+        assert_eq!(disqualified.len(), (n_0 - dealers_1) as usize);
+        for contributor in reshare_dealers.iter().skip(dealers_1 as usize) {
+            assert!(disqualified.contains(contributor));
+        }
+        let (arb, requests) = result.unwrap();
+
+        // Verify no missing shares
+        //
+        // If shares were missing, we'd need to ask for them!
+        assert!(requests.is_empty());
+
+        // Recover public key on arbiter
+        let (result, disqualified) = arb.finalize();
+        assert!(disqualified.len() == (n_0 - dealers_1) as usize);
+        for contributor in reshare_dealers.iter().skip(dealers_1 as usize) {
+            assert!(disqualified.contains(contributor));
+        }
+        let output = result.unwrap();
+
+        // Distribute final commitments to contributors and recover public key
+        for contributor in reshare_recipients.iter() {
+            let result = reshare_contributor_cons
+                .remove(contributor)
+                .unwrap()
+                .finalize(output.commitments.clone())
+                .unwrap();
+            assert_eq!(result.public, output.public);
+        }
+    }
+
+    #[test]
+    fn test_dkg_and_reshare_all_active() {
+        run_dkg_and_reshare(5, 3, 5, 10, 7, 5, 4);
+    }
+
+    #[test]
+    fn test_dkg_and_reshare_min_active() {
+        run_dkg_and_reshare(5, 3, 3, 10, 7, 3, 4);
+    }
+
+    #[test]
+    fn test_dkg_and_reshare_all_active_large() {
+        run_dkg_and_reshare(20, 13, 15, 30, 21, 15, 4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_dkg_and_reshare_insufficient_active() {
+        run_dkg_and_reshare(5, 3, 3, 10, 7, 2, 4);
+    }
+
+    fn run_dkg_reveal(defiant: bool) {
+        let (n, t) = (5, 4);
+
+        // Create contributors (must be in sorted order)
+        let mut contributors = Vec::new();
+        for i in 0..n {
+            let signer = insecure_signer(i as u16).me();
+            contributors.push(signer);
+        }
+        contributors.sort();
+
+        // Create shares
+        let mut contributor_shares = HashMap::new();
+        let mut contributor_cons = HashMap::new();
+        for con in &contributors {
+            let p0 = contributor::P0::new(
+                con.clone(),
+                t,
+                None,
+                contributors.clone(),
+                contributors.clone(),
+                1,
+            );
+            let (p1, public, shares) = p0.finalize();
+            contributor_shares.insert(con.clone(), (public, shares));
+            contributor_cons.insert(con.clone(), p1.unwrap());
+        }
+
+        // Inform arbiter of commitments
+        let mut arb = arbiter::P0::new(t, None, contributors.clone(), contributors.clone(), 1);
+        for contributor in contributors.iter() {
+            let (public, _) = contributor_shares.get(contributor).unwrap();
+            arb.commitment(contributor.clone(), public.clone()).unwrap();
+        }
+        let (result, disqualified) = arb.finalize();
+
+        // Verify disqualifications
+        assert!(disqualified.is_empty());
+        let mut arb = result.unwrap();
+
+        // Send select commitments to contributors
+        for (_, dealer, commitment) in arb.commitments().iter() {
+            for contributor in contributors.iter() {
+                contributor_cons
+                    .get_mut(contributor)
+                    .unwrap()
+                    .commitment(dealer.clone(), commitment.clone())
+                    .unwrap();
+            }
+        }
+
+        // Finalze contributor P1
+        let mut p2 = HashMap::new();
+        for contributor in contributors.iter() {
+            let output = contributor_cons
+                .remove(contributor)
+                .unwrap()
+                .finalize()
+                .unwrap();
+            p2.insert(contributor.clone(), output);
+        }
+        let mut contributor_cons = p2;
+
+        // Distribute shares to contributors and send acks to arbiter
+        for (dealer, dealer_key, _) in arb.commitments().iter() {
+            for (idx, recipient) in contributors.iter().enumerate() {
+                let (_, shares) = contributor_shares.get(dealer_key).unwrap().clone();
+                contributor_cons
+                    .get_mut(recipient)
+                    .unwrap()
+                    .share(dealer_key.clone(), shares[idx])
+                    .unwrap();
+
+                // Purposely skip ack
+                if *dealer == 0 && idx == 1 {
+                    continue;
+                }
+
+                // Skip ack for self
+                if dealer_key == recipient {
+                    continue;
+                }
+                arb.ack(recipient.clone(), *dealer).unwrap();
+            }
+        }
+
+        // Finalize arb P1
+        let (result, disqualified) = arb.finalize();
+
+        // Verify disqualifications (unchanged)
+        assert!(disqualified.is_empty());
+        let (mut arb, requests) = result.unwrap();
+
+        // Verify 1 missing share
+        //
+        // If shares were missing, we'd need to ask for them!
+        assert_eq!(requests, vec![(0, 1)]);
+
+        // Reval missing share
+        if !defiant {
+            let dealer = contributors[0].clone();
+            let share = contributor_shares.get(&dealer).unwrap().1[1];
+            arb.reveal(dealer.clone(), share).unwrap();
+
+            // Recover public key on arbiter
+            let (result, disqualified) = arb.finalize();
+            assert!(disqualified.is_empty());
+            let output = result.unwrap();
+
+            // Distribute final commitments to contributors and recover public key
+            for (idx, contributor) in contributors.iter().enumerate() {
+                let mut contributor = contributor_cons.remove(contributor).unwrap();
+                if idx == 1 {
+                    contributor.share(dealer.clone(), share).unwrap();
+                }
+                let result = contributor.finalize(output.commitments.clone()).unwrap();
+                assert_eq!(result.public, output.public);
+            }
+            return;
+        }
+
+        // Recover public key on arbiter
+        let (result, disqualified) = arb.finalize();
+
+        // Ensure dealer that did not reveal is disqualified
+        assert!(disqualified.len() == 1);
+        disqualified.get(&contributors[0]).unwrap();
+
+        // Distribute final commitments to contributors and recover public key
+        let output = result.unwrap();
+        for contributor in contributors.iter() {
+            let result = contributor_cons
+                .remove(contributor)
+                .unwrap()
+                .finalize(output.commitments.clone())
+                .unwrap();
+            assert_eq!(result.public, output.public);
+        }
+    }
+
+    #[test]
+    fn test_dkg_reveal() {
+        run_dkg_reveal(false);
+    }
+
+    #[test]
+    fn test_dkg_reveal_defiant() {
+        run_dkg_reveal(true);
+    }
+
+    #[test]
+    fn test_dkg_complaint() {
+        let (n, t) = (5, 4);
+
+        // Create contributors (must be in sorted order)
+        let mut contributors = Vec::new();
+        for i in 0..n {
+            let signer = insecure_signer(i as u16).me();
+            contributors.push(signer);
+        }
+        contributors.sort();
+
+        // Create shares
+        let mut contributor_shares = HashMap::new();
+        let mut contributor_cons = HashMap::new();
+        for con in &contributors {
+            // Generate private key
+            let p0 = contributor::P0::new(
+                con.clone(),
+                t,
+                None,
+                contributors.clone(),
+                contributors.clone(),
+                1,
+            );
+            let (p1, public, mut shares) = p0.finalize();
+
+            // Corrupt shares
+            for share in shares.iter_mut() {
+                share.private = Private::rand(&mut rand::thread_rng());
+            }
+
+            // Record shares
+            contributor_shares.insert(con.clone(), (public, shares));
+            contributor_cons.insert(con.clone(), p1.unwrap());
+        }
+
+        // Inform arbiter of commitments
+        let mut arb = arbiter::P0::new(t, None, contributors.clone(), contributors.clone(), 1);
+        for contributor in contributors.iter() {
+            let (public, _) = contributor_shares.get(contributor).unwrap();
+            arb.commitment(contributor.clone(), public.clone()).unwrap();
+        }
+        let (result, disqualified) = arb.finalize();
+
+        // Verify disqualifications
+        assert!(disqualified.is_empty());
+        let mut arb = result.unwrap();
+
+        // Send select commitments to contributors
+        for (_, dealer, commitment) in arb.commitments().iter() {
+            for contributor in contributors.iter() {
+                contributor_cons
+                    .get_mut(contributor)
+                    .unwrap()
+                    .commitment(dealer.clone(), commitment.clone())
+                    .unwrap();
+            }
+        }
+
+        // Finalze contributor P0
+        let mut p1 = HashMap::new();
+        for contributor in contributors.iter() {
+            let output = contributor_cons
+                .remove(contributor)
+                .unwrap()
+                .finalize()
+                .unwrap();
+            p1.insert(contributor.clone(), output);
+        }
+        let mut contributor_cons = p1;
+
+        // Distribute shares to contributors and send complaints to arbiter
+        for (dealer, dealer_key, _) in arb.commitments().iter() {
+            for (idx, recipient) in contributors.iter().enumerate() {
+                let (_, shares) = contributor_shares.get(dealer_key).unwrap().clone();
+                let share = shares[idx];
+                match contributor_cons
+                    .get_mut(recipient)
+                    .unwrap()
+                    .share(dealer_key.clone(), share)
+                {
+                    Err(Error::ShareWrongCommitment) => {}
+                    _ => {
+                        panic!("expected share to be invalid");
+                    }
+                }
+                let _ = arb.complaint(recipient.clone(), *dealer, &share);
+            }
+        }
+
+        // Verify failure
+        let (result, disqualified) = arb.finalize();
+        assert!(result.is_none());
+        assert!(disqualified.len() == n as usize);
+    }
+}

--- a/cryptography/src/bls12381/dkg/ops.rs
+++ b/cryptography/src/bls12381/dkg/ops.rs
@@ -1,0 +1,149 @@
+//! Stateless operations useful in a DKG/Resharing procedure.
+
+use crate::bls12381::{
+    dkg::Error,
+    primitives::{group::Share, poly},
+};
+use rayon::prelude::*;
+use rayon::ThreadPoolBuilder;
+use std::collections::BTreeMap;
+
+/// Generate shares and a commitment.
+///
+/// # Arguments
+/// * `share` - The dealer's share of the previous DKG (if any)
+/// * `n` - The total number of participants in the round
+/// * `t` - The threshold number of participants required to reconstruct the secret
+pub fn generate_shares(share: Option<Share>, n: u32, t: u32) -> (poly::Public, Vec<Share>) {
+    // Generate a secret polynomial and commit to it
+    let mut secret = poly::new(t - 1);
+    if let Some(share) = share {
+        // Set the free coefficient of the secret polynomial to the secret
+        // of the previous DKG
+        secret.set(0, share.private);
+    }
+
+    // Commit to polynomial and generate shares
+    let commitment = poly::Public::commit(secret.clone());
+    let shares = (0..n)
+        .map(|i| {
+            let eval = secret.evaluate(i);
+            Share {
+                index: eval.index,
+                private: eval.value,
+            }
+        })
+        .collect::<Vec<_>>();
+    (commitment, shares)
+}
+
+/// Verify that a given commitment is valid for a dealer. If a previous
+/// polynomial is provided, verify that the commitment is on that polynomial.
+pub fn verify_commitment(
+    previous: Option<&poly::Public>,
+    dealer: u32,
+    commitment: &poly::Public,
+    t: u32,
+) -> Result<(), Error> {
+    if let Some(previous) = previous {
+        let expected = previous.evaluate(dealer).value;
+        if expected != *commitment.constant() {
+            return Err(Error::UnexpectedPolynomial);
+        }
+    }
+    if commitment.degree() != t - 1 {
+        return Err(Error::CommitmentWrongDegree);
+    }
+    Ok(())
+}
+
+/// Verify that a given share is valid for a specified recipient.
+pub fn verify_share(
+    previous: Option<&poly::Public>,
+    dealer: u32,
+    commitment: &poly::Public,
+    t: u32,
+    recipient: u32,
+    share: &Share,
+) -> Result<(), Error> {
+    // Verify that commitment is on previous public polynomial (if provided)
+    verify_commitment(previous, dealer, commitment, t)?;
+
+    // Check if share is valid
+    if share.index != recipient {
+        return Err(Error::MisdirectedShare);
+    }
+    let expected = share.public();
+    let given = commitment.evaluate(share.index);
+    if given.value != expected {
+        return Err(Error::ShareWrongCommitment);
+    }
+    Ok(())
+}
+
+/// Construct a new public polynomial by summing all commitments.
+pub fn construct_public(
+    commitments: Vec<poly::Public>,
+    required: u32,
+) -> Result<poly::Public, Error> {
+    if commitments.len() < required as usize {
+        return Err(Error::InsufficientDealings);
+    }
+    let mut public = poly::Public::zero();
+    for commitment in commitments {
+        public.add(&commitment);
+    }
+    Ok(public)
+}
+
+/// Recover public polynomial by interpolating coeffcient-wise all
+/// polynomials.
+///
+/// It is assumed that the required number of commitments are provided.
+pub fn recover_public(
+    previous: &poly::Public,
+    commitments: BTreeMap<u32, poly::Public>,
+    threshold: u32,
+    concurrency: usize,
+) -> Result<poly::Public, Error> {
+    // Ensure we have enough commitments to interpolate
+    let required = previous.required();
+    if commitments.len() < required as usize {
+        return Err(Error::InsufficientDealings);
+    }
+
+    // Construct poool to perform interpolation
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(concurrency)
+        .build()
+        .expect("unable to build thread pool");
+
+    // Perform interpolation over each coefficient
+    let new = match pool.install(|| {
+        (0..threshold)
+            .into_par_iter()
+            .map(|coeff| {
+                let evals: Vec<_> = commitments
+                    .iter()
+                    .map(|(dealer, commitment)| poly::Eval {
+                        index: *dealer,
+                        value: commitment.get(coeff),
+                    })
+                    .collect();
+                match poly::Public::recover(required, evals) {
+                    Ok(point) => Ok(point),
+                    Err(_) => Err(Error::PublicKeyInterpolationFailed),
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()
+    }) {
+        Ok(points) => poly::Public::from(points),
+        Err(e) => return Err(e),
+    };
+
+    // Ensure public key matches
+    if previous.constant() != new.constant() {
+        return Err(Error::ReshareMismatch);
+    }
+    Ok(new)
+}

--- a/cryptography/src/bls12381/dkg/utils.rs
+++ b/cryptography/src/bls12381/dkg/utils.rs
@@ -1,0 +1,51 @@
+//! Utilities for a DKG/Resharing procedure.
+
+/// Assuming that `n = 3f + 1`, compute the minimum required threshold to satisfy `t = 2f + 1`.
+pub fn threshold(n: u32) -> Option<u32> {
+    let f = (n - 1) / 3;
+    if f == 0 {
+        return None;
+    }
+    Some((2 * f) + 1)
+}
+
+/// Assuming that `t = 2f + 1`, compute the maximum number of shares that can be revealed
+/// without allowing an adversary of size `f` to reconstruct the secret.
+pub fn max_reveals(t: u32) -> u32 {
+    (t - 1) / 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_threshold() {
+        // Test case 0: n = 3 (3*0 + 1)
+        assert_eq!(threshold(3), None);
+
+        // Test case 1: n = 4 (3*1 + 1)
+        assert_eq!(threshold(4), Some(3));
+
+        // Test case 2: n = 7 (3*2 + 1)
+        assert_eq!(threshold(7), Some(5));
+
+        // Test case 3: n = 10 (3*3 + 1)
+        assert_eq!(threshold(10), Some(7));
+    }
+
+    #[test]
+    fn test_max_reveals() {
+        // Test case 0: t = 2 (2*0 + 1)
+        assert_eq!(max_reveals(2), 0);
+
+        // Test case 1: t = 3 (2*1 + 1)
+        assert_eq!(max_reveals(3), 1);
+
+        // Test case 2: t = 5 (2*2 + 1)
+        assert_eq!(max_reveals(5), 2);
+
+        // Test case 3: t = 7 (2*3 + 1)
+        assert_eq!(max_reveals(7), 3);
+    }
+}

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -1,0 +1,218 @@
+//! Distributed Key Generation (DKG), Resharing, Signatures, and Threshold Signatures over the BLS12-381 curve.
+//!
+//! # Features
+//!
+//! This crate has the following features:
+//!
+//! - `portable`: Enables `portable` feature on `blst` (<https://github.com/supranational/blst?tab=readme-ov-file#platform-and-language-compatibility>).
+//!
+//! # Benchmarks
+//!
+//! _The following benchmarks were collected on 8/23/24 on a MacBook Pro (M3 Pro, Nov 2023)._
+//!
+//! ```bash
+//! cargo bench
+//! ```
+//!
+//! ## DKG Recovery (Contributor)
+//!
+//! ```txt
+//! conc=1 n=5 t=3          time:   [7.8876 µs 8.0956 µs 8.4308 µs]
+//! conc=1 n=10 t=7         time:   [33.342 µs 33.436 µs 33.554 µs]
+//! conc=1 n=20 t=13        time:   [121.14 µs 123.02 µs 125.79 µs]
+//! conc=1 n=50 t=33        time:   [753.15 µs 761.27 µs 773.15 µs]
+//! conc=1 n=100 t=67       time:   [3.0440 ms 3.5310 ms 4.3212 ms]
+//! conc=1 n=250 t=167      time:   [19.164 ms 19.226 ms 19.295 ms]
+//! conc=1 n=500 t=333      time:   [79.523 ms 80.812 ms 82.645 ms]
+//! ```
+//!
+//! ## Reshare Recovery (Contributor)
+//!
+//! ```txt
+//! conc=1 n=5 t=3          time:   [241.59 µs 253.86 µs 263.90 µs]
+//! conc=2 n=5 t=3          time:   [175.10 µs 178.24 µs 184.16 µs]
+//! conc=4 n=5 t=3          time:   [134.88 µs 144.18 µs 151.21 µs]
+//! conc=8 n=5 t=3          time:   [174.37 µs 184.76 µs 192.81 µs]
+//! conc=1 n=10 t=7         time:   [1.4708 ms 1.5347 ms 1.6063 ms]
+//! conc=2 n=10 t=7         time:   [827.54 µs 908.99 µs 986.19 µs]
+//! conc=4 n=10 t=7         time:   [484.35 µs 504.77 µs 535.10 µs]
+//! conc=8 n=10 t=7         time:   [508.29 µs 606.27 µs 699.82 µs]
+//! conc=1 n=20 t=13        time:   [5.0725 ms 5.0793 ms 5.0857 ms]
+//! conc=2 n=20 t=13        time:   [2.8032 ms 2.8116 ms 2.8222 ms]
+//! conc=4 n=20 t=13        time:   [1.6856 ms 1.6892 ms 1.6938 ms]
+//! conc=8 n=20 t=13        time:   [1.0313 ms 1.1604 ms 1.2300 ms]
+//! conc=1 n=50 t=33        time:   [37.000 ms 37.248 ms 37.937 ms]
+//! conc=2 n=50 t=33        time:   [19.346 ms 19.642 ms 20.312 ms]
+//! conc=4 n=50 t=33        time:   [10.533 ms 10.567 ms 10.614 ms]
+//! conc=8 n=50 t=33        time:   [6.3829 ms 6.4347 ms 6.4721 ms]
+//! conc=1 n=100 t=67       time:   [174.30 ms 175.16 ms 176.05 ms]
+//! conc=2 n=100 t=67       time:   [89.835 ms 90.204 ms 90.599 ms]
+//! conc=4 n=100 t=67       time:   [46.736 ms 47.123 ms 47.531 ms]
+//! conc=8 n=100 t=67       time:   [29.193 ms 29.519 ms 29.870 ms]
+//! conc=1 n=250 t=167      time:   [1.4814 s 1.4927 s 1.5062 s]
+//! conc=2 n=250 t=167      time:   [751.83 ms 762.08 ms 780.29 ms]
+//! conc=4 n=250 t=167      time:   [394.18 ms 397.18 ms 400.52 ms]
+//! conc=8 n=250 t=167      time:   [239.81 ms 245.78 ms 252.11 ms]
+//! conc=1 n=500 t=333      time:   [6.9914 s 7.0182 s 7.0452 s]
+//! conc=2 n=500 t=333      time:   [3.5483 s 3.5575 s 3.5670 s]
+//! conc=4 n=500 t=333      time:   [1.8668 s 1.8851 s 1.9025 s]
+//! conc=8 n=500 t=333      time:   [1.1176 s 1.1355 s 1.1539 s]
+//! ```
+//!
+//! ## Signature Generation
+//!
+//! ```txt
+//! ns_len=9 msg_len=5      time:   [232.12 µs 233.63 µs 235.42 µs]
+//! ```
+//!
+//! ## Signature Aggregation
+//!
+//! ```txt
+//! n=5 t=3                 time:   [126.85 µs 128.50 µs 130.67 µs]
+//! n=10 t=7                time:   [378.70 µs 386.74 µs 397.13 µs]
+//! n=20 t=13               time:   [764.59 µs 777.71 µs 796.76 µs]
+//! n=50 t=33               time:   [2.1320 ms 2.1399 ms 2.1547 ms]
+//! n=100 t=67              time:   [5.0113 ms 5.0155 ms 5.0203 ms]
+//! n=250 t=167             time:   [16.922 ms 16.929 ms 16.937 ms]
+//! n=500 t=333             time:   [37.642 ms 37.676 ms 37.729 ms]
+//! ```
+//!
+//! ## Signature Verification
+//!
+//! ```txt
+//! ns_len=9 msg_len=5      time:   [980.92 µs 981.37 µs 981.88 µs]
+//! ```
+
+pub mod dkg;
+pub mod primitives;
+pub mod scheme;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dkg::ops::generate_shares;
+    use primitives::group::Private;
+    use primitives::ops::{aggregate, partial_sign, partial_verify, verify};
+    use primitives::poly::public;
+
+    #[test]
+    fn test_aggregate_signature() {
+        let (n, t) = (5, 4);
+
+        // Create the private key polynomial and evaluate it at `n`
+        // points to generate the shares.
+        //
+        // If receiving a share from an untrusted party, the recipient
+        // should verify the share is on the public polynomial.
+        let (group, shares) = generate_shares(None, n, t);
+
+        // Generate the partial signatures
+        let msg = b"hello";
+        let partials = shares
+            .iter()
+            .map(|s| partial_sign(s, &msg[..]))
+            .collect::<Vec<_>>();
+
+        // Each partial sig can be partially verified against the public polynomial
+        partials.iter().for_each(|partial| {
+            partial_verify(&group, &msg[..], partial).unwrap();
+        });
+
+        // Generate and verify the threshold sig
+        let threshold_sig = aggregate(t, partials).unwrap();
+        let threshold_pub = public(&group);
+        verify(&threshold_pub, &msg[..], &threshold_sig).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "NotEnoughPartialSignatures")]
+    fn test_aggregate_signature_insufficient() {
+        let (n, t) = (5, 4);
+
+        // Create the private key polynomial and evaluate it at `n`
+        // points to generate the shares
+        let (group, shares) = generate_shares(None, n, t);
+
+        // Only take t-1 shares
+        let shares = shares.into_iter().take(t as usize - 1).collect::<Vec<_>>();
+
+        // Generate the partial signatures
+        let msg = b"hello";
+        let partials = shares
+            .iter()
+            .map(|s| partial_sign(s, &msg[..]))
+            .collect::<Vec<_>>();
+
+        // Each partial sig can be partially verified against the public polynomial
+        partials.iter().for_each(|partial| {
+            partial_verify(&group, &msg[..], partial).unwrap();
+        });
+
+        // Generate and verify the threshold sig
+        let threshold_sig = aggregate(t, partials).unwrap();
+        let threshold_pub = public(&group);
+        verify(&threshold_pub, &msg[..], &threshold_sig).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "DuplicateEval")]
+    fn test_aggregate_signature_insufficient_duplicates() {
+        let (n, t) = (5, 4);
+
+        // Create the private key polynomial and evaluate it at `n`
+        // points to generate the shares
+        let (group, shares) = generate_shares(None, n, t);
+
+        // Only take t-1 shares
+        let mut shares = shares.into_iter().take(t as usize - 1).collect::<Vec<_>>();
+        shares.push(shares[0]);
+
+        // Generate the partial signatures
+        let msg = b"hello";
+        let partials = shares
+            .iter()
+            .map(|s| partial_sign(s, &msg[..]))
+            .collect::<Vec<_>>();
+
+        // Each partial sig can be partially verified against the public polynomial
+        partials.iter().for_each(|partial| {
+            partial_verify(&group, &msg[..], partial).unwrap();
+        });
+
+        // Generate and verify the threshold sig
+        let threshold_sig = aggregate(t, partials).unwrap();
+        let threshold_pub = public(&group);
+        verify(&threshold_pub, &msg[..], &threshold_sig).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidSignature")]
+    fn test_aggregate_signature_bad_share() {
+        let (n, t) = (5, 4);
+
+        // Create the private key polynomial and evaluate it at `n`
+        // points to generate the shares
+        let (group, mut shares) = generate_shares(None, n, t);
+
+        // Corrupt a share
+        let share = shares.get_mut(3).unwrap();
+        share.private = Private::rand(&mut rand::thread_rng());
+
+        // Generate the partial signatures
+        let msg = b"hello";
+        let partials = shares
+            .iter()
+            .map(|s| partial_sign(s, &msg[..]))
+            .collect::<Vec<_>>();
+
+        // Each partial sig can be partially verified against the public polynomial
+        partials.iter().for_each(|partial| {
+            partial_verify(&group, &msg[..], partial).unwrap();
+        });
+
+        // Generate and verify the threshold sig
+        let threshold_sig = aggregate(t, partials).unwrap();
+        let threshold_pub = public(&group);
+        verify(&threshold_pub, &msg[..], &threshold_sig).unwrap();
+    }
+}

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1,0 +1,456 @@
+//! Group operations over the BLS12-381 scalar field.
+
+use blst::{
+    blst_bendian_from_scalar, blst_final_exp, blst_fp12, blst_fr, blst_fr_add, blst_fr_from_scalar,
+    blst_fr_from_uint64, blst_fr_inverse, blst_fr_mul, blst_fr_sub, blst_hash_to_g1,
+    blst_hash_to_g2, blst_keygen_v3, blst_miller_loop, blst_p1, blst_p1_add_or_double,
+    blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_in_g1, blst_p1_is_inf,
+    blst_p1_mult, blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double,
+    blst_p2_affine, blst_p2_compress, blst_p2_from_affine, blst_p2_in_g2, blst_p2_is_inf,
+    blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_scalar, blst_scalar_fr_check,
+    blst_scalar_from_bendian, blst_scalar_from_fr, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
+};
+use rand::RngCore;
+use std::ptr;
+use zeroize::Zeroize;
+
+/// An element of a group.
+pub trait Element: Clone + Eq + PartialEq + Send + Sync {
+    /// Returns the zero element of the group.
+    fn zero() -> Self;
+
+    /// Returns the one element of the group.
+    fn one() -> Self;
+
+    /// Adds to self in-place.
+    fn add(&mut self, rhs: &Self);
+
+    /// Multiplies self in-place.
+    fn mul(&mut self, rhs: &Scalar);
+
+    /// Canonically serializes the element.
+    fn serialize(&self) -> Vec<u8>;
+
+    /// Serialized size of the element.
+    fn size() -> usize;
+
+    /// Deserializes a canonically encoded element.
+    fn deserialize(bytes: &[u8]) -> Option<Self>;
+}
+
+/// An element of a group that supports message hashing.
+pub trait Point: Element {
+    /// Maps the provided data to a group element.
+    fn map(&mut self, message: &[u8]);
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct Scalar(blst_fr);
+
+const SCALAR_LENGTH: usize = 32;
+
+/// `R = 2^256 mod q` in little-endian Montgomery form which is equivalent to 1 in little-endian
+/// non-Montgomery form.
+///
+/// mod(2^256, 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001) = 0x1824b159acc5056f998c4fefecbc4ff55884b7fa0003480200000001fffffffe
+// Reference: https://github.com/filecoin-project/blstrs/blob/ffbb41d1495d84e40a712583346439924603b49a/src/scalar.rs#L77-L89
+const BLST_FR_ONE: Scalar = Scalar(blst_fr {
+    l: [
+        0x0000_0001_ffff_fffe,
+        0x5884_b7fa_0003_4802,
+        0x998c_4fef_ecbc_4ff5,
+        0x1824_b159_acc5_056f,
+    ],
+});
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct G1(blst_p1);
+
+pub const G1_ELEMENT_BYTE_LENGTH: usize = 48;
+
+/// Domain separation tag for hashing a message to G1.
+pub const DST_G1: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct G2(blst_p2);
+
+pub const G2_ELEMENT_BYTE_LENGTH: usize = 96;
+
+/// Domain separation tag for hashing a message to G2.
+pub const DST_G2: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct GT(blst_fp12);
+
+pub type Private = Scalar;
+pub const PRIVATE_KEY_LENGTH: usize = SCALAR_LENGTH;
+pub type Public = G1;
+pub type Signature = G2;
+
+/// Returns the size in bits of a given blst_scalar (represented in little-endian).
+fn bits(scalar: &blst_scalar) -> usize {
+    let mut bits: usize = SCALAR_LENGTH * 8;
+    for i in scalar.b.iter().rev() {
+        let leading = i.leading_zeros();
+        bits -= leading as usize;
+        if leading < 8 {
+            break;
+        }
+    }
+    bits
+}
+
+/// A share of a threshold signing key.
+#[derive(Clone, PartialEq, Copy)]
+pub struct Share {
+    /// The share's index in the polynomial.
+    pub index: u32,
+    /// The scalar corresponding to the share's secret.
+    pub private: Private,
+}
+
+impl Share {
+    /// Returns the public key corresponding to the share.
+    ///
+    /// This can be verified against the public polynomial.
+    pub fn public(&self) -> Public {
+        let mut public = <Public as Element>::one();
+        public.mul(&self.private);
+        public
+    }
+
+    /// Canonically serializes the share.
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut bytes = [0u8; SCALAR_LENGTH + 4];
+        bytes[..4].copy_from_slice(&self.index.to_be_bytes());
+        bytes[4..].copy_from_slice(&self.private.serialize());
+        bytes.to_vec()
+    }
+
+    /// Deserializes a canonically encoded share.
+    pub fn deserialize(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != SCALAR_LENGTH + 4 {
+            return None;
+        }
+        let index = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let private = Private::deserialize(&bytes[4..])?;
+        Some(Self { index, private })
+    }
+}
+
+impl Scalar {
+    /// Generates a random scalar using the provided RNG.
+    pub fn rand<R: RngCore>(rng: &mut R) -> Self {
+        // Generate a random 64 byte buffer
+        let mut ikm = [0u8; 64];
+        rng.fill_bytes(&mut ikm);
+
+        // Generate a scalar from the randomly populated buffer
+        let mut ret = blst_fr::default();
+        unsafe {
+            let mut sc = blst_scalar::default();
+            blst_keygen_v3(&mut sc, ikm.as_ptr(), ikm.len(), ptr::null(), 0);
+            blst_fr_from_scalar(&mut ret, &sc);
+        }
+        Self(ret)
+    }
+
+    /// Sets the scalar to be the provided integer.
+    pub fn set_int(&mut self, i: u32) {
+        // blst requires a buffer of 4 uint64 values. Failure to provide one will
+        // result in unexpected behavior (will read past the provided buffer).
+        //
+        // Reference: https://github.com/supranational/blst/blob/415d4f0e2347a794091836a3065206edfd9c72f3/bindings/blst.h#L102
+        let buffer = [i as u64, 0, 0, 0];
+        unsafe { blst_fr_from_uint64(&mut self.0, buffer.as_ptr()) };
+    }
+
+    /// Computes the inverse of the scalar.
+    pub fn inverse(&self) -> Option<Self> {
+        if *self == Self::zero() {
+            return None;
+        }
+        let mut ret = blst_fr::default();
+        unsafe { blst_fr_inverse(&mut ret, &self.0) };
+        Some(Self(ret))
+    }
+
+    /// Subtracts the provided scalar from self in-place.
+    pub fn sub(&mut self, rhs: &Self) {
+        unsafe { blst_fr_sub(&mut self.0, &self.0, &rhs.0) }
+    }
+}
+
+impl Zeroize for Scalar {
+    fn zeroize(&mut self) {
+        self.0.l.zeroize();
+    }
+}
+
+impl Element for Scalar {
+    fn zero() -> Self {
+        Self(blst_fr::default())
+    }
+
+    fn one() -> Self {
+        BLST_FR_ONE
+    }
+
+    fn add(&mut self, rhs: &Self) {
+        unsafe {
+            blst_fr_add(&mut self.0, &self.0, &rhs.0);
+        }
+    }
+
+    fn mul(&mut self, rhs: &Self) {
+        unsafe {
+            blst_fr_mul(&mut self.0, &self.0, &rhs.0);
+        }
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut bytes = [0u8; SCALAR_LENGTH];
+        unsafe {
+            let mut scalar = blst_scalar::default();
+            blst_scalar_from_fr(&mut scalar, &self.0);
+            blst_bendian_from_scalar(bytes.as_mut_ptr(), &scalar);
+        }
+        bytes.to_vec()
+    }
+
+    fn deserialize(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != SCALAR_LENGTH {
+            return None;
+        }
+        let mut ret = blst_fr::default();
+        unsafe {
+            let mut scalar = blst_scalar::default();
+            blst_scalar_from_bendian(&mut scalar, bytes.as_ptr());
+            if !blst_scalar_fr_check(&scalar) {
+                return None;
+            }
+            blst_fr_from_scalar(&mut ret, &scalar);
+        }
+        Some(Self(ret))
+    }
+
+    fn size() -> usize {
+        SCALAR_LENGTH
+    }
+}
+
+impl Element for G1 {
+    fn zero() -> Self {
+        Self(blst_p1::default())
+    }
+
+    fn one() -> Self {
+        let mut ret = blst_p1::default();
+        unsafe {
+            blst_p1_from_affine(&mut ret, &BLS12_381_G1);
+        }
+        Self(ret)
+    }
+
+    fn add(&mut self, rhs: &Self) {
+        unsafe {
+            blst_p1_add_or_double(&mut self.0, &self.0, &rhs.0);
+        }
+    }
+
+    fn mul(&mut self, rhs: &Scalar) {
+        let mut scalar: blst_scalar = blst_scalar::default();
+        unsafe {
+            blst_scalar_from_fr(&mut scalar, &rhs.0);
+            blst_p1_mult(&mut self.0, &self.0, scalar.b.as_ptr(), bits(&scalar));
+        }
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut bytes = [0u8; G1_ELEMENT_BYTE_LENGTH];
+        unsafe {
+            blst_p1_compress(bytes.as_mut_ptr(), &self.0);
+        }
+        bytes.to_vec()
+    }
+
+    fn deserialize(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != G1_ELEMENT_BYTE_LENGTH {
+            return None;
+        }
+        let mut ret = blst_p1::default();
+        unsafe {
+            let mut affine = blst_p1_affine::default();
+            if blst_p1_uncompress(&mut affine, bytes.as_ptr()) != BLST_ERROR::BLST_SUCCESS {
+                return None;
+            }
+            blst_p1_from_affine(&mut ret, &affine);
+
+            // Verify that deserialized element isn't infinite
+            if blst_p1_is_inf(&ret) {
+                return None;
+            }
+
+            // Verify that the deserialized element is in G1
+            if !blst_p1_in_g1(&ret) {
+                return None;
+            }
+        }
+        Some(Self(ret))
+    }
+
+    fn size() -> usize {
+        G1_ELEMENT_BYTE_LENGTH
+    }
+}
+
+impl Point for G1 {
+    fn map(&mut self, data: &[u8]) {
+        unsafe {
+            blst_hash_to_g1(
+                &mut self.0,
+                data.as_ptr(),
+                data.len(),
+                DST_G1.as_ptr(),
+                DST_G1.len(),
+                ptr::null(),
+                0,
+            );
+        }
+    }
+}
+
+impl Element for G2 {
+    fn zero() -> Self {
+        Self(blst_p2::default())
+    }
+
+    fn one() -> Self {
+        let mut ret = blst_p2::default();
+        unsafe {
+            blst_p2_from_affine(&mut ret, &BLS12_381_G2);
+        }
+        Self(ret)
+    }
+
+    fn add(&mut self, rhs: &Self) {
+        unsafe {
+            blst_p2_add_or_double(&mut self.0, &self.0, &rhs.0);
+        }
+    }
+
+    fn mul(&mut self, rhs: &Scalar) {
+        let mut scalar = blst_scalar::default();
+        unsafe {
+            blst_scalar_from_fr(&mut scalar, &rhs.0);
+            blst_p2_mult(&mut self.0, &self.0, scalar.b.as_ptr(), bits(&scalar));
+        }
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut bytes = [0u8; G2_ELEMENT_BYTE_LENGTH];
+        unsafe {
+            blst_p2_compress(bytes.as_mut_ptr(), &self.0);
+        }
+        bytes.to_vec()
+    }
+
+    fn deserialize(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != G2_ELEMENT_BYTE_LENGTH {
+            return None;
+        }
+        let mut ret = blst_p2::default();
+        unsafe {
+            let mut affine = blst_p2_affine::default();
+            if blst_p2_uncompress(&mut affine, bytes.as_ptr()) != BLST_ERROR::BLST_SUCCESS {
+                return None;
+            }
+            blst_p2_from_affine(&mut ret, &affine);
+
+            // Verify that deserialized element isn't infinite
+            if blst_p2_is_inf(&ret) {
+                return None;
+            }
+
+            // Verify that the deserialized element is in G2
+            if !blst_p2_in_g2(&ret) {
+                return None;
+            }
+        }
+        Some(Self(ret))
+    }
+
+    fn size() -> usize {
+        G2_ELEMENT_BYTE_LENGTH
+    }
+}
+
+impl Point for G2 {
+    fn map(&mut self, data: &[u8]) {
+        unsafe {
+            blst_hash_to_g2(
+                &mut self.0,
+                data.as_ptr(),
+                data.len(),
+                DST_G2.as_ptr(),
+                DST_G2.len(),
+                ptr::null(),
+                0,
+            );
+        }
+    }
+}
+
+fn pairing(p: &G1, q: &G2) -> GT {
+    // Reference: https://github.com/MystenLabs/fastcrypto/blob/bd4999bd3e901eab34ae3dd96dbe38b86ac646a7/fastcrypto/src/groups/bls12381.rs#L223-L234
+    let mut pa = blst_p1_affine::default();
+    let mut qa = blst_p2_affine::default();
+    let mut res = blst_fp12::default();
+    unsafe {
+        blst_p1_to_affine(&mut pa, &p.0);
+        blst_p2_to_affine(&mut qa, &q.0);
+        blst_miller_loop(&mut res, &qa, &pa);
+        blst_final_exp(&mut res, &res);
+    }
+    GT(res)
+}
+
+pub(super) fn equal(p: &G1, sig: &G2, hm: &G2) -> bool {
+    // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/b0ef82ff79769d085a5a7d3f4fe690b1c8fe6dc9/crates/threshold-bls/src/sig/bls.rs#L120-L127
+    let left = pairing(&<G1 as Element>::one(), sig);
+    let right = pairing(p, hm);
+    left == right
+}
+
+#[cfg(test)]
+mod tests {
+    // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/b0ef82ff79769d085a5a7d3f4fe690b1c8fe6dc9/crates/threshold-bls/src/curve/bls12381.rs#L200-L220
+
+    use super::*;
+    use rand::prelude::*;
+
+    #[test]
+    fn basic_group() {
+        let s = Scalar::rand(&mut thread_rng());
+        let mut e1 = s;
+        let e2 = s;
+        let mut s2 = s;
+        s2.add(&s);
+        s2.mul(&s);
+        e1.add(&e2);
+        e1.mul(&e2);
+
+        // p1 = s2 * G = (s+s)G
+        let mut p1 = G1::zero();
+        p1.mul(&s2);
+
+        // p2 = sG + sG = s2 * G
+        let mut p2 = G1::zero();
+        p2.mul(&s);
+        p2.add(&p2.clone());
+        assert_eq!(p1, p2);
+    }
+}

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1,4 +1,15 @@
 //! Group operations over the BLS12-381 scalar field.
+//!
+//! This crate implements basic group operations over BLS12-381 elements,
+//! including point addition, scalar multiplication, and pairing operations.
+//!
+//! # Warning
+//!
+//! Ensure that points are checked to belong to the correct subgroup
+//! (G1 or G2) to prevent small subgroup attacks. This is particularly important
+//! when handling deserialized points or points received from untrusted sources. This
+//! is already taken care of for you if you use the provided `serialize` and `deserialize`
+//! functions.
 
 use blst::{
     blst_bendian_from_scalar, blst_final_exp, blst_fp12, blst_fr, blst_fr_add, blst_fr_from_scalar,

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -27,10 +27,10 @@ use zeroize::Zeroize;
 
 /// An element of a group.
 pub trait Element: Clone + Eq + PartialEq + Send + Sync {
-    /// Returns the zero element of the group.
+    /// Returns the additive identity.
     fn zero() -> Self;
 
-    /// Returns the one element of the group.
+    /// Returns the multiplicative identity.
     fn one() -> Self;
 
     /// Adds to self in-place.

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -2,15 +2,17 @@
 //!
 //! # Acknowledgements
 //!
-//! * <https://github.com/celo-org/celo-threshold-bls-rs>: Provides a reference implementation of
-//!   common operations over the BLS12-381 curve, GJKR99, and Desmedt97.
-//! * <https://github.com/filecoin-project/blstrs>, <https://github.com/MystenLabs/fastcrypto>: Provide a
-//!   reference implementation of how to use `blst` to implement common operations over the BLS12-381 curve.
+//! _The following crates were used as a reference when implementing this crate. When code is very similar
+//! to the reference, it is accompanied by a comment and link._
+//!
+//! * <https://github.com/celo-org/celo-threshold-bls-rs>: Operations over the BLS12-381 scalar field, GJKR99, and Desmedt97.
+//! * <https://github.com/filecoin-project/blstrs> + <https://github.com/MystenLabs/fastcrypto>: Implenting operations over
+//!   the BLS12-381 scalar field with <https://github.com/supranational/blst>.
 //!
 //! # Example
 //!
 //! ```rust
-//! use vrf::bls12381::{
+//! use commonware_cryptography::bls12381::{
 //!     primitives::{ops::{partial_sign, partial_verify, aggregate, verify}, poly::public},
 //!     dkg::ops::{generate_shares},
 //! };

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -1,0 +1,66 @@
+//! Operations over the BLS12-381 scalar field.
+//!
+//! # Acknowledgements
+//!
+//! * <https://github.com/celo-org/celo-threshold-bls-rs>: Provides a reference implementation of
+//!   common operations over the BLS12-381 curve, GJKR99, and Desmedt97.
+//! * <https://github.com/filecoin-project/blstrs>, <https://github.com/MystenLabs/fastcrypto>: Provide a
+//!   reference implementation of how to use `blst` to implement common operations over the BLS12-381 curve.
+//!
+//! # Example
+//!
+//! ```rust
+//! use vrf::bls12381::{
+//!     primitives::{ops::{partial_sign, partial_verify, aggregate, verify}, poly::public},
+//!     dkg::ops::{generate_shares},
+//! };
+//!
+//! // Configure threshold
+//! let (n, t) = (5, 4);
+//!
+//! // Generate commitment and shares
+//! let (commitment, shares) = generate_shares(None, n, t);
+//!
+//! // Generate partial signatures from shares
+//! let msg = b"hello world";
+//! let partials: Vec<_> = shares.iter().map(|s| partial_sign(s, msg)).collect();
+//!
+//! // Verify partial signatures
+//! for p in &partials {
+//!     partial_verify(&commitment, msg, p).expect("signature should be valid");
+//! }
+//!
+//! // Aggregate partial signatures
+//! let threshold_sig = aggregate(t, partials).unwrap();
+//!
+//! // Verify threshold signature
+//! let threshold_pub = public(&commitment);
+//! verify(&threshold_pub, msg, &threshold_sig).expect("signature should be valid");
+//! ```
+
+pub mod group;
+pub mod ops;
+pub mod poly;
+
+#[derive(Debug)]
+pub enum Error {
+    NotEnoughPartialSignatures,
+    InvalidSignature,
+    InvalidRecovery,
+    NoInverse,
+    DuplicateEval,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::NotEnoughPartialSignatures => write!(f, "not enough partial signatures"),
+            Error::InvalidSignature => write!(f, "invalid signature"),
+            Error::InvalidRecovery => write!(f, "invalid recovery"),
+            Error::NoInverse => write!(f, "no inverse"),
+            Error::DuplicateEval => write!(f, "duplicate eval"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! # Acknowledgements
 //!
-//! _The following crates were used as a reference when implementing this crate. When code is very similar
+//! _The following crates were used as a reference when implementing this crate. If code is very similar
 //! to the reference, it is accompanied by a comment and link._
 //!
 //! * <https://github.com/celo-org/celo-threshold-bls-rs>: Operations over the BLS12-381 scalar field, GJKR99, and Desmedt97.

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -1,0 +1,117 @@
+//! Digital signatures over the BLS12-381 curve.
+
+use super::{
+    group::{self, equal, Element, Point, Share},
+    poly::{self, Eval},
+    Error,
+};
+use rand::RngCore;
+
+/// Returns a new keypair derived from the provided randomness.
+pub fn keypair<R: RngCore>(rng: &mut R) -> (group::Private, group::Public) {
+    let private = group::Private::rand(rng);
+    let mut public = group::Public::one();
+    public.mul(&private);
+    (private, public)
+}
+
+/// Signs the provided message with the private key.
+///
+/// The message is hashed according to RFC 9380.
+pub fn sign(private: &group::Private, msg: &[u8]) -> group::Signature {
+    let mut s = group::Signature::zero();
+    s.map(msg);
+    s.mul(private);
+    s
+}
+
+/// Verifies the signature with the provided public key.
+pub fn verify(
+    public: &group::Public,
+    msg: &[u8],
+    signature: &group::Signature,
+) -> Result<(), Error> {
+    let mut hm = group::Signature::zero();
+    hm.map(msg);
+    if !equal(public, signature, &hm) {
+        return Err(Error::InvalidSignature);
+    }
+    Ok(())
+}
+
+/// Signs the provided message with the key share.
+pub fn partial_sign(private: &Share, msg: &[u8]) -> Eval<group::Signature> {
+    let sig = sign(&private.private, msg);
+    Eval {
+        value: sig,
+        index: private.index,
+    }
+}
+
+/// Verifies the partial signature against the public polynomial.
+pub fn partial_verify(
+    public: &poly::Public,
+    msg: &[u8],
+    partial: &Eval<group::Signature>,
+) -> Result<(), Error> {
+    let public = public.evaluate(partial.index);
+    verify(&public.value, msg, &partial.value)
+}
+
+/// Aggregates the partial signatures into a final signature.
+pub fn aggregate(
+    threshold: u32,
+    partials: Vec<Eval<group::Signature>>,
+) -> Result<group::Signature, Error> {
+    if threshold as usize > partials.len() {
+        return Err(Error::NotEnoughPartialSignatures);
+    }
+    poly::Signature::recover(threshold, partials)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bls12381::{dkg::ops::generate_shares, primitives::group::DST_G2};
+    use blst::BLST_ERROR;
+    use rand::prelude::*;
+
+    /// Verify that a given signature is valid according to `blst`.
+    fn blst_verify(
+        public: &group::Public,
+        msg: &[u8],
+        signature: &group::Signature,
+    ) -> Result<(), BLST_ERROR> {
+        let public = blst::min_pk::PublicKey::from_bytes(public.serialize().as_slice()).unwrap();
+        let signature =
+            blst::min_pk::Signature::from_bytes(signature.serialize().as_slice()).unwrap();
+        match signature.verify(true, msg, DST_G2, &[], &public, true) {
+            BLST_ERROR::BLST_SUCCESS => Ok(()),
+            e => Err(e),
+        }
+    }
+
+    #[test]
+    fn test_single_compatibility() {
+        let (private, public) = keypair(&mut thread_rng());
+        let msg = &[1, 9, 6, 9];
+        let sig = sign(&private, msg);
+        verify(&public, msg, &sig).expect("signature should be valid");
+        blst_verify(&public, msg, &sig).expect("signature should be valid");
+    }
+
+    #[test]
+    fn test_threshold_compatibility() {
+        let (n, t) = (5, 4);
+        let (public, shares) = generate_shares(None, n, t);
+        let msg = &[1, 9, 6, 9];
+        let partials: Vec<_> = shares.iter().map(|s| partial_sign(s, msg)).collect();
+        for p in &partials {
+            partial_verify(&public, msg, p).expect("signature should be valid");
+        }
+        let threshold_sig = aggregate(t, partials).unwrap();
+        let threshold_pub = poly::public(&public);
+        verify(&threshold_pub, msg, &threshold_sig).expect("signature should be valid");
+        blst_verify(&threshold_pub, msg, &threshold_sig).expect("signature should be valid");
+    }
+}

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -18,6 +18,11 @@ pub fn keypair<R: RngCore>(rng: &mut R) -> (group::Private, group::Public) {
 /// Signs the provided message with the private key.
 ///
 /// The message is hashed according to RFC 9380.
+///
+/// # Determinism
+///
+/// Signatures produced by this function are deterministic and are safe
+/// to use in a consensus-critical context.
 pub fn sign(private: &group::Private, msg: &[u8]) -> group::Signature {
     let mut s = group::Signature::zero();
     s.map(msg);
@@ -59,6 +64,11 @@ pub fn partial_verify(
 }
 
 /// Aggregates the partial signatures into a final signature.
+///
+/// # Determinism
+///
+/// Signatures recovered by this function are deterministic and are safe
+/// to use in a consensus-critical context.
 pub fn aggregate(
     threshold: u32,
     partials: Vec<Eval<group::Signature>>,

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -7,8 +7,14 @@ use crate::bls12381::primitives::{
 use rand::{rngs::OsRng, RngCore};
 use std::collections::BTreeMap;
 
+/// Private polynomials are used to generate secret shares.
 pub type Private = Poly<group::Private>;
+
+/// Public polynomials represent commitments to secrets on a private polynomial.
 pub type Public = Poly<group::Public>;
+
+/// Signature polynomials are used in threshold signing (where a signature
+/// is interpolated using at least `threshold` evaluations).
 pub type Signature = Poly<group::Signature>;
 
 /// A polynomial evaluation at a specific index.

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -1,0 +1,385 @@
+//! Polynomial operations over the BLS12-381 scalar field.
+
+use crate::bls12381::primitives::{
+    group::{self, Element, Scalar},
+    Error,
+};
+use rand::{rngs::OsRng, RngCore};
+use std::collections::BTreeMap;
+
+pub type Private = Poly<group::Private>;
+pub type Public = Poly<group::Public>;
+pub type Signature = Poly<group::Signature>;
+
+/// A polynomial evaluation at a specific index.
+#[derive(Debug, Clone)]
+pub struct Eval<C: Element> {
+    pub index: u32,
+    pub value: C,
+}
+
+impl<C: Element> Eval<C> {
+    /// Canonically serializes the evaluation.
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&self.index.to_be_bytes());
+        bytes.extend_from_slice(&self.value.serialize());
+        bytes
+    }
+
+    /// Deserializes a canonically encoded evaluation.
+    pub fn deserialize(bytes: &[u8]) -> Option<Self> {
+        let index = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let value = C::deserialize(&bytes[4..])?;
+        Some(Self { index, value })
+    }
+}
+
+/// A polynomial that is using a scalar for the variable x and a generic
+/// element for the coefficients.
+///
+/// The coefficients must be able to multiply the type of the variable,
+/// which is always a scalar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+// Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/a714310be76620e10e8797d6637df64011926430/crates/threshold-bls/src/poly.rs#L24-L28
+pub struct Poly<C>(Vec<C>);
+
+/// Returns a new scalar polynomial of the given degree where each coefficients is
+/// sampled at random using kernel randomness.
+///
+/// In the context of secret sharing, the threshold is the degree + 1.
+pub fn new(degree: u32) -> Poly<Scalar> {
+    // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/a714310be76620e10e8797d6637df64011926430/crates/threshold-bls/src/poly.rs#L46-L52
+    new_from(degree, &mut OsRng)
+}
+
+// Returns a new scalar polynomial of the given degree where each coefficient is
+// sampled at random from the provided RNG.
+///
+/// In the context of secret sharing, the threshold is the degree + 1.
+pub fn new_from<R: RngCore>(degree: u32, rng: &mut R) -> Poly<Scalar> {
+    // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/a714310be76620e10e8797d6637df64011926430/crates/threshold-bls/src/poly.rs#L46-L52
+    let coeffs = (0..=degree).map(|_| Scalar::rand(rng)).collect::<Vec<_>>();
+    Poly::<Scalar>(coeffs)
+}
+
+impl<C> Poly<C> {
+    /// Creates a new polynomial from the given coefficients.
+    pub fn from(c: Vec<C>) -> Self {
+        Self(c)
+    }
+
+    /// Returns the constant term of the polynomial.
+    pub fn constant(&self) -> &C {
+        &self.0[0]
+    }
+
+    /// Returns the degree of the polynomial
+    pub fn degree(&self) -> u32 {
+        (self.0.len() - 1) as u32 // check size in deserialize, safe to cast
+    }
+
+    /// Returns the number of required shares to reconstruct the polynomial.
+    ///
+    /// This will be the threshold
+    pub fn required(&self) -> u32 {
+        self.0.len() as u32 // check size in deserialize, safe to cast
+    }
+}
+
+impl<C: Element> Poly<C> {
+    /// Commits the scalar polynomial to the group and returns a polynomial over
+    /// the group.
+    ///
+    /// This is done by multiplying each coefficient of the polynomial with the
+    /// group's generator.
+    pub fn commit(commits: Poly<Scalar>) -> Self {
+        // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/a714310be76620e10e8797d6637df64011926430/crates/threshold-bls/src/poly.rs#L322-L340
+        let commits = commits
+            .0
+            .iter()
+            .map(|c| {
+                let mut commitment = C::one();
+                commitment.mul(c);
+                commitment
+            })
+            .collect::<Vec<C>>();
+
+        Poly::<C>::from(commits)
+    }
+
+    /// Returns a zero polynomial.
+    pub fn zero() -> Self {
+        Self::from(vec![C::zero()])
+    }
+
+    /// Returns the given coefficient at the requested index.
+    ///
+    /// It panics if the index is out of range.
+    pub fn get(&self, i: u32) -> C {
+        self.0[i as usize].clone()
+    }
+
+    /// Set the given element at the specified index.
+    ///
+    /// It panics if the index is out of range.
+    pub fn set(&mut self, index: u32, value: C) {
+        self.0[index as usize] = value;
+    }
+
+    /// Performs polynomial addition in place
+    pub fn add(&mut self, other: &Self) {
+        // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/a714310be76620e10e8797d6637df64011926430/crates/threshold-bls/src/poly.rs#L87-L95
+
+        // if we have a smaller degree we should pad with zeros
+        if self.0.len() < other.0.len() {
+            self.0.resize(other.0.len(), C::zero())
+        }
+
+        self.0.iter_mut().zip(&other.0).for_each(|(a, b)| a.add(b))
+    }
+
+    /// Canonically serializes the polynomial.
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for c in &self.0 {
+            bytes.extend_from_slice(&c.serialize());
+        }
+        bytes
+    }
+
+    /// Deserializes a canonically encoded polynomial.
+    pub fn deserialize(bytes: &[u8], expected: u32) -> Option<Self> {
+        let expected = expected as usize;
+        let mut coeffs = Vec::with_capacity(expected);
+        for chunk in bytes.chunks_exact(C::size()) {
+            if coeffs.len() >= expected {
+                return None;
+            }
+            let c = C::deserialize(chunk)?;
+            coeffs.push(c);
+        }
+        if coeffs.len() != expected {
+            return None;
+        }
+        Some(Self(coeffs))
+    }
+
+    /// Evaluates the polynomial at the specified value.
+    pub fn evaluate(&self, i: u32) -> Eval<C> {
+        // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/a714310be76620e10e8797d6637df64011926430/crates/threshold-bls/src/poly.rs#L111-L129
+
+        // We add +1 because we must never evaluate the polynomial at its first point
+        // otherwise it reveals the "secret" value after a reshare (where the constant
+        // term is set to be the secret of the previous dealing).
+        let mut xi = Scalar::zero();
+        xi.set_int(i + 1);
+
+        // Use Horner's method to evaluate the polynomial
+        let res = self.0.iter().rev().fold(C::zero(), |mut sum, coeff| {
+            sum.mul(&xi);
+            sum.add(coeff);
+            sum
+        });
+        Eval {
+            value: res,
+            index: i,
+        }
+    }
+
+    /// Recover the polynomial's constant term given at least `t` polynomial evaluations.
+    pub fn recover(t: u32, mut evals: Vec<Eval<C>>) -> Result<C, Error> {
+        // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/a714310be76620e10e8797d6637df64011926430/crates/threshold-bls/src/poly.rs#L131-L165
+
+        // Ensure there are enough shares
+        let t = t as usize;
+        if evals.len() < t {
+            return Err(Error::InvalidRecovery);
+        }
+
+        // Convert the first `t` sorted shares into scalars
+        let mut err = None;
+        evals.sort_by(|a, b| a.index.cmp(&b.index));
+        let xs = evals
+            .into_iter()
+            .take(t)
+            .fold(BTreeMap::new(), |mut m, sh| {
+                let mut xi = Scalar::zero();
+                xi.set_int(sh.index + 1);
+                if m.insert(sh.index, (xi, sh.value)).is_some() {
+                    err = Some(Error::DuplicateEval);
+                }
+                m
+            });
+        if let Some(e) = err {
+            return Err(e);
+        }
+
+        // Iterate over all indices and for each multiply the lagrange basis
+        // with the value of the share
+        let mut acc = C::zero();
+        for (i, xi) in &xs {
+            let mut yi = xi.1.clone();
+            let mut num = Scalar::one();
+            let mut den = Scalar::one();
+
+            for (j, xj) in &xs {
+                if i == j {
+                    continue;
+                }
+
+                // xj - 0
+                num.mul(&xj.0);
+
+                // 1 / (xj - xi)
+                let mut tmp = xj.0;
+                tmp.sub(&xi.0);
+                den.mul(&tmp);
+            }
+
+            let inv = den.inverse().ok_or(Error::NoInverse)?;
+            num.mul(&inv);
+            yi.mul(&num);
+            acc.add(&yi);
+        }
+        Ok(acc)
+    }
+}
+
+/// Returns the public key of the polynomial (constant term).
+pub fn public(public: &Public) -> group::Public {
+    *public.constant()
+}
+
+#[cfg(test)]
+pub mod tests {
+    // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/b0ef82ff79769d085a5a7d3f4fe690b1c8fe6dc9/crates/threshold-bls/src/poly.rs#L355-L604
+
+    use super::*;
+    use crate::bls12381::primitives::group::{Scalar, G2};
+
+    #[test]
+    fn poly_degree() {
+        let s = 5;
+        let p = new(s);
+        assert_eq!(p.degree(), s);
+    }
+
+    #[test]
+    fn add_zero() {
+        let p1 = new(3);
+        let p2 = Poly::<Scalar>::zero();
+        let mut res = p1.clone();
+        res.add(&p2);
+        assert_eq!(res, p1);
+
+        let p1 = Poly::<Scalar>::zero();
+        let p2 = new(3);
+        let mut res = p1;
+        res.add(&p2);
+        assert_eq!(res, p2);
+    }
+
+    #[test]
+    fn interpolation_insufficient_shares() {
+        let degree = 4;
+        let threshold = degree + 1;
+        let poly = new(degree);
+        let shares = (0..threshold - 1)
+            .map(|i| poly.evaluate(i))
+            .collect::<Vec<_>>();
+        Poly::recover(threshold, shares).unwrap_err();
+    }
+
+    #[test]
+    fn commit() {
+        let secret = new(5);
+        let coeffs = secret.0.clone();
+        let commitment = coeffs
+            .iter()
+            .map(|coeff| {
+                let mut p = G2::one();
+                p.mul(coeff);
+                p
+            })
+            .collect::<Vec<_>>();
+        let commitment = Poly::from(commitment);
+        assert_eq!(commitment, Poly::commit(secret));
+    }
+
+    fn pow(base: Scalar, pow: usize) -> Scalar {
+        let mut res = Scalar::one();
+        for _ in 0..pow {
+            res.mul(&base)
+        }
+        res
+    }
+
+    use proptest::prelude::*;
+    proptest! {
+        #[test]
+        fn addition(deg1 in 0..100u32, deg2 in 0..100u32) {
+            dbg!(deg1, deg2);
+            let p1 = new(deg1);
+            let p2 = new(deg2);
+            let mut res = p1.clone();
+            res.add(&p2);
+
+            let (larger, smaller) = if p1.degree() > p2.degree() {
+                (&p1, &p2)
+            } else {
+                (&p2, &p1)
+            };
+
+            for i in 0..larger.degree()+1 {
+                let i = i as usize;
+                if i < (smaller.degree() + 1) as usize{
+                    let mut coeff_sum = p1.0[i];
+                    coeff_sum.add(&p2.0[i]);
+                    assert_eq!(res.0[i], coeff_sum);
+                } else {
+                    assert_eq!(res.0[i], larger.0[i]);
+                }
+            }
+            assert_eq!(res.degree(), larger.degree());
+        }
+
+
+        #[test]
+        fn interpolation(degree in 0..100u32, num_evals in 0..100u32) {
+            let poly = new(degree);
+            let expected = poly.0[0];
+
+            let shares = (0..num_evals)
+                .map(|i| poly.evaluate(i))
+                .collect::<Vec<_>>();
+            let recovered_constant = Poly::recover(num_evals, shares).unwrap();
+
+            if num_evals > degree {
+                assert_eq!(expected, recovered_constant);
+            } else {
+                assert_ne!(expected, recovered_constant);
+            }
+        }
+
+        #[test]
+        fn evaluate(d in 0..100u32, idx in 0..100_u32) {
+            let mut x = Scalar::zero();
+            x.set_int(idx + 1);
+
+            let p1 = new(d);
+            let evaluation = p1.evaluate(idx).value;
+
+            let coeffs = p1.0;
+            let mut sum = coeffs[0];
+            for (i, coeff) in coeffs.into_iter().enumerate().take((d + 1) as usize).skip(1) {
+                let xi = pow(x, i);
+                let mut var = coeff;
+                var.mul(&xi);
+                sum.add(&var);
+            }
+
+            assert_eq!(sum, evaluation);
+        }
+    }
+}

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -1,4 +1,10 @@
 //! Polynomial operations over the BLS12-381 scalar field.
+//!
+//! # Warning
+//!
+//! The security of the polynomial operations is critical for the overall
+//! security of the threshold schemes. Ensure that the scalar field operations
+//! are performed over the correct field and that all elements are valid.
 
 use crate::bls12381::primitives::{
     group::{self, Element, Scalar},

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -1,0 +1,83 @@
+//! BLS12-381 implementation of the `Scheme` trait.
+
+use super::primitives::{
+    group::{self, Element, Scalar},
+    ops,
+};
+use crate::{utils::payload, PublicKey, Scheme, Signature};
+use rand::{rngs::OsRng, SeedableRng};
+
+/// BLS12-381 implementation of the `Scheme` trait.
+///
+/// This implementation uses the `blst` crate for BLS12-381 operations. This
+/// crate implments serialization according to the "ZCash BLS12-381" specification
+/// (<https://github.com/supranational/blst/tree/master?tab=readme-ov-file#serialization-format>) and
+/// hashes messages according to RFC 9380.
+#[derive(Clone)]
+pub struct Bls12381 {
+    private: group::Private,
+    public: group::Public,
+}
+
+impl Bls12381 {
+    /// Creates a new Bls12381 signer using randomness from the operating system.
+    pub fn new() -> Self {
+        let (private, public) = ops::keypair(&mut OsRng);
+        Self { private, public }
+    }
+
+    /// Creates a new Bls12381 signer from a secret key.
+    pub fn from(signer: [u8; group::PRIVATE_KEY_LENGTH]) -> Option<Self> {
+        let private = Scalar::deserialize(&signer)?;
+        let mut public = group::Public::one();
+        public.mul(&private);
+        Some(Self { private, public })
+    }
+}
+
+impl Default for Bls12381 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Scheme for Bls12381 {
+    fn me(&self) -> PublicKey {
+        PublicKey::from(self.public.serialize())
+    }
+
+    fn sign(&mut self, namespace: &[u8], message: &[u8]) -> Signature {
+        let payload = payload(namespace, message);
+        let signature = ops::sign(&self.private, &payload);
+        signature.serialize().into()
+    }
+
+    fn validate(public_key: &PublicKey) -> bool {
+        group::Public::deserialize(public_key.as_ref()).is_some()
+    }
+
+    fn verify(
+        namespace: &[u8],
+        message: &[u8],
+        public_key: &PublicKey,
+        signature: &Signature,
+    ) -> bool {
+        let public = match group::Public::deserialize(public_key.as_ref()) {
+            Some(public) => public,
+            None => return false,
+        };
+        let signature = match group::Signature::deserialize(signature.as_ref()) {
+            Some(signature) => signature,
+            None => return false,
+        };
+        let payload = payload(namespace, message);
+        ops::verify(&public, &payload, &signature).is_ok()
+    }
+}
+
+/// Creates a new BLS12-381 signer with a secret key derived from the provided seed.
+pub fn insecure_signer(seed: u16) -> Bls12381 {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed as u64);
+    let (private, public) = ops::keypair(&mut rng);
+    Bls12381 { private, public }
+}

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -2,6 +2,7 @@
 
 use bytes::Bytes;
 
+pub mod bls12381;
 pub mod ed25519;
 pub mod utils;
 

--- a/cryptography/src/utils.rs
+++ b/cryptography/src/utils.rs
@@ -1,3 +1,5 @@
+//! Utility functions for cryptographic primitives.
+
 /// Concatenates the namespace and message into a single payload for signing.
 pub fn payload(namespace: &[u8], message: &[u8]) -> Vec<u8> {
     let mut payload = Vec::with_capacity(namespace.len() + message.len());


### PR DESCRIPTION
## Changes
* Implement DKG/Resharing Procedure (using `Arbiter` and `Contributor`) for BLS12-381
* Implement `Scheme` trait for BLS12-381
* Implement Threshold Signatures for BLS12-381

## Acknowledgements
 _The following crates were used as a reference when implementing this crate. If code is very similar to the reference, it is accompanied by a comment and link._

* https://github.com/celo-org/celo-threshold-bls-rs: Operations over the BLS12-381 scalar field, GJKR99, and Desmedt97.
* https://github.com/filecoin-project/blstrs + https://github.com/MystenLabs/fastcrypto: Implenting operations over the BLS12-381 scalar field with https://github.com/supranational/blst.