### PR TITLE
[CI] Migrate to cargo-llvm-cov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  TARPAULIN_VERSION: 0.31.2
 
 jobs:
   All:
@@ -28,20 +27,13 @@ jobs:
     - name: Remove examples from Cargo.toml
       run: |
         sed -i.bak '/examples/d' Cargo.toml
-    - name: Cache cargo-tarpaulin
-      id: cargo-tarpaulin-cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/bin/cargo-tarpaulin
-        key: ${{ runner.os }}-${{ env.TARPAULIN_VERSION }}-cargo-tarpaulin-${{ steps.rust-version.outputs.rust_version }}
-    - name: Install cargo-tarpaulin
-      if: steps.cargo-tarpaulin-cache.outputs.cache-hit != 'true'
-      run: cargo install cargo-tarpaulin --version ${{ env.TARPAULIN_VERSION }}
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate coverage report
-      run: cargo tarpaulin --timeout 600 --out Xml
+      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
-        file: ./cobertura.xml
+        files: lcov.info
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
`cargo-tarpaulin` incorrectly attributes coverage in a number of different cases: https://github.com/xd009642/tarpaulin/issues/351