### PR TITLE
[runtime/deterministic] Expose Runtime `Recover` to Deterministically Simulate Restarts

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -715,7 +715,8 @@ pub struct Context {
 impl Context {
     /// Recover the inner state (deadline, metrics, auditor, rng, synced storage, etc.) from the
     /// current runtime and use it to initialize a new instance of the runtime. A recovered runtime
-    /// does not inherit the current runtime's pending tasks, unsynced storage, or network connections.
+    /// does not inherit the current runtime's pending tasks, unsynced storage, network connections, nor
+    /// its shutdown signaler.
     ///
     /// This is useful for performing a deterministic simulation that spans multiple runtime instantiations,
     /// like simulating unclean shutdown (which involves repeatedly halting the runtime at unexpected intervals).

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1475,10 +1475,7 @@ mod tests {
         executor2.start(async move {
             let blob = context2.open(partition, name).await.unwrap();
             let len = blob.len().await.unwrap();
-            assert_eq!(
-                len, 0,
-                "Expected blob length to be 0 after recovery without sync"
-            );
+            assert_eq!(len, 0);
         });
     }
 


### PR DESCRIPTION
Related: #180 

We need this to better cleanly deterministic "unclean shutdown" simulation. A more crude version of this approach (where the caller handled internal state) was tested here: https://github.com/commonwarexyz/monorepo/blob/bb8497a131e79ba04dfa2735c674860448bd2568/runtime/src/deterministic.rs