### PR TITLE
[cryptography/bls12381] Update `DST` + Single/Threshold Proof-of-Possession + Aggregate Verify for Multiple Public Keys (Single Message)

### DIFF
--- a/cryptography/src/bls12381/benches/aggregate_public_keys.rs
+++ b/cryptography/src/bls12381/benches/aggregate_public_keys.rs
@@ -1,0 +1,27 @@
+use commonware_cryptography::bls12381::primitives::ops;
+use criterion::{criterion_group, BatchSize, Criterion};
+use rand::thread_rng;
+use std::hint::black_box;
+
+fn benchmark_aggregate_public_keys(c: &mut Criterion) {
+    for n in [10, 100, 1000, 10000].into_iter() {
+        c.bench_function(&format!("{}/pks={}", module_path!(), n), |b| {
+            b.iter_batched(
+                || {
+                    let mut public_keys = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        let public_key = ops::keypair(&mut thread_rng()).1;
+                        public_keys.push(public_key);
+                    }
+                    public_keys
+                },
+                |public_keys| {
+                    black_box(ops::aggregate_public_keys(&public_keys));
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, benchmark_aggregate_public_keys);

--- a/cryptography/src/bls12381/benches/aggregate_public_keys.rs
+++ b/cryptography/src/bls12381/benches/aggregate_public_keys.rs
@@ -24,4 +24,8 @@ fn benchmark_aggregate_public_keys(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, benchmark_aggregate_public_keys);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_aggregate_public_keys
+}

--- a/cryptography/src/bls12381/benches/aggregate_signatures.rs
+++ b/cryptography/src/bls12381/benches/aggregate_signatures.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{thread_rng, Rng};
 use std::hint::black_box;
 
-fn benchmark_signature_aggregation(c: &mut Criterion) {
+fn benchmark_aggregate_signatures(c: &mut Criterion) {
     let namespace = b"namespace";
     for n in [10, 100, 1000, 10000].into_iter() {
         let mut msgs = Vec::with_capacity(n);
@@ -12,19 +12,19 @@ fn benchmark_signature_aggregation(c: &mut Criterion) {
             thread_rng().fill(&mut msg);
             msgs.push(msg);
         }
-        c.bench_function(&format!("{}/msgs={}", module_path!(), msgs.len()), |b| {
+        c.bench_function(&format!("{}/sigs={}", module_path!(), n), |b| {
             b.iter_batched(
                 || {
                     let private = ops::keypair(&mut thread_rng()).0;
                     let mut signatures = Vec::with_capacity(n);
                     for msg in msgs.iter() {
-                        let signature = ops::sign(&private, Some(namespace), msg);
+                        let signature = ops::sign_message(&private, Some(namespace), msg);
                         signatures.push(signature);
                     }
                     signatures
                 },
                 |signatures| {
-                    black_box(ops::aggregate(&signatures));
+                    black_box(ops::aggregate_signatures(&signatures));
                 },
                 BatchSize::SmallInput,
             );
@@ -32,8 +32,4 @@ fn benchmark_signature_aggregation(c: &mut Criterion) {
     }
 }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default().sample_size(10);
-    targets = benchmark_signature_aggregation
-}
+criterion_group!(benches, benchmark_aggregate_signatures);

--- a/cryptography/src/bls12381/benches/aggregate_signatures.rs
+++ b/cryptography/src/bls12381/benches/aggregate_signatures.rs
@@ -32,4 +32,8 @@ fn benchmark_aggregate_signatures(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, benchmark_aggregate_signatures);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_aggregate_signatures
+}

--- a/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
@@ -14,12 +14,7 @@ fn benchmark_aggregate_verify_multiple_messages(c: &mut Criterion) {
         let msgs = msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<_>>();
         for concurrency in [1, 2, 4, 8].into_iter() {
             c.bench_function(
-                &format!(
-                    "{}/conc={} msgs={}",
-                    module_path!(),
-                    concurrency,
-                    msgs.len()
-                ),
+                &format!("{}/conc={} msgs={}", module_path!(), concurrency, n,),
                 |b| {
                     b.iter_batched(
                         || {

--- a/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
@@ -2,7 +2,7 @@ use commonware_cryptography::bls12381::primitives::ops;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{thread_rng, Rng};
 
-fn benchmark_signature_verify_aggregation(c: &mut Criterion) {
+fn benchmark_aggregate_verify_multiple_messages(c: &mut Criterion) {
     let namespace = b"namespace";
     for n in [10, 100, 1000, 10000, 50000].into_iter() {
         let mut msgs = Vec::with_capacity(n);
@@ -26,13 +26,13 @@ fn benchmark_signature_verify_aggregation(c: &mut Criterion) {
                             let (private, public) = ops::keypair(&mut thread_rng());
                             let mut signatures = Vec::with_capacity(n);
                             for msg in msgs.iter() {
-                                let signature = ops::sign(&private, Some(namespace), msg);
+                                let signature = ops::sign_message(&private, Some(namespace), msg);
                                 signatures.push(signature);
                             }
-                            (public, ops::aggregate(&signatures))
+                            (public, ops::aggregate_signatures(&signatures))
                         },
                         |(public, signature)| {
-                            ops::verify_aggregate(
+                            ops::aggregate_verify_multiple_messages(
                                 &public,
                                 Some(namespace),
                                 &msgs,
@@ -52,5 +52,5 @@ fn benchmark_signature_verify_aggregation(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = benchmark_signature_verify_aggregation
+    targets = benchmark_aggregate_verify_multiple_messages
 }

--- a/cryptography/src/bls12381/benches/aggregate_verify_multiple_public_keys.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_multiple_public_keys.rs
@@ -1,0 +1,42 @@
+use commonware_cryptography::bls12381::primitives::ops;
+use criterion::{criterion_group, BatchSize, Criterion};
+use rand::{thread_rng, Rng};
+
+fn benchmark_aggregate_verify_multiple_public_keys(c: &mut Criterion) {
+    let namespace = b"namespace";
+    for n in [10, 100, 1000, 10000, 50000].into_iter() {
+        let mut msg = [0u8; 32];
+        thread_rng().fill(&mut msg);
+        c.bench_function(&format!("{}/pks={}", module_path!(), n), |b| {
+            b.iter_batched(
+                || {
+                    let mut public_keys = Vec::with_capacity(n);
+                    let mut signatures = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        let (private, public) = ops::keypair(&mut thread_rng());
+                        let signature = ops::sign_message(&private, Some(namespace), &msg);
+                        public_keys.push(public);
+                        signatures.push(signature);
+                    }
+                    (public_keys, ops::aggregate_signatures(&signatures))
+                },
+                |(public_keys, signature)| {
+                    ops::aggregate_verify_multiple_public_keys(
+                        &public_keys,
+                        Some(namespace),
+                        &msg,
+                        &signature,
+                    )
+                    .unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_aggregate_verify_multiple_public_keys
+}

--- a/cryptography/src/bls12381/benches/aggregate_verify_multiple_public_keys.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_multiple_public_keys.rs
@@ -6,7 +6,7 @@ fn benchmark_aggregate_verify_multiple_public_keys(c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
     thread_rng().fill(&mut msg);
-    for n in [10, 100, 1000, 10000, 50000].into_iter() {
+    for n in [10, 100, 1000, 10000].into_iter() {
         c.bench_function(&format!("{}/pks={}", module_path!(), n), |b| {
             b.iter_batched(
                 || {

--- a/cryptography/src/bls12381/benches/aggregate_verify_multiple_public_keys.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_multiple_public_keys.rs
@@ -4,9 +4,9 @@ use rand::{thread_rng, Rng};
 
 fn benchmark_aggregate_verify_multiple_public_keys(c: &mut Criterion) {
     let namespace = b"namespace";
+    let mut msg = [0u8; 32];
+    thread_rng().fill(&mut msg);
     for n in [10, 100, 1000, 10000, 50000].into_iter() {
-        let mut msg = [0u8; 32];
-        thread_rng().fill(&mut msg);
         c.bench_function(&format!("{}/pks={}", module_path!(), n), |b| {
             b.iter_batched(
                 || {

--- a/cryptography/src/bls12381/benches/bench.rs
+++ b/cryptography/src/bls12381/benches/bench.rs
@@ -3,6 +3,7 @@ use criterion::criterion_main;
 mod aggregate_public_keys;
 mod aggregate_signatures;
 mod aggregate_verify_multiple_messages;
+mod aggregate_verify_multiple_public_keys;
 mod dkg_recovery;
 mod dkg_reshare_recovery;
 mod signature_generation;
@@ -18,4 +19,5 @@ criterion_main!(
     signature_generation::benches,
     signature_verification::benches,
     aggregate_verify_multiple_messages::benches,
+    aggregate_verify_multiple_public_keys::benches,
 );

--- a/cryptography/src/bls12381/benches/bench.rs
+++ b/cryptography/src/bls12381/benches/bench.rs
@@ -1,19 +1,21 @@
 use criterion::criterion_main;
 
+mod aggregate_public_keys;
+mod aggregate_signatures;
+mod aggregate_verify_multiple_messages;
 mod dkg_recovery;
 mod dkg_reshare_recovery;
-mod partial_signature_aggregation;
-mod signature_aggregation;
 mod signature_generation;
 mod signature_verification;
-mod signature_verify_aggregation;
+mod threshold_signature_recover;
 
 criterion_main!(
     dkg_recovery::benches,
     dkg_reshare_recovery::benches,
-    partial_signature_aggregation::benches,
-    signature_aggregation::benches,
+    threshold_signature_recover::benches,
+    aggregate_public_keys::benches,
+    aggregate_signatures::benches,
     signature_generation::benches,
     signature_verification::benches,
-    signature_verify_aggregation::benches,
+    aggregate_verify_multiple_messages::benches,
 );

--- a/cryptography/src/bls12381/benches/threshold_signature_recover.rs
+++ b/cryptography/src/bls12381/benches/threshold_signature_recover.rs
@@ -3,7 +3,7 @@ use commonware_utils::quorum;
 use criterion::{criterion_group, BatchSize, Criterion};
 use std::hint::black_box;
 
-fn benchmark_partial_signature_aggregation(c: &mut Criterion) {
+fn benchmark_threshold_signature_recover(c: &mut Criterion) {
     let namespace = b"benchmark";
     let msg = b"hello";
     for &n in &[5, 10, 20, 50, 100, 250, 500] {
@@ -14,11 +14,11 @@ fn benchmark_partial_signature_aggregation(c: &mut Criterion) {
                     let (_, shares) = dkg::ops::generate_shares(None, n, t);
                     shares
                         .iter()
-                        .map(|s| primitives::ops::partial_sign(s, Some(namespace), msg))
+                        .map(|s| primitives::ops::partial_sign_message(s, Some(namespace), msg))
                         .collect::<Vec<_>>()
                 },
                 |partials| {
-                    black_box(primitives::ops::partial_aggregate(t, partials).unwrap());
+                    black_box(primitives::ops::threshold_signature_recover(t, partials).unwrap());
                 },
                 BatchSize::SmallInput,
             );
@@ -26,4 +26,4 @@ fn benchmark_partial_signature_aggregation(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, benchmark_partial_signature_aggregation);
+criterion_group!(benches, benchmark_threshold_signature_recover);

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -131,7 +131,9 @@ mod tests {
     use super::*;
     use dkg::ops::generate_shares;
     use primitives::group::Private;
-    use primitives::ops::{partial_aggregate, partial_sign, partial_verify, verify};
+    use primitives::ops::{
+        partial_sign_message, partial_verify_message, threshold_signature_recover, verify_message,
+    };
     use primitives::poly::public;
     use primitives::Error;
 
@@ -151,18 +153,18 @@ mod tests {
         let msg = b"hello";
         let partials = shares
             .iter()
-            .map(|s| partial_sign(s, namespace, msg))
+            .map(|s| partial_sign_message(s, namespace, msg))
             .collect::<Vec<_>>();
 
         // Each partial sig can be partially verified against the public polynomial
         partials.iter().for_each(|partial| {
-            partial_verify(&group, namespace, msg, partial).unwrap();
+            partial_verify_message(&group, namespace, msg, partial).unwrap();
         });
 
         // Generate and verify the threshold sig
-        let threshold_sig = partial_aggregate(t, partials).unwrap();
+        let threshold_sig = threshold_signature_recover(t, partials).unwrap();
         let threshold_pub = public(&group);
-        verify(&threshold_pub, namespace, msg, &threshold_sig).unwrap();
+        verify_message(&threshold_pub, namespace, msg, &threshold_sig).unwrap();
     }
 
     #[test]
@@ -181,23 +183,23 @@ mod tests {
         let msg = b"hello";
         let partials = shares
             .iter()
-            .map(|s| partial_sign(s, namespace, msg))
+            .map(|s| partial_sign_message(s, namespace, msg))
             .collect::<Vec<_>>();
 
         // Each partial sig can be partially verified against the public polynomial
         let namespace = Some(&b"bad"[..]);
         partials.iter().for_each(|partial| {
             assert!(matches!(
-                partial_verify(&group, namespace, msg, partial).unwrap_err(),
+                partial_verify_message(&group, namespace, msg, partial).unwrap_err(),
                 Error::InvalidSignature
             ));
         });
 
         // Generate and verify the threshold sig
-        let threshold_sig = partial_aggregate(t, partials).unwrap();
+        let threshold_sig = threshold_signature_recover(t, partials).unwrap();
         let threshold_pub = public(&group);
         assert!(matches!(
-            verify(&threshold_pub, namespace, msg, &threshold_sig).unwrap_err(),
+            verify_message(&threshold_pub, namespace, msg, &threshold_sig).unwrap_err(),
             Error::InvalidSignature
         ));
     }
@@ -218,17 +220,17 @@ mod tests {
         let msg = b"hello";
         let partials = shares
             .iter()
-            .map(|s| partial_sign(s, namespace, msg))
+            .map(|s| partial_sign_message(s, namespace, msg))
             .collect::<Vec<_>>();
 
         // Each partial sig can be partially verified against the public polynomial
         partials.iter().for_each(|partial| {
-            partial_verify(&group, namespace, msg, partial).unwrap();
+            partial_verify_message(&group, namespace, msg, partial).unwrap();
         });
 
         // Generate the threshold sig
         assert!(matches!(
-            partial_aggregate(t, partials).unwrap_err(),
+            threshold_signature_recover(t, partials).unwrap_err(),
             Error::NotEnoughPartialSignatures(4, 3)
         ));
     }
@@ -250,17 +252,17 @@ mod tests {
         let msg = b"hello";
         let partials = shares
             .iter()
-            .map(|s| partial_sign(s, namespace, msg))
+            .map(|s| partial_sign_message(s, namespace, msg))
             .collect::<Vec<_>>();
 
         // Each partial sig can be partially verified against the public polynomial
         partials.iter().for_each(|partial| {
-            partial_verify(&group, namespace, msg, partial).unwrap();
+            partial_verify_message(&group, namespace, msg, partial).unwrap();
         });
 
         // Generate the threshold sig
         assert!(matches!(
-            partial_aggregate(t, partials).unwrap_err(),
+            threshold_signature_recover(t, partials).unwrap_err(),
             Error::DuplicateEval,
         ));
     }
@@ -283,17 +285,17 @@ mod tests {
         let msg = b"hello";
         let partials = shares
             .iter()
-            .map(|s| partial_sign(s, namespace, msg))
+            .map(|s| partial_sign_message(s, namespace, msg))
             .collect::<Vec<_>>();
 
         // Each partial sig can be partially verified against the public polynomial
         partials.iter().for_each(|partial| {
-            partial_verify(&group, namespace, msg, partial).unwrap();
+            partial_verify_message(&group, namespace, msg, partial).unwrap();
         });
 
         // Generate and verify the threshold sig
-        let threshold_sig = partial_aggregate(t, partials).unwrap();
+        let threshold_sig = threshold_signature_recover(t, partials).unwrap();
         let threshold_pub = public(&group);
-        verify(&threshold_pub, namespace, msg, &threshold_sig).unwrap();
+        verify_message(&threshold_pub, namespace, msg, &threshold_sig).unwrap();
     }
 }

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -59,7 +59,7 @@
 //! conc=8 n=500 t=167     time:   [232.44 ms 238.31 ms 247.56 ms]
 //! ```
 //!
-//! ## Partial Signature Aggregation
+//! ## Threshold Signature Recovery
 //!
 //! ```txt
 //! n=5 t=3                 time:   [126.85 µs 128.50 µs 130.67 µs]

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -8,8 +8,7 @@
 //! Ensure that points are checked to belong to the correct subgroup
 //! (G1 or G2) to prevent small subgroup attacks. This is particularly important
 //! when handling deserialized points or points received from untrusted sources. This
-//! is already taken care of for you if you use the provided `serialize` and `deserialize`
-//! functions.
+//! is already taken care of for you if you use the provided `deserialize` function.
 
 use blst::{
     blst_bendian_from_scalar, blst_final_exp, blst_fp12, blst_fr, blst_fr_add, blst_fr_from_scalar,
@@ -24,6 +23,11 @@ use blst::{
 use rand::RngCore;
 use std::ptr;
 use zeroize::Zeroize;
+
+/// Domain separation tag used when hashing a message to a curve (G1 or G2).
+///
+/// Reference: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-ciphersuites
+pub type DST = &'static [u8];
 
 /// An element of a group.
 pub trait Element: Clone + Eq + PartialEq + Send + Sync {
@@ -45,20 +49,24 @@ pub trait Element: Clone + Eq + PartialEq + Send + Sync {
     /// Serialized size of the element.
     fn size() -> usize;
 
-    /// Deserializes a canonically encoded element.
+    /// Deserializes an untrusted, canonically-encoded element.
+    ///
+    /// This function performs any validation necessary to ensure the decoded
+    /// element is valid (like an infinity or group check).
     fn deserialize(bytes: &[u8]) -> Option<Self>;
 }
 
 /// An element of a group that supports message hashing.
 pub trait Point: Element {
     /// Maps the provided data to a group element.
-    fn map(&mut self, message: &[u8]);
+    fn map(&mut self, dst: DST, message: &[u8]);
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Scalar(blst_fr);
 
+/// Length of a scalar in bytes.
 const SCALAR_LENGTH: usize = 32;
 
 /// `R = 2^256 mod q` in little-endian Montgomery form which is equivalent to 1 in little-endian
@@ -79,27 +87,64 @@ const BLST_FR_ONE: Scalar = Scalar(blst_fr {
 #[repr(transparent)]
 pub struct G1(blst_p1);
 
+/// The size in bytes of an encoded G1 element.
 pub const G1_ELEMENT_BYTE_LENGTH: usize = 48;
 
+/// Domain separation tag for hashing a proof of possession (compressed G2) to G1.
+pub const G1_PROOF_OF_POSSESSION: DST = b"BLS_POP_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_";
+
 /// Domain separation tag for hashing a message to G1.
-pub const DST_G1: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
+///
+/// We use the `POP` scheme for hashing all messages because this crate is expected to be
+/// used in a Byzantine environment (where any player may attempt a rogue key attack) and
+/// any message could be aggregated into a multi-signature (which requires a proof-of-possession
+/// to be safely deployed in this environment).
+pub const G1_MESSAGE: DST = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct G2(blst_p2);
 
+/// The size in bytes of an encoded G2 element.
 pub const G2_ELEMENT_BYTE_LENGTH: usize = 96;
 
+/// Domain separation tag for hashing a proof of possession (compressed G1) to G2.
+pub const G2_PROOF_OF_POSSESSION: DST = b"BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+
 /// Domain separation tag for hashing a message to G2.
-pub const DST_G2: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
+///
+/// We use the `POP` scheme for hashing all messages because this crate is expected to be
+/// used in a Byzantine environment (where any player may attempt a rogue key attack) and
+/// any message could be aggregated into a multi-signature (which requires a proof-of-possession
+/// to be safely deployed in this environment).
+pub const G2_MESSAGE: DST = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct GT(blst_fp12);
 
+/// The private key type.
 pub type Private = Scalar;
+
+/// The private key length.
 pub const PRIVATE_KEY_LENGTH: usize = SCALAR_LENGTH;
+
+/// The default public key type (G1).
 pub type Public = G1;
+
+/// The default public key length (G1).
+pub const PUBLIC_KEY_LENGTH: usize = G1_ELEMENT_BYTE_LENGTH;
+
+/// The default signature type (G2).
 pub type Signature = G2;
+
+/// The default signature length (G2).
+pub const SIGNATURE_LENGTH: usize = G2_ELEMENT_BYTE_LENGTH;
+
+/// The DST for hashing a proof of possession to the default signature type (G2).
+pub const PROOF_OF_POSSESSION: DST = G2_PROOF_OF_POSSESSION;
+
+/// The DST for hashing a message to the default signature type (G2).
+pub const MESSAGE: DST = G2_MESSAGE;
 
 /// Returns the size in bits of a given blst_scalar (represented in little-endian).
 fn bits(scalar: &blst_scalar) -> usize {
@@ -319,14 +364,14 @@ impl Element for G1 {
 }
 
 impl Point for G1 {
-    fn map(&mut self, data: &[u8]) {
+    fn map(&mut self, dst: DST, data: &[u8]) {
         unsafe {
             blst_hash_to_g1(
                 &mut self.0,
                 data.as_ptr(),
                 data.len(),
-                DST_G1.as_ptr(),
-                DST_G1.len(),
+                dst.as_ptr(),
+                dst.len(),
                 ptr::null(),
                 0,
             );
@@ -400,14 +445,14 @@ impl Element for G2 {
 }
 
 impl Point for G2 {
-    fn map(&mut self, data: &[u8]) {
+    fn map(&mut self, dst: DST, data: &[u8]) {
         unsafe {
             blst_hash_to_g2(
                 &mut self.0,
                 data.as_ptr(),
                 data.len(),
-                DST_G2.as_ptr(),
-                DST_G2.len(),
+                dst.as_ptr(),
+                dst.len(),
                 ptr::null(),
                 0,
             );

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -77,7 +77,7 @@ const SCALAR_LENGTH: usize = 32;
 /// `R = 2^256 mod q` in little-endian Montgomery form which is equivalent to 1 in little-endian
 /// non-Montgomery form:
 ///
-/// ```
+/// ```txt
 /// mod(2^256, 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001) = 0x1824b159acc5056f998c4fefecbc4ff55884b7fa0003480200000001fffffffe
 /// ```
 ///

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -70,10 +70,13 @@ pub struct Scalar(blst_fr);
 const SCALAR_LENGTH: usize = 32;
 
 /// `R = 2^256 mod q` in little-endian Montgomery form which is equivalent to 1 in little-endian
-/// non-Montgomery form.
+/// non-Montgomery form:
 ///
+/// ```
 /// mod(2^256, 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001) = 0x1824b159acc5056f998c4fefecbc4ff55884b7fa0003480200000001fffffffe
-// Reference: <https://github.com/filecoin-project/blstrs/blob/ffbb41d1495d84e40a712583346439924603b49a/src/scalar.rs#L77-L89>
+/// ```
+///
+/// Reference: <https://github.com/filecoin-project/blstrs/blob/ffbb41d1495d84e40a712583346439924603b49a/src/scalar.rs#L77-L89>
 const BLST_FR_ONE: Scalar = Scalar(blst_fr {
     l: [
         0x0000_0001_ffff_fffe,

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -483,13 +483,12 @@ pub(super) fn equal(p: &G1, sig: &G2, hm: &G2) -> bool {
 
 #[cfg(test)]
 mod tests {
-    // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/b0ef82ff79769d085a5a7d3f4fe690b1c8fe6dc9/crates/threshold-bls/src/curve/bls12381.rs#L200-L220
-
     use super::*;
     use rand::prelude::*;
 
     #[test]
     fn basic_group() {
+        // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/b0ef82ff79769d085a5a7d3f4fe690b1c8fe6dc9/crates/threshold-bls/src/curve/bls12381.rs#L200-L220
         let s = Scalar::rand(&mut thread_rng());
         let mut e1 = s;
         let e2 = s;

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -26,7 +26,7 @@ use zeroize::Zeroize;
 
 /// Domain separation tag used when hashing a message to a curve (G1 or G2).
 ///
-/// Reference: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-ciphersuites
+/// Reference: <https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-ciphersuites>
 pub type DST = &'static [u8];
 
 /// An element of a group.
@@ -73,7 +73,7 @@ const SCALAR_LENGTH: usize = 32;
 /// non-Montgomery form.
 ///
 /// mod(2^256, 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001) = 0x1824b159acc5056f998c4fefecbc4ff55884b7fa0003480200000001fffffffe
-// Reference: https://github.com/filecoin-project/blstrs/blob/ffbb41d1495d84e40a712583346439924603b49a/src/scalar.rs#L77-L89
+// Reference: <https://github.com/filecoin-project/blstrs/blob/ffbb41d1495d84e40a712583346439924603b49a/src/scalar.rs#L77-L89>
 const BLST_FR_ONE: Scalar = Scalar(blst_fr {
     l: [
         0x0000_0001_ffff_fffe,

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -62,6 +62,7 @@ pub trait Point: Element {
     fn map(&mut self, dst: DST, message: &[u8]);
 }
 
+/// A scalar representing an element of the BLS12-381 finite field.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Scalar(blst_fr);
@@ -69,6 +70,10 @@ pub struct Scalar(blst_fr);
 /// Length of a scalar in bytes.
 const SCALAR_LENGTH: usize = 32;
 
+/// This constant serves as the multiplicative identity (i.e., "one") in the
+/// BLS12-381 finite field, ensuring that arithmetic is carried out within the
+/// correct modulo.
+///
 /// `R = 2^256 mod q` in little-endian Montgomery form which is equivalent to 1 in little-endian
 /// non-Montgomery form:
 ///
@@ -86,6 +91,7 @@ const BLST_FR_ONE: Scalar = Scalar(blst_fr {
     ],
 });
 
+/// A point on the BLS12-381 G1 curve.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct G1(blst_p1);
@@ -104,6 +110,7 @@ pub const G1_PROOF_OF_POSSESSION: DST = b"BLS_POP_BLS12381G1_XMD:SHA-256_SSWU_RO
 /// to be safely deployed in this environment).
 pub const G1_MESSAGE: DST = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_";
 
+/// A point on the BLS12-381 G2 curve.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct G2(blst_p2);
@@ -122,6 +129,10 @@ pub const G2_PROOF_OF_POSSESSION: DST = b"BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO
 /// to be safely deployed in this environment).
 pub const G2_MESSAGE: DST = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
+/// The target group of the BLS12-381 pairing.
+///
+/// This is an element in the extension field `F_p^12` and is
+/// produced as the result of a pairing operation.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct GT(blst_fp12);
 

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! ```rust
 //! use commonware_cryptography::bls12381::{
-//!     primitives::{ops::{partial_sign, partial_verify, partial_aggregate, verify}, poly::public},
+//!     primitives::{ops::{partial_sign_message, partial_verify_message, threshold_signature_recover, verify_message}, poly::public},
 //!     dkg::ops::{generate_shares},
 //! };
 //!
@@ -26,19 +26,19 @@
 //! // Generate partial signatures from shares
 //! let namespace = Some(&b"demo"[..]);
 //! let message = b"hello world";
-//! let partials: Vec<_> = shares.iter().map(|s| partial_sign(s, namespace, message)).collect();
+//! let partials: Vec<_> = shares.iter().map(|s| partial_sign_message(s, namespace, message)).collect();
 //!
 //! // Verify partial signatures
 //! for p in &partials {
-//!     partial_verify(&commitment, namespace, message, p).expect("signature should be valid");
+//!     partial_verify_message(&commitment, namespace, message, p).expect("signature should be valid");
 //! }
 //!
 //! // Aggregate partial signatures
-//! let threshold_sig = partial_aggregate(t, partials).unwrap();
+//! let threshold_sig = threshold_signature_recover(t, partials).unwrap();
 //!
 //! // Verify threshold signature
 //! let threshold_pub = public(&commitment);
-//! verify(&threshold_pub, namespace, message, &threshold_sig).expect("signature should be valid");
+//! verify_message(&threshold_pub, namespace, message, &threshold_sig).expect("signature should be valid");
 //! ```
 
 pub mod group;

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -47,6 +47,7 @@ pub mod poly;
 
 use thiserror::Error;
 
+/// Errors that can occur when working with BLS12-381 primitives.
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("not enough partial signatures: {0}/{1}")]

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -59,6 +59,4 @@ pub enum Error {
     NoInverse,
     #[error("duplicate eval")]
     DuplicateEval,
-    #[error("duplicate message")]
-    DuplicateMessage,
 }

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -210,8 +210,8 @@ pub fn verify_aggregate(
             .map(|msg| {
                 let mut hm = group::Signature::zero();
                 match namespace {
-                    Some(namespace) => hm.map(&union_unique(namespace, msg)),
-                    None => hm.map(msg),
+                    Some(namespace) => hm.map(MESSAGE, &union_unique(namespace, msg)),
+                    None => hm.map(MESSAGE, msg),
                 };
                 hm
             })

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -196,7 +196,10 @@ pub fn threshold_signature_recover(
 ///
 /// # Warning
 ///
-/// This function assumes a group check was already performed on each `public`.
+/// This function assumes a group check was already performed on all `public_keys`,
+/// that each `public_key` is unique, and that the caller has a Proof-of-Possession (PoP)
+/// for each `public_key`. If any of these assumptions are violated, an attacker can
+/// exploit this function to verify an incorrect aggregate signature.
 pub fn aggregate_public_keys(public_keys: &[group::Public]) -> group::Public {
     let mut p = group::Public::zero();
     for pk in public_keys {
@@ -209,7 +212,9 @@ pub fn aggregate_public_keys(public_keys: &[group::Public]) -> group::Public {
 ///
 /// # Warning
 ///
-/// This function assumes a group check was already performed on each `signature`.
+/// This function assumes a group check was already performed on each `signature` and
+/// that each `signature` is unique. If any of these assumptions are violated, an attacker can
+/// exploit this function to verify an incorrect aggregate signature.
 pub fn aggregate_signatures(signatures: &[group::Signature]) -> group::Signature {
     let mut s = group::Signature::zero();
     for sig in signatures {

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -213,9 +213,9 @@ pub fn aggregate_verify_multiple_public_keys(
 ///
 /// We rely on the bilinearity property in this function to reduce pairing computations by summing
 /// the hashed messages against a single public key. If the public key were itself an aggregate of
-/// multiple public keys, an attacker could exploit this optimization in unintended ways (potentially forging signatures
-/// across different sets of participants). This would lead to this function incorrectly returning an aggregate
-/// signature is valid when it really isn't.
+/// multiple public keys, an attacker could exploit this optimization in unintended ways (potentially forging
+/// signatures across different sets of participants). This would lead to this function incorrectly returning
+/// an aggregate signature is valid when it really isn't.
 pub fn aggregate_verify_multiple_messages(
     public: &group::Public,
     namespace: Option<&[u8]>,

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -250,11 +250,10 @@ pub fn aggregate_verify_multiple_public_keys(
 ///
 /// ## Why not aggregate public keys?
 ///
-/// We rely on the bilinearity property in this function to reduce pairing computations by summing
-/// the hashed messages against a single public key. If the public key were itself an aggregate of
-/// multiple public keys, an attacker could exploit this optimization in unintended ways (potentially forging
-/// signatures across different sets of participants). This would lead to this function incorrectly returning
-/// an aggregate signature is valid when it really isn't.
+/// We rely on bilinearity to reduce pairing operations in this function, like in `aggregate_verify_multiple_public_keys`,
+/// and sum hashed messages together before performing a single pairing operation (instead of summing `len(messages)` pairings of
+/// hashed message and public key). If the public key itself is an aggregate of multiple public keys, an attacker can exploit
+/// this optimization to cause this function to return that an aggregate signature is valid when it really isn't.
 pub fn aggregate_verify_multiple_messages(
     public: &group::Public,
     namespace: Option<&[u8]>,
@@ -268,11 +267,7 @@ pub fn aggregate_verify_multiple_messages(
         .build()
         .expect("Unable to build thread pool");
 
-    // Perform hashing and summation of messages in parallel
-    //
-    // Just like public key aggregation takes advantage of the bilinearity property of
-    // pairings, so too can we reduce the number of pairings required to verify multiple
-    // messages signed by a single public key (as long as all messages are unique).
+    // Perform hashing to curve and summation of messages in parallel
     let hm_sum = pool.install(|| {
         messages
             .par_iter()

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -69,7 +69,7 @@ impl Scheme for Bls12381 {
     }
 
     fn sign(&mut self, namespace: Option<&[u8]>, message: &[u8]) -> Signature {
-        let signature = ops::sign(&self.private, namespace, message);
+        let signature = ops::sign_message(&self.private, namespace, message);
         signature.serialize().into()
     }
 
@@ -91,7 +91,7 @@ impl Scheme for Bls12381 {
             Some(signature) => signature,
             None => return false,
         };
-        ops::verify(&public, namespace, message, &signature).is_ok()
+        ops::verify_message(&public, namespace, message, &signature).is_ok()
     }
 
     fn len() -> (usize, usize) {

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -66,7 +66,7 @@ impl<E: Clock> Vrf<E> {
     ) -> Option<group::Signature> {
         // Construct payload
         let payload = round.to_be_bytes();
-        let signature = ops::partial_sign(&output.share, Some(VRF_NAMESPACE), &payload);
+        let signature = ops::partial_sign_message(&output.share, Some(VRF_NAMESPACE), &payload);
 
         // Construct partial signature
         let mut partials = vec![signature.clone()];
@@ -131,7 +131,7 @@ impl<E: Clock> Vrf<E> {
                                     continue;
                                 }
                             };
-                            match ops::partial_verify(&output.public, Some(VRF_NAMESPACE), &payload, &signature) {
+                            match ops::partial_verify_message(&output.public, Some(VRF_NAMESPACE), &payload, &signature) {
                                 Ok(_) => {
                                     partials.push(signature);
                                     debug!(round, dealer, "received partial signature");
@@ -151,7 +151,7 @@ impl<E: Clock> Vrf<E> {
         }
 
         // Aggregate partial signatures
-        match ops::partial_aggregate(self.threshold, partials) {
+        match ops::threshold_signature_recover(self.threshold, partials) {
             Ok(signature) => Some(signature),
             Err(_) => {
                 warn!(round, "failed to aggregate partial signatures");


### PR DESCRIPTION
Resolves: #279
Replaces: #282 
Unblocks: #289 

Cleans up naming, adds more comments/tests, and introduces PoP functionality for `bls12381`.