### PR TITLE
[examples/vrf] Generate bias-resistant randomness with untrusted contributors

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -26,3 +26,8 @@ jobs:
       continue-on-error: true
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    - name: Publish vrf 
+      run: cargo publish --manifest-path examples/vrf/Cargo.toml
+      continue-on-error: true
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "chrono",
  "clap",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "blst",
  "bytes",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bitvec",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,8 @@ dependencies = [
  "hex",
  "prometheus-client",
  "prost",
+ "prost-build",
+ "rand",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "commonware-vrf"
+version = "0.0.2"
+dependencies = [
+ "bytes",
+ "clap",
+ "commonware-cryptography",
+ "commonware-p2p",
+ "governor",
+ "hex",
+ "prometheus-client",
+ "prost",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-cryptography = { version = "0.0.3", path = "cryptography" }
-commonware-p2p = { version = "0.0.12", path = "p2p" }
+commonware-cryptography = { version = "0.0.4", path = "cryptography" }
+commonware-p2p = { version = "0.0.13", path = "p2p" }
 bytes = "1.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "cryptography",
     "p2p",
     "examples/chat",
+    "examples/vrf",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ _Crates in this repository are designed for deployment in adversarial environmen
 
 _Examples may include insecure code (i.e. deriving keypairs from an integer arguements) to make them easier to run. Examples are not intended to be used directly in production._
 
-* [chat](./examples/chat/README.md): Send encrypted messages to a group of friends using [commonware-cryptography](https://crates.io/crates/commonware-cryptography) and [commonware-p2p](https://crates.io/crates/commonware-p2p). 
+* [chat](./examples/chat/README.md): Send encrypted messages to a group of friends. 
+* [vrf](./examples/vrf/README.md): Generate bias-resistant randomness with untrusted contributors.
 
 ## Licensing
 

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.3"
+version = "0.0.4"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify untrusted signatures."
 readme = "README.md"

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -5,13 +5,13 @@
 //! ## Recommended: All Contributors Run the Arbiter
 //!
 //! Each contributor should run its own instance of the arbiter over a replicated
-//! log of commitments, acknowledgements, complaints, and resolutions (deterministic
-//! order of events across all contributors). All correct contributors, when given
+//! log (deterministic order of events across all contributors) of commitments,
+//! acknowledgements, complaints, and resolutions. All correct contributors, when given
 //! the same log, will arrive at the same result (will recover the same group polynomial
-//! and a share that can generate partial signatures over it).
-//!
-//! _It is a particularly powerful combination to run this log using an instance of BFT
-//! consensus with a threshold of `2f + 1` (where there exist `3f + 1` total contributors)._
+//! and a share that can generate partial signatures over it). When instantiated using
+//! BFT consensus, up to `f` contributors can behave maliciously without affecting the
+//! outcome of the DKG/Resharing procedure (which pairs nicely with a `threshold` set to
+//! `2f + 1`, in a population of `3f + 1` contributors).
 //!
 //! ## Alternative: Trusted Arbiter
 //!

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -10,8 +10,8 @@
 //! the same log, will arrive at the same result (will recover the same group polynomial
 //! and a share that can generate partial signatures over it).
 //!
-//! _It is a particularly nice combination to run this log using an instance of BFT consensus
-//! with a threshold of `2f + 1` (where there exist `3f + 1` total contributors)._
+//! _It is a particularly powerful combination to run this log using an instance of BFT
+//! consensus with a threshold of `2f + 1` (where there exist `3f + 1` total contributors)._
 //!
 //! ## Alternative: Trusted Arbiter
 //!

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -1,12 +1,23 @@
 //! Orchestrator of the DKG/Resharing procedure.
 //!
-//! It is recommended to run the arbiter over a replicated log (provided by an
-//! instance of BFT consensus) to deterministically coordinate the DKG/Resharing procedure.
+//! # Deployment Options
 //!
-//! In practice, this will often be implemented by a consensus mechanism but
-//! can be run as a trusted, standalone binary (see <https://docs.rs/commonware-vrf>).
+//! ## Recommended: All Contributors Run the Arbiter
 //!
-//! TODO: run over consensus, not implemented by
+//! Each contributor should run its own instance of the arbiter over a replicated
+//! log of commitments, acknowledgements, complaints, and resolutions (deterministic
+//! order of events across all contributors). All correct contributors, when given
+//! the same log, will arrive at the same result (will recover the same group polynomial
+//! and a share that can generate partial signatures over it).
+//!
+//! _It is a particularly nice combination to run this log using an instance of BFT consensus
+//! with a threshold of `2f + 1` (where there exist `3f + 1` total contributors)._
+//!
+//! ## Alternative: Trusted Arbiter
+//!
+//! It is possible to run the arbiter as a standalone instance that contributors
+//! must trust to track commitments, acks, complaints, and reveals. For an example of
+//! this approach, refer to <https://docs.rs/commonware-vrf>.
 //!
 //! # Disqualification on Attributable Faults
 //!

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -8,10 +8,11 @@
 //! log (deterministic order of events across all contributors) of commitments,
 //! acknowledgements, complaints, and resolutions. All correct contributors, when given
 //! the same log, will arrive at the same result (will recover the same group polynomial
-//! and a share that can generate partial signatures over it). When instantiated using
-//! BFT consensus, up to `f` contributors can behave maliciously without affecting the
-//! outcome of the DKG/Resharing procedure (which pairs nicely with a `threshold` set to
-//! `2f + 1`, in a population of `3f + 1` contributors).
+//! and a share that can generate partial signatures over it).
+//!
+//! When this log is instantiated using BFT consensus, up to `f` contributors can
+//! behave maliciously without affecting the outcome of the DKG/Resharing procedure (which
+//! pairs nicely with a `threshold` set to `2f + 1`, in a population of `3f + 1` contributors).
 //!
 //! ## Alternative: Trusted Arbiter
 //!

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -14,7 +14,7 @@
 //! behave maliciously without affecting the outcome of the DKG/Resharing procedure (which
 //! pairs nicely with a `threshold` set to `2f + 1`, in a population of `3f + 1` contributors).
 //!
-//! ## Alternative: Trusted Arbiter
+//! ## Simple Alternative: Trusted Arbiter
 //!
 //! It is possible to run the arbiter as a standalone instance that contributors
 //! must trust to track commitments, acks, complaints, and reveals. For an example of

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -1,13 +1,24 @@
 //! Orchestrator of the DKG/Resharing procedure.
 //!
+//! It is recommended to run the arbiter over a replicated log (provided by an
+//! instance of BFT consensus) to deterministically coordinate the DKG/Resharing procedure.
+//!
 //! In practice, this will often be implemented by a consensus mechanism but
 //! can be run as a trusted, standalone binary (see <https://docs.rs/commonware-vrf>).
 //!
-//! # Duplicate/Unnecessary Information
+//! TODO: run over consensus, not implemented by
 //!
-//! Duplicate/unnecessary information will error but not disqualify (to avoid including
-//! junk in a block), only invalid or missing information qualifies as an attributable
-//! fault (otherwise may occur by accident).
+//! # Disqualification on Attributable Faults
+//!
+//! Submitting duplicate and/or unnecessary information (i.e. a dealer submitting the same commitment twice
+//! or submitting an acknowledgement for a disqualified dealer) will throw an error but not disqualify the
+//! contributor. It may not be possible for contributors to know the latest state of the arbiter when submitting
+//! information and penalizing them for this is not helpful (i.e. an acknowledgement may be inflight when another
+//! contributor submits a valid complaint).
+//!
+//! Submitting invalid information (invalid commitment) or refusing to submit required information (not sending a commitment)
+//! qualifies as an attributable fault that disqualifies a dealer/recipient from a round of DKG/Resharing. A developer
+//! can additionally handle such a fault as they see fit (may warrant additional punishment).
 //!
 //! # Warning
 //!

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,7 +106,8 @@
     <div>* <a href="https://docs.rs/commonware-p2p">p2p</a>: communicate with authenticated peers over encrypted connections</div>
     <br>
     <div class="section-title">> examples</div>
-    <div>* <a href="https://docs.rs/commonware-chat">chat</a>: send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p</div>
+    <div>* <a href="https://docs.rs/commonware-chat">chat</a>: send encrypted messages to a group of friends</div>
+    <div>* <a href="https://docs.rs/commonware-vrf">vrf</a>: generate bias-resistant randomness with untrusted contributors</div>
     <br>
     <div class="section-title">> connect</div>
     <div>* <a href="https://discord.gg/wt5VtKXv5c">discord</a></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,11 +103,11 @@
     <br>
     <div class="section-title">> primitives</div>
     <div>* <a href="https://docs.rs/commonware-cryptography">cryptography</a>: generate keys, sign arbitrary messages, and deterministically verify untrusted signatures.</div>
-    <div>* <a href="https://docs.rs/commonware-p2p">p2p</a>: communicate with authenticated peers over encrypted connections</div>
+    <div>* <a href="https://docs.rs/commonware-p2p">p2p</a>: communicate with authenticated peers over encrypted connections.</div>
     <br>
     <div class="section-title">> examples</div>
-    <div>* <a href="https://docs.rs/commonware-chat">chat</a>: send encrypted messages to a group of friends</div>
-    <div>* <a href="https://docs.rs/commonware-vrf">vrf</a>: generate bias-resistant randomness with untrusted contributors</div>
+    <div>* <a href="https://docs.rs/commonware-chat">chat</a>: send encrypted messages to a group of friends.</div>
+    <div>* <a href="https://docs.rs/commonware-vrf">vrf</a>: generate bias-resistant randomness with untrusted contributors.</div>
     <br>
     <div class="section-title">> connect</div>
     <div>* <a href="https://discord.gg/wt5VtKXv5c">discord</a></div>

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.13"
+version = "0.0.14"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 publish = true
 version = "0.0.2"
 license = "MIT OR Apache-2.0"
-description = ""
+description = "Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p."
 readme = "README.md"
 homepage = "https://commonware.xyz"
 repository = "https://github.com/commonwarexyz/monorepo"
@@ -13,3 +13,12 @@ documentation = "https://docs.rs/commonware-vrf"
 [dependencies]
 commonware-cryptography = { workspace = true }
 commonware-p2p = { workspace = true } 
+tokio = { version = "1", features = ["full"] }
+clap = "4" 
+tracing-subscriber = "0.3"
+tracing = "0.1"
+hex = "0.4"
+prometheus-client = "0.22"
+prost = "0.12"
+bytes = "1"
+governor = "0.6"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "commonware-vrf"
+edition = "2021"
+publish = true
+version = "0.0.2"
+license = "MIT OR Apache-2.0"
+description = ""
+readme = "README.md"
+homepage = "https://commonware.xyz"
+repository = "https://github.com/commonwarexyz/monorepo"
+documentation = "https://docs.rs/commonware-vrf"
+
+[dependencies]
+commonware-cryptography = { workspace = true }
+commonware-p2p = { workspace = true } 

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -22,3 +22,7 @@ prometheus-client = "0.22"
 prost = "0.12"
 bytes = "1"
 governor = "0.6"
+rand = "0.8"
+
+[build-dependencies]
+prost-build = "0.12"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/commonware-vrf"
 [dependencies]
 commonware-cryptography = { workspace = true }
 commonware-p2p = { workspace = true } 
+bytes = { workspace = true } 
 tokio = { version = "1", features = ["full"] }
 clap = "4" 
 tracing-subscriber = "0.3"
@@ -20,7 +21,6 @@ tracing = "0.1"
 hex = "0.4"
 prometheus-client = "0.22"
 prost = "0.12"
-bytes = "1"
 governor = "0.6"
 rand = "0.8"
 

--- a/examples/vrf/README.md
+++ b/examples/vrf/README.md
@@ -7,8 +7,6 @@ and [commonware-p2p](https://crates.io/crates/commonware-p2p).
 
 # Usage (3 of 4 Threshold)
 
-Perform a DKG (or Reshare) -> Generate Threshold Signature -> Repeat
-
 ## Arbiter 
 ```bash
 cargo run --release -- --me 0@3000 --participants 0,1,2,3,4 --contributors 1,2,3,4

--- a/examples/vrf/README.md
+++ b/examples/vrf/README.md
@@ -2,8 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-vrf.svg)](https://crates.io/crates/commonware-vrf)
 
-Generate bias-resistant randomness with untrusted contributors using [commonware-cryptography](https://crates.io/crates/commonware-cryptography)
-and [commonware-p2p](https://crates.io/crates/commonware-p2p).
+Generate bias-resistant randomness with untrusted contributors using [commonware-cryptography](https://crates.io/crates/commonware-cryptography) and [commonware-p2p](https://crates.io/crates/commonware-p2p).
 
 # Usage (3 of 4 Threshold)
 

--- a/examples/vrf/README.md
+++ b/examples/vrf/README.md
@@ -1,0 +1,51 @@
+# commonware-vrf 
+
+[![Crates.io](https://img.shields.io/crates/v/commonware-vrf.svg)](https://crates.io/crates/commonware-vrf)
+
+# Usage (3 of 4 Threshold)
+
+Perform a DKG (or Reshare) -> Generate Threshold Signature -> Repeat
+
+## Arbiter 
+```bash
+cargo run --release -- --me 0@3000 --participants 0,1,2,3,4 --contributors 1,2,3,4
+```
+
+## Contributor 1
+```bash
+cargo run --release -- --bootstrappers 0@127.0.0.1:3000 --me 1@3001 --participants 0,1,2,3,4  --arbiter 0 --contributors 1,2,3,4
+```
+
+## Contributor 2
+```bash
+cargo run --release -- --bootstrappers 0@127.0.0.1:3000 --me 2@3002 --participants 0,1,2,3,4  --arbiter 0 --contributors 1,2,3,4
+```
+
+## Contributor 3
+```bash
+cargo run --release -- --bootstrappers 0@127.0.0.1:3000 --me 3@3003 --participants 0,1,2,3,4  --arbiter 0 --contributors 1,2,3,4
+```
+
+## Contributor 4 (Rogue)
+
+_Send invalid shares to other contributors._
+
+```bash
+cargo run --release -- --rogue --bootstrappers 0@127.0.0.1:3000 --me 4@3004 --participants 0,1,2,3,4 --arbiter 0 --contributors 1,2,3,4 
+```
+
+## Contributor 4 (Lazy)
+
+_Only share `t-1` shares. Post one share to arbiter to ensure commitment isn't dropped._
+
+```bash
+cargo run --release -- --lazy --bootstrappers 0@127.0.0.1:3000 --me 4@3004 --participants 0,1,2,3,4 --arbiter 0 --contributors 1,2,3,4 
+```
+
+## Contributor 4 (Lazy + Defiant)
+
+_Only share `t-1` shares. Don't post any requested shares to arbiter (commitment will be dropped)._
+
+```bash
+cargo run --release -- --lazy --defiant --bootstrappers 0@127.0.0.1:3000 --me 4@3004 --participants 0,1,2,3,4 --arbiter 0 --contributors 1,2,3,4 
+```

--- a/examples/vrf/README.md
+++ b/examples/vrf/README.md
@@ -2,6 +2,9 @@
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-vrf.svg)](https://crates.io/crates/commonware-vrf)
 
+Generate bias-resistant randomness with untrusted contributors using [commonware-cryptography](https://crates.io/crates/commonware-cryptography)
+and [commonware-p2p](https://crates.io/crates/commonware-p2p).
+
 # Usage (3 of 4 Threshold)
 
 Perform a DKG (or Reshare) -> Generate Threshold Signature -> Repeat

--- a/examples/vrf/build.rs
+++ b/examples/vrf/build.rs
@@ -1,0 +1,13 @@
+use std::io::Result;
+fn main() -> Result<()> {
+    let mut config = prost_build::Config::new();
+    config.protoc_arg("--experimental_allow_proto3_optional");
+    config.bytes([
+        "Complaint.signature",
+        "Reveal.signature",
+        "Share.signature",
+        "Resolution.signature",
+    ]);
+    config.compile_protos(&["src/wire.proto"], &["src/"])?;
+    Ok(())
+}

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -1,0 +1,520 @@
+use crate::{
+    bls12381::{
+        dkg::arbiter::P0,
+        primitives::{
+            group::{self, Element},
+            poly,
+        },
+    },
+    handlers::{
+        payloads::{self, SHARE_NAMESPACE},
+        utils::public_hex,
+        wire,
+    },
+};
+use commonware_cryptography::{PublicKey, Scheme};
+use commonware_p2p::{Receiver, Sender};
+use prost::Message;
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
+use tokio::{select, time};
+use tracing::{debug, info, warn};
+
+/// Replicates functionality of a consensus process.
+///
+/// Verifies that any resharing of a public key is done correctly (can't transition to invalid public group)
+///
+/// # Phases
+///
+/// * Set Round Timeouts (T_commitment, T_ack, T_repair)
+/// * Before T_commitment, broadcast a signed commitment to some polynomial
+///   * Disqualify any players who do not send a commitment (or invalid)
+/// * Before T_ack, broadcast a signed acknowledgment to any received commitments
+///   * Disqualify any players that do not have `t` acks or that have been complained against
+/// * Before T_repair, broadcast a signed plaintext share to any missing acks
+///   * Disqualify any players that do not have `n` shares distributed (or invalid)
+///
+/// # TODO
+/// * Support early phase termination (when work is done)
+/// * Support changning players
+pub struct Arbiter {
+    dkg_frequency: Duration,
+    dkg_phase_timeout: Duration,
+
+    players: Vec<PublicKey>,
+    t: u32,
+}
+
+impl Arbiter {
+    pub fn new(
+        dkg_frequency: Duration,
+        dkg_phase_timeout: Duration,
+        mut players: Vec<PublicKey>,
+        t: u32,
+    ) -> Self {
+        players.sort();
+        Self {
+            dkg_frequency,
+            dkg_phase_timeout,
+
+            players,
+            t,
+        }
+    }
+
+    async fn run_round<C: Scheme>(
+        &self,
+        round: u64,
+        previous: Option<poly::Public>,
+        sender: &Sender,
+        receiver: &mut Receiver,
+    ) -> (Option<poly::Public>, HashSet<PublicKey>) {
+        // Create a new round
+        let start = tokio::time::Instant::now();
+        let t_commitment = start + self.dkg_phase_timeout;
+        let t_ack = start + self.dkg_phase_timeout * 2;
+        let t_repair = start + self.dkg_phase_timeout * 3;
+
+        // Send round start message to players
+        let mut group = None;
+        if let Some(previous) = &previous {
+            group = Some(previous.serialize());
+            let public = poly::public(previous).serialize();
+            info!(round, public = hex::encode(public), "starting reshare");
+        } else {
+            info!(round, "starting key generation");
+        }
+        sender
+            .send(
+                None,
+                wire::Dkg {
+                    round,
+                    payload: Some(wire::dkg::Payload::Start(wire::Start { group })),
+                }
+                .encode_to_vec()
+                .into(),
+                true,
+            )
+            .await;
+
+        // Collect commitments
+        let mut p0 = P0::new(
+            self.t,
+            previous,
+            self.players.clone(),
+            self.players.clone(),
+            1,
+        );
+        loop {
+            select! {
+                biased;
+
+                _ = tokio::time::sleep_until(t_commitment) => {
+                    debug!("commitment phase timed out");
+                    break
+                }
+                msg = receiver.recv() => {
+                    if let Some((sender, msg)) = msg {
+                        let msg = match wire::Dkg::decode(msg) {
+                            Ok(msg) => msg,
+                            Err(_) => {
+                                p0.disqualify(sender);
+                                continue;
+                            }
+                        };
+                        if msg.round != round {
+                            p0.disqualify(sender);
+                            continue;
+                        }
+                        let msg = match msg.payload {
+                            Some(wire::dkg::Payload::Commitment(msg)) => msg,
+                            _ => {
+                                p0.disqualify(sender);
+                                continue;
+                            }
+                        };
+                        let commitment = match poly::Public::deserialize(&msg.commitment, self.t) {
+                            Some(commitment) => commitment,
+                            None => {
+                                p0.disqualify(sender);
+                                continue;
+                            }
+                        };
+                        let _ = p0.commitment(sender, commitment);
+                    }
+                }
+            }
+        }
+
+        // Finalize P0
+        let (p1, disqualified) = p0.finalize();
+        let mut p1 = match p1 {
+            Some(p1) => p1,
+            None => {
+                sender
+                    .send(
+                        None,
+                        wire::Dkg {
+                            round,
+                            payload: Some(wire::dkg::Payload::Abort(wire::Abort {})),
+                        }
+                        .encode_to_vec()
+                        .into(),
+                        true,
+                    )
+                    .await;
+                return (None, disqualified);
+            }
+        };
+
+        let commitments = p1.commitments();
+        info!(
+            round,
+            commitments = ?commitments.iter().map(|(_, pk, _)| hex::encode(pk)).collect::<Vec<_>>(),
+            disqualified = ?disqualified
+                .into_iter()
+                .map(hex::encode)
+                .collect::<Vec<_>>(),
+            "commitment phase complete"
+        );
+
+        // Send all commitments on preferred group
+        let mut dealers = Vec::with_capacity(commitments.len());
+        for (dealer, _, commitment) in &commitments {
+            dealers.push(wire::Dealer {
+                dealer: *dealer,
+                commitment: commitment.serialize(),
+            });
+        }
+        sender
+            .send(
+                None,
+                wire::Dkg {
+                    round,
+                    payload: Some(wire::dkg::Payload::Commitments(wire::Commitments {
+                        dealers,
+                    })),
+                }
+                .encode_to_vec()
+                .into(),
+                false,
+            )
+            .await;
+
+        // Collect acks and complaints
+        loop {
+            select! {
+                biased;
+
+                _ = tokio::time::sleep_until(t_ack) => {
+                    debug!("ack phase timed out");
+                    break
+                }
+                msg = receiver.recv() => {
+                    if let Some((sender, msg)) = msg {
+                        // Parse message as Ack or Complaint
+                        let msg = match wire::Dkg::decode(msg) {
+                            Ok(msg) => msg,
+                            Err(_) => {
+                                p1.disqualify(sender);
+                                continue;
+                            }
+                        };
+
+                        // Verify the message
+                        if msg.round != round {
+                            p1.disqualify(sender);
+                            continue;
+                        }
+
+                        match msg.payload{
+                            Some(wire::dkg::Payload::Ack(ack)) => {
+                                let _ = p1.ack(sender, ack.dealer);
+                            }
+                            Some(wire::dkg::Payload::Complaint(complaint)) => {
+                                let share = match group::Share::deserialize(&complaint.share) {
+                                    Some(share) => share,
+                                    None => {
+                                        p1.disqualify(sender);
+                                        continue;
+                                    }
+                                };
+                                let bad_dealer = match p1.dealer(complaint.dealer) {
+                                    Some(bad_dealer) => bad_dealer,
+                                    None => {
+                                        p1.disqualify(sender);
+                                        continue;
+                                    }
+                                };
+                                let payload = payloads::share(round, complaint.dealer, &complaint.share);
+                                if !C::verify(SHARE_NAMESPACE, &payload, &bad_dealer, &complaint.signature) {
+                                    p1.disqualify(sender);
+                                    continue;
+                                }
+                                let _ = p1.complaint(sender, complaint.dealer, &share);
+                            }
+                            _ => {
+                                p1.disqualify(sender);
+                                continue
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Finalize P1
+        let (p2, disqualified) = p1.finalize();
+
+        // Abort if not `t` dealings each with at least `t` acks
+        let (mut p2, requests) = match p2 {
+            Some(p2) => p2,
+            None => {
+                sender
+                    .send(
+                        None,
+                        wire::Dkg {
+                            round,
+                            payload: Some(wire::dkg::Payload::Abort(wire::Abort {})),
+                        }
+                        .encode_to_vec()
+                        .into(),
+                        true,
+                    )
+                    .await;
+                return (None, disqualified);
+            }
+        };
+        let commitments = p2.commitments();
+        info!(
+            round,
+            commitments = ?commitments.iter().map(|(_, pk, _)| hex::encode(pk)).collect::<Vec<_>>(),
+            disqualified = ?disqualified.into_iter().map(hex::encode).collect::<Vec<_>>(),
+            "ack phase complete"
+        );
+
+        // If no shares to reveal, broadcast success
+        if requests.is_empty() {
+            debug!(round, "no shares to reveal, recovering public key");
+
+            let (result, disqualified) = p2.finalize();
+            if let Err(e) = result {
+                warn!(round, error=?e, "unable to recover public key");
+                sender
+                    .send(
+                        None,
+                        wire::Dkg {
+                            round,
+                            payload: Some(wire::dkg::Payload::Abort(wire::Abort {})),
+                        }
+                        .encode_to_vec()
+                        .into(),
+                        true,
+                    )
+                    .await;
+                return (None, disqualified);
+            }
+
+            let result = result.unwrap();
+            sender
+                .send(
+                    None,
+                    wire::Dkg {
+                        round,
+                        payload: Some(wire::dkg::Payload::Success(wire::Success {
+                            dealers: result.commitments,
+                            resolutions: Vec::new(),
+                        })),
+                    }
+                    .encode_to_vec()
+                    .into(),
+                    true,
+                )
+                .await;
+            return (Some(result.public), disqualified);
+        }
+
+        // Broadcast missing shares
+        let mut missing = Vec::new();
+        for (dealer, recipient) in &requests {
+            missing.push(wire::Request {
+                dealer: *dealer,
+                share: *recipient,
+            });
+        }
+        debug!(round, missing = missing.len(), "requesting missing shares");
+        sender
+            .send(
+                None,
+                wire::Dkg {
+                    round,
+                    payload: Some(wire::dkg::Payload::Missing(wire::Missing {
+                        shares: missing,
+                    })),
+                }
+                .encode_to_vec()
+                .into(),
+                false,
+            )
+            .await;
+
+        // Collect missing shares
+        let mut signatures = HashMap::new();
+        loop {
+            select! {
+                biased;
+
+                _ = tokio::time::sleep_until(t_repair) => {
+                    break
+                }
+                msg = receiver.recv() => {
+                    if let Some((sender, msg)) = msg {
+                        let msg = match wire::Dkg::decode(msg) {
+                            Ok(msg) => msg,
+                            Err(_) => {
+                                p2.disqualify(sender);
+                                continue;
+                            }
+                        };
+                        if msg.round != round {
+                            p2.disqualify(sender);
+                            continue;
+                        }
+                        let msg = match msg.payload {
+                            Some(wire::dkg::Payload::Reveal(msg)) => msg,
+                            _ => {
+                                p2.disqualify(sender);
+                                continue;
+                            }
+                        };
+                        let share = match group::Share::deserialize(&msg.share) {
+                            Some(share) => share,
+                            None => {
+                                p2.disqualify(sender);
+                                continue;
+                            }
+                        };
+                        let dealer = match p2.dealer(&sender) {
+                            Some(dealer) => dealer,
+                            None => {
+                                p2.disqualify(sender);
+                                continue;
+                            }
+                        };
+                        let payload = payloads::share(round, dealer, &msg.share);
+                        if !C::verify(SHARE_NAMESPACE, &payload, &sender, &msg.signature) {
+                            p2.disqualify(sender);
+                            continue;
+                        }
+                        match p2.reveal(sender.clone(), share) {
+                            Ok(()) => {
+                                signatures.insert((dealer, share.index), msg.signature);
+                            }
+                            Err(_) => {
+                                p2.disqualify(sender);
+                                continue;
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        // Finalize P2
+        let (result, disqualified) = p2.finalize();
+        let result = match result {
+            Ok(result) => result,
+            Err(e) => {
+                warn!(round, error=?e,  "unable to recover public key");
+                sender
+                    .send(
+                        None,
+                        wire::Dkg {
+                            round,
+                            payload: Some(wire::dkg::Payload::Abort(wire::Abort {})),
+                        }
+                        .encode_to_vec()
+                        .into(),
+                        true,
+                    )
+                    .await;
+                return (None, disqualified);
+            }
+        };
+        info!(
+            round,
+            commitments = ?commitments.iter().map(|(_, pk, _)| hex::encode(pk)).collect::<Vec<_>>(),
+            disqualified = ?disqualified
+                .iter()
+                .map(hex::encode)
+                .collect::<Vec<_>>(),
+            "repair phase complete"
+        );
+
+        // Broadcast resolutions
+        let mut resolutions = Vec::new();
+        for ((dealer, recipient), share) in result.resolutions {
+            let signature = signatures
+                .remove(&(dealer, recipient))
+                .expect("missing signature");
+            resolutions.push(wire::Resolution {
+                dealer,
+                share: share.serialize(),
+                signature,
+            });
+        }
+        sender
+            .send(
+                None,
+                wire::Dkg {
+                    round,
+                    payload: Some(wire::dkg::Payload::Success(wire::Success {
+                        dealers: result.commitments,
+                        resolutions,
+                    })),
+                }
+                .encode_to_vec()
+                .into(),
+                true,
+            )
+            .await;
+
+        (Some(result.public), disqualified)
+    }
+
+    pub async fn run<C: Scheme>(self, sender: Sender, mut receiver: Receiver) {
+        let mut round = 0;
+        let mut previous = None;
+        loop {
+            let (public, disqualified) = self
+                .run_round::<C>(round, previous.clone(), &sender, &mut receiver)
+                .await;
+
+            // Log round results
+            match public {
+                Some(public) => {
+                    info!(
+                        round,
+                        public = public_hex(&public),
+                        disqualified = ?disqualified.into_iter().map(hex::encode).collect::<Vec<_>>(),
+                        "round complete"
+                    );
+
+                    // Only update previous if the round was successful
+                    previous = Some(public);
+                }
+                None => {
+                    info!(round, disqualified = ?disqualified.into_iter().map(hex::encode).collect::<Vec<_>>(), "round aborted");
+                }
+            }
+
+            // Update state
+            round += 1;
+
+            // Wait for next round
+            time::sleep(self.dkg_frequency).await;
+        }
+    }
+}

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -1,4 +1,9 @@
-use crate::{
+use crate::handlers::{
+    payloads::{self, SHARE_NAMESPACE},
+    utils::public_hex,
+    wire,
+};
+use commonware_cryptography::{
     bls12381::{
         dkg::arbiter::P0,
         primitives::{
@@ -6,13 +11,8 @@ use crate::{
             poly,
         },
     },
-    handlers::{
-        payloads::{self, SHARE_NAMESPACE},
-        utils::public_hex,
-        wire,
-    },
+    PublicKey, Scheme,
 };
-use commonware_cryptography::{PublicKey, Scheme};
 use commonware_p2p::{Receiver, Sender};
 use prost::Message;
 use std::{

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -1,0 +1,618 @@
+use crate::{
+    bls12381::{
+        dkg::{
+            self,
+            contributor::{Output, P0, P1},
+        },
+        primitives::{
+            group::{self, Private},
+            poly,
+        },
+    },
+    handlers::{
+        payloads::{self, SHARE_NAMESPACE},
+        utils::public_hex,
+        wire,
+    },
+};
+use commonware_cryptography::{PublicKey, Scheme};
+use commonware_p2p::{Receiver, Sender};
+use prost::Message;
+use rand::thread_rng;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+pub struct Contributor<C: Scheme> {
+    crypto: C,
+    arbiter: PublicKey,
+    contributors: Vec<PublicKey>,
+    contributors_ordered: HashMap<PublicKey, u32>,
+    t: u32,
+    rogue: bool,
+    lazy: bool,
+    defiant: bool,
+
+    signatures: mpsc::Sender<(u64, Output)>,
+}
+
+impl<C: Scheme> Contributor<C> {
+    pub fn new(
+        crypto: C,
+        arbiter: PublicKey,
+        mut contributors: Vec<PublicKey>,
+        t: u32,
+        rogue: bool,
+        lazy: bool,
+        defiant: bool,
+    ) -> (Self, mpsc::Receiver<(u64, Output)>) {
+        contributors.sort();
+        let contributors_ordered: HashMap<PublicKey, u32> = contributors
+            .iter()
+            .enumerate()
+            .map(|(idx, pk)| (pk.clone(), idx as u32))
+            .collect();
+        let (sender, receiver) = mpsc::channel(32);
+        (
+            Self {
+                crypto,
+                arbiter,
+                contributors,
+                contributors_ordered,
+                t,
+                rogue,
+                lazy,
+                defiant,
+                signatures: sender,
+            },
+            receiver,
+        )
+    }
+
+    async fn run_round(
+        &mut self,
+        previous: Option<&Output>,
+        sender: &Sender,
+        receiver: &mut Receiver,
+    ) -> (u64, Option<Output>) {
+        // Configure me
+        let me = self.crypto.me();
+        let me_idx = *self.contributors_ordered.get(&me).unwrap();
+
+        // Wait for start message from arbiter
+        let (public, round) = loop {
+            match receiver.recv().await {
+                Some((sender, msg)) => {
+                    if sender != self.arbiter {
+                        debug!("dropping messages until receive start message from arbiter");
+                        continue;
+                    }
+                    let msg = match wire::Dkg::decode(msg) {
+                        Ok(msg) => msg,
+                        Err(_) => {
+                            warn!("received invalid message from arbiter");
+                            continue;
+                        }
+                    };
+                    let round = msg.round;
+                    let msg = match msg.payload {
+                        Some(wire::dkg::Payload::Start(msg)) => msg,
+                        _ => {
+                            // This could happen if out-of-sync on phase.
+                            return (round, None);
+                        }
+                    };
+                    if let Some(group) = msg.group {
+                        let result = poly::Public::deserialize(&group, self.t);
+                        if result.is_none() {
+                            warn!("received invalid group polynomial");
+                            continue;
+                        }
+                        break (Some(result.unwrap()), round);
+                    }
+                    break (None, round);
+                }
+                None => {
+                    debug!("did not receive start message");
+                    continue;
+                }
+            }
+        };
+
+        // If don't have polynomial or there is a round mismatch, attempt to
+        // recover using round but don't deal.
+        let mut should_deal = true;
+        match (&previous, &public) {
+            (Some(previous), None) => {
+                warn!(
+                    expected = public_hex(&previous.public),
+                    "previous group polynomial but found none"
+                );
+                should_deal = false;
+            }
+            (Some(previous), Some(public)) => {
+                if previous.public != *public {
+                    warn!(
+                        expected = public_hex(&previous.public),
+                        found = public_hex(public),
+                        "group polynomial does not match expected"
+                    );
+                    should_deal = false;
+                }
+            }
+            (None, Some(public)) => {
+                warn!(
+                    found = public_hex(public),
+                    "found group polynomial but expected none"
+                );
+                should_deal = false;
+            }
+            _ => {}
+        }
+        info!(
+            round,
+            should_deal,
+            reshare = public.is_some(),
+            "starting round"
+        );
+
+        // Send commitment to arbiter
+        let (mut p1, shares) = if should_deal {
+            let previous = public
+                .as_ref()
+                .map(|public| (public.clone(), previous.unwrap().share));
+            let p0 = P0::new(
+                me.clone(),
+                self.t,
+                previous,
+                self.contributors.clone(),
+                self.contributors.clone(),
+                1,
+            );
+            let (p1, commitment, shares) = p0.finalize();
+            let mut p1 = p1.unwrap();
+            if let Err(e) = p1.commitment(me.clone(), commitment.clone()) {
+                warn!(round, error = ?e, "failed to add our commitment");
+                return (round, None);
+            }
+            sender
+                .send(
+                    Some(vec![self.arbiter.clone()]),
+                    wire::Dkg {
+                        round,
+                        payload: Some(wire::dkg::Payload::Commitment(wire::Commitment {
+                            commitment: commitment.serialize(),
+                        })),
+                    }
+                    .encode_to_vec()
+                    .into(),
+                    true,
+                )
+                .await;
+            debug!(round, "sent commitment");
+
+            (p1, Some(shares))
+        } else {
+            (
+                P1::new(
+                    me.clone(),
+                    self.t,
+                    public,
+                    self.contributors.clone(),
+                    self.contributors.clone(),
+                    1,
+                ),
+                None,
+            )
+        };
+
+        // Wait for other commitments
+        loop {
+            match receiver.recv().await {
+                Some((sender, msg)) => {
+                    if sender != self.arbiter {
+                        debug!("dropping messages until receive commitments from arbiter");
+                        continue;
+                    }
+                    let msg = match wire::Dkg::decode(msg) {
+                        Ok(msg) => msg,
+                        Err(_) => {
+                            warn!("received invalid message from arbiter");
+                            return (round, None);
+                        }
+                    };
+                    if msg.round != round {
+                        warn!(
+                            round,
+                            msg_round = msg.round,
+                            "received commitments round does not match expected"
+                        );
+                        return (round, None);
+                    }
+                    let msg = match msg.payload {
+                        Some(wire::dkg::Payload::Commitments(msg)) => msg,
+                        _ => {
+                            return (round, None);
+                        }
+                    };
+
+                    // Compile commitments
+                    for commitment in msg.dealers {
+                        let dealer = commitment.dealer;
+                        let dealer = match self.contributors.get(dealer as usize) {
+                            Some(dealer) => dealer,
+                            None => {
+                                warn!(
+                                    round,
+                                    dealer,
+                                    "received commitment of invalid contributor from arbiter"
+                                );
+                                return (round, None);
+                            }
+                        };
+                        let commitment =
+                            match poly::Public::deserialize(&commitment.commitment, self.t) {
+                                Some(commitment) => commitment,
+                                None => {
+                                    warn!("received invalid commitment from player");
+                                    return (round, None);
+                                }
+                            };
+
+                        // Verify commitment is on public
+                        if let Err(e) = p1.commitment(dealer.clone(), commitment) {
+                            warn!(round, dealer = hex::encode(dealer), error = ?e, "received invalid commitment");
+                            return (round, None);
+                        }
+                    }
+                    break;
+                }
+                None => {
+                    debug!("did not receive commitments");
+                    return (round, None);
+                }
+            }
+        }
+        if !p1.has(me.clone()) && should_deal {
+            warn!(round, "commitment is missing from arbiter");
+            should_deal = false;
+        }
+
+        // Exit if not enough commitments
+        let commitments = p1.count();
+        let mut p2 = match p1.finalize() {
+            Some(p2) => {
+                info!(
+                    round,
+                    commitments, "received sufficient commitments from arbiter"
+                );
+                p2
+            }
+            None => {
+                warn!(round, commitments, "insufficient commitments");
+                return (round, None);
+            }
+        };
+
+        // Send shares to other contributors
+        let mut shares_sent = 0;
+        if should_deal {
+            let shares = shares.clone().unwrap();
+            for (idx, player) in self.contributors.iter().enumerate() {
+                let share = shares[idx];
+                if idx == me_idx as usize {
+                    if let Err(e) = p2.share(me.clone(), share) {
+                        warn!(round, error = ?e, "failed to add our share");
+                        return (round, None);
+                    }
+                    continue;
+                }
+                let mut share_bytes = share.serialize();
+
+                // Tweak behavior depending on role
+                if self.rogue {
+                    // If we are rogue, randomly modify the share.
+                    share_bytes = group::Share {
+                        index: share.index,
+                        private: Private::rand(&mut thread_rng()),
+                    }
+                    .serialize();
+                    warn!(round, player = idx, "modified share");
+                }
+                if self.lazy && shares_sent == self.t - 1 {
+                    warn!(round, recipient = idx, "not sending share beause lazy");
+                    continue;
+                }
+
+                let payload = payloads::share(round, me_idx, &share_bytes);
+                let signature = self.crypto.sign(SHARE_NAMESPACE, &payload);
+                sender
+                    .send(
+                        Some(vec![player.clone()]),
+                        wire::Dkg {
+                            round,
+                            payload: Some(wire::dkg::Payload::Share(wire::Share {
+                                share: share_bytes,
+                                signature,
+                            })),
+                        }
+                        .encode_to_vec()
+                        .into(),
+                        true,
+                    )
+                    .await;
+                debug!(round, player = idx, "sent share");
+                shares_sent += 1;
+            }
+        }
+
+        // Send acks to arbiter when receive shares from other contributors
+        let dealers = loop {
+            match receiver.recv().await {
+                Some((s, msg)) => {
+                    let msg = match wire::Dkg::decode(msg) {
+                        Ok(msg) => msg,
+                        Err(_) => {
+                            warn!("received invalid message from arbiter");
+                            return (round, None);
+                        }
+                    };
+                    if round != msg.round {
+                        warn!(
+                            round,
+                            msg.round, "received success message with wrong round"
+                        );
+                        return (round, None);
+                    }
+                    if s == self.arbiter {
+                        match msg.payload {
+                            Some(wire::dkg::Payload::Missing(msg)) => {
+                                if !should_deal {
+                                    continue;
+                                }
+                                let shares = shares.clone().unwrap();
+                                for missing_share in msg.shares {
+                                    if missing_share.dealer != me_idx {
+                                        continue;
+                                    }
+                                    if self.defiant {
+                                        warn!(
+                                            round,
+                                            recipient = missing_share.share,
+                                            "ignoring missing share request"
+                                        );
+                                        continue;
+                                    }
+                                    let recipient = missing_share.share;
+                                    let share = match shares.get(recipient as usize) {
+                                        Some(share) => {
+                                            warn!(round, recipient, "revealing missing share");
+                                            share.serialize()
+                                        }
+                                        None => {
+                                            warn!("arbiter sent missing share request for invalid recipient");
+                                            continue;
+                                        }
+                                    };
+                                    let payload = payloads::share(round, me_idx, &share);
+                                    let signature = self.crypto.sign(SHARE_NAMESPACE, &payload);
+                                    sender
+                                        .send(
+                                            Some(vec![self.arbiter.clone()]),
+                                            wire::Dkg {
+                                                round,
+                                                payload: Some(wire::dkg::Payload::Reveal(
+                                                    wire::Reveal { share, signature },
+                                                )),
+                                            }
+                                            .encode_to_vec()
+                                            .into(),
+                                            true,
+                                        )
+                                        .await;
+                                }
+                                continue;
+                            }
+                            Some(wire::dkg::Payload::Success(msg)) => {
+                                for resolution in msg.resolutions {
+                                    if resolution.dealer == me_idx {
+                                        continue;
+                                    }
+                                    let dealer =
+                                        match self.contributors.get(resolution.dealer as usize) {
+                                            Some(dealer) => dealer,
+                                            None => {
+                                                warn!(
+                                                    round,
+                                                    resolution.dealer,
+                                                    "received share resolution for invalid dealer"
+                                                );
+                                                return (round, None);
+                                            }
+                                        };
+                                    let payload = payloads::share(
+                                        round,
+                                        resolution.dealer,
+                                        &resolution.share,
+                                    );
+                                    // The arbiter should have already verified the signature but we verify just in case!
+                                    if !C::verify(
+                                        SHARE_NAMESPACE,
+                                        &payload,
+                                        dealer,
+                                        &resolution.signature,
+                                    ) {
+                                        warn!(
+                                            round,
+                                            resolution.dealer,
+                                            "received share with invalid signature from arbiter"
+                                        );
+                                        return (round, None);
+                                    }
+                                    debug!(
+                                        round,
+                                        resolution.dealer, "received missing share resolution"
+                                    );
+                                    let share = match group::Share::deserialize(&resolution.share) {
+                                        Some(share) => share,
+                                        None => {
+                                            warn!(
+                                                round,
+                                                resolution.dealer,
+                                                "received invalid share from arbiter"
+                                            );
+                                            return (round, None);
+                                        }
+                                    };
+                                    if share.index != me_idx {
+                                        continue;
+                                    }
+                                    if let Err(e) = p2.share(dealer.clone(), share) {
+                                        warn!(round, resolution.dealer, error = ?e, "received invalid share from arbiter");
+                                        return (round, None);
+                                    }
+                                }
+                                break msg.dealers;
+                            }
+                            _ => {
+                                return (round, None);
+                            }
+                        }
+                    }
+                    let dealer = match self.contributors_ordered.get(&s) {
+                        Some(dealer) => dealer,
+                        None => {
+                            warn!(round, "received share from invalid player");
+                            continue;
+                        }
+                    };
+                    let msg = match msg.payload {
+                        Some(wire::dkg::Payload::Share(msg)) => msg,
+                        _ => {
+                            warn!(round, "received unexpected message from player");
+                            continue;
+                        }
+                    };
+                    let share = match group::Share::deserialize(&msg.share) {
+                        Some(share) => share,
+                        None => {
+                            warn!(round, dealer, "received invalid share");
+                            continue;
+                        }
+                    };
+
+                    // Verify signature on incoming share
+                    let payload = payloads::share(round, *dealer as u32, &msg.share);
+                    if !C::verify(SHARE_NAMESPACE, &payload, &s, &msg.signature) {
+                        warn!(round, dealer, "received invalid share signature");
+                        continue;
+                    }
+
+                    // Store share
+                    match p2.share(s, share) {
+                        Ok(_) => {
+                            // Send share ack
+                            sender
+                                .send(
+                                    Some(vec![self.arbiter.clone()]),
+                                    wire::Dkg {
+                                        round,
+                                        payload: Some(wire::dkg::Payload::Ack(wire::Ack {
+                                            dealer: *dealer as u32,
+                                        })),
+                                    }
+                                    .encode_to_vec()
+                                    .into(),
+                                    true,
+                                )
+                                .await;
+                            debug!(round, dealer, "sent ack");
+                        }
+                        Err(dkg::Error::ShareWrongCommitment)
+                        | Err(dkg::Error::CommitmentWrongDegree) => {
+                            warn!(round, dealer, "received invalid share");
+
+                            // Send complaint
+                            sender
+                                .send(
+                                    Some(vec![self.arbiter.clone()]),
+                                    wire::Dkg {
+                                        round,
+                                        payload: Some(wire::dkg::Payload::Complaint(
+                                            wire::Complaint {
+                                                dealer: *dealer as u32,
+                                                share: msg.share,
+                                                signature: msg.signature,
+                                            },
+                                        )),
+                                    }
+                                    .encode_to_vec()
+                                    .into(),
+                                    true,
+                                )
+                                .await;
+                            warn!(round, dealer, "sent complaint");
+                        }
+                        Err(e) => {
+                            // Some errors may occur if the share is sent to the wrong participant (but it may still
+                            // be correct).
+                            warn!(round, dealer, error=?e, "received invalid share");
+                        }
+                    }
+                }
+                None => {
+                    debug!("did not receive shares");
+                    return (round, None);
+                }
+            };
+        };
+
+        // Construct new public + share
+        let output = match p2.finalize(dealers) {
+            Ok(output) => Some(output),
+            Err(e) => {
+                warn!(round, error = ?e, "failed to finalize round");
+                None
+            }
+        };
+        (round, output)
+    }
+
+    pub async fn run(mut self, sender: Sender, mut receiver: Receiver) {
+        if self.rogue {
+            warn!("running as rogue player");
+        }
+        if self.lazy {
+            warn!("running as lazy player");
+        }
+        if self.defiant {
+            warn!("running as defiant player");
+        }
+        let mut previous = None;
+        loop {
+            let (round, output) = self
+                .run_round(previous.as_ref(), &sender, &mut receiver)
+                .await;
+            match output {
+                None => {
+                    warn!(round, "round failed");
+                    continue;
+                }
+                Some(output) => {
+                    info!(
+                        round,
+                        participants = output.commitments.len(),
+                        public = public_hex(&output.public),
+                        "round complete"
+                    );
+
+                    // Generate signature over round
+                    self.signatures.send((round, output.clone())).await.unwrap();
+
+                    // Update state
+                    previous = Some(output);
+                }
+            }
+        }
+    }
+}

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -1,4 +1,9 @@
-use crate::{
+use crate::handlers::{
+    payloads::{self, SHARE_NAMESPACE},
+    utils::public_hex,
+    wire,
+};
+use commonware_cryptography::{
     bls12381::{
         dkg::{
             self,
@@ -9,13 +14,8 @@ use crate::{
             poly,
         },
     },
-    handlers::{
-        payloads::{self, SHARE_NAMESPACE},
-        utils::public_hex,
-        wire,
-    },
+    PublicKey, Scheme,
 };
-use commonware_cryptography::{PublicKey, Scheme};
 use commonware_p2p::{Receiver, Sender};
 use prost::Message;
 use rand::thread_rng;

--- a/examples/vrf/src/handlers/mod.rs
+++ b/examples/vrf/src/handlers/mod.rs
@@ -1,0 +1,16 @@
+mod arbiter;
+mod contributor;
+mod payloads;
+mod utils;
+mod vrf;
+
+pub use arbiter::Arbiter;
+pub use contributor::Contributor;
+pub use vrf::Vrf;
+
+pub const DKG_CHANNEL: u32 = 0;
+pub const VRF_CHANNEL: u32 = 1;
+
+mod wire {
+    include!(concat!(env!("OUT_DIR"), "/wire.rs"));
+}

--- a/examples/vrf/src/handlers/mod.rs
+++ b/examples/vrf/src/handlers/mod.rs
@@ -1,6 +1,5 @@
 mod arbiter;
 mod contributor;
-mod payloads;
 mod utils;
 mod vrf;
 
@@ -8,7 +7,10 @@ pub use arbiter::Arbiter;
 pub use contributor::Contributor;
 pub use vrf::Vrf;
 
+/// The channel used for DKG messages.
 pub const DKG_CHANNEL: u32 = 0;
+
+/// The channel used for VRF messages.
 pub const VRF_CHANNEL: u32 = 1;
 
 mod wire {

--- a/examples/vrf/src/handlers/payloads.rs
+++ b/examples/vrf/src/handlers/payloads.rs
@@ -1,0 +1,9 @@
+pub const SHARE_NAMESPACE: &[u8] = b"_COMMONWARE_DKG_SHARE_";
+
+pub fn share(round: u64, dealer: u32, share: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&round.to_be_bytes());
+    payload.extend_from_slice(&dealer.to_be_bytes());
+    payload.extend_from_slice(share);
+    payload
+}

--- a/examples/vrf/src/handlers/payloads.rs
+++ b/examples/vrf/src/handlers/payloads.rs
@@ -1,9 +1,0 @@
-pub const SHARE_NAMESPACE: &[u8] = b"_COMMONWARE_DKG_SHARE_";
-
-pub fn share(round: u64, dealer: u32, share: &[u8]) -> Vec<u8> {
-    let mut payload = Vec::new();
-    payload.extend_from_slice(&round.to_be_bytes());
-    payload.extend_from_slice(&dealer.to_be_bytes());
-    payload.extend_from_slice(share);
-    payload
-}

--- a/examples/vrf/src/handlers/utils.rs
+++ b/examples/vrf/src/handlers/utils.rs
@@ -1,6 +1,7 @@
-use crate::bls12381::primitives::group::Element;
-use crate::bls12381::primitives::poly;
+use commonware_cryptography::bls12381::primitives::{group::Element, poly};
 
+/// Convert a public polynomial to a hexadecimal representation of
+/// the public key.
 pub fn public_hex(public: &poly::Public) -> String {
     hex::encode(poly::public(public).serialize())
 }

--- a/examples/vrf/src/handlers/utils.rs
+++ b/examples/vrf/src/handlers/utils.rs
@@ -1,5 +1,19 @@
 use commonware_cryptography::bls12381::primitives::{group::Element, poly};
 
+pub const SHARE_NAMESPACE: &[u8] = b"_COMMONWARE_DKG_SHARE_";
+
+/// Create a payload for sharing a secret.
+///
+/// This payload is used to verify that a particular dealer shared an
+/// invalid secret during the DKG/Resharing procedure.
+pub fn payload(round: u64, dealer: u32, share: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&round.to_be_bytes());
+    payload.extend_from_slice(&dealer.to_be_bytes());
+    payload.extend_from_slice(share);
+    payload
+}
+
 /// Convert a public polynomial to a hexadecimal representation of
 /// the public key.
 pub fn public_hex(public: &poly::Public) -> String {

--- a/examples/vrf/src/handlers/utils.rs
+++ b/examples/vrf/src/handlers/utils.rs
@@ -1,0 +1,6 @@
+use crate::bls12381::primitives::group::Element;
+use crate::bls12381::primitives::poly;
+
+pub fn public_hex(public: &poly::Public) -> String {
+    hex::encode(poly::public(public).serialize())
+}

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -17,9 +17,8 @@ use std::time::Duration;
 use tokio::{select, sync::mpsc};
 use tracing::{debug, info, warn};
 
-/// Threshold Signature-based VRF that generates signatures
-/// over a round identifier (u64) when prompted by an external
-/// party.
+/// Generate bias-resistant, verifiable randomness using BLS12-381
+/// Threshold Signatures.
 pub struct Vrf {
     timeout: Duration,
     threshold: u32,

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -1,0 +1,172 @@
+use crate::{
+    bls12381::{
+        dkg::contributor::Output,
+        primitives::{
+            group::{self, Element},
+            ops,
+            poly::Eval,
+        },
+    },
+    handlers::wire,
+};
+use commonware_cryptography::PublicKey;
+use commonware_p2p::{Receiver, Sender};
+use prost::Message;
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+use tokio::{select, sync::mpsc};
+use tracing::{debug, info, warn};
+
+pub struct Vrf {
+    timeout: Duration,
+    threshold: u32,
+    contributors: Vec<PublicKey>,
+    ordered_contributors: HashMap<PublicKey, u32>,
+    requests: mpsc::Receiver<(u64, Output)>,
+}
+
+impl Vrf {
+    pub fn new(
+        timeout: Duration,
+        threshold: u32,
+        mut contributors: Vec<PublicKey>,
+        requests: mpsc::Receiver<(u64, Output)>,
+    ) -> Self {
+        contributors.sort();
+        let ordered_contributors = contributors
+            .iter()
+            .enumerate()
+            .map(|(i, pk)| (pk.clone(), i as u32))
+            .collect();
+        Self {
+            timeout,
+            threshold,
+            contributors,
+            ordered_contributors,
+            requests,
+        }
+    }
+
+    async fn run_round(
+        &self,
+        output: &Output,
+        round: u64,
+        sender: &Sender,
+        receiver: &mut Receiver,
+    ) -> Option<group::Signature> {
+        // Construct payload
+        let payload = round.to_be_bytes();
+        let signature = ops::partial_sign(&output.share, &payload);
+
+        // Construct partial signature
+        let mut partials = vec![signature.clone()];
+
+        // Send partial signature to peers
+        sender
+            .send(
+                Some(self.contributors.clone()),
+                wire::Vrf {
+                    round,
+                    signature: signature.serialize(),
+                }
+                .encode_to_vec()
+                .into(),
+                true,
+            )
+            .await;
+
+        // Wait for partial signatures from peers or timeout
+        let start = tokio::time::Instant::now();
+        let t_signature = start + self.timeout;
+        let mut received = HashSet::new();
+        loop {
+            select! {
+                biased;
+
+                _ = tokio::time::sleep_until(t_signature) => {
+                    debug!(round, "signature timeout");
+                    break;
+                }
+                msg = receiver.recv() => {
+                    if let Some((sender, msg)) = msg {
+                        let dealer = match self.ordered_contributors.get(&sender) {
+                            Some(sender) => sender,
+                            None => {
+                                warn!(round, "received signature from invalid player");
+                                continue;
+                            }
+                        };
+                        if !received.insert(*dealer) {
+                            warn!(round, dealer, "received duplicate signature");
+                            continue;
+                        }
+                        let msg = match wire::Vrf::decode(msg) {
+                            Ok(msg) => msg,
+                            Err(_) => {
+                                warn!(round, "received invalid message from player");
+                                continue;
+                            }
+                        };
+                        if msg.round != round {
+                            warn!(
+                                round,
+                                msg.round, "received signature message with wrong round"
+                            );
+                            continue;
+                        }
+                        let signature: Eval<group::Signature> = match Eval::deserialize(&msg.signature) {
+                            Some(signature) => signature,
+                            None => {
+                                warn!(round, dealer, "received invalid signature");
+                                continue;
+                            }
+                        };
+                        match ops::partial_verify(&output.public, &payload, &signature) {
+                            Ok(_) => {
+                                partials.push(signature);
+                                debug!(round, dealer, "received partial signature");
+                            }
+                            Err(_) => {
+                                warn!(round, dealer, "received invalid partial signature");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Aggregate partial signatures
+        match ops::aggregate(self.threshold, partials) {
+            Ok(signature) => Some(signature),
+            Err(_) => {
+                warn!(round, "failed to aggregate partial signatures");
+                None
+            }
+        }
+    }
+
+    pub async fn run(mut self, sender: Sender, mut receiver: Receiver) {
+        loop {
+            let (round, output) = match self.requests.recv().await {
+                Some(request) => request,
+                None => {
+                    return;
+                }
+            };
+
+            match self.run_round(&output, round, &sender, &mut receiver).await {
+                Some(signature) => {
+                    let signature = signature.serialize();
+                    info!(
+                        round,
+                        siganture = hex::encode(signature),
+                        "generated signature"
+                    );
+                }
+                None => {
+                    warn!(round, "failed to generate signature");
+                }
+            }
+        }
+    }
+}

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -1,4 +1,5 @@
-use crate::{
+use crate::handlers::wire;
+use commonware_cryptography::{
     bls12381::{
         dkg::contributor::Output,
         primitives::{
@@ -7,9 +8,8 @@ use crate::{
             poly::Eval,
         },
     },
-    handlers::wire,
+    PublicKey,
 };
-use commonware_cryptography::PublicKey;
 use commonware_p2p::{Receiver, Sender};
 use prost::Message;
 use std::collections::{HashMap, HashSet};

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -17,6 +17,9 @@ use std::time::Duration;
 use tokio::{select, sync::mpsc};
 use tracing::{debug, info, warn};
 
+/// Threshold Signature-based VRF that generates signatures
+/// over a round identifier (u64) when prompted by an external
+/// party.
 pub struct Vrf {
     timeout: Duration,
     threshold: u32,

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -12,11 +12,11 @@
 //!
 //! # Joining After a DKG
 //!
-//! In the case that a new contributor joins the VRF after a successful DKG, the new contributor will jump to "Phase 1"
-//! during the next Resharing and wait for a commitment and shares to be distributed from online contributors. As long
-//! as `t` contributors are online and honest at this time, the new contributor will be able to recover the group public
-//! polynomial and generate a share that can be used to generate partial signatures. They will also be able to participate
-//! in future Resharings.
+//! If a new contributor joins the group after a successful DKG, the new contributor will jump to "Phase 1" of the contributor
+//! state machine during the next Resharing. They will skip the generation of a commitment/shares and just wait for commitments
+//! and shares from online contributors to be distributed to them. As long as `t` contributors are online and honest at this time,
+//! the new contributor will be able to recover the group public polynomial and generate a share that can be used to generate valid
+//! partial signatures. They will also be able to participate (share commitment/shares) in future Resharings.
 //!
 //! # Trust Assumptions
 //!

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -25,6 +25,8 @@
 //! contributors over a replicated log (commonly instantiated with a BFT consensus algorithm). This ensures that all
 //! correct contributors have the same view of the arbiter's state at the end of a round.
 //!
+//! _Following the release of `commonware-consensus`, this example will be updated to use the "replicated arbiter" approach._
+//!
 //! `Threshold` contributors are assumed to be honest and online. `n-threshold` contributors can behave arbitrarily and
 //! will not be able to interrupt a DKG, Resharing, or Threshold Signature. Diverging contributors will be identified
 //! by the arbiter and reported at the end of a DKG/Resharing.

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -1,14 +1,22 @@
 //! Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p.
 //!
 //! Contributors to this VRF connect to each other over commonware-p2p (using ED25519 identities), perform an initial
-//! DKG (to generate a static public key), and then perform a proactive refresh every 10 seconds. After a successful
-//! DKG and/or Reshare, contributors generate partial signatures over the round number and gossip them to others in
-//! the group (again using commonware-p2p). These partial signatures, when aggregated, form a threshold signature that
-//! was not knowable by any contributor prior to signing.
+//! Distributed Key Generation (DKG) to generate a static public key, and then perform a proactive Resharing every 10
+//! seconds. After a successful DKG and/or Reshare, contributors generate partial signatures over the round number and
+//! gossip them to others in the group (again using commonware-p2p). These partial signatures, when aggregated, form
+//! a threshold signature that was not knowable by any contributor prior to collecting `t` partial signatures.
 //!
 //! To demonstrate how malicious contributors are handled, the CLI also lets you behave as a "rogue" dealer that generates
-//! invalid shares, a "lazy" dealer that doesn't distribute shares to other contributors, or a "defiant" dealer that doesn't
-//! respond to requests to reveal shares that weren't acknowledged by other contributors.
+//! invalid shares, a "lazy" dealer that doesn't distribute shares to other contributors, and/or a "defiant" dealer that
+//! doesn't respond to requests to reveal shares that weren't acknowledged by other contributors.
+//!
+//! # Joining After a DKG
+//!
+//! In the case that a new contributor joins the VRF after a successful DKG, the new contributor will jump to "Phase 1"
+//! during the next Resharing and wait for a commitment and shares to be distributed from online contributors. As long
+//! as `t` contributors are online and honest at this time, the new contributor will be able to recover the group public
+//! polynomial and generate a share that can be used to generate partial signatures. They will also be able to participate
+//! in future Resharings.
 //!
 //! # Trust Assumptions
 //!

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -10,6 +10,17 @@
 //! invalid shares, a "lazy" dealer that doesn't distribute shares to other contributors, or a "defiant" dealer that doesn't
 //! respond to requests to reveal shares that weren't acknowledged by other contributors.
 //!
+//! # Trust Assumptions
+//!
+//! In this example, the arbiter is assumed to be honest.
+//!
+//! TODO....
+//!
+//! Contributors, on the hand, can behave arbitrarily. As long as `threshold` are online and honest, it will work.
+//!
+//! TODO....
+//!
+//!
 //! # Usage (3 of 4 Threshold)
 //!
 //! ## Arbiter

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -12,11 +12,15 @@
 //!
 //! # Trust Assumptions
 //!
-//! In this example, the arbiter is assumed to be honest.
+//! In this example, the arbiter is assumed to be honest. It tallies commitments from contributors, tracks acknowledgements
+//! and complaints, and communicates to contributors what dealers (commitments and shares) to use when recovering the group public polynomial (and
+//! each contributor's corresponding share). In a production deployment, the arbiter should be replaced with a consensus
+//! process (that all contributors run).
 //!
 //! TODO....
 //!
-//! Contributors, on the hand, can behave arbitrarily. As long as `threshold` are online and honest, it will work.
+//! Contributors, on the other hand, can behave arbitrarily. As long as `threshold` are online and honest, the DKG, Resharing, and
+//! Threshold Signature can be constructed.
 //!
 //! TODO....
 //!

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -20,18 +20,14 @@
 //!
 //! # Trust Assumptions
 //!
-//! In this example, the arbiter is assumed to be honest. It tallies commitments from contributors, tracks acknowledgements
-//! and complaints, and communicates to contributors what dealers (commitments and shares) to use when recovering the group public polynomial (and
-//! each contributor's corresponding share). In a production deployment, the arbiter should be replaced with a consensus
-//! process (that all contributors run).
+//! In this example, the arbiter is trusted. It tracks commitments, acknowledgements, complaints, and reveals submitted
+//! by contributors. As alluded to in the arbiter docs, production deployments of the arbiter should be run by all
+//! contributors over a replicated log (commonly instantiated with a BFT consensus algorithm). This ensures that all
+//! correct contributors have the same view of the arbiter's state at the end of a round.
 //!
-//! TODO....
-//!
-//! Contributors, on the other hand, can behave arbitrarily. As long as `threshold` are online and honest, the DKG, Resharing, and
-//! Threshold Signature can be constructed.
-//!
-//! TODO....
-//!
+//! `Threshold` contributors are assumed to be honest and online. `n-threshold` contributors can behave arbitrarily and
+//! will not be able to interrupt a DKG, Resharing, or Threshold Signature. Diverging contributors will be identified
+//! by the arbiter and reported at the end of a DKG/Resharing.
 //!
 //! # Usage (3 of 4 Threshold)
 //!

--- a/examples/vrf/src/wire.proto
+++ b/examples/vrf/src/wire.proto
@@ -1,0 +1,84 @@
+syntax = "proto3";
+package wire;
+
+// All messages that can be sent in DKG
+message DKG {
+    uint64 round = 1;
+    oneof payload {
+        Start start = 2;
+        Commitment commitment = 3;
+        Commitments commitments = 4;
+        Share share = 5;
+        Ack ack = 6;
+        Complaint complaint = 7;
+        Missing missing = 8;
+        Reveal reveal = 9;
+        Success success = 10;
+        Abort abort = 11;
+    }
+}
+
+message Start {
+    optional bytes group = 1;
+}
+
+message Commitment {
+    bytes commitment = 1;
+}
+
+message Dealer {
+    uint32 dealer = 1;
+    bytes commitment = 2;
+}
+
+message Commitments {
+    repeated Dealer dealers = 1;
+}
+
+message Share {
+    bytes share = 1;
+    bytes signature = 2;
+}
+
+message Ack {
+    uint32 dealer = 1;
+}
+
+message Complaint {
+    uint32 dealer = 1;
+    bytes share = 2;
+    bytes signature = 3;
+}
+
+message Request {
+    uint32 dealer = 1;
+    uint32 share = 2;
+}
+
+message Missing {
+    repeated Request shares = 1;
+}
+
+message Reveal {
+    bytes share = 2;
+    bytes signature = 3;
+}
+
+message Resolution {
+    uint32 dealer = 1;
+    bytes share = 2;
+    bytes signature = 3;
+}
+
+message Success {
+    repeated uint32 dealers = 1;
+    repeated Resolution resolutions = 2;
+}
+
+message Abort {}
+
+// Message that can be sent in signature
+message VRF {
+    uint64 round = 1;
+    bytes signature = 2;
+}

--- a/examples/vrf/src/wire.proto
+++ b/examples/vrf/src/wire.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package wire;
 
-// All messages that can be sent in DKG
+// All messages that can be sent over DKG_CHANNEL. 
 message DKG {
     uint64 round = 1;
     oneof payload {
@@ -77,7 +77,7 @@ message Success {
 
 message Abort {}
 
-// Message that can be sent in signature
+// All messages that can be sent over VRF_CHANNEL. 
 message VRF {
     uint64 round = 1;
     bytes signature = 2;

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.12"
+version = "0.0.13"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"


### PR DESCRIPTION
## Changes
* Introduce a new example that demonstrates how to use the cryptographic primitives introduced in #42.
* Add more context on `Arbiter` deployment options.
* Update website to list `commonware-vrf`.
* Update all crate versions.