### PR TITLE
nit: use Option<i32> instead of Option<u8> for compression level

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -182,7 +182,7 @@ fn main() {
 
         // Initialize chat
         const MAX_MESSAGE_BACKLOG: usize = 128;
-        const COMPRESSION_LEVEL: Option<i8> = Some(3);
+        const COMPRESSION_LEVEL: Option<i32> = Some(3);
         let (chat_sender, chat_receiver) = network.register(
             handler::CHANNEL,
             Quota::per_second(NonZeroU32::new(128).unwrap()),

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -182,7 +182,7 @@ fn main() {
 
         // Initialize chat
         const MAX_MESSAGE_BACKLOG: usize = 128;
-        const COMPRESSION_LEVEL: Option<u8> = Some(3);
+        const COMPRESSION_LEVEL: Option<i8> = Some(3);
         let (chat_sender, chat_receiver) = network.register(
             handler::CHANNEL,
             Quota::per_second(NonZeroU32::new(128).unwrap()),

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -237,7 +237,7 @@ fn main() {
 
         // Check if I am the arbiter
         const DEFAULT_MESSAGE_BACKLOG: usize = 256;
-        const COMPRESSION_LEVEL: Option<u8> = Some(3);
+        const COMPRESSION_LEVEL: Option<i8> = Some(3);
         if let Some(arbiter) = matches.get_one::<u64>("arbiter") {
             // Create contributor
             let rogue = matches.get_flag("rogue");

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -237,7 +237,7 @@ fn main() {
 
         // Check if I am the arbiter
         const DEFAULT_MESSAGE_BACKLOG: usize = 256;
-        const COMPRESSION_LEVEL: Option<i8> = Some(3);
+        const COMPRESSION_LEVEL: Option<i32> = Some(3);
         if let Some(arbiter) = matches.get_one::<u64>("arbiter") {
             // Create contributor
             let rogue = matches.get_flag("rogue");

--- a/p2p/src/authenticated/channels.rs
+++ b/p2p/src/authenticated/channels.rs
@@ -63,8 +63,7 @@ impl crate::Sender for Sender {
     ) -> Result<Vec<PublicKey>, Error> {
         // If compression is enabled, compress the message before sending.
         if let Some(level) = self.compression {
-            let compressed =
-                compress(&message, level).map_err(|_| Error::CompressionFailed)?;
+            let compressed = compress(&message, level).map_err(|_| Error::CompressionFailed)?;
             message = compressed.into();
         }
 

--- a/p2p/src/authenticated/channels.rs
+++ b/p2p/src/authenticated/channels.rs
@@ -13,7 +13,7 @@ use zstd::bulk::{compress, decompress};
 pub struct Sender {
     channel: Channel,
     max_size: usize,
-    compression: Option<u8>,
+    compression: Option<i8>,
     messenger: Messenger,
 }
 
@@ -21,7 +21,7 @@ impl Sender {
     pub(super) fn new(
         channel: Channel,
         max_size: usize,
-        compression: Option<u8>,
+        compression: Option<i8>,
         messenger: Messenger,
     ) -> Self {
         Self {
@@ -148,7 +148,7 @@ impl Channels {
         channel: Channel,
         rate: governor::Quota,
         backlog: usize,
-        compression: Option<u8>,
+        compression: Option<i8>,
     ) -> (Sender, Receiver) {
         let (sender, receiver) = mpsc::channel(backlog);
         if self.receivers.insert(channel, (rate, sender)).is_some() {

--- a/p2p/src/authenticated/channels.rs
+++ b/p2p/src/authenticated/channels.rs
@@ -13,7 +13,7 @@ use zstd::bulk::{compress, decompress};
 pub struct Sender {
     channel: Channel,
     max_size: usize,
-    compression: Option<i8>,
+    compression: Option<i32>,
     messenger: Messenger,
 }
 
@@ -21,7 +21,7 @@ impl Sender {
     pub(super) fn new(
         channel: Channel,
         max_size: usize,
-        compression: Option<i8>,
+        compression: Option<i32>,
         messenger: Messenger,
     ) -> Self {
         Self {
@@ -64,7 +64,7 @@ impl crate::Sender for Sender {
         // If compression is enabled, compress the message before sending.
         if let Some(level) = self.compression {
             let compressed =
-                compress(&message, level as i32).map_err(|_| Error::CompressionFailed)?;
+                compress(&message, level).map_err(|_| Error::CompressionFailed)?;
             message = compressed.into();
         }
 
@@ -148,7 +148,7 @@ impl Channels {
         channel: Channel,
         rate: governor::Quota,
         backlog: usize,
-        compression: Option<i8>,
+        compression: Option<i32>,
     ) -> (Sender, Receiver) {
         let (sender, receiver) = mpsc::channel(backlog);
         if self.receivers.insert(channel, (rate, sender)).is_some() {

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -548,7 +548,7 @@ mod tests {
         });
     }
 
-    fn test_message_too_large(compression: Option<u8>) {
+    fn test_message_too_large(compression: Option<i8>) {
         // Configure test
         let base_port = 3000;
         let n: usize = 2;

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -149,7 +149,7 @@
 //!
 //!     // Register some channel
 //!     const MAX_MESSAGE_BACKLOG: usize = 128;
-//!     const COMPRESSION_LEVEL: Option<u8> = Some(3);
+//!     const COMPRESSION_LEVEL: Option<i32> = Some(3);
 //!     let (sender, receiver) = network.register(
 //!         0,
 //!         Quota::per_second(NonZeroU32::new(1).unwrap()),

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -548,7 +548,7 @@ mod tests {
         });
     }
 
-    fn test_message_too_large(compression: Option<i8>) {
+    fn test_message_too_large(compression: Option<i32>) {
         // Configure test
         let base_port = 3000;
         let n: usize = 2;

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -137,7 +137,7 @@ impl<
         channel: Channel,
         rate: Quota,
         backlog: usize,
-        compression: Option<i8>,
+        compression: Option<i32>,
     ) -> (channels::Sender, channels::Receiver) {
         self.channels.register(channel, rate, backlog, compression)
     }

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -137,7 +137,7 @@ impl<
         channel: Channel,
         rate: Quota,
         backlog: usize,
-        compression: Option<u8>,
+        compression: Option<i8>,
     ) -> (channels::Sender, channels::Receiver) {
         self.channels.register(channel, rate, backlog, compression)
     }


### PR DESCRIPTION
The zstd library recognizes compression level values < 0 and > 255. This PR allows those compression levels to be used. If we'll never use these, feel free to close this.