### PR TITLE
documentation parameter name in read_prefix method

### DIFF
--- a/storage/src/journal/storage.rs
+++ b/storage/src/journal/storage.rs
@@ -143,7 +143,7 @@ impl<B: Blob, E: Storage<B>> Journal<B, E> {
     /// # Warning
     ///
     /// This method bypasses the checksum verification and the caller is responsible for ensuring
-    /// the integrity of any data read. If `exact` exceeds the size of an item (and runs over the blob
+    /// the integrity of any data read. If `prefix` exceeds the size of an item (and runs over the blob
     /// length), it will lead to unintentional truncation of data.
     async fn read_prefix(blob: &B, offset: u32, prefix: u32) -> Result<(u32, u32, Bytes), Error> {
         // Read item size and first `prefix` bytes


### PR DESCRIPTION


File: storage/src/journal/storage.rs
Change:
- Old: If exact exceeds the size of an item
- New: If prefix exceeds the size of an item

The current documentation incorrectly references an 'exact' parameter in the warning comment of read_prefix method, while the method actually uses a 'prefix' parameter. This change aligns the documentation with the actual implementation to improve clarity and prevent confusion.

