### PR TITLE
[p2p] Restore handshake timeout functionality

### DIFF
--- a/p2p/src/authenticated/actors/listener.rs
+++ b/p2p/src/authenticated/actors/listener.rs
@@ -104,6 +104,7 @@ impl<
             &connection.crypto,
             connection.synchrony_bound,
             connection.max_handshake_age,
+            connection.handshake_timeout,
             sink,
             stream,
         )

--- a/p2p/src/authenticated/config.rs
+++ b/p2p/src/authenticated/config.rs
@@ -55,6 +55,12 @@ pub struct Config<C: Scheme> {
     /// Duration after which a handshake message is considered stale.
     pub max_handshake_age: Duration,
 
+    /// Timeout for the handshake process.
+    ///
+    /// This is often set to some value less than the connection read timeout to prevent
+    /// unauthenticated peers from holding open connection.
+    pub handshake_timeout: Duration,
+
     /// Quota for connection attempts per peer (incoming or outgoing).
     pub allowed_connection_rate_per_peer: Quota,
 
@@ -117,6 +123,7 @@ impl<C: Scheme> Config<C> {
             mailbox_size: 1_000,
             synchrony_bound: Duration::from_secs(5),
             max_handshake_age: Duration::from_secs(10),
+            handshake_timeout: Duration::from_secs(5),
             allowed_connection_rate_per_peer: Quota::per_minute(NonZeroU32::new(1).unwrap()),
             allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(256).unwrap()),
             dial_frequency: Duration::from_secs(60),
@@ -153,6 +160,7 @@ impl<C: Scheme> Config<C> {
             mailbox_size: 1_000,
             synchrony_bound: Duration::from_secs(5),
             max_handshake_age: Duration::from_secs(10),
+            handshake_timeout: Duration::from_secs(5),
             allowed_connection_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
             allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(256).unwrap()),
             dial_frequency: Duration::from_secs(5),
@@ -185,6 +193,7 @@ impl<C: Scheme> Config<C> {
             mailbox_size: 1_000,
             synchrony_bound: Duration::from_secs(5),
             max_handshake_age: Duration::from_secs(10),
+            handshake_timeout: Duration::from_secs(5),
             allowed_connection_rate_per_peer: Quota::per_second(NonZeroU32::new(1_024).unwrap()),
             allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(1_024).unwrap()),
             dial_frequency: Duration::from_secs(1),

--- a/p2p/src/authenticated/connection/handshake.rs
+++ b/p2p/src/authenticated/connection/handshake.rs
@@ -328,7 +328,7 @@ mod tests {
             .await;
 
             // Assert that the result is an error
-            assert!(result.is_err());
+            assert!(matches!(result, Err(Error::UnableToDecode(_))));
         });
     }
 

--- a/p2p/src/authenticated/connection/mod.rs
+++ b/p2p/src/authenticated/connection/mod.rs
@@ -19,6 +19,7 @@ pub struct Config<C: Scheme> {
     pub max_message_size: usize,
     pub synchrony_bound: Duration,
     pub max_handshake_age: Duration,
+    pub handshake_timeout: Duration,
 }
 
 #[derive(Error, Debug)]
@@ -35,6 +36,8 @@ pub enum Error {
     InvalidPeerPublicKey,
     #[error("handshake not for us")]
     HandshakeNotForUs,
+    #[error("handshake timeout")]
+    HandshakeTimeout,
     #[error("missing signature")]
     MissingSignature,
     #[error("invalid signature")]

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -152,6 +152,7 @@ impl<
             max_message_size: self.cfg.max_message_size,
             synchrony_bound: self.cfg.synchrony_bound,
             max_handshake_age: self.cfg.max_handshake_age,
+            handshake_timeout: self.cfg.handshake_timeout,
         };
         let listener = listener::Actor::new(
             self.context.clone(),


### PR DESCRIPTION
Terminate a connection prior to read/write timeout based on `handshake_timeout`.