### PR TITLE
[stream] Remove need for specifying cryptography in `stream::public_key::Connection`

### DIFF
--- a/p2p/src/authenticated/actors/peer/actor.rs
+++ b/p2p/src/authenticated/actors/peer/actor.rs
@@ -1,6 +1,6 @@
 use super::{Config, Error, Mailbox, Message, Relay};
 use crate::authenticated::{actors::tracker, channels::Channels, metrics, wire};
-use commonware_cryptography::{PublicKey, Scheme};
+use commonware_cryptography::PublicKey;
 use commonware_macros::select;
 use commonware_runtime::{Clock, Handle, Sink, Spawner, Stream};
 use commonware_stream::{
@@ -83,10 +83,10 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng> Actor<E> {
         Ok(())
     }
 
-    pub async fn run<C: Scheme, Si: Sink, St: Stream>(
+    pub async fn run<Si: Sink, St: Stream>(
         mut self,
         peer: PublicKey,
-        connection: Connection<C, Si, St>,
+        connection: Connection<Si, St>,
         mut tracker: tracker::Mailbox<E>,
         channels: Channels,
     ) -> Error {

--- a/p2p/src/authenticated/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/actors/spawner/actor.rs
@@ -6,7 +6,6 @@ use crate::authenticated::{
     actors::{peer, router, tracker},
     metrics,
 };
-use commonware_cryptography::Scheme;
 use commonware_runtime::{Clock, Sink, Spawner, Stream};
 use commonware_utils::hex;
 use futures::{channel::mpsc, StreamExt};
@@ -16,7 +15,7 @@ use rand::{CryptoRng, Rng};
 use std::time::Duration;
 use tracing::{debug, info};
 
-pub struct Actor<E: Spawner + Clock, C: Scheme, Si: Sink, St: Stream> {
+pub struct Actor<E: Spawner + Clock, Si: Sink, St: Stream> {
     runtime: E,
 
     mailbox_size: usize,
@@ -24,21 +23,17 @@ pub struct Actor<E: Spawner + Clock, C: Scheme, Si: Sink, St: Stream> {
     allowed_bit_vec_rate: Quota,
     allowed_peers_rate: Quota,
 
-    receiver: mpsc::Receiver<Message<E, C, Si, St>>,
+    receiver: mpsc::Receiver<Message<E, Si, St>>,
 
     sent_messages: Family<metrics::Message, Counter>,
     received_messages: Family<metrics::Message, Counter>,
     rate_limited: Family<metrics::Message, Counter>,
 }
 
-impl<
-        E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng,
-        C: Scheme,
-        Si: Sink,
-        St: Stream,
-    > Actor<E, C, Si, St>
+impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng, Si: Sink, St: Stream>
+    Actor<E, Si, St>
 {
-    pub fn new(runtime: E, cfg: Config) -> (Self, Mailbox<E, C, Si, St>) {
+    pub fn new(runtime: E, cfg: Config) -> (Self, Mailbox<E, Si, St>) {
         let sent_messages = Family::<metrics::Message, Counter>::default();
         let received_messages = Family::<metrics::Message, Counter>::default();
         let rate_limited = Family::<metrics::Message, Counter>::default();

--- a/p2p/src/authenticated/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/actors/spawner/ingress.rs
@@ -1,30 +1,30 @@
 use crate::authenticated::actors::tracker;
-use commonware_cryptography::{PublicKey, Scheme};
+use commonware_cryptography::PublicKey;
 use commonware_runtime::{Clock, Sink, Spawner, Stream};
 use commonware_stream::public_key::Connection;
 use futures::{channel::mpsc, SinkExt};
 
-pub enum Message<E: Spawner + Clock, C: Scheme, Si: Sink, St: Stream> {
+pub enum Message<E: Spawner + Clock, Si: Sink, St: Stream> {
     Spawn {
         peer: PublicKey,
-        connection: Connection<C, Si, St>,
+        connection: Connection<Si, St>,
         reservation: tracker::Reservation<E>,
     },
 }
 
-pub struct Mailbox<E: Spawner + Clock, C: Scheme, Si: Sink, St: Stream> {
-    sender: mpsc::Sender<Message<E, C, Si, St>>,
+pub struct Mailbox<E: Spawner + Clock, Si: Sink, St: Stream> {
+    sender: mpsc::Sender<Message<E, Si, St>>,
 }
 
-impl<E: Spawner + Clock, C: Scheme, Si: Sink, St: Stream> Mailbox<E, C, Si, St> {
-    pub fn new(sender: mpsc::Sender<Message<E, C, Si, St>>) -> Self {
+impl<E: Spawner + Clock, Si: Sink, St: Stream> Mailbox<E, Si, St> {
+    pub fn new(sender: mpsc::Sender<Message<E, Si, St>>) -> Self {
         Self { sender }
     }
 
     pub async fn spawn(
         &mut self,
         peer: PublicKey,
-        connection: Connection<C, Si, St>,
+        connection: Connection<Si, St>,
         reservation: tracker::Reservation<E>,
     ) {
         self.sender
@@ -38,7 +38,7 @@ impl<E: Spawner + Clock, C: Scheme, Si: Sink, St: Stream> Mailbox<E, C, Si, St> 
     }
 }
 
-impl<E: Spawner + Clock, C: Scheme, Si: Sink, St: Stream> Clone for Mailbox<E, C, Si, St> {
+impl<E: Spawner + Clock, Si: Sink, St: Stream> Clone for Mailbox<E, Si, St> {
     /// Clone the mailbox.
     ///
     /// We manually implement `clone` because the auto-generated `derive` would

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -162,7 +162,7 @@ impl<
         );
 
         // Start listener
-        let connection = public_key::Config {
+        let stream_cfg = public_key::Config {
             crypto: self.cfg.crypto,
             namespace: self.cfg.namespace,
             max_message_size: self.cfg.max_message_size + PROTOBUF_OVERHEAD,
@@ -175,7 +175,7 @@ impl<
             listener::Config {
                 registry: self.cfg.registry.clone(),
                 address: self.cfg.listen,
-                connection: connection.clone(),
+                stream_cfg: stream_cfg.clone(),
                 allowed_incoming_connectioned_rate: self.cfg.allowed_incoming_connection_rate,
             },
         );
@@ -189,7 +189,7 @@ impl<
             self.runtime.clone(),
             dialer::Config {
                 registry: self.cfg.registry,
-                connection,
+                stream_cfg,
                 dial_frequency: self.cfg.dial_frequency,
                 dial_rate: self.cfg.dial_rate,
             },


### PR DESCRIPTION
- The cryptography is used only for the handshake authentication, the actual connection is agnostic to the crypto used
- Cleaned up some variable naming like `connection` that was used to refer to a `Config`