### PR TITLE
[runtime] Support `join`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ version = "0.0.2"
 dependencies = [
  "futures",
  "rand",
+ "thiserror",
  "tokio",
  "tracing",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -15,3 +15,4 @@ futures = { workspace = true }
 rand = { workspace = true }
 tracing = { workspace = true } 
 tokio = { workspace = true, features = ["full"] }
+thiserror = { workspace = true }

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,8 +1,8 @@
 # commonware-runtime
 
-[![Crates.io](https://img.shields.io/crates/v/commonware-executor.svg)](https://crates.io/crates/commonware-executor)
+[![Crates.io](https://img.shields.io/crates/v/commonware-runtime.svg)](https://crates.io/crates/commonware-runtime)
 
-TBD
+TODO: Execute asynchronous code with a compile-time scheduling configuration.
 
 ## Status 
 

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -354,7 +354,7 @@ mod tests {
     use crate::utils::run_tasks;
     use futures::task::noop_waker;
 
-    fn run_with_seed(seed: u64) -> Vec<String> {
+    fn run_with_seed(seed: u64) -> Vec<usize> {
         let (runner, context) = Executor::init(seed, Duration::from_millis(1));
         run_tasks(30, runner, context)
     }

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -4,18 +4,15 @@
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, deterministic::Executor};
 //! use std::time::Duration;
-//! use tokio::sync::oneshot;
 //!
 //! let (runner, context) = Executor::init(42, Duration::from_millis(1));
 //! runner.start(async move {
 //!     println!("Parent started");
-//!     let (sender, mut receiver) = oneshot::channel();
-//!     context.spawn(async move {
+//!     let result = context.spawn(async move {
 //!         println!("Child started");
-//!         sender.send(()).unwrap();
-//!         println!("Child exited");
+//!         "hello"
 //!     });
-//!     receiver.await.unwrap();
+//!     println!("Child result: {:?}", result.await);
 //!     println!("Parent exited");
 //! });
 //! ```

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -19,8 +19,7 @@
 
 use crate::Handle;
 use futures::task::{waker_ref, ArcWake};
-use rand::prelude::SliceRandom;
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{prelude::SliceRandom, rngs::StdRng, RngCore, SeedableRng};
 use std::{
     collections::BinaryHeap,
     future::Future,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -43,11 +43,9 @@ pub trait Clock: Clone + Send + 'static {
 
 #[cfg(test)]
 mod tests {
-    use std::panic::{catch_unwind, AssertUnwindSafe};
-
-    use utils::reschedule;
-
     use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use utils::reschedule;
 
     fn test_error_future(runner: impl Runner) {
         async fn error_future() -> Result<&'static str, &'static str> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -80,7 +80,7 @@ mod tests {
         });
     }
 
-    fn test_root_aborts(runner: impl Runner, context: impl Spawner) {
+    fn test_root_finishes(runner: impl Runner, context: impl Spawner) {
         runner.start(async move {
             context.spawn(async move {
                 loop {
@@ -129,7 +129,7 @@ mod tests {
         }
         {
             let (runner, context) = deterministic::Executor::init(1, Duration::from_millis(1));
-            test_root_aborts(runner, context);
+            test_root_finishes(runner, context);
         }
         {
             let (runner, _) = deterministic::Executor::init(1, Duration::from_millis(1));
@@ -157,7 +157,7 @@ mod tests {
         }
         {
             let (runner, context) = tokio::Executor::init(1);
-            test_root_aborts(runner, context);
+            test_root_finishes(runner, context);
         }
         {
             let (runner, _) = tokio::Executor::init(1);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -29,6 +29,8 @@ pub trait Runner {
 }
 
 pub trait Spawner: Clone + Send + 'static {
+    /// Unlike a future, a spawned task will start executing immediately (even if the caller
+    /// does not await the handle).
     fn spawn<F, T>(&self, f: F) -> Handle<T>
     where
         F: Future<Output = T> + Send + 'static,

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -19,6 +19,7 @@
 //! });
 //! ```
 
+use crate::Handle;
 use rand::{rngs::OsRng, RngCore};
 use std::{
     future::Future,
@@ -68,11 +69,14 @@ pub struct Context {
 }
 
 impl crate::Spawner for Context {
-    fn spawn<F>(&self, f: F)
+    fn spawn<F, T>(&self, f: F) -> Handle<T>
     where
-        F: Future<Output = ()> + Send + 'static,
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
     {
+        let (f, handle) = Handle::init(f);
         self.executor.runtime.spawn(f);
+        handle
     }
 }
 

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -3,18 +3,15 @@
 //! # Example
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, tokio::Executor};
-//! use tokio::sync::oneshot;
 //!
 //! let (runner, context) = Executor::init(2);
 //! runner.start(async move {
 //!     println!("Parent started");
-//!     let (sender, mut receiver) = oneshot::channel();
-//!     context.spawn(async move {
+//!     let result = context.spawn(async move {
 //!         println!("Child started");
-//!         sender.send(()).unwrap();
-//!         println!("Child exited");
+//!         "hello"
 //!     });
-//!     receiver.await.unwrap();
+//!     println!("Child result: {:?}", result.await);
 //!     println!("Parent exited");
 //! });
 //! ```

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -3,10 +3,9 @@
 use crate::Error;
 #[cfg(test)]
 use crate::{Runner, Spawner};
-use futures::channel::oneshot;
 #[cfg(test)]
 use futures::stream::{FuturesUnordered, StreamExt};
-use futures::FutureExt;
+use futures::{channel::oneshot, FutureExt};
 use std::{
     future::Future,
     panic::AssertUnwindSafe,

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -3,6 +3,8 @@
 use crate::Error;
 #[cfg(test)]
 use crate::{Runner, Spawner};
+#[cfg(test)]
+use futures::stream::{FuturesUnordered, StreamExt};
 use futures::FutureExt;
 use std::{
     future::Future,
@@ -10,8 +12,6 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-#[cfg(test)]
-use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
 /// Yield control back to the runtime.
@@ -73,28 +73,41 @@ where
     }
 }
 
-#[cfg(test)]
-async fn task(name: String, messages: mpsc::UnboundedSender<String>) {
-    for _ in 0..5 {
-        reschedule().await;
+impl<T> Future for Handle<T>
+where
+    T: Send + 'static,
+{
+    type Output = Result<T, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.receiver)
+            .poll(cx)
+            .map(|res| res.map_err(|_| Error::Closed).and_then(|r| r))
     }
-    messages.send(name).unwrap();
 }
 
 #[cfg(test)]
-pub fn run_tasks(tasks: usize, runner: impl Runner, context: impl Spawner) -> Vec<String> {
+async fn task(i: usize) -> usize {
+    for _ in 0..5 {
+        reschedule().await;
+    }
+    i
+}
+
+#[cfg(test)]
+pub fn run_tasks(tasks: usize, runner: impl Runner, context: impl Spawner) -> Vec<usize> {
     runner.start(async move {
         // Randomly schedule tasks
-        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let mut handles = FuturesUnordered::new();
         for i in 0..tasks - 1 {
-            context.spawn(task(format!("Task {}", i), sender.clone()));
+            handles.push(context.spawn(task(i)));
         }
-        context.spawn(task(format!("Task {}", tasks - 1), sender));
+        handles.push(context.spawn(task(tasks - 1)));
 
         // Collect output order
         let mut outputs = Vec::new();
-        while let Some(message) = receiver.recv().await {
-            outputs.push(message);
+        while let Some(result) = handles.next().await {
+            outputs.push(result.unwrap());
         }
         assert_eq!(outputs.len(), tasks);
         outputs

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -3,6 +3,7 @@
 use crate::Error;
 #[cfg(test)]
 use crate::{Runner, Spawner};
+use futures::channel::oneshot;
 #[cfg(test)]
 use futures::stream::{FuturesUnordered, StreamExt};
 use futures::FutureExt;
@@ -12,7 +13,6 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::sync::oneshot;
 
 /// Yield control back to the runtime.
 pub async fn reschedule() {


### PR DESCRIPTION
To support integration with `p2p::authenticated`, we must return `Handle` from `Spawner::spawn`.