### PR TITLE
[security] enable overflow checks in profile config (#291)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,20 @@ crossterm = "0.28.1"
 serde_json = "1.0.122"
 
 [profile.bench]
+# Because we enable overflow checks in "release," we should benchmark with them.
 overflow-checks = true
 
 [profile.dev]
+# Although overflow checks are enabled by default in "dev", we explicitly
+# enable them here for clarity.
 overflow-checks = true
 
 [profile.release]
+# To guard against unexpected behavior in production, we enable overflow checks in
+# "release" although they incur some performance penalty.
 overflow-checks = true
 
 [profile.test]
+# Although overflow checks are enabled by default in "test", we explicitly
+# enable them here for clarity.
 overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,15 @@ chrono = "0.4.39"
 ratatui = "0.27.0"
 crossterm = "0.28.1"
 serde_json = "1.0.122"
+
+[profile.bench]
+overflow-checks = true
+
+[profile.dev]
+overflow-checks = true
+
+[profile.release]
+overflow-checks = true
+
+[profile.test]
+overflow-checks = true


### PR DESCRIPTION
Use rust's overflow-check build profile configuration option for release builds, so we panic on attempted integer overflows/underflows instead of wrapping.