### PR TITLE
[docs] Add link to `docs.rs`

### DIFF
--- a/cryptography/README.md
+++ b/cryptography/README.md
@@ -1,6 +1,7 @@
 # commonware-cryptography
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-cryptography.svg)](https://crates.io/crates/commonware-cryptography)
+[![Docs.rs](https://docs.rs/commonware-cryptography/badge.svg)](https://docs.rs/commonware-cryptography)
 
 Generate keys, sign arbitrary messages, and deterministically verify untrusted signatures.
 

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -1,6 +1,7 @@
 # commonware-chat 
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-chat.svg)](https://crates.io/crates/commonware-chat)
+[![Docs.rs](https://docs.rs/commonware-chat/badge.svg)](https://docs.rs/commonware-chat)
 
 Send encrypted messages to a group of friends using [commonware-cryptography::ed25519](https://docs.rs/commonware-cryptography/latest/commonware_cryptography/ed25519/index.html)
 and [commonware-p2p::authenticated](https://docs.rs/commonware-p2p/latest/commonware_p2p/authenticated/index.html).

--- a/examples/vrf/README.md
+++ b/examples/vrf/README.md
@@ -1,6 +1,7 @@
 # commonware-vrf 
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-vrf.svg)](https://crates.io/crates/commonware-vrf)
+[![Docs.rs](https://docs.rs/commonware-vrf/badge.svg)](https://docs.rs/commonware-vrf)
 
 Generate bias-resistant randomness with untrusted contributors using [commonware-cryptography](https://crates.io/crates/commonware-cryptography) and [commonware-p2p](https://crates.io/crates/commonware-p2p).
 

--- a/macros/README.md
+++ b/macros/README.md
@@ -1,6 +1,7 @@
 # commonware-macros
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-macros.svg)](https://crates.io/crates/commonware-macros)
+[![Docs.rs](https://docs.rs/commonware-macros/badge.svg)](https://docs.rs/commonware-macros)
 
 Augment the development of primitives with procedural macros.
 

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -1,6 +1,7 @@
 # commonware-p2p
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-p2p.svg)](https://crates.io/crates/commonware-p2p)
+[![Docs.rs](https://docs.rs/commonware-p2p/badge.svg)](https://docs.rs/commonware-p2p)
 
 Communicate with authenticated peers over encrypted connections.
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,6 +1,7 @@
 # commonware-runtime
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-runtime.svg)](https://crates.io/crates/commonware-runtime)
+[![Docs.rs](https://docs.rs/commonware-runtime/badge.svg)](https://docs.rs/commonware-runtime)
 
 Execute asynchronous tasks with a configurable scheduler.
 

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,6 +1,7 @@
 # commonware-storage
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-storage.svg)](https://crates.io/crates/commonware-storage)
+[![Docs.rs](https://docs.rs/commonware-storage/badge.svg)](https://docs.rs/commonware-storage)
 
 Persist and retrieve data from an abstract store.
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,6 +1,7 @@
 # commonware-utils
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-utils.svg)](https://crates.io/crates/commonware-utils)
+[![Docs.rs](https://docs.rs/commonware-utils/badge.svg)](https://docs.rs/commonware-utils)
 
 Leverage common functionality across multiple primitives.
 


### PR DESCRIPTION
This pull request adds documentation badges to the README files of various components in the `commonware` project, linking to the corresponding documentation on `docs.rs`.

Documentation updates:

* [`cryptography/README.md`](diffhunk://#diff-4167d58ef14ee44a62d151f7d4da5bd99cc34a932e4a8d1193207fe653ca9c62R4): Added `Docs.rs` badge.
* [`examples/chat/README.md`](diffhunk://#diff-1deb0660a12cd239eca5630f7b7448aec0c2e4faf5d888ff4c5486289f4b6d5aR4): Added `Docs.rs` badge.
* [`examples/vrf/README.md`](diffhunk://#diff-6f540488d9822fd83112e71ae23415c55231c22654a12b1292f0834f459c7641R4): Added `Docs.rs` badge.
* [`macros/README.md`](diffhunk://#diff-73e985ca9d8395b876fe121ff3505ae9891d48caced22d8272a39668a08e168eR4): Added `Docs.rs` badge.
* [`p2p/README.md`](diffhunk://#diff-396b68b686c33ea09380afa92e0e009a33b6a1e56bc95bfe2c092350e84a951eR4): Added `Docs.rs` badge.
* [`runtime/README.md`](diffhunk://#diff-5891ec7eadfb449ec343281ee04e99dded25a8121dcdd9aedae243e47a811babR4): Added `Docs.rs` badge.
* [`storage/README.md`](diffhunk://#diff-6f5d0df1f76c52646a08fba33b565bf6a18a5463a883bccbba76ac682fb78feaR4): Added `Docs.rs` badge.
* [`utils/README.md`](diffhunk://#diff-fe77bcb67b20e672b347e20835c80a2f5e7fdb2f76e350e2d6123fca38f73da0R4): Added `Docs.rs` badge.