### PR TITLE
Improve Grammatical Accuracy in Comments

### DIFF
--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -7,7 +7,7 @@
 //! by both index and key (truncated representation using a caller-provided `Translator`) to
 //! enable **single-read lookups** for both query patterns over all archived data.
 //!
-//! _Notably, `Archive` does not make use of compaction nor on-disk indexes (and thus has no read nor
+//! _Notably, `Archive` does not make use of compaction or on-disk indexes (and thus has no read nor
 //! write amplification during normal operation)._
 //!
 //! # Format

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -7,7 +7,7 @@
 //! by both index and key (truncated representation using a caller-provided `Translator`) to
 //! enable **single-read lookups** for both query patterns over all archived data.
 //!
-//! _Notably, `Archive` does not make use of compaction or on-disk indexes (and thus has no read nor
+//! _Notably, `Archive` does not make use of compaction or on-disk indexes (and thus has no read or
 //! write amplification during normal operation)._
 //!
 //! # Format

--- a/storage/src/mmr/hasher.rs
+++ b/storage/src/mmr/hasher.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::Hasher as CHasher;
 
-/// Hasher decorator the MMR uses for computing leaf, node and root hashes.
+/// Hasher decorator that the MMR uses for computing leaf, node and root hashes.
 pub(crate) struct Hasher<'a, H: CHasher> {
     hasher: &'a mut H,
 }


### PR DESCRIPTION
File: storage/src/archive/mod.rs
Old Text: _Notably, \Archive\ does not make use of compaction nor on-disk indexes (and thus has no read or
New Text: _Notably, \Archive\ does not make use of compaction or on-disk indexes (and thus has no read or
Reason: Changed "nor" to "or" for grammatical correctness.
2. File: storage/src/mmr/hasher.rs
Old Text: /// Hasher decorator the MMR uses for computing leaf, node and root hashes.
New Text: /// Hasher decorator that the MMR uses for computing leaf, node and root hashes.
Reason: Added "that" for clarity and grammatical accuracy.