### PR TITLE
chore: fix argument type in bytes method call in build.rs

### DIFF
--- a/consensus/build.rs
+++ b/consensus/build.rs
@@ -6,7 +6,6 @@ fn main() -> Result<()> {
     config.bytes(&[
         "Signature.public_key",
         "Signature.signature",
-        "Parent.digest",
         "Proposal.payload",
     ]);
     config.compile_protos(&["src/simplex/wire.proto"], &["src/simplex/"])?;

--- a/consensus/build.rs
+++ b/consensus/build.rs
@@ -1,8 +1,9 @@
 use std::io::Result;
+
 fn main() -> Result<()> {
     // Proto compilation rules for `simplex` dialect
     let mut config = prost_build::Config::new();
-    config.bytes([
+    config.bytes(&[
         "Signature.public_key",
         "Signature.signature",
         "Parent.digest",
@@ -12,7 +13,7 @@ fn main() -> Result<()> {
 
     // Proto compilation rules for `threshold_simplex` dialect
     let mut config = prost_build::Config::new();
-    config.bytes([
+    config.bytes(&[
         "Parent.digest",
         "Proposal.payload",
         "Notarize.proposal_signature",
@@ -31,5 +32,6 @@ fn main() -> Result<()> {
         &["src/threshold_simplex/wire.proto"],
         &["src/threshold_simplex/"],
     )?;
+
     Ok(())
 }


### PR DESCRIPTION
The `bytes` method was being called with an array of strings `[&str; N]`, but it actually expects a slice of strings `&[&str]`. I've fixed this by adding a `&` before the array.
This ensures the correct type is passed and avoids any potential issues.  
