### PR TITLE
Fix: Typos in Documentation and Code Comments

### DIFF
--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -65,7 +65,7 @@ pub struct P0 {
 }
 
 impl P0 {
-    /// Create a new abiter for a DKG/Resharing procedure.
+    /// Create a new arbiter for a DKG/Resharing procedure.
     pub fn new(
         threshold: u32,
         previous: Option<poly::Public>,

--- a/cryptography/src/bls12381/dkg/mod.rs
+++ b/cryptography/src/bls12381/dkg/mod.rs
@@ -92,7 +92,7 @@
 //! ### [Phase 2] Step 5: Finalize Commitments and Distribute Reveals
 //!
 //! After Step 2 (or 4), the arbiter will forward all commitments with at least `threshold - 1` acks to
-//! all qualified contributors (and any accompanying reveals). The arbtier will then recover the
+//! all qualified contributors (and any accompanying reveals). The arbiter will then recover the
 //! new group polynomial using all valid commitments, if a DKG, or the first `threshold` commitments
 //! (sorted by participant identity), if a reshare.
 //!

--- a/cryptography/src/bls12381/dkg/ops.rs
+++ b/cryptography/src/bls12381/dkg/ops.rs
@@ -111,7 +111,7 @@ pub fn recover_public(
         return Err(Error::InsufficientDealings);
     }
 
-    // Construct poool to perform interpolation
+    // Construct pool to perform interpolation
     let pool = ThreadPoolBuilder::new()
         .num_threads(concurrency)
         .build()

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -6,7 +6,7 @@
 //! to the reference, it is accompanied by a comment and link._
 //!
 //! * <https://github.com/celo-org/celo-threshold-bls-rs>: Operations over the BLS12-381 scalar field, GJKR99, and Desmedt97.
-//! * <https://github.com/filecoin-project/blstrs> + <https://github.com/MystenLabs/fastcrypto>: Implenting operations over
+//! * <https://github.com/filecoin-project/blstrs> + <https://github.com/MystenLabs/fastcrypto>: Implementing operations over
 //!   the BLS12-381 scalar field with <https://github.com/supranational/blst>.
 //!
 //! # Example

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -29,7 +29,7 @@ use rand::{CryptoRng, Rng, SeedableRng};
 /// BLS12-381 implementation of the `Scheme` trait.
 ///
 /// This implementation uses the `blst` crate for BLS12-381 operations. This
-/// crate implments serialization according to the "ZCash BLS12-381" specification
+/// crate implements serialization according to the "ZCash BLS12-381" specification
 /// (<https://github.com/supranational/blst/tree/master?tab=readme-ov-file#serialization-format>) and
 /// hashes messages according to RFC 9380.
 #[derive(Clone)]


### PR DESCRIPTION
### Modified Files
1. **`arbiter.rs`**:
   - Corrected "abiter" → "arbiter".

2. **`mod.rs` (within `dkg`)**:
   - Fixed "arbtier" → "arbiter".

3. **`ops.rs`**:
   - Corrected "poool" → "pool".

4. **`mod.rs` (within `primitives`)**:
   - Fixed "Implenting" → "Implementing".

5. **`scheme.rs`**:
   - Corrected "implments" → "implements".