### PR TITLE
[cryptography] Improve Comments for Deployment Options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "blst",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-cryptography = { version = "0.0.4", path = "cryptography" }
+commonware-cryptography = { version = "0.0.5", path = "cryptography" }
 commonware-p2p = { version = "0.0.13", path = "p2p" }
 bytes = "1.7.1"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.4"
+version = "0.0.5"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify untrusted signatures."
 readme = "README.md"

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -10,8 +10,8 @@
 //! the same log, will arrive at the same result (will recover the same group polynomial
 //! and a share that can generate partial signatures over it). Using a replicated log allows
 //! us to provide both reliable broadcast (all honest contributors see all messages from
-//! all other honest contributors) and to enforce a "timeout" on when a phase of DKG/Resharing
-//! is complete (needed to support a `2f + 1` threshold).
+//! all other honest contributors) and to enforce a "timeout" (using log index) for each
+//! phase of DKG/Resharing (needed to support a `2f + 1` threshold in this construction).
 //!
 //! ## Trusted Alternative: Standalone Process
 //!

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -8,17 +8,19 @@
 //! log (deterministic order of events across all contributors) of commitments,
 //! acknowledgements, complaints, and resolutions. All correct contributors, when given
 //! the same log, will arrive at the same result (will recover the same group polynomial
-//! and a share that can generate partial signatures over it).
+//! and a share that can generate partial signatures over it). Using a replicated log allows
+//! us to provide both reliable broadcast (all honest contributors see all messages from
+//! all other honest contributors) and to enforce a "timeout" on when a phase of DKG/Resharing
+//! is complete (needed to support a `2f + 1` threshold).
 //!
-//! When this log is instantiated using BFT consensus, up to `f` contributors can
-//! behave maliciously without affecting the outcome of the DKG/Resharing procedure (which
-//! pairs nicely with a `threshold` set to `2f + 1`, in a population of `3f + 1` contributors).
+//! ## Trusted Alternative: Standalone Process
 //!
-//! ## Simple Alternative: Trusted Arbiter
+//! It is possible to run the arbiter as a standalone process that contributors
+//! must trust to track commitments, acks, complaints, and reveals. A rogue arbiter
+//! could request reveals from all dealers for all participants and recover the group
+//! secret key.
 //!
-//! It is possible to run the arbiter as a standalone instance that contributors
-//! must trust to track commitments, acks, complaints, and reveals. For an example of
-//! this approach, refer to <https://docs.rs/commonware-vrf>.
+//! _For an example of this approach, refer to <https://docs.rs/commonware-vrf>._
 //!
 //! # Disqualification on Attributable Faults
 //!


### PR DESCRIPTION
## Changes
* Explicitly refer to the "recommended option" as a superset of reliable broadcast (needed to have a timeout).