### PR TITLE
[cryptography/secp256r1] add test verifying signature with r=0 and s=0

### DIFF
--- a/cryptography/src/secp256r1.rs
+++ b/cryptography/src/secp256r1.rs
@@ -347,6 +347,51 @@ mod tests {
     }
 
     #[test]
+    fn test_scheme_verify_signature_r0() {
+        let private_key: PrivateKey = commonware_utils::from_hex_formatted(
+            "c9806898a0334916c860748880a541f093b579a9b1f32934d86c363c39800357",
+        )
+        .unwrap()
+        .into();
+        let message = b"sample";
+        let mut signer = <Secp256r1 as Scheme>::from(private_key).unwrap();
+        let signature = signer.sign(None, message);
+        let (_, s) = signature.split_at(32);
+        let mut signature: Vec<u8> = vec![0x00; 32];
+        signature.extend_from_slice(s);
+
+        assert!(!Secp256r1::verify(
+            None,
+            message,
+            &signer.public_key(),
+            &signature.into(),
+        ));
+    }
+
+    #[test]
+    fn test_scheme_verify_signature_s0() {
+        let private_key: PrivateKey = commonware_utils::from_hex_formatted(
+            "c9806898a0334916c860748880a541f093b579a9b1f32934d86c363c39800357",
+        )
+        .unwrap()
+        .into();
+        let message = b"sample";
+        let mut signer = <Secp256r1 as Scheme>::from(private_key).unwrap();
+        let signature = signer.sign(None, message);
+        let (r, _) = signature.split_at(32);
+        let s: Vec<u8> = vec![0x00; 32];
+        let mut signature = r.to_vec();
+        signature.extend(s);
+
+        assert!(!Secp256r1::verify(
+            None,
+            message,
+            &signer.public_key(),
+            &signature.into(),
+        ));
+    }
+
+    #[test]
     fn test_keypairs() {
         let cases = [
             vector_keypair_1(),


### PR DESCRIPTION
@patrick-ogrady I figured out I missed your comment https://github.com/commonwarexyz/monorepo/pull/314#discussion_r1907653295.
This adds test for Scheme::verify with a signature embedding `r=0` and `s=0`.
