### PR TITLE
docs: improve DuplicateEval error message clarity

### DIFF
--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -59,6 +59,6 @@ pub enum Error {
     InvalidRecovery,
     #[error("no inverse")]
     NoInverse,
-    #[error("duplicate eval")]
+    #[error("duplicate polynomial evaluation point")]
     DuplicateEval,
 }


### PR DESCRIPTION
Changed "duplicate eval" to "duplicate polynomial evaluation point"  to better explain what actually went wrong.