### PR TITLE
[cryptography/bls12381] Use negated generator constant

### DIFF
--- a/cryptography/src/bls12381/benches/signature_generation.rs
+++ b/cryptography/src/bls12381/benches/signature_generation.rs
@@ -1,11 +1,12 @@
 use commonware_cryptography::{Bls12381, Scheme};
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::thread_rng;
+use rand::{thread_rng, Rng};
 use std::hint::black_box;
 
 fn benchmark_signature_generation(c: &mut Criterion) {
     let namespace = b"namespace";
-    let msg = b"hello";
+    let mut msg = [0u8; 32];
+    thread_rng().fill(&mut msg);
     c.bench_function(
         &format!(
             "{}/ns_len={} msg_len={}",
@@ -17,7 +18,7 @@ fn benchmark_signature_generation(c: &mut Criterion) {
             b.iter_batched(
                 || Bls12381::new(&mut thread_rng()),
                 |mut signer| {
-                    black_box(signer.sign(Some(namespace), msg));
+                    black_box(signer.sign(Some(namespace), &msg));
                 },
                 BatchSize::SmallInput,
             );

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -15,10 +15,10 @@ use blst::{
     blst_fr_from_uint64, blst_fr_inverse, blst_fr_mul, blst_fr_sub, blst_hash_to_g1,
     blst_hash_to_g2, blst_keygen, blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_compress,
     blst_p1_from_affine, blst_p1_in_g1, blst_p1_is_inf, blst_p1_mult, blst_p1_to_affine,
-    blst_p1_uncompress, blst_p2, blst_p2_add_or_double, blst_p2_affine, blst_p2_cneg,
-    blst_p2_compress, blst_p2_from_affine, blst_p2_in_g2, blst_p2_is_inf, blst_p2_mult,
-    blst_p2_to_affine, blst_p2_uncompress, blst_scalar, blst_scalar_from_bendian,
-    blst_scalar_from_fr, blst_sk_check, Pairing, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
+    blst_p1_uncompress, blst_p2, blst_p2_add_or_double, blst_p2_affine, blst_p2_compress,
+    blst_p2_from_affine, blst_p2_in_g2, blst_p2_is_inf, blst_p2_mult, blst_p2_to_affine,
+    blst_p2_uncompress, blst_scalar, blst_scalar_from_bendian, blst_scalar_from_fr, blst_sk_check,
+    Pairing, BLS12_381_G1, BLS12_381_G2, BLS12_381_NEG_G1, BLST_ERROR,
 };
 use rand::RngCore;
 use std::ptr;
@@ -486,30 +486,23 @@ impl Point for G2 {
     }
 }
 
-/// Verifies that the pairing of `pk` and `hm` is equal to the pairing of `G1::one()` and `sig`.
-pub(super) fn equal(pk: &G1, sig: &G2, mut hm: G2) -> bool {
+/// Verifies that `e(pk, hm)` is equal to `e(G1::one(), sig)` using a single pairing.
+pub(super) fn equal(pk: &G1, sig: &G2, hm: &G2) -> bool {
     // Create a pairing context
     //
     // We only handle pre-hashed messages, so we don't need to provide a `DST`.
     let mut pairing = Pairing::new(false, &[]);
 
-    // Convert G1::one() and 'sig' into affine
-    let mut p = blst_p1_affine::default();
+    // Convert 'sig' into affine
     let mut q = blst_p2_affine::default();
     unsafe {
-        blst_p1_to_affine(&mut p, &<G1 as Element>::one().0);
         blst_p2_to_affine(&mut q, &sig.0);
+
+        // Aggregate e(-G1::one(), sig)
+        pairing.raw_aggregate(&q, &BLS12_381_NEG_G1);
     }
 
-    // Aggregate e(G1::one(), sig)
-    pairing.raw_aggregate(&q, &p);
-
-    // Negate `hm`
-    unsafe {
-        blst_p2_cneg(&mut hm.0, true);
-    }
-
-    // Convert 'pk' and '-hm' into affine
+    // Convert 'pk' and 'hm' into affine
     let mut p = blst_p1_affine::default();
     let mut q = blst_p2_affine::default();
     unsafe {
@@ -517,7 +510,7 @@ pub(super) fn equal(pk: &G1, sig: &G2, mut hm: G2) -> bool {
         blst_p2_to_affine(&mut q, &hm.0);
     }
 
-    // Aggregate e(pk, -hm)
+    // Aggregate e(pk, hm)
     pairing.raw_aggregate(&q, &p);
 
     // Return GT==1

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -42,7 +42,7 @@ pub fn verify(
 ) -> Result<(), Error> {
     let mut hm = group::Signature::zero();
     hm.map(dst, payload);
-    if !equal(public, signature, hm) {
+    if !equal(public, signature, &hm) {
         return Err(Error::InvalidSignature);
     }
     Ok(())
@@ -291,7 +291,7 @@ pub fn aggregate_verify_multiple_messages(
     });
 
     // Verify the signature
-    if !equal(public, signature, hm_sum) {
+    if !equal(public, signature, &hm_sum) {
         return Err(Error::InvalidSignature);
     }
     Ok(())


### PR DESCRIPTION
To further speed up verification, we can use the negated generator constant for `g1` instead of negating `hm` at runtime.