### PR TITLE
fix: Replace len() == 0 with is_empty() for better efficiency

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -132,7 +132,7 @@ fn main() {
         .get_many::<u64>("friends")
         .expect("Please provide friends to chat with")
         .copied();
-    if allowed_keys.len() == 0 {
+    if allowed_keys.is_empty() {
         panic!("Please provide at least one friend");
     }
     for peer in allowed_keys {


### PR DESCRIPTION
using `len() == 0` to check for emptiness can be less efficient compared to the `is_empty()` method.
i’ve updated the code to use `is_empty()` where applicable.
this should improve performance and align with best practices.