### PR TITLE
[storage/journal] Implement skip reads

### DIFF
--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -22,6 +22,8 @@ pub enum Error {
     DuplicateKey,
     #[error("already pruned to section: {0}")]
     AlreadyPrunedToSection(u64),
+    #[error("invalid key length")]
+    InvalidKeyLength,
 }
 
 pub trait Translator: Clone {
@@ -35,6 +37,13 @@ pub trait Translator: Clone {
 pub struct Config<T: Translator> {
     /// Registry for metrics.
     pub registry: Arc<Mutex<Registry>>,
+
+    /// Length of each key in bytes.
+    ///
+    /// The `Archive` assumes that all keys are of the same length. This
+    /// trick is used to store data more efficiently on disk and to substantially
+    /// reduce the number of disk reads during initialization.
+    pub key_len: usize,
 
     /// Logic to transform keys into their index representation.
     ///

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -94,6 +94,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 registry,
+                key_len: 8,
                 translator: FourCap,
                 pending_writes: 10,
             };
@@ -102,7 +103,7 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let section = 1u64;
-            let key = b"testkey";
+            let key = b"testkeyy";
             let data = Bytes::from("testdata");
 
             // Put the key-data pair
@@ -150,6 +151,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 registry,
+                key_len: 8,
                 translator: FourCap,
                 pending_writes: 10,
             };
@@ -211,6 +213,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 registry,
+                key_len: 8,
                 translator: FourCap,
                 pending_writes: 10,
             };
@@ -254,6 +257,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 registry,
+                key_len: 8,
                 translator: FourCap,
                 pending_writes: 10,
             };
@@ -326,6 +330,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 registry,
+                key_len: 8,
                 translator: FourCap,
                 pending_writes: 10,
             };
@@ -392,6 +397,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 registry: registry.clone(),
+                key_len: 8,
                 translator: FourCap,
                 pending_writes: 10,
             };
@@ -490,6 +496,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 registry: registry.clone(),
+                key_len: 8,
                 translator: TwoCap,
                 pending_writes: 10,
             };

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -55,6 +55,9 @@ pub struct Config<T: Translator> {
     ///
     /// If set to 0, the journal will be synced each time a new item is stored.
     pub pending_writes: usize,
+
+    /// The number of blobs to replay concurrently.
+    pub replay_concurrency: usize,
 }
 
 #[cfg(test)]
@@ -97,6 +100,7 @@ mod tests {
                 key_len: 7,
                 translator: FourCap,
                 pending_writes: 10,
+                replay_concurrency: 4,
             };
             let mut archive = Archive::init(journal, cfg.clone())
                 .await
@@ -154,6 +158,7 @@ mod tests {
                 key_len: 8,
                 translator: FourCap,
                 pending_writes: 10,
+                replay_concurrency: 4,
             };
             let mut archive = Archive::init(journal, cfg.clone())
                 .await
@@ -205,6 +210,7 @@ mod tests {
                 key_len: 9,
                 translator: FourCap,
                 pending_writes: 10,
+                replay_concurrency: 4,
             };
             let mut archive = Archive::init(journal, cfg.clone())
                 .await
@@ -267,6 +273,7 @@ mod tests {
                 key_len: 11,
                 translator: FourCap,
                 pending_writes: 10,
+                replay_concurrency: 4,
             };
             let archive = Archive::init(journal, cfg.clone())
                 .await
@@ -311,6 +318,7 @@ mod tests {
                 key_len: 5,
                 translator: FourCap,
                 pending_writes: 10,
+                replay_concurrency: 4,
             };
             let mut archive = Archive::init(journal, cfg.clone())
                 .await
@@ -384,6 +392,7 @@ mod tests {
                 key_len: 5,
                 translator: FourCap,
                 pending_writes: 10,
+                replay_concurrency: 4,
             };
             let mut archive = Archive::init(journal, cfg.clone())
                 .await
@@ -451,6 +460,7 @@ mod tests {
                 key_len: 9,
                 translator: FourCap,
                 pending_writes: 10,
+                replay_concurrency: 4,
             };
             let mut archive = Archive::init(journal, cfg.clone())
                 .await
@@ -550,6 +560,7 @@ mod tests {
                 key_len: 32,
                 translator: TwoCap,
                 pending_writes: 10,
+                replay_concurrency: 4,
             };
             let mut archive = Archive::init(journal, cfg.clone())
                 .await

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -42,7 +42,7 @@ pub struct Config<T: Translator> {
     ///
     /// The `Archive` assumes that all keys are of the same length. This
     /// trick is used to store data more efficiently on disk and to substantially
-    /// reduce the number of disk reads during initialization.
+    /// reduce the number of IO during initialization.
     pub key_len: usize,
 
     /// Logic to transform keys into their index representation.

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -43,7 +43,7 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
         let mut overlaps: u128 = 0;
         {
             debug!("initializing archive");
-            let stream = journal.replay(Some(cfg.key_len + 4));
+            let stream = journal.replay(cfg.replay_concurrency, Some(cfg.key_len + 4));
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 // Extract key from record

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -241,6 +241,8 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
         // Store item in journal
         let mut buf = Vec::with_capacity(1 + key.len() + data.len());
         buf.put(key);
+        // We store the checksum of the key because we employ partial reads from
+        // the journal, which aren't verified before returning to the archive.
         buf.put_u32(crc32fast::hash(key));
         buf.put(data); // we don't need to store data len because we already get this from the journal
         let offset = self.journal.append(section, buf.into()).await?;

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -43,7 +43,9 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
         let mut overlaps: u128 = 0;
         {
             debug!("initializing archive");
-            let stream = journal.replay(cfg.replay_concurrency, Some(cfg.key_len + 4));
+            let stream = journal
+                .replay(cfg.replay_concurrency, Some(cfg.key_len + 4))
+                .await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 // Extract key from record

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -208,6 +208,11 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
 
     /// Only check for equality at provided section
     pub async fn put(&mut self, section: u64, key: &[u8], data: Bytes) -> Result<(), Error> {
+        // Check key length
+        if key.len() != self.cfg.key_len {
+            return Err(Error::InvalidKeyLength);
+        }
+
         // Check last pruned
         let oldest_allowed = self.oldest_allowed.unwrap_or(0);
         if section < oldest_allowed {
@@ -261,6 +266,11 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
     }
 
     pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>, Error> {
+        // Check key length
+        if key.len() != self.cfg.key_len {
+            return Err(Error::InvalidKeyLength);
+        }
+
         // Update metrics
         self.gets.inc();
 

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -37,18 +37,6 @@ pub struct Archive<T: Translator, B: Blob, E: Storage<B>> {
 }
 
 impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
-    fn parse_item(mut data: Bytes) -> Result<(Bytes, Bytes), Error> {
-        if data.remaining() == 0 {
-            return Err(Error::RecordCorrupted);
-        }
-        let key_len = data.get_u8() as usize;
-        if data.remaining() < key_len {
-            return Err(Error::RecordCorrupted);
-        }
-        let key = data.copy_to_bytes(key_len);
-        Ok((key, data))
-    }
-
     pub async fn init(mut journal: Journal<B, E>, cfg: Config<T>) -> Result<Self, Error> {
         // Initialize keys and run corruption check
         let mut keys = HashMap::new();
@@ -125,6 +113,18 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
             unnecessary_reads,
             gets,
         })
+    }
+
+    fn parse_item(mut data: Bytes) -> Result<(Bytes, Bytes), Error> {
+        if data.remaining() == 0 {
+            return Err(Error::RecordCorrupted);
+        }
+        let key_len = data.get_u8() as usize;
+        if data.remaining() < key_len {
+            return Err(Error::RecordCorrupted);
+        }
+        let key = data.copy_to_bytes(key_len);
+        Ok((key, data))
     }
 
     /// Checks if there exists a duplicate key in the provided section.

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -108,7 +108,7 @@ mod tests {
 
             // Replay the journal and collect items
             let mut items = Vec::new();
-            let stream = journal.replay(None);
+            let stream = journal.replay(1, None);
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 match result {
@@ -180,7 +180,7 @@ mod tests {
             for limit in [None, Some(100)].iter() {
                 let mut items = Vec::new();
                 {
-                    let stream = journal.replay(*limit);
+                    let stream = journal.replay(2, *limit);
                     pin_mut!(stream);
                     while let Some(result) = stream.next().await {
                         match result {
@@ -202,7 +202,7 @@ mod tests {
 
             // Replay just first bytes
             {
-                let stream = journal.replay(Some(4));
+                let stream = journal.replay(2, Some(4));
                 pin_mut!(stream);
                 while let Some(result) = stream.next().await {
                     match result {
@@ -279,7 +279,7 @@ mod tests {
             // Replay the journal and collect items
             let mut items = Vec::new();
             {
-                let stream = journal.replay(None);
+                let stream = journal.replay(1, None);
                 pin_mut!(stream);
                 while let Some(result) = stream.next().await {
                     match result {
@@ -376,7 +376,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay(limit);
+            let stream = journal.replay(1, limit);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -432,7 +432,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay(limit);
+            let stream = journal.replay(1, limit);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -501,7 +501,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay(None);
+            let stream = journal.replay(1, None);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -566,7 +566,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay(None);
+            let stream = journal.replay(1, None);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -638,7 +638,7 @@ mod tests {
 
             // Attempt to replay the journal
             let mut items = Vec::new();
-            let stream = journal.replay(None);
+            let stream = journal.replay(1, None);
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 match result {

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -343,8 +343,7 @@ mod tests {
         });
     }
 
-    #[test_traced]
-    fn test_journal_read_size_missing() {
+    fn journal_read_size_missing(limit: Option<usize>) {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
 
@@ -377,7 +376,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay(None);
+            let stream = journal.replay(limit);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -391,7 +390,16 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_journal_read_item_missing() {
+    fn test_journal_read_size_missing_no_limit() {
+        journal_read_size_missing(None);
+    }
+
+    #[test_traced]
+    fn test_journal_read_size_missing_with_limit() {
+        journal_read_size_missing(Some(1));
+    }
+
+    fn journal_read_item_missing(limit: Option<usize>) {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
 
@@ -424,7 +432,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay(None);
+            let stream = journal.replay(limit);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -435,6 +443,16 @@ mod tests {
             }
             assert!(items.is_empty());
         });
+    }
+
+    #[test_traced]
+    fn test_journal_read_item_missing_no_limit() {
+        journal_read_item_missing(None);
+    }
+
+    #[test_traced]
+    fn test_journal_read_item_missing_with_limit() {
+        journal_read_item_missing(Some(1));
     }
 
     #[test_traced]

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -108,7 +108,7 @@ mod tests {
 
             // Replay the journal and collect items
             let mut items = Vec::new();
-            let stream = journal.replay();
+            let stream = journal.replay(None);
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 match result {
@@ -178,7 +178,7 @@ mod tests {
 
             // Replay the journal and collect items
             let mut items = Vec::new();
-            let stream = journal.replay();
+            let stream = journal.replay(None);
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 match result {
@@ -261,7 +261,7 @@ mod tests {
             // Replay the journal and collect items
             let mut items = Vec::new();
             {
-                let stream = journal.replay();
+                let stream = journal.replay(None);
                 pin_mut!(stream);
                 while let Some(result) = stream.next().await {
                     match result {
@@ -359,7 +359,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay();
+            let stream = journal.replay(None);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -406,7 +406,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay();
+            let stream = journal.replay(None);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -465,7 +465,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay();
+            let stream = journal.replay(None);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -530,7 +530,7 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
-            let stream = journal.replay();
+            let stream = journal.replay(None);
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -602,7 +602,7 @@ mod tests {
 
             // Attempt to replay the journal
             let mut items = Vec::new();
-            let stream = journal.replay();
+            let stream = journal.replay(None);
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 match result {

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -44,8 +44,10 @@ pub enum Error {
     ItemTooLarge(usize),
     #[error("already pruned to section: {0}")]
     AlreadyPrunedToSection(u64),
-    #[error("item smaller than requested read: size={0} requested={1}")]
-    ItemTooSmall(usize, usize),
+    #[error("usize too small")]
+    UsizeTooSmall,
+    #[error("offset overflow")]
+    OffsetOverflow,
 }
 
 /// Configuration for `journal` storage.

--- a/storage/src/journal/storage.rs
+++ b/storage/src/journal/storage.rs
@@ -187,7 +187,7 @@ impl<B: Blob, E: Storage<B>> Journal<B, E> {
         // occupying too much memory with buffered data)
         stream::iter(blobs)
             .map(move |(section, blob)| async move {
-                futures::stream::unfold(
+                stream::unfold(
                     (section, blob, 0),
                     move |(section, blob, offset)| async move {
                         let len = blob.len().await.map_err(Error::Runtime).ok()?;

--- a/storage/src/journal/storage.rs
+++ b/storage/src/journal/storage.rs
@@ -155,9 +155,16 @@ impl<B: Blob, E: Storage<B>> Journal<B, E> {
     ///
     /// If any data is found to be corrupt, it will be removed from the journal during this iteration.
     ///
-    /// If `limit` is provided, the stream will only read up to `limit` bytes of each item. Notably,
+    /// # Limit
+    ///
+    /// If `limit` is provided, the stream will only read up to `limit` bytes of each item. Consequently,
     /// this means we will not compute a checksum of the entire data and it is up to the caller to deal
     /// with the consequences of this.
+    ///
+    /// Reading `limit` bytes and skipping ahead to a future location in a blob is the theoretically optimal
+    /// way to read only what is required from storage, however, different storage implementations may take
+    /// the opportunity to readahead past what is required (needlessly). If the underlying storage can be tuned
+    /// for random access prior to invoking replay, it may lead to less IO.
     pub fn replay(
         &mut self,
         limit: Option<usize>,

--- a/storage/src/journal/storage.rs
+++ b/storage/src/journal/storage.rs
@@ -260,13 +260,19 @@ impl<B: Blob, E: Storage<B>> Journal<B, E> {
     }
 
     /// Retrieves an item from the `journal` at a given `section` and `offset`.
-    pub async fn get(&self, section: u64, offset: usize) -> Result<Option<Bytes>, Error> {
+    pub async fn get(
+        &self,
+        section: u64,
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Result<Option<Bytes>, Error> {
         self.prune_guard(section, false)?;
         let blob = match self.blobs.get(&section) {
             Some(blob) => blob,
             None => return Ok(None),
         };
-        let (_, item) = Self::read(blob, offset, None, None).await?;
+        let blob_len = blob.len().await.map_err(Error::Runtime)?;
+        let (_, item) = Self::read(blob, offset, Some(blob_len), limit).await?;
         Ok(Some(item))
     }
 


### PR DESCRIPTION
## TODO
- [x] Instead of reading entire entries from the journal, allow for reading a part of an entry unsafely (no checksum on contents).
- [x] Concurrently read blobs back
- [x] Don't invoke `len()` on each iteration