### PR TITLE
[stream] Initial `IncomingHandshake` Cleanup

### DIFF
--- a/p2p/src/authenticated/actors/listener.rs
+++ b/p2p/src/authenticated/actors/listener.rs
@@ -3,7 +3,7 @@
 use crate::authenticated::actors::{spawner, tracker};
 use commonware_cryptography::Scheme;
 use commonware_runtime::{Clock, Listener, Network, Sink, Spawner, Stream};
-use commonware_stream::public_key::{Config as StreamConfig, Connection, IncomingHandshake};
+use commonware_stream::public_key::{Config as StreamConfig, Connection, PartialConnection};
 use commonware_utils::hex;
 use governor::{
     clock::ReasonablyRealtime,
@@ -96,32 +96,23 @@ impl<
     ) {
         // Wait for the peer to send us their public key
         //
-        // PartialHandshake limits how long we will wait for the peer to send us their public key
+        // PartialConnection limits how long we will wait for the peer to send us their public key
         // to ensure an adversary can't force us to hold many pending connections open.
-        let handshake = match IncomingHandshake::verify(
-            runtime.clone(),
-            &stream_cfg.crypto,
-            &stream_cfg.namespace,
-            stream_cfg.max_message_size,
-            stream_cfg.synchrony_bound,
-            stream_cfg.max_handshake_age,
-            stream_cfg.handshake_timeout,
-            sink,
-            stream,
-        )
-        .await
-        {
-            Ok(incoming) => incoming,
-            Err(e) => {
-                debug!(error = ?e, "failed to complete handshake");
-                return;
-            }
-        };
+        let partial =
+            match PartialConnection::verify_listener(runtime.clone(), stream_cfg, sink, stream)
+                .await
+            {
+                Ok(partial) => partial,
+                Err(e) => {
+                    debug!(error = ?e, "failed to receive public key");
+                    return;
+                }
+            };
 
         // Attempt to claim the connection
         //
         // Reserve also checks if the peer is authorized.
-        let peer = handshake.peer_public_key.clone();
+        let peer = partial.public_key();
         let reservation = match tracker.reserve(peer.clone()).await {
             Some(reservation) => reservation,
             None => {
@@ -131,7 +122,7 @@ impl<
         };
 
         // Perform handshake
-        let stream = match Connection::upgrade_listener(runtime, stream_cfg, handshake).await {
+        let stream = match Connection::upgrade_listener(runtime, partial).await {
             Ok(connection) => connection,
             Err(e) => {
                 debug!(error = ?e, peer=hex(&peer), "failed to upgrade connection");

--- a/p2p/src/authenticated/actors/listener.rs
+++ b/p2p/src/authenticated/actors/listener.rs
@@ -3,7 +3,7 @@
 use crate::authenticated::actors::{spawner, tracker};
 use commonware_cryptography::Scheme;
 use commonware_runtime::{Clock, Listener, Network, Sink, Spawner, Stream};
-use commonware_stream::public_key::{Config as StreamConfig, Connection, PartialConnection};
+use commonware_stream::public_key::{Config as StreamConfig, Connection, IncomingConnection};
 use commonware_utils::hex;
 use governor::{
     clock::ReasonablyRealtime,
@@ -96,12 +96,10 @@ impl<
     ) {
         // Wait for the peer to send us their public key
         //
-        // PartialConnection limits how long we will wait for the peer to send us their public key
+        // IncomingConnection limits how long we will wait for the peer to send us their public key
         // to ensure an adversary can't force us to hold many pending connections open.
-        let partial =
-            match PartialConnection::verify_listener(runtime.clone(), stream_cfg, sink, stream)
-                .await
-            {
+        let incoming =
+            match IncomingConnection::new(runtime.clone(), stream_cfg, sink, stream).await {
                 Ok(partial) => partial,
                 Err(e) => {
                     debug!(error = ?e, "failed to receive public key");
@@ -112,7 +110,7 @@ impl<
         // Attempt to claim the connection
         //
         // Reserve also checks if the peer is authorized.
-        let peer = partial.public_key();
+        let peer = incoming.peer();
         let reservation = match tracker.reserve(peer.clone()).await {
             Some(reservation) => reservation,
             None => {
@@ -122,7 +120,7 @@ impl<
         };
 
         // Perform handshake
-        let stream = match Connection::upgrade_listener(runtime, partial).await {
+        let stream = match Connection::upgrade_listener(runtime, incoming).await {
             Ok(connection) => connection,
             Err(e) => {
                 debug!(error = ?e, peer=hex(&peer), "failed to upgrade connection");

--- a/p2p/src/authenticated/actors/listener.rs
+++ b/p2p/src/authenticated/actors/listener.rs
@@ -101,7 +101,7 @@ impl<
         let incoming = match IncomingConnection::verify(&runtime, stream_cfg, sink, stream).await {
             Ok(partial) => partial,
             Err(e) => {
-                debug!(error = ?e, "failed to receive public key");
+                debug!(error = ?e, "failed to verify incoming handshake");
                 return;
             }
         };

--- a/p2p/src/authenticated/actors/listener.rs
+++ b/p2p/src/authenticated/actors/listener.rs
@@ -98,14 +98,13 @@ impl<
         //
         // IncomingConnection limits how long we will wait for the peer to send us their public key
         // to ensure an adversary can't force us to hold many pending connections open.
-        let incoming =
-            match IncomingConnection::new(runtime.clone(), stream_cfg, sink, stream).await {
-                Ok(partial) => partial,
-                Err(e) => {
-                    debug!(error = ?e, "failed to receive public key");
-                    return;
-                }
-            };
+        let incoming = match IncomingConnection::new(&runtime, stream_cfg, sink, stream).await {
+            Ok(partial) => partial,
+            Err(e) => {
+                debug!(error = ?e, "failed to receive public key");
+                return;
+            }
+        };
 
         // Attempt to claim the connection
         //

--- a/p2p/src/authenticated/actors/listener.rs
+++ b/p2p/src/authenticated/actors/listener.rs
@@ -98,7 +98,7 @@ impl<
         //
         // IncomingConnection limits how long we will wait for the peer to send us their public key
         // to ensure an adversary can't force us to hold many pending connections open.
-        let incoming = match IncomingConnection::new(&runtime, stream_cfg, sink, stream).await {
+        let incoming = match IncomingConnection::verify(&runtime, stream_cfg, sink, stream).await {
             Ok(partial) => partial,
             Err(e) => {
                 debug!(error = ?e, "failed to receive public key");

--- a/p2p/src/authenticated/actors/mod.rs
+++ b/p2p/src/authenticated/actors/mod.rs
@@ -2,7 +2,6 @@ pub mod dialer;
 pub mod listener;
 pub mod peer;
 pub mod router;
+pub use router::Messenger;
 pub mod spawner;
 pub mod tracker;
-
-pub use router::Messenger;

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -31,10 +31,10 @@ use tracing::{debug, info, warn};
 const PROTOBUF_OVERHEAD: usize = 64;
 
 /// Unique suffix for all messages signed by the tracker.
-const TRACKER_SUFFIX: &[u8] = b"_TRACKER_";
+const TRACKER_SUFFIX: &[u8] = b"_TRACKER";
 
 /// Unique suffix for all messages signed in a stream.
-const STREAM_SUFFIX: &[u8] = b"_STREAM_";
+const STREAM_SUFFIX: &[u8] = b"_STREAM";
 
 /// Implementation of an `authenticated` network.
 pub struct Network<

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -10,6 +10,7 @@ use commonware_cryptography::Scheme;
 use commonware_macros::select;
 use commonware_runtime::{Clock, Listener, Network as RNetwork, Sink, Spawner, Stream};
 use commonware_stream::public_key;
+use commonware_utils::union;
 use governor::{clock::ReasonablyRealtime, Quota};
 use rand::{CryptoRng, Rng};
 use std::marker::PhantomData;
@@ -28,6 +29,12 @@ use tracing::{debug, info, warn};
 //
 // (*) assumes that the length is no more than 4GB
 const PROTOBUF_OVERHEAD: usize = 64;
+
+/// Unique suffix for all messages signed by the tracker.
+const TRACKER_SUFFIX: &[u8] = b"_TRACKER_";
+
+/// Unique suffix for all messages signed in a stream.
+const STREAM_SUFFIX: &[u8] = b"_STREAM_";
 
 /// Implementation of an `authenticated` network.
 pub struct Network<
@@ -74,7 +81,7 @@ impl<
             runtime.clone(),
             tracker::Config {
                 crypto: cfg.crypto.clone(),
-                namespace: cfg.namespace.clone(),
+                namespace: union(&cfg.namespace, TRACKER_SUFFIX),
                 registry: cfg.registry.clone(),
                 address: cfg.dialable,
                 bootstrappers: cfg.bootstrappers.clone(),
@@ -164,7 +171,7 @@ impl<
         // Start listener
         let stream_cfg = public_key::Config {
             crypto: self.cfg.crypto,
-            namespace: self.cfg.namespace,
+            namespace: union(&self.cfg.namespace, STREAM_SUFFIX),
             max_message_size: self.cfg.max_message_size + PROTOBUF_OVERHEAD,
             synchrony_bound: self.cfg.synchrony_bound,
             max_handshake_age: self.cfg.max_handshake_age,

--- a/stream/src/lib.rs
+++ b/stream/src/lib.rs
@@ -7,6 +7,7 @@ use prost::DecodeError;
 use std::future::Future;
 use thiserror::Error;
 
+/// Errors that can occur when interacting with a stream.
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("unexpected message")]

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -28,8 +28,8 @@ pub struct IncomingConnection<C: Scheme, Si: Sink, St: Stream> {
 }
 
 impl<C: Scheme, Si: Sink, St: Stream> IncomingConnection<C, Si, St> {
-    pub async fn new(
-        runtime: impl Rng + CryptoRng + Spawner + Clock,
+    pub async fn new<R: Rng + CryptoRng + Spawner + Clock>(
+        runtime: &R,
         config: Config<C>,
         sink: Si,
         stream: St,
@@ -64,8 +64,8 @@ pub struct Connection<Si: Sink, St: Stream> {
 }
 
 impl<Si: Sink, St: Stream> Connection<Si, St> {
-    pub async fn upgrade_dialer<C: Scheme>(
-        mut runtime: impl Rng + CryptoRng + Spawner + Clock,
+    pub async fn upgrade_dialer<R: Rng + CryptoRng + Spawner + Clock, C: Scheme>(
+        mut runtime: R,
         mut config: Config<C>,
         mut sink: Si,
         mut stream: St,
@@ -110,7 +110,7 @@ impl<Si: Sink, St: Stream> Connection<Si, St> {
 
         // Verify handshake message from peer
         let handshake = Handshake::verify(
-            runtime,
+            &runtime,
             &config.crypto,
             &config.namespace,
             config.synchrony_bound,
@@ -138,8 +138,8 @@ impl<Si: Sink, St: Stream> Connection<Si, St> {
         })
     }
 
-    pub async fn upgrade_listener<C: Scheme>(
-        mut runtime: impl Rng + CryptoRng + Spawner + Clock,
+    pub async fn upgrade_listener<R: Rng + CryptoRng + Spawner + Clock, C: Scheme>(
+        mut runtime: R,
         incoming: IncomingConnection<C, Si, St>,
     ) -> Result<Self, Error> {
         // Generate shared secret

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -36,7 +36,6 @@ impl<C: Scheme, Si: Sink, St: Stream> IncomingConnection<C, Si, St> {
         sink: Si,
         stream: St,
     ) -> Result<Self, Error> {
-        // Verify incoming
         let handshake = IncomingHandshake::verify(
             runtime,
             &config.crypto,
@@ -185,6 +184,7 @@ impl<Si: Sink, St: Stream> Connection<Si, St> {
         let cipher = ChaCha20Poly1305::new_from_slice(shared_secret.as_bytes())
             .map_err(|_| Error::CipherCreationFailed)?;
 
+        // Track whether or not we are the dialer to ensure we send correctly formatted nonces.
         Ok(Connection {
             dialer: false,
             sink: handshake.sink,

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -43,8 +43,8 @@ pub fn create_handshake<C: Scheme>(
 }
 
 pub struct Handshake {
-    pub(super) ephemeral_public_key: x25519_dalek::PublicKey,
-    pub(super) peer_public_key: PublicKey,
+    pub ephemeral_public_key: x25519_dalek::PublicKey,
+    pub peer_public_key: PublicKey,
 }
 
 impl Handshake {
@@ -123,11 +123,11 @@ impl Handshake {
 }
 
 pub struct IncomingHandshake<Si: Sink, St: Stream> {
-    pub(super) sink: Si,
-    pub(super) stream: St,
-    pub(super) deadline: SystemTime,
-    pub(super) ephemeral_public_key: x25519_dalek::PublicKey,
-    pub(super) peer_public_key: PublicKey,
+    pub sink: Si,
+    pub stream: St,
+    pub deadline: SystemTime,
+    pub ephemeral_public_key: x25519_dalek::PublicKey,
+    pub peer_public_key: PublicKey,
 }
 
 impl<Si: Sink, St: Stream> IncomingHandshake<Si, St> {

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -127,7 +127,7 @@ pub struct IncomingHandshake<Si: Sink, St: Stream> {
     pub(super) stream: St,
     pub(super) deadline: SystemTime,
     pub(super) ephemeral_public_key: x25519_dalek::PublicKey,
-    pub peer_public_key: PublicKey,
+    pub(super) peer_public_key: PublicKey,
 }
 
 impl<Si: Sink, St: Stream> IncomingHandshake<Si, St> {

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -49,7 +49,7 @@ pub struct Handshake {
 
 impl Handshake {
     pub fn verify<E: Clock, C: Scheme>(
-        runtime: E,
+        runtime: &E,
         crypto: &C,
         namespace: &[u8],
         synchrony_bound: Duration,
@@ -133,7 +133,7 @@ pub struct IncomingHandshake<Si: Sink, St: Stream> {
 impl<Si: Sink, St: Stream> IncomingHandshake<Si, St> {
     #[allow(clippy::too_many_arguments)]
     pub async fn verify<E: Clock + Spawner, C: Scheme>(
-        runtime: E,
+        runtime: &E,
         crypto: &C,
         namespace: &[u8],
         max_message_size: usize,
@@ -240,7 +240,7 @@ mod tests {
 
             // Verify using the handshake struct
             let handshake = Handshake::verify(
-                runtime,
+                &runtime,
                 &recipient,
                 TEST_NAMESPACE,
                 synchrony_bound,
@@ -286,7 +286,7 @@ mod tests {
 
             // Call the verify function
             let result = IncomingHandshake::verify(
-                runtime,
+                &runtime,
                 &recipient,
                 TEST_NAMESPACE,
                 ONE_MEGABYTE,
@@ -337,7 +337,7 @@ mod tests {
 
             // Call the verify function
             let result = IncomingHandshake::verify(
-                runtime,
+                &runtime,
                 &Ed25519::from_seed(2),
                 TEST_NAMESPACE,
                 ONE_MEGABYTE,
@@ -372,7 +372,7 @@ mod tests {
 
             // Call the verify function
             let result = IncomingHandshake::verify(
-                runtime,
+                &runtime,
                 &Ed25519::from_seed(0),
                 TEST_NAMESPACE,
                 ONE_MEGABYTE,
@@ -426,7 +426,7 @@ mod tests {
 
             // Call the verify function
             let result = IncomingHandshake::verify(
-                runtime,
+                &runtime,
                 &recipient,
                 TEST_NAMESPACE,
                 ONE_MEGABYTE,
@@ -479,7 +479,7 @@ mod tests {
 
             // Verify the handshake
             let result = Handshake::verify(
-                runtime,
+                &runtime,
                 &crypto,
                 TEST_NAMESPACE,
                 Duration::from_secs(5),
@@ -516,7 +516,7 @@ mod tests {
 
             // Verify the handshake
             let result = Handshake::verify(
-                runtime,
+                &runtime,
                 &crypto,
                 TEST_NAMESPACE,
                 Duration::from_secs(5),
@@ -563,7 +563,7 @@ mod tests {
 
             // Verify the handshake
             let result = Handshake::verify(
-                runtime,
+                &runtime,
                 &crypto,
                 TEST_NAMESPACE,
                 Duration::from_secs(5),
@@ -601,7 +601,7 @@ mod tests {
 
             // Verify the handshake, it should be fine still.
             Handshake::verify(
-                runtime.clone(),
+                &runtime,
                 &crypto,
                 TEST_NAMESPACE,
                 synchrony_bound,
@@ -615,7 +615,7 @@ mod tests {
 
             // Verify that a timeout error is returned.
             let result = Handshake::verify(
-                runtime,
+                &runtime,
                 &crypto,
                 TEST_NAMESPACE,
                 synchrony_bound,
@@ -658,7 +658,7 @@ mod tests {
 
             // Verify the okay handshake.
             Handshake::verify(
-                runtime.clone(),
+                &runtime,
                 &crypto,
                 TEST_NAMESPACE,
                 synchrony_bound,
@@ -668,7 +668,7 @@ mod tests {
 
             // Handshake too far into the future fails.
             let result = Handshake::verify(
-                runtime,
+                &runtime,
                 &crypto,
                 TEST_NAMESPACE,
                 synchrony_bound,

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -82,7 +82,7 @@ use commonware_cryptography::Scheme;
 use std::time::Duration;
 
 mod connection;
-pub use connection::{Connection, IncomingConnection, Sender};
+pub use connection::{Connection, IncomingConnection, Receiver, Sender};
 mod handshake;
 mod utils;
 mod wire {

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -89,7 +89,7 @@ mod wire {
 }
 mod x25519;
 
-pub use connection::{Connection, Sender};
+pub use connection::{Connection, PartialConnection, Sender};
 pub use handshake::IncomingHandshake;
 
 /// Configuration for a connection.

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -82,15 +82,13 @@ use commonware_cryptography::Scheme;
 use std::time::Duration;
 
 mod connection;
+pub use connection::{Connection, IncomingConnection, Sender};
 mod handshake;
 mod utils;
 mod wire {
     include!(concat!(env!("OUT_DIR"), "/wire.rs"));
 }
 mod x25519;
-
-pub use connection::{Connection, PartialConnection, Sender};
-pub use handshake::IncomingHandshake;
 
 /// Configuration for a connection.
 ///


### PR DESCRIPTION
Resolves: #181 

* Refactor `Connection` to avoid exposing `Handshake`.
* Use a reference to `runtime` in handshake verification to reduce cloning.
* Add comments to public structs and functions.