### PR TITLE
docs: Cleaned up typos in comments

### DIFF
--- a/examples/chat/src/logger.rs
+++ b/examples/chat/src/logger.rs
@@ -50,7 +50,7 @@ impl std::io::Write for Writer {
             msg,
         );
 
-        // Add remaning fields
+        // Add remaining fields
         Self::add_to_log_message("", &json, &mut log_message);
         let log_message = format!("{})", log_message.trim_end());
 

--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -363,7 +363,7 @@ impl<E: Spawner + Rng + Clock + GClock, C: Scheme> Actor<E, C> {
         //
         // It is not safe to rate limit how many times this can happen
         // over some interval because a malicious peer may just replay
-        // old IPs to prevent us from propogating a new one.
+        // old IPs to prevent us from propagating a new one.
         let record = self.peers.get_mut(peer).unwrap();
         let wire_time = address.peer.timestamp;
         if !record.set_network(address) {
@@ -741,7 +741,7 @@ mod tests {
             let msg = peer_receiver.next().await.unwrap();
             assert!(matches!(msg, peer::Message::Kill));
 
-            // Find sorted indicies
+            // Find sorted indices
             let mut peers = vec![
                 peer0.public_key(),
                 peer1.clone(),

--- a/p2p/src/authenticated/config.rs
+++ b/p2p/src/authenticated/config.rs
@@ -96,7 +96,7 @@ pub struct Config<C: Scheme> {
     /// Quota for bit vector messages a peer can send us.
     pub allowed_bit_vec_rate: Quota,
 
-    /// Maximum number of peers we will send or consider valid when receiving in a single messsage.
+    /// Maximum number of peers we will send or consider valid when receiving in a single message.
     ///
     /// This is used to prevent malicious peers from sending us a large number of peers at one time (each
     /// of which requires a signature verification).

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -285,7 +285,7 @@ mod tests {
             // Wait to connect to all peers, and then send messages to everyone
             runtime.spawn("network", network.run());
 
-            // Send/Recieve messages
+            // Send/Receive messages
             let handler = runtime.spawn("agent", {
                 let addresses = addresses.clone();
                 let runtime = runtime.clone();
@@ -508,7 +508,7 @@ mod tests {
                 // Wait to connect to all peers, and then send messages to everyone
                 runtime.spawn("network", network.run());
 
-                // Send/Recieve messages
+                // Send/Receive messages
                 let handler = runtime.spawn("agent", {
                     let runtime = runtime.clone();
                     async move {

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -17,7 +17,7 @@ pub mod utils;
 
 /// Tuple representing a message received from a given public key.
 ///
-/// This message is guranteed to adhere to the configuration of the channel and
+/// This message is guaranteed to adhere to the configuration of the channel and
 /// will already be decrypted and authenticated.
 pub type Message = (PublicKey, Bytes);
 


### PR DESCRIPTION
Hello! I went through the code and fixed a few typos in the comments. Nothing major, but it should make things a bit easier to read and less distracting.

### What’s fixed:
- **logger.rs**: "remaning" → "remaining".
- **actor.rs**: "propogating" → "propagating", "indicies" → "indices".
- **config.rs**: "messsage" → "message".
- **mod.rs**: "Recieve" → "Receive".
- **lib.rs**: "guranteed" → "guaranteed".