### PR TITLE
[CI] Add WASM Support for `consensus` and `storage`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,10 @@ jobs:
       run: cargo build --target wasm32-unknown-unknown --release --manifest-path macros/Cargo.toml # can't check size because it is a proc-macro
     - name: Build utils
       run: cargo build --target wasm32-unknown-unknown --release --manifest-path utils/Cargo.toml && du -h target/wasm32-unknown-unknown/release/commonware_utils.wasm
+    - name: Build consensus
+      run: cargo build --target wasm32-unknown-unknown --release --manifest-path consensus/Cargo.toml && du -h target/wasm32-unknown-unknown/release/commonware_consensus.wasm
+    - name: Build storage
+      run: cargo build --target wasm32-unknown-unknown --release --manifest-path storage/Cargo.toml && du -h target/wasm32-unknown-unknown/release/commonware_storage.wasm
 
   Scripts:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ name = "commonware-consensus"
 version = "0.0.6"
 dependencies = [
  "bytes",
+ "cfg-if",
  "commonware-cryptography",
  "commonware-macros",
  "commonware-p2p",
@@ -549,6 +550,7 @@ name = "commonware-storage"
 version = "0.0.9"
 dependencies = [
  "bytes",
+ "cfg-if",
  "commonware-cryptography",
  "commonware-macros",
  "commonware-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,6 @@ dependencies = [
  "prost-build",
  "rand",
  "rand_distr",
- "sha2 0.10.8",
  "thiserror",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ chrono = "0.4.39"
 ratatui = "0.27.0"
 crossterm = "0.28.1"
 serde_json = "1.0.122"
+cfg-if = "1.0.0"
 
 [profile.bench]
 # Because we enable overflow checks in "release," we should benchmark with them.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -12,24 +12,23 @@ documentation = "https://docs.rs/commonware-consensus"
 
 [dependencies]
 commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
 commonware-utils = { workspace = true }
 bytes = { workspace = true }
-rand = { workspace = true }
-rand_distr = { workspace = true }
-thiserror = { workspace = true }
 futures = { workspace = true }
-sha2 = { workspace = true }
 tracing = { workspace = true }
 prost = { workspace = true }
 cfg-if = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+commonware-macros = { workspace = true }
 commonware-p2p = { workspace = true }
 commonware-runtime = { workspace = true }
 commonware-storage = { workspace = true }
 prometheus-client = { workspace = true }
 governor = { workspace = true }
+thiserror = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -22,6 +22,7 @@ futures = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
 prost = { workspace = true }
+cfg-if = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 commonware-p2p = { workspace = true }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -13,19 +13,21 @@ documentation = "https://docs.rs/commonware-consensus"
 [dependencies]
 commonware-cryptography = { workspace = true }
 commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-storage = { workspace = true }
 commonware-utils = { workspace = true }
 bytes = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 thiserror = { workspace = true }
 futures = { workspace = true }
+sha2 = { workspace = true }
 tracing = { workspace = true }
 prost = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+commonware-p2p = { workspace = true }
+commonware-runtime = { workspace = true }
+commonware-storage = { workspace = true }
 prometheus-client = { workspace = true }
-sha2 = { workspace = true }
 governor = { workspace = true }
 
 [build-dependencies]
@@ -36,3 +38,5 @@ tracing-subscriber = { workspace = true }
 
 [lib]
 bench = false
+crate-type = ["rlib", "cdylib"]
+

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -39,4 +39,3 @@ tracing-subscriber = { workspace = true }
 [lib]
 bench = false
 crate-type = ["rlib", "cdylib"]
-

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -14,8 +14,6 @@ documentation = "https://docs.rs/commonware-consensus"
 commonware-cryptography = { workspace = true }
 commonware-utils = { workspace = true }
 bytes = { workspace = true }
-futures = { workspace = true }
-tracing = { workspace = true }
 prost = { workspace = true }
 cfg-if = { workspace = true }
 
@@ -27,8 +25,10 @@ commonware-storage = { workspace = true }
 prometheus-client = { workspace = true }
 governor = { workspace = true }
 thiserror = { workspace = true }
+futures = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -6,71 +6,9 @@
 //! expect breaking changes and occasional instability.
 
 use bytes::Bytes;
-use commonware_cryptography::{Digest, PublicKey};
-use futures::channel::oneshot;
-use std::future::Future;
 
 pub mod simplex;
 pub mod threshold_simplex;
-
-/// Automaton is the interface responsible for driving the consensus forward by proposing new payloads
-/// and verifying payloads proposed by other participants.
-pub trait Automaton: Clone + Send + 'static {
-    /// Context is metadata provided by the consensus engine to associated with a given payload.
-    ///
-    /// This often includes things like the proposer, view number, the height, or the epoch.
-    type Context;
-
-    /// Payload used to initialize the consensus engine.
-    fn genesis(&mut self) -> impl Future<Output = Digest> + Send;
-
-    /// Generate a new payload for the given context.
-    ///
-    /// If it is possible to generate a payload, the Digest should be returned over the provided
-    /// channel. If it is not possible to generate a payload, the channel can be dropped. If construction
-    /// takes too long, the consensus engine may drop the provided proposal.
-    fn propose(
-        &mut self,
-        context: Self::Context,
-    ) -> impl Future<Output = oneshot::Receiver<Digest>> + Send;
-
-    /// Verify the payload is valid.
-    ///
-    /// If it is possible to verify the payload, a boolean should be returned indicating whether
-    /// the payload is valid. If it is not possible to verify the payload, the channel can be dropped.
-    fn verify(
-        &mut self,
-        context: Self::Context,
-        payload: Digest,
-    ) -> impl Future<Output = oneshot::Receiver<bool>> + Send;
-}
-
-/// Relay is the interface responsible for broadcasting payloads to the network.
-///
-/// The consensus engine is only aware of a payload's digest, not its contents. It is up
-/// to the relay to efficiently broadcast the full payload to other participants.
-pub trait Relay: Clone + Send + 'static {
-    /// Called once consensus begins working towards a proposal provided by `Automaton` (i.e.
-    /// it isn't dropped).
-    ///
-    /// Other participants may not begin voting on a proposal until they have the full contents,
-    /// so timely delivery often yields better performance.
-    fn broadcast(&mut self, payload: Digest) -> impl Future<Output = ()> + Send;
-}
-
-/// Proof is a blob that attests to some data.
-pub type Proof = Bytes;
-
-/// Committer is the interface responsible for handling notifications of payload status.
-pub trait Committer: Clone + Send + 'static {
-    /// Event that a payload has made some progress towards finalization but is not yet finalized.
-    ///
-    /// This is often used to provide an early ("best guess") confirmation to users.
-    fn prepared(&mut self, proof: Proof, payload: Digest) -> impl Future<Output = ()> + Send;
-
-    /// Event indicating the container has been finalized.
-    fn finalized(&mut self, proof: Proof, payload: Digest) -> impl Future<Output = ()> + Send;
-}
 
 /// Activity is specified by the underlying consensus implementation and can be interpreted if desired.
 ///
@@ -80,64 +18,131 @@ pub trait Committer: Clone + Send + 'static {
 /// both equally may better align incentives with desired behavior.
 pub type Activity = u8;
 
-/// Supervisor is the interface responsible for managing which participants are active at a given time.
-///
-/// ## Synchronization
-///
-/// It is up to the user to ensure changes in this list are synchronized across nodes in the network
-/// at a given `Index`. If care is not taken to do this, consensus could halt (as different participants
-/// may have a different view of who is active at a given time).
-///
-/// The simplest way to avoid this complexity is to use a consensus implementation that reaches finalization
-/// on application data before transitioning to a new `Index` (i.e. [Tendermint](https://arxiv.org/abs/1807.04938)).
-///
-/// Implementations that do not work this way (like `simplex`) must introduce some synchrony bound for changes
-/// (where it is assumed all participants have finalized some previous set change by some point) or "sync points"
-/// (i.e. epochs) where participants agree that some finalization occurred at some point in the past.
-pub trait Supervisor: Clone + Send + 'static {
-    /// Index is the type used to indicate the in-progress consensus decision.
-    type Index;
+/// Proof is a blob that attests to some data.
+pub type Proof = Bytes;
 
-    /// Return the leader at a given index for the provided seed.
-    fn leader(&self, index: Self::Index) -> Option<PublicKey>;
+cfg_if::cfg_if! {
+    if #[cfg(not(target_arch = "wasm32"))] {
+        use commonware_cryptography::{Digest, PublicKey};
+        use futures::channel::oneshot;
+        use std::future::Future;
 
-    /// Get the **sorted** participants for the given view. This is called when entering a new view before
-    /// listening for proposals or votes. If nothing is returned, the view will not be entered.
-    fn participants(&self, index: Self::Index) -> Option<&Vec<PublicKey>>;
+        /// Automaton is the interface responsible for driving the consensus forward by proposing new payloads
+        /// and verifying payloads proposed by other participants.
+        pub trait Automaton: Clone + Send + 'static {
+            /// Context is metadata provided by the consensus engine to associated with a given payload.
+            ///
+            /// This often includes things like the proposer, view number, the height, or the epoch.
+            type Context;
 
-    // Indicate whether some candidate is a participant at the given view.
-    fn is_participant(&self, index: Self::Index, candidate: &PublicKey) -> Option<u32>;
+            /// Payload used to initialize the consensus engine.
+            fn genesis(&mut self) -> impl Future<Output = Digest> + Send;
 
-    /// Report some activity observed by the consensus implementation.
-    fn report(&self, activity: Activity, proof: Proof) -> impl Future<Output = ()> + Send;
-}
+            /// Generate a new payload for the given context.
+            ///
+            /// If it is possible to generate a payload, the Digest should be returned over the provided
+            /// channel. If it is not possible to generate a payload, the channel can be dropped. If construction
+            /// takes too long, the consensus engine may drop the provided proposal.
+            fn propose(
+                &mut self,
+                context: Self::Context,
+            ) -> impl Future<Output = oneshot::Receiver<Digest>> + Send;
 
-/// ThresholdSupervisor is the interface responsible for managing which `identity` (typically a group polynomial with
-/// a fixed constant factor) and `share` for a participant is active at a given time.
-///
-/// ## Synchronization
-///
-/// The same considerations for `Supervisor` apply here.
-pub trait ThresholdSupervisor: Supervisor {
-    /// Seed is some random value used to bias the leader selection process.
-    type Seed;
+            /// Verify the payload is valid.
+            ///
+            /// If it is possible to verify the payload, a boolean should be returned indicating whether
+            /// the payload is valid. If it is not possible to verify the payload, the channel can be dropped.
+            fn verify(
+                &mut self,
+                context: Self::Context,
+                payload: Digest,
+            ) -> impl Future<Output = oneshot::Receiver<bool>> + Send;
+        }
 
-    /// Identity is the type against which partial signatures are verified.
-    type Identity;
+        /// Relay is the interface responsible for broadcasting payloads to the network.
+        ///
+        /// The consensus engine is only aware of a payload's digest, not its contents. It is up
+        /// to the relay to efficiently broadcast the full payload to other participants.
+        pub trait Relay: Clone + Send + 'static {
+            /// Called once consensus begins working towards a proposal provided by `Automaton` (i.e.
+            /// it isn't dropped).
+            ///
+            /// Other participants may not begin voting on a proposal until they have the full contents,
+            /// so timely delivery often yields better performance.
+            fn broadcast(&mut self, payload: Digest) -> impl Future<Output = ()> + Send;
+        }
 
-    /// Share is the type used to generate a partial signature that can be verified
-    /// against `Identity`.
-    type Share;
+        /// Committer is the interface responsible for handling notifications of payload status.
+        pub trait Committer: Clone + Send + 'static {
+            /// Event that a payload has made some progress towards finalization but is not yet finalized.
+            ///
+            /// This is often used to provide an early ("best guess") confirmation to users.
+            fn prepared(&mut self, proof: Proof, payload: Digest) -> impl Future<Output = ()> + Send;
 
-    /// Return the leader at a given index over the provided seed.
-    fn leader(&self, index: Self::Index, seed: Self::Seed) -> Option<PublicKey>;
+            /// Event indicating the container has been finalized.
+            fn finalized(&mut self, proof: Proof, payload: Digest) -> impl Future<Output = ()> + Send;
+        }
 
-    /// Returns the identity (typically a group polynomial with a fixed constant factor)
-    /// at the given index. This is used to verify partial signatures from participants
-    /// enumerated in `Supervisor::participants`.
-    fn identity(&self, index: Self::Index) -> Option<&Self::Identity>;
+        /// Supervisor is the interface responsible for managing which participants are active at a given time.
+        ///
+        /// ## Synchronization
+        ///
+        /// It is up to the user to ensure changes in this list are synchronized across nodes in the network
+        /// at a given `Index`. If care is not taken to do this, consensus could halt (as different participants
+        /// may have a different view of who is active at a given time).
+        ///
+        /// The simplest way to avoid this complexity is to use a consensus implementation that reaches finalization
+        /// on application data before transitioning to a new `Index` (i.e. [Tendermint](https://arxiv.org/abs/1807.04938)).
+        ///
+        /// Implementations that do not work this way (like `simplex`) must introduce some synchrony bound for changes
+        /// (where it is assumed all participants have finalized some previous set change by some point) or "sync points"
+        /// (i.e. epochs) where participants agree that some finalization occurred at some point in the past.
+        pub trait Supervisor: Clone + Send + 'static {
+            /// Index is the type used to indicate the in-progress consensus decision.
+            type Index;
 
-    /// Returns share to sign with at a given index. After resharing, the share
-    /// may change (and old shares may be deleted).
-    fn share(&self, index: Self::Index) -> Option<&Self::Share>;
+            /// Return the leader at a given index for the provided seed.
+            fn leader(&self, index: Self::Index) -> Option<PublicKey>;
+
+            /// Get the **sorted** participants for the given view. This is called when entering a new view before
+            /// listening for proposals or votes. If nothing is returned, the view will not be entered.
+            fn participants(&self, index: Self::Index) -> Option<&Vec<PublicKey>>;
+
+            // Indicate whether some candidate is a participant at the given view.
+            fn is_participant(&self, index: Self::Index, candidate: &PublicKey) -> Option<u32>;
+
+            /// Report some activity observed by the consensus implementation.
+            fn report(&self, activity: Activity, proof: Proof) -> impl Future<Output = ()> + Send;
+        }
+
+        /// ThresholdSupervisor is the interface responsible for managing which `identity` (typically a group polynomial with
+        /// a fixed constant factor) and `share` for a participant is active at a given time.
+        ///
+        /// ## Synchronization
+        ///
+        /// The same considerations for `Supervisor` apply here.
+        pub trait ThresholdSupervisor: Supervisor {
+            /// Seed is some random value used to bias the leader selection process.
+            type Seed;
+
+            /// Identity is the type against which partial signatures are verified.
+            type Identity;
+
+            /// Share is the type used to generate a partial signature that can be verified
+            /// against `Identity`.
+            type Share;
+
+            /// Return the leader at a given index over the provided seed.
+            fn leader(&self, index: Self::Index, seed: Self::Seed) -> Option<PublicKey>;
+
+            /// Returns the identity (typically a group polynomial with a fixed constant factor)
+            /// at the given index. This is used to verify partial signatures from participants
+            /// enumerated in `Supervisor::participants`.
+            fn identity(&self, index: Self::Index) -> Option<&Self::Identity>;
+
+            /// Returns share to sign with at a given index. After resharing, the share
+            /// may change (and old shares may be deleted).
+            fn share(&self, index: Self::Index) -> Option<&Self::Share>;
+        }
+    }
 }

--- a/consensus/src/simplex/mocks/relay.rs
+++ b/consensus/src/simplex/mocks/relay.rs
@@ -49,3 +49,9 @@ impl Relay {
         }
     }
 }
+
+impl Default for Relay {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -115,30 +115,30 @@
 //! * Introduce message rebroadcast to continue making progress if messages from a given view are dropped (only way
 //!   to ensure messages are reliably delivered is with a heavyweight reliable broadcast protocol).
 
+use cfg_if::cfg_if;
 use commonware_cryptography::Digest;
 
-#[cfg(not(target_arch = "wasm32"))]
-mod actors;
-#[cfg(not(target_arch = "wasm32"))]
-mod config;
-#[cfg(not(target_arch = "wasm32"))]
-pub use config::Config;
 mod encoder;
-#[cfg(not(target_arch = "wasm32"))]
-mod engine;
-#[cfg(not(target_arch = "wasm32"))]
-pub use engine::Engine;
-#[cfg(not(target_arch = "wasm32"))]
-mod metrics;
-#[cfg(test)]
-mod mocks;
 mod prover;
 pub use prover::Prover;
-#[cfg(not(target_arch = "wasm32"))]
-mod verifier;
 mod wire {
     include!(concat!(env!("OUT_DIR"), "/simplex.wire.rs"));
 }
+
+cfg_if! {
+    if #[cfg(not(target_arch = "wasm32"))] {
+        mod actors;
+        mod config;
+        pub use config::Config;
+        mod engine;
+        pub use engine::Engine;
+        mod metrics;
+        mod verifier;
+    }
+}
+
+#[cfg(test)]
+pub mod mocks;
 
 /// View is a monotonically increasing counter that represents the current focus of consensus.
 pub type View = u64;

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -117,17 +117,24 @@
 
 use commonware_cryptography::Digest;
 
+#[cfg(not(target_arch = "wasm32"))]
 mod actors;
+#[cfg(not(target_arch = "wasm32"))]
 mod config;
+#[cfg(not(target_arch = "wasm32"))]
 pub use config::Config;
 mod encoder;
+#[cfg(not(target_arch = "wasm32"))]
 mod engine;
+#[cfg(not(target_arch = "wasm32"))]
 pub use engine::Engine;
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics;
 #[cfg(test)]
 mod mocks;
 mod prover;
 pub use prover::Prover;
+#[cfg(not(target_arch = "wasm32"))]
 mod verifier;
 mod wire {
     include!(concat!(env!("OUT_DIR"), "/simplex.wire.rs"));

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -115,7 +115,6 @@
 //! * Introduce message rebroadcast to continue making progress if messages from a given view are dropped (only way
 //!   to ensure messages are reliably delivered is with a heavyweight reliable broadcast protocol).
 
-use cfg_if::cfg_if;
 use commonware_cryptography::Digest;
 
 mod encoder;
@@ -125,7 +124,7 @@ mod wire {
     include!(concat!(env!("OUT_DIR"), "/simplex.wire.rs"));
 }
 
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(not(target_arch = "wasm32"))] {
         mod actors;
         mod config;

--- a/consensus/src/simplex/prover.rs
+++ b/consensus/src/simplex/prover.rs
@@ -8,9 +8,7 @@ use super::{
 use crate::Proof;
 use bytes::{Buf, BufMut};
 use commonware_cryptography::{Digest, Hasher, PublicKey, Scheme, Signature};
-use commonware_utils::hex;
 use std::{collections::HashSet, marker::PhantomData};
-use tracing::debug;
 
 /// Encode and decode proofs of activity.
 ///
@@ -82,16 +80,9 @@ impl<C: Scheme, H: Hasher> Prover<C, H> {
         let proposal_message = proposal_message(view, parent, &payload);
         if check_sig {
             if !C::validate(&public_key) {
-                debug!(public_key = hex(&public_key), "invalid public key");
                 return None;
             }
             if !C::verify(Some(namespace), &proposal_message, &public_key, &signature) {
-                debug!(
-                    namespace = hex(namespace),
-                    public_key = hex(&public_key),
-                    signature = hex(&signature),
-                    "signature verification failed"
-                );
                 return None;
             }
         }

--- a/consensus/src/simplex/prover.rs
+++ b/consensus/src/simplex/prover.rs
@@ -40,7 +40,7 @@ impl<C: Scheme, H: Hasher> Prover<C, H> {
     }
 
     /// Serialize a proposal proof.
-    pub(crate) fn serialize_proposal(
+    pub fn serialize_proposal(
         proposal: &wire::Proposal,
         public_key: &PublicKey,
         signature: &Signature,
@@ -100,7 +100,7 @@ impl<C: Scheme, H: Hasher> Prover<C, H> {
     }
 
     /// Serialize an aggregation proof.
-    pub(crate) fn serialize_aggregation(
+    pub fn serialize_aggregation(
         proposal: &wire::Proposal,
         signatures: Vec<(&PublicKey, &Signature)>,
     ) -> Proof {
@@ -217,7 +217,7 @@ impl<C: Scheme, H: Hasher> Prover<C, H> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn serialize_conflicting_proposal(
+    pub fn serialize_conflicting_proposal(
         view: View,
         public_key: &PublicKey,
         parent_1: View,
@@ -296,7 +296,7 @@ impl<C: Scheme, H: Hasher> Prover<C, H> {
 
     /// Serialize a conflicting notarize proof.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn serialize_conflicting_notarize(
+    pub fn serialize_conflicting_notarize(
         view: View,
         public_key: &PublicKey,
         parent_1: View,
@@ -329,7 +329,7 @@ impl<C: Scheme, H: Hasher> Prover<C, H> {
 
     /// Serialize a conflicting finalize proof.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn serialize_conflicting_finalize(
+    pub fn serialize_conflicting_finalize(
         view: View,
         public_key: &PublicKey,
         parent_1: View,
@@ -361,7 +361,7 @@ impl<C: Scheme, H: Hasher> Prover<C, H> {
     }
 
     /// Serialize a conflicting nullify and finalize proof.
-    pub(crate) fn serialize_nullify_finalize(
+    pub fn serialize_nullify_finalize(
         view: View,
         public_key: &PublicKey,
         parent: View,

--- a/consensus/src/threshold_simplex/mocks/relay.rs
+++ b/consensus/src/threshold_simplex/mocks/relay.rs
@@ -50,3 +50,9 @@ impl Relay {
         }
     }
 }
+
+impl Default for Relay {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -146,30 +146,30 @@
 //! * Introduce message rebroadcast to continue making progress if messages from a given view are dropped (only way
 //!   to ensure messages are reliably delivered is with a heavyweight reliable broadcast protocol).
 
+use cfg_if::cfg_if;
 use commonware_cryptography::Digest;
 
-#[cfg(not(target_arch = "wasm32"))]
-mod actors;
-#[cfg(not(target_arch = "wasm32"))]
-mod config;
-#[cfg(not(target_arch = "wasm32"))]
-pub use config::Config;
 mod encoder;
-#[cfg(not(target_arch = "wasm32"))]
-mod engine;
-#[cfg(not(target_arch = "wasm32"))]
-pub use engine::Engine;
-#[cfg(not(target_arch = "wasm32"))]
-mod metrics;
 mod prover;
 pub use prover::Prover;
-#[cfg(test)]
-pub mod mocks;
-#[cfg(not(target_arch = "wasm32"))]
-mod verifier;
 mod wire {
     include!(concat!(env!("OUT_DIR"), "/threshold_simplex.wire.rs"));
 }
+
+cfg_if! {
+    if #[cfg(not(target_arch = "wasm32"))] {
+        mod actors;
+        mod config;
+        pub use config::Config;
+        mod engine;
+        pub use engine::Engine;
+        mod metrics;
+        mod verifier;
+    }
+}
+
+#[cfg(test)]
+pub mod mocks;
 
 /// View is a monotonically increasing counter that represents the current focus of consensus.
 pub type View = u64;

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -148,17 +148,24 @@
 
 use commonware_cryptography::Digest;
 
+#[cfg(not(target_arch = "wasm32"))]
 mod actors;
+#[cfg(not(target_arch = "wasm32"))]
 mod config;
+#[cfg(not(target_arch = "wasm32"))]
 pub use config::Config;
 mod encoder;
+#[cfg(not(target_arch = "wasm32"))]
 mod engine;
+#[cfg(not(target_arch = "wasm32"))]
 pub use engine::Engine;
+#[cfg(not(target_arch = "wasm32"))]
 mod metrics;
 mod prover;
 pub use prover::Prover;
 #[cfg(test)]
 pub mod mocks;
+#[cfg(not(target_arch = "wasm32"))]
 mod verifier;
 mod wire {
     include!(concat!(env!("OUT_DIR"), "/threshold_simplex.wire.rs"));

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -146,7 +146,6 @@
 //! * Introduce message rebroadcast to continue making progress if messages from a given view are dropped (only way
 //!   to ensure messages are reliably delivered is with a heavyweight reliable broadcast protocol).
 
-use cfg_if::cfg_if;
 use commonware_cryptography::Digest;
 
 mod encoder;
@@ -156,7 +155,7 @@ mod wire {
     include!(concat!(env!("OUT_DIR"), "/threshold_simplex.wire.rs"));
 }
 
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(not(target_arch = "wasm32"))] {
         mod actors;
         mod config;

--- a/consensus/src/threshold_simplex/prover.rs
+++ b/consensus/src/threshold_simplex/prover.rs
@@ -74,10 +74,7 @@ impl<H: Hasher> Prover<H> {
     }
 
     /// Serialize a proposal proof.
-    pub(crate) fn serialize_proposal(
-        proposal: &wire::Proposal,
-        partial_signature: &Signature,
-    ) -> Proof {
+    pub fn serialize_proposal(proposal: &wire::Proposal, partial_signature: &Signature) -> Proof {
         // Setup proof
         let len = 8 + 8 + proposal.payload.len() + partial_signature.len();
 
@@ -128,7 +125,7 @@ impl<H: Hasher> Prover<H> {
     }
 
     /// Serialize an aggregation proof.
-    pub(crate) fn serialize_threshold(
+    pub fn serialize_threshold(
         proposal: &wire::Proposal,
         signature: &Signature,
         seed: &Signature,
@@ -208,7 +205,7 @@ impl<H: Hasher> Prover<H> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn serialize_conflicting_proposal(
+    pub fn serialize_conflicting_proposal(
         view: View,
         parent_1: View,
         payload_1: &Digest,
@@ -300,7 +297,7 @@ impl<H: Hasher> Prover<H> {
 
     /// Serialize a conflicting notarize proof.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn serialize_conflicting_notarize(
+    pub fn serialize_conflicting_notarize(
         view: View,
         parent_1: View,
         payload_1: &Digest,
@@ -327,7 +324,7 @@ impl<H: Hasher> Prover<H> {
 
     /// Serialize a conflicting finalize proof.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn serialize_conflicting_finalize(
+    pub fn serialize_conflicting_finalize(
         view: View,
         parent_1: View,
         payload_1: &Digest,
@@ -353,7 +350,7 @@ impl<H: Hasher> Prover<H> {
     }
 
     /// Serialize a conflicting nullify and finalize proof.
-    pub(crate) fn serialize_nullify_finalize(
+    pub fn serialize_nullify_finalize(
         view: View,
         parent: View,
         payload: &Digest,

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -12,9 +12,14 @@ documentation = "https://docs.rs/commonware-storage"
 
 [dependencies]
 commonware-cryptography = {workspace = true}
+cfg-if = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+bytes = { workspace = true }
+commonware-runtime = { workspace = true }
 commonware-macros = { workspace = true }
 commonware-utils = { workspace = true }
-bytes = { workspace = true }
+prometheus-client = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 thiserror = { workspace = true }
@@ -22,11 +27,6 @@ tracing = { workspace = true }
 zstd = { workspace = true }
 crc32fast = "1.4.2"
 rangemap = "1.5.1"
-cfg-if = { workspace = true }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-commonware-runtime = { workspace = true }
-prometheus-client = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -12,6 +12,8 @@ documentation = "https://docs.rs/commonware-storage"
 
 [dependencies]
 commonware-cryptography = {workspace = true}
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 commonware-macros = { workspace = true }
 commonware-runtime = { workspace = true }
 commonware-utils = { workspace = true }
@@ -32,6 +34,7 @@ criterion = { workspace = true }
 
 [lib]
 bench = false
+crate-type = ["rlib", "cdylib"]
 
 [[bench]]
 name="archive"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -12,20 +12,20 @@ documentation = "https://docs.rs/commonware-storage"
 
 [dependencies]
 commonware-cryptography = {workspace = true}
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 commonware-macros = { workspace = true }
-commonware-runtime = { workspace = true }
 commonware-utils = { workspace = true }
-thiserror = { workspace = true }
-tracing = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
-prometheus-client = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
 zstd = { workspace = true }
 crc32fast = "1.4.2"
 rangemap = "1.5.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+commonware-runtime = { workspace = true }
+prometheus-client = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 zstd = { workspace = true }
 crc32fast = "1.4.2"
 rangemap = "1.5.1"
+cfg-if = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 commonware-runtime = { workspace = true }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -5,10 +5,14 @@
 //! `commonware-storage` is **ALPHA** software and is not yet recommended for production use. Developers should
 //! expect breaking changes and occasional instability.
 
-#[cfg(not(target_arch = "wasm32"))]
-pub mod archive;
-#[cfg(not(target_arch = "wasm32"))]
-pub mod journal;
-#[cfg(not(target_arch = "wasm32"))]
-pub mod metadata;
+use cfg_if::cfg_if;
+
 pub mod mmr;
+
+cfg_if! {
+    if #[cfg(not(target_arch = "wasm32"))] {
+        pub mod archive;
+        pub mod journal;
+        pub mod metadata;
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -5,11 +5,9 @@
 //! `commonware-storage` is **ALPHA** software and is not yet recommended for production use. Developers should
 //! expect breaking changes and occasional instability.
 
-use cfg_if::cfg_if;
-
 pub mod mmr;
 
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(not(target_arch = "wasm32"))] {
         pub mod archive;
         pub mod journal;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -5,7 +5,10 @@
 //! `commonware-storage` is **ALPHA** software and is not yet recommended for production use. Developers should
 //! expect breaking changes and occasional instability.
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod archive;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod journal;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod metadata;
 pub mod mmr;


### PR DESCRIPTION
It can be VERY useful to use pre-existing proof verification logic from consensus/storage in WASM environments. This makes that possible (and adds a test to ensure forward-compatibility).