### PR TITLE
[p2p] Remove Chunking

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -184,7 +184,6 @@ fn main() {
         let (chat_sender, chat_receiver) = network.register(
             handler::CHANNEL,
             Quota::per_second(NonZeroU32::new(128).unwrap()),
-            MAX_MESSAGE_SIZE,
             MAX_MESSAGE_BACKLOG,
             COMPRESSION_LEVEL,
         );

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -261,7 +261,6 @@ fn main() {
             let (contributor_sender, contributor_receiver) = network.register(
                 handlers::DKG_CHANNEL,
                 Quota::per_second(NonZeroU32::new(10).unwrap()),
-                MAX_MESSAGE_SIZE,
                 DEFAULT_MESSAGE_BACKLOG,
                 COMPRESSION_LEVEL,
             );
@@ -284,7 +283,6 @@ fn main() {
             let (vrf_sender, vrf_receiver) = network.register(
                 handlers::VRF_CHANNEL,
                 Quota::per_second(NonZeroU32::new(10).unwrap()),
-                MAX_MESSAGE_SIZE,
                 DEFAULT_MESSAGE_BACKLOG,
                 None,
             );
@@ -300,7 +298,6 @@ fn main() {
             let (arbiter_sender, arbiter_receiver) = network.register(
                 handlers::DKG_CHANNEL,
                 Quota::per_second(NonZeroU32::new(10).unwrap()),
-                MAX_MESSAGE_SIZE,
                 DEFAULT_MESSAGE_BACKLOG,
                 COMPRESSION_LEVEL,
             );

--- a/p2p/build.rs
+++ b/p2p/build.rs
@@ -5,7 +5,7 @@ fn main() -> Result<()> {
     config.bytes([
         "Signature.public_key",
         "Signature.signature",
-        "Chunk.content",
+        "Data.message",
     ]);
     config.compile_protos(&["src/authenticated/wire.proto"], &["src/authenticated/"])?;
     Ok(())

--- a/p2p/src/authenticated/actors/peer/actor.rs
+++ b/p2p/src/authenticated/actors/peer/actor.rs
@@ -1,10 +1,9 @@
-use super::{ingress::Data, Config, Error, Mailbox, Message, Relay};
+use super::{Config, Error, Mailbox, Message, Relay};
 use crate::authenticated::{
     actors::tracker,
     channels::Channels,
     metrics, wire,
 };
-use bytes::BytesMut;
 use commonware_cryptography::{PublicKey, Scheme};
 use commonware_macros::select;
 use commonware_runtime::{Clock, Handle, Sink, Spawner, Stream};
@@ -15,7 +14,7 @@ use governor::{clock::ReasonablyRealtime, Quota, RateLimiter};
 use prometheus_client::metrics::{counter::Counter, family::Family};
 use prost::Message as _;
 use rand::{CryptoRng, Rng};
-use std::{cmp::min, collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tracing::{debug, trace};
 
 pub struct Actor<E: Spawner + Clock + ReasonablyRealtime> {
@@ -27,8 +26,8 @@ pub struct Actor<E: Spawner + Clock + ReasonablyRealtime> {
 
     mailbox: Mailbox,
     control: mpsc::Receiver<Message>,
-    high: mpsc::Receiver<Data>,
-    low: mpsc::Receiver<Data>,
+    high: mpsc::Receiver<wire::Data>,
+    low: mpsc::Receiver<wire::Data>,
 
     sent_messages: Family<metrics::Message, Counter>,
     received_messages: Family<metrics::Message, Counter>,
@@ -37,10 +36,6 @@ pub struct Actor<E: Spawner + Clock + ReasonablyRealtime> {
     // When reservation goes out-of-scope, the tracker will be notified.
     _reservation: tracker::Reservation<E>,
 }
-
-// The maximum overhead caused by protobuf encoding chunk data.
-// TODO: Remove this constant (https://github.com/commonwarexyz/monorepo/issues/186).
-const CHUNK_HEADER_SIZE: usize = 64 /* protobuf overhead */ + 12 /* chunk info */;
 
 impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
     pub fn new(runtime: E, cfg: Config, reservation: tracker::Reservation<E>) -> (Self, Relay) {
@@ -69,10 +64,9 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
 
     async fn send_content<Si: Sink>(
         max_size: usize,
-        max_content_size: usize,
         sender: &mut Sender<Si>,
         peer: &PublicKey,
-        data: Data,
+        data: wire::Data,
         sent_messages: &Family<metrics::Message, Counter>,
     ) -> Result<(), Error> {
         // Ensure message is not too large
@@ -81,47 +75,22 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
             return Err(Error::MessageTooLarge(message_len));
         }
 
-        // Compute required parts
-        let mut total_parts = message_len / max_content_size;
-        if message_len % max_content_size != 0 {
-            total_parts += 1;
-        }
-        if total_parts > u32::MAX as usize {
-            // Should never happen
-            return Err(Error::MessageTooLarge(message_len));
-        }
-
-        // Chunk data
-        let mut part = 0;
+        // Send data
         let channel = data.channel;
-        while part < total_parts {
-            let start = part * max_content_size;
-            let end = min((part + 1) * max_content_size, message_len);
-            let content = data.message.slice(start..end);
-            let msg = wire::Message {
-                payload: Some(wire::message::Payload::Chunk({
-                    wire::Chunk {
-                        channel,
-                        part: part as u32,
-                        total_parts: total_parts as u32,
-                        content,
-                    }
-                })),
-            }.encode_to_vec();
-            trace!(
-                part = part,
-                total_parts = total_parts - 1,
-                peer = hex(peer),
-                "sending chunk",
-            );
-            sender.send(&msg)
-                .await
-                .map_err(Error::SendFailed)?;
-            sent_messages
-                .get_or_create(&metrics::Message::new_chunk(peer, channel))
-                .inc();
-            part += 1;
-        }
+        let msg = wire::Message {
+            payload: Some(wire::message::Payload::Data(data)),
+        }.encode_to_vec();
+        trace!(
+            peer = hex(peer),
+            "sending data",
+        );
+        sender.send(&msg)
+            .await
+            .map_err(Error::SendFailed)?;
+        sent_messages
+            .get_or_create(&metrics::Message::new_data(peer, channel))
+            .inc();
+
         Ok(())
     }
 
@@ -143,10 +112,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
         let rate_limits = Arc::new(rate_limits);
 
         // Send/Receive messages from the peer
-        let (max_message_size, mut conn_sender, mut conn_receiver) = connection.split();
-        // TODO: Normally check for underflow here, but CHUNK_HEADER_SIZE is being removed,
-        // see (https://github.com/commonwarexyz/monorepo/issues/186).
-        let max_chunk_size = max_message_size - CHUNK_HEADER_SIZE;
+        let (mut conn_sender, mut conn_receiver) = connection.split();
         let mut send_handler: Handle<Result<(), Error>> = self.runtime.spawn("sender",{
             let runtime = self.runtime.clone();
             let mut tracker = tracker.clone();
@@ -207,7 +173,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
                                 return Err(Error::InvalidChannel);
                             }
                             let (_, max_size) = entry.unwrap();
-                            Self::send_content(*max_size, max_chunk_size, &mut conn_sender, &peer, msg, &self.sent_messages).await?;
+                            Self::send_content(*max_size, &mut conn_sender, &peer, msg, &self.sent_messages).await?;
                         },
                         msg_low = self.low.next() => {
                             let msg = match msg_low {
@@ -219,7 +185,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
                                 return Err(Error::InvalidChannel);
                             }
                             let (_, max_size) = entry.unwrap();
-                            Self::send_content(*max_size, max_chunk_size, &mut conn_sender, &peer, msg, &self.sent_messages).await?;
+                            Self::send_content(*max_size, &mut conn_sender, &peer, msg, &self.sent_messages).await?;
                         }
                     }
                 }
@@ -280,13 +246,13 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
                             // Send peers to tracker
                             tracker.peers(peers, self.mailbox.clone()).await;
                         }
-                        Some(wire::message::Payload::Chunk(chunk)) => {
+                        Some(wire::message::Payload::Data(data)) => {
                             self.received_messages
-                                .get_or_create(&metrics::Message::new_chunk(&peer, chunk.channel))
+                                .get_or_create(&metrics::Message::new_data(&peer, data.channel))
                                 .inc();
 
                             // Ensure peer is not spamming us with content messages
-                            let entry = rate_limits.get(&chunk.channel);
+                            let entry = rate_limits.get(&data.channel);
                             if entry.is_none() {
                                 // We permit unknown messages to be received in case peers
                                 // are on a newer version than us
@@ -297,10 +263,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
                                 Ok(_) => {}
                                 Err(negative) => {
                                     self.rate_limited
-                                        .get_or_create(&metrics::Message::new_chunk(
-                                            &peer,
-                                            chunk.channel,
-                                        ))
+                                        .get_or_create(&metrics::Message::new_data(&peer, data.channel))
                                         .inc();
                                     let wait = negative.wait_time_from(runtime.now());
                                     runtime.sleep(wait).await;
@@ -308,67 +271,20 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
                             }
 
                             // Ensure message is not too large
-                            let chunk_len = chunk.content.len();
-                            if chunk_len > *max_size {
-                                return Err(Error::MessageTooLarge(chunk_len));
-                            }
-
-                            // Gather all chunks
-                            let mut message = BytesMut::from(&chunk.content[..]);
-                            let total_parts = chunk.total_parts;
-                            if total_parts > 1 {
-                                // Ensure first part is the max size
-                                if chunk_len != max_chunk_size {
-                                    return Err(Error::InvalidChunk);
-                                }
-
-                                // Read chunk messages until we have all parts
-                                let channel = chunk.channel;
-                                let mut next_part = chunk.part + 1;
-                                while next_part < total_parts {
-                                    let msg = conn_receiver
-                                        .receive()
-                                        .await
-                                        .map_err(Error::ReceiveFailed)?;
-                                    let msg = wire::Message::decode(msg)
-                                        .map_err(Error::DecodeFailed)?;
-                                    let chunk = match msg.payload {
-                                        Some(wire::message::Payload::Chunk(chunk)) => chunk,
-                                        _ => return Err(Error::InvalidChunk),
-                                    };
-                                    if chunk.channel != channel {
-                                        return Err(Error::InvalidChunk);
-                                    }
-                                    if chunk.total_parts != total_parts {
-                                        return Err(Error::InvalidChunk);
-                                    }
-                                    if chunk.part != next_part {
-                                        return Err(Error::InvalidChunk);
-                                    }
-                                    let chunk_len = chunk.content.len();
-                                    if chunk.part != total_parts - 1
-                                        && chunk_len != max_chunk_size
-                                    {
-                                        return Err(Error::InvalidChunk);
-                                    }
-                                    let new_len = message.len() + chunk_len;
-                                    if new_len > *max_size {
-                                        return Err(Error::MessageTooLarge(new_len));
-                                    }
-                                    message.extend_from_slice(&chunk.content);
-                                    next_part += 1;
-                                }
+                            let len = data.message.len();
+                            if len > *max_size {
+                                return Err(Error::MessageTooLarge(len));
                             }
 
                             // Send message to client
                             //
                             // If the channel handler is closed, we log an error but don't
                             // close the peer (as other channels may still be open).
-                            let sender = senders.get_mut(&chunk.channel).unwrap();
+                            let sender = senders.get_mut(&data.channel).unwrap();
                             if let Err(e) = sender
-                                .send((peer.clone(), message.freeze()))
+                                .send((peer.clone(), data.message))
                                 .await
-                                .map_err(|_| Error::ChannelClosed(chunk.channel))
+                                .map_err(|_| Error::ChannelClosed(data.channel))
                             {
                                 debug!(err=?e, "failed to send message to client");
                             }

--- a/p2p/src/authenticated/actors/peer/ingress.rs
+++ b/p2p/src/authenticated/actors/peer/ingress.rs
@@ -38,19 +38,14 @@ impl Mailbox {
     }
 }
 
-pub struct Data {
-    pub channel: Channel,
-    pub message: Bytes,
-}
-
 #[derive(Clone)]
 pub struct Relay {
-    low: mpsc::Sender<Data>,
-    high: mpsc::Sender<Data>,
+    low: mpsc::Sender<wire::Data>,
+    high: mpsc::Sender<wire::Data>,
 }
 
 impl Relay {
-    pub fn new(low: mpsc::Sender<Data>, high: mpsc::Sender<Data>) -> Self {
+    pub fn new(low: mpsc::Sender<wire::Data>, high: mpsc::Sender<wire::Data>) -> Self {
         Self { low, high }
     }
 
@@ -68,12 +63,12 @@ impl Relay {
         if priority {
             return self
                 .high
-                .send(Data { channel, message })
+                .send(wire::Data { channel, message })
                 .await
                 .map_err(|_| Error::MessageDropped);
         }
         self.low
-            .send(Data { channel, message })
+            .send(wire::Data { channel, message })
             .await
             .map_err(|_| Error::MessageDropped)
     }
@@ -93,7 +88,7 @@ mod tests {
             let mut relay = Relay::new(low_sender, high_sender);
 
             // Send a high priority message
-            let data = Data {
+            let data = wire::Data {
                 channel: 1,
                 message: Bytes::from("test high prio message"),
             };
@@ -111,7 +106,7 @@ mod tests {
             assert!(low_receiver.try_next().is_err());
 
             // Send a low priority message
-            let data = Data {
+            let data = wire::Data {
                 channel: 1,
                 message: Bytes::from("test low prio message"),
             };

--- a/p2p/src/authenticated/actors/peer/mod.rs
+++ b/p2p/src/authenticated/actors/peer/mod.rs
@@ -41,8 +41,6 @@ pub enum Error {
     UnexpectedFailure(commonware_runtime::Error),
     #[error("message dropped")]
     MessageDropped,
-    #[error("message too large: {0}")]
-    MessageTooLarge(usize),
     #[error("invalid channel")]
     InvalidChannel,
     #[error("channel closed: {0}")]

--- a/p2p/src/authenticated/actors/peer/mod.rs
+++ b/p2p/src/authenticated/actors/peer/mod.rs
@@ -43,8 +43,6 @@ pub enum Error {
     MessageDropped,
     #[error("message too large: {0}")]
     MessageTooLarge(usize),
-    #[error("invalid chunk")]
-    InvalidChunk,
     #[error("invalid channel")]
     InvalidChannel,
     #[error("channel closed: {0}")]

--- a/p2p/src/authenticated/actors/router/actor.rs
+++ b/p2p/src/authenticated/actors/router/actor.rs
@@ -64,12 +64,12 @@ impl Actor {
                 sent.push(recipient.clone());
             } else {
                 self.messages_dropped
-                    .get_or_create(&metrics::Message::new_chunk(recipient, channel))
+                    .get_or_create(&metrics::Message::new_data(recipient, channel))
                     .inc();
             }
         } else {
             self.messages_dropped
-                .get_or_create(&metrics::Message::new_chunk(recipient, channel))
+                .get_or_create(&metrics::Message::new_data(recipient, channel))
                 .inc();
         }
     }
@@ -128,9 +128,7 @@ impl Actor {
                                     sent.push(recipient.clone());
                                 } else {
                                     self.messages_dropped
-                                        .get_or_create(&metrics::Message::new_chunk(
-                                            recipient, channel,
-                                        ))
+                                        .get_or_create(&metrics::Message::new_data(recipient, channel))
                                         .inc();
                                 }
                             }

--- a/p2p/src/authenticated/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/actors/spawner/actor.rs
@@ -114,9 +114,9 @@ impl<
 
                             // Run peer
                             let e = actor.run(peer.clone(), connection, tracker, channels).await;
-                            info!(error = ?e, peer=hex(&peer), "peer shutdown");
 
                             // Let the router know the peer has exited
+                            info!(error = ?e, peer=hex(&peer), "peer shutdown");
                             router.release(peer).await;
                         }
                     });

--- a/p2p/src/authenticated/config.rs
+++ b/p2p/src/authenticated/config.rs
@@ -42,6 +42,7 @@ pub struct Config<C: Scheme> {
     pub allow_private_ips: bool,
 
     /// Maximum size allowed for messages over any connection.
+    ///
     /// The actual size of the network message will be higher due to overhead from the protocol;
     /// this includes additional metadata, protobuf encoding of the bytes, and cryptographic signatures.
     pub max_message_size: usize,

--- a/p2p/src/authenticated/config.rs
+++ b/p2p/src/authenticated/config.rs
@@ -42,8 +42,6 @@ pub struct Config<C: Scheme> {
     pub allow_private_ips: bool,
 
     /// Maximum size allowed for messages over any connection.
-    ///
-    /// Messages larger than this size will be chunked.
     pub max_message_size: usize,
 
     /// Message backlog allowed for internal actors.

--- a/p2p/src/authenticated/config.rs
+++ b/p2p/src/authenticated/config.rs
@@ -42,6 +42,8 @@ pub struct Config<C: Scheme> {
     pub allow_private_ips: bool,
 
     /// Maximum size allowed for messages over any connection.
+    /// The actual size of the network message will be higher due to overhead from the protocol;
+    /// this includes additional metadata, protobuf encoding of the bytes, and cryptographic signatures.
     pub max_message_size: usize,
 
     /// Message backlog allowed for internal actors.

--- a/p2p/src/authenticated/metrics.rs
+++ b/p2p/src/authenticated/metrics.rs
@@ -37,7 +37,7 @@ impl Message {
             message: Self::PEERS_TYPE,
         }
     }
-    pub fn new_chunk(peer: &PublicKey, channel: Channel) -> Self {
+    pub fn new_data(peer: &PublicKey, channel: Channel) -> Self {
         Self {
             peer: hex(peer),
             message: channel as i32,

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -70,8 +70,8 @@
 //!
 //! ## Messages
 //!
-//! To send messages, use the Data message type. This message type is used to send arbitrary bytes to a given channel.
-//! The data must be smaller than the configured maximum message size. If the message is larger, an error will be returned.
+//! Messages are sent using the Data message type. This message type is used to send arbitrary bytes to a given channel.
+//! The message must be smaller (in bytes) than the configured maximum message size. If the message is larger, an error will be returned.
 //! It is possible for a sender to prioritize messages over others.
 //!
 //! ```protobuf

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -153,7 +153,6 @@
 //!     let (sender, receiver) = network.register(
 //!         0,
 //!         Quota::per_second(NonZeroU32::new(1).unwrap()),
-//!         MAX_MESSAGE_SIZE,
 //!         MAX_MESSAGE_BACKLOG,
 //!         COMPRESSION_LEVEL,
 //!     );
@@ -225,8 +224,6 @@ mod tests {
         One,
     }
 
-    const ONE_KILOBYTE: usize = 1_024;
-    const ONE_MEGABYTE: usize = 1_024 * ONE_KILOBYTE;
     const DEFAULT_MESSAGE_BACKLOG: usize = 128;
 
     /// Test connectivity between `n` peers.
@@ -281,7 +278,6 @@ mod tests {
             let (mut sender, mut receiver) = network.register(
                 0,
                 Quota::per_second(NonZeroU32::new(5).unwrap()), // Ensure we hit the rate limit
-                ONE_KILOBYTE,
                 DEFAULT_MESSAGE_BACKLOG,
                 None,
             );
@@ -505,7 +501,6 @@ mod tests {
                 let (mut sender, mut receiver) = network.register(
                     0,
                     Quota::per_second(NonZeroU32::new(10).unwrap()),
-                    ONE_MEGABYTE,
                     DEFAULT_MESSAGE_BACKLOG,
                     None,
                 );
@@ -587,7 +582,6 @@ mod tests {
             let (mut sender, _) = network.register(
                 0,
                 Quota::per_second(NonZeroU32::new(10).unwrap()),
-                ONE_MEGABYTE,
                 DEFAULT_MESSAGE_BACKLOG,
                 compression,
             );

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -11,7 +11,6 @@
 //! * Automatic Peer Discovery Using Bit Vectors (Used as Ping/Pongs)
 //! * Multiplexing With Configurable Rate Limiting Per Channel and Send Prioritization
 //! * Optional Message Compression (using `zstd`)
-//! * Embedded Message Chunking
 //!
 //! # Design
 //!
@@ -69,25 +68,18 @@
 //! This allows peers that have a more up-to-date version of the peer set to connect, exchange application-level information, and for
 //! the said peer to potentially learn of an updated peer set (of which it is part)._
 //!
-//! ## Chunking
+//! ## Messages
 //!
-//! To support arbitrarily large messages (while maintaining a small frame size), this crate automatically chunks messages
-//! that exceed the frame size (the frame size is configurable). A connection will be blocked until all chunks of a given
-//! message are sent. It is possible for a sender to prioritize messages over others but not to be interleaved with an
-//! ongoing multi-chunk message.
+//! To send messages, use the Data message type. This message type is used to send arbitrary bytes to a given channel.
+//! The data must be smaller than the configured maximum message size. If the message is larger, an error will be returned.
+//! It is possible for a sender to prioritize messages over others.
 //!
 //! ```protobuf
-//! message Chunk {
+//! message Data {
 //!     uint32 channel = 1;
-//!     uint32 part = 2;
-//!     uint32 total_parts = 3;
-//!     bytes content = 4;
+//!     bytes message = 2;
 //! }
 //! ```
-//!
-//! To minimize the number of chunks sent and to ensure each chunk is full (otherwise someone could send us a million chunks
-//! each 1 byte), content is compressed (if enabled) before chunking rather than after. As a result, the configuration
-//! chosen for frame size has no impact on compression efficiency.
 //!
 //! # Example
 //!
@@ -210,7 +202,6 @@ pub use network::Network;
 mod tests {
     use super::*;
     use crate::{Receiver, Recipients, Sender};
-    use bytes::Bytes;
     use commonware_cryptography::{Ed25519, Scheme};
     use commonware_macros::test_traced;
     use commonware_runtime::{
@@ -560,127 +551,6 @@ mod tests {
                 waiter.await.unwrap();
             }
         });
-    }
-
-    fn test_chunking(compression: Option<u8>) {
-        // Configure test
-        let base_port = 3000;
-        let n: usize = 2;
-
-        // Initialize runtime
-        let (executor, mut runtime, _) = deterministic::Executor::default();
-        executor.start(async move {
-            // Create peers
-            let mut peers = Vec::new();
-            for i in 0..n {
-                peers.push(Ed25519::from_seed(i as u64));
-            }
-            let addresses = peers.iter().map(|p| p.public_key()).collect::<Vec<_>>();
-
-            // Create random message
-            let mut msg = vec![0u8; 2 * 1024 * 1024]; // 2MB (greater than frame capacity)
-            runtime.fill(&mut msg[..]);
-
-            // Create networks
-            let mut waiters = Vec::new();
-            for (i, peer) in peers.iter().enumerate() {
-                // Derive port
-                let port = base_port + i as u16;
-
-                // Create bootstrappers
-                let mut bootstrappers = Vec::new();
-                if i > 0 {
-                    bootstrappers.push((
-                        addresses[0].clone(),
-                        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port),
-                    ));
-                }
-
-                // Create network
-                let signer = peer.clone();
-                let registry = Arc::new(Mutex::new(Registry::with_prefix("p2p")));
-                let config = Config::test(
-                    signer.clone(),
-                    registry,
-                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
-                    bootstrappers,
-                    1_024 * 1_024, // 1MB
-                );
-                let (mut network, mut oracle) = Network::new(runtime.clone(), config);
-
-                // Register peers
-                oracle.register(0, addresses.clone()).await;
-
-                // Register basic application
-                let (mut sender, mut receiver) = network.register(
-                    0,
-                    Quota::per_second(NonZeroU32::new(10).unwrap()),
-                    5 * ONE_MEGABYTE,
-                    DEFAULT_MESSAGE_BACKLOG,
-                    compression,
-                );
-
-                // Wait to connect to all peers, and then send messages to everyone
-                runtime.spawn("network", network.run());
-
-                // Send/Recieve messages
-                let msg = Bytes::from(msg.clone());
-                let msg_sender = addresses[0].clone();
-                let msg_recipient = addresses[1].clone();
-                let peer_handler = runtime.spawn("agent", {
-                    let runtime = runtime.clone();
-                    async move {
-                        if i == 0 {
-                            // Loop until success
-                            let recipient = Recipients::One(msg_recipient);
-                            loop {
-                                if sender
-                                    .send(recipient.clone(), msg.clone(), true)
-                                    .await
-                                    .unwrap()
-                                    .len()
-                                    == 1
-                                {
-                                    break;
-                                }
-
-                                // Sleep and try again (avoid busy loop)
-                                runtime.sleep(Duration::from_millis(100)).await;
-                            }
-                        } else {
-                            // Ensure message equals sender identity
-                            let (sender, message) = receiver.recv().await.unwrap();
-                            assert_eq!(sender, msg_sender);
-
-                            // Ensure message equals sent message
-                            assert_eq!(message.len(), msg.len());
-                            for (i, (&byte1, &byte2)) in message.iter().zip(msg.iter()).enumerate()
-                            {
-                                assert_eq!(byte1, byte2, "byte {} mismatch", i);
-                            }
-                        }
-                    }
-                });
-
-                // Add to waiters
-                waiters.push(peer_handler);
-            }
-
-            // Wait for waiters to finish (receiver before sender)
-            for waiter in waiters.into_iter().rev() {
-                waiter.await.unwrap();
-            }
-        });
-    }
-
-    #[test_traced]
-    fn test_chunking_no_compression() {
-        test_chunking(None);
-    }
-
-    #[test_traced]
-    fn test_chunking_compression() {
-        test_chunking(Some(3));
     }
 
     fn test_message_too_large(compression: Option<u8>) {

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -15,11 +15,19 @@ use rand::{CryptoRng, Rng};
 use std::marker::PhantomData;
 use tracing::{debug, info, warn};
 
-/// The maximum overhead of encoding a message in protobuf.
-const PROTOBUF_OVERHEAD: usize =
-    1 + 10 + // Encode Data (field + length varint)
-    1 + 5 + // Encode Channel (field + 32-bit varint)
-    1 + 10; // Encode Message (field + length varint)
+// The maximum overhead of encoding a `message: Bytes` into a protobuf `message Message`
+// Should be at most 18 bytes for messages under 4GB, but we add a bit of padding.
+//
+// The byte overhead is calculated as follows:
+// - 1  Data field number
+// - 5* Data length varint
+// - 1  Channel field number
+// - 5  Channel value varint
+// - 1  Message field number
+// - 5* Message length varint
+//
+// (*) assumes that the length is no more than 4GB
+const PROTOBUF_OVERHEAD: usize = 64;
 
 /// Implementation of an `authenticated` network.
 pub struct Network<
@@ -82,13 +90,14 @@ impl<
             registry: cfg.registry.clone(),
             mailbox_size: cfg.mailbox_size,
         });
+        let channels = Channels::new(messenger, cfg.max_message_size);
 
         (
             Self {
                 runtime,
                 cfg,
 
-                channels: Channels::new(messenger),
+                channels,
                 tracker,
                 tracker_mailbox,
                 router,
@@ -108,7 +117,6 @@ impl<
     ///
     /// * `channel` - Unique identifier for the channel.
     /// * `rate` - Rate at which messages can be received over the channel.
-    /// * `max_size` - Maximum size of a message that can be sent/received over the channel.
     /// * `backlog` - Maximum number of messages that can be queued on the channel before blocking.
     /// * `compression` - Optional compression level (using `zstd`) to use for messages on the channel.
     ///
@@ -121,12 +129,10 @@ impl<
         &mut self,
         channel: Channel,
         rate: Quota,
-        max_size: usize,
         backlog: usize,
         compression: Option<u8>,
     ) -> (channels::Sender, channels::Receiver) {
-        self.channels
-            .register(channel, rate, max_size, backlog, compression)
+        self.channels.register(channel, rate, backlog, compression)
     }
 
     /// Starts the network.

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -15,6 +15,12 @@ use rand::{CryptoRng, Rng};
 use std::marker::PhantomData;
 use tracing::{debug, info, warn};
 
+/// The maximum overhead of encoding a message in protobuf.
+const PROTOBUF_OVERHEAD: usize =
+    1 + 10 + // Encode Data (field + length varint)
+    1 + 5 + // Encode Channel (field + 32-bit varint)
+    1 + 10; // Encode Message (field + length varint)
+
 /// Implementation of an `authenticated` network.
 pub struct Network<
     Si: Sink,
@@ -153,7 +159,7 @@ impl<
         let connection = placeholder::Config {
             crypto: self.cfg.crypto,
             namespace: self.cfg.namespace,
-            max_message_size: self.cfg.max_message_size,
+            max_message_size: self.cfg.max_message_size + PROTOBUF_OVERHEAD,
             synchrony_bound: self.cfg.synchrony_bound,
             max_handshake_age: self.cfg.max_handshake_age,
             handshake_timeout: self.cfg.handshake_timeout,

--- a/p2p/src/authenticated/wire.proto
+++ b/p2p/src/authenticated/wire.proto
@@ -6,7 +6,7 @@ message Message {
     oneof payload {
         BitVec bit_vec = 1;
         Peers peers = 2;
-        Chunk chunk = 3;
+        Data data = 3;
     }
 }
 
@@ -36,17 +36,11 @@ message Peers {
     repeated Peer peers = 1;
 }
 
-// Chunk is one of potentially many parts of a message
-// sent by a peer.
-//
-// If there is more than one part, the recipient will combine
-// all parts into a single message.
-message Chunk {
+// Data is an arbitrary data message sent between peers.
+message Data {
     uint32 channel = 1;
-    uint32 part = 2;
-    uint32 total_parts = 3;
-    bytes content = 4;
-} 
+    bytes message = 2;
+}
 
 // Signature is an arbitrary public key and signature over
 // either a Handshake or Peer message.

--- a/p2p/src/authenticated/wire.proto
+++ b/p2p/src/authenticated/wire.proto
@@ -36,7 +36,7 @@ message Peers {
     repeated Peer peers = 1;
 }
 
-// Data is an arbitrary data message sent between peers.
+// Data is an arbitrary message sent between peers.
 message Data {
     uint32 channel = 1;
     bytes message = 2;

--- a/stream/src/placeholder/instance.rs
+++ b/stream/src/placeholder/instance.rs
@@ -144,9 +144,8 @@ impl<C: Scheme, Si: Sink, St: Stream> Instance<C, Si, St> {
         })
     }
 
-    pub fn split(self) -> (usize, Sender<Si>, Receiver<St>) {
+    pub fn split(self) -> (Sender<Si>, Receiver<St>) {
         (
-            self.config.max_message_size,
             Sender {
                 cipher: self.cipher.clone(),
                 sink: self.sink,


### PR DESCRIPTION
Fixes #186 

Also slightly touches the `split()` function in the `stream` crate to not return the maximum message size allowed