### PR TITLE
Standardize SHA-256 and MMR Documentation

### DIFF
--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 
 const DIGEST_LENGTH: usize = 32;
 
-/// Generate a SHA-256 digest from a message.
+/// Generate an SHA-256 digest from a message.
 pub fn hash(message: &[u8]) -> Digest {
     let array: [u8; DIGEST_LENGTH] = ISha256::digest(message).into();
     Digest::from(array)
@@ -62,7 +62,7 @@ impl Hasher for Sha256 {
     }
 }
 
-/// Digest of a SHA-256 hashing operation.
+/// Digest of an SHA-256 hashing operation.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct Digest([u8; DIGEST_LENGTH]);

--- a/storage/src/mmr/iterator.rs
+++ b/storage/src/mmr/iterator.rs
@@ -13,7 +13,7 @@ pub(crate) struct PeakIterator {
 }
 
 impl PeakIterator {
-    /// Return a new PeakIterator over the peaks of a MMR with the given number of nodes.
+    /// Return a new PeakIterator over the peaks of an MMR with the given number of nodes.
     pub(crate) fn new(size: u64) -> PeakIterator {
         if size == 0 {
             return PeakIterator::default();


### PR DESCRIPTION
### Changes:
- **Refined SHA-256 documentation in `mod.rs`**:
  - Updated `"Generate a SHA-256 digest"` → `"Generate an SHA-256 digest"` for grammatical correctness.
  - Corrected `"Digest of a SHA-256 hashing operation"` → `"Digest of an SHA-256 hashing operation"`.

- **Improved documentation for MMR iterator in `iterator.rs`**:
  - Updated `"Return a new PeakIterator over the peaks of a MMR"` → `"Return a new PeakIterator over the peaks of an MMR"` for improved readability and accuracy.

