### PR TITLE
[cryptography/bls12381] Migrate to `blst_keygen`

### DIFF
--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -13,12 +13,13 @@
 use blst::{
     blst_bendian_from_scalar, blst_final_exp, blst_fp12, blst_fr, blst_fr_add, blst_fr_from_scalar,
     blst_fr_from_uint64, blst_fr_inverse, blst_fr_mul, blst_fr_sub, blst_hash_to_g1,
-    blst_hash_to_g2, blst_keygen_v3, blst_miller_loop, blst_p1, blst_p1_add_or_double,
-    blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_in_g1, blst_p1_is_inf,
-    blst_p1_mult, blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double,
-    blst_p2_affine, blst_p2_compress, blst_p2_from_affine, blst_p2_in_g2, blst_p2_is_inf,
-    blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_scalar, blst_scalar_from_bendian,
-    blst_scalar_from_fr, blst_sk_check, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
+    blst_hash_to_g2, blst_keygen, blst_keygen_v4_5, blst_miller_loop, blst_p1,
+    blst_p1_add_or_double, blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_in_g1,
+    blst_p1_is_inf, blst_p1_mult, blst_p1_to_affine, blst_p1_uncompress, blst_p2,
+    blst_p2_add_or_double, blst_p2_affine, blst_p2_compress, blst_p2_from_affine, blst_p2_in_g2,
+    blst_p2_is_inf, blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_scalar,
+    blst_scalar_from_bendian, blst_scalar_from_fr, blst_sk_check, BLS12_381_G1, BLS12_381_G2,
+    BLST_ERROR,
 };
 use rand::RngCore;
 use std::ptr;
@@ -218,11 +219,19 @@ impl Scalar {
         let mut ikm = [0u8; 64];
         rng.fill_bytes(&mut ikm);
 
-        // Generate a scalar from the randomly populated buffer
+        // Generate a scalar from the randomly populated buffer.
         let mut ret = blst_fr::default();
         unsafe {
             let mut sc = blst_scalar::default();
-            blst_keygen_v3(&mut sc, ikm.as_ptr(), ikm.len(), ptr::null(), 0);
+            blst_keygen_v4_5(
+                &mut sc,
+                ikm.as_ptr(),
+                ikm.len(),
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+            );
             blst_fr_from_scalar(&mut ret, &sc);
         }
 

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -13,13 +13,12 @@
 use blst::{
     blst_bendian_from_scalar, blst_final_exp, blst_fp12, blst_fr, blst_fr_add, blst_fr_from_scalar,
     blst_fr_from_uint64, blst_fr_inverse, blst_fr_mul, blst_fr_sub, blst_hash_to_g1,
-    blst_hash_to_g2, blst_keygen, blst_keygen_v4_5, blst_miller_loop, blst_p1,
-    blst_p1_add_or_double, blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_in_g1,
-    blst_p1_is_inf, blst_p1_mult, blst_p1_to_affine, blst_p1_uncompress, blst_p2,
-    blst_p2_add_or_double, blst_p2_affine, blst_p2_compress, blst_p2_from_affine, blst_p2_in_g2,
-    blst_p2_is_inf, blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_scalar,
-    blst_scalar_from_bendian, blst_scalar_from_fr, blst_sk_check, BLS12_381_G1, BLS12_381_G2,
-    BLST_ERROR,
+    blst_hash_to_g2, blst_keygen_v4_5, blst_miller_loop, blst_p1, blst_p1_add_or_double,
+    blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_in_g1, blst_p1_is_inf,
+    blst_p1_mult, blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double,
+    blst_p2_affine, blst_p2_compress, blst_p2_from_affine, blst_p2_in_g2, blst_p2_is_inf,
+    blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_scalar, blst_scalar_from_bendian,
+    blst_scalar_from_fr, blst_sk_check, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
 };
 use rand::RngCore;
 use std::ptr;
@@ -219,7 +218,7 @@ impl Scalar {
         let mut ikm = [0u8; 64];
         rng.fill_bytes(&mut ikm);
 
-        // Generate a scalar from the randomly populated buffer.
+        // Generate a scalar from the randomly populated buffer
         let mut ret = blst_fr::default();
         unsafe {
             let mut sc = blst_scalar::default();

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -13,11 +13,11 @@
 use blst::{
     blst_bendian_from_scalar, blst_final_exp, blst_fp12, blst_fr, blst_fr_add, blst_fr_from_scalar,
     blst_fr_from_uint64, blst_fr_inverse, blst_fr_mul, blst_fr_sub, blst_hash_to_g1,
-    blst_hash_to_g2, blst_keygen_v4_5, blst_miller_loop, blst_p1, blst_p1_add_or_double,
-    blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_in_g1, blst_p1_is_inf,
-    blst_p1_mult, blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double,
-    blst_p2_affine, blst_p2_compress, blst_p2_from_affine, blst_p2_in_g2, blst_p2_is_inf,
-    blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_scalar, blst_scalar_from_bendian,
+    blst_hash_to_g2, blst_keygen, blst_miller_loop, blst_p1, blst_p1_add_or_double, blst_p1_affine,
+    blst_p1_compress, blst_p1_from_affine, blst_p1_in_g1, blst_p1_is_inf, blst_p1_mult,
+    blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_add_or_double, blst_p2_affine,
+    blst_p2_compress, blst_p2_from_affine, blst_p2_in_g2, blst_p2_is_inf, blst_p2_mult,
+    blst_p2_to_affine, blst_p2_uncompress, blst_scalar, blst_scalar_from_bendian,
     blst_scalar_from_fr, blst_sk_check, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
 };
 use rand::RngCore;
@@ -222,15 +222,7 @@ impl Scalar {
         let mut ret = blst_fr::default();
         unsafe {
             let mut sc = blst_scalar::default();
-            blst_keygen_v4_5(
-                &mut sc,
-                ikm.as_ptr(),
-                ikm.len(),
-                ptr::null(),
-                0,
-                ptr::null(),
-                0,
-            );
+            blst_keygen(&mut sc, ikm.as_ptr(), ikm.len(), ptr::null(), 0);
             blst_fr_from_scalar(&mut ret, &sc);
         }
 


### PR DESCRIPTION
The [latest IETF draft](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#section-5.1) updated `keygen` to satisfy the HKDF security analysis assumptions:

> KeyGen uses HKDF to generate keys. The security analysis of HKDF assumes that the salt value is either empty (in which case it is replaced by the all-zeros string) or an unstructured string. Versions of this document prior to number 4 set the salt parameter to "BLS-SIG-KEYGEN-SALT-", which does not meet this requirement. If, as is common, the hash function H is modeled as a random oracle, this requirement is obviated.

This PR updates the code to use `blst_keygen` (which uses the `v4` keygen algorithm) from `blst_keygen_v3` (which does not satisfy the assumptions).

## Why not `blst_keygen_v4_5`?

While we could use `blst_keygen_v4_5` with a null `salt` argument (defaults to `salt` in `v4` of `H("BLS-SIG-KEYGEN-SALT-")`), IMO it is clearer to use the default keygen function (to indicate we aren't doing anything "custom").

## Why not `blst_keygen_v5` (latest)?

While we could use `blst_keygen_v5` (doesn't allow null `salt`) and require the user to provide a `salt`/manage a default `salt` on our side, it seemed both unlikely 99% of users would have a good reason for providing their own `salt` and error-prone for us to just populate an argument with the default (if it could be handled by another function).


For context, [using `v5` with the `salt` of `H("BLS-SIG-KEYGEN-SALT-")` is equivalent to using `v4`](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#section-2.3) (what we now do):

> For compatibility with prior versions of this document, implementations SHOULD allow applications to choose the salt value. Setting salt to the value `H("BLS-SIG-KEYGEN-SALT-")` (i.e., the hash of an ASCII string comprising 20 octets) results in a KeyGen algorithm that is compatible with version 4 of this document.