### PR TITLE
use `Config` struct instead of its component fields

### DIFF
--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -38,12 +38,7 @@ impl<C: Scheme, Si: Sink, St: Stream> IncomingConnection<C, Si, St> {
     ) -> Result<Self, Error> {
         let handshake = IncomingHandshake::verify(
             runtime,
-            &config.crypto,
-            &config.namespace,
-            config.max_message_size,
-            config.synchrony_bound,
-            config.max_handshake_age,
-            config.handshake_timeout,
+            &config,
             sink,
             stream,
         )

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -120,7 +120,6 @@ pub struct IncomingHandshake<Si: Sink, St: Stream> {
 }
 
 impl<Si: Sink, St: Stream> IncomingHandshake<Si, St> {
-    #[allow(clippy::too_many_arguments)]
     pub async fn verify<E: Clock + Spawner, C: Scheme>(
         runtime: &E,
         config: &Config<C>,


### PR DESCRIPTION
`IncomingHandshake::verify` currently has this signature:

```rust
    pub async fn verify<E: Clock + Spawner, C: Scheme>(
        runtime: &E,
        crypto: &C,
        namespace: &[u8],
        max_message_size: usize,
        synchrony_bound: Duration,
        max_handshake_age: Duration,
        handshake_timeout: Duration,
        sink: Si,
        mut stream: St,
    ) -> Result<Self, Error> {
```

This PR replaces:

```rust
        crypto: &C,
        namespace: &[u8],
        max_message_size: usize,
        synchrony_bound: Duration,
        max_handshake_age: Duration,
        handshake_timeout: Duration,
```

with `Config`, which contains the same fields.

I think this is a bit nicer because it reduces the number of parameters (we can remove a `#[allow(clippy::too_many_arguments)]`)