### PR TITLE
[runtime] Add value (`i32`) to signal

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -102,7 +102,7 @@ pub trait Spawner: Clone + Send + Sync + 'static {
     /// Returns an instance of a `Signal` that resolves when `stop` is called by
     /// any task.
     ///
-    /// If `stop` has already been called, the returned `Waiter` will resolve immediately.
+    /// If `stop` has already been called, the returned `Signal` will resolve immediately.
     fn stopped(&self) -> Signal;
 }
 

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -237,7 +237,7 @@ pub struct Executor {
     metrics: Arc<Metrics>,
     runtime: Runtime,
     fs: AsyncMutex<()>,
-    stopper: Mutex<Signaler>,
+    signaler: Mutex<Signaler>,
     signal: Signal,
 }
 
@@ -250,13 +250,13 @@ impl Executor {
             .enable_all()
             .build()
             .expect("failed to create Tokio runtime");
-        let (stopper, signal) = Signaler::new();
+        let (signaler, signal) = Signaler::new();
         let executor = Arc::new(Self {
             cfg,
             metrics,
             runtime,
             fs: AsyncMutex::new(()),
-            stopper: Mutex::new(stopper),
+            signaler: Mutex::new(signaler),
             signal,
         });
         (
@@ -330,7 +330,7 @@ impl crate::Spawner for Context {
     }
 
     fn stop(&self, value: i32) {
-        self.executor.stopper.lock().unwrap().signal(value);
+        self.executor.signaler.lock().unwrap().signal(value);
     }
 
     fn stopped(&self) -> Signal {

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -208,8 +208,8 @@ pub type Signal = Shared<oneshot::Receiver<i32>>;
 ///     context.spawn("task", {
 ///         let context = context.clone();
 ///         async move {
-///             // Wait for signal or sleep
 ///             loop {
+///                 // Wait for signal or sleep
 ///                 select! {
 ///                      sig = &mut signal => {
 ///                          println!("Received signal: {}", sig.unwrap());

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -203,9 +203,9 @@ pub type Signal = Shared<oneshot::Receiver<i32>>;
 ///     // Setup signaler and get future
 ///     let (mut signaler, mut signal) = Signaler::new();
 ///
-///     // Loop on the waiter until signal is received
+///     // Loop on the signal until resolved
 ///     let (tx, rx) = oneshot::channel();
-///     context.spawn("waiter", {
+///     context.spawn("task", {
 ///         let context = context.clone();
 ///         async move {
 ///             // Wait for signal or sleep


### PR DESCRIPTION
This pull request includes several changes to improve the signaling mechanism in the `runtime` module, replacing the `Waiter` type with `Signal` and updating related methods to handle an integer value for the signal. The most important changes include modifications to the `Auditor` and `Executor` structures, updates to the `Spawner` trait, and adjustments in the `Signaler` implementation.

### Updates to Signaling Mechanism:

* [`runtime/src/deterministic.rs`](diffhunk://#diff-57b9bbe7c482353953ff44aa19e62cb28916a2b6fdbba6de0667d5084e12aee1L25-R25): Replaced `Waiter` with `Signal` in `Auditor`, `Executor`, and `Context` structures and methods, and updated the `stop` method to accept an integer value. [[1]](diffhunk://#diff-57b9bbe7c482353953ff44aa19e62cb28916a2b6fdbba6de0667d5084e12aee1L25-R25) [[2]](diffhunk://#diff-57b9bbe7c482353953ff44aa19e62cb28916a2b6fdbba6de0667d5084e12aee1L166-R171) [[3]](diffhunk://#diff-57b9bbe7c482353953ff44aa19e62cb28916a2b6fdbba6de0667d5084e12aee1L451-R453) [[4]](diffhunk://#diff-57b9bbe7c482353953ff44aa19e62cb28916a2b6fdbba6de0667d5084e12aee1L470-R471) [[5]](diffhunk://#diff-57b9bbe7c482353953ff44aa19e62cb28916a2b6fdbba6de0667d5084e12aee1L485-R487) [[6]](diffhunk://#diff-57b9bbe7c482353953ff44aa19e62cb28916a2b6fdbba6de0667d5084e12aee1L748-R756)

* [`runtime/src/lib.rs`](diffhunk://#diff-0ec06ea58bd455f09ce6b3bb4c2c1c0d37bda51c1e1be2151c560c9c973959ecL19-R19): Updated the `Spawner` trait to use `Signal` instead of `Waiter` and modified related methods to handle an integer value for the signal. [[1]](diffhunk://#diff-0ec06ea58bd455f09ce6b3bb4c2c1c0d37bda51c1e1be2151c560c9c973959ecL19-R19) [[2]](diffhunk://#diff-0ec06ea58bd455f09ce6b3bb4c2c1c0d37bda51c1e1be2151c560c9c973959ecL99-R106) [[3]](diffhunk://#diff-0ec06ea58bd455f09ce6b3bb4c2c1c0d37bda51c1e1be2151c560c9c973959ecR692-R699) [[4]](diffhunk://#diff-0ec06ea58bd455f09ce6b3bb4c2c1c0d37bda51c1e1be2151c560c9c973959ecL706-R713) [[5]](diffhunk://#diff-0ec06ea58bd455f09ce6b3bb4c2c1c0d37bda51c1e1be2151c560c9c973959ecL725-R728)

* [`runtime/src/tokio.rs`](diffhunk://#diff-f6c3b37dc02740cf8d3dfa5e51c92e8c0690b389e1a346cee683d79ba49375e7L26-R26): Replaced `Waiter` with `Signal` in `Executor` and `Context` structures and methods, and updated the `stop` method to accept an integer value. [[1]](diffhunk://#diff-f6c3b37dc02740cf8d3dfa5e51c92e8c0690b389e1a346cee683d79ba49375e7L26-R26) [[2]](diffhunk://#diff-f6c3b37dc02740cf8d3dfa5e51c92e8c0690b389e1a346cee683d79ba49375e7L240-R241) [[3]](diffhunk://#diff-f6c3b37dc02740cf8d3dfa5e51c92e8c0690b389e1a346cee683d79ba49375e7L253-R260) [[4]](diffhunk://#diff-f6c3b37dc02740cf8d3dfa5e51c92e8c0690b389e1a346cee683d79ba49375e7L332-R337)

* [`runtime/src/utils.rs`](diffhunk://#diff-24c3c0a65522b7c9405017f8d7f9d8a05d2257c96d58b6aeccf5de8e1381db45L157-R163): Renamed `Waiter` to `Signal`, updated the `Signaler` struct and its methods to handle an integer value, and adjusted documentation to reflect these changes. [[1]](diffhunk://#diff-24c3c0a65522b7c9405017f8d7f9d8a05d2257c96d58b6aeccf5de8e1381db45L157-R163) [[2]](diffhunk://#diff-24c3c0a65522b7c9405017f8d7f9d8a05d2257c96d58b6aeccf5de8e1381db45L176-R184) [[3]](diffhunk://#diff-24c3c0a65522b7c9405017f8d7f9d8a05d2257c96d58b6aeccf5de8e1381db45L191-R193) [[4]](diffhunk://#diff-24c3c0a65522b7c9405017f8d7f9d8a05d2257c96d58b6aeccf5de8e1381db45L202-R215) [[5]](diffhunk://#diff-24c3c0a65522b7c9405017f8d7f9d8a05d2257c96d58b6aeccf5de8e1381db45L223-R248)