### PR TITLE
Fix spelling errors in tokio.rs, ops.rs

### DIFF
--- a/cryptography/src/bls12381/dkg/ops.rs
+++ b/cryptography/src/bls12381/dkg/ops.rs
@@ -96,7 +96,7 @@ pub fn construct_public(
     Ok(public)
 }
 
-/// Recover public polynomial by interpolating coeffcient-wise all
+/// Recover public polynomial by interpolating coefficient-wise all
 /// polynomials.
 ///
 /// It is assumed that the required number of commitments are provided.

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -3,7 +3,7 @@
 //!
 //! # Domain Separation Tag (DST)
 //!
-//! All signatures use the `POP` (Proof of Possession) scheme during signing. For Proof-of-Posession (POP) signatures,
+//! All signatures use the `POP` (Proof of Possession) scheme during signing. For Proof-of-Possession (POP) signatures,
 //! the domain separation tag is `BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_`. For signatures over other messages, the
 //! domain separation tag is `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_`. You can read more about DSTs [here](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#section-4.2).
 

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -501,7 +501,7 @@ pub struct Blob {
     name: Vec<u8>,
 
     // Files must be seeked prior to any read or write operation and are thus
-    // not safe to concurrently interact with. If we switched to mmaping files
+    // not safe to concurrently interact with. If we switched to mapping files
     // we could remove this lock.
     //
     // We also track the virtual file size because metadata isn't updated until


### PR DESCRIPTION
- Corrected "coeffcient-wise" to "coefficient-wise" in `ops.rs`.
- Corrected "Proof-of-Posession" to "Proof-of-Possession" in `ops.rs` for clarity.
- Fixed "mmaping" to "mapping" in `tokio.rs`.