### PR TITLE
Update variable names in engine.rs for better clarity

### DIFF
--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -122,7 +122,7 @@ impl<
     ) {
         // Start the voter
         let (voter_sender, voter_receiver) = voter_network;
-        let mut voter = self.runtime.spawn("voter", async move {
+        let mut voter_handle = self.runtime.spawn("voter", async move {
             self.voter
                 .run(self.resolver_mailbox, voter_sender, voter_receiver)
                 .await;
@@ -130,7 +130,7 @@ impl<
 
         // Start the resolver
         let (resolver_sender, resolver_receiver) = resolver_network;
-        let mut resolver = self.runtime.spawn("resolver", async move {
+        let mut resolver_handle = self.runtime.spawn("resolver", async move {
             self.resolver
                 .run(self.voter_mailbox, resolver_sender, resolver_receiver)
                 .await;


### PR DESCRIPTION


Changes in consensus/src/threshold_simplex/engine.rs:
- Renamed `voter` → `voter_handle`
- Renamed `resolver` → `resolver_handle`

Why:
- Better reflects that these variables are task handles rather than actors
- Reduces confusion between actor instances and spawned task handles
- Improves code readability and maintainability
- Makes code more self-documenting

Note: Changes are purely cosmetic and do not affect functionality.