### PR TITLE
[fix]: Address Typos and Remove Duplicate CSS Rules

### DIFF
--- a/docs/blogs/commonware-cryptography.html
+++ b/docs/blogs/commonware-cryptography.html
@@ -113,7 +113,7 @@
         <p>Contributors to this VRF connect to each other over commonware-p2p (using ED25519 identities), perform an initial DKG (to generate a static public key), and then perform a proactive refresh every 10 seconds. After a successful DKG and/or Reshare, contributors generate partial signatures over the round number and gossip them to others in the group (again using commonware-p2p). These partial signatures, when aggregated, form a bias-resistant source of randomness that was not knowable to any contributor prior to signing.</p>
         <p>To demonstrate how malicious contributors are tolerated, the CLI also lets you behave as a "rogue" dealer that generates invalid shares, a "lazy" dealer that doesn't distribute shares to other contributors, or a "defiant" dealer that doesn't respond to requests to reveal shares that weren't acknowledged by other contributors.</p>
         <p>Next up, commonware-consensus!</p>
-        <p><i>To support contributors and developers working with the Commonware Library, we launched a <a href="https://discord.gg/wt5VtKXv5cDiscord">Discord</a>. We look forward to seeing you there soon!</i></p>
+        <p><i>To support contributors and developers working with the Commonware Library, we launched a <a href="https://discord.gg/wt5VtKXv5c">Discord</a>. We look forward to seeing you there soon!</i></p>
     </div>
 
     <div id="footer-placeholder"></div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -86,11 +86,6 @@ img {
 }
 
 .image-container {
-    display: block;
-    margin: 20px 0;
-}
-
-.image-container {
     max-width: 100%;
     height: auto;
     display: block;

--- a/docs/style.css
+++ b/docs/style.css
@@ -89,7 +89,7 @@ img {
     max-width: 100%;
     height: auto;
     display: block;
-    margin: 0;
+    margin: 20px 0;
 }
 
 .image-caption {

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -13,7 +13,7 @@ and [commonware-p2p::authenticated](https://docs.rs/commonware-p2p/latest/common
 of `p2p_connections` in the "Metrics Panel" in the right corner of the window. This metric should be equal to
 `count(friends)- 1` (you don't connect to yourself).
 
-## Synchonized Friends
+## Synchronized Friends
 
 `commonware-p2p::authenticated` requires all friends to have the same set of friends for friend discovery to work
 correctly. If you do not synchronize friends, you may be able to form connections between specific friends but may


### PR DESCRIPTION
This pull request addresses the following issues:

1. **Typos in `commonware-cryptography.html`:**
   - Corrected the Discord link by removing redundant text (`Discord`).

2. **Duplicate CSS in `style.css`:**
   - Removed the duplicate `.image-container` rule to streamline the stylesheet.

3. **Spelling Error in `README.md`:**
   - Corrected "Synchonized" to "Synchronized" in the "Synchronized Friends" section.