### PR TITLE
fix: Remove redundant Digest import in SHA-256 implementation

### DIFF
--- a/cryptography/src/sha256.rs
+++ b/cryptography/src/sha256.rs
@@ -1,7 +1,7 @@
 //! SHA-256 implementation of the `Hasher` trait.
 
 use crate::{Digest, Hasher};
-use sha2::{Digest as _, Sha256 as ISha256};
+use sha2::Sha256 as ISha256;
 
 const DIGEST_LENGTH: usize = 32;
 


### PR DESCRIPTION
### Description 
Import `Digest as _` in the line `use sha2::{Digest as _, Sha256 as ISha256};` is unnecessary since the `Digest` trait from `sha2` isn't directly used in the code. I removed it to clean up the imports and improve code readability.