### PR TITLE
[cryptography/bls12381] vector tests

### DIFF
--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -225,6 +225,9 @@ impl Scalar {
             blst_keygen_v3(&mut sc, ikm.as_ptr(), ikm.len(), ptr::null(), 0);
             blst_fr_from_scalar(&mut ret, &sc);
         }
+
+        // Zeroize the ikm buffer
+        ikm.zeroize();
         Self(ret)
     }
 

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -299,8 +299,15 @@ impl Element for Scalar {
         unsafe {
             let mut scalar = blst_scalar::default();
             blst_scalar_from_bendian(&mut scalar, bytes.as_ptr());
-            // blst_scalar_fr_check is replaced by blst_sk_check as it enforces
-            // a non-zero scalar check.
+            // We use `blst_sk_check` instead of `blst_scalar_fr_check` because the former
+            // performs a non-zero check.
+            //
+            // The IETF BLS12-381 specification allows for zero scalars up to (inclusive) Draft 3
+            // but disallows them after.
+            //
+            // References:
+            // * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-2.3
+            // * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.3
             if !blst_sk_check(&scalar) {
                 return None;
             }

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -17,8 +17,8 @@ use blst::{
     blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_in_g1, blst_p1_is_inf,
     blst_p1_mult, blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double,
     blst_p2_affine, blst_p2_compress, blst_p2_from_affine, blst_p2_in_g2, blst_p2_is_inf,
-    blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_scalar, blst_scalar_fr_check,
-    blst_scalar_from_bendian, blst_scalar_from_fr, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
+    blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_scalar, blst_scalar_from_bendian,
+    blst_scalar_from_fr, blst_sk_check, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
 };
 use rand::RngCore;
 use std::ptr;
@@ -299,7 +299,9 @@ impl Element for Scalar {
         unsafe {
             let mut scalar = blst_scalar::default();
             blst_scalar_from_bendian(&mut scalar, bytes.as_ptr());
-            if !blst_scalar_fr_check(&scalar) {
+            // blst_scalar_fr_check is replaced by blst_sk_check as it enforces
+            // a non-zero scalar check.
+            if !blst_sk_check(&scalar) {
                 return None;
             }
             blst_fr_from_scalar(&mut ret, &scalar);

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -106,7 +106,8 @@ impl Scheme for Bls12381 {
 
 #[cfg(test)]
 mod tests {
-    // Tests use the bls12381 test vectors from https://github.com/ethereum/bls12-381-tests
+    /// Tests use the bls12381 test vectors
+    /// from https://github.com/ethereum/bls12-381-tests (v0.1.2).
     use super::{Bls12381, Scheme};
     use crate::PrivateKey;
     use crate::PublicKey;
@@ -189,7 +190,8 @@ mod tests {
         }
     }
 
-    fn vector_sign_test(test_id: usize, private_key: Vec<u8>, message: Vec<u8>, output: Vec<u8>) {
+    /// Runs the provided `sign` vector test.
+    fn test_vector_sign(test_id: usize, private_key: Vec<u8>, message: Vec<u8>, output: Vec<u8>) {
         let private_key = PrivateKey::from(private_key);
         let mut signer =
             <Bls12381 as Scheme>::from(private_key).expect("unable to deserialize private key");
@@ -197,6 +199,7 @@ mod tests {
         assert_eq!(signature, output, "vector_sign_{} failed", test_id);
     }
 
+    /// Runs the provided `verfify` vector test.
     fn test_vector_verify(
         test_id: usize,
         public_key: Vec<u8>,
@@ -210,6 +213,7 @@ mod tests {
         assert_eq!(res, output, "vector_verify_{}", test_id);
     }
 
+    /// Generates `sign` vector from hex encoded data.
     fn vector_sign(
         private_key: &str,
         message: &str,
@@ -222,6 +226,7 @@ mod tests {
         )
     }
 
+    /// Generates `verify` vector from hex encoded data.
     fn vector_verify(
         public_key: &str,
         message: &str,

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -26,6 +26,8 @@ use super::primitives::{
 use crate::{PrivateKey, PublicKey, Scheme, Signature};
 use rand::{CryptoRng, Rng, SeedableRng};
 
+const ZERO_PRIVATEKEY_BYTES: [u8; 32] = [0; 32];
+
 /// BLS12-381 implementation of the `Scheme` trait.
 ///
 /// This implementation uses the `blst` crate for BLS12-381 operations. This
@@ -49,6 +51,9 @@ impl Scheme for Bls12381 {
             Ok(key) => key,
             Err(_) => return None,
         };
+        if private_key == ZERO_PRIVATEKEY_BYTES {
+            return None;
+        }
         let private = Scalar::deserialize(&private_key)?;
         let mut public = group::Public::one();
         public.mul(&private);
@@ -96,5 +101,518 @@ impl Scheme for Bls12381 {
 
     fn len() -> (usize, usize) {
         (group::G1_ELEMENT_BYTE_LENGTH, group::G2_ELEMENT_BYTE_LENGTH)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Tests use the bls12381 test vectors from https://github.com/ethereum/bls12-381-tests
+    use super::{Bls12381, Scheme};
+    use crate::PrivateKey;
+    use crate::PublicKey;
+    use bytes::Bytes;
+
+    #[test]
+    fn sign() {
+        let tests_cases = [
+            vector_sign_1(),
+            vector_sign_2(),
+            vector_sign_3(),
+            vector_sign_4(),
+            vector_sign_5(),
+            vector_sign_6(),
+            vector_sign_7(),
+            vector_sign_8(),
+            vector_sign_9(),
+        ];
+
+        for (index, test_case) in tests_cases.iter().enumerate() {
+            vector_sign_test(
+                index + 1,
+                test_case.0.clone(),
+                test_case.1.clone(),
+                test_case.2.clone(),
+            );
+        }
+    }
+
+    #[test]
+    fn sign_zero_private_key() {
+        let v = vector_sign_10();
+        let private_key = PrivateKey::from(v.0);
+        let signer = <Bls12381 as Scheme>::from(private_key);
+        assert!(signer.is_none())
+    }
+
+    #[test]
+    fn verify() {
+        let tests_cases = [
+            vector_verify_1(),
+            vector_verify_2(),
+            vector_verify_3(),
+            vector_verify_4(),
+            vector_verify_5(),
+            vector_verify_6(),
+            vector_verify_7(),
+            vector_verify_8(),
+            vector_verify_9(),
+            vector_verify_10(),
+            vector_verify_11(),
+            vector_verify_12(),
+            vector_verify_13(),
+            vector_verify_14(),
+            vector_verify_15(),
+            vector_verify_16(),
+            vector_verify_17(),
+            vector_verify_18(),
+            vector_verify_19(),
+            vector_verify_20(),
+            vector_verify_21(),
+            vector_verify_22(),
+            vector_verify_23(),
+            vector_verify_24(),
+            vector_verify_25(),
+            vector_verify_26(),
+            vector_verify_27(),
+            vector_verify_28(),
+            vector_verify_29(),
+        ];
+
+        for (index, test_case) in tests_cases.iter().enumerate() {
+            test_vector_verify(
+                index + 1,
+                test_case.0.clone(),
+                test_case.1.clone(),
+                test_case.2.clone(),
+                test_case.3,
+            );
+        }
+    }
+
+    fn vector_sign_test(test_id: usize, private_key: Vec<u8>, message: Vec<u8>, output: Vec<u8>) {
+        let private_key = PrivateKey::from(private_key);
+        let mut signer =
+            <Bls12381 as Scheme>::from(private_key).expect("unable to deserialize private key");
+        let signature = signer.sign(None, &message);
+        assert_eq!(signature, output, "vector_sign_{} failed", test_id);
+    }
+
+    fn test_vector_verify(
+        test_id: usize,
+        public_key: Vec<u8>,
+        message: Vec<u8>,
+        signature: Vec<u8>,
+        output: bool,
+    ) {
+        let public_key = PublicKey::from(public_key);
+        let signature = Bytes::from(signature);
+        let res = Bls12381::verify(None, &message, &public_key, &signature);
+        assert_eq!(res, output, "vector_verify_{}", test_id);
+    }
+
+    fn vector_sign(
+        private_key: &str,
+        message: &str,
+        signature: &str,
+    ) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        (
+            commonware_utils::from_hex_formatted(private_key).unwrap(),
+            commonware_utils::from_hex_formatted(message).unwrap(),
+            commonware_utils::from_hex_formatted(signature).unwrap(),
+        )
+    }
+
+    fn vector_verify(
+        public_key: &str,
+        message: &str,
+        signature: &str,
+        output: bool,
+    ) -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        (
+            commonware_utils::from_hex_formatted(public_key).unwrap(),
+            commonware_utils::from_hex_formatted(message).unwrap(),
+            commonware_utils::from_hex_formatted(signature).unwrap(),
+            output,
+        )
+    }
+
+    // sign_case_8cd3d4d0d9a5b265
+    fn vector_sign_1() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+        "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
+        )
+    }
+
+    // sign_case_11b8c7cad5238946
+    fn vector_sign_2() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+        "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9"
+        )
+    }
+
+    // sign_case_84d45c9c7cca6b92
+    fn vector_sign_3() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+        "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9"
+        )
+    }
+
+    // sign_case_142f678a8d05fcd1
+    fn vector_sign_4() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+        "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe"
+        )
+    }
+
+    // sign_case_37286e1a6d1f6eb3
+    fn vector_sign_5() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+        "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df"
+        )
+    }
+
+    // sign_case_7055381f640f2c1d
+    fn vector_sign_6() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+        "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115"
+        )
+    }
+
+    // sign_case_c82df61aa3ee60fb
+    fn vector_sign_7() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+        "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55"
+        )
+    }
+
+    // sign_case_d0e28d7e76eb6e9c
+    fn vector_sign_8() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+        "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
+        )
+    }
+
+    // sign_case_f2ae1097e7d0e18b
+    fn vector_sign_9() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+        "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121"
+        )
+    }
+
+    // sign_case_zero_privkey
+    fn vector_sign_10() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        vector_sign(
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xabababababababababababababababababababababababababababababababab",
+            "",
+        )
+    }
+
+    // verify_infinity_pubkey_and_infinity_signature
+    fn vector_verify_1() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "0x1212121212121212121212121212121212121212121212121212121212121212",
+        "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        false,
+        )
+    }
+
+    // verify_tampered_signature_case_2ea479adf8c40300
+    fn vector_verify_2() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972ffffffff",
+        false,
+        )
+    }
+
+    // verify_tampered_signature_case_2f09d443ab8a3ac2
+    fn vector_verify_3() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dffffffff",
+        false,
+        )
+    }
+
+    // verify_tampered_signature_case_6b3b17f6962a490c
+    fn vector_verify_4() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffffffff",
+        false
+        )
+    }
+
+    // verify_tampered_signature_case_6eeb7c52dfd9baf0
+    fn vector_verify_5() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5ffffffff",
+        false,
+        )
+    }
+
+    // verify_tampered_signature_case_8761a0b7e920c323
+    fn vector_verify_6() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b71ffffffff",
+        false,
+        )
+    }
+
+    // verify_tampered_signature_case_195246ee3bd3b6ec
+    fn vector_verify_7() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9ffffffff",
+        false,
+        )
+    }
+
+    // verify_tampered_signature_case_3208262581c8fc09
+    fn vector_verify_8() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363ffffffff",
+        false,
+        )
+    }
+
+    // verify_tampered_signature_case_d34885d766d5f705
+    fn vector_verify_9() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075effffffff",
+        false,
+        )
+    }
+
+    // verify_tampered_signature_case_e8a50c445c855360
+    fn vector_verify_10() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380bffffffff",
+        false,
+        )
+    }
+
+    // verify_valid_case_2ea479adf8c40300
+    fn vector_verify_11() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
+        true,
+        )
+    }
+
+    // verify_valid_case_2f09d443ab8a3ac2
+    fn vector_verify_12() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
+        true,
+        )
+    }
+
+    // verify_valid_case_6b3b17f6962a490c
+    fn vector_verify_13() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
+        true,
+        )
+    }
+
+    // verify_valid_case_6eeb7c52dfd9baf0
+    fn vector_verify_14() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
+        true,
+        )
+    }
+
+    // verify_valid_case_8761a0b7e920c323
+    fn vector_verify_15() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
+        true,
+        )
+    }
+
+    // verify_valid_case_195246ee3bd3b6ec
+    fn vector_verify_16() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
+        true,
+        )
+    }
+
+    // verify_valid_case_3208262581c8fc09
+    fn vector_verify_17() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
+        true,
+        )
+    }
+
+    // verify_valid_case_d34885d766d5f705
+    fn vector_verify_18() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
+        true,
+        )
+    }
+
+    // verify_valid_case_e8a50c445c855360
+    fn vector_verify_19() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
+        true,
+        )
+    }
+
+    // verify_wrong_pubkey_case_2ea479adf8c40300
+    fn vector_verify_20() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
+        false,
+        )
+    }
+
+    // verify_wrong_pubkey_case_2f09d443ab8a3ac2
+    fn vector_verify_21() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
+        false,
+        )
+    }
+
+    // verify_wrong_pubkey_case_6b3b17f6962a490c
+    fn vector_verify_22() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
+        false,
+        )
+    }
+
+    // verify_wrong_pubkey_case_6eeb7c52dfd9baf0
+    fn vector_verify_23() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
+        false,
+        )
+    }
+
+    // verify_wrong_pubkey_case_8761a0b7e920c323
+    fn vector_verify_24() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
+        false,
+        )
+    }
+
+    // verify_wrong_pubkey_case_195246ee3bd3b6ec
+    fn vector_verify_25() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+        "0xabababababababababababababababababababababababababababababababab",
+        "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
+        false,
+        )
+    }
+
+    // verify_wrong_pubkey_case_3208262581c8fc09
+    fn vector_verify_26() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+        "0x5656565656565656565656565656565656565656565656565656565656565656",
+        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
+        false,
+        )
+    }
+
+    // verify_wrong_pubkey_case_d34885d766d5f705
+    fn vector_verify_27() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
+        false,
+        )
+    }
+
+    // verify_wrong_pubkey_case_e8a50c445c855360
+    fn vector_verify_28() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
+        false,
+        )
+    }
+
+    // verifycase_one_privkey_47117849458281be
+    fn vector_verify_29() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
+        vector_verify(
+        "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb",
+        "0x1212121212121212121212121212121212121212121212121212121212121212",
+        "0xa42ae16f1c2a5fa69c04cb5998d2add790764ce8dd45bf25b29b4700829232052b52352dcff1cf255b3a7810ad7269601810f03b2bc8b68cf289cf295b206770605a190b6842583e47c3d1c0f73c54907bfb2a602157d46a4353a20283018763",
+        true,
+        )
     }
 }

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -208,37 +208,18 @@ mod tests {
         assert_eq!(res, success, "vector_verify_{}", test_id);
     }
 
-    /// Generates `sign` vector from hex encoded data.
-    fn vector_sign(
-        private_key: &str,
-        message: &str,
-        signature: &str,
-    ) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    /// Generates vector from hex encoded data.
+    fn generate_vector(s1: &str, s2: &str, s3: &str) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
         (
-            commonware_utils::from_hex_formatted(private_key).unwrap(),
-            commonware_utils::from_hex_formatted(message).unwrap(),
-            commonware_utils::from_hex_formatted(signature).unwrap(),
-        )
-    }
-
-    /// Generates `verify` vector from hex encoded data.
-    fn vector_verify(
-        public_key: &str,
-        message: &str,
-        signature: &str,
-        success: bool,
-    ) -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        (
-            commonware_utils::from_hex_formatted(public_key).unwrap(),
-            commonware_utils::from_hex_formatted(message).unwrap(),
-            commonware_utils::from_hex_formatted(signature).unwrap(),
-            success,
+            commonware_utils::from_hex_formatted(s1).unwrap(),
+            commonware_utils::from_hex_formatted(s2).unwrap(),
+            commonware_utils::from_hex_formatted(s3).unwrap(),
         )
     }
 
     // sign_case_8cd3d4d0d9a5b265
     fn vector_sign_1() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
         "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
@@ -247,7 +228,7 @@ mod tests {
 
     // sign_case_11b8c7cad5238946
     fn vector_sign_2() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
         "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9"
@@ -256,7 +237,7 @@ mod tests {
 
     // sign_case_84d45c9c7cca6b92
     fn vector_sign_3() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
         "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
         "0xabababababababababababababababababababababababababababababababab",
         "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9"
@@ -265,7 +246,7 @@ mod tests {
 
     // sign_case_142f678a8d05fcd1
     fn vector_sign_4() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
         "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe"
@@ -274,7 +255,7 @@ mod tests {
 
     // sign_case_37286e1a6d1f6eb3
     fn vector_sign_5() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
         "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
         "0xabababababababababababababababababababababababababababababababab",
         "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df"
@@ -283,7 +264,7 @@ mod tests {
 
     // sign_case_7055381f640f2c1d
     fn vector_sign_6() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
         "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115"
@@ -292,7 +273,7 @@ mod tests {
 
     // sign_case_c82df61aa3ee60fb
     fn vector_sign_7() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
         "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55"
@@ -301,7 +282,7 @@ mod tests {
 
     // sign_case_d0e28d7e76eb6e9c
     fn vector_sign_8() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
         "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
@@ -310,7 +291,7 @@ mod tests {
 
     // sign_case_f2ae1097e7d0e18b
     fn vector_sign_9() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
         "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
         "0xabababababababababababababababababababababababababababababababab",
         "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121"
@@ -319,7 +300,7 @@ mod tests {
 
     // sign_case_zero_privkey
     fn vector_sign_10() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        vector_sign(
+        generate_vector(
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             "0xabababababababababababababababababababababababababababababababab",
             "",
@@ -328,291 +309,291 @@ mod tests {
 
     // verify_infinity_pubkey_and_infinity_signature
     fn vector_verify_1() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         "0x1212121212121212121212121212121212121212121212121212121212121212",
         "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_tampered_signature_case_2ea479adf8c40300
     fn vector_verify_2() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972ffffffff",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_tampered_signature_case_2f09d443ab8a3ac2
     fn vector_verify_3() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dffffffff",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_tampered_signature_case_6b3b17f6962a490c
     fn vector_verify_4() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffffffff",
-        false
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_tampered_signature_case_6eeb7c52dfd9baf0
     fn vector_verify_5() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0xabababababababababababababababababababababababababababababababab",
         "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5ffffffff",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_tampered_signature_case_8761a0b7e920c323
     fn vector_verify_6() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0xabababababababababababababababababababababababababababababababab",
         "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b71ffffffff",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_tampered_signature_case_195246ee3bd3b6ec
     fn vector_verify_7() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0xabababababababababababababababababababababababababababababababab",
         "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9ffffffff",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_tampered_signature_case_3208262581c8fc09
     fn vector_verify_8() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363ffffffff",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_tampered_signature_case_d34885d766d5f705
     fn vector_verify_9() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075effffffff",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_tampered_signature_case_e8a50c445c855360
     fn vector_verify_10() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v= generate_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380bffffffff",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_valid_case_2ea479adf8c40300
     fn vector_verify_11() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v= generate_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 
     // verify_valid_case_2f09d443ab8a3ac2
     fn vector_verify_12() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 
     // verify_valid_case_6b3b17f6962a490c
     fn vector_verify_13() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 
     // verify_valid_case_6eeb7c52dfd9baf0
     fn vector_verify_14() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0xabababababababababababababababababababababababababababababababab",
         "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 
     // verify_valid_case_8761a0b7e920c323
     fn vector_verify_15() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0xabababababababababababababababababababababababababababababababab",
         "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 
     // verify_valid_case_195246ee3bd3b6ec
     fn vector_verify_16() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0xabababababababababababababababababababababababababababababababab",
         "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 
     // verify_valid_case_3208262581c8fc09
     fn vector_verify_17() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 
     // verify_valid_case_d34885d766d5f705
     fn vector_verify_18() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 
     // verify_valid_case_e8a50c445c855360
     fn vector_verify_19() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 
     // verify_wrong_pubkey_case_2ea479adf8c40300
     fn vector_verify_20() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_wrong_pubkey_case_2f09d443ab8a3ac2
     fn vector_verify_21() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_wrong_pubkey_case_6b3b17f6962a490c
     fn vector_verify_22() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_wrong_pubkey_case_6eeb7c52dfd9baf0
     fn vector_verify_23() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0xabababababababababababababababababababababababababababababababab",
         "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_wrong_pubkey_case_8761a0b7e920c323
     fn vector_verify_24() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0xabababababababababababababababababababababababababababababababab",
         "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_wrong_pubkey_case_195246ee3bd3b6ec
     fn vector_verify_25() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0xabababababababababababababababababababababababababababababababab",
         "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_wrong_pubkey_case_3208262581c8fc09
     fn vector_verify_26() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_wrong_pubkey_case_d34885d766d5f705
     fn vector_verify_27() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verify_wrong_pubkey_case_e8a50c445c855360
     fn vector_verify_28() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v = generate_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
-        false,
-        )
+        );
+        (v.0, v.1, v.2, false)
     }
 
     // verifycase_one_privkey_47117849458281be
     fn vector_verify_29() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        vector_verify(
+        let v= generate_vector(
         "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb",
         "0x1212121212121212121212121212121212121212121212121212121212121212",
         "0xa42ae16f1c2a5fa69c04cb5998d2add790764ce8dd45bf25b29b4700829232052b52352dcff1cf255b3a7810ad7269601810f03b2bc8b68cf289cf295b206770605a190b6842583e47c3d1c0f73c54907bfb2a602157d46a4353a20283018763",
-        true,
-        )
+        );
+        (v.0, v.1, v.2, true)
     }
 }

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -104,9 +104,7 @@ mod tests {
     /// Tests use the bls12381 test vectors
     /// from https://github.com/ethereum/bls12-381-tests (v0.1.2).
     use super::{Bls12381, Scheme};
-    use crate::PrivateKey;
-    use crate::PublicKey;
-    use bytes::Bytes;
+    use crate::{PrivateKey, PublicKey, Signature};
 
     #[test]
     fn sign() {
@@ -123,12 +121,11 @@ mod tests {
         ];
 
         for (index, test_case) in tests_cases.iter().enumerate() {
-            test_vector_sign(
-                index + 1,
-                test_case.0.clone(),
-                test_case.1.clone(),
-                test_case.2.clone(),
-            );
+            let (private_key, message, exp_signature) = test_case;
+            let mut signer = <Bls12381 as Scheme>::from(private_key.clone())
+                .expect("unable to deserialize private key");
+            let signature = signer.sign(None, message);
+            assert_eq!(signature, exp_signature, "vector_sign_{} failed", index + 1);
         }
     }
 
@@ -175,51 +172,33 @@ mod tests {
         ];
 
         for (index, test_case) in tests_cases.iter().enumerate() {
-            test_vector_verify(
-                index + 1,
-                test_case.0.clone(),
-                test_case.1.clone(),
-                test_case.2.clone(),
-                test_case.3,
-            );
+            let (public_key, message, signature, exp_success) = test_case;
+            let success = Bls12381::verify(None, message, public_key, signature);
+            assert_eq!(success, *exp_success, "vector_verify_{}", index + 1);
         }
     }
 
-    /// Runs the provided `sign` vector test.
-    fn test_vector_sign(test_id: usize, private_key: Vec<u8>, message: Vec<u8>, output: Vec<u8>) {
-        let private_key = PrivateKey::from(private_key);
-        let mut signer =
-            <Bls12381 as Scheme>::from(private_key).expect("unable to deserialize private key");
-        let signature = signer.sign(None, &message);
-        assert_eq!(signature, output, "vector_sign_{} failed", test_id);
-    }
-
-    /// Runs the provided `verfify` vector test.
-    fn test_vector_verify(
-        test_id: usize,
-        public_key: Vec<u8>,
-        message: Vec<u8>,
-        signature: Vec<u8>,
-        success: bool,
-    ) {
-        let public_key = PublicKey::from(public_key);
-        let signature = Bytes::from(signature);
-        let res = Bls12381::verify(None, &message, &public_key, &signature);
-        assert_eq!(res, success, "vector_verify_{}", test_id);
-    }
-
-    /// Generates vector from hex encoded data.
-    fn generate_vector(s1: &str, s2: &str, s3: &str) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    /// Parse `sign` vector from hex encoded data.
+    fn parse_sign_vector(s1: &str, s2: &str, s3: &str) -> (PrivateKey, Vec<u8>, Signature) {
         (
-            commonware_utils::from_hex_formatted(s1).unwrap(),
+            commonware_utils::from_hex_formatted(s1).unwrap().into(),
             commonware_utils::from_hex_formatted(s2).unwrap(),
-            commonware_utils::from_hex_formatted(s3).unwrap(),
+            commonware_utils::from_hex_formatted(s3).unwrap().into(),
+        )
+    }
+
+    /// Parse `verify` vector from hex encoded data.
+    fn parse_verify_vector(s1: &str, s2: &str, s3: &str) -> (PublicKey, Vec<u8>, Signature) {
+        (
+            commonware_utils::from_hex_formatted(s1).unwrap().into(),
+            commonware_utils::from_hex_formatted(s2).unwrap(),
+            commonware_utils::from_hex_formatted(s3).unwrap().into(),
         )
     }
 
     // sign_case_8cd3d4d0d9a5b265
-    fn vector_sign_1() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_1() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
         "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
@@ -227,8 +206,8 @@ mod tests {
     }
 
     // sign_case_11b8c7cad5238946
-    fn vector_sign_2() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_2() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
         "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9"
@@ -236,8 +215,8 @@ mod tests {
     }
 
     // sign_case_84d45c9c7cca6b92
-    fn vector_sign_3() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_3() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
         "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
         "0xabababababababababababababababababababababababababababababababab",
         "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9"
@@ -245,8 +224,8 @@ mod tests {
     }
 
     // sign_case_142f678a8d05fcd1
-    fn vector_sign_4() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_4() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
         "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe"
@@ -254,8 +233,8 @@ mod tests {
     }
 
     // sign_case_37286e1a6d1f6eb3
-    fn vector_sign_5() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_5() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
         "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
         "0xabababababababababababababababababababababababababababababababab",
         "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df"
@@ -263,8 +242,8 @@ mod tests {
     }
 
     // sign_case_7055381f640f2c1d
-    fn vector_sign_6() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_6() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
         "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115"
@@ -272,8 +251,8 @@ mod tests {
     }
 
     // sign_case_c82df61aa3ee60fb
-    fn vector_sign_7() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_7() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
         "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55"
@@ -281,8 +260,8 @@ mod tests {
     }
 
     // sign_case_d0e28d7e76eb6e9c
-    fn vector_sign_8() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_8() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
         "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
@@ -290,8 +269,8 @@ mod tests {
     }
 
     // sign_case_f2ae1097e7d0e18b
-    fn vector_sign_9() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_9() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
         "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
         "0xabababababababababababababababababababababababababababababababab",
         "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121"
@@ -299,8 +278,8 @@ mod tests {
     }
 
     // sign_case_zero_privkey
-    fn vector_sign_10() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        generate_vector(
+    fn vector_sign_10() -> (PrivateKey, Vec<u8>, Signature) {
+        parse_sign_vector(
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             "0xabababababababababababababababababababababababababababababababab",
             "",
@@ -308,8 +287,8 @@ mod tests {
     }
 
     // verify_infinity_pubkey_and_infinity_signature
-    fn vector_verify_1() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_1() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         "0x1212121212121212121212121212121212121212121212121212121212121212",
         "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -318,8 +297,8 @@ mod tests {
     }
 
     // verify_tampered_signature_case_2ea479adf8c40300
-    fn vector_verify_2() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_2() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972ffffffff",
@@ -328,8 +307,8 @@ mod tests {
     }
 
     // verify_tampered_signature_case_2f09d443ab8a3ac2
-    fn vector_verify_3() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_3() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dffffffff",
@@ -338,8 +317,8 @@ mod tests {
     }
 
     // verify_tampered_signature_case_6b3b17f6962a490c
-    fn vector_verify_4() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_4() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffffffff",
@@ -348,8 +327,8 @@ mod tests {
     }
 
     // verify_tampered_signature_case_6eeb7c52dfd9baf0
-    fn vector_verify_5() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_5() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0xabababababababababababababababababababababababababababababababab",
         "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5ffffffff",
@@ -358,8 +337,8 @@ mod tests {
     }
 
     // verify_tampered_signature_case_8761a0b7e920c323
-    fn vector_verify_6() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_6() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0xabababababababababababababababababababababababababababababababab",
         "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b71ffffffff",
@@ -368,8 +347,8 @@ mod tests {
     }
 
     // verify_tampered_signature_case_195246ee3bd3b6ec
-    fn vector_verify_7() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_7() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0xabababababababababababababababababababababababababababababababab",
         "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9ffffffff",
@@ -378,8 +357,8 @@ mod tests {
     }
 
     // verify_tampered_signature_case_3208262581c8fc09
-    fn vector_verify_8() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_8() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363ffffffff",
@@ -388,8 +367,8 @@ mod tests {
     }
 
     // verify_tampered_signature_case_d34885d766d5f705
-    fn vector_verify_9() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_9() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075effffffff",
@@ -398,8 +377,8 @@ mod tests {
     }
 
     // verify_tampered_signature_case_e8a50c445c855360
-    fn vector_verify_10() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v= generate_vector(
+    fn vector_verify_10() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v= parse_verify_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380bffffffff",
@@ -408,8 +387,8 @@ mod tests {
     }
 
     // verify_valid_case_2ea479adf8c40300
-    fn vector_verify_11() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v= generate_vector(
+    fn vector_verify_11() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v= parse_verify_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
@@ -418,8 +397,8 @@ mod tests {
     }
 
     // verify_valid_case_2f09d443ab8a3ac2
-    fn vector_verify_12() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_12() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
@@ -428,8 +407,8 @@ mod tests {
     }
 
     // verify_valid_case_6b3b17f6962a490c
-    fn vector_verify_13() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_13() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
@@ -438,8 +417,8 @@ mod tests {
     }
 
     // verify_valid_case_6eeb7c52dfd9baf0
-    fn vector_verify_14() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_14() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0xabababababababababababababababababababababababababababababababab",
         "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
@@ -448,8 +427,8 @@ mod tests {
     }
 
     // verify_valid_case_8761a0b7e920c323
-    fn vector_verify_15() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_15() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0xabababababababababababababababababababababababababababababababab",
         "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
@@ -458,8 +437,8 @@ mod tests {
     }
 
     // verify_valid_case_195246ee3bd3b6ec
-    fn vector_verify_16() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_16() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0xabababababababababababababababababababababababababababababababab",
         "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
@@ -468,8 +447,8 @@ mod tests {
     }
 
     // verify_valid_case_3208262581c8fc09
-    fn vector_verify_17() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_17() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
@@ -478,8 +457,8 @@ mod tests {
     }
 
     // verify_valid_case_d34885d766d5f705
-    fn vector_verify_18() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_18() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
@@ -488,8 +467,8 @@ mod tests {
     }
 
     // verify_valid_case_e8a50c445c855360
-    fn vector_verify_19() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_19() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
@@ -498,8 +477,8 @@ mod tests {
     }
 
     // verify_wrong_pubkey_case_2ea479adf8c40300
-    fn vector_verify_20() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_20() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
@@ -508,8 +487,8 @@ mod tests {
     }
 
     // verify_wrong_pubkey_case_2f09d443ab8a3ac2
-    fn vector_verify_21() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_21() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
@@ -518,8 +497,8 @@ mod tests {
     }
 
     // verify_wrong_pubkey_case_6b3b17f6962a490c
-    fn vector_verify_22() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_22() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
@@ -528,8 +507,8 @@ mod tests {
     }
 
     // verify_wrong_pubkey_case_6eeb7c52dfd9baf0
-    fn vector_verify_23() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_23() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0xabababababababababababababababababababababababababababababababab",
         "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
@@ -538,8 +517,8 @@ mod tests {
     }
 
     // verify_wrong_pubkey_case_8761a0b7e920c323
-    fn vector_verify_24() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_24() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0xabababababababababababababababababababababababababababababababab",
         "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
@@ -548,8 +527,8 @@ mod tests {
     }
 
     // verify_wrong_pubkey_case_195246ee3bd3b6ec
-    fn vector_verify_25() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_25() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0xabababababababababababababababababababababababababababababababab",
         "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
@@ -558,8 +537,8 @@ mod tests {
     }
 
     // verify_wrong_pubkey_case_3208262581c8fc09
-    fn vector_verify_26() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_26() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
         "0x5656565656565656565656565656565656565656565656565656565656565656",
         "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
@@ -568,8 +547,8 @@ mod tests {
     }
 
     // verify_wrong_pubkey_case_d34885d766d5f705
-    fn vector_verify_27() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_27() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
@@ -578,8 +557,8 @@ mod tests {
     }
 
     // verify_wrong_pubkey_case_e8a50c445c855360
-    fn vector_verify_28() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v = generate_vector(
+    fn vector_verify_28() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v = parse_verify_vector(
         "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
@@ -588,8 +567,8 @@ mod tests {
     }
 
     // verifycase_one_privkey_47117849458281be
-    fn vector_verify_29() -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
-        let v= generate_vector(
+    fn vector_verify_29() -> (PublicKey, Vec<u8>, Signature, bool) {
+        let v= parse_verify_vector(
         "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb",
         "0x1212121212121212121212121212121212121212121212121212121212121212",
         "0xa42ae16f1c2a5fa69c04cb5998d2add790764ce8dd45bf25b29b4700829232052b52352dcff1cf255b3a7810ad7269601810f03b2bc8b68cf289cf295b206770605a190b6842583e47c3d1c0f73c54907bfb2a602157d46a4353a20283018763",

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -26,8 +26,6 @@ use super::primitives::{
 use crate::{PrivateKey, PublicKey, Scheme, Signature};
 use rand::{CryptoRng, Rng, SeedableRng};
 
-const ZERO_PRIVATEKEY_BYTES: [u8; 32] = [0; 32];
-
 /// BLS12-381 implementation of the `Scheme` trait.
 ///
 /// This implementation uses the `blst` crate for BLS12-381 operations. This
@@ -51,9 +49,6 @@ impl Scheme for Bls12381 {
             Ok(key) => key,
             Err(_) => return None,
         };
-        if private_key == ZERO_PRIVATEKEY_BYTES {
-            return None;
-        }
         let private = Scalar::deserialize(&private_key)?;
         let mut public = group::Public::one();
         public.mul(&private);

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -200,12 +200,12 @@ mod tests {
         public_key: Vec<u8>,
         message: Vec<u8>,
         signature: Vec<u8>,
-        output: bool,
+        success: bool,
     ) {
         let public_key = PublicKey::from(public_key);
         let signature = Bytes::from(signature);
         let res = Bls12381::verify(None, &message, &public_key, &signature);
-        assert_eq!(res, output, "vector_verify_{}", test_id);
+        assert_eq!(res, success, "vector_verify_{}", test_id);
     }
 
     /// Generates `sign` vector from hex encoded data.
@@ -226,13 +226,13 @@ mod tests {
         public_key: &str,
         message: &str,
         signature: &str,
-        output: bool,
+        success: bool,
     ) -> (Vec<u8>, Vec<u8>, Vec<u8>, bool) {
         (
             commonware_utils::from_hex_formatted(public_key).unwrap(),
             commonware_utils::from_hex_formatted(message).unwrap(),
             commonware_utils::from_hex_formatted(signature).unwrap(),
-            output,
+            success,
         )
     }
 

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -99,16 +99,15 @@ impl Scheme for Bls12381 {
     }
 }
 
+/// Test vectors sources from https://github.com/ethereum/bls12-381-tests/releases/tag/v0.1.2.
 #[cfg(test)]
 mod tests {
-    /// Tests use the bls12381 test vectors
-    /// from https://github.com/ethereum/bls12-381-tests (v0.1.2).
     use super::{Bls12381, Scheme};
     use crate::{PrivateKey, PublicKey, Signature};
 
     #[test]
-    fn sign() {
-        let tests_cases = [
+    fn test_sign() {
+        let cases = [
             vector_sign_1(),
             vector_sign_2(),
             vector_sign_3(),
@@ -119,18 +118,17 @@ mod tests {
             vector_sign_8(),
             vector_sign_9(),
         ];
-
-        for (index, test_case) in tests_cases.iter().enumerate() {
-            let (private_key, message, exp_signature) = test_case;
-            let mut signer = <Bls12381 as Scheme>::from(private_key.clone())
-                .expect("unable to deserialize private key");
-            let signature = signer.sign(None, message);
-            assert_eq!(signature, exp_signature, "vector_sign_{} failed", index + 1);
+        for (index, test) in cases.into_iter().enumerate() {
+            let (private_key, message, expected) = test;
+            let mut signer =
+                <Bls12381 as Scheme>::from(private_key).expect("unable to deserialize private key");
+            let signature = signer.sign(None, &message);
+            assert_eq!(signature, expected, "vector_sign_{}", index + 1);
         }
     }
 
     #[test]
-    fn sign_zero_private_key() {
+    fn test_sign_zero_private_key() {
         let v = vector_sign_10();
         let private_key = PrivateKey::from(v.0);
         let signer = <Bls12381 as Scheme>::from(private_key);
@@ -138,8 +136,8 @@ mod tests {
     }
 
     #[test]
-    fn verify() {
-        let tests_cases = [
+    fn test_verify() {
+        let cases = [
             vector_verify_1(),
             vector_verify_2(),
             vector_verify_3(),
@@ -170,110 +168,108 @@ mod tests {
             vector_verify_28(),
             vector_verify_29(),
         ];
-
-        for (index, test_case) in tests_cases.iter().enumerate() {
-            let (public_key, message, signature, exp_success) = test_case;
-            let success = Bls12381::verify(None, message, public_key, signature);
-            assert_eq!(success, *exp_success, "vector_verify_{}", index + 1);
+        for (index, test) in cases.into_iter().enumerate() {
+            let (public_key, message, signature, expected) = test;
+            let success = Bls12381::verify(None, &message, &public_key, &signature);
+            assert_eq!(success, expected, "vector_verify_{}", index + 1);
         }
     }
 
     /// Parse `sign` vector from hex encoded data.
-    fn parse_sign_vector(s1: &str, s2: &str, s3: &str) -> (PrivateKey, Vec<u8>, Signature) {
+    fn parse_sign_vector(
+        private_key: &str,
+        msg: &str,
+        signature: &str,
+    ) -> (PrivateKey, Vec<u8>, Signature) {
         (
-            commonware_utils::from_hex_formatted(s1).unwrap().into(),
-            commonware_utils::from_hex_formatted(s2).unwrap(),
-            commonware_utils::from_hex_formatted(s3).unwrap().into(),
-        )
-    }
-
-    /// Parse `verify` vector from hex encoded data.
-    fn parse_verify_vector(s1: &str, s2: &str, s3: &str) -> (PublicKey, Vec<u8>, Signature) {
-        (
-            commonware_utils::from_hex_formatted(s1).unwrap().into(),
-            commonware_utils::from_hex_formatted(s2).unwrap(),
-            commonware_utils::from_hex_formatted(s3).unwrap().into(),
+            commonware_utils::from_hex_formatted(private_key)
+                .unwrap()
+                .into(),
+            commonware_utils::from_hex_formatted(msg).unwrap(),
+            commonware_utils::from_hex_formatted(signature)
+                .unwrap()
+                .into(),
         )
     }
 
     // sign_case_8cd3d4d0d9a5b265
     fn vector_sign_1() -> (PrivateKey, Vec<u8>, Signature) {
         parse_sign_vector(
-        "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
+            "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
         )
     }
 
     // sign_case_11b8c7cad5238946
     fn vector_sign_2() -> (PrivateKey, Vec<u8>, Signature) {
         parse_sign_vector(
-        "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9"
+            "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9"
         )
     }
 
     // sign_case_84d45c9c7cca6b92
     fn vector_sign_3() -> (PrivateKey, Vec<u8>, Signature) {
         parse_sign_vector(
-        "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9"
+            "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9"
         )
     }
 
     // sign_case_142f678a8d05fcd1
     fn vector_sign_4() -> (PrivateKey, Vec<u8>, Signature) {
         parse_sign_vector(
-        "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe"
+            "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe"
         )
     }
 
     // sign_case_37286e1a6d1f6eb3
     fn vector_sign_5() -> (PrivateKey, Vec<u8>, Signature) {
         parse_sign_vector(
-        "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df"
+            "0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df"
         )
     }
 
     // sign_case_7055381f640f2c1d
     fn vector_sign_6() -> (PrivateKey, Vec<u8>, Signature) {
         parse_sign_vector(
-        "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115"
+            "0x328388aff0d4a5b7dc9205abd374e7e98f3cd9f3418edb4eafda5fb16473d216",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115"
         )
     }
 
     // sign_case_c82df61aa3ee60fb
     fn vector_sign_7() -> (PrivateKey, Vec<u8>, Signature) {
         parse_sign_vector(
-        "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55"
+            "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55"
         )
     }
 
     // sign_case_d0e28d7e76eb6e9c
     fn vector_sign_8() -> (PrivateKey, Vec<u8>, Signature) {
         parse_sign_vector(
-        "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
+            "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb"
         )
     }
 
     // sign_case_f2ae1097e7d0e18b
     fn vector_sign_9() -> (PrivateKey, Vec<u8>, Signature) {
         parse_sign_vector(
-        "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121"
+            "0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121"
         )
     }
 
@@ -286,12 +282,29 @@ mod tests {
         )
     }
 
+    /// Parse `verify` vector from hex encoded data.
+    fn parse_verify_vector(
+        public_key: &str,
+        msg: &str,
+        signature: &str,
+    ) -> (PublicKey, Vec<u8>, Signature) {
+        (
+            commonware_utils::from_hex_formatted(public_key)
+                .unwrap()
+                .into(),
+            commonware_utils::from_hex_formatted(msg).unwrap(),
+            commonware_utils::from_hex_formatted(signature)
+                .unwrap()
+                .into(),
+        )
+    }
+
     // verify_infinity_pubkey_and_infinity_signature
     fn vector_verify_1() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-        "0x1212121212121212121212121212121212121212121212121212121212121212",
-        "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "0x1212121212121212121212121212121212121212121212121212121212121212",
+            "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         );
         (v.0, v.1, v.2, false)
     }
@@ -299,9 +312,9 @@ mod tests {
     // verify_tampered_signature_case_2ea479adf8c40300
     fn vector_verify_2() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972ffffffff",
+            "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972ffffffff",
         );
         (v.0, v.1, v.2, false)
     }
@@ -309,9 +322,9 @@ mod tests {
     // verify_tampered_signature_case_2f09d443ab8a3ac2
     fn vector_verify_3() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dffffffff",
+            "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dffffffff",
         );
         (v.0, v.1, v.2, false)
     }
@@ -319,9 +332,9 @@ mod tests {
     // verify_tampered_signature_case_6b3b17f6962a490c
     fn vector_verify_4() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffffffff",
+            "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffffffff",
         );
         (v.0, v.1, v.2, false)
     }
@@ -329,9 +342,9 @@ mod tests {
     // verify_tampered_signature_case_6eeb7c52dfd9baf0
     fn vector_verify_5() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5ffffffff",
+            "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5ffffffff",
         );
         (v.0, v.1, v.2, false)
     }
@@ -339,9 +352,9 @@ mod tests {
     // verify_tampered_signature_case_8761a0b7e920c323
     fn vector_verify_6() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b71ffffffff",
+            "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b71ffffffff",
         );
         (v.0, v.1, v.2, false)
     }
@@ -349,9 +362,9 @@ mod tests {
     // verify_tampered_signature_case_195246ee3bd3b6ec
     fn vector_verify_7() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9ffffffff",
+            "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9ffffffff",
         );
         (v.0, v.1, v.2, false)
     }
@@ -359,9 +372,9 @@ mod tests {
     // verify_tampered_signature_case_3208262581c8fc09
     fn vector_verify_8() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363ffffffff",
+            "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363ffffffff",
         );
         (v.0, v.1, v.2, false)
     }
@@ -369,9 +382,9 @@ mod tests {
     // verify_tampered_signature_case_d34885d766d5f705
     fn vector_verify_9() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075effffffff",
+            "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075effffffff",
         );
         (v.0, v.1, v.2, false)
     }
@@ -379,9 +392,9 @@ mod tests {
     // verify_tampered_signature_case_e8a50c445c855360
     fn vector_verify_10() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v= parse_verify_vector(
-        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380bffffffff",
+            "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380bffffffff",
         );
         (v.0, v.1, v.2, false)
     }
@@ -389,9 +402,9 @@ mod tests {
     // verify_valid_case_2ea479adf8c40300
     fn vector_verify_11() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v= parse_verify_vector(
-        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
+            "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
         );
         (v.0, v.1, v.2, true)
     }
@@ -399,9 +412,9 @@ mod tests {
     // verify_valid_case_2f09d443ab8a3ac2
     fn vector_verify_12() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
+            "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
         );
         (v.0, v.1, v.2, true)
     }
@@ -409,9 +422,9 @@ mod tests {
     // verify_valid_case_6b3b17f6962a490c
     fn vector_verify_13() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
+            "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
         );
         (v.0, v.1, v.2, true)
     }
@@ -419,9 +432,9 @@ mod tests {
     // verify_valid_case_6eeb7c52dfd9baf0
     fn vector_verify_14() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
+            "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
         );
         (v.0, v.1, v.2, true)
     }
@@ -429,9 +442,9 @@ mod tests {
     // verify_valid_case_8761a0b7e920c323
     fn vector_verify_15() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
+            "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
         );
         (v.0, v.1, v.2, true)
     }
@@ -439,9 +452,9 @@ mod tests {
     // verify_valid_case_195246ee3bd3b6ec
     fn vector_verify_16() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
+            "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
         );
         (v.0, v.1, v.2, true)
     }
@@ -449,9 +462,9 @@ mod tests {
     // verify_valid_case_3208262581c8fc09
     fn vector_verify_17() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
+            "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
         );
         (v.0, v.1, v.2, true)
     }
@@ -459,9 +472,9 @@ mod tests {
     // verify_valid_case_d34885d766d5f705
     fn vector_verify_18() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
+            "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
         );
         (v.0, v.1, v.2, true)
     }
@@ -469,9 +482,9 @@ mod tests {
     // verify_valid_case_e8a50c445c855360
     fn vector_verify_19() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
+            "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
         );
         (v.0, v.1, v.2, true)
     }
@@ -479,9 +492,9 @@ mod tests {
     // verify_wrong_pubkey_case_2ea479adf8c40300
     fn vector_verify_20() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
+            "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0xa4efa926610b8bd1c8330c918b7a5e9bf374e53435ef8b7ec186abf62e1b1f65aeaaeb365677ac1d1172a1f5b44b4e6d022c252c58486c0a759fbdc7de15a756acc4d343064035667a594b4c2a6f0b0b421975977f297dba63ee2f63ffe47bb6",
         );
         (v.0, v.1, v.2, false)
     }
@@ -489,9 +502,9 @@ mod tests {
     // verify_wrong_pubkey_case_2f09d443ab8a3ac2
     fn vector_verify_21() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
+            "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xb6ed936746e01f8ecf281f020953fbf1f01debd5657c4a383940b020b26507f6076334f91e2366c96e9ab279fb5158090352ea1c5b0c9274504f4f0e7053af24802e51e4568d164fe986834f41e55c8e850ce1f98458c0cfc9ab380b55285a55",
         );
         (v.0, v.1, v.2, false)
     }
@@ -499,9 +512,9 @@ mod tests {
     // verify_wrong_pubkey_case_6b3b17f6962a490c
     fn vector_verify_22() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
+            "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0xaf1390c3c47acdb37131a51216da683c509fce0e954328a59f93aebda7e4ff974ba208d9a4a2a2389f892a9d418d618418dd7f7a6bc7aa0da999a9d3a5b815bc085e14fd001f6a1948768a3f4afefc8b8240dda329f984cb345c6363272ba4fe",
         );
         (v.0, v.1, v.2, false)
     }
@@ -509,9 +522,9 @@ mod tests {
     // verify_wrong_pubkey_case_6eeb7c52dfd9baf0
     fn vector_verify_23() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
+            "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121",
         );
         (v.0, v.1, v.2, false)
     }
@@ -519,9 +532,9 @@ mod tests {
     // verify_wrong_pubkey_case_8761a0b7e920c323
     fn vector_verify_24() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
+            "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9",
         );
         (v.0, v.1, v.2, false)
     }
@@ -529,9 +542,9 @@ mod tests {
     // verify_wrong_pubkey_case_195246ee3bd3b6ec
     fn vector_verify_25() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
-        "0xabababababababababababababababababababababababababababababababab",
-        "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
+            "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+            "0xabababababababababababababababababababababababababababababababab",
+            "0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df",
         );
         (v.0, v.1, v.2, false)
     }
@@ -539,9 +552,9 @@ mod tests {
     // verify_wrong_pubkey_case_3208262581c8fc09
     fn vector_verify_26() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
-        "0x5656565656565656565656565656565656565656565656565656565656565656",
-        "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
+            "0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81",
+            "0x5656565656565656565656565656565656565656565656565656565656565656",
+            "0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb",
         );
         (v.0, v.1, v.2, false)
     }
@@ -549,9 +562,9 @@ mod tests {
     // verify_wrong_pubkey_case_d34885d766d5f705
     fn vector_verify_27() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
+            "0xb53d21a4cfd562c469cc81514d4ce5a6b577d8403d32a394dc265dd190b47fa9f829fdd7963afdf972e5e77854051f6f",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0xb23c46be3a001c63ca711f87a005c200cc550b9429d5f4eb38d74322144f1b63926da3388979e5321012fb1a0526bcd100b5ef5fe72628ce4cd5e904aeaa3279527843fae5ca9ca675f4f51ed8f83bbf7155da9ecc9663100a885d5dc6df96d9",
         );
         (v.0, v.1, v.2, false)
     }
@@ -559,9 +572,9 @@ mod tests {
     // verify_wrong_pubkey_case_e8a50c445c855360
     fn vector_verify_28() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v = parse_verify_vector(
-        "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
+            "0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x948a7cb99f76d616c2c564ce9bf4a519f1bea6b0a624a02276443c245854219fabb8d4ce061d255af5330b078d5380681751aa7053da2c98bae898edc218c75f07e24d8802a17cd1f6833b71e58f5eb5b94208b4d0bb3848cecb075ea21be115",
         );
         (v.0, v.1, v.2, false)
     }
@@ -569,9 +582,9 @@ mod tests {
     // verifycase_one_privkey_47117849458281be
     fn vector_verify_29() -> (PublicKey, Vec<u8>, Signature, bool) {
         let v= parse_verify_vector(
-        "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb",
-        "0x1212121212121212121212121212121212121212121212121212121212121212",
-        "0xa42ae16f1c2a5fa69c04cb5998d2add790764ce8dd45bf25b29b4700829232052b52352dcff1cf255b3a7810ad7269601810f03b2bc8b68cf289cf295b206770605a190b6842583e47c3d1c0f73c54907bfb2a602157d46a4353a20283018763",
+            "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb",
+            "0x1212121212121212121212121212121212121212121212121212121212121212",
+            "0xa42ae16f1c2a5fa69c04cb5998d2add790764ce8dd45bf25b29b4700829232052b52352dcff1cf255b3a7810ad7269601810f03b2bc8b68cf289cf295b206770605a190b6842583e47c3d1c0f73c54907bfb2a602157d46a4353a20283018763",
         );
         (v.0, v.1, v.2, true)
     }

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -128,7 +128,7 @@ mod tests {
         ];
 
         for (index, test_case) in tests_cases.iter().enumerate() {
-            vector_sign_test(
+            test_vector_sign(
                 index + 1,
                 test_case.0.clone(),
                 test_case.1.clone(),

--- a/cryptography/src/ed25519.rs
+++ b/cryptography/src/ed25519.rs
@@ -125,9 +125,9 @@ impl Scheme for Ed25519 {
     }
 }
 
+/// Test vectors sourced from https://datatracker.ietf.org/doc/html/rfc8032#section-7.1.
 #[cfg(test)]
 mod tests {
-    // Tests use the Ed25519 test vectors from https://datatracker.ietf.org/doc/html/rfc8032#section-7.1
     use super::*;
 
     fn test_sign_and_verify(


### PR DESCRIPTION
Relates #287 

This adds a first test coming from https://github.com/ethereum/bls12-381-tests.
I don't know if I missed something when creating the BLS Scheme, but the generated signature is not the expected value provided by the vector.
When comparing the obtained `BigInt` (the one used to create the PrivateKey) and the `int` they use in the test, they look the same.
@patrick-ogrady do you see any reason why this could failed?