### PR TITLE
[runtime] Add support for `Storage` and `Blob`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,10 @@ jobs:
         rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Lint with clippy
       run: cargo clippy -- -D warnings
+    - name: Check docs
+      run: cargo doc --no-deps --document-private-items
+      env:
+        RUSTDOCFLAGS: "-D warnings"
     - name: Run tests
       run: cargo test --verbose
   

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -62,7 +62,7 @@ pub struct Link {
     /// Standard deviation of the latency for the delivery of a message in milliseconds.
     pub jitter: f64,
 
-    /// Probability of a message being delivered successfully (in range [0,1]).
+    /// Probability of a message being delivered successfully (in range \[0,1\]).
     pub success_rate: f64,
 }
 

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -666,8 +666,9 @@ impl crate::Runner for Runner {
     }
 }
 
-/// Implementation of [`crate::Spawner`] and [`crate::Clock`]
-/// for the `deterministic` runtime.
+/// Implementation of [`crate::Spawner`], [`crate::Clock`],
+/// [`crate::Network`], and [`crate::Storage`] for the `deterministic`
+/// runtime.
 #[derive(Clone)]
 pub struct Context {
     executor: Arc<Executor>,
@@ -910,6 +911,7 @@ impl crate::Network<Listener, Sink, Stream> for Context {
     }
 }
 
+/// Implementation of [`crate::Listener`] for the `deterministic` runtime.
 pub struct Listener {
     metrics: Arc<Metrics>,
     auditor: Arc<Auditor>,
@@ -944,6 +946,7 @@ impl crate::Listener<Sink, Stream> for Listener {
     }
 }
 
+/// Implementation of [`crate::Sink`] for the `deterministic` runtime.
 pub struct Sink {
     metrics: Arc<Metrics>,
     auditor: Arc<Auditor>,
@@ -965,6 +968,7 @@ impl crate::Sink for Sink {
     }
 }
 
+/// Implementation of [`crate::Stream`] for the `deterministic` runtime.
 pub struct Stream {
     auditor: Arc<Auditor>,
     me: SocketAddr,
@@ -1016,6 +1020,7 @@ impl Partition {
     }
 }
 
+/// Implementation of [`crate::Blob`] for the `deterministic` runtime.
 pub struct Blob {
     executor: Arc<Executor>,
 

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -38,7 +38,7 @@ use prometheus_client::{
 use rand::{prelude::SliceRandom, rngs::StdRng, CryptoRng, RngCore, SeedableRng};
 use sha2::{Digest, Sha256};
 use std::{
-    collections::{hash_map::Entry, BinaryHeap, HashMap},
+    collections::{hash_map::Entry, BTreeMap, BinaryHeap, HashMap},
     future::Future,
     mem::replace,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -403,7 +403,7 @@ pub struct Executor {
     time: Mutex<SystemTime>,
     tasks: Arc<Tasks>,
     sleeping: Mutex<BinaryHeap<Alarm>>,
-    files: Mutex<HashMap<String, File>>,
+    files: Mutex<File>,
 }
 
 impl Executor {
@@ -1002,7 +1002,7 @@ impl CryptoRng for Context {}
 
 enum Content {
     Bytes(Vec<u8>),
-    Directory(HashMap<String, File>),
+    Directory(BTreeMap<String, File>),
 }
 
 pub struct File {

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -990,7 +990,6 @@ impl RngCore for Context {
 
 impl CryptoRng for Context {}
 
-#[derive(Clone)]
 pub struct File {
     executor: Arc<Executor>,
     path: String,
@@ -1064,7 +1063,7 @@ impl crate::File for File {
         Ok(to_read)
     }
 
-    async fn write_at(&mut self, buf: &[u8], offset: u64) -> Result<usize, Error> {
+    async fn write_at(&mut self, buf: &[u8], offset: u64) -> Result<(), Error> {
         let len = buf.len();
         self.executor.auditor.write_at(&self.path, offset, len);
         if self.permissions.readonly() {
@@ -1080,7 +1079,7 @@ impl crate::File for File {
             .metrics
             .disk_write_bandwidth
             .inc_by(len as u64);
-        Ok(len)
+        Ok(())
     }
 
     async fn sync(&mut self) -> Result<(), Error> {

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -40,7 +40,6 @@ use sha2::{Digest, Sha256};
 use std::{
     collections::{BinaryHeap, HashMap},
     future::Future,
-    hash::Hash,
     mem::replace,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     ops::Range,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -46,14 +46,16 @@ pub enum Error {
     PartitionCreationFailed(String),
     #[error("partition missing: {0}")]
     PartitionMissing(String),
+    #[error("partition corrupt: {0}")]
+    PartitionCorrupt(String),
     #[error("blob open failed: {0}/{1}")]
     BlobOpenFailed(String, String),
     #[error("blob missing: {0}/{1}")]
     BlobMissing(String, String),
-    #[error("blob sync failed")]
-    BlobSyncFailed,
-    #[error("blob close failed")]
-    BlobCloseFailed,
+    #[error("blob sync failed: {0}/{1}")]
+    BlobSyncFailed(String, String),
+    #[error("blob close failed: {0}/{1}")]
+    BlobCloseFailed(String, String),
 }
 
 /// Interface that any task scheduler must implement to start

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -140,17 +140,23 @@ pub trait Filesystem<F>: Clone + Send + Sync + 'static
 where
     F: File,
 {
-    /// Create a new file (error if already exists).
-    fn create(&self, path: &str, permissions: u32)
-        -> impl Future<Output = Result<F, Error>> + Send;
+    /// Create a new directory and any parent directories along the way (error if already exists).
+    fn create_dir(&self, path: &str) -> impl Future<Output = Result<(), Error>> + Send;
 
-    /// Open an existing file.
-    fn open(&self, path: &str) -> impl Future<Output = Result<F, Error>> + Send;
+    /// Remove a directory.
+    fn remove_dir(&self, path: &str) -> impl Future<Output = Result<(), Error>> + Send;
+
+    /// Read the contents of a directory.
+    fn read_dir(&self, path: &str) -> impl Future<Output = Result<Vec<String>, Error>> + Send;
+
+    /// Create a new file for reading and writing (error if already exists).
+    fn create_file(&self, path: &str) -> impl Future<Output = Result<F, Error>> + Send;
+
+    /// Open an existing file for reading and writing.
+    fn open_file(&self, path: &str) -> impl Future<Output = Result<F, Error>> + Send;
 
     /// Remove a file.
-    fn remove(&self, path: &str) -> impl Future<Output = Result<(), Error>> + Send;
-
-    // TODO: add directory operations (mkdir, rmdir, readdir)
+    fn remove_file(&self, path: &str) -> impl Future<Output = Result<(), Error>> + Send;
 }
 
 /// Interface to read and write to a file.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -48,6 +48,8 @@ pub enum Error {
     FileNotFound(String),
     #[error("permission denied")]
     PermissionDenied,
+    #[error("file operation failed")]
+    FileOpFailed,
 }
 
 /// Interface that any task scheduler must implement to start
@@ -168,7 +170,7 @@ pub trait File: Send + Sync + 'static {
         &mut self,
         buf: &[u8],
         offset: u64,
-    ) -> impl Future<Output = Result<usize, Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Sync the file to disk.
     fn sync(&mut self) -> impl Future<Output = Result<(), Error>> + Send;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -150,17 +150,25 @@ pub trait Storage<B>: Clone + Send + Sync + 'static
 where
     B: Blob,
 {
-    fn partition(&self, namespace: &str) -> impl Future<Output = Result<Self, Error>> + Send;
+    /// Open an existing blob in a given partition or create a new one.
+    fn open(
+        &mut self,
+        partition: &str,
+        name: &str,
+    ) -> impl Future<Output = Result<B, Error>> + Send;
 
-    fn open(&mut self, name: &str) -> impl Future<Output = Result<B, Error>> + Send;
+    /// Remove a blob from a given partition.
+    fn remove(
+        &mut self,
+        partition: &str,
+        name: &str,
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
-    fn remove(&mut self, name: &str) -> impl Future<Output = Result<(), Error>> + Send;
-
-    /// Read the contents of a directory.
-    fn scan(&self) -> impl Future<Output = Result<Vec<String>, Error>> + Send;
+    /// Read the contents of a partition.
+    fn scan(&self, partition: &str) -> impl Future<Output = Result<Vec<String>, Error>> + Send;
 }
 
-/// Interface to read and write to a file.
+/// Interface to read and write to a blob.
 pub trait Blob: Send + Sync + 'static {
     /// Get the length of the blob.
     fn len(&self) -> impl Future<Output = Result<u64, Error>> + Send;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -140,7 +140,7 @@ pub trait Filesystem<F>: Clone + Send + Sync + 'static
 where
     F: File,
 {
-    /// Create a new directory and any parent directories along the way (error if already exists).
+    /// Create a new directory with default permissions (0o666) and any parent directories along the way (error if already exists).
     fn create_dir(&self, path: &str) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Remove a directory.
@@ -149,7 +149,7 @@ where
     /// Read the contents of a directory.
     fn read_dir(&self, path: &str) -> impl Future<Output = Result<Vec<String>, Error>> + Send;
 
-    /// Create a new file for reading and writing (error if already exists).
+    /// Create a new file with default permissions (0o666) for reading and writing (error if already exists).
     fn create_file(&self, path: &str) -> impl Future<Output = Result<F, Error>> + Send;
 
     /// Open an existing file for reading and writing.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -127,6 +127,45 @@ pub trait Stream: Sync + Send + 'static {
     fn recv(&mut self) -> impl Future<Output = Result<Bytes, Error>> + Send;
 }
 
+/// Interface to interact with the filesystem.
+pub trait Filesystem<F>: Clone + Send + Sync + 'static
+where
+    F: File,
+{
+    /// Create a new file (error if already exists).
+    fn create(&self, path: &str, permissions: u32)
+        -> impl Future<Output = Result<F, Error>> + Send;
+
+    /// Open an existing file.
+    fn open(&self, path: &str) -> impl Future<Output = Result<F, Error>> + Send;
+
+    /// Remove a file.
+    fn remove(&self, path: &str) -> impl Future<Output = Result<(), Error>> + Send;
+}
+
+/// Interface to read and write to a file.
+pub trait File: Send + Sync + 'static {
+    /// Read from the file at the given offset.
+    fn read_at(
+        &self,
+        offset: u64,
+        buf: &mut [u8],
+    ) -> impl Future<Output = Result<usize, Error>> + Send;
+
+    /// Write to the file at the given offset.
+    fn write_at(
+        &mut self,
+        offset: u64,
+        buf: &[u8],
+    ) -> impl Future<Output = Result<usize, Error>> + Send;
+
+    /// Sync the file to disk.
+    fn sync(&mut self) -> impl Future<Output = Result<(), Error>> + Send;
+
+    /// Close the file.
+    fn close(&mut self) -> impl Future<Output = Result<(), Error>> + Send;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -42,10 +42,18 @@ pub enum Error {
     WriteFailed,
     #[error("read failed")]
     ReadFailed,
+    #[error("partition creation failed: {0}")]
+    PartitionCreationFailed(String),
     #[error("partition missing: {0}")]
     PartitionMissing(String),
+    #[error("blob open failed: {0}/{1}")]
+    BlobOpenFailed(String, String),
     #[error("blob missing: {0}/{1}")]
     BlobMissing(String, String),
+    #[error("blob sync failed")]
+    BlobSyncFailed,
+    #[error("blob close failed")]
+    BlobCloseFailed,
 }
 
 /// Interface that any task scheduler must implement to start
@@ -152,11 +160,12 @@ where
         name: Option<&str>,
     ) -> impl Future<Output = Result<(), Error>> + Send;
 
-    /// Read the contents of a partition.
+    /// Return all blobs in a given partition.
     fn scan(&self, partition: &str) -> impl Future<Output = Result<Vec<String>, Error>> + Send;
 }
 
 /// Interface to read and write to a blob.
+#[allow(clippy::len_without_is_empty)]
 pub trait Blob: Send + Sync + 'static {
     /// Get the length of the blob.
     fn len(&self) -> impl Future<Output = Result<usize, Error>> + Send;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -468,7 +468,7 @@ mod tests {
         B: Blob,
     {
         runner.start(async move {
-            let partitions = vec!["partition1", "partition2", "partition3"];
+            let partitions = ["partition1", "partition2", "partition3"];
             let name = "test_blob_rw";
 
             for (additional, partition) in partitions.iter().enumerate() {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -147,6 +147,9 @@ where
     B: Blob,
 {
     /// Open an existing blob in a given partition or create a new one.
+    ///
+    /// Multiple instances of the same blob can be opened concurrently, however,
+    /// writing to the same blob concurrently may lead to undefined behavior.
     fn open(
         &mut self,
         partition: &str,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -141,8 +141,6 @@ where
     F: File,
 {
     /// Create a new file (error if already exists).
-    ///
-    /// Any missing parent directories will be created.
     fn create(&self, path: &str, permissions: u32)
         -> impl Future<Output = Result<F, Error>> + Send;
 
@@ -151,6 +149,8 @@ where
 
     /// Remove a file.
     fn remove(&self, path: &str) -> impl Future<Output = Result<(), Error>> + Send;
+
+    // TODO: add directory operations (mkdir, rmdir, readdir)
 }
 
 /// Interface to read and write to a file.

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -38,7 +38,6 @@ use prometheus_client::{
 use rand::{rngs::OsRng, CryptoRng, RngCore};
 use std::{
     future::Future,
-    io::SeekFrom,
     net::SocketAddr,
     sync::{Arc, Mutex},
     time::{Duration, SystemTime},

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -205,6 +205,11 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
+        // Generate a random directory name to avoid conflicts (used in tests, so we shouldn't need to reload)
+        let rng = OsRng.next_u64();
+        let storage_directory = env::temp_dir().join(format!("commonware_tokio_runtime_{}", rng));
+
+        // Return the configuration
         Self {
             registry: Arc::new(Mutex::new(Registry::default())),
             threads: 2,
@@ -213,7 +218,7 @@ impl Default for Config {
             read_timeout: Duration::from_secs(60),
             write_timeout: Duration::from_secs(30),
             tcp_nodelay: None,
-            storage_directory: env::temp_dir().join("commonware_tokio_runtime"),
+            storage_directory,
         }
     }
 }

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -38,11 +38,14 @@ use prometheus_client::{
 use rand::{rngs::OsRng, CryptoRng, RngCore};
 use std::{
     future::Future,
+    io::SeekFrom,
     net::SocketAddr,
     sync::{Arc, Mutex},
     time::{Duration, SystemTime},
 };
 use tokio::{
+    fs::{File as TFile, OpenOptions},
+    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
     runtime::{Builder, Runtime},
     task_local,
@@ -432,6 +435,63 @@ impl RngCore for Context {
 }
 
 impl CryptoRng for Context {}
+
+pub struct File {
+    file: TFile,
+}
+
+impl crate::Filesystem for Context {
+    async fn create(&self, path: &str, permissions: u32) -> Result<File, Error> {
+        let mut options = OpenOptions::new();
+        options.mode(permissions);
+        let file = options
+            .open(path)
+            .await
+            .map_err(|_| Error::FileOpenFailed)?;
+        Ok(File { file })
+    }
+
+    async fn open(&self, path: &str) -> Result<File, Error> {}
+
+    async fn remove(&self, path: &str) -> Result<(), Error> {}
+}
+
+impl crate::File for File {
+    async fn len(&self) -> Result<u64, Error> {
+        self.file
+            .metadata()
+            .await
+            .map(|metadata| metadata.len())
+            .map_err(|_| Error::FileOpFailed)
+    }
+
+    async fn read_at(&mut self, buf: &mut [u8], offset: u64) -> Result<usize, Error> {
+        self.file
+            .seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|_| Error::FileOpFailed)?;
+        self.file.read(buf).await.map_err(|_| Error::FileOpFailed)
+    }
+
+    async fn write_at(&mut self, buf: &[u8], offset: u64) -> Result<(), Error> {
+        self.file
+            .seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|_| Error::FileOpFailed)?;
+        self.file
+            .write_all(buf)
+            .await
+            .map_err(|_| Error::FileOpFailed)
+    }
+
+    async fn sync(&mut self) -> Result<(), Error> {
+        self.file.sync_all().await.map_err(|_| Error::FileOpFailed)
+    }
+
+    async fn close(&mut self) -> Result<(), Error> {
+        self.file.shutdown().await.map_err(|_| Error::FileOpFailed)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -73,7 +73,7 @@ struct Metrics {
     inbound_bandwidth: Counter,
     outbound_bandwidth: Counter,
 
-    open_files: Gauge,
+    open_blobs: Gauge,
     storage_reads: Counter,
     storage_read_bytes: Counter,
     storage_writes: Counter,
@@ -89,7 +89,7 @@ impl Metrics {
             outbound_connections: Counter::default(),
             inbound_bandwidth: Counter::default(),
             outbound_bandwidth: Counter::default(),
-            open_files: Gauge::default(),
+            open_blobs: Gauge::default(),
             storage_reads: Counter::default(),
             storage_read_bytes: Counter::default(),
             storage_writes: Counter::default(),
@@ -128,9 +128,9 @@ impl Metrics {
                 metrics.outbound_bandwidth.clone(),
             );
             registry.register(
-                "open_files",
-                "Number of open files",
-                metrics.open_files.clone(),
+                "open_blobs",
+                "Number of open blobs",
+                metrics.open_blobs.clone(),
             );
             registry.register(
                 "storage_reads",
@@ -508,7 +508,7 @@ impl crate::Storage<Blob> for Context {
             .await
             .map_err(|_| Error::BlobOpenFailed(partition.into(), name.into()))?;
 
-        self.executor.metrics.open_files.inc();
+        self.executor.metrics.open_blobs.inc();
         Ok(Blob {
             file,
             metrics: self.executor.metrics.clone(),
@@ -603,7 +603,7 @@ impl crate::Blob for Blob {
 
 impl Drop for Blob {
     fn drop(&mut self) {
-        self.metrics.open_files.dec();
+        self.metrics.open_blobs.dec();
     }
 }
 

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -275,8 +275,9 @@ impl crate::Runner for Runner {
     }
 }
 
-/// Implementation of [`crate::Spawner`] and [`crate::Clock`]
-/// for the `tokio` runtime.
+/// Implementation of [`crate::Spawner`], [`crate::Clock`],
+/// [`crate::Network`], and [`crate::Storage`] for the `tokio`
+/// runtime.
 #[derive(Clone)]
 pub struct Context {
     executor: Arc<Executor>,
@@ -390,6 +391,7 @@ impl crate::Network<Listener, Sink, Stream> for Context {
     }
 }
 
+/// Implementation of [`crate::Listener`] for the `tokio` runtime.
 pub struct Listener {
     context: Context,
     listener: TcpListener,
@@ -421,6 +423,7 @@ impl crate::Listener<Sink, Stream> for Listener {
     }
 }
 
+/// Implementation of [`crate::Sink`] for the `tokio` runtime.
 pub struct Sink {
     context: Context,
     sink: SplitSink<Framed<TcpStream, LengthDelimitedCodec>, Bytes>,
@@ -442,6 +445,7 @@ impl crate::Sink for Sink {
     }
 }
 
+/// Implementation of [`crate::Stream`] for the `tokio` runtime.
 pub struct Stream {
     context: Context,
     stream: SplitStream<Framed<TcpStream, LengthDelimitedCodec>>,
@@ -483,6 +487,7 @@ impl RngCore for Context {
 
 impl CryptoRng for Context {}
 
+/// Implementation of [`crate::Blob`] for the `tokio` runtime.
 pub struct Blob {
     metrics: Arc<Metrics>,
 


### PR DESCRIPTION
Make it possible for runtimes to provide access to persistent storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced blob storage management with new methods for opening, removing, scanning, and manipulating blobs.
	- Introduced a new `Blob` struct for file operations and metrics tracking.
	- Added detailed metrics for storage operations including reads and writes.

- **Documentation**
	- Updated documentation to reflect new storage capabilities and metrics tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->