### PR TITLE
[p2p] Message Compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,10 @@ name = "cc"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -458,6 +462,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "x25519-dalek",
+ "zstd",
 ]
 
 [[package]]
@@ -1063,6 +1068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1360,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"
@@ -2568,4 +2588,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/examples/chat/src/handler.rs
+++ b/examples/chat/src/handler.rs
@@ -158,7 +158,8 @@ pub async fn run(
                             }
                             let mut successful = sender
                                 .send(Recipients::All, input.clone().into_bytes().into(), false)
-                                .await.unwrap();
+                                .await
+                                .expect("failed to send message");
                             if !successful.is_empty() {
                                 successful.sort();
                                 let mut friends = String::from_str("[").unwrap();

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -154,7 +154,7 @@ async fn main() {
         Quota::per_second(NonZeroU32::new(128).unwrap()),
         1024, // 1 KB max message size
         128,  // 128 messages inflight
-        None,
+        Some(3),
     );
 
     // Start network

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -154,6 +154,7 @@ async fn main() {
         Quota::per_second(NonZeroU32::new(128).unwrap()),
         1024, // 1 KB max message size
         128,  // 128 messages inflight
+        None,
     );
 
     // Start network

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -85,7 +85,8 @@ impl Arbiter {
                 .into(),
                 true,
             )
-            .await;
+            .await
+            .expect("failed to send start message");
 
         // Collect commitments
         let mut p0 = P0::new(
@@ -156,7 +157,8 @@ impl Arbiter {
                         .into(),
                         true,
                     )
-                    .await;
+                    .await
+                    .expect("failed to send abort message");
                 return (None, disqualified);
             }
         };
@@ -193,7 +195,8 @@ impl Arbiter {
                 .into(),
                 false,
             )
-            .await;
+            .await
+            .expect("failed to send commitments");
 
         // Collect acks and complaints
         loop {
@@ -279,7 +282,8 @@ impl Arbiter {
                         .into(),
                         true,
                     )
-                    .await;
+                    .await
+                    .expect("failed to send abort message");
                 return (None, disqualified);
             }
         };
@@ -309,7 +313,8 @@ impl Arbiter {
                         .into(),
                         true,
                     )
-                    .await;
+                    .await
+                    .expect("failed to send abort message");
                 return (None, disqualified);
             }
 
@@ -328,7 +333,8 @@ impl Arbiter {
                     .into(),
                     true,
                 )
-                .await;
+                .await
+                .expect("failed to send success message");
             return (Some(result.public), disqualified);
         }
 
@@ -354,7 +360,8 @@ impl Arbiter {
                 .into(),
                 false,
             )
-            .await;
+            .await
+            .expect("failed to send missing shares");
 
         // Collect missing shares
         let mut signatures = HashMap::new();
@@ -439,7 +446,8 @@ impl Arbiter {
                         .into(),
                         true,
                     )
-                    .await;
+                    .await
+                    .expect("failed to send abort message");
                 return (None, disqualified);
             }
         };
@@ -479,8 +487,8 @@ impl Arbiter {
                 .into(),
                 true,
             )
-            .await;
-
+            .await
+            .expect("failed to send success message");
         (Some(result.public), disqualified)
     }
 

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -103,8 +103,8 @@ impl Arbiter {
                     debug!("commitment phase timed out");
                     break
                 }
-                msg = receiver.recv() => {
-                    if let Some((sender, msg)) = msg {
+                result = receiver.recv() => match result {
+                    Ok((sender, msg)) =>{
                         let msg = match wire::Dkg::decode(msg) {
                             Ok(msg) => msg,
                             Err(_) => {
@@ -131,6 +131,10 @@ impl Arbiter {
                             }
                         };
                         let _ = p0.commitment(sender, commitment);
+                    },
+                    Err(err) => {
+                        warn!(round, ?err, "failed to receive commitment");
+                        break;
                     }
                 }
             }
@@ -200,8 +204,8 @@ impl Arbiter {
                     debug!("ack phase timed out");
                     break
                 }
-                msg = receiver.recv() => {
-                    if let Some((sender, msg)) = msg {
+                result = receiver.recv() => match result {
+                    Ok((sender, msg)) =>{
                         // Parse message as Ack or Complaint
                         let msg = match wire::Dkg::decode(msg) {
                             Ok(msg) => msg,
@@ -248,6 +252,10 @@ impl Arbiter {
                                 continue
                             }
                         }
+                    }
+                    Err(err) => {
+                        warn!(round, ?err, "failed to receive ack or complaint");
+                        break;
                     }
                 }
             }
@@ -357,8 +365,8 @@ impl Arbiter {
                 _ = tokio::time::sleep_until(t_repair) => {
                     break
                 }
-                msg = receiver.recv() => {
-                    if let Some((sender, msg)) = msg {
+                result = receiver.recv() => match result {
+                    Ok((sender, msg)) => {
                         let msg = match wire::Dkg::decode(msg) {
                             Ok(msg) => msg,
                             Err(_) => {
@@ -405,6 +413,10 @@ impl Arbiter {
                                 continue;
                             }
                         }
+                    }
+                    Err(err) => {
+                        warn!(round, ?err, "failed to receive missing share");
+                        break;
                     }
                 }
             };

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -190,7 +190,8 @@ impl<C: Scheme> Contributor<C> {
                     .into(),
                     true,
                 )
-                .await;
+                .await
+                .expect("could not send commitment");
             debug!(round, "sent commitment");
 
             (p1, Some(shares))
@@ -342,7 +343,8 @@ impl<C: Scheme> Contributor<C> {
                         .into(),
                         true,
                     )
-                    .await;
+                    .await
+                    .expect("could not send share");
                 debug!(round, player = idx, "sent share");
                 shares_sent += 1;
             }
@@ -411,7 +413,8 @@ impl<C: Scheme> Contributor<C> {
                                             .into(),
                                             true,
                                         )
-                                        .await;
+                                        .await
+                                        .expect("could not send reveal");
                                 }
                                 continue;
                             }
@@ -524,7 +527,8 @@ impl<C: Scheme> Contributor<C> {
                                     .into(),
                                     true,
                                 )
-                                .await;
+                                .await
+                                .expect("could not send ack");
                             debug!(round, dealer, "sent ack");
                         }
                         Err(dkg::Error::ShareWrongCommitment)
@@ -549,7 +553,8 @@ impl<C: Scheme> Contributor<C> {
                                     .into(),
                                     true,
                                 )
-                                .await;
+                                .await
+                                .expect("could not send complaint");
                             warn!(round, dealer, "sent complaint");
                         }
                         Err(e) => {

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -84,7 +84,7 @@ impl<C: Scheme> Contributor<C> {
         // Wait for start message from arbiter
         let (public, round) = loop {
             match receiver.recv().await {
-                Some((sender, msg)) => {
+                Ok((sender, msg)) => {
                     if sender != self.arbiter {
                         debug!("dropping messages until receive start message from arbiter");
                         continue;
@@ -114,8 +114,8 @@ impl<C: Scheme> Contributor<C> {
                     }
                     break (None, round);
                 }
-                None => {
-                    debug!("did not receive start message");
+                Err(err) => {
+                    debug!(?err, "did not receive start message");
                     continue;
                 }
             }
@@ -211,7 +211,7 @@ impl<C: Scheme> Contributor<C> {
         // Wait for other commitments
         loop {
             match receiver.recv().await {
-                Some((sender, msg)) => {
+                Ok((sender, msg)) => {
                     if sender != self.arbiter {
                         debug!("dropping messages until receive commitments from arbiter");
                         continue;
@@ -269,8 +269,8 @@ impl<C: Scheme> Contributor<C> {
                     }
                     break;
                 }
-                None => {
-                    debug!("did not receive commitments");
+                Err(err) => {
+                    debug!(?err, "did not receive commitments");
                     return (round, None);
                 }
             }
@@ -351,7 +351,7 @@ impl<C: Scheme> Contributor<C> {
         // Send acks to arbiter when receive shares from other contributors
         let dealers = loop {
             match receiver.recv().await {
-                Some((s, msg)) => {
+                Ok((s, msg)) => {
                     let msg = match wire::Dkg::decode(msg) {
                         Ok(msg) => msg,
                         Err(_) => {
@@ -559,8 +559,8 @@ impl<C: Scheme> Contributor<C> {
                         }
                     }
                 }
-                None => {
-                    debug!("did not receive shares");
+                Err(err) => {
+                    debug!(?err, "did not receive shares");
                     return (round, None);
                 }
             };

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -76,7 +76,8 @@ impl Vrf {
                 .into(),
                 true,
             )
-            .await;
+            .await
+            .expect("failed to send signature");
 
         // Wait for partial signatures from peers or timeout
         let start = tokio::time::Instant::now();

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -90,8 +90,8 @@ impl Vrf {
                     debug!(round, "signature timeout");
                     break;
                 }
-                msg = receiver.recv() => {
-                    if let Some((sender, msg)) = msg {
+                result = receiver.recv() => match result{
+                    Ok((sender, msg)) => {
                         let dealer = match self.ordered_contributors.get(&sender) {
                             Some(sender) => sender,
                             None => {
@@ -133,6 +133,10 @@ impl Vrf {
                                 warn!(round, dealer, "received invalid partial signature");
                             }
                         }
+                    },
+                    Err(err) => {
+                        warn!(round, ?err, "failed to receive signature");
+                        break;
                     }
                 }
             }

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -250,7 +250,7 @@ async fn main() {
             Quota::per_second(NonZeroU32::new(10).unwrap()),
             1024 * 1024, // 1 MB max message size
             256,         // 256 messages in flight
-            None,
+            Some(3),
         );
         let arbiter = insecure_signer(*arbiter).me();
         let (contributor, requests) = handlers::Contributor::new(
@@ -280,7 +280,7 @@ async fn main() {
             Quota::per_second(NonZeroU32::new(10).unwrap()),
             1024 * 1024, // 1 MB max message size
             256,         // 256 messages in flight
-            None,
+            Some(3),
         );
         let arbiter = handlers::Arbiter::new(
             Duration::from_secs(10),

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -250,6 +250,7 @@ async fn main() {
             Quota::per_second(NonZeroU32::new(10).unwrap()),
             1024 * 1024, // 1 MB max message size
             256,         // 256 messages in flight
+            None,
         );
         let arbiter = insecure_signer(*arbiter).me();
         let (contributor, requests) = handlers::Contributor::new(
@@ -269,6 +270,7 @@ async fn main() {
             Quota::per_second(NonZeroU32::new(10).unwrap()),
             1024 * 1024, // 1 MB max message size
             256,         // 256 messages in flight
+            None,
         );
         let signer = handlers::Vrf::new(Duration::from_secs(5), threshold, contributors, requests);
         tokio::spawn(signer.run(vrf_sender, vrf_receiver));
@@ -278,6 +280,7 @@ async fn main() {
             Quota::per_second(NonZeroU32::new(10).unwrap()),
             1024 * 1024, // 1 MB max message size
             256,         // 256 messages in flight
+            None,
         );
         let arbiter = handlers::Arbiter::new(
             Duration::from_secs(10),

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -26,6 +26,7 @@ prost = "0.12"
 tracing = "0.1"
 bitvec = "1"
 prometheus-client = "0.22"
+zstd = "0.13"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/p2p/src/channels.rs
+++ b/p2p/src/channels.rs
@@ -1,18 +1,16 @@
-use crate::actors::Messenger;
+use crate::{actors::Messenger, Error};
 use bytes::Bytes;
 use commonware_cryptography::PublicKey;
 use governor::Quota;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
+use zstd::bulk::{compress, decompress_to_buffer};
 
 /// Tuple representing a message received from a given public key.
 ///
 /// This message is guranteed to adhere to the configuration of the channel and
 /// will already be decrypted and authenticated.
 pub type Message = (PublicKey, Bytes);
-
-/// Channel to asynchronously receive messages from a channel.
-pub type Receiver = mpsc::Receiver<Message>;
 
 /// Enum indicating the set of recipients to send a message to.
 #[derive(Clone)]
@@ -27,12 +25,24 @@ pub enum Recipients {
 #[derive(Clone)]
 pub struct Sender {
     channel: u32,
+    max_size: usize,
+    compression: Option<u8>,
     messenger: Messenger,
 }
 
 impl Sender {
-    pub(super) fn new(channel: u32, messenger: Messenger) -> Self {
-        Self { channel, messenger }
+    pub(super) fn new(
+        channel: u32,
+        max_size: usize,
+        compression: Option<u8>,
+        messenger: Messenger,
+    ) -> Self {
+        Self {
+            channel,
+            max_size,
+            compression,
+            messenger,
+        }
     }
 
     /// Sends a message to a set of recipients.
@@ -51,18 +61,76 @@ impl Sender {
     ///
     /// # Returns
     ///
-    /// The set of recipients that the message was sent to. Note, a successful send does not
-    /// mean that the recipient will receive the message (connection may no longer be active and
-    /// we may not know that yet).
+    /// If the message can be compressed (if enabled) and the message is `< max_size`, The set of recipients
+    /// that the message was sent to. Note, a successful send does not mean that the recipient will
+    /// receive the message (connection may no longer be active and we may not know that yet).
     pub async fn send(
         &self,
         recipients: Recipients,
-        message: Bytes,
+        mut message: Bytes,
         priority: bool,
-    ) -> Vec<PublicKey> {
-        self.messenger
+    ) -> Result<Vec<PublicKey>, Error> {
+        // If compression is enabled, compress the message before sending.
+        if let Some(level) = self.compression {
+            let compressed =
+                compress(&message, level as i32).map_err(|_| Error::CompressionFailed)?;
+            message = compressed.into();
+        }
+
+        // Ensure message isn't too large
+        let message_len = message.len();
+        if message_len > self.max_size {
+            return Err(Error::MessageTooLarge(message_len));
+        }
+
+        // Wait for messenger to let us know who we sent to
+        Ok(self
+            .messenger
             .content(recipients, self.channel, message, priority)
+            .await)
+    }
+}
+
+/// Channel to asynchronously receive messages from a channel.
+pub struct Receiver {
+    max_size: usize,
+    compression: bool,
+    receiver: mpsc::Receiver<Message>,
+}
+
+impl Receiver {
+    pub(super) fn new(
+        max_size: usize,
+        compression: bool,
+        receiver: mpsc::Receiver<Message>,
+    ) -> Self {
+        Self {
+            max_size,
+            compression,
+            receiver,
+        }
+    }
+
+    /// Receives a message from the channel.
+    ///
+    /// This method will block until a message is received.
+    pub async fn recv(&mut self) -> Result<Message, Error> {
+        let (sender, mut message) = self
+            .receiver
+            .recv()
             .await
+            .ok_or_else(|| Error::NetworkClosed)?;
+
+        // If compression is enabled, decompress the message before returning.
+        if self.compression {
+            let mut buf = Vec::with_capacity(self.max_size);
+            decompress_to_buffer(&message, &mut buf).map_err(|_| Error::DecompressionFailed)?;
+            message = buf.into();
+        }
+
+        // We don't check that the message is too large here because we already enforce
+        // that on the network layer.
+        return Ok((sender, message));
     }
 }
 
@@ -86,6 +154,7 @@ impl Channels {
         rate: governor::Quota,
         max_size: usize,
         backlog: usize,
+        compression: Option<u8>,
     ) -> (Sender, Receiver) {
         let (sender, receiver) = mpsc::channel(backlog);
         if self
@@ -95,7 +164,10 @@ impl Channels {
         {
             panic!("duplicate channel registration: {}", channel);
         }
-        (Sender::new(channel, self.messenger.clone()), receiver)
+        (
+            Sender::new(channel, max_size, compression, self.messenger.clone()),
+            Receiver::new(max_size, compression.is_some(), receiver),
+        )
     }
 
     pub fn collect(self) -> HashMap<u32, (Quota, usize, mpsc::Sender<Message>)> {

--- a/p2p/src/channels.rs
+++ b/p2p/src/channels.rs
@@ -115,11 +115,7 @@ impl Receiver {
     ///
     /// This method will block until a message is received.
     pub async fn recv(&mut self) -> Result<Message, Error> {
-        let (sender, mut message) = self
-            .receiver
-            .recv()
-            .await
-            .ok_or_else(|| Error::NetworkClosed)?;
+        let (sender, mut message) = self.receiver.recv().await.ok_or(Error::NetworkClosed)?;
 
         // If compression is enabled, decompress the message before returning.
         if self.compression {
@@ -130,7 +126,7 @@ impl Receiver {
 
         // We don't check that the message is too large here because we already enforce
         // that on the network layer.
-        return Ok((sender, message));
+        Ok((sender, message))
     }
 }
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -150,6 +150,10 @@
 //! }  
 //! ```
 //!
+//! To minimize the number of chunks sent and to ensure each chunk is full (otherwise someone could send us a million chunks
+//! each 1 byte), content is compressed (if enabled) before chunking rather than after. As a result, the configuration
+//! chosen for frame size has no impact on compression efficiency.
+//!
 //! # Example
 //!
 //! ```rust

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -534,7 +534,8 @@ mod tests {
 
         // Send message
         let recipient = Recipients::One(addresses[1].clone());
-        sender.send(recipient, msg.into(), true).await.unwrap();
+        let result = sender.send(recipient, msg.into(), true).await;
+        assert!(matches!(result, Err(Error::MessageTooLarge(_))));
     }
 
     #[tokio::test]

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -431,12 +431,12 @@ mod tests {
             let network_handler = tokio::spawn(network.run());
 
             // Crate random message
-            let mut msg = vec![0u8; 4 * 1024 * 1024]; // 4MB (greater than frame capacity)
+            let mut msg = vec![0u8; 2 * 1024 * 1024]; // 2MB (greater than frame capacity)
             let mut rng = thread_rng();
             rng.fill(&mut msg[..]);
 
             // Send/Recieve messages
-            let msg = Bytes::from(msg.to_vec());
+            let msg = Bytes::from(msg);
             let msg_sender = addresses[0].clone();
             let msg_recipient = addresses[1].clone();
             let peer_handler = tokio::spawn(async move {
@@ -516,7 +516,7 @@ mod tests {
         oracle.register(0, addresses.clone()).await;
 
         // Register basic application
-        let (sender, mut receiver) = network.register(
+        let (sender, _) = network.register(
             0,
             Quota::per_second(NonZeroU32::new(10).unwrap()),
             1_024 * 1_024, // 1MB

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -389,6 +389,11 @@ mod tests {
         }
         let addresses = peers.iter().map(|p| p.me()).collect::<Vec<_>>();
 
+        // Create random message
+        let mut msg = vec![0u8; 2 * 1024 * 1024]; // 2MB (greater than frame capacity)
+        let mut rng = thread_rng();
+        rng.fill(&mut msg[..]);
+
         // Create networks
         let mut waiters = Vec::new();
         for (i, peer) in peers.iter().enumerate() {
@@ -430,13 +435,8 @@ mod tests {
             // Wait to connect to all peers, and then send messages to everyone
             let network_handler = tokio::spawn(network.run());
 
-            // Crate random message
-            let mut msg = vec![0u8; 2 * 1024 * 1024]; // 2MB (greater than frame capacity)
-            let mut rng = thread_rng();
-            rng.fill(&mut msg[..]);
-
             // Send/Recieve messages
-            let msg = Bytes::from(msg);
+            let msg = Bytes::from(msg.clone());
             let msg_sender = addresses[0].clone();
             let msg_recipient = addresses[1].clone();
             let peer_handler = tokio::spawn(async move {

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -463,7 +463,10 @@ mod tests {
                     assert_eq!(sender, msg_sender);
 
                     // Ensure message equals sent message
-                    assert_eq!(message, msg);
+                    assert_eq!(message.len(), msg.len());
+                    for (i, (&byte1, &byte2)) in message.iter().zip(msg.iter()).enumerate() {
+                        assert_eq!(byte1, byte2, "byte {} mismatch", i);
+                    }
                 }
 
                 // Shutdown network

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -200,7 +200,13 @@
 //!     oracle.register(0, vec![signer.me(), peer1, peer2, peer3]);
 //!
 //!     // Register some channel
-//!     let (sender, receiver) = network.register(0, Quota::per_second(NonZeroU32::new(1).unwrap()), 1024, 128);
+//!     let (sender, receiver) = network.register(
+//!         0,
+//!         Quota::per_second(NonZeroU32::new(1).unwrap()),
+//!         1024, // max message size
+//!         128, // max backlog
+//!         Some(3), // compression level
+//!     );
 //!
 //!     // Run network
 //!     let network_handler = tokio::spawn(network.run());

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -378,9 +378,8 @@ mod tests {
         test_connectivity(3100, 35).await; // 35 is greater than the max number of peers per response
     }
 
-    async fn test_chunking(compression: Option<u8>) {
+    async fn test_chunking(base_port: u16, compression: Option<u8>) {
         const N: usize = 2;
-        const BASE_PORT: u16 = 3200;
 
         // Create peers
         let mut peers = Vec::new();
@@ -398,14 +397,14 @@ mod tests {
         let mut waiters = Vec::new();
         for (i, peer) in peers.iter().enumerate() {
             // Derive port
-            let port = BASE_PORT + i as u16;
+            let port = base_port + i as u16;
 
             // Create bootstrappers
             let mut bootstrappers = Vec::new();
             if i > 0 {
                 bootstrappers.push((
                     addresses[0].clone(),
-                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), BASE_PORT),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port),
                 ));
             }
 
@@ -485,17 +484,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_chunking_no_compression() {
-        test_chunking(None).await;
+        test_chunking(3200, None).await;
     }
 
     #[tokio::test]
     async fn test_chunking_compression() {
-        test_chunking(Some(3)).await;
+        test_chunking(3300, Some(3)).await;
     }
 
-    async fn test_message_too_large(compression: Option<u8>) {
+    async fn test_message_too_large(base_port: u16, compression: Option<u8>) {
         const N: usize = 2;
-        const BASE_PORT: u16 = 3300;
 
         // Create peers
         let mut peers = Vec::new();
@@ -510,7 +508,7 @@ mod tests {
         let config = Config::test(
             signer.clone(),
             registry,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), BASE_PORT),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port),
             Vec::new(),
         );
         let (mut network, oracle) = Network::new(config);
@@ -543,11 +541,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_message_too_large_no_compression() {
-        test_message_too_large(None).await;
+        test_message_too_large(3400, None).await;
     }
 
     #[tokio::test]
     async fn test_message_too_large_compression() {
-        test_message_too_large(Some(3)).await;
+        test_message_too_large(3500, Some(3)).await;
     }
 }

--- a/p2p/src/network.rs
+++ b/p2p/src/network.rs
@@ -71,6 +71,7 @@ impl<C: Scheme> Network<C> {
     /// * `rate` - Rate at which messages can be received over the channel.
     /// * `max_size` - Maximum size of a message that can be sent/received over the channel.
     /// * `backlog` - Maximum number of messages that can be queued on the channel before blocking.
+    /// * `compression` - Optional compression level (using `zstd`) to use for messages on the channel.
     ///
     /// # Returns
     ///
@@ -82,8 +83,10 @@ impl<C: Scheme> Network<C> {
         rate: governor::Quota,
         max_size: usize,
         backlog: usize,
+        compression: Option<u8>,
     ) -> (channels::Sender, channels::Receiver) {
-        self.channels.register(channel, rate, max_size, backlog)
+        self.channels
+            .register(channel, rate, max_size, backlog, compression)
     }
 
     /// Starts the network.


### PR DESCRIPTION
## Changes
* Allow a channel to specify whether or not it should be compressed (using `zstd`)
* Return an error if send fails (because the message is too large)