### PR TITLE
[storage/archive] Remove `Index` padding

### DIFF
--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -144,6 +144,8 @@ pub enum Error {
     AlreadyPrunedToSection(u64),
     #[error("invalid key length")]
     InvalidKeyLength,
+    #[error("record too large")]
+    RecordTooLarge,
 }
 
 /// Translate keys into an internal representation used in `Archive`'s

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -144,7 +144,7 @@ pub struct Config<T: Translator> {
     /// The `Archive` assumes that all keys are of the same length. This
     /// trick is used to store data more efficiently on disk and to substantially
     /// reduce the number of IO during initialization.
-    pub key_len: usize,
+    pub key_len: u32,
 
     /// Logic to transform keys into their index representation.
     ///

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -26,11 +26,11 @@
 //! # Uniqueness
 //!
 //! `Archive` assumes all keys stored are unique and only ever associated with a single `section`. If
-//! the same key is written to multiple sections, there is no guarantee which value will be returned. If the
-//! same key is written to the same section, the `Archive` will return an error. The `Archive` can be
-//! checked for the existence of a key using the `has` method.
+//! the same key is written to multiple sections, there is no guarantee which value will be returned (and no error
+//! will be returned when calling `put`). If the same key is written to the same section, the `Archive`
+//! will return an error. The `Archive` can be checked for the existence of a key using the `has` method.
 //!
-//! # Conflicts
+//! ## Conflicts
 //!
 //! Because a truncated representation of a key is only ever stored in memory, it is possible
 //! that two keys will be represented by the same truncated key. To resolve this case, the `Archive`
@@ -53,8 +53,11 @@
 //! If the `Translator` provided by the caller does not uniformly distribute keys across the key space or
 //! uses a truncated representation that means keys on average have many conflicts, performance will degrade.
 //!
-//! All of this means that the memory overhead per key is `truncated(key).len() + 24` bytes (where `24` is
-//! the size of the `Index` struct).
+//! ## Memory Overhead
+//!
+//! The memory used to track each key is `~truncated(key).len() + 24` bytes (where `24` is the size of the `Index`
+//! struct). This means that an `Archive` employing a `Translator` that uses the first `8` bytes of a key will
+//! use `32` bytes per key in its in-memory index.
 //!
 //! # Sync
 //!

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -9,11 +9,13 @@ use tracing::debug;
 
 /// In the case there are multiple records with the same key, we store them in a linked list.
 ///
-/// This is the most memory-efficient way to maintain a multi-map.
+/// This is the most memory-efficient way to maintain a multi-map (24 bytes per entry, not including
+/// the key used to lookup a given index).
 struct Index {
     section: u64,
-    offset: u64,
+    offset: u32,
     len: u32,
+
     next: Option<Box<Index>>,
 }
 

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -12,8 +12,8 @@ use tracing::debug;
 /// This is the most memory-efficient way to maintain a multi-map.
 struct Index {
     section: u64,
-    offset: usize,
-    len: usize,
+    offset: u64,
+    len: u32,
     next: Option<Box<Index>>,
 }
 
@@ -145,11 +145,11 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
         })
     }
 
-    fn parse_key(key_len: usize, mut data: Bytes) -> Result<Bytes, Error> {
-        if data.remaining() != key_len + 4 {
+    fn parse_key(key_len: u32, mut data: Bytes) -> Result<Bytes, Error> {
+        if data.remaining() != key_len as usize + 4 {
             return Err(Error::RecordCorrupted);
         }
-        let key = data.copy_to_bytes(key_len);
+        let key = data.copy_to_bytes(key_len as usize);
         let checksum = data.get_u32();
         if checksum != crc32fast::hash(&key) {
             return Err(Error::RecordCorrupted);
@@ -157,11 +157,11 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
         Ok(key)
     }
 
-    fn parse_item(key_len: usize, mut data: Bytes) -> Result<(Bytes, Bytes), Error> {
-        if data.remaining() < key_len + 4 {
+    fn parse_item(key_len: u32, mut data: Bytes) -> Result<(Bytes, Bytes), Error> {
+        if data.remaining() < key_len as usize + 4 {
             return Err(Error::RecordCorrupted);
         }
-        let key = data.copy_to_bytes(key_len);
+        let key = data.copy_to_bytes(key_len as usize);
 
         // We don't need to compute checksum here as the underlying journal
         // already performs this check for us.
@@ -264,7 +264,7 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
         force_sync: bool,
     ) -> Result<(), Error> {
         // Check key length
-        if key.len() != self.cfg.key_len {
+        if key.len() != self.cfg.key_len as usize {
             return Err(Error::InvalidKeyLength);
         }
 
@@ -298,7 +298,7 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
                 entry.next = Some(Box::new(Index {
                     section,
                     offset,
-                    len: buf_len,
+                    len: buf_len as u32,
                     next: entry.next.take(),
                 }));
             }
@@ -306,7 +306,7 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
                 entry.insert(Index {
                     section,
                     offset,
-                    len: buf_len,
+                    len: buf_len as u32,
                     next: None,
                 });
             }
@@ -329,7 +329,7 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
     /// Retrieve a value from the archive.
     pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>, Error> {
         // Check key length
-        if key.len() != self.cfg.key_len {
+        if key.len() != self.cfg.key_len as usize {
             return Err(Error::InvalidKeyLength);
         }
 
@@ -369,7 +369,7 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
     /// Check if a key exists in the archive.
     pub async fn has(&self, key: &[u8]) -> Result<bool, Error> {
         // Check key length
-        if key.len() != self.cfg.key_len {
+        if key.len() != self.cfg.key_len as usize {
             return Err(Error::InvalidKeyLength);
         }
 

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! Data stored in the journal is persisted in one of many `Blobs` within a caller-provided
 //! `partition`. The particular blob in which data is stored is identified by a `section`
-//! number. Within a blob, data is appended to the end of each blob in chunks of the following
+//! number. Within a section, data is appended to the end of each blob in chunks of the following
 //! format:
 //!
 //! ```text
@@ -26,6 +26,12 @@
 //! _To ensure data returned by `journal` is correct, a checksum (CRC32) is stored at the end of
 //! each item. If the checksum of the read data does not match the stored checksum, an error is
 //! returned._
+//!
+//! # Open Blobs
+//!
+//! `journal` uses 1 `Blob` per `section` to store data. All blobs in a caller-provided `partition` are
+//! kept open during the lifetime of the `journal`. If you wish to bound the number of open blobs, you
+//! should group data into fewer sections and/or prune unused sections.
 //!
 //! # Offset Alignment
 //!

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -27,6 +27,12 @@
 //! each item. If the checksum of the read data does not match the stored checksum, an error is
 //! returned._
 //!
+//! # Offset Alignment
+//!
+//! In practice, `journal` users won't store `u64::MAX` bytes of data in a given `section`. To reduce
+//! the memory requirement for interacting with the journal, offsets are thus `u32` (4 bytes vs 8 bytes)
+//! and aligned to 64 bytes. This means that the maximum size of any section is `u32::MAX * 64` bytes (~270 GB).
+//!
 //! # Sync
 //!
 //! Data written to the `journal` may not be immediately persisted to `Storage`. It is up to the caller

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -608,6 +608,8 @@ mod tests {
                 .expect("Failed to initialize journal");
 
             // Attempt to replay the journal
+            //
+            // This will truncate the leftover bytes from our manual write.
             let stream = journal
                 .replay(1, None)
                 .await

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -37,7 +37,8 @@
 //!
 //! In practice, `journal` users won't store `u64::MAX` bytes of data in a given `section`. To reduce
 //! the memory requirement for interacting with the journal, offsets are thus `u32` (4 bytes vs 8 bytes)
-//! and aligned to 64 bytes. This means that the maximum size of any section is `u32::MAX * 64` bytes (~270 GB).
+//! and aligned to 16 bytes. This means that the maximum size of any section is `u32::MAX * 17 = ~70GB`
+//! bytes (the last offset item can store up to `u32::MAX` bytes).
 //!
 //! # Sync
 //!
@@ -827,7 +828,7 @@ mod tests {
 
     // Define the `INDEX_ALIGNMENT` again explicitly to ensure we catch any accidental
     // changes to the value
-    const INDEX_ALIGNMENT: u64 = 64;
+    const INDEX_ALIGNMENT: u64 = 16;
 
     #[test_traced]
     fn test_journal_large_offset() {

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -108,7 +108,7 @@ pub enum Error {
     #[error("offset overflow")]
     OffsetOverflow,
     #[error("unexpected size: expected={0} actual={1}")]
-    UnexpectedSize(usize, usize),
+    UnexpectedSize(u32, u32),
 }
 
 /// Configuration for `journal` storage.
@@ -182,7 +182,7 @@ mod tests {
             while let Some(result) = stream.next().await {
                 match result {
                     Ok((blob_index, _, full_len, item)) => {
-                        assert_eq!(full_len, item.len());
+                        assert_eq!(full_len as usize, item.len());
                         items.push((blob_index, item))
                     }
                     Err(err) => panic!("Failed to read item: {}", err),
@@ -259,7 +259,7 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((blob_index, _, full_len, item)) => {
-                            assert_eq!(full_len, item.len());
+                            assert_eq!(full_len as usize, item.len());
                             items.push((blob_index, item))
                         }
                         Err(err) => panic!("Failed to read item: {}", err),
@@ -287,7 +287,7 @@ mod tests {
                     match result {
                         Ok((_, _, full_len, item)) => {
                             assert_eq!(item, Bytes::from("Data"));
-                            assert!(full_len > item.len());
+                            assert!(full_len as usize > item.len());
                         }
                         Err(err) => panic!("Failed to read item: {}", err),
                     }
@@ -426,7 +426,7 @@ mod tests {
         });
     }
 
-    fn journal_read_size_missing(exact: Option<usize>) {
+    fn journal_read_size_missing(exact: Option<u32>) {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
 
@@ -485,7 +485,7 @@ mod tests {
         journal_read_size_missing(Some(1));
     }
 
-    fn journal_read_item_missing(exact: Option<usize>) {
+    fn journal_read_item_missing(exact: Option<u32>) {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
 
@@ -644,7 +644,7 @@ mod tests {
             blob.write_at(item_data, offset)
                 .await
                 .expect("Failed to write item data");
-            offset += item_data.len();
+            offset += item_data.len() as u64;
 
             // Write incorrect checksum
             blob.write_at(&incorrect_checksum.to_be_bytes(), offset)

--- a/storage/src/journal/storage.rs
+++ b/storage/src/journal/storage.rs
@@ -226,8 +226,11 @@ impl<B: Blob, E: Storage<B>> Journal<B, E> {
     ///
     /// # Repair
     ///
+    /// If any corrupted data is found, the stream will return an error.
+    ///
     /// If any trailing data is found (i.e. misaligned entries), the journal will be truncated
-    /// to the last valid item.
+    /// to the last valid item. For this reason, it is recommended to call `replay` before
+    /// calling `append` (as data added to trailing bytes will fail checksum after restart).
     ///
     /// # Concurrency
     ///
@@ -322,10 +325,13 @@ impl<B: Blob, E: Storage<B>> Journal<B, E> {
 
     /// Appends an item to the `journal` in a given `section`.
     ///
+    /// # Warning
+    ///
     /// If there exist trailing bytes in the `Blob` of a particular `section` and
     /// `replay` is not called before this, it is likely that subsequent data added
     /// to the `Blob` will be considered corrupted (as the trailing bytes will fail
-    /// the checksum verification).
+    /// the checksum verification). It is recommended to call `replay` before calling
+    /// `append` to prevent this.
     pub async fn append(&mut self, section: u64, item: Bytes) -> Result<u32, Error> {
         // Check last pruned
         self.prune_guard(section, false)?;

--- a/storage/src/journal/storage.rs
+++ b/storage/src/journal/storage.rs
@@ -7,7 +7,7 @@ use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use std::collections::{btree_map::Entry, BTreeMap};
 use tracing::{debug, trace, warn};
 
-const ITEM_ALIGNMENT: u64 = 64;
+const ITEM_ALIGNMENT: u64 = 16;
 
 /// Implementation of an append-only log for storing arbitrary data.
 pub struct Journal<B: Blob, E: Storage<B>> {

--- a/storage/src/journal/storage.rs
+++ b/storage/src/journal/storage.rs
@@ -321,6 +321,11 @@ impl<B: Blob, E: Storage<B>> Journal<B, E> {
     }
 
     /// Appends an item to the `journal` in a given `section`.
+    ///
+    /// If there exist trailing bytes in the `Blob` of a particular `section` and
+    /// `replay` is not called before this, it is likely that subsequent data added
+    /// to the `Blob` will be considered corrupted (as the trailing bytes will fail
+    /// the checksum verification).
     pub async fn append(&mut self, section: u64, item: Bytes) -> Result<u32, Error> {
         // Check last pruned
         self.prune_guard(section, false)?;

--- a/storage/src/journal/storage.rs
+++ b/storage/src/journal/storage.rs
@@ -359,7 +359,7 @@ impl<B: Blob, E: Storage<B>> Journal<B, E> {
         blob.write_at(&buf, offset as u64 * ITEM_ALIGNMENT)
             .await
             .map_err(Error::Runtime)?;
-        trace!(blob = section, offset, len, "appended item");
+        trace!(blob = section, previous_len = len, offset, "appended item");
         Ok(offset)
     }
 

--- a/storage/src/journal/storage.rs
+++ b/storage/src/journal/storage.rs
@@ -23,6 +23,8 @@ pub struct Journal<B: Blob, E: Storage<B>> {
     pruned: Counter,
 }
 
+/// Computes the next offset for an item using the underlying `u64`
+/// offset of `Blob`.
 fn compute_next_offset(mut offset: u64) -> Result<u32, Error> {
     let overage = offset % ITEM_ALIGNMENT;
     if overage != 0 {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced handling of larger data sizes and offsets across various components, allowing for improved performance with extensive data structures.

- **Bug Fixes**
  - Improved error handling with the addition of new error variants to manage overflow scenarios effectively.

- **Documentation**
  - Updated documentation to clarify behaviors regarding duplicate keys and memory overhead in the Archive module.
  - Expanded sections on blob management and offset alignment in the journal module.

- **Refactor**
  - Adjusted method signatures and field types to utilize `u32` and `u64` for better compatibility with larger data sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## TODO
- [x] existing tests pass
- [x] update `mod.rs` comments about how `Index` works