### PR TITLE
Use `Vec::with_capacity()` when we know vec capacity

### DIFF
--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -225,7 +225,8 @@ impl<E: Clock + RngCore, H: Hasher> Application<E, H> {
         }
 
         // Generate the payload
-        let mut payload = Vec::new();
+        let payload_len = std::mem::size_of::<u64>() + context.parent.1.len() + std::mem::size_of::<u64>();
+        let mut payload = Vec::with_capacity(payload_len);
         payload.extend_from_slice(&context.view.to_be_bytes());
         payload.extend_from_slice(&context.parent.1);
         payload.put_u64(self.runtime.gen::<u64>()); // Ensures we always have a unique payload

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -13,6 +13,7 @@ use rand::{Rng, RngCore};
 use rand_distr::{Distribution, Normal};
 use std::{
     collections::{HashMap, HashSet},
+    mem::size_of,
     sync::Arc,
     time::Duration,
 };
@@ -225,7 +226,7 @@ impl<E: Clock + RngCore, H: Hasher> Application<E, H> {
         }
 
         // Generate the payload
-        let payload_len = std::mem::size_of::<u64>() + context.parent.1.len() + std::mem::size_of::<u64>();
+        let payload_len = size_of::<u64>() + context.parent.1.len() + size_of::<u64>();
         let mut payload = Vec::with_capacity(payload_len);
         payload.extend_from_slice(&context.view.to_be_bytes());
         payload.extend_from_slice(&context.parent.1);

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -33,10 +33,10 @@ pub struct Eval<C: Element> {
 impl<C: Element> Eval<C> {
     /// Canonically serializes the evaluation.
     pub fn serialize(&self) -> Vec<u8> {
-        let serialized = self.value.serialize();
-        let mut bytes = Vec::with_capacity(std::mem::size_of::<u32>() + serialized.len());
+        let value_serialized = self.value.serialize();
+        let mut bytes = Vec::with_capacity(std::mem::size_of::<u32>() + value_serialized.len());
         bytes.extend_from_slice(&self.index.to_be_bytes());
-        bytes.extend_from_slice(&serialized);
+        bytes.extend_from_slice(&value_serialized);
         bytes
     }
 

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -33,9 +33,10 @@ pub struct Eval<C: Element> {
 impl<C: Element> Eval<C> {
     /// Canonically serializes the evaluation.
     pub fn serialize(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
+        let serialized = self.value.serialize();
+        let mut bytes = Vec::with_capacity(std::mem::size_of::<u32>() + serialized.len());
         bytes.extend_from_slice(&self.index.to_be_bytes());
-        bytes.extend_from_slice(&self.value.serialize());
+        bytes.extend_from_slice(&serialized);
         bytes
     }
 

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -11,7 +11,7 @@ use crate::bls12381::primitives::{
     Error,
 };
 use rand::{rngs::OsRng, RngCore};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, mem::size_of};
 
 /// Private polynomials are used to generate secret shares.
 pub type Private = Poly<group::Private>;
@@ -34,7 +34,7 @@ impl<C: Element> Eval<C> {
     /// Canonically serializes the evaluation.
     pub fn serialize(&self) -> Vec<u8> {
         let value_serialized = self.value.serialize();
-        let mut bytes = Vec::with_capacity(std::mem::size_of::<u32>() + value_serialized.len());
+        let mut bytes = Vec::with_capacity(size_of::<u32>() + value_serialized.len());
         bytes.extend_from_slice(&self.index.to_be_bytes());
         bytes.extend_from_slice(&value_serialized);
         bytes

--- a/examples/vrf/src/handlers/utils.rs
+++ b/examples/vrf/src/handlers/utils.rs
@@ -1,5 +1,6 @@
 use commonware_cryptography::bls12381::primitives::{group::Element, poly};
 use commonware_utils::hex;
+use std::mem::size_of;
 
 pub const SHARE_NAMESPACE: &[u8] = b"_COMMONWARE_DKG_SHARE_";
 
@@ -8,7 +9,7 @@ pub const SHARE_NAMESPACE: &[u8] = b"_COMMONWARE_DKG_SHARE_";
 /// This payload is used to verify that a particular dealer shared an
 /// invalid secret during the DKG/Resharing procedure.
 pub fn payload(round: u64, dealer: u32, share: &[u8]) -> Vec<u8> {
-    let mut payload = Vec::with_capacity(std::mem::size_of::<u64>() + std::mem::size_of::<u32>() + share.len());
+    let mut payload = Vec::with_capacity(size_of::<u64>() + size_of::<u32>() + share.len());
     payload.extend_from_slice(&round.to_be_bytes());
     payload.extend_from_slice(&dealer.to_be_bytes());
     payload.extend_from_slice(share);

--- a/examples/vrf/src/handlers/utils.rs
+++ b/examples/vrf/src/handlers/utils.rs
@@ -8,7 +8,7 @@ pub const SHARE_NAMESPACE: &[u8] = b"_COMMONWARE_DKG_SHARE_";
 /// This payload is used to verify that a particular dealer shared an
 /// invalid secret during the DKG/Resharing procedure.
 pub fn payload(round: u64, dealer: u32, share: &[u8]) -> Vec<u8> {
-    let mut payload = Vec::new();
+    let mut payload = Vec::with_capacity(std::mem::size_of::<u64>() + std::mem::size_of::<u32>() + share.len());
     payload.extend_from_slice(&round.to_be_bytes());
     payload.extend_from_slice(&dealer.to_be_bytes());
     payload.extend_from_slice(share);

--- a/p2p/src/authenticated/actors/tracker/address.rs
+++ b/p2p/src/authenticated/actors/tracker/address.rs
@@ -18,7 +18,7 @@ pub struct Signature {
 }
 
 pub fn wire_peer_payload(peer: &Peer) -> Vec<u8> {
-    let mut payload = Vec::new();
+    let mut payload = Vec::with_capacity(peer.socket.len()+std::mem::size_of::<u64>());
     payload.extend_from_slice(&peer.socket);
     payload.extend_from_slice(&peer.timestamp.to_be_bytes());
     payload
@@ -26,7 +26,7 @@ pub fn wire_peer_payload(peer: &Peer) -> Vec<u8> {
 
 pub fn socket_peer_payload(socket: &SocketAddr, timestamp: u64) -> (Vec<u8>, Vec<u8>) {
     let socket = bytes(socket);
-    let mut payload = Vec::new();
+    let mut payload = Vec::with_capacity(socket.len()+std::mem::size_of::<u64>());
     payload.extend_from_slice(&socket);
     payload.extend_from_slice(&timestamp.to_be_bytes());
     (socket, payload)

--- a/p2p/src/authenticated/actors/tracker/address.rs
+++ b/p2p/src/authenticated/actors/tracker/address.rs
@@ -1,6 +1,9 @@
 use super::Error;
 use crate::authenticated::wire::Peer;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::{
+    mem::size_of,
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+};
 
 #[derive(Clone)]
 pub enum Address {
@@ -18,7 +21,7 @@ pub struct Signature {
 }
 
 pub fn wire_peer_payload(peer: &Peer) -> Vec<u8> {
-    let mut payload = Vec::with_capacity(peer.socket.len()+std::mem::size_of::<u64>());
+    let mut payload = Vec::with_capacity(peer.socket.len() + size_of::<u64>());
     payload.extend_from_slice(&peer.socket);
     payload.extend_from_slice(&peer.timestamp.to_be_bytes());
     payload
@@ -26,7 +29,7 @@ pub fn wire_peer_payload(peer: &Peer) -> Vec<u8> {
 
 pub fn socket_peer_payload(socket: &SocketAddr, timestamp: u64) -> (Vec<u8>, Vec<u8>) {
     let socket = bytes(socket);
-    let mut payload = Vec::with_capacity(socket.len()+std::mem::size_of::<u64>());
+    let mut payload = Vec::with_capacity(socket.len() + size_of::<u64>());
     payload.extend_from_slice(&socket);
     payload.extend_from_slice(&timestamp.to_be_bytes());
     (socket, payload)

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -16,9 +16,11 @@ pub fn create_handshake<C: Scheme>(
     ephemeral_public_key: x25519_dalek::PublicKey,
 ) -> Result<Bytes, Error> {
     // Sign their public key
-    let mut payload = Vec::new();
+    let ephemeral_public_key_bytes = ephemeral_public_key.as_bytes();
+    let payload_len = recipient_public_key.len() + ephemeral_public_key_bytes.len() + std::mem::size_of::<u64>();
+    let mut payload = Vec::with_capacity(payload_len);
     payload.extend_from_slice(&recipient_public_key);
-    payload.extend_from_slice(ephemeral_public_key.as_bytes());
+    payload.extend_from_slice(ephemeral_public_key_bytes);
     payload.extend_from_slice(&timestamp.to_be_bytes());
     let signature = crypto.sign(namespace, &payload);
 
@@ -94,7 +96,8 @@ impl Handshake {
         }
 
         // Construct signing payload (ephemeral public key + my public key + timestamp)
-        let mut payload = Vec::new();
+        let payload_len =  our_public_key.len() + handshake.ephemeral_public_key.len() + std::mem::size_of::<u64>();
+        let mut payload = Vec::with_capacity(payload_len);
         payload.extend_from_slice(&our_public_key);
         payload.extend_from_slice(&handshake.ephemeral_public_key);
         payload.extend_from_slice(&handshake.timestamp.to_be_bytes());

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -6,7 +6,10 @@ use commonware_macros::select;
 use commonware_runtime::{Clock, Sink, Spawner, Stream};
 use commonware_utils::SystemTimeExt;
 use prost::Message;
-use std::time::{Duration, SystemTime};
+use std::{
+    mem::size_of,
+    time::{Duration, SystemTime},
+};
 
 pub fn create_handshake<C: Scheme>(
     crypto: &mut C,
@@ -17,7 +20,8 @@ pub fn create_handshake<C: Scheme>(
 ) -> Result<Bytes, Error> {
     // Sign their public key
     let ephemeral_public_key_bytes = ephemeral_public_key.as_bytes();
-    let payload_len = recipient_public_key.len() + ephemeral_public_key_bytes.len() + std::mem::size_of::<u64>();
+    let payload_len =
+        recipient_public_key.len() + ephemeral_public_key_bytes.len() + size_of::<u64>();
     let mut payload = Vec::with_capacity(payload_len);
     payload.extend_from_slice(&recipient_public_key);
     payload.extend_from_slice(ephemeral_public_key_bytes);
@@ -96,7 +100,8 @@ impl Handshake {
         }
 
         // Construct signing payload (ephemeral public key + my public key + timestamp)
-        let payload_len =  our_public_key.len() + handshake.ephemeral_public_key.len() + std::mem::size_of::<u64>();
+        let payload_len =
+            our_public_key.len() + handshake.ephemeral_public_key.len() + size_of::<u64>();
         let mut payload = Vec::with_capacity(payload_len);
         payload.extend_from_slice(&our_public_key);
         payload.extend_from_slice(&handshake.ephemeral_public_key);


### PR DESCRIPTION
I ignored usages of `Vec::new()` in tests. You may think that using `std::mem::size_of::<u64>()` (etc.) is overkill. If so, fair enough. If you want, let me know and I'll change it to a good ol' `8` or `4`.

In some instances, you may feel that the extra code/clutter doesn't merit the performance gains. Again, fair enough. In those cases where we care about code aesthetics more than performance, I'd suggest doing, for example:

```rust
     [
        round.to_be_bytes().as_slice(),
        dealer.to_be_bytes().as_slice(),
        share,
    ]
    .concat()
```

rather than

```rust
    let mut payload = Vec::new();
    payload.extend_from_slice(&round.to_be_bytes());
    payload.extend_from_slice(&dealer.to_be_bytes());
    payload.extend_from_slice(share);
    payload
```

I believe these are semantically equivalent (don't quote me on that) and fwiw I think the former is prettier and maybe more Rusty.