### PR TITLE
[cryptography/bls12381] Construct and Verify Aggregate Signatures

### DIFF
--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -47,9 +47,9 @@ harness = false
 path = "src/bls12381/benches/signature_generation.rs"
 
 [[bench]]
-name="signature_aggregation"
+name="partial_signature_aggregation"
 harness = false
-path = "src/bls12381/benches/signature_aggregation.rs"
+path = "src/bls12381/benches/partial_signature_aggregation.rs"
 
 [[bench]]
 name="signature_verification"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -55,3 +55,8 @@ path = "src/bls12381/benches/partial_signature_aggregation.rs"
 name="signature_verification"
 harness = false
 path = "src/bls12381/benches/signature_verification.rs"
+
+[[bench]]
+name="signature_aggregation"
+harness = false
+path = "src/bls12381/benches/signature_aggregation.rs"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -60,3 +60,8 @@ path = "src/bls12381/benches/signature_verification.rs"
 name="signature_aggregation"
 harness = false
 path = "src/bls12381/benches/signature_aggregation.rs"
+
+[[bench]]
+name="signature_verify_aggregation"
+harness = false
+path = "src/bls12381/benches/signature_verify_aggregation.rs"

--- a/cryptography/src/bls12381/benches/partial_signature_aggregation.rs
+++ b/cryptography/src/bls12381/benches/partial_signature_aggregation.rs
@@ -3,7 +3,7 @@ use commonware_utils::quorum;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use std::hint::black_box;
 
-fn benchmark_signature_aggregation(c: &mut Criterion) {
+fn benchmark_partial_signature_aggregation(c: &mut Criterion) {
     let namespace = b"benchmark";
     let msg = b"hello";
     for &n in &[5, 10, 20, 50, 100, 250, 500] {
@@ -26,5 +26,5 @@ fn benchmark_signature_aggregation(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, benchmark_signature_aggregation);
+criterion_group!(benches, benchmark_partial_signature_aggregation);
 criterion_main!(benches);

--- a/cryptography/src/bls12381/benches/signature_aggregation.rs
+++ b/cryptography/src/bls12381/benches/signature_aggregation.rs
@@ -18,7 +18,7 @@ fn benchmark_signature_aggregation(c: &mut Criterion) {
                         .collect::<Vec<_>>()
                 },
                 |partials| {
-                    black_box(primitives::ops::aggregate(t, partials).unwrap());
+                    black_box(primitives::ops::partial_aggregate(t, partials).unwrap());
                 },
                 BatchSize::SmallInput,
             );

--- a/cryptography/src/bls12381/benches/signature_aggregation.rs
+++ b/cryptography/src/bls12381/benches/signature_aggregation.rs
@@ -1,0 +1,40 @@
+use commonware_cryptography::bls12381::primitives::ops;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use rand::{thread_rng, Rng};
+use std::hint::black_box;
+
+fn benchmark_signature_aggregation(c: &mut Criterion) {
+    let namespace = b"namespace";
+    for n in [10, 100, 1000, 10000].into_iter() {
+        let mut msgs = Vec::with_capacity(n);
+        for _ in 0..n {
+            let mut msg = [0u8; 32];
+            thread_rng().fill(&mut msg);
+            msgs.push(msg);
+        }
+        c.bench_function(&format!("msgs={}", msgs.len()), |b| {
+            b.iter_batched(
+                || {
+                    let private = ops::keypair(&mut thread_rng()).0;
+                    let mut signatures = Vec::with_capacity(n);
+                    for msg in msgs.iter() {
+                        let signature = ops::sign(&private, namespace, msg);
+                        signatures.push(signature);
+                    }
+                    signatures
+                },
+                |signatures| {
+                    black_box(ops::aggregate(&signatures));
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_signature_aggregation
+}
+criterion_main!(benches);

--- a/cryptography/src/bls12381/benches/signature_verify_aggregation.rs
+++ b/cryptography/src/bls12381/benches/signature_verify_aggregation.rs
@@ -1,0 +1,40 @@
+use commonware_cryptography::bls12381::primitives::ops;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use rand::{thread_rng, Rng};
+
+fn benchmark_signature_verify_aggregation(c: &mut Criterion) {
+    let namespace = b"namespace";
+    for n in [10, 100, 1000, 10000].into_iter() {
+        let mut msgs = Vec::with_capacity(n);
+        for _ in 0..n {
+            let mut msg = [0u8; 32];
+            thread_rng().fill(&mut msg);
+            msgs.push(msg);
+        }
+        let msgs = msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<_>>();
+        c.bench_function(&format!("msgs={}", msgs.len()), |b| {
+            b.iter_batched(
+                || {
+                    let (private, public) = ops::keypair(&mut thread_rng());
+                    let mut signatures = Vec::with_capacity(n);
+                    for msg in msgs.iter() {
+                        let signature = ops::sign(&private, namespace, msg);
+                        signatures.push(signature);
+                    }
+                    (public, ops::aggregate(&signatures))
+                },
+                |(public, signature)| {
+                    ops::verify_aggregate(&public, namespace, &msgs, &signature).unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_signature_verify_aggregation
+}
+criterion_main!(benches);

--- a/cryptography/src/bls12381/dkg/ops.rs
+++ b/cryptography/src/bls12381/dkg/ops.rs
@@ -4,8 +4,7 @@ use crate::bls12381::{
     dkg::Error,
     primitives::{group::Share, poly},
 };
-use rayon::prelude::*;
-use rayon::ThreadPoolBuilder;
+use rayon::{prelude::*, ThreadPoolBuilder};
 use std::collections::BTreeMap;
 
 /// Generate shares and a commitment.

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! # Benchmarks
 //!
-//! _The following benchmarks were collected on 8/23/24 on a MacBook Pro (M3 Pro, Nov 2023)._
+//! _The following benchmarks were collected on 11/6/24 on a MacBook Pro (M3 Pro, Nov 2023)._
 //!
 //! ```bash
 //! cargo bench
@@ -94,10 +94,31 @@
 //! ## Aggregate Signature Verification (Same Public Key)
 //!
 //! ```txt
-//! msgs=10                 time:   [1.9449 ms 2.0191 ms 2.1215 ms]
-//! msgs=100                time:   [12.586 ms 12.599 ms 12.615 ms]
-//! msgs=1000               time:   [118.65 ms 118.78 ms 118.94 ms]
-//! msgs=10000              time:   [1.1794 s 1.1811 s 1.1836 s]
+//! conc=1 msgs=10          time:   [1.9960 ms 2.0150 ms 2.0263 ms]
+//! conc=2 msgs=10          time:   [1.3962 ms 1.3979 ms 1.3998 ms]
+//! conc=4 msgs=10          time:   [1.1857 ms 1.1882 ms 1.1906 ms]
+//! conc=8 msgs=10          time:   [1.1787 ms 1.1873 ms 1.2022 ms]
+//! conc=16 msgs=10         time:   [1.3770 ms 1.3882 ms 1.4133 ms]
+//! conc=1 msgs=100         time:   [12.687 ms 12.704 ms 12.723 ms]
+//! conc=2 msgs=100         time:   [6.8790 ms 6.9518 ms 7.0950 ms]
+//! conc=4 msgs=100         time:   [3.9784 ms 3.9912 ms 4.0085 ms]
+//! conc=8 msgs=100         time:   [2.8804 ms 2.9236 ms 2.9558 ms]
+//! conc=16 msgs=100        time:   [2.7870 ms 2.8007 ms 2.8139 ms]
+//! conc=1 msgs=1000        time:   [119.06 ms 119.11 ms 119.17 ms]
+//! conc=2 msgs=1000        time:   [61.170 ms 61.244 ms 61.332 ms]
+//! conc=4 msgs=1000        time:   [31.822 ms 31.882 ms 31.948 ms]
+//! conc=8 msgs=1000        time:   [19.635 ms 19.991 ms 20.547 ms]
+//! conc=16 msgs=1000       time:   [16.950 ms 17.039 ms 17.126 ms]
+//! conc=1 msgs=10000       time:   [1.1826 s 1.1905 s 1.2018 s]
+//! conc=2 msgs=10000       time:   [603.82 ms 610.05 ms 618.48 ms]
+//! conc=4 msgs=10000       time:   [309.44 ms 312.92 ms 318.01 ms]
+//! conc=8 msgs=10000       time:   [187.57 ms 192.75 ms 198.37 ms]
+//! conc=16 msgs=10000      time:   [158.16 ms 161.60 ms 165.44 ms]
+//! conc=1 msgs=50000       time:   [5.9263 s 5.9377 s 5.9547 s]
+//! conc=2 msgs=50000       time:   [3.0152 s 3.0266 s 3.0417 s]
+//! conc=4 msgs=50000       time:   [1.5420 s 1.5458 s 1.5500 s]
+//! conc=8 msgs=50000       time:   [925.32 ms 929.07 ms 933.83 ms]
+//! conc=16 msgs=50000      time:   [769.73 ms 773.88 ms 777.97 ms]
 //! ```
 
 pub mod dkg;

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -93,12 +93,12 @@ mod tests {
     use super::*;
     use dkg::ops::generate_shares;
     use primitives::group::Private;
-    use primitives::ops::{aggregate, partial_sign, partial_verify, verify};
+    use primitives::ops::{partial_aggregate, partial_sign, partial_verify, verify};
     use primitives::poly::public;
     use primitives::Error;
 
     #[test]
-    fn test_aggregate_signature() {
+    fn test_partial_aggregate_signature() {
         let (n, t) = (5, 4);
 
         // Create the private key polynomial and evaluate it at `n`
@@ -122,13 +122,13 @@ mod tests {
         });
 
         // Generate and verify the threshold sig
-        let threshold_sig = aggregate(t, partials).unwrap();
+        let threshold_sig = partial_aggregate(t, partials).unwrap();
         let threshold_pub = public(&group);
         verify(&threshold_pub, namespace, msg, &threshold_sig).unwrap();
     }
 
     #[test]
-    fn test_aggregate_signature_bad_namespace() {
+    fn test_partial_aggregate_signature_bad_namespace() {
         let (n, t) = (5, 4);
 
         // Create the private key polynomial and evaluate it at `n`
@@ -156,7 +156,7 @@ mod tests {
         });
 
         // Generate and verify the threshold sig
-        let threshold_sig = aggregate(t, partials).unwrap();
+        let threshold_sig = partial_aggregate(t, partials).unwrap();
         let threshold_pub = public(&group);
         assert!(matches!(
             verify(&threshold_pub, namespace, msg, &threshold_sig).unwrap_err(),
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate_signature_insufficient() {
+    fn test_partial_aggregate_signature_insufficient() {
         let (n, t) = (5, 4);
 
         // Create the private key polynomial and evaluate it at `n`
@@ -190,13 +190,13 @@ mod tests {
 
         // Generate the threshold sig
         assert!(matches!(
-            aggregate(t, partials).unwrap_err(),
+            partial_aggregate(t, partials).unwrap_err(),
             Error::NotEnoughPartialSignatures(4, 3)
         ));
     }
 
     #[test]
-    fn test_aggregate_signature_insufficient_duplicates() {
+    fn test_partial_aggregate_signature_insufficient_duplicates() {
         let (n, t) = (5, 4);
 
         // Create the private key polynomial and evaluate it at `n`
@@ -222,14 +222,14 @@ mod tests {
 
         // Generate the threshold sig
         assert!(matches!(
-            aggregate(t, partials).unwrap_err(),
+            partial_aggregate(t, partials).unwrap_err(),
             Error::DuplicateEval,
         ));
     }
 
     #[test]
     #[should_panic(expected = "InvalidSignature")]
-    fn test_aggregate_signature_bad_share() {
+    fn test_partial_aggregate_signature_bad_share() {
         let (n, t) = (5, 4);
 
         // Create the private key polynomial and evaluate it at `n`
@@ -254,7 +254,7 @@ mod tests {
         });
 
         // Generate and verify the threshold sig
-        let threshold_sig = aggregate(t, partials).unwrap();
+        let threshold_sig = partial_aggregate(t, partials).unwrap();
         let threshold_pub = public(&group);
         verify(&threshold_pub, namespace, msg, &threshold_sig).unwrap();
     }

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -81,6 +81,14 @@
 //! ```txt
 //! ns_len=9 msg_len=5      time:   [980.92 µs 981.37 µs 981.88 µs]
 //! ```
+//!
+//! ## Signature Aggregation (Same Public Key)
+//! ```txt
+//! msgs=10                 time:   [11.731 µs 12.516 µs 13.316 µs]
+//! msgs=100                time:   [117.02 µs 117.16 µs 117.37 µs]
+//! msgs=1000               time:   [1.1751 ms 1.1777 ms 1.1803 ms]
+//! msgs=10000              time:   [11.878 ms 11.966 ms 12.068 ms]
+//! ```
 
 pub mod dkg;
 pub mod primitives;

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -59,13 +59,7 @@
 //! conc=8 n=500 t=333      time:   [1.1176 s 1.1355 s 1.1539 s]
 //! ```
 //!
-//! ## Signature Generation
-//!
-//! ```txt
-//! ns_len=9 msg_len=5      time:   [232.12 µs 233.63 µs 235.42 µs]
-//! ```
-//!
-//! ## Signature Aggregation
+//! ## Partial Signature Aggregation
 //!
 //! ```txt
 //! n=5 t=3                 time:   [126.85 µs 128.50 µs 130.67 µs]
@@ -75,6 +69,11 @@
 //! n=100 t=67              time:   [5.0113 ms 5.0155 ms 5.0203 ms]
 //! n=250 t=167             time:   [16.922 ms 16.929 ms 16.937 ms]
 //! n=500 t=333             time:   [37.642 ms 37.676 ms 37.729 ms]
+//! ```
+//! ## Signature Generation (Signing)
+//!
+//! ```txt
+//! ns_len=9 msg_len=5      time:   [232.12 µs 233.63 µs 235.42 µs]
 //! ```
 //!
 //! ## Signature Verification

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -83,11 +83,21 @@
 //! ```
 //!
 //! ## Signature Aggregation (Same Public Key)
+//!
 //! ```txt
 //! msgs=10                 time:   [11.731 µs 12.516 µs 13.316 µs]
 //! msgs=100                time:   [117.02 µs 117.16 µs 117.37 µs]
 //! msgs=1000               time:   [1.1751 ms 1.1777 ms 1.1803 ms]
 //! msgs=10000              time:   [11.878 ms 11.966 ms 12.068 ms]
+//! ```
+//!
+//! ## Aggregate Signature Verification (Same Public Key)
+//!
+//! ```txt
+//! msgs=10                 time:   [1.9449 ms 2.0191 ms 2.1215 ms]
+//! msgs=100                time:   [12.586 ms 12.599 ms 12.615 ms]
+//! msgs=1000               time:   [118.65 ms 118.78 ms 118.94 ms]
+//! msgs=10000              time:   [1.1794 s 1.1811 s 1.1836 s]
 //! ```
 
 pub mod dkg;

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -59,4 +59,6 @@ pub enum Error {
     NoInverse,
     #[error("duplicate eval")]
     DuplicateEval,
+    #[error("duplicate message")]
+    DuplicateMessage,
 }

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! ```rust
 //! use commonware_cryptography::bls12381::{
-//!     primitives::{ops::{partial_sign, partial_verify, aggregate, verify}, poly::public},
+//!     primitives::{ops::{partial_sign, partial_verify, partial_aggregate, verify}, poly::public},
 //!     dkg::ops::{generate_shares},
 //! };
 //!

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -34,7 +34,7 @@
 //! }
 //!
 //! // Aggregate partial signatures
-//! let threshold_sig = aggregate(t, partials).unwrap();
+//! let threshold_sig = partial_aggregate(t, partials).unwrap();
 //!
 //! // Verify threshold signature
 //! let threshold_pub = public(&commitment);

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -74,7 +74,7 @@ pub fn partial_verify(
 ///
 /// Signatures recovered by this function are deterministic and are safe
 /// to use in a consensus-critical context.
-pub fn aggregate(
+pub fn partial_aggregate(
     threshold: u32,
     partials: Vec<Eval<group::Signature>>,
 ) -> Result<group::Signature, Error> {
@@ -142,7 +142,7 @@ mod tests {
         for p in &partials {
             partial_verify(&public, namespace, msg, p).expect("signature should be valid");
         }
-        let threshold_sig = aggregate(t, partials).unwrap();
+        let threshold_sig = partial_aggregate(t, partials).unwrap();
         let threshold_pub = poly::public(&public);
         verify(&threshold_pub, namespace, msg, &threshold_sig).expect("signature should be valid");
         let payload = union(namespace, msg);

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -100,6 +100,8 @@ pub fn aggregate(signatures: &[group::Signature]) -> group::Signature {
 }
 
 /// Verifies the aggregate signature over multiple unique messages from the same public key.
+///
+/// If the same message is provided multiple times, the function will error.
 pub fn verify_aggregate(
     public: &group::Public,
     namespace: &[u8],

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -108,7 +108,7 @@ pub fn verify_aggregate(
     messages: &[&[u8]],
     signature: &group::Signature,
 ) -> Result<(), Error> {
-    let mut seen = HashSet::new();
+    let mut seen = HashSet::with_capacity(messages.len());
     let mut hm_sum = group::Signature::zero();
     for msg in messages {
         if seen.contains(msg) {

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -151,7 +151,7 @@ impl<E: Clock> Vrf<E> {
         }
 
         // Aggregate partial signatures
-        match ops::aggregate(self.threshold, partials) {
+        match ops::partial_aggregate(self.threshold, partials) {
             Ok(signature) => Some(signature),
             Err(_) => {
                 warn!(round, "failed to aggregate partial signatures");


### PR DESCRIPTION
This pull request introduces several new benchmarking functions and refactors existing ones in the `cryptography` module, particularly focused on the BLS12-381 cryptographic operations. Additionally, it includes updates to documentation and test cases to reflect these changes.

### New Benchmarking Functions:
* Added `benchmark_partial_signature_aggregation` in `cryptography/src/bls12381/benches/partial_signature_aggregation.rs` to benchmark partial signature aggregation.
* Added `benchmark_signature_verify_aggregation` in `cryptography/src/bls12381/benches/signature_verify_aggregation.rs` to benchmark signature verification with aggregation.

### Refactoring and Updates:
* Refactored `benchmark_signature_aggregation` in `cryptography/src/bls12381/benches/signature_aggregation.rs` to use a different set of messages and updated the aggregation logic.
* Updated documentation in `cryptography/src/bls12381/mod.rs` to reflect new and updated benchmarks, including partial signature aggregation and aggregate signature verification. [[1]](diffhunk://#diff-f8bc317b1c83024f0e59342c78474c0566e1e44f6eee99af9162520f0edaeb05L11-R11) [[2]](diffhunk://#diff-f8bc317b1c83024f0e59342c78474c0566e1e44f6eee99af9162520f0edaeb05L62-R62) [[3]](diffhunk://#diff-f8bc317b1c83024f0e59342c78474c0566e1e44f6eee99af9162520f0edaeb05R73-R122)
* Renamed functions and updated test cases to use `partial_aggregate` instead of `aggregate` for partial signature aggregation in `cryptography/src/bls12381/mod.rs` and `cryptography/src/bls12381/primitives/ops.rs`. [[1]](diffhunk://#diff-f8bc317b1c83024f0e59342c78474c0566e1e44f6eee99af9162520f0edaeb05L96-R139) [[2]](diffhunk://#diff-b94a6904036bbf18e106e71697add22b2b12c7422e8522684e2301f91762dc1aL77-R79)

### Code Enhancements:
* Added new error type `DuplicateMessage` in `cryptography/src/bls12381/primitives/mod.rs` to handle duplicate message scenarios in signature aggregation.
* Introduced new functions `aggregate` and `verify_aggregate` in `cryptography/src/bls12381/primitives/ops.rs` for aggregating multiple signatures and verifying them.

These changes collectively enhance the benchmarking capabilities and improve the handling of signature aggregation and verification in the cryptographic module.