### PR TITLE
[cryptography/hasher] Remove `DIGEST_LENGTH` const

### DIFF
--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -268,7 +268,7 @@ impl<E: Clock + RngCore, H: Hasher> Application<E, H> {
                 parsed_view, context.view
             ));
         }
-        let parsed_parent: Digest = contents.copy_to_bytes(H::DIGEST_LENGTH);
+        let parsed_parent: Digest = contents.copy_to_bytes(size_of::<H::Digest>());
         if parsed_parent != context.parent.1 {
             self.panic(&format!(
                 "invalid parent (in payload): {} != {}",

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -177,7 +177,7 @@ pub const NULLIFY_AND_FINALIZE: Activity = 4;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use commonware_cryptography::{Ed25519, Hasher, PublicKey, Scheme, Sha256};
+    use commonware_cryptography::{sha256, Ed25519, PublicKey, Scheme, Sha256};
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{
@@ -199,6 +199,8 @@ mod tests {
         time::Duration,
     };
     use tracing::debug;
+
+    const DIGEST_LENGTH: usize = size_of::<sha256::Digest>();
 
     /// Registers all validators using the oracle.
     async fn register_validators(
@@ -322,7 +324,7 @@ mod tests {
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
 
             // Create engines
-            let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(&namespace, DIGEST_LENGTH);
             let relay = Arc::new(mocks::relay::Relay::new());
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -548,7 +550,7 @@ mod tests {
                 link_validators(&mut oracle, &validators, Action::Link(link), None).await;
 
                 // Create engines
-                let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+                let prover = Prover::new(&namespace, DIGEST_LENGTH);
                 let relay = Arc::new(mocks::relay::Relay::new());
                 let mut supervisors = HashMap::new();
                 let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -757,7 +759,7 @@ mod tests {
             .await;
 
             // Create engines
-            let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(&namespace, DIGEST_LENGTH);
             let relay = Arc::new(mocks::relay::Relay::new());
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -1041,7 +1043,7 @@ mod tests {
             .await;
 
             // Create engines
-            let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(&namespace, DIGEST_LENGTH);
             let relay = Arc::new(mocks::relay::Relay::new());
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -1219,7 +1221,7 @@ mod tests {
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
 
             // Create engines
-            let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(&namespace, DIGEST_LENGTH);
             let relay = Arc::new(mocks::relay::Relay::new());
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -1403,7 +1405,7 @@ mod tests {
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
 
             // Create engines
-            let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(&namespace, DIGEST_LENGTH);
             let relay = Arc::new(mocks::relay::Relay::new());
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -1569,7 +1571,7 @@ mod tests {
             link_validators(&mut oracle, &validators, Action::Link(link.clone()), None).await;
 
             // Create engines
-            let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(&namespace, DIGEST_LENGTH);
             let relay = Arc::new(mocks::relay::Relay::new());
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -1792,7 +1794,7 @@ mod tests {
             link_validators(&mut oracle, &validators, Action::Link(degraded_link), None).await;
 
             // Create engines
-            let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(&namespace, DIGEST_LENGTH);
             let relay = Arc::new(mocks::relay::Relay::new());
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -1964,7 +1966,7 @@ mod tests {
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
 
             // Create engines
-            let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(&namespace, DIGEST_LENGTH);
             let relay = Arc::new(mocks::relay::Relay::new());
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -2148,7 +2150,7 @@ mod tests {
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
 
             // Create engines
-            let prover = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(&namespace, DIGEST_LENGTH);
             let relay = Arc::new(mocks::relay::Relay::new());
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();

--- a/consensus/src/simplex/prover.rs
+++ b/consensus/src/simplex/prover.rs
@@ -457,16 +457,18 @@ impl<C: Scheme> Prover<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use commonware_cryptography::{Ed25519, Hasher, Sha256};
+    use commonware_cryptography::{sha256, Ed25519};
+
+    const DIGEST_LENGTH: usize = size_of::<sha256::Digest>();
 
     #[test]
     fn test_deserialize_aggregation_empty() {
         // Create a proof with no signers
-        let prover = Prover::<Ed25519>::new(b"test", Sha256::DIGEST_LENGTH);
+        let prover = Prover::<Ed25519>::new(b"test", DIGEST_LENGTH);
         let mut proof = Vec::new();
         proof.put_u64(1); // view
         proof.put_u64(0); // parent
-        proof.extend_from_slice(&[0; Sha256::DIGEST_LENGTH]); // payload
+        proof.extend_from_slice(&[0; DIGEST_LENGTH]); // payload
         proof.put_u32(0); // count of 0 signatures is valid
 
         // Verify that the proof is accepted
@@ -481,10 +483,10 @@ mod tests {
         let mut proof = Vec::new();
         proof.put_u64(1); // view
         proof.put_u64(0); // parent
-        proof.extend_from_slice(&[0; Sha256::DIGEST_LENGTH]); // payload
+        proof.extend_from_slice(&[0; DIGEST_LENGTH]); // payload
 
         // Verify that the proof is rejected
-        let prover = Prover::<Ed25519>::new(b"test", Sha256::DIGEST_LENGTH);
+        let prover = Prover::<Ed25519>::new(b"test", DIGEST_LENGTH);
         let result = prover.deserialize_aggregation(
             proof.into(),
             u32::MAX, // Allow any count to test overflow protection
@@ -500,11 +502,11 @@ mod tests {
         let mut proof = Vec::new();
         proof.put_u64(1); // view
         proof.put_u64(0); // parent
-        proof.extend_from_slice(&[0; Sha256::DIGEST_LENGTH]); // payload
+        proof.extend_from_slice(&[0; DIGEST_LENGTH]); // payload
         proof.put_u32(100);
 
         // Verify that the proof is rejected
-        let prover = Prover::<Ed25519>::new(b"test", Sha256::DIGEST_LENGTH);
+        let prover = Prover::<Ed25519>::new(b"test", DIGEST_LENGTH);
         let result = prover.deserialize_aggregation(
             proof.into(),
             u32::MAX, // Allow any count to test overflow protection

--- a/consensus/src/threshold_simplex/mocks/application.rs
+++ b/consensus/src/threshold_simplex/mocks/application.rs
@@ -270,7 +270,7 @@ impl<E: Clock + RngCore, H: Hasher> Application<E, H> {
                 parsed_view, context.view
             ));
         }
-        let parsed_parent: Digest = contents.copy_to_bytes(H::DIGEST_LENGTH);
+        let parsed_parent: Digest = contents.copy_to_bytes(size_of::<H::Digest>());
         if parsed_parent != context.parent.1 {
             self.panic(&format!(
                 "invalid parent (in payload): {} != {}",

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -210,7 +210,7 @@ mod tests {
     use super::*;
     use commonware_cryptography::{
         bls12381::{dkg::ops, primitives::poly},
-        Ed25519, Hasher, PublicKey, Scheme, Sha256,
+        sha256, Ed25519, PublicKey, Scheme, Sha256,
     };
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
@@ -232,6 +232,8 @@ mod tests {
         time::Duration,
     };
     use tracing::debug;
+
+    const DIGEST_LENGTH: usize = size_of::<sha256::Digest>();
 
     /// Registers all validators using the oracle.
     async fn register_validators(
@@ -356,7 +358,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut runtime, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -593,7 +595,7 @@ mod tests {
                 link_validators(&mut oracle, &validators, Action::Link(link), None).await;
 
                 // Create engines
-                let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+                let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
                 let relay = Arc::new(mocks::relay::Relay::new());
                 let mut supervisors = HashMap::new();
                 let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -812,7 +814,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut runtime, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1106,7 +1108,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut runtime, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1291,7 +1293,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut runtime, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1482,7 +1484,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut runtime, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1655,7 +1657,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut runtime, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1884,7 +1886,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut runtime, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -2063,7 +2065,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut runtime, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -2248,7 +2250,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut runtime, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace, Sha256::DIGEST_LENGTH);
+            let prover = Prover::new(pk, &namespace, DIGEST_LENGTH);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());

--- a/consensus/src/threshold_simplex/prover.rs
+++ b/consensus/src/threshold_simplex/prover.rs
@@ -440,10 +440,12 @@ mod tests {
             dkg::ops::generate_shares,
             primitives::group::{self, Share},
         },
-        Hasher, Sha256,
+        sha256,
     };
     use ops::{keypair, partial_sign_message, sign_message};
     use rand::{rngs::StdRng, SeedableRng};
+
+    const DIGEST_LENGTH: usize = size_of::<sha256::Digest>();
 
     fn generate_threshold() -> (group::Public, poly::Public, Vec<Share>) {
         let mut sampler = StdRng::seed_from_u64(0);
@@ -460,8 +462,8 @@ mod tests {
     fn test_deserialize_proposal() {
         // Create valid signature
         let (public, poly, shares) = generate_threshold();
-        let prover = Prover::new(public, b"test", Sha256::DIGEST_LENGTH);
-        let payload = Digest::from(vec![0; Sha256::DIGEST_LENGTH]);
+        let prover = Prover::new(public, b"test", DIGEST_LENGTH);
+        let payload = Digest::from(vec![0; DIGEST_LENGTH]);
         let signature = partial_sign_message(
             &shares[0],
             Some(&prover.seed_namespace),
@@ -487,8 +489,8 @@ mod tests {
     fn test_deserialize_proposal_invalid() {
         // Create valid signature
         let (public, poly, shares) = generate_threshold();
-        let prover = Prover::new(public, b"test", Sha256::DIGEST_LENGTH);
-        let payload = Digest::from(vec![0; Sha256::DIGEST_LENGTH]);
+        let prover = Prover::new(public, b"test", DIGEST_LENGTH);
+        let payload = Digest::from(vec![0; DIGEST_LENGTH]);
         let signature = partial_sign_message(
             &shares[0],
             Some(&prover.seed_namespace),
@@ -514,8 +516,8 @@ mod tests {
     fn test_deserialize_proposal_underflow() {
         // Create valid signature
         let (public, _, shares) = generate_threshold();
-        let prover = Prover::new(public, b"test", Sha256::DIGEST_LENGTH);
-        let payload = Digest::from(vec![0; Sha256::DIGEST_LENGTH]);
+        let prover = Prover::new(public, b"test", DIGEST_LENGTH);
+        let payload = Digest::from(vec![0; DIGEST_LENGTH]);
         let signature = partial_sign_message(
             &shares[0],
             Some(&prover.seed_namespace),
@@ -542,8 +544,8 @@ mod tests {
     fn test_deserialize_proposal_overflow() {
         // Create valid signature
         let (public, _, shares) = generate_threshold();
-        let prover = Prover::new(public, b"test", Sha256::DIGEST_LENGTH);
-        let payload = Digest::from(vec![0; Sha256::DIGEST_LENGTH]);
+        let prover = Prover::new(public, b"test", DIGEST_LENGTH);
+        let payload = Digest::from(vec![0; DIGEST_LENGTH]);
         let signature = partial_sign_message(
             &shares[0],
             Some(&prover.seed_namespace),
@@ -570,10 +572,10 @@ mod tests {
     fn test_deserialize_threshold() {
         // Create valid signature
         let (private, public) = generate_keypair();
-        let prover = Prover::new(public, b"test", Sha256::DIGEST_LENGTH);
+        let prover = Prover::new(public, b"test", DIGEST_LENGTH);
 
         // Generate a valid signature
-        let payload = Digest::from(vec![0; Sha256::DIGEST_LENGTH]);
+        let payload = Digest::from(vec![0; DIGEST_LENGTH]);
         let proposal_signature = sign_message(
             &private,
             Some(&prover.notarize_namespace),
@@ -600,10 +602,10 @@ mod tests {
     fn test_deserialize_threshold_invalid() {
         // Create valid signature
         let (private, public) = generate_keypair();
-        let prover = Prover::new(public, b"test", Sha256::DIGEST_LENGTH);
+        let prover = Prover::new(public, b"test", DIGEST_LENGTH);
 
         // Generate a valid signature
-        let payload = Digest::from(vec![0; Sha256::DIGEST_LENGTH]);
+        let payload = Digest::from(vec![0; DIGEST_LENGTH]);
         let proposal_signature = sign_message(
             &private,
             Some(&prover.notarize_namespace),
@@ -630,10 +632,10 @@ mod tests {
     fn test_deserialize_threshold_underflow() {
         // Create valid signature
         let (private, public) = generate_keypair();
-        let prover = Prover::new(public, b"test", Sha256::DIGEST_LENGTH);
+        let prover = Prover::new(public, b"test", DIGEST_LENGTH);
 
         // Generate a valid signature
-        let payload = Digest::from(vec![0; Sha256::DIGEST_LENGTH]);
+        let payload = Digest::from(vec![0; DIGEST_LENGTH]);
         let proposal_signature = sign_message(
             &private,
             Some(&prover.notarize_namespace),
@@ -663,10 +665,10 @@ mod tests {
     fn test_deserialize_threshold_overflow() {
         // Create valid signature
         let (private, public) = generate_keypair();
-        let prover = Prover::new(public, b"test", Sha256::DIGEST_LENGTH);
+        let prover = Prover::new(public, b"test", DIGEST_LENGTH);
 
         // Generate a valid signature
-        let payload = Digest::from(vec![0; Sha256::DIGEST_LENGTH]);
+        let payload = Digest::from(vec![0; DIGEST_LENGTH]);
         let proposal_signature = sign_message(
             &private,
             Some(&prover.notarize_namespace),

--- a/cryptography/src/ed25519/mod.rs
+++ b/cryptography/src/ed25519/mod.rs
@@ -1,3 +1,29 @@
+//! Ed25519 implementation of the `Scheme` trait.
+//!
+//! This implementation uses the `ed25519-consensus` crate to adhere to a strict
+//! set of validation rules for Ed25519 signatures (which is necessary for
+//! stability in a consensus context). You can read more about this
+//! [here](https://hdevalence.ca/blog/2020-10-04-its-25519am).
+//!
+//! # Example
+//! ```rust
+//! use commonware_cryptography::{Ed25519, Scheme};
+//! use rand::rngs::OsRng;
+//!
+//! // Generate a new private key
+//! let mut signer = Ed25519::new(&mut OsRng);
+//!
+//! // Create a message to sign
+//! let namespace = Some(&b"demo"[..]);
+//! let msg = b"hello, world!";
+//!
+//! // Sign the message
+//! let signature = signer.sign(namespace, msg);
+//!
+//! // Verify the signature
+//! assert!(Ed25519::verify(namespace, msg, &signer.public_key(), &signature));
+//! ```
+
 mod scheme;
 
 pub use scheme::Ed25519;

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -1,29 +1,3 @@
-//! Ed25519 implementation of the `Scheme` trait.
-//!
-//! This implementation uses the `ed25519-consensus` crate to adhere to a strict
-//! set of validation rules for Ed25519 signatures (which is necessary for
-//! stability in a consensus context). You can read more about this
-//! [here](https://hdevalence.ca/blog/2020-10-04-its-25519am).
-//!
-//! # Example
-//! ```rust
-//! use commonware_cryptography::{Ed25519, Scheme};
-//! use rand::rngs::OsRng;
-//!
-//! // Generate a new private key
-//! let mut signer = Ed25519::new(&mut OsRng);
-//!
-//! // Create a message to sign
-//! let namespace = Some(&b"demo"[..]);
-//! let msg = b"hello, world!";
-//!
-//! // Sign the message
-//! let signature = signer.sign(namespace, msg);
-//!
-//! // Verify the signature
-//! assert!(Ed25519::verify(namespace, msg, &signer.public_key(), &signature));
-//! ```
-
 use crate::{BatchScheme, PrivateKey, PublicKey, Scheme, Signature};
 use commonware_utils::union_unique;
 use ed25519_consensus;

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -7,6 +7,7 @@
 
 use std::fmt::Debug;
 use std::ops::Deref;
+use std::ops::DerefMut;
 
 use bytes::Bytes;
 use rand::{CryptoRng, Rng, RngCore, SeedableRng};
@@ -152,6 +153,8 @@ pub trait Hasher: Clone + Send + Sync + 'static {
         + for<'a> TryFrom<&'a [u8], Error = Error>
         + for<'a> TryFrom<&'a Vec<u8>, Error = Error>
         + Deref<Target = [u8]>
+        + DerefMut<Target = [u8]>
+        + Sized
         + Into<Bytes>
         + Clone
         + Send
@@ -162,9 +165,6 @@ pub trait Hasher: Clone + Send + Sync + 'static {
         + Ord
         + PartialOrd
         + Debug;
-
-    /// The length of the digest in bytes.
-    const DIGEST_LENGTH: usize;
 
     /// Create a new hasher.
     fn new() -> Self;
@@ -440,7 +440,7 @@ mod tests {
         hasher.update(b"hello world");
         let digest = hasher.finalize();
         assert!(H::Digest::try_from(digest.as_ref()).is_ok());
-        assert_eq!(digest.as_ref().len(), H::DIGEST_LENGTH);
+        assert_eq!(digest.as_ref().len(), size_of::<H::Digest>());
 
         // Reuse hasher without reset
         hasher.update(b"hello world");

--- a/cryptography/src/secp256r1/mod.rs
+++ b/cryptography/src/secp256r1/mod.rs
@@ -1,3 +1,28 @@
+//! Secp256r1 implementation of the `Scheme` trait.
+//!
+//! This implementation operates over public keys in compressed form (SEC 1, Version 2.0, Section 2.3.3), generates
+//! deterministic signatures as specified in [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979), and enforces
+//! signatures are normalized according to [BIP 62](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures).
+//!
+//! # Example
+//! ```rust
+//! use commonware_cryptography::{Scheme, Secp256r1};
+//! use rand::rngs::OsRng;
+//!
+//! // Generate a new private key
+//! let mut signer = Secp256r1::new(&mut OsRng);
+//!
+//! // Create a message to sign
+//! let namespace = Some(&b"demo"[..]);
+//! let msg = b"hello, world!";
+//!
+//! // Sign the message
+//! let signature = signer.sign(namespace, msg);
+//!
+//! // Verify the signature
+//! assert!(Secp256r1::verify(namespace, msg, &signer.public_key(), &signature));
+//! ```
+
 mod scheme;
 
 pub use scheme::Secp256r1;

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -1,28 +1,3 @@
-//! Secp256r1 implementation of the `Scheme` trait.
-//!
-//! This implementation operates over public keys in compressed form (SEC 1, Version 2.0, Section 2.3.3), generates
-//! deterministic signatures as specified in [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979), and enforces
-//! signatures are normalized according to [BIP 62](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures).
-//!
-//! # Example
-//! ```rust
-//! use commonware_cryptography::{Scheme, Secp256r1};
-//! use rand::rngs::OsRng;
-//!
-//! // Generate a new private key
-//! let mut signer = Secp256r1::new(&mut OsRng);
-//!
-//! // Create a message to sign
-//! let namespace = Some(&b"demo"[..]);
-//! let msg = b"hello, world!";
-//!
-//! // Sign the message
-//! let signature = signer.sign(namespace, msg);
-//!
-//! // Verify the signature
-//! assert!(Secp256r1::verify(namespace, msg, &signer.public_key(), &signature));
-//! ```
-
 use crate::{PrivateKey, PublicKey, Scheme, Signature};
 use commonware_utils::union_unique;
 use p256::{
@@ -39,7 +14,7 @@ const PRIVATE_KEY_LENGTH: usize = 32;
 const PUBLIC_KEY_LENGTH: usize = 33; // Y-Parity || X
 const SIGNATURE_LENGTH: usize = 64; // R || S
 
-/// Secp256r1 implementation of the `Scheme` trait.
+/// Secp256r1 Signer.
 #[derive(Clone)]
 pub struct Secp256r1 {
     signer: SigningKey,

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -4,7 +4,7 @@ use crate::{Error, Hasher};
 use bytes::Bytes;
 use rand::{CryptoRng, Rng};
 use sha2::{Digest as _, Sha256 as ISha256};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 const DIGEST_LENGTH: usize = 32;
 
@@ -29,7 +29,6 @@ impl Clone for Sha256 {
 
 impl Hasher for Sha256 {
     type Digest = Digest;
-    const DIGEST_LENGTH: usize = DIGEST_LENGTH;
 
     fn new() -> Self {
         Self {
@@ -52,7 +51,7 @@ impl Hasher for Sha256 {
     }
 
     fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self::Digest {
-        let mut digest = [0u8; Self::DIGEST_LENGTH];
+        let mut digest = [0u8; DIGEST_LENGTH];
         rng.fill_bytes(&mut digest);
         Self::Digest::from(digest)
     }
@@ -114,6 +113,12 @@ impl Deref for Digest {
     }
 }
 
+impl DerefMut for Digest {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,6 +150,6 @@ mod tests {
 
     #[test]
     fn test_sha256_len() {
-        assert_eq!(Sha256::DIGEST_LENGTH, DIGEST_LENGTH);
+        assert_eq!(size_of::<<Sha256 as Hasher>::Digest>(), DIGEST_LENGTH);
     }
 }

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -57,6 +57,7 @@ impl Hasher for Sha256 {
     }
 }
 
+/// Digest of a SHA-256 hashing operation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(transparent)]
 pub struct Digest([u8; DIGEST_LENGTH]);

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -150,6 +150,6 @@ mod tests {
 
     #[test]
     fn test_sha256_len() {
-        assert_eq!(size_of::<<Sha256 as Hasher>::Digest>(), DIGEST_LENGTH);
+        assert_eq!(size_of::<Digest>(), DIGEST_LENGTH);
     }
 }

--- a/examples/bridge/src/bin/indexer.rs
+++ b/examples/bridge/src/bin/indexer.rs
@@ -4,7 +4,7 @@ use commonware_bridge::{wire, APPLICATION_NAMESPACE, CONSENSUS_SUFFIX, INDEXER_N
 use commonware_consensus::{threshold_simplex::Prover, Digest};
 use commonware_cryptography::{
     bls12381::primitives::group::{self, Element},
-    Ed25519, Hasher, Scheme, Sha256,
+    sha256, Ed25519, Hasher, Scheme, Sha256,
 };
 use commonware_runtime::{tokio::Executor, Listener, Network, Runner, Spawner};
 use commonware_stream::{
@@ -117,7 +117,7 @@ fn main() {
         let network = from_hex(network).expect("Network not well-formed");
         let public = group::Public::deserialize(&network).expect("Network not well-formed");
         let namespace = union(APPLICATION_NAMESPACE, CONSENSUS_SUFFIX);
-        let prover = Prover::new(public, &namespace, Sha256::DIGEST_LENGTH);
+        let prover = Prover::new(public, &namespace, size_of::<sha256::Digest>());
         provers.insert(network.clone(), prover);
         blocks.insert(network.clone(), HashMap::new());
         finalizations.insert(network, BTreeMap::new());

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -8,7 +8,8 @@ use commonware_cryptography::{
         group::{self, Element},
         poly::{self, Poly},
     },
-    Ed25519, Hasher, Scheme, Sha256,
+    sha256::Digest,
+    Ed25519, Scheme, Sha256,
 };
 use commonware_p2p::authenticated;
 use commonware_runtime::{
@@ -227,9 +228,9 @@ fn main() {
 
         // Initialize application
         let consensus_namespace = union(APPLICATION_NAMESPACE, CONSENSUS_SUFFIX);
-        let prover: Prover = Prover::new(public, &consensus_namespace, Sha256::DIGEST_LENGTH);
+        let prover: Prover = Prover::new(public, &consensus_namespace, size_of::<Digest>());
         let other_prover: Prover =
-            Prover::new(other_identity, &consensus_namespace, Sha256::DIGEST_LENGTH);
+            Prover::new(other_identity, &consensus_namespace, size_of::<Digest>());
         let (application, supervisor, mailbox) = application::Application::new(
             runtime.clone(),
             application::Config {

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -49,7 +49,7 @@ mod gui;
 
 use clap::{value_parser, Arg, Command};
 use commonware_consensus::simplex::{self, Engine, Prover};
-use commonware_cryptography::{Ed25519, Hasher, Scheme, Sha256};
+use commonware_cryptography::{sha256::Digest, Ed25519, Scheme, Sha256};
 use commonware_p2p::authenticated::{self, Network};
 use commonware_runtime::{
     tokio::{self, Executor},
@@ -204,7 +204,7 @@ fn main() {
 
         // Initialize application
         let namespace = union(APPLICATION_NAMESPACE, b"_CONSENSUS");
-        let prover: Prover<Ed25519> = Prover::new(&namespace, Sha256::DIGEST_LENGTH);
+        let prover: Prover<Ed25519> = Prover::new(&namespace, size_of::<Digest>());
         let (application, supervisor, mailbox) = application::Application::new(
             runtime.clone(),
             application::Config {

--- a/storage/src/mmr/hasher.rs
+++ b/storage/src/mmr/hasher.rs
@@ -78,13 +78,13 @@ mod tests {
         let mut hasher = H::new();
         let mut mmr_hasher = super::Hasher::new(&mut hasher);
         // input hashes to use
-        let hash1 = H::Digest::try_from(&vec![1u8; H::DIGEST_LENGTH]).unwrap();
-        let hash2 = H::Digest::try_from(&vec![2u8; H::DIGEST_LENGTH]).unwrap();
+        let hash1 = H::Digest::try_from(&vec![1u8; size_of::<H::Digest>()]).unwrap();
+        let hash2 = H::Digest::try_from(&vec![2u8; size_of::<H::Digest>()]).unwrap();
 
         let out = mmr_hasher.leaf_hash(0, &hash1);
         assert_ne!(
             out,
-            H::Digest::try_from(vec![0u8; H::DIGEST_LENGTH].as_ref() as &[u8]).unwrap(),
+            H::Digest::try_from(vec![0u8; size_of::<H::Digest>()].as_ref() as &[u8]).unwrap(),
             "hash should be non-zero"
         );
 
@@ -103,14 +103,14 @@ mod tests {
         let mut mmr_hasher = super::Hasher::new(&mut hasher);
         // input hashes to use
 
-        let hash1 = H::Digest::try_from(&vec![1u8; H::DIGEST_LENGTH]).unwrap();
-        let hash2 = H::Digest::try_from(&vec![2u8; H::DIGEST_LENGTH]).unwrap();
-        let hash3 = H::Digest::try_from(&vec![3u8; H::DIGEST_LENGTH]).unwrap();
+        let hash1 = H::Digest::try_from(&vec![1u8; size_of::<H::Digest>()]).unwrap();
+        let hash2 = H::Digest::try_from(&vec![2u8; size_of::<H::Digest>()]).unwrap();
+        let hash3 = H::Digest::try_from(&vec![3u8; size_of::<H::Digest>()]).unwrap();
 
         let out = mmr_hasher.node_hash(0, &hash1, &hash2);
         assert_ne!(
             out,
-            H::Digest::try_from(&vec![0u8; H::DIGEST_LENGTH]).unwrap(),
+            H::Digest::try_from(&vec![0u8; size_of::<H::Digest>()]).unwrap(),
             "hash should be non-zero"
         );
 
@@ -143,16 +143,16 @@ mod tests {
         let mut hasher = H::new();
         let mut mmr_hasher = super::Hasher::new(&mut hasher);
         // input hashes to use
-        let hash1 = H::Digest::try_from(&vec![1u8; H::DIGEST_LENGTH]).unwrap();
-        let hash2 = H::Digest::try_from(&vec![2u8; H::DIGEST_LENGTH]).unwrap();
-        let hash3 = H::Digest::try_from(&vec![3u8; H::DIGEST_LENGTH]).unwrap();
-        let hash4 = H::Digest::try_from(&vec![4u8; H::DIGEST_LENGTH]).unwrap();
+        let hash1 = H::Digest::try_from(&vec![1u8; size_of::<H::Digest>()]).unwrap();
+        let hash2 = H::Digest::try_from(&vec![2u8; size_of::<H::Digest>()]).unwrap();
+        let hash3 = H::Digest::try_from(&vec![3u8; size_of::<H::Digest>()]).unwrap();
+        let hash4 = H::Digest::try_from(&vec![4u8; size_of::<H::Digest>()]).unwrap();
 
         let empty_vec: Vec<H::Digest> = Vec::new();
         let empty_out = mmr_hasher.root_hash(0, empty_vec.iter());
         assert_ne!(
             empty_out,
-            H::Digest::try_from(&vec![0u8; H::DIGEST_LENGTH]).unwrap(),
+            H::Digest::try_from(&vec![0u8; size_of::<H::Digest>()]).unwrap(),
             "root hash of empty MMR should be non-zero"
         );
 
@@ -160,7 +160,7 @@ mod tests {
         let out = mmr_hasher.root_hash(10, vec.iter());
         assert_ne!(
             out,
-            H::Digest::try_from(&vec![0u8; H::DIGEST_LENGTH]).unwrap(),
+            H::Digest::try_from(&vec![0u8; size_of::<H::Digest>()]).unwrap(),
             "root hash should be non-zero"
         );
         assert_ne!(out, empty_out, "root hash should differ from empty MMR");

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -104,7 +104,7 @@ impl<H: CHasher> Proof<H> {
 
     /// Return the maximum size in bytes of any serialized `Proof`.
     pub fn max_serialization_size() -> usize {
-        size_of::<u64>() + (u8::MAX as usize * H::DIGEST_LENGTH)
+        size_of::<u64>() + (u8::MAX as usize * size_of::<H::Digest>())
     }
 
     /// Canonically serializes the `Proof` as:
@@ -113,7 +113,7 @@ impl<H: CHasher> Proof<H> {
     ///    [8-...): raw bytes of each hash, each of length `H::len()`
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
-        let bytes_len = size_of::<u64>() + (self.hashes.len() * H::DIGEST_LENGTH);
+        let bytes_len = size_of::<u64>() + (self.hashes.len() * size_of::<H::Digest>());
         let mut bytes = Vec::with_capacity(bytes_len);
         bytes.put_u64(self.size);
 
@@ -141,13 +141,13 @@ impl<H: CHasher> Proof<H> {
 
         // A proof should divide neatly into the hash length and not contain more than 255 hashes.
         let buf_remaining = buf.remaining();
-        let hashes_len = buf_remaining / H::DIGEST_LENGTH;
-        if buf_remaining % H::DIGEST_LENGTH != 0 || hashes_len > u8::MAX as usize {
+        let hashes_len = buf_remaining / size_of::<H::Digest>();
+        if buf_remaining % size_of::<H::Digest>() != 0 || hashes_len > u8::MAX as usize {
             return None;
         }
         let mut hashes = Vec::with_capacity(hashes_len);
         for _ in 0..hashes_len {
-            let hash = buf.copy_to_bytes(H::DIGEST_LENGTH);
+            let hash = buf.copy_to_bytes(size_of::<H::Digest>());
             let hash = match H::Digest::try_from(&hash) {
                 Ok(hash) => hash,
                 Err(_) => return None,
@@ -235,6 +235,10 @@ mod tests {
 
     type Sha256Digest = <Sha256 as CHasher>::Digest;
 
+    fn test_digest(v: u8) -> Sha256Digest {
+        Sha256Digest::from([v; size_of::<Sha256Digest>()])
+    }
+
     #[test]
     fn test_verify_element() {
         // create an 11 element MMR over which we'll test single-element inclusion proofs
@@ -273,21 +277,16 @@ mod tests {
             "proof verification should fail with incorrect element position 2"
         );
         assert!(
-            !proof.verify_element_inclusion(
-                &mut hasher,
-                &Sha256Digest::from([0u8; Sha256::DIGEST_LENGTH]),
-                POS,
-                &root_hash,
-            ),
+            !proof.verify_element_inclusion(&mut hasher, &test_digest(0), POS, &root_hash,),
             "proof verification should fail with mangled element"
         );
-        let root_hash2 = Sha256Digest::from([0u8; Sha256::DIGEST_LENGTH]);
+        let root_hash2 = test_digest(0);
         assert!(
             !proof.verify_element_inclusion(&mut hasher, &element, POS, &root_hash2),
             "proof verification should fail with mangled root_hash"
         );
         let mut proof2 = proof.clone();
-        proof2.hashes[0] = Sha256Digest::from([0u8; Sha256::DIGEST_LENGTH]);
+        proof2.hashes[0] = test_digest(0);
         assert!(
             !proof2.verify_element_inclusion(&mut hasher, &element, POS, &root_hash),
             "proof verification should fail with mangled proof hash"
@@ -299,9 +298,7 @@ mod tests {
             "proof verification should fail with incorrect size"
         );
         proof2 = proof.clone();
-        proof2
-            .hashes
-            .push(Sha256Digest::from([0u8; Sha256::DIGEST_LENGTH]));
+        proof2.hashes.push(test_digest(0));
         assert!(
             !proof2.verify_element_inclusion(&mut hasher, &element, POS, &root_hash),
             "proof verification should fail with extra hash"
@@ -321,9 +318,7 @@ mod tests {
             .hashes
             .extend(proof.hashes[0..PEAK_COUNT - 1].iter().cloned());
         // sneak in an extra hash that won't be used in the computation and make sure it's detected
-        proof2
-            .hashes
-            .push(Sha256Digest::from([0u8; Sha256::DIGEST_LENGTH]));
+        proof2.hashes.push(test_digest(0));
         proof2
             .hashes
             .extend(proof.hashes[PEAK_COUNT - 1..].iter().cloned());
@@ -340,7 +335,7 @@ mod tests {
         let mut elements = Vec::<Sha256Digest>::new();
         let mut element_positions = Vec::<u64>::new();
         for i in 0..49 {
-            elements.push(Sha256Digest::from([i as u8; Sha256::DIGEST_LENGTH]));
+            elements.push(test_digest(i));
             element_positions.push(mmr.add(elements.last().unwrap()));
         }
         // test range proofs over all possible ranges of at least 2 elements
@@ -416,7 +411,7 @@ mod tests {
             }
         }
         // confirm proof fails with invalid root hash
-        let mut invalid_root_hash = vec![0; Sha256::DIGEST_LENGTH];
+        let mut invalid_root_hash = test_digest(0);
         invalid_root_hash[29] = root_hash.as_ref()[29] + 1;
         assert!(
             !range_proof.verify_range_inclusion(
@@ -424,13 +419,13 @@ mod tests {
                 valid_elements,
                 start_pos,
                 end_pos,
-                &Sha256Digest::try_from(&invalid_root_hash).unwrap(),
+                &invalid_root_hash,
             ),
             "range proof with invalid root hash should fail"
         );
         // mangle the proof and confirm it fails
         let mut invalid_proof = range_proof.clone();
-        invalid_proof.hashes[1] = Sha256Digest::from([0u8; Sha256::DIGEST_LENGTH]);
+        invalid_proof.hashes[1] = test_digest(0);
         assert!(
             !invalid_proof.verify_range_inclusion(
                 &mut hasher,
@@ -444,9 +439,7 @@ mod tests {
         // inserting elements into the proof should also cause it to fail (malleability check)
         for i in 0..range_proof.hashes.len() {
             let mut invalid_proof = range_proof.clone();
-            invalid_proof
-                .hashes
-                .insert(i, Sha256Digest::from([0u8; Sha256::DIGEST_LENGTH]));
+            invalid_proof.hashes.insert(i, test_digest(0));
             assert!(
                 !invalid_proof.verify_range_inclusion(
                     &mut hasher,
@@ -505,7 +498,7 @@ mod tests {
         let mut elements = Vec::<Sha256Digest>::new();
         let mut element_positions = Vec::<u64>::new();
         for i in 0..49 {
-            elements.push(Sha256Digest::from([i as u8; Sha256::DIGEST_LENGTH]));
+            elements.push(test_digest(i));
             element_positions.push(mmr.add(elements.last().unwrap()));
         }
 
@@ -544,7 +537,7 @@ mod tests {
 
         // add a few more nodes, forget again, and test again to make sure repeated forgetting works
         for i in 0..37 {
-            elements.push(Sha256Digest::from([i as u8; Sha256::DIGEST_LENGTH]));
+            elements.push(test_digest(i));
             element_positions.push(mmr.add(elements.last().unwrap()));
         }
         let updated_root_hash = mmr.root_hash();
@@ -584,7 +577,7 @@ mod tests {
         let mut elements = Vec::<Sha256Digest>::new();
         let mut element_positions = Vec::<u64>::new();
         for i in 0..25 {
-            elements.push(Sha256Digest::from([i as u8; Sha256::DIGEST_LENGTH]));
+            elements.push(test_digest(i));
             element_positions.push(mmr.add(elements.last().unwrap()));
         }
         // Generate proofs over all possible ranges of elements and confirm each

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -231,19 +231,17 @@ fn peak_hash_from_range<'a, H: CHasher>(
 mod tests {
     use super::Proof;
     use crate::mmr::mem::Mmr;
-    use commonware_cryptography::{Hasher as CHasher, Sha256};
+    use commonware_cryptography::{sha256::Digest, Sha256};
 
-    type Sha256Digest = <Sha256 as CHasher>::Digest;
-
-    fn test_digest(v: u8) -> Sha256Digest {
-        Sha256Digest::from([v; size_of::<Sha256Digest>()])
+    fn test_digest(v: u8) -> Digest {
+        Digest::from([v; size_of::<Digest>()])
     }
 
     #[test]
     fn test_verify_element() {
         // create an 11 element MMR over which we'll test single-element inclusion proofs
         let mut mmr = Mmr::<Sha256>::new();
-        let element = Sha256Digest::from(*b"01234567012345670123456701234567");
+        let element = Digest::from(*b"01234567012345670123456701234567");
         let mut leaves: Vec<u64> = Vec::new();
         for _ in 0..11 {
             leaves.push(mmr.add(&element));
@@ -332,7 +330,7 @@ mod tests {
     fn test_verify_range() {
         // create a new MMR and add a non-trivial amount (49) of elements
         let mut mmr: Mmr<Sha256> = Mmr::default();
-        let mut elements = Vec::<Sha256Digest>::new();
+        let mut elements = Vec::<Digest>::new();
         let mut element_positions = Vec::<u64>::new();
         for i in 0..49 {
             elements.push(test_digest(i));
@@ -495,7 +493,7 @@ mod tests {
     fn test_range_proofs_after_forgetting() {
         // create a new MMR and add a non-trivial amount (49) of elements
         let mut mmr: Mmr<Sha256> = Mmr::default();
-        let mut elements = Vec::<Sha256Digest>::new();
+        let mut elements = Vec::<Digest>::new();
         let mut element_positions = Vec::<u64>::new();
         for i in 0..49 {
             elements.push(test_digest(i));
@@ -574,7 +572,7 @@ mod tests {
         );
         // create a new MMR and add a non-trivial amount of elements
         let mut mmr: Mmr<Sha256> = Mmr::default();
-        let mut elements = Vec::<Sha256Digest>::new();
+        let mut elements = Vec::<Digest>::new();
         let mut element_positions = Vec::<u64>::new();
         for i in 0..25 {
             elements.push(test_digest(i));


### PR DESCRIPTION
To simplify the `Hasher` trait, we add `Sized` to `Digest` instead of using the const `DIGEST_LENGTH`. This doesn't impact whether or not the length is known at compile-time.