### PR TITLE
Update verifier.rs: Fix inconsistent debug messages

### DIFF
--- a/consensus/src/simplex/verifier.rs
+++ b/consensus/src/simplex/verifier.rs
@@ -82,7 +82,7 @@ pub fn verify_notarization<S: Supervisor<Index = View>, C: Scheme>(
                     view = proposal.view,
                     signer = signature.public_key,
                     reason = "invalid validator",
-                    "dropping finalization"
+                    "dropping nullification"
                 );
                 return false;
             }
@@ -121,7 +121,7 @@ pub fn verify_nullification<S: Supervisor<Index = View>, C: Scheme>(
             debug!(
                 view = nullification.view,
                 reason = "unable to compute participants for view",
-                "dropping finalization"
+                "dropping nullificationn"
             );
             return false;
         }
@@ -132,7 +132,7 @@ pub fn verify_nullification<S: Supervisor<Index = View>, C: Scheme>(
             debug!(
                 view = nullification.view,
                 reason = "unable to compute participants for view",
-                "dropping finalization"
+                "dropping nullification"
             );
             return false;
         }
@@ -204,7 +204,7 @@ pub fn verify_finalization<S: Supervisor<Index = View>, C: Scheme>(
     let proposal = match &finalization.proposal {
         Some(proposal) => proposal,
         None => {
-            debug!(reason = "missing proposal", "dropping notarization");
+            debug!(reason = "missing proposal", "dropping finalization");
             return false;
         }
     };

--- a/consensus/src/simplex/verifier.rs
+++ b/consensus/src/simplex/verifier.rs
@@ -168,7 +168,7 @@ pub fn verify_nullification<S: Supervisor<Index = View>, C: Scheme>(
                     view = nullification.view,
                     signer = signature.public_key,
                     reason = "invalid validator",
-                    "dropping finalization"
+                    "dropping notarization"
                 );
                 return false;
             }

--- a/consensus/src/simplex/verifier.rs
+++ b/consensus/src/simplex/verifier.rs
@@ -35,7 +35,7 @@ pub fn verify_notarization<S: Supervisor<Index = View>, C: Scheme>(
             debug!(
                 view = proposal.view,
                 reason = "unable to compute participants for view",
-                "dropping finalization"
+                "dropping notarization"
             );
             return false;
         }
@@ -46,7 +46,7 @@ pub fn verify_notarization<S: Supervisor<Index = View>, C: Scheme>(
             debug!(
                 view = proposal.view,
                 reason = "unable to compute participants for view",
-                "dropping finalization"
+                "dropping notarization"
             );
             return false;
         }
@@ -82,7 +82,7 @@ pub fn verify_notarization<S: Supervisor<Index = View>, C: Scheme>(
                     view = proposal.view,
                     signer = signature.public_key,
                     reason = "invalid validator",
-                    "dropping nullification"
+                    "dropping notarization"
                 );
                 return false;
             }
@@ -121,7 +121,7 @@ pub fn verify_nullification<S: Supervisor<Index = View>, C: Scheme>(
             debug!(
                 view = nullification.view,
                 reason = "unable to compute participants for view",
-                "dropping nullificationn"
+                "dropping nullification"
             );
             return false;
         }
@@ -168,7 +168,7 @@ pub fn verify_nullification<S: Supervisor<Index = View>, C: Scheme>(
                     view = nullification.view,
                     signer = signature.public_key,
                     reason = "invalid validator",
-                    "dropping notarization"
+                    "dropping nullification"
                 );
                 return false;
             }
@@ -179,7 +179,7 @@ pub fn verify_nullification<S: Supervisor<Index = View>, C: Scheme>(
             debug!(
                 signer = hex(public_key),
                 reason = "duplicate signature",
-                "dropping notarization"
+                "dropping nullification"
             );
             return false;
         }
@@ -187,7 +187,7 @@ pub fn verify_nullification<S: Supervisor<Index = View>, C: Scheme>(
 
         // Verify signature
         if !C::verify(Some(namespace), &message, public_key, &signature.signature) {
-            debug!(reason = "invalid signature", "dropping notarization");
+            debug!(reason = "invalid signature", "dropping nullification");
             return false;
         }
     }

--- a/consensus/src/threshold_simplex/verifier.rs
+++ b/consensus/src/threshold_simplex/verifier.rs
@@ -123,6 +123,7 @@ pub fn verify_nullification<S: ThresholdSupervisor<Index = View, Identity = poly
         debug!(reason = "invalid seed signature", "dropping nullification");
         return false;
     }
+    debug!(view = nullification.view, "seed verified");
     true
 }
 
@@ -136,7 +137,7 @@ pub fn verify_finalization<S: ThresholdSupervisor<Index = View, Identity = poly:
     let proposal = match &finalization.proposal {
         Some(proposal) => proposal,
         None => {
-            debug!(reason = "missing proposal", "dropping notarization");
+            debug!(reason = "missing proposal", "dropping finalization");
             return false;
         }
     };
@@ -154,7 +155,7 @@ pub fn verify_finalization<S: ThresholdSupervisor<Index = View, Identity = poly:
 
     // Parse signature
     let Some(signature) = group::Signature::deserialize(&finalization.proposal_signature) else {
-        debug!(reason = "invalid signature", "dropping nullification");
+        debug!(reason = "invalid signature", "dropping finalization");
         return false;
     };
 
@@ -185,5 +186,6 @@ pub fn verify_finalization<S: ThresholdSupervisor<Index = View, Identity = poly:
         debug!(reason = "invalid seed signature", "dropping finalization");
         return false;
     }
+    debug!(view = proposal.view, "seed verified");
     true
 }


### PR DESCRIPTION


## Changes Made
In `consensus/src/simplex/verifier.rs`:

1. `verify_nullification`:
   - "dropping finalization" -> "dropping nullification" (3 instances)

2. `verify_finalization`:
   - "dropping notarization" -> "dropping finalization" (1 instance)

## Why Needed
Debug messages were inconsistent with their verification functions. Each function should use messages that match its operation type (notarization/nullification/finalization) for better debugging and code clarity.

These are text-only changes that improve code maintainability without affecting functionality.
