### PR TITLE
fix: Rename test function to correct name

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -133,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn repltest_from_hex_formatted() {
+    fn test_from_hex_formatted() {
         // Test case 0: empty bytes
         let b = &[];
         let h = hex(b);


### PR DESCRIPTION
Rename `repltest_from_hex_formatted` to `test_from_hex_formatted` to follow consistent test naming convention