### PR TITLE
[commonware-storage/mmr] add forgetting support to the in-mem mmr

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/commonware-storage"
 [dependencies]
 commonware-cryptography = {workspace = true}
 cfg-if = { workspace = true }
+thiserror = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bytes = { workspace = true }

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -51,7 +51,7 @@ fn bench_prove_many_elements(c: &mut Criterion) {
                         |samples| {
                             let mut hasher = Sha256::new();
                             for ((start_index, end_index), (start_pos, end_pos)) in samples {
-                                let proof = mmr.range_proof(start_pos, end_pos);
+                                let proof = mmr.range_proof(start_pos, end_pos).unwrap();
                                 assert!(proof.verify_range_inclusion(
                                     &elements[start_index..=end_index],
                                     start_pos,

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -35,7 +35,7 @@ fn bench_prove_single_element(c: &mut Criterion) {
                     |samples| {
                         let mut hasher = Sha256::new();
                         for (pos, element) in samples {
-                            let proof = mmr.proof(pos);
+                            let proof = mmr.proof(pos).unwrap();
                             assert!(proof.verify_element_inclusion(
                                 &element,
                                 pos,

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -1,5 +1,4 @@
-//! A bare-bones MMR structure without pruning and where all nodes are hashes & maintained in
-//! memory within a single vector.
+//! A basic MMR where all nodes are stored in-memory.
 
 use crate::mmr::hasher::Hasher;
 use crate::mmr::iterator::{nodes_needing_parents, PathIterator, PeakIterator};
@@ -8,8 +7,12 @@ use crate::mmr::Error;
 use crate::mmr::Error::{ElementPruned, InvalidElementPosition};
 use commonware_cryptography::{Digest, Hasher as CHasher};
 
-/// Implementation of `Mmr`. The maximum number of elements that can be stored is usize::MAX
-/// (u32::MAX on 32 bit architectures).
+/// Implementation of `Mmr`.
+///
+/// # Max Capacity
+///
+/// The maximum number of elements that can be stored is usize::MAX
+/// (u32::MAX on 32-bit architectures).
 pub struct Mmr<H: CHasher> {
     hasher: H,
     // The nodes of the MMR, laid out according to a post-order traversal of the MMR trees, starting

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -4,6 +4,8 @@
 use crate::mmr::hasher::Hasher;
 use crate::mmr::iterator::{nodes_needing_parents, PathIterator, PeakIterator};
 use crate::mmr::verification::Proof;
+use crate::mmr::Error;
+use crate::mmr::Error::InvalidElementPosition;
 use commonware_cryptography::{Digest, Hasher as CHasher};
 
 /// Implementation of `Mmr`.
@@ -12,6 +14,10 @@ pub struct Mmr<H: CHasher> {
     // The nodes of the MMR, laid out according to a post-order traversal of the MMR trees, starting
     // from the from tallest tree to shortest.
     nodes: Vec<Digest>,
+    // The position of the very oldest element still maintained by the MMR. Will be 0 unless
+    // forgetting has been invoked. If non-zero, then proofs can only be generated for elements with
+    // positions strictly after this point.
+    oldest_remembered_pos: u64,
 }
 
 impl<H: CHasher> Default for Mmr<H> {
@@ -26,22 +32,28 @@ impl<H: CHasher> Mmr<H> {
         Self {
             hasher: H::new(),
             nodes: Vec::new(),
+            oldest_remembered_pos: 0,
         }
     }
 
     pub fn size(&self) -> usize {
-        self.nodes.len()
+        self.nodes.len() + self.oldest_remembered_pos as usize
     }
 
     /// Return a new iterator over the peaks of the MMR.
     fn peak_iterator(&self) -> PeakIterator {
-        PeakIterator::new(self.nodes.len() as u64)
+        PeakIterator::new(self.size() as u64)
+    }
+
+    // Return the position of the element given its index in the current nodes vector.
+    fn index_to_pos(&self, index: usize) -> u64 {
+        index as u64 + self.oldest_remembered_pos
     }
 
     /// Add an element to the MMR and return its position in the MMR.
     pub fn add(&mut self, element: &Digest) -> u64 {
         let peaks = nodes_needing_parents(self.peak_iterator());
-        let element_pos = self.nodes.len() as u64;
+        let element_pos = self.index_to_pos(self.nodes.len());
         let hasher = &mut Hasher::new(&mut self.hasher);
 
         // Insert the element into the MMR as a leaf.
@@ -50,8 +62,9 @@ impl<H: CHasher> Mmr<H> {
 
         // Compute the new parent nodes, if any, and insert them into the MMR.
         for sibling_pos in peaks.into_iter().rev() {
-            let parent_pos = self.nodes.len() as u64;
-            hash = hasher.node_hash(parent_pos, &self.nodes[sibling_pos as usize], &hash);
+            let parent_pos = self.oldest_remembered_pos + self.nodes.len() as u64;
+            let sibling_index = (sibling_pos - self.oldest_remembered_pos) as usize;
+            hash = hasher.node_hash(parent_pos, &self.nodes[sibling_index], &hash);
             self.nodes.push(hash.clone());
         }
         element_pos
@@ -61,23 +74,28 @@ impl<H: CHasher> Mmr<H> {
     pub fn root_hash(&mut self) -> Digest {
         let peaks = self
             .peak_iterator()
-            .map(|(peak_pos, _)| &self.nodes[peak_pos as usize]);
-        let hasher = &mut Hasher::new(&mut self.hasher);
-        hasher.root_hash(self.nodes.len() as u64, peaks)
+            .map(|(peak_pos, _)| &self.nodes[(peak_pos - self.oldest_remembered_pos) as usize]);
+        let size = self.size() as u64;
+        Hasher::new(&mut self.hasher).root_hash(size, peaks)
     }
 
-    /// Return an inclusion proof for the specified element that consists of the size of the MMR and
-    /// a vector of hashes. The proof vector contains: (1) the peak hashes other than the peak of
-    /// the perfect tree containing the element, followed by: (2) the nodes in the remaining perfect
-    /// tree necessary for reconstructing its peak hash from the specified element. Both segments
-    /// are ordered by decreasing height.
-    pub fn proof(&self, element_pos: u64) -> Proof {
+    /// Return an inclusion proof for the specified element. Returns `InvalidElementPosition` error
+    /// if the requested element is not currently stored by this MMR.
+    pub fn proof(&self, element_pos: u64) -> Result<Proof, Error> {
         self.range_proof(element_pos, element_pos)
     }
 
-    // Return an inclusion proof for the specified range of elements. The range is inclusive of
-    // both endpoints.
-    pub fn range_proof(&self, start_element_pos: u64, end_element_pos: u64) -> Proof {
+    // Return an inclusion proof for the specified range of elements. The range is inclusive of both
+    // endpoints. Returns `InvalidElementPosition` if the requested range is outside the range
+    // currently stored by this MMR.
+    pub fn range_proof(
+        &self,
+        start_element_pos: u64,
+        end_element_pos: u64,
+    ) -> Result<Proof, Error> {
+        if start_element_pos != 0 && start_element_pos <= self.oldest_remembered_pos {
+            return Err(InvalidElementPosition);
+        }
         let mut hashes: Vec<Digest> = Vec::new();
         let mut start_tree_with_element = (u64::MAX, 0);
         let mut end_tree_with_element = (u64::MAX, 0);
@@ -102,7 +120,7 @@ impl<H: CHasher> Mmr<H> {
                     }
                 }
             } else {
-                hashes.push(self.nodes[item.0 as usize].clone());
+                hashes.push(self.nodes[(item.0 - self.oldest_remembered_pos) as usize].clone());
             }
         }
         assert!(start_tree_with_element.0 != u64::MAX);
@@ -142,12 +160,63 @@ impl<H: CHasher> Mmr<H> {
         hashes.extend(
             siblings
                 .iter()
-                .map(|(_, pos)| self.nodes[*pos as usize].clone()),
+                .map(|(_, pos)| self.nodes[(*pos - self.oldest_remembered_pos) as usize].clone()),
         );
-        Proof {
-            size: self.nodes.len() as u64,
+        Ok(Proof {
+            size: self.size() as u64,
             hashes,
+        })
+    }
+
+    // Returns the position of the oldest element that must be retained by this MMR in order to
+    // preserve its ability to generate proofs for new elements. This is the position of the
+    // right-most leaf in the left-most peak. For the example tree in mod.rs, this would be node 11.
+    pub fn oldest_required_element(&self) -> u64 {
+        match self.peak_iterator().next() {
+            None => {
+                // Degenerate case, only happens when MMR is empty.
+                0
+            }
+            Some((pos, height)) => {
+                // Rightmost leaf position in a tree is the position of its peak minus its height.
+                pos - height as u64
+            }
         }
+    }
+
+    // Removes all nodes up to but not including that with the given position from the MMR. Returns
+    // `InvalidElementPosition` error if removing the nodes would break the ability to generate
+    // proofs for new elements. After forgetting, you will only be able to generate proofs for
+    // (ranges of) nodes non-inclusively following the given node.
+    pub fn forget(&mut self, oldest_to_remember_pos: u64) -> Result<(), Error> {
+        if oldest_to_remember_pos <= self.oldest_remembered_pos {
+            return Ok(());
+        }
+        let oldest_required_pos = self.oldest_required_element();
+        if oldest_to_remember_pos > oldest_required_pos {
+            return Err(InvalidElementPosition);
+        }
+        self.forget_to_pos(oldest_to_remember_pos);
+        Ok(())
+    }
+
+    // Forget as many nodes as possible without breaking proof generation going forward, returning
+    // the position of the oldest remembered node after forgetting, or 0 if nothing was forgotten.
+    pub fn forget_max(&mut self) -> u64 {
+        let top_peak = self.peak_iterator().next();
+        match top_peak {
+            None => 0,
+            Some((pos, height)) => {
+                self.forget_to_pos(pos - height as u64);
+                self.oldest_remembered_pos
+            }
+        }
+    }
+
+    fn forget_to_pos(&mut self, pos: u64) {
+        let nodes_to_remove = (pos - self.oldest_remembered_pos) as usize;
+        self.oldest_remembered_pos = pos;
+        self.nodes = self.nodes[nodes_to_remove..self.nodes.len()].to_vec();
     }
 }
 
@@ -158,16 +227,26 @@ mod tests {
     use crate::mmr::mem::Mmr;
     use commonware_cryptography::{Digest, Sha256};
 
-    #[test]
     /// Test MMR building by consecutively adding 11 equal elements to a new MMR, producing the
     /// structure in the example documented at the top of the mmr crate's mod.rs file with 19 nodes
     /// and 3 peaks.
+    #[test]
     fn test_add_eleven_values() {
         let mut mmr: Mmr<Sha256> = Mmr::<Sha256>::new();
         assert_eq!(
             mmr.peak_iterator().next(),
             None,
             "empty iterator should have no peaks"
+        );
+        assert_eq!(
+            mmr.forget_max(),
+            0,
+            "forget_max on empty MMR should do nothing"
+        );
+        assert_eq!(
+            mmr.oldest_required_element(),
+            0,
+            "oldest_required_element should return 0 on empty MMR"
         );
 
         let element = Digest::from_static(b"01234567012345670123456701234567");
@@ -176,11 +255,11 @@ mod tests {
             leaves.push(mmr.add(&element));
             let peaks: Vec<(u64, u32)> = mmr.peak_iterator().collect();
             assert_ne!(peaks.len(), 0);
-            assert!(peaks.len() <= mmr.nodes.len());
+            assert!(peaks.len() <= mmr.size());
             let nodes_needing_parents = nodes_needing_parents(mmr.peak_iterator());
             assert!(nodes_needing_parents.len() <= peaks.len());
         }
-        assert_eq!(mmr.nodes.len(), 19, "mmr not of expected size");
+        assert_eq!(mmr.size(), 19, "mmr not of expected size");
         assert_eq!(
             leaves,
             vec![0, 1, 3, 4, 7, 8, 10, 11, 15, 16, 18],
@@ -239,5 +318,37 @@ mod tests {
         let peak_hashes = [hash14, hash17, mmr.nodes[18].clone()];
         let expected_root_hash = mmr_hasher.root_hash(19, peak_hashes.iter());
         assert_eq!(root_hash, expected_root_hash, "incorrect root hash");
+
+        // forgetting tests
+        assert_eq!(
+            mmr.forget_max(),
+            11,
+            "forget_max should forget to right-most leaf of leftmost peak"
+        );
+        assert!(
+            mmr.forget(12).is_err(),
+            "forgetting too many nodes should fail"
+        );
+        assert!(
+            mmr.forget(10).is_ok(),
+            "forgetting already forgotten nodes should be ok"
+        );
+        let root_hash_after_forget = mmr.root_hash();
+        assert_eq!(
+            root_hash, root_hash_after_forget,
+            "root hash changed after forgetting"
+        );
+        assert!(
+            mmr.proof(11).is_err(),
+            "attempts to prove elements at or before the oldest remaining should fail"
+        );
+        assert!(
+            mmr.range_proof(10, 15).is_err(),
+            "attempts to range_prove elements at or before the oldest remaining should fail"
+        );
+        assert!(
+            mmr.range_proof(15, 18).is_ok(),
+            "attempts to range_prove over elements following oldest remaining should succeed"
+        );
     }
 }

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -74,4 +74,6 @@ use thiserror::Error;
 pub enum Error {
     #[error("invalid element position")]
     InvalidElementPosition,
+    #[error("requested element does not follow oldest known: {0}")]
+    ElementPruned(u64),
 }

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -67,3 +67,11 @@ mod hasher;
 mod iterator;
 pub mod mem;
 pub mod verification;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("invalid element position")]
+    InvalidElementPosition,
+}


### PR DESCRIPTION
adds a forget() capability (+ tests) to the MMR that removes older nodes from memory without affecting the ability to generate inclusion proofs for remaining elements and any newly added elements.
