### PR TITLE
[CI] Only Post Statuses to PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,3 +15,4 @@ coverage:
     project:
       default:
         threshold: 0.25%
+        only_pulls: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 comment:
   layout: "header, diff, files, footer"
-  behavior: new 
+  behavior: new
   require_changes: false
   require_head: false
   require_base: false
@@ -11,6 +11,7 @@ coverage:
     patch:
       default:
         threshold: 0.25%
+        only_pulls: true
     project:
       default:
         threshold: 0.25%


### PR DESCRIPTION
Merges to `main` sometimes look like they are failing because of `codecov`:

<img width="956" alt="image" src="https://github.com/user-attachments/assets/d907be45-f448-4ba6-9f44-7dd984df4697" />

Source: https://docs.codecov.com/docs/commit-status#only_pulls