### PR TITLE
Remove `Parent.digest` Lines

### DIFF
--- a/consensus/build.rs
+++ b/consensus/build.rs
@@ -5,7 +5,6 @@ fn main() -> Result<()> {
     config.bytes([
         "Signature.public_key",
         "Signature.signature",
-        "Parent.digest",
         "Proposal.payload",
     ]);
     config.compile_protos(&["src/simplex/wire.proto"], &["src/simplex/"])?;
@@ -13,7 +12,6 @@ fn main() -> Result<()> {
     // Proto compilation rules for `threshold_simplex` dialect
     let mut config = prost_build::Config::new();
     config.bytes([
-        "Parent.digest",
         "Proposal.payload",
         "Notarize.proposal_signature",
         "Notarize.seed_signature",


### PR DESCRIPTION
there’s no `Parent.digest` field defined in the corresponding `.proto` files, there’s nothing for the compiler to generate. As a result, both `"Parent.digest"` lines should be removed from the configuration.