### PR TITLE
[runtime] Ensure termination behavior is consistent

### DIFF
--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -285,7 +285,7 @@ mod tests {
             // Wait to connect to all peers, and then send messages to everyone
             runtime.spawn("network", network.run());
 
-            // Send/Recieve messages
+            // Send/Receive messages
             let handler = runtime.spawn("agent", {
                 let addresses = addresses.clone();
                 let runtime = runtime.clone();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -782,7 +782,6 @@ mod tests {
             async move {
                 // Add to counter
                 context.spawn("locker", {
-                    let context = context.clone();
                     let counter = counter.clone();
                     async move {
                         loop {
@@ -791,9 +790,8 @@ mod tests {
                                 *counter += 1;
                             }
 
-                            // We keep a reference to context to ensure it doesn't affect whether
-                            // or not the task is dropped.
-                            context.sleep(Duration::from_millis(1)).await;
+                            // We reschedule to ensure the runtime eventually has a chance to exit.
+                            reschedule().await;
                         }
                     }
                 });
@@ -807,8 +805,7 @@ mod tests {
                         }
                     }
 
-                    // We reschedule to ensure the runtime eventually has a chance to execute
-                    // the inner task.
+                    // We reschedule to ensure the runtime eventually has a chance to exit.
                     reschedule().await;
                 }
             }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -814,9 +814,6 @@ mod tests {
             }
         });
 
-        // Give time for the runtime to shutdown
-        sleep(Duration::from_millis(100));
-
         // Ensure counter is not being updated
         let initial = *counter.lock().unwrap();
         for _ in 0..10 {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -254,6 +254,7 @@ mod tests {
     use prometheus_client::registry::Registry;
     use std::panic::{catch_unwind, AssertUnwindSafe};
     use std::sync::{Arc, Mutex};
+    use std::thread::sleep;
     use utils::reschedule;
 
     fn test_error_future(runner: impl Runner) {
@@ -768,6 +769,62 @@ mod tests {
         });
     }
 
+    fn test_start_terminates(runner: impl Runner, context: impl Spawner + Clock) {
+        // To verify inner tasks are dropped, we continuously increment a counter
+        // and then verify that counter is no longer incremented after the root task
+        // completes.
+        //
+        // This test is a bit involved, however, it is important to ensure this variant
+        // is satisfied and its worth the complexity.
+        let counter = Arc::new(Mutex::new(0));
+        runner.start({
+            let counter = counter.clone();
+            async move {
+                // Add to counter
+                context.spawn("locker", {
+                    let counter = counter.clone();
+                    async move {
+                        loop {
+                            {
+                                let mut counter = counter.lock().unwrap();
+                                *counter += 1;
+                            }
+
+                            // We reschedule to ensure the runtime eventually has a chance
+                            // to drop the task.
+                            reschedule().await;
+                        }
+                    }
+                });
+
+                // Wait for counter to reach some value
+                loop {
+                    {
+                        let counter = counter.lock().unwrap();
+                        if *counter >= 10 {
+                            break;
+                        }
+                    }
+
+                    // We reschedule to ensure the runtime eventually has a chance to execute
+                    // the inner task.
+                    reschedule().await;
+                }
+            }
+        });
+
+        // Ensure counter is not being updated
+        let initial = *counter.lock().unwrap();
+        for _ in 0..20 {
+            let next = *counter.lock().unwrap();
+            assert_eq!(initial, next);
+
+            // Assume task can make progress (if alive), in this
+            // period of time.
+            sleep(Duration::from_millis(1));
+        }
+    }
+
     #[test]
     fn test_deterministic_future() {
         let (runner, _, _) = deterministic::Executor::default();
@@ -883,6 +940,12 @@ mod tests {
     }
 
     #[test]
+    fn test_deterministic_start_terminates() {
+        let (executor, runtime, _) = deterministic::Executor::default();
+        test_start_terminates(executor, runtime);
+    }
+
+    #[test]
     fn test_tokio_error_future() {
         let (runner, _) = tokio::Executor::default();
         test_error_future(runner);
@@ -992,5 +1055,11 @@ mod tests {
     fn test_tokio_spawn_after_complete() {
         let (executor, runtime) = tokio::Executor::default();
         test_spawn_after_complete(executor, runtime);
+    }
+
+    #[test]
+    fn test_tokio_start_terminates() {
+        let (executor, runtime) = tokio::Executor::default();
+        test_start_terminates(executor, runtime);
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -70,7 +70,9 @@ pub enum Error {
 /// Interface that any task scheduler must implement to start
 /// running tasks.
 pub trait Runner {
-    /// Start running a root task.
+    /// Run some task to completion.
+    ///
+    /// Any spawned tasks
     fn start<F>(self, f: F) -> F::Output
     where
         F: Future + Send + 'static,

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -277,8 +277,11 @@ impl crate::Runner for Runner {
         };
 
         // Shutdown the runtime after the task completes
-        let runtime = self.executor.runtime.write().unwrap().take().unwrap();
-        runtime.shutdown_background();
+        //
+        // Dropping the runtime will result in a blocking shutdown of all outstanding
+        // tasks. If we used `.shutdown_background()`, we would not wait for all tasks
+        // to halt (and may leak those resources).
+        let _ = self.executor.runtime.write().unwrap().take().unwrap();
         result
     }
 }


### PR DESCRIPTION
`runtime::{deterministic, tokio}` don't have consistent shutdown behavior. When `start()` returns in `runtime::deterministic`, all task execution halts (in `tokio` it continues).

We should align on a single approach to this case and ensure they are consistent.