### PR TITLE
[release] 11/6/24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bytes",
  "commonware-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ commonware-cryptography = { version = "0.0.12", path = "cryptography" }
 commonware-macros = { version = "0.0.4", path = "macros" }
 commonware-p2p = { version = "0.0.23", path = "p2p" }
 commonware-runtime = { version = "0.0.9", path = "runtime" }
-commonware-storage = { version = "0.0.3", path = "storage" }
+commonware-storage = { version = "0.0.4", path = "storage" }
 commonware-utils = { version = "0.0.4", path = "utils" }
 thiserror = "1.0.63"
 bytes = "1.7.1"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-storage"
 edition = "2021"
 publish = true
-version = "0.0.3"
+version = "0.0.4"
 license = "MIT OR Apache-2.0"
 description = "Persist and retrieve data from an abstract store."
 readme = "README.md"


### PR DESCRIPTION
This pull request includes version updates for the `commonware-storage` dependency in the project. The changes ensure that the latest version of the `commonware-storage` library is used.

Version updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L19-R19): Updated `commonware-storage` version from `0.0.3` to `0.0.4`.
* [`storage/Cargo.toml`](diffhunk://#diff-1bc5295720b3cef85cb02ee50bf34162eeabbbbac323d766e7faa38599da5d57L5-R5): Updated `commonware-storage` version from `0.0.3` to `0.0.4`.