### PR TITLE
[consensus] Explore Using Prost Type Attributes to Reduce Parsing Logic

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -117,16 +117,17 @@ cfg_if::cfg_if! {
         pub trait Supervisor: Clone + Send + 'static {
             /// Index is the type used to indicate the in-progress consensus decision.
             type Index;
+            type PublicKey: PublicKey;
 
             /// Return the leader at a given index for the provided seed.
-            fn leader(&self, index: Self::Index) -> Option<PublicKey>;
+            fn leader(&self, index: Self::Index) -> Option<Self::PublicKey>;
 
             /// Get the **sorted** participants for the given view. This is called when entering a new view before
             /// listening for proposals or votes. If nothing is returned, the view will not be entered.
-            fn participants(&self, index: Self::Index) -> Option<&Vec<PublicKey>>;
+            fn participants(&self, index: Self::Index) -> Option<&Vec<Self::PublicKey>>;
 
             // Indicate whether some candidate is a participant at the given view.
-            fn is_participant(&self, index: Self::Index, candidate: &PublicKey) -> Option<u32>;
+            fn is_participant(&self, index: Self::Index, candidate: &Self::PublicKey) -> Option<u32>;
 
             /// Report some activity observed by the consensus implementation.
             fn report(&self, activity: Activity, proof: Proof) -> impl Future<Output = ()> + Send;
@@ -149,8 +150,9 @@ cfg_if::cfg_if! {
             /// against `Identity`.
             type Share;
 
+
             /// Return the leader at a given index over the provided seed.
-            fn leader(&self, index: Self::Index, seed: Self::Seed) -> Option<PublicKey>;
+            fn leader(&self, index: Self::Index, seed: Self::Seed) -> Option<Self::PublicKey>;
 
             /// Returns the identity (typically a group polynomial with a fixed constant factor)
             /// at the given index. This is used to verify partial signatures from participants

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -7,7 +7,7 @@ use crate::{
         actors::voter,
         encoder::{notarize_namespace, nullify_namespace},
         verifier::{verify_notarization, verify_nullification},
-        wire::{self, Request},
+        wire::{self},
         View,
     },
     Parsed, Supervisor,
@@ -280,7 +280,7 @@ impl<
 
                 // Try to send
                 if sender
-                    .send(Recipients::One(recipient.clone()), encoded, false)
+                    .send(Recipients::One(recipient), encoded, false)
                     .await
                     .unwrap()
                     .is_empty()
@@ -461,7 +461,7 @@ impl<
                             // Ensure too many notarizations/nullifications aren't requested
                             if request.notarizations.len() + request.nullifications.len() > self.max_fetch_count {
                                 warn!(sender = hex(&s), "request too large");
-                                self.requester.block(s.clone());
+                                self.requester.block(s);
                                 continue;
                             }
 
@@ -509,7 +509,7 @@ impl<
                             .encode_to_vec()
                             .into();
                             sender
-                                .send(Recipients::One(s.clone()), response, false)
+                                .send(Recipients::One(s), response, false)
                                 .await
                                 .unwrap();
                         },
@@ -540,14 +540,14 @@ impl<
                                     Some(proposal) => proposal,
                                     None => {
                                         warn!(sender = hex(&s), "missing proposal");
-                                        self.requester.block(s.clone());
+                                        self.requester.block(s);
                                         continue;
                                     },
                                 };
                                 let view = proposal.view;
                                 let Ok(payload) = D::try_from(&proposal.payload) else {
                                     warn!(view, sender = hex(&s), "invalid proposal");
-                                    self.requester.block(s.clone());
+                                    self.requester.block(s);
                                     continue;
                                 };
                                 let entry = Entry { task: Task::Notarization, view };
@@ -557,7 +557,7 @@ impl<
                                 }
                                 if !verify_notarization::<S,C,D>(&self.supervisor, &self.notarize_namespace, &notarization) {
                                     warn!(view, sender = hex(&s), "invalid notarization");
-                                    self.requester.block(s.clone());
+                                    self.requester.block(s);
                                     continue;
                                 }
                                 self.required.remove(&entry);
@@ -579,7 +579,7 @@ impl<
                                 }
                                 if !verify_nullification::<S,C>(&self.supervisor, &self.nullify_namespace, &nullification) {
                                     warn!(view, sender = hex(&s), "invalid nullification");
-                                    self.requester.block(s.clone());
+                                    self.requester.block(s);
                                     continue;
                                 }
                                 self.required.remove(&entry);

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -15,7 +15,7 @@ use crate::{
     Automaton, Committer, Parsed, Relay, Supervisor,
 };
 use commonware_cryptography::{
-    sha256::hash, sha256::Digest as Sha256Digest, Digest, PublicKey, Scheme,
+    sha256::hash, sha256::Digest as Sha256Digest, Digest, Scheme,
 };
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
@@ -1100,7 +1100,7 @@ impl<
         info!(view, "entered view");
 
         // Check if we should fast exit this view
-        let leader = round.leader.clone();
+        let leader = round.leader;
         if view < self.activity_timeout || leader == self.crypto.public_key() {
             // Don't fast exit the view
             return;
@@ -2101,13 +2101,12 @@ impl<
                         let proposal = notarize.proposal.as_ref().unwrap().clone();
                         let payload = D::try_from(&proposal.payload).unwrap();
                         let public_key = notarize.signature.as_ref().unwrap().public_key;
-                        let public_key = self
+                        let public_key = *self
                             .supervisor
                             .participants(proposal.view)
                             .unwrap()
                             .get(public_key as usize)
-                            .unwrap()
-                            .clone();
+                            .unwrap();
                         self.handle_notarize(
                             &public_key,
                             Parsed {
@@ -2139,13 +2138,12 @@ impl<
                         // Handle nullify
                         let view = nullify.view;
                         let public_key = nullify.signature.as_ref().unwrap().public_key;
-                        let public_key = self
+                        let public_key = *self
                             .supervisor
                             .participants(view)
                             .unwrap()
                             .get(public_key as usize)
-                            .unwrap()
-                            .clone();
+                            .unwrap();
                         self.handle_nullify(&public_key, nullify).await;
 
                         // Update round info
@@ -2161,13 +2159,12 @@ impl<
                         let view = proposal.view;
                         let payload = D::try_from(&proposal.payload).unwrap();
                         let public_key = finalize.signature.as_ref().unwrap().public_key;
-                        let public_key = self
+                        let public_key = *self
                             .supervisor
                             .participants(view)
                             .unwrap()
                             .get(public_key as usize)
-                            .unwrap()
-                            .clone();
+                            .unwrap();
                         self.handle_finalize(
                             &public_key,
                             Parsed {

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -50,7 +50,7 @@ struct Round<C: Scheme, D: Digest, S: Supervisor<Index = View>> {
     _digest: PhantomData<D>,
 
     view: View,
-    leader: PublicKey,
+    leader: C::PublicKey,
     leader_deadline: Option<SystemTime>,
     advance_deadline: Option<SystemTime>,
     nullify_retry: Option<SystemTime>,
@@ -78,7 +78,7 @@ struct Round<C: Scheme, D: Digest, S: Supervisor<Index = View>> {
     broadcast_finalization: bool,
 }
 
-impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
+impl<C: Scheme, D: Digest, S: Supervisor<Index = View, PublicKey = C::PublicKey>> Round<C, D, S> {
     pub fn new(supervisor: S, view: View) -> Self {
         let leader = supervisor.leader(view).expect("unable to compute leader");
         Self {
@@ -114,7 +114,7 @@ impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
 
     async fn add_verified_notarize(
         &mut self,
-        public_key: &PublicKey,
+        public_key: &C::PublicKey,
         notarize: Parsed<wire::Notarize, D>,
     ) -> bool {
         // Get proposal
@@ -123,6 +123,19 @@ impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
         // Compute proposal digest
         let message = proposal_message(proposal.view, proposal.parent, &notarize.digest);
         let proposal_digest = hash(&message);
+
+        // Get Signature
+        let Ok(notarize_signature) = C::Signature::try_from(
+            notarize
+                .message
+                .signature
+                .as_ref()
+                .unwrap()
+                .signature
+                .as_ref(),
+        ) else {
+            return false;
+        };
 
         // Check if already notarized
         let public_key_index = notarize.message.signature.as_ref().unwrap().public_key;
@@ -145,20 +158,27 @@ impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
                 .get(&public_key_index)
                 .unwrap();
             let previous_proposal = previous_notarize.message.proposal.as_ref().unwrap();
+            let Ok(previous_notarize_signature) = C::Signature::try_from(
+                previous_notarize
+                    .message
+                    .signature
+                    .as_ref()
+                    .unwrap()
+                    .signature
+                    .as_ref(),
+            ) else {
+                return false;
+            };
+
             let proof = Prover::<C, D>::serialize_conflicting_notarize(
                 self.view,
                 public_key,
                 previous_proposal.parent,
                 &previous_notarize.digest,
-                &previous_notarize
-                    .message
-                    .signature
-                    .as_ref()
-                    .unwrap()
-                    .signature,
+                &previous_notarize_signature,
                 proposal.parent,
                 &notarize.digest,
-                &notarize.message.signature.as_ref().unwrap().signature,
+                &notarize_signature,
             );
             self.supervisor.report(CONFLICTING_NOTARIZE, proof).await;
             warn!(
@@ -179,8 +199,7 @@ impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
             return false;
         }
         let entry = self.notarizes.entry(proposal_digest).or_default();
-        let signature = &notarize.message.signature.as_ref().unwrap().signature;
-        let proof = Prover::<C, D>::serialize_proposal(proposal, public_key, signature);
+        let proof = Prover::<C, D>::serialize_proposal(proposal, public_key, &notarize_signature);
         entry.insert(public_key_index, notarize);
         self.supervisor.report(NOTARIZE, proof).await;
         true
@@ -188,7 +207,7 @@ impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
 
     async fn add_verified_nullify(
         &mut self,
-        public_key: &PublicKey,
+        public_key: &C::PublicKey,
         nullify: wire::Nullify,
     ) -> bool {
         // Check if already issued finalize
@@ -207,14 +226,32 @@ impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
             .unwrap()
             .get(&public_key_index)
             .unwrap();
+        let Ok(finalize_signature) = C::Signature::try_from(
+            finalize
+                .message
+                .signature
+                .as_ref()
+                .unwrap()
+                .signature
+                .as_ref(),
+        ) else {
+            return false;
+        };
+
+        let Ok(nullify_signature) =
+            C::Signature::try_from(nullify.signature.as_ref().unwrap().signature.as_ref())
+        else {
+            return false;
+        };
+
         let finalize_proposal = finalize.message.proposal.as_ref().unwrap();
         let proof = Prover::<C, D>::serialize_nullify_finalize(
             self.view,
             public_key,
             finalize_proposal.parent,
             &finalize.digest,
-            &finalize.message.signature.as_ref().unwrap().signature,
-            &nullify.signature.as_ref().unwrap().signature,
+            &finalize_signature,
+            &nullify_signature,
         );
         self.supervisor.report(NULLIFY_AND_FINALIZE, proof).await;
         warn!(
@@ -273,22 +310,39 @@ impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
 
     async fn add_verified_finalize(
         &mut self,
-        public_key: &PublicKey,
+        public_key: &C::PublicKey,
         finalize: Parsed<wire::Finalize, D>,
     ) -> bool {
         // Check if also issued nullify
         let proposal = finalize.message.proposal.as_ref().unwrap();
         let public_key_index = finalize.message.signature.as_ref().unwrap().public_key;
+        let Ok(finalize_signature) = C::Signature::try_from(
+            finalize
+                .message
+                .signature
+                .as_ref()
+                .unwrap()
+                .signature
+                .as_ref(),
+        ) else {
+            return false;
+        };
+
         let null = self.nullifies.get(&public_key_index);
         if let Some(null) = null {
+            let Ok(null_signature) =
+                C::Signature::try_from(null.signature.as_ref().unwrap().signature.as_ref())
+            else {
+                return false;
+            };
             // Create fault
             let proof = Prover::<C, D>::serialize_nullify_finalize(
                 self.view,
                 public_key,
                 proposal.parent,
                 &finalize.digest,
-                &finalize.message.signature.as_ref().unwrap().signature,
-                &null.signature.as_ref().unwrap().signature,
+                &finalize_signature,
+                &null_signature,
             );
             self.supervisor.report(NULLIFY_AND_FINALIZE, proof).await;
             warn!(
@@ -323,20 +377,26 @@ impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
                 .get(&public_key_index)
                 .unwrap();
             let previous_proposal = previous_finalize.message.proposal.as_ref().unwrap();
+            let Ok(previous_finalize_signature) = C::Signature::try_from(
+                previous_finalize
+                    .message
+                    .signature
+                    .as_ref()
+                    .unwrap()
+                    .signature
+                    .as_ref(),
+            ) else {
+                return false;
+            };
             let proof = Prover::<C, D>::serialize_conflicting_finalize(
                 self.view,
                 public_key,
                 previous_proposal.parent,
                 &previous_finalize.digest,
-                &previous_finalize
-                    .message
-                    .signature
-                    .as_ref()
-                    .unwrap()
-                    .signature,
+                &previous_finalize_signature,
                 proposal.parent,
                 &finalize.digest,
-                &finalize.message.signature.as_ref().unwrap().signature,
+                &finalize_signature,
             );
             self.supervisor.report(CONFLICTING_FINALIZE, proof).await;
             warn!(
@@ -357,8 +417,7 @@ impl<C: Scheme, D: Digest, S: Supervisor<Index = View>> Round<C, D, S> {
             return false;
         }
         let entry = self.finalizes.entry(proposal_digest).or_default();
-        let signature = &finalize.message.signature.as_ref().unwrap().signature;
-        let proof = Prover::<C, D>::serialize_proposal(proposal, public_key, signature);
+        let proof = Prover::<C, D>::serialize_proposal(proposal, public_key, &finalize_signature);
         entry.insert(public_key_index, finalize);
         self.supervisor.report(FINALIZE, proof).await;
         true
@@ -430,7 +489,7 @@ pub struct Actor<
     A: Automaton<Context = Context<D>, Digest = D>,
     R: Relay<Digest = D>,
     F: Committer<Digest = D>,
-    S: Supervisor<Index = View>,
+    S: Supervisor<Index = View, PublicKey = C::PublicKey>,
 > {
     runtime: E,
     crypto: C,
@@ -473,7 +532,7 @@ impl<
         A: Automaton<Context = Context<D>, Digest = D>,
         R: Relay<Digest = D>,
         F: Committer<Digest = D>,
-        S: Supervisor<Index = View>,
+        S: Supervisor<Index = View, PublicKey = C::PublicKey>,
     > Actor<B, E, C, D, A, R, F, S>
 {
     pub fn new(
@@ -760,7 +819,10 @@ impl<
             view: self.view,
             signature: Some(wire::Signature {
                 public_key: public_key_index,
-                signature: self.crypto.sign(Some(&self.nullify_namespace), &message),
+                signature: self
+                    .crypto
+                    .sign(Some(&self.nullify_namespace), &message)
+                    .into(),
             }),
         };
 
@@ -812,11 +874,14 @@ impl<
 
         // Verify the signature
         let nullify_message = nullify_message(nullify.view);
+        let Ok(sig) = C::Signature::try_from(signature.signature.as_ref()) else {
+            return;
+        };
         if !C::verify(
             Some(&self.nullify_namespace),
             &nullify_message,
             &public_key,
-            &signature.signature,
+            &sig,
         ) {
             return;
         }
@@ -825,7 +890,7 @@ impl<
         self.handle_nullify(&public_key, nullify).await;
     }
 
-    async fn handle_nullify(&mut self, public_key: &PublicKey, nullify: wire::Nullify) {
+    async fn handle_nullify(&mut self, public_key: &C::PublicKey, nullify: wire::Nullify) {
         // Check to see if nullify is for proposal in view
         let view = nullify.view;
         let round = self
@@ -1150,13 +1215,16 @@ impl<
             return;
         };
 
+        let Ok(sig) = C::Signature::try_from(signature.signature.as_ref()) else {
+            return;
+        };
         // Verify the signature
         let notarize_message = proposal_message(proposal.view, proposal.parent, &payload);
         if !C::verify(
             Some(&self.notarize_namespace),
             &notarize_message,
             &public_key,
-            &signature.signature,
+            &sig,
         ) {
             return;
         }
@@ -1174,7 +1242,7 @@ impl<
 
     async fn handle_notarize(
         &mut self,
-        public_key: &PublicKey,
+        public_key: &C::PublicKey,
         notarize: Parsed<wire::Notarize, D>,
     ) {
         // Check to see if notarize is for proposal in view
@@ -1400,13 +1468,16 @@ impl<
             return;
         };
 
+        let Ok(sig) = C::Signature::try_from(signature.signature.as_ref()) else {
+            return;
+        };
         // Verify the signature
         let finalize_message = proposal_message(proposal.view, proposal.parent, &payload);
         if !C::verify(
             Some(&self.finalize_namespace),
             &finalize_message,
             &public_key,
-            &signature.signature,
+            &sig,
         ) {
             return;
         }
@@ -1424,7 +1495,7 @@ impl<
 
     async fn handle_finalize(
         &mut self,
-        public_key: &PublicKey,
+        public_key: &C::PublicKey,
         finalize: Parsed<wire::Finalize, D>,
     ) {
         // Get view for finalize
@@ -1590,7 +1661,10 @@ impl<
                 proposal: Some(proposal.message.clone()),
                 signature: Some(wire::Signature {
                     public_key,
-                    signature: self.crypto.sign(Some(&self.notarize_namespace), &message),
+                    signature: self
+                        .crypto
+                        .sign(Some(&self.notarize_namespace), &message)
+                        .into(),
                 }),
             },
             digest: proposal.digest.clone(),
@@ -1707,7 +1781,10 @@ impl<
                 proposal: Some(proposal.message.clone()),
                 signature: Some(wire::Signature {
                     public_key,
-                    signature: self.crypto.sign(Some(&self.finalize_namespace), &message),
+                    signature: self
+                        .crypto
+                        .sign(Some(&self.finalize_namespace), &message)
+                        .into(),
                 }),
             },
             digest: proposal.digest.clone(),
@@ -1810,9 +1887,14 @@ impl<
             let mut signatures = Vec::with_capacity(notarization.message.signatures.len());
             for signature in &notarization.message.signatures {
                 let public_key = validators.get(signature.public_key as usize).unwrap();
-                signatures.push((public_key, &signature.signature));
+                // TODO : manage error.
+                let signature = C::Signature::try_from(signature.signature.as_ref()).unwrap();
+                signatures.push((public_key, signature));
             }
-            let proof = Prover::<C, D>::serialize_aggregation(proposal, signatures);
+            let proof = Prover::<C, D>::serialize_aggregation(
+                proposal,
+                signatures.iter().map(|(pk, sig)| (*pk, sig)).collect(),
+            );
             self.committer.prepared(proof, notarization.digest).await;
 
             // Broadcast the notarization
@@ -1960,9 +2042,14 @@ impl<
             let mut signatures = Vec::with_capacity(finalization.message.signatures.len());
             for signature in &finalization.message.signatures {
                 let public_key = validators.get(signature.public_key as usize).unwrap();
-                signatures.push((public_key, &signature.signature));
+                // TODO: manage error.
+                let signature = C::Signature::try_from(signature.signature.as_ref()).unwrap();
+                signatures.push((public_key, signature));
             }
-            let proof = Prover::<C, D>::serialize_aggregation(proposal, signatures);
+            let proof = Prover::<C, D>::serialize_aggregation(
+                proposal,
+                signatures.iter().map(|(pk, sig)| (*pk, sig)).collect(),
+            );
             self.committer.finalized(proof, finalization.digest).await;
 
             // Broadcast the finalization

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -22,7 +22,7 @@ pub struct Engine<
     A: Automaton<Context = Context<D>, Digest = D>,
     R: Relay<Digest = D>,
     F: Committer<Digest = D>,
-    S: Supervisor<Index = View>,
+    S: Supervisor<Index = View, PublicKey = C::PublicKey>,
 > {
     runtime: E,
 
@@ -40,7 +40,7 @@ impl<
         A: Automaton<Context = Context<D>, Digest = D>,
         R: Relay<Digest = D>,
         F: Committer<Digest = D>,
-        S: Supervisor<Index = View>,
+        S: Supervisor<Index = View, PublicKey = C::PublicKey>,
     > Engine<B, E, C, D, A, R, F, S>
 {
     /// Create a new `simplex` consensus engine.
@@ -103,8 +103,14 @@ impl<
     /// This will also rebuild the state of the engine from provided `Journal`.
     pub async fn run(
         self,
-        voter_network: (impl Sender, impl Receiver),
-        resolver_network: (impl Sender, impl Receiver),
+        voter_network: (
+            impl Sender<PublicKey = C::PublicKey>,
+            impl Receiver<PublicKey = C::PublicKey>,
+        ),
+        resolver_network: (
+            impl Sender<PublicKey = C::PublicKey>,
+            impl Receiver<PublicKey = C::PublicKey>,
+        ),
     ) {
         // Start the voter
         let (voter_sender, voter_receiver) = voter_network;

--- a/consensus/src/simplex/metrics.rs
+++ b/consensus/src/simplex/metrics.rs
@@ -45,42 +45,42 @@ pub struct PeerMessage {
 }
 
 impl PeerMessage {
-    pub fn notarize(peer: &PublicKey) -> Self {
+    pub fn notarize<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: NOTARIZE_TYPE,
         }
     }
 
-    pub fn notarization(peer: &PublicKey) -> Self {
+    pub fn notarization<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: NOTARIZATION_TYPE,
         }
     }
 
-    pub fn nullify(peer: &PublicKey) -> Self {
+    pub fn nullify<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: NULLIFY_TYPE,
         }
     }
 
-    pub fn nullification(peer: &PublicKey) -> Self {
+    pub fn nullification<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: NULLIFICATION_TYPE,
         }
     }
 
-    pub fn finalize(peer: &PublicKey) -> Self {
+    pub fn finalize<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: FINALIZE_TYPE,
         }
     }
 
-    pub fn finalization(peer: &PublicKey) -> Self {
+    pub fn finalization<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: FINALIZATION_TYPE,

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -174,7 +174,7 @@ pub struct Application<E: Clock + RngCore, H: Hasher, P: PublicKey> {
 impl<E: Clock + RngCore, H: Hasher, P: PublicKey> Application<E, H, P> {
     pub fn new(runtime: E, cfg: Config<H, P>) -> (Self, Mailbox<H::Digest>) {
         // Register self on relay
-        let broadcast = cfg.relay.register(cfg.participant.clone());
+        let broadcast = cfg.relay.register(cfg.participant);
 
         // Generate samplers
         let propose_latency = Normal::new(cfg.propose_latency.0, cfg.propose_latency.1).unwrap();
@@ -298,7 +298,7 @@ impl<E: Clock + RngCore, H: Hasher, P: PublicKey> Application<E, H, P> {
         let _ = self
             .tracker
             .send((
-                self.participant.clone(),
+                self.participant,
                 Progress::Notarized(proof, payload),
             ))
             .await;
@@ -311,7 +311,7 @@ impl<E: Clock + RngCore, H: Hasher, P: PublicKey> Application<E, H, P> {
         let _ = self
             .tracker
             .send((
-                self.participant.clone(),
+                self.participant,
                 Progress::Finalized(proof, payload),
             ))
             .await;

--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -26,7 +26,7 @@ pub struct Conflicter<
     E: Clock + Rng + CryptoRng + Spawner,
     C: Scheme,
     H: Hasher,
-    S: Supervisor<Index = View>,
+    S: Supervisor<Index = View, PublicKey = C::PublicKey>,
 > {
     runtime: E,
     crypto: C,
@@ -37,8 +37,12 @@ pub struct Conflicter<
     finalize_namespace: Vec<u8>,
 }
 
-impl<E: Clock + Rng + CryptoRng + Spawner, C: Scheme, H: Hasher, S: Supervisor<Index = View>>
-    Conflicter<E, C, H, S>
+impl<
+        E: Clock + Rng + CryptoRng + Spawner,
+        C: Scheme,
+        H: Hasher,
+        S: Supervisor<Index = View, PublicKey = C::PublicKey>,
+    > Conflicter<E, C, H, S>
 {
     pub fn new(runtime: E, cfg: Config<C, S>) -> Self {
         Self {
@@ -103,7 +107,10 @@ impl<E: Clock + Rng + CryptoRng + Spawner, C: Scheme, H: Hasher, S: Supervisor<I
                         proposal: Some(proposal),
                         signature: Some(wire::Signature {
                             public_key: public_key_index,
-                            signature: self.crypto.sign(Some(&self.notarize_namespace), &msg),
+                            signature: self
+                                .crypto
+                                .sign(Some(&self.notarize_namespace), &msg)
+                                .into(),
                         }),
                     };
                     let msg = wire::Voter {
@@ -126,7 +133,10 @@ impl<E: Clock + Rng + CryptoRng + Spawner, C: Scheme, H: Hasher, S: Supervisor<I
                         }),
                         signature: Some(wire::Signature {
                             public_key: public_key_index,
-                            signature: self.crypto.sign(Some(&self.notarize_namespace), &msg),
+                            signature: self
+                                .crypto
+                                .sign(Some(&self.notarize_namespace), &msg)
+                                .into(),
                         }),
                     };
                     let msg = wire::Voter {
@@ -164,7 +174,10 @@ impl<E: Clock + Rng + CryptoRng + Spawner, C: Scheme, H: Hasher, S: Supervisor<I
                         proposal: Some(proposal),
                         signature: Some(wire::Signature {
                             public_key: public_key_index,
-                            signature: self.crypto.sign(Some(&self.finalize_namespace), &msg),
+                            signature: self
+                                .crypto
+                                .sign(Some(&self.finalize_namespace), &msg)
+                                .into(),
                         }),
                     };
                     let msg = wire::Voter {
@@ -187,7 +200,10 @@ impl<E: Clock + Rng + CryptoRng + Spawner, C: Scheme, H: Hasher, S: Supervisor<I
                         }),
                         signature: Some(wire::Signature {
                             public_key: public_key_index,
-                            signature: self.crypto.sign(Some(&self.finalize_namespace), &msg),
+                            signature: self
+                                .crypto
+                                .sign(Some(&self.finalize_namespace), &msg)
+                                .into(),
                         }),
                     };
                     let msg = wire::Voter {

--- a/consensus/src/simplex/mocks/relay.rs
+++ b/consensus/src/simplex/mocks/relay.rs
@@ -4,18 +4,18 @@ use futures::{channel::mpsc, SinkExt};
 use std::{collections::BTreeMap, sync::Mutex};
 
 /// Relay is a mock for distributing artifacts between applications.
-pub struct Relay<D: Digest> {
-    recipients: Mutex<BTreeMap<PublicKey, mpsc::UnboundedSender<(D, Bytes)>>>,
+pub struct Relay<D: Digest, P: PublicKey> {
+    recipients: Mutex<BTreeMap<P, mpsc::UnboundedSender<(D, Bytes)>>>,
 }
 
-impl<D: Digest> Relay<D> {
+impl<D: Digest, P: PublicKey> Relay<D, P> {
     pub fn new() -> Self {
         Self {
             recipients: Mutex::new(BTreeMap::new()),
         }
     }
 
-    pub fn register(&self, public_key: PublicKey) -> mpsc::UnboundedReceiver<(D, Bytes)> {
+    pub fn register(&self, public_key: P) -> mpsc::UnboundedReceiver<(D, Bytes)> {
         let (sender, receiver) = mpsc::unbounded();
         if self
             .recipients
@@ -29,7 +29,7 @@ impl<D: Digest> Relay<D> {
         receiver
     }
 
-    pub async fn broadcast(&self, sender: &PublicKey, payload: (D, Bytes)) {
+    pub async fn broadcast(&self, sender: &P, payload: (D, Bytes)) {
         let channels = {
             let mut channels = Vec::new();
             let recipients = self.recipients.lock().unwrap();
@@ -50,7 +50,7 @@ impl<D: Digest> Relay<D> {
     }
 }
 
-impl<D: Digest> Default for Relay<D> {
+impl<D: Digest, P: PublicKey> Default for Relay<D, P> {
     fn default() -> Self {
         Self::new()
     }

--- a/consensus/src/simplex/mocks/supervisor.rs
+++ b/consensus/src/simplex/mocks/supervisor.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     Activity, Proof, Supervisor as Su,
 };
-use commonware_cryptography::{Digest, PublicKey, Scheme};
+use commonware_cryptography::{Digest, Scheme};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::{Arc, Mutex},

--- a/consensus/src/simplex/mocks/supervisor.rs
+++ b/consensus/src/simplex/mocks/supervisor.rs
@@ -16,8 +16,8 @@ pub struct Config<C: Scheme, D: Digest> {
     pub participants: BTreeMap<View, Vec<C::PublicKey>>,
 }
 
-type Participation<D, P: PublicKey> = HashMap<View, HashMap<D, HashSet<P>>>;
-type Faults<P: PublicKey> = HashMap<P, HashMap<View, HashSet<Activity>>>;
+type Participation<D, P> = HashMap<View, HashMap<D, HashSet<P>>>;
+type Faults<P> = HashMap<P, HashMap<View, HashSet<Activity>>>;
 
 #[derive(Clone)]
 pub struct Supervisor<C: Scheme, D: Digest> {
@@ -36,7 +36,7 @@ impl<C: Scheme, D: Digest> Supervisor<C, D> {
         for (view, mut validators) in cfg.participants.into_iter() {
             let mut map = HashMap::new();
             for (index, validator) in validators.iter().enumerate() {
-                map.insert(validator.clone(), index as u32);
+                map.insert(*validator, index as u32);
             }
             validators.sort();
             parsed_participants.insert(view, (map, validators));
@@ -62,7 +62,7 @@ impl<C: Scheme, D: Digest> Su for Supervisor<C, D> {
                 panic!("no participants in required range");
             }
         };
-        Some(closest.1[index as usize % closest.1.len()].clone())
+        Some(closest.1[index as usize % closest.1.len()])
     }
 
     fn participants(&self, index: Self::Index) -> Option<&Vec<Self::PublicKey>> {

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -205,10 +205,10 @@ mod tests {
     use tracing::debug;
 
     /// Registers all validators using the oracle.
-    async fn register_validators(
-        oracle: &mut Oracle,
-        validators: &[PublicKey],
-    ) -> HashMap<PublicKey, ((Sender, Receiver), (Sender, Receiver))> {
+    async fn register_validators<P: PublicKey>(
+        oracle: &mut Oracle<P>,
+        validators: &[P],
+    ) -> HashMap<P, ((Sender<P>, Receiver<P>), (Sender<P>, Receiver<P>))> {
         let mut registrations = HashMap::new();
         for validator in validators.iter() {
             let (voter_sender, voter_receiver) =
@@ -238,9 +238,9 @@ mod tests {
     /// The `action` parameter determines the action (e.g. link, unlink) to take.
     /// The `restrict_to` function can be used to restrict the linking to certain connections,
     /// otherwise all validators will be linked to all other validators.
-    async fn link_validators(
-        oracle: &mut Oracle,
-        validators: &[PublicKey],
+    async fn link_validators<P: PublicKey>(
+        oracle: &mut Oracle<P>,
+        validators: &[P],
         action: Action,
         restrict_to: Option<fn(usize, usize, usize) -> bool>,
     ) {

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -212,11 +212,11 @@ mod tests {
         let mut registrations = HashMap::new();
         for validator in validators.iter() {
             let (voter_sender, voter_receiver) =
-                oracle.register(validator.clone(), 0).await.unwrap();
+                oracle.register(*validator, 0).await.unwrap();
             let (resolver_sender, resolver_receiver) =
-                oracle.register(validator.clone(), 1).await.unwrap();
+                oracle.register(*validator, 1).await.unwrap();
             registrations.insert(
-                validator.clone(),
+                *validator,
                 (
                     (voter_sender, voter_receiver),
                     (resolver_sender, resolver_receiver),
@@ -261,7 +261,7 @@ mod tests {
                 // Do any unlinking first
                 match action {
                     Action::Update(_) | Action::Unlink => {
-                        oracle.remove_link(v1.clone(), v2.clone()).await.unwrap();
+                        oracle.remove_link(*v1, *v2).await.unwrap();
                     }
                     _ => {}
                 }
@@ -270,7 +270,7 @@ mod tests {
                 match action {
                     Action::Link(ref link) | Action::Update(ref link) => {
                         oracle
-                            .add_link(v1.clone(), v2.clone(), link.clone())
+                            .add_link(*v1, *v2, link.clone())
                             .await
                             .unwrap();
                     }
@@ -344,7 +344,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -567,11 +567,11 @@ mod tests {
                     };
                     let supervisor =
                         mocks::supervisor::Supervisor::<Ed25519, Sha256Digest>::new(supervisor_config);
-                    supervisors.insert(validator.clone(), supervisor.clone());
+                    supervisors.insert(validator, supervisor.clone());
                     let application_cfg = mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),
@@ -785,7 +785,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -920,7 +920,7 @@ mod tests {
             let application_cfg = mocks::application::Config {
                 hasher: Sha256::default(),
                 relay: relay.clone(),
-                participant: validator.clone(),
+                participant: validator,
                 tracker: done_sender.clone(),
                 propose_latency: (10.0, 5.0),
                 verify_latency: (10.0, 5.0),
@@ -1071,7 +1071,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -1246,7 +1246,7 @@ mod tests {
                     mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (3_000.0, 0.0),
                         verify_latency: (3_000.0, 5.0),
@@ -1255,7 +1255,7 @@ mod tests {
                     mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),
@@ -1430,7 +1430,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -1597,7 +1597,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -1821,7 +1821,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -2008,7 +2008,7 @@ mod tests {
                     let application_cfg = mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),
@@ -2193,7 +2193,7 @@ mod tests {
                     let application_cfg = mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),

--- a/consensus/src/simplex/prover.rs
+++ b/consensus/src/simplex/prover.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::Proof;
 use bytes::{Buf, BufMut};
-use commonware_cryptography::{Digest, PublicKey, Scheme, Signature};
+use commonware_cryptography::{Digest, Scheme};
 use std::{collections::HashSet, marker::PhantomData};
 
 /// Encode and decode proofs of activity.
@@ -85,10 +85,8 @@ impl<C: Scheme, D: Digest> Prover<C, D> {
 
         // Verify signature
         let proposal_message = proposal_message(view, parent, &payload);
-        if check_sig {
-            if !C::verify(Some(namespace), &proposal_message, &public_key, &signature) {
-                return None;
-            }
+        if check_sig && !C::verify(Some(namespace), &proposal_message, &public_key, &signature) {
+            return None;
         }
 
         Some((view, parent, payload, public_key))
@@ -162,7 +160,7 @@ impl<C: Scheme, D: Digest> Prover<C, D> {
             if seen.contains(&public_key) {
                 return None;
             }
-            seen.insert(public_key.clone());
+            seen.insert(public_key);
 
             // Verify signature
             if check_sigs {

--- a/consensus/src/threshold_simplex/actors/resolver/actor.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/actor.rs
@@ -278,7 +278,7 @@ impl<
 
                 // Try to send
                 if sender
-                    .send(Recipients::One(recipient.clone()), encoded, false)
+                    .send(Recipients::One(recipient), encoded, false)
                     .await
                     .unwrap()
                     .is_empty()
@@ -459,7 +459,7 @@ impl<
                             // Ensure too many notarizations/nullifications aren't requested
                             if request.notarizations.len() + request.nullifications.len() > self.max_fetch_count {
                                 warn!(sender = hex(&s), "request too large");
-                                self.requester.block(s.clone());
+                                self.requester.block(s);
                                 continue;
                             }
 
@@ -507,7 +507,7 @@ impl<
                             .encode_to_vec()
                             .into();
                             sender
-                                .send(Recipients::One(s.clone()), response, false)
+                                .send(Recipients::One(s), response, false)
                                 .await
                                 .unwrap();
                         },
@@ -538,14 +538,14 @@ impl<
                                     Some(proposal) => proposal,
                                     None => {
                                         warn!(sender = hex(&s), "missing proposal");
-                                        self.requester.block(s.clone());
+                                        self.requester.block(s);
                                         continue;
                                     },
                                 };
                                 let view = proposal.view;
                                 let Ok(payload) = D::try_from(&proposal.payload) else {
                                     warn!(view, sender = hex(&s), "invalid proposal");
-                                    self.requester.block(s.clone());
+                                    self.requester.block(s);
                                     continue;
                                 };
                                 let entry = Entry { task: Task::Notarization, view };
@@ -555,7 +555,7 @@ impl<
                                 }
                                 if !verify_notarization::<D, S>(&self.supervisor, &self.notarize_namespace, &self.seed_namespace, &notarization) {
                                     warn!(view, sender = hex(&s), "invalid notarization");
-                                    self.requester.block(s.clone());
+                                    self.requester.block(s);
                                     continue;
                                 }
                                 self.required.remove(&entry);
@@ -577,7 +577,7 @@ impl<
                                 }
                                 if !verify_nullification::<S>(&self.supervisor, &self.nullify_namespace, &self.seed_namespace, &nullification) {
                                     warn!(view, sender = hex(&s), "invalid nullification");
-                                    self.requester.block(s.clone());
+                                    self.requester.block(s);
                                     continue;
                                 }
                                 self.required.remove(&entry);

--- a/consensus/src/threshold_simplex/actors/resolver/actor.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/actor.rs
@@ -100,7 +100,7 @@ pub struct Actor<
     E: Clock + GClock + Rng,
     C: Scheme,
     D: Digest,
-    S: ThresholdSupervisor<Index = View, Identity = poly::Public>,
+    S: ThresholdSupervisor<Index = View, Identity = poly::Public, PublicKey = C::PublicKey>,
 > {
     runtime: E,
     supervisor: S,
@@ -135,7 +135,7 @@ impl<
         E: Clock + GClock + Rng,
         C: Scheme,
         D: Digest,
-        S: ThresholdSupervisor<Index = View, Identity = poly::Public>,
+        S: ThresholdSupervisor<Index = View, Identity = poly::Public, PublicKey = C::PublicKey>,
     > Actor<E, C, D, S>
 {
     pub fn new(runtime: E, cfg: Config<C, S>) -> (Self, Mailbox) {
@@ -204,7 +204,7 @@ impl<
     }
 
     /// Concurrent indicates whether we should send a new request (only if we see a request for the first time)
-    async fn send(&mut self, shuffle: bool, sender: &mut impl Sender) {
+    async fn send(&mut self, shuffle: bool, sender: &mut impl Sender<PublicKey = C::PublicKey>) {
         // Clear retry
         self.retry = None;
 
@@ -306,8 +306,8 @@ impl<
     pub async fn run(
         mut self,
         mut voter: voter::Mailbox<D>,
-        mut sender: impl Sender,
-        mut receiver: impl Receiver,
+        mut sender: impl Sender<PublicKey = C::PublicKey>,
+        mut receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) {
         // Wait for an event
         let mut current_view = 0;

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -22,7 +22,7 @@ use commonware_cryptography::{
     },
     hash,
     sha256::Digest as Sha256Digest,
-    Digest, PublicKey, Scheme,
+    Digest, Scheme,
 };
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
@@ -355,7 +355,7 @@ impl<
         }
         let entry = self.finalizes.entry(proposal_digest).or_default();
         let signature = &finalize.message.proposal_signature;
-        let proof = Prover::<D>::serialize_proposal(proposal, &signature);
+        let proof = Prover::<D>::serialize_proposal(proposal, signature);
         entry.insert(public_key_index, finalize);
         self.supervisor.report(FINALIZE, proof).await;
         true
@@ -1328,7 +1328,7 @@ impl<
         }
 
         // Check if we should fast exit this view
-        let leader = round.leader.as_ref().unwrap().clone();
+        let leader = *round.leader.as_ref().unwrap();
         if view < self.activity_timeout || leader == self.crypto.public_key() {
             // Don't fast exit the view
             return;
@@ -2203,13 +2203,12 @@ impl<
                         let signature: Eval<group::Signature> =
                             Eval::deserialize(&notarize.proposal_signature).unwrap();
                         let public_key_index = signature.index;
-                        let public_key = self
+                        let public_key = *self
                             .supervisor
                             .participants(proposal.view)
                             .unwrap()
                             .get(public_key_index as usize)
-                            .unwrap()
-                            .clone();
+                            .unwrap();
                         self.handle_notarize(
                             public_key_index,
                             Parsed {
@@ -2256,13 +2255,12 @@ impl<
                         let signature: Eval<group::Signature> =
                             Eval::deserialize(&nullify.view_signature).unwrap();
                         let public_key_index = signature.index;
-                        let public_key = self
+                        let public_key = *self
                             .supervisor
                             .participants(view)
                             .unwrap()
                             .get(public_key_index as usize)
-                            .unwrap()
-                            .clone();
+                            .unwrap();
                         self.handle_nullify(public_key_index, nullify).await;
 
                         // Update round info
@@ -2288,13 +2286,12 @@ impl<
                         let signature: Eval<group::Signature> =
                             Eval::deserialize(&finalize.proposal_signature).unwrap();
                         let public_key_index = signature.index;
-                        let public_key = self
+                        let public_key = *self
                             .supervisor
                             .participants(proposal.view)
                             .unwrap()
                             .get(public_key_index as usize)
-                            .unwrap()
-                            .clone();
+                            .unwrap();
                         self.handle_finalize(
                             public_key_index,
                             Parsed {

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -30,6 +30,7 @@ pub struct Engine<
         Index = View,
         Share = group::Share,
         Identity = poly::Public,
+        PublicKey = C::PublicKey,
     >,
 > {
     runtime: E,
@@ -53,6 +54,7 @@ impl<
             Index = View,
             Share = group::Share,
             Identity = poly::Public,
+            PublicKey = C::PublicKey,
         >,
     > Engine<B, E, C, D, A, R, F, S>
 {
@@ -116,8 +118,14 @@ impl<
     /// This will also rebuild the state of the engine from provided `Journal`.
     pub async fn run(
         self,
-        voter_network: (impl Sender, impl Receiver),
-        resolver_network: (impl Sender, impl Receiver),
+        voter_network: (
+            impl Sender<PublicKey = C::PublicKey>,
+            impl Receiver<PublicKey = C::PublicKey>,
+        ),
+        resolver_network: (
+            impl Sender<PublicKey = C::PublicKey>,
+            impl Receiver<PublicKey = C::PublicKey>,
+        ),
     ) {
         // Start the voter
         let (voter_sender, voter_receiver) = voter_network;

--- a/consensus/src/threshold_simplex/metrics.rs
+++ b/consensus/src/threshold_simplex/metrics.rs
@@ -45,42 +45,42 @@ pub struct PeerMessage {
 }
 
 impl PeerMessage {
-    pub fn notarize(peer: &PublicKey) -> Self {
+    pub fn notarize<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: NOTARIZE_TYPE,
         }
     }
 
-    pub fn notarization(peer: &PublicKey) -> Self {
+    pub fn notarization<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: NOTARIZATION_TYPE,
         }
     }
 
-    pub fn nullify(peer: &PublicKey) -> Self {
+    pub fn nullify<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: NULLIFY_TYPE,
         }
     }
 
-    pub fn nullification(peer: &PublicKey) -> Self {
+    pub fn nullification<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: NULLIFICATION_TYPE,
         }
     }
 
-    pub fn finalize(peer: &PublicKey) -> Self {
+    pub fn finalize<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: FINALIZE_TYPE,
         }
     }
 
-    pub fn finalization(peer: &PublicKey) -> Self {
+    pub fn finalization<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: FINALIZATION_TYPE,

--- a/consensus/src/threshold_simplex/mocks/application.rs
+++ b/consensus/src/threshold_simplex/mocks/application.rs
@@ -174,7 +174,7 @@ pub struct Application<E: Clock + RngCore, H: Hasher, P: PublicKey> {
 impl<E: Clock + RngCore, H: Hasher, P: PublicKey> Application<E, H, P> {
     pub fn new(runtime: E, cfg: Config<H, P>) -> (Self, Mailbox<H::Digest>) {
         // Register self on relay
-        let broadcast = cfg.relay.register(cfg.participant.clone());
+        let broadcast = cfg.relay.register(cfg.participant);
 
         // Generate samplers
         let propose_latency = Normal::new(cfg.propose_latency.0, cfg.propose_latency.1).unwrap();
@@ -298,7 +298,7 @@ impl<E: Clock + RngCore, H: Hasher, P: PublicKey> Application<E, H, P> {
         let _ = self
             .tracker
             .send((
-                self.participant.clone(),
+                self.participant,
                 Progress::Notarized(proof, payload),
             ))
             .await;
@@ -311,7 +311,7 @@ impl<E: Clock + RngCore, H: Hasher, P: PublicKey> Application<E, H, P> {
         let _ = self
             .tracker
             .send((
-                self.participant.clone(),
+                self.participant,
                 Progress::Finalized(proof, payload),
             ))
             .await;

--- a/consensus/src/threshold_simplex/mocks/relay.rs
+++ b/consensus/src/threshold_simplex/mocks/relay.rs
@@ -4,11 +4,11 @@ use futures::{channel::mpsc, SinkExt};
 use std::{collections::BTreeMap, sync::Mutex};
 
 /// Relay is a mock for distributing artifacts between applications.
-pub struct Relay<D: Digest> {
-    recipients: Mutex<BTreeMap<PublicKey, mpsc::UnboundedSender<(D, Bytes)>>>,
+pub struct Relay<D: Digest, P: PublicKey> {
+    recipients: Mutex<BTreeMap<P, mpsc::UnboundedSender<(D, Bytes)>>>,
 }
 
-impl<D: Digest> Relay<D> {
+impl<D: Digest, P: PublicKey> Relay<D, P> {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
@@ -16,7 +16,7 @@ impl<D: Digest> Relay<D> {
         }
     }
 
-    pub fn register(&self, public_key: PublicKey) -> mpsc::UnboundedReceiver<(D, Bytes)> {
+    pub fn register(&self, public_key: P) -> mpsc::UnboundedReceiver<(D, Bytes)> {
         let (sender, receiver) = mpsc::unbounded();
         if self
             .recipients
@@ -30,7 +30,7 @@ impl<D: Digest> Relay<D> {
         receiver
     }
 
-    pub async fn broadcast(&self, sender: &PublicKey, payload: (D, Bytes)) {
+    pub async fn broadcast(&self, sender: &P, payload: (D, Bytes)) {
         let channels = {
             let mut channels = Vec::new();
             let recipients = self.recipients.lock().unwrap();
@@ -51,7 +51,7 @@ impl<D: Digest> Relay<D> {
     }
 }
 
-impl<D: Digest> Default for Relay<D> {
+impl<D: Digest, P: PublicKey> Default for Relay<D, P> {
     fn default() -> Self {
         Self::new()
     }

--- a/consensus/src/threshold_simplex/mocks/supervisor.rs
+++ b/consensus/src/threshold_simplex/mocks/supervisor.rs
@@ -10,7 +10,7 @@ use commonware_cryptography::{
         group::{self, Element},
         poly,
     },
-    Digest, PublicKey,
+    Digest, PublicKey, Scheme,
 };
 use commonware_utils::modulo;
 use std::{
@@ -18,33 +18,33 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-type ViewInfo = (
+type ViewInfo<P: PublicKey> = (
     poly::Poly<group::Public>,
-    HashMap<PublicKey, u32>,
-    Vec<PublicKey>,
+    HashMap<P, u32>,
+    Vec<P>,
     group::Share,
 );
 
-pub struct Config<D: Digest> {
+pub struct Config<P: PublicKey, D: Digest> {
     pub prover: Prover<D>,
-    pub participants: BTreeMap<View, (poly::Poly<group::Public>, Vec<PublicKey>, group::Share)>,
+    pub participants: BTreeMap<View, (poly::Poly<group::Public>, Vec<P>, group::Share)>,
 }
 
-type Participation<D> = HashMap<View, HashMap<D, HashSet<PublicKey>>>;
-type Faults = HashMap<PublicKey, HashMap<View, HashSet<Activity>>>;
+type Participation<D, P: PublicKey> = HashMap<View, HashMap<D, HashSet<P>>>;
+type Faults<P: PublicKey> = HashMap<P, HashMap<View, HashSet<Activity>>>;
 
 #[derive(Clone)]
-pub struct Supervisor<D: Digest> {
+pub struct Supervisor<P: PublicKey, D: Digest> {
     prover: Prover<D>,
-    participants: BTreeMap<View, ViewInfo>,
+    participants: BTreeMap<View, ViewInfo<P>>,
 
-    pub notarizes: Arc<Mutex<Participation<D>>>,
-    pub finalizes: Arc<Mutex<Participation<D>>>,
-    pub faults: Arc<Mutex<Faults>>,
+    pub notarizes: Arc<Mutex<Participation<D, P>>>,
+    pub finalizes: Arc<Mutex<Participation<D, P>>>,
+    pub faults: Arc<Mutex<Faults<P>>>,
 }
 
-impl<D: Digest> Supervisor<D> {
-    pub fn new(cfg: Config<D>) -> Self {
+impl<P: PublicKey, D: Digest> Supervisor<P, D> {
+    pub fn new(cfg: Config<P, D>) -> Self {
         let mut parsed_participants = BTreeMap::new();
         for (view, (identity, mut validators, share)) in cfg.participants.into_iter() {
             let mut map = HashMap::new();
@@ -64,14 +64,15 @@ impl<D: Digest> Supervisor<D> {
     }
 }
 
-impl<D: Digest> Su for Supervisor<D> {
+impl<P: PublicKey, D: Digest> Su for Supervisor<P, D> {
     type Index = View;
+    type PublicKey = P;
 
-    fn leader(&self, _: Self::Index) -> Option<PublicKey> {
+    fn leader(&self, _: Self::Index) -> Option<Self::PublicKey> {
         unimplemented!("only defined in supertrait")
     }
 
-    fn participants(&self, index: Self::Index) -> Option<&Vec<PublicKey>> {
+    fn participants(&self, index: Self::Index) -> Option<&Vec<Self::PublicKey>> {
         let closest = match self.participants.range(..=index).next_back() {
             Some((_, (_, _, p, _))) => p,
             None => {
@@ -81,7 +82,7 @@ impl<D: Digest> Su for Supervisor<D> {
         Some(closest)
     }
 
-    fn is_participant(&self, index: Self::Index, candidate: &PublicKey) -> Option<u32> {
+    fn is_participant(&self, index: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {
         let closest = match self.participants.range(..=index).next_back() {
             Some((_, (_, p, _, _))) => p,
             None => {
@@ -198,12 +199,12 @@ impl<D: Digest> Su for Supervisor<D> {
     }
 }
 
-impl<D: Digest> TSu for Supervisor<D> {
+impl<P: PublicKey, D: Digest> TSu for Supervisor<P, D> {
     type Seed = group::Signature;
     type Identity = poly::Public;
     type Share = group::Share;
 
-    fn leader(&self, index: Self::Index, seed: Self::Seed) -> Option<PublicKey> {
+    fn leader(&self, index: Self::Index, seed: Self::Seed) -> Option<Self::PublicKey> {
         let closest = match self.participants.range(..=index).next_back() {
             Some((_, (_, _, p, _))) => p,
             None => {

--- a/consensus/src/threshold_simplex/mocks/supervisor.rs
+++ b/consensus/src/threshold_simplex/mocks/supervisor.rs
@@ -18,7 +18,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-type ViewInfo<P: PublicKey> = (
+type ViewInfo<P> = (
     poly::Poly<group::Public>,
     HashMap<P, u32>,
     Vec<P>,
@@ -30,8 +30,8 @@ pub struct Config<P: PublicKey, D: Digest> {
     pub participants: BTreeMap<View, (poly::Poly<group::Public>, Vec<P>, group::Share)>,
 }
 
-type Participation<D, P: PublicKey> = HashMap<View, HashMap<D, HashSet<P>>>;
-type Faults<P: PublicKey> = HashMap<P, HashMap<View, HashSet<Activity>>>;
+type Participation<D, P> = HashMap<View, HashMap<D, HashSet<P>>>;
+type Faults<P> = HashMap<P, HashMap<View, HashSet<Activity>>>;
 
 #[derive(Clone)]
 pub struct Supervisor<P: PublicKey, D: Digest> {
@@ -49,7 +49,7 @@ impl<P: PublicKey, D: Digest> Supervisor<P, D> {
         for (view, (identity, mut validators, share)) in cfg.participants.into_iter() {
             let mut map = HashMap::new();
             for (index, validator) in validators.iter().enumerate() {
-                map.insert(validator.clone(), index as u32);
+                map.insert(*validator, index as u32);
             }
             validators.sort();
             parsed_participants.insert(view, (identity, map, validators, share));
@@ -106,7 +106,7 @@ impl<P: PublicKey, D: Digest> Su for Supervisor<P, D> {
                     }
                 };
                 let public_key_index = verifier.verify(identity).unwrap();
-                let public_key = validators[public_key_index as usize].clone();
+                let public_key = validators[public_key_index as usize];
                 self.notarizes
                     .lock()
                     .unwrap()
@@ -125,7 +125,7 @@ impl<P: PublicKey, D: Digest> Su for Supervisor<P, D> {
                     }
                 };
                 let public_key_index = verifier.verify(identity).unwrap();
-                let public_key = validators[public_key_index as usize].clone();
+                let public_key = validators[public_key_index as usize];
                 self.finalizes
                     .lock()
                     .unwrap()
@@ -144,7 +144,7 @@ impl<P: PublicKey, D: Digest> Su for Supervisor<P, D> {
                     }
                 };
                 let public_key_index = verifier.verify(identity).unwrap();
-                let public_key = validators[public_key_index as usize].clone();
+                let public_key = validators[public_key_index as usize];
                 self.faults
                     .lock()
                     .unwrap()
@@ -163,7 +163,7 @@ impl<P: PublicKey, D: Digest> Su for Supervisor<P, D> {
                     }
                 };
                 let public_key_index = verifier.verify(identity).unwrap();
-                let public_key = validators[public_key_index as usize].clone();
+                let public_key = validators[public_key_index as usize];
                 self.faults
                     .lock()
                     .unwrap()
@@ -182,7 +182,7 @@ impl<P: PublicKey, D: Digest> Su for Supervisor<P, D> {
                     }
                 };
                 let public_key_index = verifier.verify(identity).unwrap();
-                let public_key = validators[public_key_index as usize].clone();
+                let public_key = validators[public_key_index as usize];
                 self.faults
                     .lock()
                     .unwrap()
@@ -213,7 +213,7 @@ impl<P: PublicKey, D: Digest> TSu for Supervisor<P, D> {
         };
         let seed = seed.serialize();
         let index = modulo(&seed, closest.len() as u64);
-        Some(closest[index as usize].clone())
+        Some(closest[index as usize])
     }
 
     fn identity(&self, index: Self::Index) -> Option<&Self::Identity> {

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -246,11 +246,11 @@ mod tests {
         let mut registrations = HashMap::new();
         for validator in validators.iter() {
             let (voter_sender, voter_receiver) =
-                oracle.register(validator.clone(), 0).await.unwrap();
+                oracle.register(*validator, 0).await.unwrap();
             let (resolver_sender, resolver_receiver) =
-                oracle.register(validator.clone(), 1).await.unwrap();
+                oracle.register(*validator, 1).await.unwrap();
             registrations.insert(
-                validator.clone(),
+                *validator,
                 (
                     (voter_sender, voter_receiver),
                     (resolver_sender, resolver_receiver),
@@ -295,7 +295,7 @@ mod tests {
                 // Do any unlinking first
                 match action {
                     Action::Update(_) | Action::Unlink => {
-                        oracle.remove_link(v1.clone(), v2.clone()).await.unwrap();
+                        oracle.remove_link(*v1, *v2).await.unwrap();
                     }
                     _ => {}
                 }
@@ -304,7 +304,7 @@ mod tests {
                 match action {
                     Action::Link(ref link) | Action::Update(ref link) => {
                         oracle
-                            .add_link(v1.clone(), v2.clone(), link.clone())
+                            .add_link(*v1, *v2, link.clone())
                             .await
                             .unwrap();
                     }
@@ -382,7 +382,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -614,11 +614,11 @@ mod tests {
                     };
                     let supervisor =
                         mocks::supervisor::Supervisor::new(supervisor_config);
-                    supervisors.insert(validator.clone(), supervisor.clone());
+                    supervisors.insert(validator, supervisor.clone());
                     let application_cfg = mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),
@@ -843,7 +843,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -980,7 +980,7 @@ mod tests {
             let application_cfg = mocks::application::Config {
                 hasher: Sha256::default(),
                 relay: relay.clone(),
-                participant: validator.clone(),
+                participant: validator,
                 tracker: done_sender.clone(),
                 propose_latency: (10.0, 5.0),
                 verify_latency: (10.0, 5.0),
@@ -1137,7 +1137,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -1318,7 +1318,7 @@ mod tests {
                     mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (3_000.0, 0.0),
                         verify_latency: (3_000.0, 5.0),
@@ -1327,7 +1327,7 @@ mod tests {
                     mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),
@@ -1508,7 +1508,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -1681,7 +1681,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -1910,7 +1910,7 @@ mod tests {
                 let application_cfg = mocks::application::Config {
                     hasher: Sha256::default(),
                     relay: relay.clone(),
-                    participant: validator.clone(),
+                    participant: validator,
                     tracker: done_sender.clone(),
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
@@ -2102,7 +2102,7 @@ mod tests {
                     let application_cfg = mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),
@@ -2286,7 +2286,7 @@ mod tests {
                     let application_cfg = mocks::application::Config {
                         hasher: Sha256::default(),
                         relay: relay.clone(),
-                        participant: validator.clone(),
+                        participant: validator,
                         tracker: done_sender.clone(),
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -146,6 +146,7 @@
 //! * Introduce message rebroadcast to continue making progress if messages from a given view are dropped (only way
 //!   to ensure messages are reliably delivered is with a heavyweight reliable broadcast protocol).
 
+use bytes::Bytes;
 use commonware_cryptography::Digest;
 
 mod encoder;
@@ -172,6 +173,8 @@ pub mod mocks;
 
 /// View is a monotonically increasing counter that represents the current focus of consensus.
 pub type View = u64;
+
+type Signature = Bytes;
 
 use crate::Activity;
 
@@ -236,10 +239,10 @@ mod tests {
     use tracing::debug;
 
     /// Registers all validators using the oracle.
-    async fn register_validators(
-        oracle: &mut Oracle,
-        validators: &[PublicKey],
-    ) -> HashMap<PublicKey, ((Sender, Receiver), (Sender, Receiver))> {
+    async fn register_validators<P: PublicKey>(
+        oracle: &mut Oracle<P>,
+        validators: &[P],
+    ) -> HashMap<P, ((Sender<P>, Receiver<P>), (Sender<P>, Receiver<P>))> {
         let mut registrations = HashMap::new();
         for validator in validators.iter() {
             let (voter_sender, voter_receiver) =
@@ -269,9 +272,9 @@ mod tests {
     /// The `action` parameter determines the action (e.g. link, unlink) to take.
     /// The `restrict_to` function can be used to restrict the linking to certain connections,
     /// otherwise all validators will be linked to all other validators.
-    async fn link_validators(
-        oracle: &mut Oracle,
-        validators: &[PublicKey],
+    async fn link_validators<P: PublicKey>(
+        oracle: &mut Oracle<P>,
+        validators: &[P],
         action: Action,
         restrict_to: Option<fn(usize, usize, usize) -> bool>,
     ) {

--- a/consensus/src/threshold_simplex/prover.rs
+++ b/consensus/src/threshold_simplex/prover.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use super::Signature;
 use super::{
     encoder::{
         finalize_namespace, notarize_namespace, nullify_message, nullify_namespace,
@@ -15,7 +16,7 @@ use commonware_cryptography::{
         ops,
         poly::{self, Eval},
     },
-    Digest, Signature,
+    Digest, Ed25519, Scheme,
 };
 
 type Callback = Box<dyn Fn(&poly::Poly<group::Public>) -> Option<u32>>;

--- a/consensus/src/threshold_simplex/prover.rs
+++ b/consensus/src/threshold_simplex/prover.rs
@@ -16,7 +16,7 @@ use commonware_cryptography::{
         ops,
         poly::{self, Eval},
     },
-    Digest, Ed25519, Scheme,
+    Digest, Scheme,
 };
 
 type Callback = Box<dyn Fn(&poly::Poly<group::Public>) -> Option<u32>>;

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -25,9 +25,9 @@ fn benchmark_dkg_recovery(c: &mut Criterion) {
                     contributors.sort();
 
                     // Create player
-                    let me = contributors[0].clone();
+                    let me = contributors[0];
                     let mut player = Player::new(
-                        me.clone(),
+                        me,
                         None,
                         contributors.clone(),
                         contributors.clone(),
@@ -40,7 +40,7 @@ fn benchmark_dkg_recovery(c: &mut Criterion) {
                         let (_, commitment, shares) =
                             Dealer::new(&mut rng, None, contributors.clone());
                         player
-                            .share(dealer.clone(), commitment.clone(), shares[0])
+                            .share(*dealer, commitment.clone(), shares[0])
                             .unwrap();
                         commitments.insert(idx as u32, commitment);
                     }

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -25,13 +25,7 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
         // Create players
         let mut players = Vec::with_capacity(n);
         for con in &contributors {
-            let player = Player::new(
-                con.clone(),
-                None,
-                contributors.clone(),
-                contributors.clone(),
-                1,
-            );
+            let player = Player::new(*con, None, contributors.clone(), contributors.clone(), 1);
             players.push(player);
         }
 
@@ -42,7 +36,7 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
             for (player_idx, player) in players.iter_mut().enumerate() {
                 player
-                    .share(dealer.clone(), commitment.clone(), shares[player_idx])
+                    .share(*dealer, commitment.clone(), shares[player_idx])
                     .unwrap();
             }
             commitments.insert(dealer_idx as u32, commitment);
@@ -65,9 +59,9 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
                     b.iter_batched(
                         || {
                             // Create player
-                            let me = contributors[0].clone();
+                            let me = contributors[0];
                             let mut player = Player::new(
-                                me.clone(),
+                                me,
                                 Some(outputs[0].public.clone()),
                                 contributors.clone(),
                                 contributors.clone(),
@@ -83,7 +77,7 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
                                     contributors.clone(),
                                 );
                                 player
-                                    .share(dealer.clone(), commitment.clone(), shares[0])
+                                    .share(*dealer, commitment.clone(), shares[0])
                                     .unwrap();
                                 commitments.insert(idx as u32, commitment);
                             }

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -36,11 +36,13 @@
 //! not provided by the arbiter because this authorization function is highly dependent on
 //! the context in which the dealer is being used.
 
-use crate::bls12381::{
-    dkg::{ops, Error},
-    primitives::{group::Share, poly},
+use crate::{
+    bls12381::{
+        dkg::{ops, Error},
+        primitives::{group::Share, poly},
+    },
+    PublicKey,
 };
-use crate::PublicKey;
 use commonware_utils::{max_faults, quorum};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -58,33 +60,33 @@ pub struct Output {
 }
 
 /// Gather commitments, acknowledgements, and reveals from all dealers.
-pub struct Arbiter {
+pub struct Arbiter<P: PublicKey> {
     previous: Option<poly::Public>,
     dealer_threshold: u32,
     player_threshold: u32,
     concurrency: usize,
 
-    dealers: HashMap<PublicKey, u32>,
-    players: Vec<PublicKey>,
+    dealers: HashMap<P, u32>,
+    players: Vec<P>,
 
     commitments: BTreeMap<u32, (poly::Public, Vec<u32>, Vec<Share>)>,
-    disqualified: HashSet<PublicKey>,
+    disqualified: HashSet<P>,
 }
 
-impl Arbiter {
+impl<P: PublicKey> Arbiter<P> {
     /// Create a new arbiter for a DKG/Resharing procedure.
     pub fn new(
         previous: Option<poly::Public>,
-        mut dealers: Vec<PublicKey>,
-        mut players: Vec<PublicKey>,
+        mut dealers: Vec<P>,
+        mut players: Vec<P>,
         concurrency: usize,
     ) -> Self {
         dealers.sort();
         let dealers = dealers
             .iter()
             .enumerate()
-            .map(|(i, pk)| (pk.clone(), i as u32))
-            .collect::<HashMap<PublicKey, _>>();
+            .map(|(i, pk)| (*pk, i as u32))
+            .collect::<HashMap<P, _>>();
         players.sort();
         Self {
             dealer_threshold: quorum(dealers.len() as u32).expect("insufficient dealers"),
@@ -101,14 +103,14 @@ impl Arbiter {
     }
 
     /// Disqualify a participant from the DKG for external reason (i.e. sending invalid messages).
-    pub fn disqualify(&mut self, participant: PublicKey) {
+    pub fn disqualify(&mut self, participant: P) {
         self.disqualified.insert(participant);
     }
 
     /// Verify and track a commitment, acknowledgements, and reveals collected by a dealer.
     pub fn commitment(
         &mut self,
-        dealer: PublicKey,
+        dealer: P,
         commitment: poly::Public,
         acks: Vec<u32>,
         reveals: Vec<Share>,
@@ -214,7 +216,7 @@ impl Arbiter {
     /// Recover the group polynomial and return `2f + 1` commitments and reveals from dealers.
     ///
     /// Return the disqualified dealers.
-    pub fn finalize(mut self) -> (Result<Output, Error>, HashSet<PublicKey>) {
+    pub fn finalize(mut self) -> (Result<Output, Error>, HashSet<P>) {
         // Drop commitments from disqualified dealers
         for disqualified in self.disqualified.iter() {
             let idx = self.dealers.get(disqualified).unwrap();
@@ -226,7 +228,7 @@ impl Arbiter {
             if self.commitments.contains_key(idx) {
                 continue;
             }
-            self.disqualified.insert(dealer.clone());
+            self.disqualified.insert(*dealer);
         }
 
         // Ensure we have enough commitments to proceed

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -41,7 +41,7 @@ use crate::{
         dkg::{ops, Error},
         primitives::{group::Share, poly},
     },
-    PublicKey,
+    Component,
 };
 use commonware_utils::{max_faults, quorum};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -60,7 +60,7 @@ pub struct Output {
 }
 
 /// Gather commitments, acknowledgements, and reveals from all dealers.
-pub struct Arbiter<P: PublicKey> {
+pub struct Arbiter<P: Component> {
     previous: Option<poly::Public>,
     dealer_threshold: u32,
     player_threshold: u32,
@@ -73,7 +73,7 @@ pub struct Arbiter<P: PublicKey> {
     disqualified: HashSet<P>,
 }
 
-impl<P: PublicKey> Arbiter<P> {
+impl<P: Component> Arbiter<P> {
     /// Create a new arbiter for a DKG/Resharing procedure.
     pub fn new(
         previous: Option<poly::Public>,

--- a/cryptography/src/bls12381/dkg/dealer.rs
+++ b/cryptography/src/bls12381/dkg/dealer.rs
@@ -1,11 +1,13 @@
 //! Participants in a DKG/Resharing procedure that distribute dealings
 //! to players and collect their acknowledgements.
 
-use crate::bls12381::{
-    dkg::{ops, Error},
-    primitives::{group::Share, poly},
+use crate::{
+    bls12381::{
+        dkg::{ops, Error},
+        primitives::{group::Share, poly},
+    },
+    PublicKey,
 };
-use crate::PublicKey;
 use commonware_utils::quorum;
 use rand::RngCore;
 use std::collections::{HashMap, HashSet};
@@ -22,26 +24,26 @@ pub struct Output {
 }
 
 /// Track acknowledgements from players.
-pub struct Dealer {
+pub struct Dealer<P: PublicKey> {
     threshold: u32,
-    players: HashMap<PublicKey, u32>,
+    players: HashMap<P, u32>,
 
     acks: HashSet<u32>,
 }
 
-impl Dealer {
+impl<P: PublicKey> Dealer<P> {
     /// Create a new dealer for a DKG/Resharing procedure.
     pub fn new<R: RngCore>(
         rng: &mut R,
         share: Option<Share>,
-        mut players: Vec<PublicKey>,
+        mut players: Vec<P>,
     ) -> (Self, poly::Public, Vec<Share>) {
         // Order players
         players.sort();
         let players_ordered = players
             .iter()
             .enumerate()
-            .map(|(i, pk)| (pk.clone(), i as u32))
+            .map(|(i, pk)| (*pk, i as u32))
             .collect();
 
         // Generate shares and commitment
@@ -60,7 +62,7 @@ impl Dealer {
     }
 
     /// Track acknowledgement from a player.
-    pub fn ack(&mut self, player: PublicKey) -> Result<(), Error> {
+    pub fn ack(&mut self, player: P) -> Result<(), Error> {
         // Ensure player is valid
         let idx = match self.players.get(&player) {
             Some(player) => *player,

--- a/cryptography/src/bls12381/dkg/dealer.rs
+++ b/cryptography/src/bls12381/dkg/dealer.rs
@@ -6,7 +6,7 @@ use crate::{
         dkg::{ops, Error},
         primitives::{group::Share, poly},
     },
-    PublicKey,
+    Component,
 };
 use commonware_utils::quorum;
 use rand::RngCore;
@@ -24,14 +24,14 @@ pub struct Output {
 }
 
 /// Track acknowledgements from players.
-pub struct Dealer<P: PublicKey> {
+pub struct Dealer<P: Component> {
     threshold: u32,
     players: HashMap<P, u32>,
 
     acks: HashSet<u32>,
 }
 
-impl<P: PublicKey> Dealer<P> {
+impl<P: Component> Dealer<P> {
     /// Create a new dealer for a DKG/Resharing procedure.
     pub fn new<R: RngCore>(
         rng: &mut R,

--- a/cryptography/src/bls12381/dkg/mod.rs
+++ b/cryptography/src/bls12381/dkg/mod.rs
@@ -214,21 +214,21 @@ mod tests {
         let mut dealers = HashMap::new();
         for con in contributors.iter().take(dealers_0 as usize) {
             let (dealer, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
-            dealer_shares.insert(con.clone(), (commitment, shares));
-            dealers.insert(con.clone(), dealer);
+            dealer_shares.insert(*con, (commitment, shares));
+            dealers.insert(*con, dealer);
         }
 
         // Create players
         let mut players = HashMap::new();
         for con in &contributors {
             let player = Player::new(
-                con.clone(),
+                *con,
                 None,
                 contributors.clone(),
                 contributors.clone(),
                 concurrency,
             );
-            players.insert(con.clone(), player);
+            players.insert(*con, player);
         }
 
         // Create arbiter
@@ -250,11 +250,11 @@ mod tests {
                 // Process share
                 let player_obj = players.get_mut(player).unwrap();
                 player_obj
-                    .share(dealer.clone(), commitment.clone(), shares[player_idx])
+                    .share(dealer, commitment.clone(), shares[player_idx])
                     .unwrap();
 
                 // Collect ack
-                dealer_obj.ack(player.clone()).unwrap();
+                dealer_obj.ack(*player).unwrap();
             }
 
             // Finalize dealer
@@ -295,7 +295,7 @@ mod tests {
                 .unwrap()
                 .finalize(output.commitments.clone(), HashMap::new())
                 .unwrap();
-            outputs.insert(player.clone(), result);
+            outputs.insert(*player, result);
         }
 
         // Test that can generate proof-of-possession
@@ -324,21 +324,21 @@ mod tests {
             let output = outputs.get(con).unwrap();
             let (dealer, commitment, shares) =
                 Dealer::new(&mut rng, Some(output.share), reshare_players.clone());
-            reshare_shares.insert(con.clone(), (commitment, shares));
-            reshare_dealers.insert(con.clone(), dealer);
+            reshare_shares.insert(*con, (commitment, shares));
+            reshare_dealers.insert(*con, dealer);
         }
 
         // Create reshare player objects
         let mut reshare_player_objs = HashMap::new();
         for con in &reshare_players {
             let player = Player::new(
-                con.clone(),
+                *con,
                 Some(output.public.clone()),
                 contributors.clone(),
                 reshare_players.clone(),
                 concurrency,
             );
-            reshare_player_objs.insert(con.clone(), player);
+            reshare_player_objs.insert(*con, player);
         }
 
         // Create arbiter
@@ -360,11 +360,11 @@ mod tests {
                 // Process share
                 let player_obj = reshare_player_objs.get_mut(player).unwrap();
                 player_obj
-                    .share(dealer.clone(), commitment.clone(), shares[player_idx])
+                    .share(dealer, commitment.clone(), shares[player_idx])
                     .unwrap();
 
                 // Collect ack
-                dealer_obj.ack(player.clone()).unwrap();
+                dealer_obj.ack(*player).unwrap();
             }
 
             // Finalize dealer
@@ -470,7 +470,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -478,7 +478,7 @@ mod tests {
         );
 
         // Send invalid commitment to player
-        let result = player.share(contributors[0].clone(), public, shares[0]);
+        let result = player.share(contributors[0], public, shares[0]);
         assert!(matches!(result, Err(Error::ShareWrongCommitment)));
     }
 
@@ -505,7 +505,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -514,11 +514,11 @@ mod tests {
 
         // Send valid commitment to player
         player
-            .share(contributors[0].clone(), commitment, shares[0])
+            .share(contributors[0], commitment, shares[0])
             .unwrap();
 
         // Send alternative commitment to player
-        let result = player.share(contributors[0].clone(), other_commitment, shares[0]);
+        let result = player.share(contributors[0], other_commitment, shares[0]);
         assert!(matches!(result, Err(Error::MismatchedCommitment)));
     }
 
@@ -545,7 +545,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -554,11 +554,11 @@ mod tests {
 
         // Send valid share to player
         player
-            .share(contributors[0].clone(), commitment.clone(), shares[0])
+            .share(contributors[0], commitment.clone(), shares[0])
             .unwrap();
 
         // Send alternative share to player
-        let result = player.share(contributors[0].clone(), commitment, other_shares[0]);
+        let result = player.share(contributors[0], commitment, other_shares[0]);
         assert!(matches!(result, Err(Error::MismatchedShare)));
     }
 
@@ -581,7 +581,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -590,11 +590,11 @@ mod tests {
 
         // Send valid share to player
         player
-            .share(contributors[0].clone(), commitment.clone(), shares[0])
+            .share(contributors[0], commitment.clone(), shares[0])
             .unwrap();
 
         // Send alternative share to player
-        let result = player.share(contributors[0].clone(), commitment, shares[0]);
+        let result = player.share(contributors[0], commitment, shares[0]);
         assert!(matches!(result, Err(Error::DuplicateShare)));
     }
 
@@ -617,7 +617,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -625,7 +625,7 @@ mod tests {
         );
 
         // Send misdirected share to player
-        let result = player.share(contributors[0].clone(), commitment.clone(), shares[1]);
+        let result = player.share(contributors[0], commitment.clone(), shares[1]);
         assert!(matches!(result, Err(Error::MisdirectedShare)));
     }
 
@@ -648,7 +648,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -657,7 +657,7 @@ mod tests {
 
         // Send share from invalid dealer
         let dealer = Ed25519::from_seed(n as u64).public_key();
-        let result = player.share(dealer.clone(), commitment.clone(), shares[0]);
+        let result = player.share(dealer, commitment.clone(), shares[0]);
         assert!(matches!(result, Err(Error::DealerInvalid)));
 
         // Create arbiter
@@ -690,7 +690,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -698,19 +698,14 @@ mod tests {
         );
 
         // Send invalid commitment to player
-        let result = player.share(contributors[0].clone(), public.clone(), shares[0]);
+        let result = player.share(contributors[0], public.clone(), shares[0]);
         assert!(matches!(result, Err(Error::CommitmentWrongDegree)));
 
         // Create arbiter
         let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
 
         // Send invalid commitment to arbiter
-        let result = arb.commitment(
-            contributors[0].clone(),
-            public,
-            vec![0, 1, 2, 3, 4],
-            Vec::new(),
-        );
+        let result = arb.commitment(contributors[0], public, vec![0, 1, 2, 3, 4], Vec::new());
         assert!(matches!(result, Err(Error::CommitmentWrongDegree)));
     }
 
@@ -736,7 +731,7 @@ mod tests {
 
         // Add commitment to arbiter
         arb.commitment(
-            contributors[0].clone(),
+            contributors[0],
             commitment,
             vec![0, 1, 2, 3],
             vec![shares[4]],
@@ -771,7 +766,7 @@ mod tests {
             reveals.push(shares[4]);
 
             // Add commitment to arbiter
-            arb.commitment(con.clone(), commitment, vec![0, 1, 2, 3], vec![shares[4]])
+            arb.commitment(*con, commitment, vec![0, 1, 2, 3], vec![shares[4]])
                 .unwrap();
         }
 
@@ -816,7 +811,7 @@ mod tests {
 
         // Add commitment to arbiter
         arb.commitment(
-            contributors[0].clone(),
+            contributors[0],
             commitment.clone(),
             vec![0, 1, 2, 3],
             vec![shares[4]],
@@ -825,7 +820,7 @@ mod tests {
 
         // Add commitment to arbiter (again)
         let result = arb.commitment(
-            contributors[0].clone(),
+            contributors[0],
             commitment,
             vec![0, 1, 2, 3],
             vec![shares[4]],
@@ -855,7 +850,7 @@ mod tests {
 
         // Add commitment to arbiter
         let result = arb.commitment(
-            contributors[0].clone(),
+            contributors[0],
             commitment,
             vec![0, 1, 2, 3],
             vec![shares[3]],
@@ -885,7 +880,7 @@ mod tests {
 
         // Add commitment to arbiter
         let result = arb.commitment(
-            contributors[0].clone(),
+            contributors[0],
             commitment.clone(),
             vec![0, 1, 2, 3],
             Vec::new(),
@@ -893,12 +888,7 @@ mod tests {
         assert!(matches!(result, Err(Error::IncorrectActive)));
 
         // Add valid commitment to arbiter after disqualified
-        let result = arb.commitment(
-            contributors[0].clone(),
-            commitment,
-            vec![0, 1, 2, 3, 4],
-            Vec::new(),
-        );
+        let result = arb.commitment(contributors[0], commitment, vec![0, 1, 2, 3, 4], Vec::new());
         assert!(matches!(result, Err(Error::DealerDisqualified)));
     }
 
@@ -923,15 +913,10 @@ mod tests {
         let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
 
         // Disqualify dealer
-        arb.disqualify(contributors[0].clone());
+        arb.disqualify(contributors[0]);
 
         // Add valid commitment to arbiter after disqualified
-        let result = arb.commitment(
-            contributors[0].clone(),
-            commitment,
-            vec![0, 1, 2, 3, 4],
-            Vec::new(),
-        );
+        let result = arb.commitment(contributors[0], commitment, vec![0, 1, 2, 3, 4], Vec::new());
         assert!(matches!(result, Err(Error::DealerDisqualified)));
     }
 
@@ -957,7 +942,7 @@ mod tests {
 
         // Add commitment to arbiter
         let result = arb.commitment(
-            contributors[0].clone(),
+            contributors[0],
             commitment,
             vec![0, 1, 2],
             vec![shares[3], shares[4]],
@@ -991,7 +976,7 @@ mod tests {
 
         // Add commitment to arbiter
         let result = arb.commitment(
-            contributors[0].clone(),
+            contributors[0],
             commitment,
             vec![0, 1, 2, 3],
             vec![shares[4]],
@@ -1024,12 +1009,7 @@ mod tests {
         share.index = 4;
 
         // Add commitment to arbiter
-        let result = arb.commitment(
-            contributors[0].clone(),
-            commitment,
-            vec![0, 1, 2, 3],
-            vec![share],
-        );
+        let result = arb.commitment(contributors[0], commitment, vec![0, 1, 2, 3], vec![share]);
         assert!(matches!(result, Err(Error::ShareWrongCommitment)));
     }
 
@@ -1054,12 +1034,7 @@ mod tests {
         let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
 
         // Add commitment to arbiter
-        let result = arb.commitment(
-            contributors[0].clone(),
-            commitment,
-            vec![0, 1, 2, 2],
-            Vec::new(),
-        );
+        let result = arb.commitment(contributors[0], commitment, vec![0, 1, 2, 2], Vec::new());
         assert!(matches!(result, Err(Error::AlreadyActive)));
     }
 
@@ -1084,12 +1059,7 @@ mod tests {
         let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
 
         // Add commitment to arbiter
-        let result = arb.commitment(
-            contributors[0].clone(),
-            commitment,
-            vec![0, 1, 2, 10],
-            Vec::new(),
-        );
+        let result = arb.commitment(contributors[0], commitment, vec![0, 1, 2, 10], Vec::new());
         assert!(matches!(result, Err(Error::PlayerInvalid)));
     }
 
@@ -1118,12 +1088,7 @@ mod tests {
         share.index = 10;
 
         // Add commitment to arbiter
-        let result = arb.commitment(
-            contributors[0].clone(),
-            commitment,
-            vec![0, 1, 2, 3],
-            vec![share],
-        );
+        let result = arb.commitment(contributors[0], commitment, vec![0, 1, 2, 3], vec![share]);
         assert!(matches!(result, Err(Error::PlayerInvalid)));
     }
 
@@ -1146,7 +1111,7 @@ mod tests {
 
         // Ack all players
         for player in &contributors {
-            dealer.ack(player.clone()).unwrap();
+            dealer.ack(*player).unwrap();
         }
 
         // Finalize dealer
@@ -1174,7 +1139,7 @@ mod tests {
 
         // Ack all players
         for player in contributors.iter().take(4) {
-            dealer.ack(player.clone()).unwrap();
+            dealer.ack(*player).unwrap();
         }
 
         // Finalize dealer
@@ -1202,7 +1167,7 @@ mod tests {
 
         // Ack all players
         for player in contributors.iter().take(2) {
-            dealer.ack(player.clone()).unwrap();
+            dealer.ack(*player).unwrap();
         }
 
         // Finalize dealer
@@ -1227,11 +1192,11 @@ mod tests {
         let (mut dealer, _, _) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Ack player
-        let player = contributors[0].clone();
-        dealer.ack(player.clone()).unwrap();
+        let player = contributors[0];
+        dealer.ack(player).unwrap();
 
         // Ack player (again)
-        let result = dealer.ack(player.clone());
+        let result = dealer.ack(player);
         assert!(matches!(result, Err(Error::DuplicateAck)));
     }
 
@@ -1254,7 +1219,7 @@ mod tests {
 
         // Ack invalid player
         let player = Ed25519::from_seed(n as u64).public_key();
-        let result = dealer.ack(player.clone());
+        let result = dealer.ack(player);
         assert!(matches!(result, Err(Error::PlayerInvalid)));
     }
 
@@ -1274,7 +1239,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -1285,9 +1250,7 @@ mod tests {
         let mut commitments = HashMap::new();
         for (i, con) in contributors.iter().enumerate().take(2) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
-            player
-                .share(con.clone(), commitment.clone(), shares[0])
-                .unwrap();
+            player.share(*con, commitment.clone(), shares[0]).unwrap();
             commitments.insert(i as u32, commitment);
         }
 
@@ -1315,7 +1278,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -1326,9 +1289,7 @@ mod tests {
         let mut commitments = HashMap::new();
         for (i, con) in contributors.iter().enumerate().take(2) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
-            player
-                .share(con.clone(), commitment.clone(), shares[0])
-                .unwrap();
+            player.share(*con, commitment.clone(), shares[0]).unwrap();
             commitments.insert(i as u32, commitment);
         }
 
@@ -1355,7 +1316,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -1366,9 +1327,7 @@ mod tests {
         let mut commitments = HashMap::new();
         for (i, con) in contributors.iter().enumerate().take(2) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
-            player
-                .share(con.clone(), commitment.clone(), shares[0])
-                .unwrap();
+            player.share(*con, commitment.clone(), shares[0]).unwrap();
             commitments.insert(i as u32, commitment);
         }
 
@@ -1393,7 +1352,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -1404,9 +1363,7 @@ mod tests {
         let mut commitments = HashMap::new();
         for (i, con) in contributors.iter().enumerate().take(2) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
-            player
-                .share(con.clone(), commitment.clone(), shares[0])
-                .unwrap();
+            player.share(*con, commitment.clone(), shares[0]).unwrap();
             commitments.insert(i as u32, commitment);
         }
 
@@ -1435,7 +1392,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -1446,9 +1403,7 @@ mod tests {
         let mut commitments = HashMap::new();
         for (i, con) in contributors.iter().enumerate().take(2) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
-            player
-                .share(con.clone(), commitment.clone(), shares[0])
-                .unwrap();
+            player.share(*con, commitment.clone(), shares[0]).unwrap();
             commitments.insert(i as u32, commitment);
         }
 
@@ -1477,7 +1432,7 @@ mod tests {
 
         // Create player
         let mut player = Player::new(
-            contributors[0].clone(),
+            contributors[0],
             None,
             contributors.clone(),
             contributors.clone(),
@@ -1488,9 +1443,7 @@ mod tests {
         let mut commitments = HashMap::new();
         for (i, con) in contributors.iter().enumerate().take(2) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
-            player
-                .share(con.clone(), commitment.clone(), shares[0])
-                .unwrap();
+            player.share(*con, commitment.clone(), shares[0]).unwrap();
             commitments.insert(i as u32, commitment);
         }
 

--- a/cryptography/src/bls12381/dkg/player.rs
+++ b/cryptography/src/bls12381/dkg/player.rs
@@ -1,14 +1,16 @@
 //! Participants in a DKG/Resharing procedure that receive dealings from dealers
 //! and eventually maintain a share of a shared secret.
 
-use crate::bls12381::{
-    dkg::{ops, Error},
-    primitives::{
-        group::{self, Element, Share},
-        poly::{self, Eval},
+use crate::{
+    bls12381::{
+        dkg::{ops, Error},
+        primitives::{
+            group::{self, Element, Share},
+            poly::{self, Eval},
+        },
     },
+    Component,
 };
-use crate::PublicKey;
 use commonware_utils::quorum;
 use std::collections::{BTreeMap, HashMap};
 
@@ -25,7 +27,7 @@ pub struct Output {
 }
 
 /// Track commitments and dealings distributed by dealers.
-pub struct Player<P: PublicKey> {
+pub struct Player<P: Component> {
     me: u32,
     dealer_threshold: u32,
     player_threshold: u32,
@@ -37,7 +39,7 @@ pub struct Player<P: PublicKey> {
     dealings: HashMap<u32, (poly::Public, Share)>,
 }
 
-impl<P: PublicKey> Player<P> {
+impl<P: Component> Player<P> {
     /// Create a new player for a DKG/Resharing procedure.
     pub fn new(
         me: P,

--- a/cryptography/src/bls12381/dkg/player.rs
+++ b/cryptography/src/bls12381/dkg/player.rs
@@ -25,33 +25,33 @@ pub struct Output {
 }
 
 /// Track commitments and dealings distributed by dealers.
-pub struct Player {
+pub struct Player<P: PublicKey> {
     me: u32,
     dealer_threshold: u32,
     player_threshold: u32,
     previous: Option<poly::Public>,
     concurrency: usize,
 
-    dealers: HashMap<PublicKey, u32>,
+    dealers: HashMap<P, u32>,
 
     dealings: HashMap<u32, (poly::Public, Share)>,
 }
 
-impl Player {
+impl<P: PublicKey> Player<P> {
     /// Create a new player for a DKG/Resharing procedure.
     pub fn new(
-        me: PublicKey,
+        me: P,
         previous: Option<poly::Public>,
-        mut dealers: Vec<PublicKey>,
-        mut recipients: Vec<PublicKey>,
+        mut dealers: Vec<P>,
+        mut recipients: Vec<P>,
         concurrency: usize,
     ) -> Self {
         dealers.sort();
         let dealers = dealers
             .iter()
             .enumerate()
-            .map(|(i, pk)| (pk.clone(), i as u32))
-            .collect::<HashMap<PublicKey, _>>();
+            .map(|(i, pk)| (*pk, i as u32))
+            .collect::<HashMap<P, _>>();
         recipients.sort();
         let mut me_idx = None;
         for (idx, recipient) in recipients.iter().enumerate() {
@@ -76,7 +76,7 @@ impl Player {
     /// Verify and track a commitment from a dealer.
     pub fn share(
         &mut self,
-        dealer: PublicKey,
+        dealer: P,
         commitment: poly::Public,
         share: Share,
     ) -> Result<(), Error> {

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -76,10 +76,6 @@ impl Scheme for Bls12381 {
         Signature::from(&signature)
     }
 
-    //fn validate(public_key: &PublicKey) -> bool {
-    //    group::Public::deserialize(public_key.as_ref()).is_some()
-    //}
-
     fn verify(
         namespace: Option<&[u8]>,
         message: &[u8],
@@ -95,10 +91,6 @@ impl Scheme for Bls12381 {
             None => return false,
         };
         ops::verify_message(&public, namespace, message, &signature).is_ok()
-    }
-
-    fn len() -> (usize, usize) {
-        (group::G1_ELEMENT_BYTE_LENGTH, group::G2_ELEMENT_BYTE_LENGTH)
     }
 }
 

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -23,10 +23,7 @@ use super::primitives::{
     group::{self, Element, Scalar, G1},
     ops,
 };
-use crate::{
-    Error, PrivateKey as CPrivateKey, PublicKey as CPublicKey, Scheme, Signature as CSignature,
-};
-use bytes::Bytes;
+use crate::{Component, Error, Scheme};
 use rand::{CryptoRng, Rng};
 use std::ops::Deref;
 
@@ -98,7 +95,7 @@ impl Scheme for Bls12381 {
 #[repr(transparent)]
 pub struct PrivateKey([u8; group::PRIVATE_KEY_LENGTH]);
 
-impl CPrivateKey for PrivateKey {}
+impl Component for PrivateKey {}
 
 impl AsRef<[u8]> for PrivateKey {
     fn as_ref(&self) -> &[u8] {
@@ -160,18 +157,11 @@ impl TryFrom<Vec<u8>> for PrivateKey {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<Bytes> for PrivateKey {
-    fn into(self) -> Bytes {
-        Bytes::copy_from_slice(self.as_ref())
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct PublicKey([u8; group::PUBLIC_KEY_LENGTH]);
 
-impl CPublicKey for PublicKey {}
+impl Component for PublicKey {}
 
 impl AsRef<[u8]> for PublicKey {
     fn as_ref(&self) -> &[u8] {
@@ -222,18 +212,11 @@ impl TryFrom<Vec<u8>> for PublicKey {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<Bytes> for PublicKey {
-    fn into(self) -> Bytes {
-        Bytes::copy_from_slice(self.as_ref())
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct Signature([u8; group::SIGNATURE_LENGTH]);
 
-impl CSignature for Signature {}
+impl Component for Signature {}
 
 impl AsRef<[u8]> for Signature {
     fn as_ref(&self) -> &[u8] {
@@ -278,13 +261,6 @@ impl TryFrom<Vec<u8>> for Signature {
     type Error = Error;
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         Self::try_from(value.as_slice())
-    }
-}
-
-#[allow(clippy::from_over_into)]
-impl Into<Bytes> for Signature {
-    fn into(self) -> Bytes {
-        Bytes::copy_from_slice(self.as_ref())
     }
 }
 

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -75,10 +75,6 @@ impl Scheme for Ed25519 {
             None => public_key.verify(&signature, message).is_ok(),
         }
     }
-
-    fn len() -> (usize, usize) {
-        (PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH)
-    }
 }
 
 /// Ed25519 Batch Verifier.

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -1,8 +1,4 @@
-use crate::{
-    BatchScheme, Error, PrivateKey as CPrivateKey, PublicKey as CPublicKey, Scheme,
-    Signature as CSignature,
-};
-use bytes::Bytes;
+use crate::{BatchScheme, Component, Error, Scheme};
 use commonware_utils::union_unique;
 use ed25519_consensus::{self, VerificationKey, VerificationKeyBytes};
 use rand::{CryptoRng, Rng, RngCore};
@@ -119,7 +115,7 @@ impl BatchScheme for Ed25519Batch {
 #[repr(transparent)]
 pub struct PrivateKey([u8; PRIVATE_KEY_LENGTH]);
 
-impl CPrivateKey for PrivateKey {}
+impl Component for PrivateKey {}
 
 impl AsRef<[u8]> for PrivateKey {
     fn as_ref(&self) -> &[u8] {
@@ -179,18 +175,13 @@ impl TryFrom<Vec<u8>> for PrivateKey {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<Bytes> for PrivateKey {
-    fn into(self) -> Bytes {
-        Bytes::copy_from_slice(self.as_ref())
-    }
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PublicKey {
+    parsed: [u8; PUBLIC_KEY_LENGTH],
+    verifying_key: VerificationKey,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[repr(transparent)]
-pub struct PublicKey([u8; PUBLIC_KEY_LENGTH]);
-
-impl CPublicKey for PublicKey {}
+impl Component for PublicKey {}
 
 impl AsRef<[u8]> for PublicKey {
     fn as_ref(&self) -> &[u8] {
@@ -236,18 +227,13 @@ impl TryFrom<Vec<u8>> for PublicKey {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<Bytes> for PublicKey {
-    fn into(self) -> Bytes {
-        Bytes::copy_from_slice(self.as_ref())
-    }
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Signature {
+    parsed: [u8; SIGNATURE_LENGTH],
+    signature: ed25519_consensus::Signature,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[repr(transparent)]
-pub struct Signature([u8; SIGNATURE_LENGTH]);
-
-impl CSignature for Signature {}
+impl Component for Signature {}
 
 impl AsRef<[u8]> for Signature {
     fn as_ref(&self) -> &[u8] {
@@ -293,13 +279,6 @@ impl TryFrom<Vec<u8>> for Signature {
     type Error = Error;
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         Self::try_from(value.as_slice())
-    }
-}
-
-#[allow(clippy::from_over_into)]
-impl Into<Bytes> for Signature {
-    fn into(self) -> Bytes {
-        Bytes::copy_from_slice(self.as_ref())
     }
 }
 

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -140,9 +140,6 @@ pub trait Scheme: Clone + Send + Sync + 'static {
         public_key: &Self::PublicKey,
         signature: &Self::Signature,
     ) -> bool;
-
-    /// Returns the size of a public key and signature in bytes.
-    fn len() -> (usize, usize);
 }
 
 /// Interface that commonware crates rely on for batched cryptographic operations.
@@ -425,7 +422,8 @@ mod tests {
 
     #[test]
     fn test_ed25519_len() {
-        assert_eq!(Ed25519::len(), (32, 64));
+        assert_eq!(size_of::<<Ed25519 as Scheme>::PublicKey>(), 32);
+        assert_eq!(size_of::<<Ed25519 as Scheme>::Signature>(), 64);
     }
 
     #[test]
@@ -475,7 +473,8 @@ mod tests {
 
     #[test]
     fn test_bls12381_len() {
-        assert_eq!(Bls12381::len(), (48, 96));
+        assert_eq!(size_of::<<Bls12381 as Scheme>::PublicKey>(), 48);
+        assert_eq!(size_of::<<Bls12381 as Scheme>::Signature>(), 96);
     }
 
     #[test]
@@ -525,7 +524,8 @@ mod tests {
 
     #[test]
     fn test_secp256r1_len() {
-        assert_eq!(Secp256r1::len(), (33, 64));
+        assert_eq!(size_of::<<Secp256r1 as Scheme>::PublicKey>(), 33);
+        assert_eq!(size_of::<<Secp256r1 as Scheme>::Signature>(), 64);
     }
 
     fn test_hasher_multiple_runs<H: Hasher>() {

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -6,7 +6,6 @@
 //! expect breaking changes and occasional instability.
 
 use bytes::Buf;
-use bytes::Bytes;
 use rand::{CryptoRng, Rng, RngCore, SeedableRng};
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -24,14 +23,12 @@ pub use sha256::Sha256;
 pub mod secp256r1;
 pub use secp256r1::Secp256r1;
 
-pub trait PrivateKey:
+pub trait Component:
     AsRef<[u8]>
     + for<'a> TryFrom<&'a [u8], Error = Error>
     + for<'a> TryFrom<&'a Vec<u8>, Error = Error>
     + TryFrom<Vec<u8>, Error = Error>
     + Deref<Target = [u8]>
-    + Into<Bytes>
-    + Default
     + Sized
     + Copy
     + Send
@@ -44,55 +41,34 @@ pub trait PrivateKey:
     + Debug
     + Hash
 {
-}
+    /// Attempts to read a digest from the provided buffer.
+    fn read_from<B: Buf>(buf: &mut B) -> Result<Self, Error> {
+        // Check if there are enough bytes in the buffer to read a digest.
+        let digest_len = size_of::<Self>();
+        if buf.remaining() < digest_len {
+            return Err(Error::InvalidDigestLength);
+        }
 
-pub trait PublicKey:
-    AsRef<[u8]>
-    + for<'a> TryFrom<&'a [u8], Error = Error>
-    + for<'a> TryFrom<&'a Vec<u8>, Error = Error>
-    + TryFrom<Vec<u8>, Error = Error>
-    + Deref<Target = [u8]>
-    + Into<Bytes>
-    + Sized
-    + Copy
-    + Send
-    + Sync
-    + 'static
-    + Eq
-    + PartialEq
-    + Ord
-    + PartialOrd
-    + Debug
-    + Hash
-{
-}
+        // If there are enough contiguous bytes in the buffer, use them directly.
+        let chunk = buf.chunk();
+        if chunk.len() >= digest_len {
+            let digest = Self::try_from(&chunk[..digest_len])?;
+            buf.advance(digest_len);
+            return Ok(digest);
+        }
 
-pub trait Signature:
-    AsRef<[u8]>
-    + for<'a> TryFrom<&'a [u8], Error = Error>
-    + for<'a> TryFrom<&'a Vec<u8>, Error = Error>
-    + TryFrom<Vec<u8>, Error = Error>
-    + Deref<Target = [u8]>
-    + Into<Bytes>
-    + Sized
-    + Copy
-    + Send
-    + Sync
-    + 'static
-    + Eq
-    + PartialEq
-    + Ord
-    + PartialOrd
-    + Debug
-    + Hash
-{
+        // Otherwise, copy the bytes into a temporary buffer.
+        let mut temp = vec![0u8; digest_len];
+        buf.copy_to_slice(&mut temp);
+        Self::try_from(temp)
+    }
 }
 
 /// Interface that commonware crates rely on for most cryptographic operations.
 pub trait Scheme: Clone + Send + Sync + 'static {
-    type PrivateKey: PrivateKey;
-    type PublicKey: PublicKey;
-    type Signature: Signature;
+    type PrivateKey: Component;
+    type PublicKey: Component;
+    type Signature: Component;
     /// Returns a new instance of the scheme.
     fn new<R: Rng + CryptoRng>(rng: &mut R) -> Self;
 
@@ -144,8 +120,8 @@ pub trait Scheme: Clone + Send + Sync + 'static {
 
 /// Interface that commonware crates rely on for batched cryptographic operations.
 pub trait BatchScheme {
-    type PublicKey: PublicKey;
-    type Signature: Signature;
+    type PublicKey: Component;
+    type Signature: Component;
 
     /// Create a new batch scheme.
     fn new() -> Self;
@@ -198,49 +174,6 @@ pub enum Error {
     InvalidPublicKey,
 }
 
-/// Byte array representing an arbitrary hash digest.
-pub trait Digest:
-    AsRef<[u8]>
-    + for<'a> TryFrom<&'a [u8], Error = Error>
-    + for<'a> TryFrom<&'a Vec<u8>, Error = Error>
-    + TryFrom<Vec<u8>, Error = Error>
-    + Deref<Target = [u8]>
-    + Default
-    + Sized
-    + Clone
-    + Send
-    + Sync
-    + 'static
-    + Eq
-    + PartialEq
-    + Ord
-    + PartialOrd
-    + Debug
-    + Hash
-{
-    /// Attempts to read a digest from the provided buffer.
-    fn read_from<B: Buf>(buf: &mut B) -> Result<Self, Error> {
-        // Check if there are enough bytes in the buffer to read a digest.
-        let digest_len = size_of::<Self>();
-        if buf.remaining() < digest_len {
-            return Err(Error::InvalidDigestLength);
-        }
-
-        // If there are enough contiguous bytes in the buffer, use them directly.
-        let chunk = buf.chunk();
-        if chunk.len() >= digest_len {
-            let digest = Self::try_from(&chunk[..digest_len])?;
-            buf.advance(digest_len);
-            return Ok(digest);
-        }
-
-        // Otherwise, copy the bytes into a temporary buffer.
-        let mut temp = vec![0u8; digest_len];
-        buf.copy_to_slice(&mut temp);
-        Self::try_from(temp)
-    }
-}
-
 /// Interface that commonware crates rely on for hashing.
 ///
 /// Hash functions in commonware primitives are not typically hardcoded
@@ -255,7 +188,7 @@ pub trait Digest:
 /// after cloning.
 pub trait Hasher: Clone + Send + Sync + 'static {
     /// Byte array representing a hash digest.
-    type Digest: Digest;
+    type Digest: Component;
 
     /// Create a new hasher.
     fn new() -> Self;

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Error, PrivateKey as CPrivateKey, PublicKey as CPublicKey, Scheme, Signature as CSignature,
-};
-use bytes::Bytes;
+use crate::{Component, Error, Scheme};
 use commonware_utils::union_unique;
 use p256::{
     ecdsa::{
@@ -108,7 +105,7 @@ impl Scheme for Secp256r1 {
 #[repr(transparent)]
 pub struct PrivateKey([u8; PRIVATE_KEY_LENGTH]);
 
-impl CPrivateKey for PrivateKey {}
+impl Component for PrivateKey {}
 
 impl AsRef<[u8]> for PrivateKey {
     fn as_ref(&self) -> &[u8] {
@@ -162,18 +159,11 @@ impl TryFrom<Vec<u8>> for PrivateKey {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<Bytes> for PrivateKey {
-    fn into(self) -> Bytes {
-        Bytes::copy_from_slice(self.as_ref())
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct PublicKey([u8; PUBLIC_KEY_LENGTH]);
 
-impl CPublicKey for PublicKey {}
+impl Component for PublicKey {}
 
 impl AsRef<[u8]> for PublicKey {
     fn as_ref(&self) -> &[u8] {
@@ -227,18 +217,11 @@ impl TryFrom<Vec<u8>> for PublicKey {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<Bytes> for PublicKey {
-    fn into(self) -> Bytes {
-        Bytes::copy_from_slice(self.as_ref())
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct Signature([u8; SIGNATURE_LENGTH]);
 
-impl CSignature for Signature {}
+impl Component for Signature {}
 
 impl AsRef<[u8]> for Signature {
     fn as_ref(&self) -> &[u8] {
@@ -286,13 +269,6 @@ impl TryFrom<Vec<u8>> for Signature {
     type Error = Error;
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         Self::try_from(value.as_slice())
-    }
-}
-
-#[allow(clippy::from_over_into)]
-impl Into<Bytes> for Signature {
-    fn into(self) -> Bytes {
-        Bytes::copy_from_slice(self.as_ref())
     }
 }
 

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -102,10 +102,6 @@ impl Scheme for Secp256r1 {
         };
         verifier.verify(&payload, &signature).is_ok()
     }
-
-    fn len() -> (usize, usize) {
-        (PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH)
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -1,6 +1,6 @@
 //! SHA-256 implementation of the `Hasher` trait.
 
-use crate::{Digest as CDigest, Error, Hasher};
+use crate::{Component, Error, Hasher};
 use rand::{CryptoRng, Rng};
 use sha2::{Digest as _, Sha256 as ISha256};
 use std::ops::Deref;
@@ -63,11 +63,11 @@ impl Hasher for Sha256 {
 }
 
 /// Digest of a SHA-256 hashing operation.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct Digest([u8; DIGEST_LENGTH]);
 
-impl CDigest for Digest {}
+impl Component for Digest {}
 
 impl From<[u8; DIGEST_LENGTH]> for Digest {
     fn from(value: [u8; DIGEST_LENGTH]) -> Self {
@@ -121,12 +121,6 @@ impl Deref for Digest {
     type Target = [u8];
     fn deref(&self) -> &[u8] {
         &self.0
-    }
-}
-
-impl Default for Digest {
-    fn default() -> Self {
-        Self([0u8; DIGEST_LENGTH])
     }
 }
 

--- a/examples/bridge/src/application/actor.rs
+++ b/examples/bridge/src/application/actor.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::wire;
 
 use super::{
@@ -9,7 +11,7 @@ use bytes::BufMut;
 use commonware_consensus::threshold_simplex::Prover;
 use commonware_cryptography::{
     bls12381::primitives::{group::Element, poly},
-    Hasher,
+    Hasher, PublicKey,
 };
 use commonware_runtime::{Sink, Stream};
 use commonware_stream::{public_key::Connection, Receiver, Sender};
@@ -36,7 +38,10 @@ pub struct Application<R: Rng, H: Hasher, Si: Sink, St: Stream> {
 
 impl<R: Rng, H: Hasher, Si: Sink, St: Stream> Application<R, H, Si, St> {
     /// Create a new application actor.
-    pub fn new(runtime: R, config: Config<H, Si, St>) -> (Self, Supervisor, Mailbox<H::Digest>) {
+    pub fn new<P: PublicKey>(
+        runtime: R,
+        config: Config<H, Si, St, P>,
+    ) -> (Self, Supervisor<P>, Mailbox<H::Digest>) {
         let (sender, mailbox) = mpsc::channel(config.mailbox_size);
         (
             Self {

--- a/examples/bridge/src/application/actor.rs
+++ b/examples/bridge/src/application/actor.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 
 use crate::wire;
 

--- a/examples/bridge/src/application/mod.rs
+++ b/examples/bridge/src/application/mod.rs
@@ -16,7 +16,7 @@ mod ingress;
 mod supervisor;
 
 /// Configuration for the application.
-pub struct Config<H: Hasher, Si: Sink, St: Stream> {
+pub struct Config<H: Hasher, Si: Sink, St: Stream, P: PublicKey> {
     pub indexer: Connection<Si, St>,
 
     /// Hashing scheme to use.
@@ -32,7 +32,7 @@ pub struct Config<H: Hasher, Si: Sink, St: Stream> {
     pub other_network: group::Public,
 
     /// Participants active in consensus.
-    pub participants: Vec<PublicKey>,
+    pub participants: Vec<P>,
 
     pub share: group::Share,
 

--- a/examples/bridge/src/application/supervisor.rs
+++ b/examples/bridge/src/application/supervisor.rs
@@ -13,18 +13,18 @@ use std::collections::HashMap;
 
 /// Implementation of `commonware-consensus::Supervisor`.
 #[derive(Clone)]
-pub struct Supervisor {
+pub struct Supervisor<P: PublicKey> {
     identity: Poly<group::Public>,
-    participants: Vec<PublicKey>,
-    participants_map: HashMap<PublicKey, u32>,
+    participants: Vec<P>,
+    participants_map: HashMap<P, u32>,
 
     share: group::Share,
 }
 
-impl Supervisor {
+impl<P: PublicKey> Supervisor<P> {
     pub fn new(
         identity: Poly<group::Public>,
-        mut participants: Vec<PublicKey>,
+        mut participants: Vec<P>,
         share: group::Share,
     ) -> Self {
         // Setup participants
@@ -44,18 +44,19 @@ impl Supervisor {
     }
 }
 
-impl Su for Supervisor {
+impl<P: PublicKey> Su for Supervisor<P> {
     type Index = View;
+    type PublicKey = P;
 
-    fn leader(&self, _: Self::Index) -> Option<PublicKey> {
+    fn leader(&self, _: Self::Index) -> Option<Self::PublicKey> {
         unimplemented!("only defined in supertrait")
     }
 
-    fn participants(&self, _: Self::Index) -> Option<&Vec<PublicKey>> {
+    fn participants(&self, _: Self::Index) -> Option<&Vec<Self::PublicKey>> {
         Some(&self.participants)
     }
 
-    fn is_participant(&self, _: Self::Index, candidate: &PublicKey) -> Option<u32> {
+    fn is_participant(&self, _: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {
         self.participants_map.get(candidate).cloned()
     }
 
@@ -65,12 +66,12 @@ impl Su for Supervisor {
     }
 }
 
-impl TSu for Supervisor {
+impl<P: PublicKey> TSu for Supervisor<P> {
     type Seed = group::Signature;
     type Identity = poly::Public;
     type Share = group::Share;
 
-    fn leader(&self, _: Self::Index, seed: Self::Seed) -> Option<PublicKey> {
+    fn leader(&self, _: Self::Index, seed: Self::Seed) -> Option<Self::PublicKey> {
         let seed = seed.serialize();
         let index = modulo(&seed, self.participants.len() as u64);
         Some(self.participants[index as usize].clone())

--- a/examples/bridge/src/application/supervisor.rs
+++ b/examples/bridge/src/application/supervisor.rs
@@ -31,7 +31,7 @@ impl<P: PublicKey> Supervisor<P> {
         participants.sort();
         let mut participants_map = HashMap::new();
         for (index, validator) in participants.iter().enumerate() {
-            participants_map.insert(validator.clone(), index as u32);
+            participants_map.insert(*validator, index as u32);
         }
 
         // Return supervisor
@@ -74,7 +74,7 @@ impl<P: PublicKey> TSu for Supervisor<P> {
     fn leader(&self, _: Self::Index, seed: Self::Seed) -> Option<Self::PublicKey> {
         let seed = seed.serialize();
         let index = modulo(&seed, self.participants.len() as u64);
-        Some(self.participants[index as usize].clone())
+        Some(self.participants[index as usize])
     }
 
     fn identity(&self, _: Self::Index) -> Option<&Self::Identity> {

--- a/examples/log/src/application/actor.rs
+++ b/examples/log/src/application/actor.rs
@@ -23,7 +23,10 @@ pub struct Application<R: Rng, C: Scheme, H: Hasher> {
 
 impl<R: Rng, C: Scheme, H: Hasher> Application<R, C, H> {
     /// Create a new application actor.
-    pub fn new(runtime: R, config: Config<C, H>) -> (Self, Supervisor, Mailbox<H::Digest>) {
+    pub fn new(
+        runtime: R,
+        config: Config<C, H>,
+    ) -> (Self, Supervisor<C::PublicKey>, Mailbox<H::Digest>) {
         let (sender, mailbox) = mpsc::channel(config.mailbox_size);
         (
             Self {

--- a/examples/log/src/application/mod.rs
+++ b/examples/log/src/application/mod.rs
@@ -3,7 +3,7 @@
 //! participants are active at a given view.
 
 use commonware_consensus::simplex::Prover;
-use commonware_cryptography::{Hasher, PublicKey, Scheme};
+use commonware_cryptography::{Hasher, Scheme};
 
 mod actor;
 pub use actor::Application;

--- a/examples/log/src/application/mod.rs
+++ b/examples/log/src/application/mod.rs
@@ -19,7 +19,7 @@ pub struct Config<C: Scheme, H: Hasher> {
     pub prover: Prover<C, H::Digest>,
 
     /// Participants active in consensus.
-    pub participants: Vec<PublicKey>,
+    pub participants: Vec<C::PublicKey>,
 
     /// Number of messages from consensus to hold in our backlog
     /// before blocking.

--- a/examples/log/src/application/supervisor.rs
+++ b/examples/log/src/application/supervisor.rs
@@ -15,7 +15,7 @@ impl<P: PublicKey> Supervisor<P> {
         participants.sort();
         let mut participants_map = HashMap::new();
         for (index, validator) in participants.iter().enumerate() {
-            participants_map.insert(validator.clone(), index as u32);
+            participants_map.insert(*validator, index as u32);
         }
 
         // Return supervisor
@@ -31,7 +31,7 @@ impl<P: PublicKey> Su for Supervisor<P> {
     type PublicKey = P;
 
     fn leader(&self, index: Self::Index) -> Option<Self::PublicKey> {
-        Some(self.participants[index as usize % self.participants.len()].clone())
+        Some(self.participants[index as usize % self.participants.len()])
     }
 
     fn participants(&self, _: Self::Index) -> Option<&Vec<Self::PublicKey>> {

--- a/examples/log/src/application/supervisor.rs
+++ b/examples/log/src/application/supervisor.rs
@@ -4,13 +4,13 @@ use std::collections::HashMap;
 
 /// Implementation of `commonware-consensus::Supervisor`.
 #[derive(Clone)]
-pub struct Supervisor {
-    participants: Vec<PublicKey>,
-    participants_map: HashMap<PublicKey, u32>,
+pub struct Supervisor<P: PublicKey> {
+    participants: Vec<P>,
+    participants_map: HashMap<P, u32>,
 }
 
-impl Supervisor {
-    pub fn new(mut participants: Vec<PublicKey>) -> Self {
+impl<P: PublicKey> Supervisor<P> {
+    pub fn new(mut participants: Vec<P>) -> Self {
         // Setup participants
         participants.sort();
         let mut participants_map = HashMap::new();
@@ -26,18 +26,19 @@ impl Supervisor {
     }
 }
 
-impl Su for Supervisor {
+impl<P: PublicKey> Su for Supervisor<P> {
     type Index = View;
+    type PublicKey = P;
 
-    fn leader(&self, index: Self::Index) -> Option<PublicKey> {
+    fn leader(&self, index: Self::Index) -> Option<Self::PublicKey> {
         Some(self.participants[index as usize % self.participants.len()].clone())
     }
 
-    fn participants(&self, _: Self::Index) -> Option<&Vec<PublicKey>> {
+    fn participants(&self, _: Self::Index) -> Option<&Vec<Self::PublicKey>> {
         Some(&self.participants)
     }
 
-    fn is_participant(&self, _: Self::Index, candidate: &PublicKey) -> Option<u32> {
+    fn is_participant(&self, _: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {
         self.participants_map.get(candidate).cloned()
     }
 

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -9,8 +9,7 @@ use commonware_cryptography::{
             group::{self, Element},
             poly,
         },
-    },
-    PublicKey, Scheme,
+    }, Scheme,
 };
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
@@ -177,7 +176,7 @@ impl<E: Clock, C: Scheme> Arbiter<E, C> {
                             // Check dealer commitment
                             //
                             // Any faults here will be considered as a disqualification.
-                            if let Err(e) = arbiter.commitment(sender.clone(), commitment, acks, reveals) {
+                            if let Err(e) = arbiter.commitment(sender, commitment, acks, reveals) {
                                 warn!(round, error = ?e, sender = hex(&sender), "failed to process commitment");
                                 break;
                             }
@@ -249,7 +248,7 @@ impl<E: Clock, C: Scheme> Arbiter<E, C> {
             let reveals = reveals.remove(&(player_idx as u32)).unwrap_or_default();
             sender
                 .send(
-                    Recipients::One(player.clone()),
+                    Recipients::One(*player),
                     wire::Dkg {
                         round,
                         payload: Some(wire::dkg::Payload::Success(wire::Success {

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -25,10 +25,10 @@ pub struct Contributor<E: Clock + Rng, C: Scheme> {
     runtime: E,
     crypto: C,
     dkg_phase_timeout: Duration,
-    arbiter: PublicKey,
+    arbiter: C::PublicKey,
     t: u32,
-    contributors: Vec<PublicKey>,
-    contributors_ordered: HashMap<PublicKey, u32>,
+    contributors: Vec<C::PublicKey>,
+    contributors_ordered: HashMap<C::PublicKey, u32>,
 
     corrupt: bool,
     lazy: bool,
@@ -43,14 +43,14 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
         runtime: E,
         crypto: C,
         dkg_phase_timeout: Duration,
-        arbiter: PublicKey,
-        mut contributors: Vec<PublicKey>,
+        arbiter: C::PublicKey,
+        mut contributors: Vec<C::PublicKey>,
         corrupt: bool,
         lazy: bool,
         forger: bool,
     ) -> (Self, mpsc::Receiver<(u64, Output)>) {
         contributors.sort();
-        let contributors_ordered: HashMap<PublicKey, u32> = contributors
+        let contributors_ordered: HashMap<C::PublicKey, u32> = contributors
             .iter()
             .enumerate()
             .map(|(idx, pk)| (pk.clone(), idx as u32))
@@ -79,8 +79,8 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
     async fn run_round(
         &mut self,
         previous: Option<&Output>,
-        sender: &mut impl Sender,
-        receiver: &mut impl Receiver,
+        sender: &mut impl Sender<PublicKey = C::PublicKey>,
+        receiver: &mut impl Receiver<PublicKey = C::PublicKey>,
     ) -> (u64, Option<Output>) {
         // Configure me
         let me = self.crypto.public_key();
@@ -213,7 +213,8 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
                     let _ = dealer.ack(player.clone());
                     let mut signature = vec![0u8; C::len().1];
                     self.runtime.fill_bytes(&mut signature);
-                    acks.insert(idx as u32, signature.into());
+                    let signature = C::Signature::try_from(&signature).unwrap();
+                    acks.insert(idx as u32, signature);
                     warn!(
                         round,
                         player = hex(player),
@@ -314,7 +315,11 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
 
                                         // Verify signature on incoming ack
                                         let payload = payload(round, &me, commitment);
-                                        if !C::verify(Some(ACK_NAMESPACE), &payload, &s, &msg.signature) {
+                                        let Ok(signature) = C::Signature::try_from(msg.signature.as_ref()) else {
+                                            warn!(round, sender = hex(&s), "received invalid ack signature");
+                                            continue;
+                                        };
+                                        if !C::verify(Some(ACK_NAMESPACE), &payload, &s, &signature) {
                                             warn!(round, sender = hex(&s), "received invalid ack signature");
                                             continue;
                                         }
@@ -324,7 +329,7 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
                                             warn!(round, error = ?e, sender = hex(&s), "failed to record ack");
                                             continue;
                                         }
-                                        acks.insert(msg.public_key, msg.signature);
+                                        acks.insert(msg.public_key, signature);
 
                                     },
                                     Some(wire::dkg::Payload::Share(msg)) => {
@@ -362,7 +367,7 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
                                                     round,
                                                     payload: Some(wire::dkg::Payload::Ack(wire::Ack {
                                                         public_key: me_idx,
-                                                        signature,
+                                                        signature: signature.into(),
                                                     })),
                                                 }
                                                 .encode_to_vec()
@@ -396,7 +401,7 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
                     Some(signature) => {
                         ack_vec.push(wire::Ack {
                             public_key: idx,
-                            signature: signature.clone(),
+                            signature: signature.clone().into(),
                         });
                     }
                     None => {
@@ -508,7 +513,11 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
         }
     }
 
-    pub async fn run(mut self, mut sender: impl Sender, mut receiver: impl Receiver) {
+    pub async fn run(
+        mut self,
+        mut sender: impl Sender<PublicKey = C::PublicKey>,
+        mut receiver: impl Receiver<PublicKey = C::PublicKey>,
+    ) {
         if self.corrupt {
             warn!("running as corrupt");
         }

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -6,7 +6,8 @@ use commonware_cryptography::{
     bls12381::{
         dkg::{player::Output, Dealer, Player},
         primitives::{group, poly},
-    }, Scheme,
+    },
+    Scheme,
 };
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
@@ -195,9 +196,7 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
                 // Send to self
                 let share = shares[idx];
                 if idx == me_idx as usize {
-                    player_obj
-                        .share(me, commitment.clone(), share)
-                        .unwrap();
+                    player_obj.share(me, commitment.clone(), share).unwrap();
                     dealer.ack(me).unwrap();
                     let payload = payload(round, &me, serialized_commitment);
                     let signature = self.crypto.sign(Some(ACK_NAMESPACE), &payload);
@@ -210,7 +209,7 @@ impl<E: Clock + Rng, C: Scheme> Contributor<E, C> {
                 if self.forger {
                     // If we are a forger, don't send any shares and instead create fake signatures.
                     let _ = dealer.ack(*player);
-                    let mut signature = vec![0u8; C::len().1];
+                    let mut signature = vec![0u8; size_of::<C::Signature>()];
                     self.runtime.fill_bytes(&mut signature);
                     let signature = C::Signature::try_from(&signature).unwrap();
                     acks.insert(idx as u32, signature);

--- a/examples/vrf/src/handlers/utils.rs
+++ b/examples/vrf/src/handlers/utils.rs
@@ -9,7 +9,7 @@ use std::mem::size_of;
 pub const ACK_NAMESPACE: &[u8] = b"_COMMONWARE_DKG_ACK_";
 
 /// Create a payload for acking a secret.
-pub fn payload(round: u64, dealer: &PublicKey, commitment: &[u8]) -> Vec<u8> {
+pub fn payload<P: PublicKey>(round: u64, dealer: &P, commitment: &[u8]) -> Vec<u8> {
     let mut payload = Vec::with_capacity(size_of::<u64>() + dealer.len() + commitment.len());
     payload.put_u64(round);
     payload.extend_from_slice(dealer);

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -45,7 +45,7 @@ impl<E: Clock, P: PublicKey> Vrf<E, P> {
         let ordered_contributors = contributors
             .iter()
             .enumerate()
-            .map(|(i, pk)| (pk.clone(), i as u32))
+            .map(|(i, pk)| (*pk, i as u32))
             .collect();
         Self {
             runtime,

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -304,17 +304,14 @@ fn main() {
                 DEFAULT_MESSAGE_BACKLOG,
                 COMPRESSION_LEVEL,
             );
-            let arbiter = handlers::Arbiter::new(
+            let arbiter: handlers::Arbiter<_, Ed25519> = handlers::Arbiter::new(
                 runtime.clone(),
                 DKG_FREQUENCY,
                 DKG_PHASE_TIMEOUT,
                 contributors,
                 threshold,
             );
-            runtime.spawn(
-                "arbiter",
-                arbiter.run::<Ed25519>(arbiter_sender, arbiter_receiver),
-            );
+            runtime.spawn("arbiter", arbiter.run(arbiter_sender, arbiter_receiver));
         }
         network.run().await;
     });

--- a/p2p/src/authenticated/actors/dialer.rs
+++ b/p2p/src/authenticated/actors/dialer.rs
@@ -82,8 +82,8 @@ impl<
 
     async fn dial_peers(
         &self,
-        tracker: &mut tracker::Mailbox<E>,
-        supervisor: &mut spawner::Mailbox<E, Si, St>,
+        tracker: &mut tracker::Mailbox<E, C::PublicKey>,
+        supervisor: &mut spawner::Mailbox<E, Si, St, C::PublicKey>,
     ) {
         for (peer, address, reservation) in tracker.dialable().await {
             // Check if we have hit rate limit for dialing and if so, skip (we don't
@@ -117,21 +117,15 @@ impl<
                     );
 
                     // Upgrade connection
-                    let instance = match Connection::upgrade_dialer(
-                        runtime,
-                        config,
-                        sink,
-                        stream,
-                        peer.clone(),
-                    )
-                    .await
-                    {
-                        Ok(instance) => instance,
-                        Err(e) => {
-                            debug!(peer=hex(&peer), error = ?e, "failed to upgrade connection");
-                            return;
-                        }
-                    };
+                    let instance =
+                        match Connection::upgrade_dialer(runtime, config, sink, stream, peer).await
+                        {
+                            Ok(instance) => instance,
+                            Err(e) => {
+                                debug!(peer=hex(&peer), error = ?e, "failed to upgrade connection");
+                                return;
+                            }
+                        };
                     debug!(peer = hex(&peer), "upgraded connection");
 
                     // Start peer to handle messages
@@ -143,8 +137,8 @@ impl<
 
     pub async fn run(
         mut self,
-        mut tracker: tracker::Mailbox<E>,
-        mut supervisor: spawner::Mailbox<E, Si, St>,
+        mut tracker: tracker::Mailbox<E, C::PublicKey>,
+        mut supervisor: spawner::Mailbox<E, Si, St, C::PublicKey>,
     ) {
         loop {
             // Attempt to dial peers we know about

--- a/p2p/src/authenticated/actors/router/ingress.rs
+++ b/p2p/src/authenticated/actors/router/ingress.rs
@@ -9,35 +9,35 @@ use futures::{
     SinkExt,
 };
 
-pub enum Message {
+pub enum Message<P: PublicKey> {
     Ready {
-        peer: PublicKey,
+        peer: P,
         relay: peer::Relay,
-        channels: oneshot::Sender<Channels>,
+        channels: oneshot::Sender<Channels<P>>,
     },
     Release {
-        peer: PublicKey,
+        peer: P,
     },
     Content {
-        recipients: Recipients,
+        recipients: Recipients<P>,
         channel: Channel,
         message: Bytes,
         priority: bool,
-        success: oneshot::Sender<Vec<PublicKey>>,
+        success: oneshot::Sender<Vec<P>>,
     },
 }
 
 #[derive(Clone)]
-pub struct Mailbox {
-    sender: mpsc::Sender<Message>,
+pub struct Mailbox<P: PublicKey> {
+    sender: mpsc::Sender<Message<P>>,
 }
 
-impl Mailbox {
-    pub fn new(sender: mpsc::Sender<Message>) -> Self {
+impl<P: PublicKey> Mailbox<P> {
+    pub fn new(sender: mpsc::Sender<Message<P>>) -> Self {
         Self { sender }
     }
 
-    pub async fn ready(&mut self, peer: PublicKey, relay: peer::Relay) -> Channels {
+    pub async fn ready(&mut self, peer: P, relay: peer::Relay) -> Channels<P> {
         let (response, receiver) = oneshot::channel();
         self.sender
             .send(Message::Ready {
@@ -50,28 +50,28 @@ impl Mailbox {
         receiver.await.unwrap()
     }
 
-    pub async fn release(&mut self, peer: PublicKey) {
+    pub async fn release(&mut self, peer: P) {
         self.sender.send(Message::Release { peer }).await.unwrap();
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct Messenger {
-    sender: mpsc::Sender<Message>,
+pub struct Messenger<P: PublicKey> {
+    sender: mpsc::Sender<Message<P>>,
 }
 
-impl Messenger {
-    pub fn new(sender: mpsc::Sender<Message>) -> Self {
+impl<P: PublicKey> Messenger<P> {
+    pub fn new(sender: mpsc::Sender<Message<P>>) -> Self {
         Self { sender }
     }
 
     pub async fn content(
         &mut self,
-        recipients: Recipients,
+        recipients: Recipients<P>,
         channel: Channel,
         message: Bytes,
         priority: bool,
-    ) -> Vec<PublicKey> {
+    ) -> Vec<P> {
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(Message::Content {

--- a/p2p/src/authenticated/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/actors/spawner/ingress.rs
@@ -4,28 +4,28 @@ use commonware_runtime::{Clock, Sink, Spawner, Stream};
 use commonware_stream::public_key::Connection;
 use futures::{channel::mpsc, SinkExt};
 
-pub enum Message<E: Spawner + Clock, Si: Sink, St: Stream> {
+pub enum Message<E: Spawner + Clock, Si: Sink, St: Stream, P: PublicKey> {
     Spawn {
-        peer: PublicKey,
+        peer: P,
         connection: Connection<Si, St>,
-        reservation: tracker::Reservation<E>,
+        reservation: tracker::Reservation<E, P>,
     },
 }
 
-pub struct Mailbox<E: Spawner + Clock, Si: Sink, St: Stream> {
-    sender: mpsc::Sender<Message<E, Si, St>>,
+pub struct Mailbox<E: Spawner + Clock, Si: Sink, St: Stream, P: PublicKey> {
+    sender: mpsc::Sender<Message<E, Si, St, P>>,
 }
 
-impl<E: Spawner + Clock, Si: Sink, St: Stream> Mailbox<E, Si, St> {
-    pub fn new(sender: mpsc::Sender<Message<E, Si, St>>) -> Self {
+impl<E: Spawner + Clock, Si: Sink, St: Stream, P: PublicKey> Mailbox<E, Si, St, P> {
+    pub fn new(sender: mpsc::Sender<Message<E, Si, St, P>>) -> Self {
         Self { sender }
     }
 
     pub async fn spawn(
         &mut self,
-        peer: PublicKey,
+        peer: P,
         connection: Connection<Si, St>,
-        reservation: tracker::Reservation<E>,
+        reservation: tracker::Reservation<E, P>,
     ) {
         self.sender
             .send(Message::Spawn {
@@ -38,7 +38,7 @@ impl<E: Spawner + Clock, Si: Sink, St: Stream> Mailbox<E, Si, St> {
     }
 }
 
-impl<E: Spawner + Clock, Si: Sink, St: Stream> Clone for Mailbox<E, Si, St> {
+impl<E: Spawner + Clock, Si: Sink, St: Stream, P: PublicKey> Clone for Mailbox<E, Si, St, P> {
     /// Clone the mailbox.
     ///
     /// We manually implement `clone` because the auto-generated `derive` would

--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -745,7 +745,7 @@ mod tests {
             assert!(matches!(msg, peer::Message::Kill));
 
             // Find sorted indices
-            let mut peers = vec![peer0.public_key(), peer1, peer2.clone(), peer3.clone()];
+            let mut peers = vec![peer0.public_key(), peer1, peer2, peer3];
             peers.sort();
             let me_idx = peers
                 .iter()
@@ -807,7 +807,7 @@ mod tests {
             }
 
             // Register new peers
-            oracle.register(1, vec![peer2.clone(), peer3.clone()]).await;
+            oracle.register(1, vec![peer2, peer3]).await;
 
             // Request bit vector until both indexes returned
             let mut index_0_returned = false;
@@ -842,7 +842,7 @@ mod tests {
             }
 
             // Register some peers
-            oracle.register(2, vec![peer2.clone()]).await;
+            oracle.register(2, vec![peer2]).await;
 
             // Ensure peer1 has been evicted from the peer tracker and should die
             mailbox.construct(peer1, peer_mailbox.clone()).await;
@@ -853,7 +853,7 @@ mod tests {
             let mut index_1_returned = false;
             let mut index_2_returned = false;
             while !index_1_returned || !index_2_returned {
-                mailbox.construct(peer2.clone(), peer_mailbox.clone()).await; // peer1 no longer allowed
+                mailbox.construct(peer2, peer_mailbox.clone()).await; // peer1 no longer allowed
                 let msg = peer_receiver.next().await.unwrap();
                 let bit_vec = match msg {
                     peer::Message::BitVec { bit_vec } => bit_vec,

--- a/p2p/src/authenticated/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/actors/tracker/ingress.rs
@@ -7,16 +7,16 @@ use futures::{
 };
 use std::net::SocketAddr;
 
-pub enum Message<E: Spawner> {
+pub enum Message<E: Spawner, P: PublicKey> {
     // Used by oracle
     Register {
         index: u64,
-        peers: Vec<PublicKey>,
+        peers: Vec<P>,
     },
 
     // Used by peer
     Construct {
-        public_key: PublicKey,
+        public_key: P,
         peer: peer::Mailbox,
     },
     BitVec {
@@ -30,32 +30,32 @@ pub enum Message<E: Spawner> {
 
     // Used by dialer
     Dialable {
-        peers: oneshot::Sender<Vec<(PublicKey, SocketAddr, Reservation<E>)>>,
+        peers: oneshot::Sender<Vec<(P, SocketAddr, Reservation<E, P>)>>,
     },
 
     // Used by listener
     Reserve {
-        peer: PublicKey,
-        reservation: oneshot::Sender<Option<Reservation<E>>>,
+        peer: P,
+        reservation: oneshot::Sender<Option<Reservation<E, P>>>,
     },
 
     // Used by peer
     Release {
-        peer: PublicKey,
+        peer: P,
     },
 }
 
 #[derive(Clone)]
-pub struct Mailbox<E: Spawner> {
-    sender: mpsc::Sender<Message<E>>,
+pub struct Mailbox<E: Spawner, P: PublicKey> {
+    sender: mpsc::Sender<Message<E, P>>,
 }
 
-impl<E: Spawner> Mailbox<E> {
-    pub(super) fn new(sender: mpsc::Sender<Message<E>>) -> Self {
+impl<E: Spawner, P: PublicKey> Mailbox<E, P> {
+    pub(super) fn new(sender: mpsc::Sender<Message<E, P>>) -> Self {
         Self { sender }
     }
 
-    pub async fn construct(&mut self, public_key: PublicKey, peer: peer::Mailbox) {
+    pub async fn construct(&mut self, public_key: P, peer: peer::Mailbox) {
         self.sender
             .send(Message::Construct { public_key, peer })
             .await
@@ -76,7 +76,7 @@ impl<E: Spawner> Mailbox<E> {
             .unwrap();
     }
 
-    pub async fn dialable(&mut self) -> Vec<(PublicKey, SocketAddr, Reservation<E>)> {
+    pub async fn dialable(&mut self) -> Vec<(P, SocketAddr, Reservation<E, P>)> {
         let (response, receiver) = oneshot::channel();
         self.sender
             .send(Message::Dialable { peers: response })
@@ -85,7 +85,7 @@ impl<E: Spawner> Mailbox<E> {
         receiver.await.unwrap()
     }
 
-    pub async fn reserve(&mut self, peer: PublicKey) -> Option<Reservation<E>> {
+    pub async fn reserve(&mut self, peer: P) -> Option<Reservation<E, P>> {
         let (tx, rx) = oneshot::channel();
         self.sender
             .send(Message::Reserve {
@@ -97,7 +97,7 @@ impl<E: Spawner> Mailbox<E> {
         rx.await.unwrap()
     }
 
-    pub async fn release(&mut self, peer: PublicKey) {
+    pub async fn release(&mut self, peer: P) {
         self.sender.send(Message::Release { peer }).await.unwrap();
     }
 }
@@ -107,12 +107,12 @@ impl<E: Spawner> Mailbox<E> {
 /// Peers that are not explicitly authorized
 /// will be blocked by commonware-p2p.
 #[derive(Clone)]
-pub struct Oracle<E: Spawner> {
-    sender: mpsc::Sender<Message<E>>,
+pub struct Oracle<E: Spawner, P: PublicKey> {
+    sender: mpsc::Sender<Message<E, P>>,
 }
 
-impl<E: Spawner> Oracle<E> {
-    pub(super) fn new(sender: mpsc::Sender<Message<E>>) -> Self {
+impl<E: Spawner, P: PublicKey> Oracle<E, P> {
+    pub(super) fn new(sender: mpsc::Sender<Message<E, P>>) -> Self {
         Self { sender }
     }
 
@@ -127,18 +127,18 @@ impl<E: Spawner> Oracle<E> {
     /// * `index` - Index of the set of authorized peers (like a blockchain height).
     ///   Should be monotonically increasing.
     /// * `peers` - Vector of authorized peers at an `index` (does not need to be sorted).
-    pub async fn register(&mut self, index: u64, peers: Vec<PublicKey>) {
+    pub async fn register(&mut self, index: u64, peers: Vec<P>) {
         let _ = self.sender.send(Message::Register { index, peers }).await;
     }
 }
 
-pub struct Reservation<E: Spawner> {
+pub struct Reservation<E: Spawner, P: PublicKey> {
     runtime: E,
-    closer: Option<(PublicKey, Mailbox<E>)>,
+    closer: Option<(P, Mailbox<E, P>)>,
 }
 
-impl<E: Spawner> Reservation<E> {
-    pub fn new(runtime: E, peer: PublicKey, mailbox: Mailbox<E>) -> Self {
+impl<E: Spawner, P: PublicKey> Reservation<E, P> {
+    pub fn new(runtime: E, peer: P, mailbox: Mailbox<E, P>) -> Self {
         Self {
             runtime,
             closer: Some((peer, mailbox)),
@@ -146,7 +146,7 @@ impl<E: Spawner> Reservation<E> {
     }
 }
 
-impl<E: Spawner> Drop for Reservation<E> {
+impl<E: Spawner, P: PublicKey> Drop for Reservation<E, P> {
     fn drop(&mut self) {
         let (peer, mut mailbox) = self.closer.take().unwrap();
         self.runtime.spawn("reservation", async move {

--- a/p2p/src/authenticated/actors/tracker/mod.rs
+++ b/p2p/src/authenticated/actors/tracker/mod.rs
@@ -22,7 +22,7 @@ pub struct Config<C: Scheme> {
     pub namespace: Vec<u8>,
     pub registry: Arc<Mutex<Registry>>,
     pub address: SocketAddr,
-    pub bootstrappers: Vec<Bootstrapper>,
+    pub bootstrappers: Vec<Bootstrapper<C::PublicKey>>,
     pub allow_private_ips: bool,
     pub mailbox_size: usize,
     pub synchrony_bound: Duration,

--- a/p2p/src/authenticated/channels.rs
+++ b/p2p/src/authenticated/channels.rs
@@ -10,19 +10,19 @@ use zstd::bulk::{compress, decompress};
 /// Sender is the mechanism used to send arbitrary bytes to
 /// a set of recipients over a pre-defined channel.
 #[derive(Clone, Debug)]
-pub struct Sender {
+pub struct Sender<P: PublicKey> {
     channel: Channel,
     max_size: usize,
     compression: Option<i32>,
-    messenger: Messenger,
+    messenger: Messenger<P>,
 }
 
-impl Sender {
+impl<P: PublicKey> Sender<P> {
     pub(super) fn new(
         channel: Channel,
         max_size: usize,
         compression: Option<i32>,
-        messenger: Messenger,
+        messenger: Messenger<P>,
     ) -> Self {
         Self {
             channel,
@@ -33,8 +33,9 @@ impl Sender {
     }
 }
 
-impl crate::Sender for Sender {
+impl<P: PublicKey> crate::Sender for Sender<P> {
     type Error = Error;
+    type PublicKey = P;
 
     /// Sends a message to a set of recipients.
     ///
@@ -57,10 +58,10 @@ impl crate::Sender for Sender {
     /// receive the message (connection may no longer be active and we may not know that yet).
     async fn send(
         &mut self,
-        recipients: Recipients,
+        recipients: Recipients<Self::PublicKey>,
         mut message: Bytes,
         priority: bool,
-    ) -> Result<Vec<PublicKey>, Error> {
+    ) -> Result<Vec<Self::PublicKey>, Error> {
         // If compression is enabled, compress the message before sending.
         if let Some(level) = self.compression {
             let compressed = compress(&message, level).map_err(|_| Error::CompressionFailed)?;
@@ -83,17 +84,17 @@ impl crate::Sender for Sender {
 
 /// Channel to asynchronously receive messages from a channel.
 #[derive(Debug)]
-pub struct Receiver {
+pub struct Receiver<P: PublicKey> {
     max_size: usize,
     compression: bool,
-    receiver: mpsc::Receiver<Message>,
+    receiver: mpsc::Receiver<Message<P>>,
 }
 
-impl Receiver {
+impl<P: PublicKey> Receiver<P> {
     pub(super) fn new(
         max_size: usize,
         compression: bool,
-        receiver: mpsc::Receiver<Message>,
+        receiver: mpsc::Receiver<Message<P>>,
     ) -> Self {
         Self {
             max_size,
@@ -103,14 +104,15 @@ impl Receiver {
     }
 }
 
-impl crate::Receiver for Receiver {
+impl<P: PublicKey> crate::Receiver for Receiver<P> {
     type Error = Error;
+    type PublicKey = P;
 
     /// Receives a message from the channel.
     ///
     /// This method will block until a message is received or the underlying
     /// network shuts down.
-    async fn recv(&mut self) -> Result<Message, Error> {
+    async fn recv(&mut self) -> Result<Message<Self::PublicKey>, Error> {
         let (sender, mut message) = self.receiver.next().await.ok_or(Error::NetworkClosed)?;
 
         // If compression is enabled, decompress the message before returning.
@@ -127,14 +129,14 @@ impl crate::Receiver for Receiver {
 }
 
 #[derive(Clone)]
-pub struct Channels {
-    messenger: Messenger,
+pub struct Channels<P: PublicKey> {
+    messenger: Messenger<P>,
     max_size: usize,
-    receivers: BTreeMap<Channel, (Quota, mpsc::Sender<Message>)>,
+    receivers: BTreeMap<Channel, (Quota, mpsc::Sender<Message<P>>)>,
 }
 
-impl Channels {
-    pub fn new(messenger: Messenger, max_size: usize) -> Self {
+impl<P: PublicKey> Channels<P> {
+    pub fn new(messenger: Messenger<P>, max_size: usize) -> Self {
         Self {
             messenger,
             max_size,
@@ -148,7 +150,7 @@ impl Channels {
         rate: governor::Quota,
         backlog: usize,
         compression: Option<i32>,
-    ) -> (Sender, Receiver) {
+    ) -> (Sender<P>, Receiver<P>) {
         let (sender, receiver) = mpsc::channel(backlog);
         if self.receivers.insert(channel, (rate, sender)).is_some() {
             panic!("duplicate channel registration: {}", channel);
@@ -159,7 +161,7 @@ impl Channels {
         )
     }
 
-    pub fn collect(self) -> BTreeMap<u32, (Quota, mpsc::Sender<Message>)> {
+    pub fn collect(self) -> BTreeMap<u32, (Quota, mpsc::Sender<Message<P>>)> {
         self.receivers
     }
 }

--- a/p2p/src/authenticated/config.rs
+++ b/p2p/src/authenticated/config.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{PublicKey, Scheme};
+use commonware_cryptography::Scheme;
 use governor::Quota;
 use prometheus_client::registry::Registry;
 use std::{
@@ -9,7 +9,7 @@ use std::{
 };
 
 /// Known peer and its accompanying address that will be dialed on startup.
-pub type Bootstrapper = (PublicKey, SocketAddr);
+pub type Bootstrapper<Pk> = (Pk, SocketAddr);
 
 /// Configuration for the peer-to-peer instance.
 ///
@@ -36,7 +36,7 @@ pub struct Config<C: Scheme> {
     pub dialable: SocketAddr,
 
     /// Peers dialed on startup.
-    pub bootstrappers: Vec<Bootstrapper>,
+    pub bootstrappers: Vec<Bootstrapper<C::PublicKey>>,
 
     /// Whether or not to allow connections with private IP addresses.
     pub allow_private_ips: bool,
@@ -113,7 +113,7 @@ impl<C: Scheme> Config<C> {
         namespace: &[u8],
         registry: Arc<Mutex<Registry>>,
         listen: SocketAddr,
-        bootstrappers: Vec<Bootstrapper>,
+        bootstrappers: Vec<Bootstrapper<C::PublicKey>>,
         max_message_size: usize,
     ) -> Self {
         Self {
@@ -152,7 +152,7 @@ impl<C: Scheme> Config<C> {
         namespace: &[u8],
         registry: Arc<Mutex<Registry>>,
         listen: SocketAddr,
-        bootstrappers: Vec<Bootstrapper>,
+        bootstrappers: Vec<Bootstrapper<C::PublicKey>>,
         max_message_size: usize,
     ) -> Self {
         Self {
@@ -186,7 +186,7 @@ impl<C: Scheme> Config<C> {
         crypto: C,
         registry: Arc<Mutex<Registry>>,
         listen: SocketAddr,
-        bootstrappers: Vec<Bootstrapper>,
+        bootstrappers: Vec<Bootstrapper<C::PublicKey>>,
         max_message_size: usize,
     ) -> Self {
         Self {

--- a/p2p/src/authenticated/metrics.rs
+++ b/p2p/src/authenticated/metrics.rs
@@ -9,7 +9,7 @@ pub struct Peer {
 }
 
 impl Peer {
-    pub fn new(peer: &PublicKey) -> Self {
+    pub fn new<P: PublicKey>(peer: &P) -> Self {
         Self { peer: hex(peer) }
     }
 }
@@ -25,25 +25,25 @@ impl Message {
     const PEERS_TYPE: i32 = -2;
     const UNKNOWN_TYPE: i32 = i32::MIN;
 
-    pub fn new_bit_vec(peer: &PublicKey) -> Self {
+    pub fn new_bit_vec<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: Self::BIT_VEC_TYPE,
         }
     }
-    pub fn new_peers(peer: &PublicKey) -> Self {
+    pub fn new_peers<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: Self::PEERS_TYPE,
         }
     }
-    pub fn new_data(peer: &PublicKey, channel: Channel) -> Self {
+    pub fn new_data<P: PublicKey>(peer: &P, channel: Channel) -> Self {
         Self {
             peer: hex(peer),
             message: channel as i32,
         }
     }
-    pub fn new_unknown(peer: &PublicKey) -> Self {
+    pub fn new_unknown<P: PublicKey>(peer: &P) -> Self {
         Self {
             peer: hex(peer),
             message: Self::UNKNOWN_TYPE,

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -116,7 +116,7 @@
 //! // Configure bootstrappers
 //! //
 //! // In production, it is likely that the address of bootstrappers will be some public address.
-//! let bootstrappers = vec![(peer1.clone(), SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3001))];
+//! let bootstrappers = vec![(peer1, SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3001))];
 //!
 //! // Configure namespace
 //! //
@@ -296,7 +296,7 @@ mod tests {
                         while received.len() < n - 1 {
                             // Ensure message equals sender identity
                             let (sender, message) = receiver.recv().await.unwrap();
-                            assert_eq!(sender, message);
+                            assert_eq!(sender.as_ref(), message.as_ref());
 
                             // Add to received set
                             received.insert(sender);
@@ -316,14 +316,18 @@ mod tests {
                                 // Loop until success
                                 loop {
                                     let sent = sender
-                                        .send(Recipients::One(recipient.clone()), msg.clone(), true)
+                                        .send(
+                                            Recipients::One(recipient.clone()),
+                                            msg.clone().into(),
+                                            true,
+                                        )
                                         .await
                                         .unwrap();
                                     if sent.len() != 1 {
                                         runtime.sleep(Duration::from_millis(100)).await;
                                         continue;
                                     }
-                                    assert_eq!(sent[0], recipient);
+                                    assert_eq!(&sent[0], recipient);
                                     break;
                                 }
                             }
@@ -337,7 +341,11 @@ mod tests {
                             // Loop until all peer sends successful
                             loop {
                                 let mut sent = sender
-                                    .send(Recipients::Some(recipients.clone()), msg.clone(), true)
+                                    .send(
+                                        Recipients::Some(recipients.clone()),
+                                        msg.clone().into(),
+                                        true,
+                                    )
                                     .await
                                     .unwrap();
                                 if sent.len() != n - 1 {
@@ -360,7 +368,7 @@ mod tests {
                             // Loop until all peer sends successful
                             loop {
                                 let mut sent = sender
-                                    .send(Recipients::All, msg.clone(), true)
+                                    .send(Recipients::All, msg.clone().into(), true)
                                     .await
                                     .unwrap();
                                 if sent.len() != n - 1 {
@@ -517,7 +525,7 @@ mod tests {
                             let msg = signer.public_key();
                             loop {
                                 if sender
-                                    .send(Recipients::All, msg.clone(), true)
+                                    .send(Recipients::All, msg.clone().into(), true)
                                     .await
                                     .unwrap()
                                     .len()
@@ -532,7 +540,7 @@ mod tests {
                         } else {
                             // Ensure message equals sender identity
                             let (sender, message) = receiver.recv().await.unwrap();
-                            assert_eq!(sender, message);
+                            assert_eq!(sender.as_ref(), message.as_ref());
                         }
                     }
                 });

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -254,7 +254,7 @@ mod tests {
             let mut bootstrappers = Vec::new();
             if i > 0 {
                 bootstrappers.push((
-                    addresses[0].clone(),
+                    addresses[0],
                     SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port),
                 ));
             }
@@ -316,11 +316,7 @@ mod tests {
                                 // Loop until success
                                 loop {
                                     let sent = sender
-                                        .send(
-                                            Recipients::One(recipient.clone()),
-                                            msg.clone().into(),
-                                            true,
-                                        )
+                                        .send(Recipients::One(*recipient), msg.into(), true)
                                         .await
                                         .unwrap();
                                     if sent.len() != 1 {
@@ -341,11 +337,7 @@ mod tests {
                             // Loop until all peer sends successful
                             loop {
                                 let mut sent = sender
-                                    .send(
-                                        Recipients::Some(recipients.clone()),
-                                        msg.clone().into(),
-                                        true,
-                                    )
+                                    .send(Recipients::Some(recipients.clone()), msg.into(), true)
                                     .await
                                     .unwrap();
                                 if sent.len() != n - 1 {
@@ -368,7 +360,7 @@ mod tests {
                             // Loop until all peer sends successful
                             loop {
                                 let mut sent = sender
-                                    .send(Recipients::All, msg.clone().into(), true)
+                                    .send(Recipients::All, msg.into(), true)
                                     .await
                                     .unwrap();
                                 if sent.len() != n - 1 {
@@ -479,7 +471,7 @@ mod tests {
                 let mut bootstrappers = Vec::new();
                 if i > 0 {
                     bootstrappers.push((
-                        addresses[0].clone(),
+                        addresses[0],
                         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port),
                     ));
                 }
@@ -497,10 +489,8 @@ mod tests {
                 let (mut network, mut oracle) = Network::new(runtime.clone(), config);
 
                 // Register peers at separate indices
-                oracle.register(0, vec![addresses[0].clone()]).await;
-                oracle
-                    .register(1, vec![addresses[1].clone(), addresses[2].clone()])
-                    .await;
+                oracle.register(0, vec![addresses[0]]).await;
+                oracle.register(1, vec![addresses[1], addresses[2]]).await;
                 oracle
                     .register(2, addresses.iter().skip(2).cloned().collect())
                     .await;
@@ -525,7 +515,7 @@ mod tests {
                             let msg = signer.public_key();
                             loop {
                                 if sender
-                                    .send(Recipients::All, msg.clone().into(), true)
+                                    .send(Recipients::All, msg.into(), true)
                                     .await
                                     .unwrap()
                                     .len()
@@ -602,7 +592,7 @@ mod tests {
             runtime.fill(&mut msg[..]);
 
             // Send message
-            let recipient = Recipients::One(addresses[1].clone());
+            let recipient = Recipients::One(addresses[1]);
             let result = sender.send(recipient, msg.into(), true).await;
             assert!(matches!(result, Err(Error::MessageTooLarge(_))));
         });

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -47,11 +47,11 @@ pub struct Network<
     runtime: E,
     cfg: Config<C>,
 
-    channels: Channels,
+    channels: Channels<C::PublicKey>,
     tracker: tracker::Actor<E, C>,
-    tracker_mailbox: tracker::Mailbox<E>,
-    router: router::Actor,
-    router_mailbox: router::Mailbox,
+    tracker_mailbox: tracker::Mailbox<E, C::PublicKey>,
+    router: router::Actor<C::PublicKey>,
+    router_mailbox: router::Mailbox<C::PublicKey>,
 
     _phantom_si: PhantomData<Si>,
     _phantom_st: PhantomData<St>,
@@ -76,7 +76,7 @@ impl<
     ///
     /// * A tuple containing the network instance and the oracle that
     ///   can be used by a developer to configure which peers are authorized.
-    pub fn new(runtime: E, cfg: Config<C>) -> (Self, tracker::Oracle<E>) {
+    pub fn new(runtime: E, cfg: Config<C>) -> (Self, tracker::Oracle<E, C::PublicKey>) {
         let (tracker, tracker_mailbox, oracle) = tracker::Actor::new(
             runtime.clone(),
             tracker::Config {
@@ -138,7 +138,10 @@ impl<
         rate: Quota,
         backlog: usize,
         compression: Option<i32>,
-    ) -> (channels::Sender, channels::Receiver) {
+    ) -> (
+        channels::Sender<C::PublicKey>,
+        channels::Receiver<C::PublicKey>,
+    ) {
         self.channels.register(channel, rate, backlog, compression)
     }
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -19,36 +19,40 @@ pub mod utils;
 ///
 /// This message is guaranteed to adhere to the configuration of the channel and
 /// will already be decrypted and authenticated.
-pub type Message = (PublicKey, Bytes);
+pub type Message<Pk> = (Pk, Bytes);
 
 /// Alias for identifying communication channels.
 pub type Channel = u32;
 
 /// Enum indicating the set of recipients to send a message to.
 #[derive(Clone)]
-pub enum Recipients {
+pub enum Recipients<P: PublicKey> {
     All,
-    Some(Vec<PublicKey>),
-    One(PublicKey),
+    Some(Vec<P>),
+    One(P),
 }
 
 /// Interface for sending messages to a set of recipients.
 pub trait Sender: Clone + Debug + Send + 'static {
     type Error: Debug + StdError + Send;
+    type PublicKey: PublicKey;
 
     /// Send a message to a set of recipients.
     fn send(
         &mut self,
-        recipients: Recipients,
+        recipients: Recipients<Self::PublicKey>,
         message: Bytes,
         priority: bool,
-    ) -> impl Future<Output = Result<Vec<PublicKey>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<Self::PublicKey>, Self::Error>> + Send;
 }
 
 /// Interface for receiving messages from arbitrary recipients.
 pub trait Receiver: Debug + Send + 'static {
     type Error: Debug + StdError + Send;
+    type PublicKey: PublicKey;
 
     /// Receive a message from an arbitrary recipient.
-    fn recv(&mut self) -> impl Future<Output = Result<Message, Self::Error>> + Send;
+    fn recv(
+        &mut self,
+    ) -> impl Future<Output = Result<Message<Self::PublicKey>, Self::Error>> + Send;
 }

--- a/p2p/src/simulated/ingress.rs
+++ b/p2p/src/simulated/ingress.rs
@@ -7,22 +7,22 @@ use futures::{
 };
 use rand_distr::Normal;
 
-pub enum Message {
+pub enum Message<P: PublicKey> {
     Register {
-        public_key: PublicKey,
+        public_key: P,
         channel: Channel,
-        result: oneshot::Sender<Result<(Sender, Receiver), Error>>,
+        result: oneshot::Sender<Result<(Sender<P>, Receiver<P>), Error>>,
     },
     AddLink {
-        sender: PublicKey,
-        receiver: PublicKey,
+        sender: P,
+        receiver: P,
         sampler: Normal<f64>,
         success_rate: f64,
         result: oneshot::Sender<Result<(), Error>>,
     },
     RemoveLink {
-        sender: PublicKey,
-        receiver: PublicKey,
+        sender: P,
+        receiver: P,
         result: oneshot::Sender<Result<(), Error>>,
     },
 }
@@ -48,12 +48,12 @@ pub struct Link {
 /// At any point, peers can be added/removed and links
 /// between said peers can be modified.
 #[derive(Clone)]
-pub struct Oracle {
-    sender: mpsc::UnboundedSender<Message>,
+pub struct Oracle<P: PublicKey> {
+    sender: mpsc::UnboundedSender<Message<P>>,
 }
 
-impl Oracle {
-    pub(crate) fn new(sender: mpsc::UnboundedSender<Message>) -> Self {
+impl<P: PublicKey> Oracle<P> {
+    pub(crate) fn new(sender: mpsc::UnboundedSender<Message<P>>) -> Self {
         Self { sender }
     }
 
@@ -63,9 +63,9 @@ impl Oracle {
     /// registered on a given channel, it will return an error.
     pub async fn register(
         &mut self,
-        public_key: PublicKey,
+        public_key: P,
         channel: Channel,
-    ) -> Result<(Sender, Receiver), Error> {
+    ) -> Result<(Sender<P>, Receiver<P>), Error> {
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(Message::Register {
@@ -82,12 +82,7 @@ impl Oracle {
     ///
     /// Link can be called multiple times for the same sender/receiver. The latest
     /// setting will be used.
-    pub async fn add_link(
-        &mut self,
-        sender: PublicKey,
-        receiver: PublicKey,
-        config: Link,
-    ) -> Result<(), Error> {
+    pub async fn add_link(&mut self, sender: P, receiver: P, config: Link) -> Result<(), Error> {
         // Sanity checks
         if sender == receiver {
             return Err(Error::LinkingSelf);
@@ -121,11 +116,7 @@ impl Oracle {
     /// Remove a unidirectional link between two peers.
     ///
     /// If no link exists, this will return an error.
-    pub async fn remove_link(
-        &mut self,
-        sender: PublicKey,
-        receiver: PublicKey,
-    ) -> Result<(), Error> {
+    pub async fn remove_link(&mut self, sender: P, receiver: P) -> Result<(), Error> {
         // Sanity checks
         if sender == receiver {
             return Err(Error::LinkingSelf);

--- a/p2p/src/simulated/metrics.rs
+++ b/p2p/src/simulated/metrics.rs
@@ -11,7 +11,7 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn new(origin: &PublicKey, recipient: &PublicKey, channel: Channel) -> Self {
+    pub fn new<P: PublicKey>(origin: &P, recipient: &P, channel: Channel) -> Self {
         Self {
             origin: hex(origin),
             recipient: hex(recipient),

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -160,7 +160,7 @@ mod tests {
             let (seen_sender, mut seen_receiver) = mpsc::channel(1024);
             for i in 0..size {
                 let pk = Ed25519::from_seed(i as u64).public_key();
-                let (sender, mut receiver) = oracle.register(pk.clone(), 0).await.unwrap();
+                let (sender, mut receiver) = oracle.register(pk, 0).await.unwrap();
                 agents.insert(pk, sender);
                 let mut agent_sender = seen_sender.clone();
                 runtime.spawn("agent_receiver", async move {
@@ -183,8 +183,8 @@ mod tests {
                 for other in agents.keys() {
                     let result = oracle
                         .add_link(
-                            agent.clone(),
-                            other.clone(),
+                            *agent,
+                            *other,
                             Link {
                                 latency: 5.0,
                                 jitter: 2.5,
@@ -275,7 +275,7 @@ mod tests {
             let mut agents = HashMap::new();
             for i in 0..10 {
                 let pk = Ed25519::from_seed(i as u64).public_key();
-                let (sender, _) = oracle.register(pk.clone(), 0).await.unwrap();
+                let (sender, _) = oracle.register(pk, 0).await.unwrap();
                 agents.insert(pk, sender);
             }
 
@@ -314,13 +314,13 @@ mod tests {
 
             // Register agents
             let pk = Ed25519::from_seed(0).public_key();
-            oracle.register(pk.clone(), 0).await.unwrap();
+            oracle.register(pk, 0).await.unwrap();
 
             // Attempt to link self
             let result = oracle
                 .add_link(
-                    pk.clone(),
-                    pk.clone(),
+                    pk,
+                    pk,
                     Link {
                         latency: 5.0,
                         jitter: 2.5,
@@ -352,7 +352,7 @@ mod tests {
 
             // Register agents
             let pk = Ed25519::from_seed(0).public_key();
-            oracle.register(pk.clone(), 0).await.unwrap();
+            oracle.register(pk, 0).await.unwrap();
             let result = oracle.register(pk, 0).await;
 
             // Confirm error is correct
@@ -379,14 +379,14 @@ mod tests {
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();
             let pk2 = Ed25519::from_seed(1).public_key();
-            oracle.register(pk1.clone(), 0).await.unwrap();
-            oracle.register(pk2.clone(), 0).await.unwrap();
+            oracle.register(pk1, 0).await.unwrap();
+            oracle.register(pk2, 0).await.unwrap();
 
             // Attempt to link with invalid success rate
             let result = oracle
                 .add_link(
-                    pk1.clone(),
-                    pk2.clone(),
+                    pk1,
+                    pk2,
                     Link {
                         latency: 5.0,
                         jitter: 2.5,
@@ -419,14 +419,14 @@ mod tests {
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();
             let pk2 = Ed25519::from_seed(1).public_key();
-            oracle.register(pk1.clone(), 0).await.unwrap();
-            oracle.register(pk2.clone(), 0).await.unwrap();
+            oracle.register(pk1, 0).await.unwrap();
+            oracle.register(pk2, 0).await.unwrap();
 
             // Attempt to link with invalid jitter
             let result = oracle
                 .add_link(
-                    pk1.clone(),
-                    pk2.clone(),
+                    pk1,
+                    pk2,
                     Link {
                         latency: -5.0,
                         jitter: 2.5,
@@ -441,8 +441,8 @@ mod tests {
             // Attempt to link with invalid jitter
             let result = oracle
                 .add_link(
-                    pk1.clone(),
-                    pk2.clone(),
+                    pk1,
+                    pk2,
                     Link {
                         latency: 5.0,
                         jitter: -2.5,
@@ -475,18 +475,18 @@ mod tests {
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();
             let pk2 = Ed25519::from_seed(1).public_key();
-            let (mut sender1, mut receiver1) = oracle.register(pk1.clone(), 0).await.unwrap();
-            let (mut sender2, mut receiver2) = oracle.register(pk2.clone(), 0).await.unwrap();
+            let (mut sender1, mut receiver1) = oracle.register(pk1, 0).await.unwrap();
+            let (mut sender2, mut receiver2) = oracle.register(pk2, 0).await.unwrap();
 
             // Register unused channels
-            let _ = oracle.register(pk1.clone(), 1).await.unwrap();
-            let _ = oracle.register(pk2.clone(), 2).await.unwrap();
+            let _ = oracle.register(pk1, 1).await.unwrap();
+            let _ = oracle.register(pk2, 2).await.unwrap();
 
             // Link agents
             oracle
                 .add_link(
-                    pk1.clone(),
-                    pk2.clone(),
+                    pk1,
+                    pk2,
                     Link {
                         latency: 5.0,
                         jitter: 2.5,
@@ -497,8 +497,8 @@ mod tests {
                 .unwrap();
             oracle
                 .add_link(
-                    pk2.clone(),
-                    pk1.clone(),
+                    pk2,
+                    pk1,
                     Link {
                         latency: 5.0,
                         jitter: 2.5,
@@ -512,11 +512,11 @@ mod tests {
             let msg1 = Bytes::from("hello from pk1");
             let msg2 = Bytes::from("hello from pk2");
             sender1
-                .send(Recipients::One(pk2.clone()), msg1.clone(), false)
+                .send(Recipients::One(pk2), msg1.clone(), false)
                 .await
                 .unwrap();
             sender2
-                .send(Recipients::One(pk1.clone()), msg2.clone(), false)
+                .send(Recipients::One(pk1), msg2.clone(), false)
                 .await
                 .unwrap();
 
@@ -549,14 +549,14 @@ mod tests {
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();
             let pk2 = Ed25519::from_seed(1).public_key();
-            let (mut sender1, _) = oracle.register(pk1.clone(), 0).await.unwrap();
-            let (_, mut receiver2) = oracle.register(pk2.clone(), 1).await.unwrap();
+            let (mut sender1, _) = oracle.register(pk1, 0).await.unwrap();
+            let (_, mut receiver2) = oracle.register(pk2, 1).await.unwrap();
 
             // Link agents
             oracle
                 .add_link(
-                    pk1.clone(),
-                    pk2.clone(),
+                    pk1,
+                    pk2,
                     Link {
                         latency: 5.0,
                         jitter: 0.0,
@@ -569,7 +569,7 @@ mod tests {
             // Send message
             let msg = Bytes::from("hello from pk1");
             sender1
-                .send(Recipients::One(pk2.clone()), msg, false)
+                .send(Recipients::One(pk2), msg, false)
                 .await
                 .unwrap();
 
@@ -602,14 +602,14 @@ mod tests {
             // Define agents
             let pk1 = Ed25519::from_seed(0).public_key();
             let pk2 = Ed25519::from_seed(1).public_key();
-            let (mut sender1, mut receiver1) = oracle.register(pk1.clone(), 0).await.unwrap();
-            let (mut sender2, mut receiver2) = oracle.register(pk2.clone(), 0).await.unwrap();
+            let (mut sender1, mut receiver1) = oracle.register(pk1, 0).await.unwrap();
+            let (mut sender2, mut receiver2) = oracle.register(pk2, 0).await.unwrap();
 
             // Link agents
             oracle
                 .add_link(
-                    pk1.clone(),
-                    pk2.clone(),
+                    pk1,
+                    pk2,
                     Link {
                         latency: 5.0,
                         jitter: 2.5,
@@ -620,8 +620,8 @@ mod tests {
                 .unwrap();
             oracle
                 .add_link(
-                    pk2.clone(),
-                    pk1.clone(),
+                    pk2,
+                    pk1,
                     Link {
                         latency: 5.0,
                         jitter: 2.5,
@@ -635,11 +635,11 @@ mod tests {
             let msg1 = Bytes::from("attempt 1: hello from pk1");
             let msg2 = Bytes::from("attempt 1: hello from pk2");
             sender1
-                .send(Recipients::One(pk2.clone()), msg1.clone(), false)
+                .send(Recipients::One(pk2), msg1.clone(), false)
                 .await
                 .unwrap();
             sender2
-                .send(Recipients::One(pk1.clone()), msg2.clone(), false)
+                .send(Recipients::One(pk1), msg2.clone(), false)
                 .await
                 .unwrap();
 
@@ -672,18 +672,18 @@ mod tests {
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();
             let pk2 = Ed25519::from_seed(1).public_key();
-            let (mut sender1, mut receiver1) = oracle.register(pk1.clone(), 0).await.unwrap();
-            let (mut sender2, mut receiver2) = oracle.register(pk2.clone(), 0).await.unwrap();
+            let (mut sender1, mut receiver1) = oracle.register(pk1, 0).await.unwrap();
+            let (mut sender2, mut receiver2) = oracle.register(pk2, 0).await.unwrap();
 
             // Send messages
             let msg1 = Bytes::from("attempt 1: hello from pk1");
             let msg2 = Bytes::from("attempt 1: hello from pk2");
             sender1
-                .send(Recipients::One(pk2.clone()), msg1.clone(), false)
+                .send(Recipients::One(pk2), msg1.clone(), false)
                 .await
                 .unwrap();
             sender2
-                .send(Recipients::One(pk1.clone()), msg2.clone(), false)
+                .send(Recipients::One(pk1), msg2.clone(), false)
                 .await
                 .unwrap();
 
@@ -701,8 +701,8 @@ mod tests {
             // Link agents
             oracle
                 .add_link(
-                    pk1.clone(),
-                    pk2.clone(),
+                    pk1,
+                    pk2,
                     Link {
                         latency: 5.0,
                         jitter: 2.5,
@@ -713,8 +713,8 @@ mod tests {
                 .unwrap();
             oracle
                 .add_link(
-                    pk2.clone(),
-                    pk1.clone(),
+                    pk2,
+                    pk1,
                     Link {
                         latency: 5.0,
                         jitter: 2.5,
@@ -728,11 +728,11 @@ mod tests {
             let msg1 = Bytes::from("attempt 2: hello from pk1");
             let msg2 = Bytes::from("attempt 2: hello from pk2");
             sender1
-                .send(Recipients::One(pk2.clone()), msg1.clone(), false)
+                .send(Recipients::One(pk2), msg1.clone(), false)
                 .await
                 .unwrap();
             sender2
-                .send(Recipients::One(pk1.clone()), msg2.clone(), false)
+                .send(Recipients::One(pk1), msg2.clone(), false)
                 .await
                 .unwrap();
 
@@ -745,18 +745,18 @@ mod tests {
             assert_eq!(message, msg1);
 
             // Remove links
-            oracle.remove_link(pk1.clone(), pk2.clone()).await.unwrap();
-            oracle.remove_link(pk2.clone(), pk1.clone()).await.unwrap();
+            oracle.remove_link(pk1, pk2).await.unwrap();
+            oracle.remove_link(pk2, pk1).await.unwrap();
 
             // Send messages
             let msg1 = Bytes::from("attempt 3: hello from pk1");
             let msg2 = Bytes::from("attempt 3: hello from pk2");
             sender1
-                .send(Recipients::One(pk2.clone()), msg1.clone(), false)
+                .send(Recipients::One(pk2), msg1.clone(), false)
                 .await
                 .unwrap();
             sender2
-                .send(Recipients::One(pk1.clone()), msg2.clone(), false)
+                .send(Recipients::One(pk1), msg2.clone(), false)
                 .await
                 .unwrap();
 
@@ -772,7 +772,7 @@ mod tests {
             }
 
             // Remove non-existent links
-            let result = oracle.remove_link(pk1.clone(), pk2.clone()).await;
+            let result = oracle.remove_link(pk1, pk2).await;
             assert!(matches!(result, Err(Error::LinkMissing)));
         });
     }

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -35,13 +35,7 @@ use tracing::{error, trace};
 const SIZE_OF_CHANNEL: usize = size_of::<Channel>();
 
 /// Task type representing a message to be sent within the network.
-type Task = (
-    Channel,
-    PublicKey,
-    Recipients,
-    Bytes,
-    oneshot::Sender<Vec<PublicKey>>,
-);
+type Task<Pk> = (Channel, Pk, Recipients<Pk>, Bytes, oneshot::Sender<Vec<Pk>>);
 
 /// Configuration for the simulated network.
 pub struct Config {
@@ -53,7 +47,7 @@ pub struct Config {
 }
 
 /// Implementation of a simulated network.
-pub struct Network<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock> {
+pub struct Network<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock, P: PublicKey> {
     runtime: E,
 
     // Maximum size of a message that can be sent over the network
@@ -64,31 +58,31 @@ pub struct Network<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock> 
     next_addr: SocketAddr,
 
     // Channel to receive messages from the oracle
-    ingress: mpsc::UnboundedReceiver<ingress::Message>,
+    ingress: mpsc::UnboundedReceiver<ingress::Message<P>>,
 
     // A channel to receive tasks from peers
     // The sender is cloned and given to each peer
     // The receiver is polled in the main loop
-    sender: mpsc::UnboundedSender<Task>,
-    receiver: mpsc::UnboundedReceiver<Task>,
+    sender: mpsc::UnboundedSender<Task<P>>,
+    receiver: mpsc::UnboundedReceiver<Task<P>>,
 
     // A map from a pair of public keys (from, to) to a link between the two peers
-    links: HashMap<(PublicKey, PublicKey), Link>,
+    links: HashMap<(P, P), Link>,
 
     // A map from a public key to a peer
-    peers: BTreeMap<PublicKey, Peer>,
+    peers: BTreeMap<P, Peer<P>>,
 
     // Metrics for received and sent messages
     received_messages: Family<metrics::Message, Counter>,
     sent_messages: Family<metrics::Message, Counter>,
 }
 
-impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock> Network<E> {
+impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock, P: PublicKey> Network<E, P> {
     /// Create a new simulated network with a given runtime and configuration.
     ///
     /// Returns a tuple containing the network instance and the oracle that can
     /// be used to modify the state of the network during runtime.
-    pub fn new(runtime: E, cfg: Config) -> (Self, Oracle) {
+    pub fn new(runtime: E, cfg: Config) -> (Self, Oracle<P>) {
         let (sender, receiver) = mpsc::unbounded();
         let (oracle_sender, oracle_receiver) = mpsc::unbounded();
         let sent_messages = Family::<metrics::Message, Counter>::default();
@@ -154,7 +148,7 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock> Network<E> {
     /// Handle an ingress message.
     ///
     /// This method is called when a message is received from the oracle.
-    async fn handle_ingress(&mut self, message: ingress::Message) {
+    async fn handle_ingress(&mut self, message: ingress::Message<P>) {
         // It is important to ensure that no failed receipt of a message will cause us to exit.
         // This could happen if the caller drops the `Oracle` after updating the network topology.
         // Thus, we create a helper function to send the result to the oracle and log any errors.
@@ -178,7 +172,7 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock> Network<E> {
                 if !self.peers.contains_key(&public_key) {
                     let peer = Peer::new(
                         &mut self.runtime.clone(),
-                        public_key.clone(),
+                        public_key,
                         self.get_next_socket(),
                         self.max_size,
                     );
@@ -219,7 +213,7 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock> Network<E> {
                 };
 
                 // Require link to not already exist
-                let key = (sender.clone(), receiver);
+                let key = (sender, receiver);
                 if self.links.contains_key(&key) {
                     return send_result(result, Err(Error::LinkExists));
                 }
@@ -253,7 +247,7 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock> Network<E> {
     ///
     /// This method is called when a task is received from the sender, which can come from
     /// any peer in the network.
-    fn handle_task(&mut self, task: Task) {
+    fn handle_task(&mut self, task: Task<P>) {
         // Collect recipients
         let (channel, origin, recipients, message, reply) = task;
         let recipients = match recipients {
@@ -277,11 +271,7 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock> Network<E> {
             }
 
             // Determine if there is a link between the sender and recipient
-            let mut link = match self
-                .links
-                .get(&(origin.clone(), recipient.clone()))
-                .cloned()
-            {
+            let mut link = match self.links.get(&(origin, recipient)).cloned() {
                 Some(link) => link,
                 None => {
                     trace!(
@@ -404,21 +394,21 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock> Network<E> {
 
 /// Implementation of a [`crate::Sender`] for the simulated network.
 #[derive(Clone, Debug)]
-pub struct Sender {
-    me: PublicKey,
+pub struct Sender<P: PublicKey> {
+    me: P,
     channel: Channel,
     max_size: usize,
-    high: mpsc::UnboundedSender<Task>,
-    low: mpsc::UnboundedSender<Task>,
+    high: mpsc::UnboundedSender<Task<P>>,
+    low: mpsc::UnboundedSender<Task<P>>,
 }
 
-impl Sender {
+impl<P: PublicKey> Sender<P> {
     fn new(
         runtime: impl Spawner,
-        me: PublicKey,
+        me: P,
         channel: Channel,
         max_size: usize,
-        mut sender: mpsc::UnboundedSender<Task>,
+        mut sender: mpsc::UnboundedSender<Task<P>>,
     ) -> Self {
         // Listen for messages
         let (high, mut high_receiver) = mpsc::unbounded();
@@ -460,15 +450,16 @@ impl Sender {
     }
 }
 
-impl crate::Sender for Sender {
+impl<P: PublicKey> crate::Sender for Sender<P> {
     type Error = Error;
+    type PublicKey = P;
 
     async fn send(
         &mut self,
-        recipients: Recipients,
+        recipients: Recipients<P>,
         message: Bytes,
         priority: bool,
-    ) -> Result<Vec<PublicKey>, Error> {
+    ) -> Result<Vec<P>, Error> {
         // Check message size
         if message.len() > self.max_size {
             return Err(Error::MessageTooLarge(message.len()));
@@ -485,19 +476,20 @@ impl crate::Sender for Sender {
     }
 }
 
-type MessageReceiver = mpsc::UnboundedReceiver<Message>;
-type MessageReceiverResult = Result<MessageReceiver, Error>;
+type MessageReceiver<Pk> = mpsc::UnboundedReceiver<Message<Pk>>;
+type MessageReceiverResult<P> = Result<MessageReceiver<P>, Error>;
 
 /// Implementation of a [`crate::Receiver`] for the simulated network.
 #[derive(Debug)]
-pub struct Receiver {
-    receiver: MessageReceiver,
+pub struct Receiver<P: PublicKey> {
+    receiver: MessageReceiver<P>,
 }
 
-impl crate::Receiver for Receiver {
+impl<P: PublicKey> crate::Receiver for Receiver<P> {
     type Error = Error;
+    type PublicKey = P;
 
-    async fn recv(&mut self) -> Result<Message, Error> {
+    async fn recv(&mut self) -> Result<Message<Self::PublicKey>, Error> {
         self.receiver.next().await.ok_or(Error::NetworkClosed)
     }
 }
@@ -505,22 +497,22 @@ impl crate::Receiver for Receiver {
 /// A peer in the simulated network.
 ///
 /// The peer can register channels, which allows it to receive messages sent to the channel from other peers.
-struct Peer {
+struct Peer<P: PublicKey> {
     // Socket address that the peer is listening on
     socket: SocketAddr,
 
     // Control to register new channels
-    control: mpsc::UnboundedSender<(Channel, oneshot::Sender<MessageReceiverResult>)>,
+    control: mpsc::UnboundedSender<(Channel, oneshot::Sender<MessageReceiverResult<P>>)>,
 }
 
-impl Peer {
+impl<P: PublicKey> Peer<P> {
     /// Create and return a new peer.
     ///
     /// The peer will listen for incoming connections on the given `socket` address.
     /// `max_size` is the maximum size of a message that can be sent to the peer.
     fn new<E: Spawner + RNetwork<Listener, Sink, Stream>>(
         runtime: &mut E,
-        public_key: PublicKey,
+        public_key: P,
         socket: SocketAddr,
         max_size: usize,
     ) -> Self {
@@ -543,7 +535,7 @@ impl Peer {
                     // Listen for control messages, which are used to register channels
                     control = control_receiver.next() => {
                         // If control is closed, exit
-                        let (channel, result): (Channel, oneshot::Sender<MessageReceiverResult>) = match control {
+                        let (channel, result): (Channel, oneshot::Sender<MessageReceiverResult<P>>) = match control {
                             Some(control) => control,
                             None => break,
                         };
@@ -611,6 +603,10 @@ impl Peer {
                                     return;
                                 }
                             };
+                            let Ok(dialer) = P::try_from(dialer.as_ref()) else {
+                                error!("received public key is invalid");
+                                return;
+                            };
 
                             // Continually receive messages from the dialer and send them to the inbox
                             while let Ok(data) = recv_frame(&mut stream, max_size).await {
@@ -643,7 +639,7 @@ impl Peer {
     ///
     /// This allows the peer to receive messages sent to the channel.
     /// Returns a receiver that can be used to receive messages sent to the channel.
-    async fn register(&mut self, channel: Channel) -> MessageReceiverResult {
+    async fn register(&mut self, channel: Channel) -> MessageReceiverResult<P> {
         let (sender, receiver) = oneshot::channel();
         self.control
             .send((channel, sender))
@@ -663,9 +659,9 @@ struct Link {
 }
 
 impl Link {
-    fn new<E: Spawner + RNetwork<Listener, Sink, Stream>>(
+    fn new<E: Spawner + RNetwork<Listener, Sink, Stream>, P: PublicKey>(
         runtime: &mut E,
-        dialer: PublicKey,
+        dialer: P,
         socket: SocketAddr,
         sampler: Normal<f64>,
         success_rate: f64,
@@ -775,7 +771,12 @@ mod tests {
             max_size: MAX_MESSAGE_SIZE,
         };
         let (_, runtime, _) = Executor::default();
-        let (mut network, _) = Network::new(runtime.clone(), cfg);
+        type PublicKey = <Ed25519 as Scheme>::PublicKey;
+        let (mut network, _) =
+            Network::<commonware_runtime::deterministic::Context, PublicKey>::new(
+                runtime.clone(),
+                cfg,
+            );
 
         // Test that the next socket address is incremented correctly
         let mut original = network.next_addr;

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -303,10 +303,8 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock, P: PublicKey> 
             // Send message
             self.runtime.spawn("messenger", {
                 let runtime = self.runtime.clone();
-                let recipient = recipient;
                 let message = message.clone();
                 let mut acquired_sender = acquired_sender.clone();
-                let origin = origin;
                 let received_messages = self.received_messages.clone();
                 async move {
                     // Mark as sent as soon as soon as execution starts
@@ -614,9 +612,8 @@ impl<P: PublicKey> Peer<P> {
                                     data[..SIZE_OF_CHANNEL].try_into().unwrap(),
                                 );
                                 let message = data.slice(SIZE_OF_CHANNEL..);
-                                if let Err(err) = inbox_sender
-                                    .send((channel, (dialer, message)))
-                                    .await
+                                if let Err(err) =
+                                    inbox_sender.send((channel, (dialer, message))).await
                                 {
                                     error!(?err, "failed to send message to mailbox");
                                     break;
@@ -734,14 +731,14 @@ mod tests {
             let pk2 = Ed25519::from_seed(2).public_key();
 
             // Register
-            oracle.register(pk1.clone(), 0).await.unwrap();
-            oracle.register(pk1.clone(), 1).await.unwrap();
-            oracle.register(pk2.clone(), 0).await.unwrap();
-            oracle.register(pk2.clone(), 1).await.unwrap();
+            oracle.register(pk1, 0).await.unwrap();
+            oracle.register(pk1, 1).await.unwrap();
+            oracle.register(pk2, 0).await.unwrap();
+            oracle.register(pk2, 1).await.unwrap();
 
             // Expect error when registering again
             assert!(matches!(
-                oracle.register(pk1.clone(), 1).await,
+                oracle.register(pk1, 1).await,
                 Err(Error::ChannelAlreadyRegistered(_))
             ));
 
@@ -751,14 +748,11 @@ mod tests {
                 jitter: 1.0,
                 success_rate: 0.9,
             };
-            oracle
-                .add_link(pk1.clone(), pk2.clone(), link.clone())
-                .await
-                .unwrap();
+            oracle.add_link(pk1, pk2, link.clone()).await.unwrap();
 
             // Expect error when adding link again
             assert!(matches!(
-                oracle.add_link(pk1.clone(), pk2.clone(), link).await,
+                oracle.add_link(pk1, pk2, link).await,
                 Err(Error::LinkExists)
             ));
         });

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -176,7 +176,7 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock, P: PublicKey> 
                         self.get_next_socket(),
                         self.max_size,
                     );
-                    self.peers.insert(public_key.clone(), peer);
+                    self.peers.insert(public_key, peer);
                 }
 
                 // Create a receiver that allows receiving messages from the network for a certain channel
@@ -303,10 +303,10 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock, P: PublicKey> 
             // Send message
             self.runtime.spawn("messenger", {
                 let runtime = self.runtime.clone();
-                let recipient = recipient.clone();
+                let recipient = recipient;
                 let message = message.clone();
                 let mut acquired_sender = acquired_sender.clone();
-                let origin = origin.clone();
+                let origin = origin;
                 let received_messages = self.received_messages.clone();
                 async move {
                     // Mark as sent as soon as soon as execution starts
@@ -469,7 +469,7 @@ impl<P: PublicKey> crate::Sender for Sender<P> {
         let (sender, receiver) = oneshot::channel();
         let mut channel = if priority { &self.high } else { &self.low };
         channel
-            .send((self.channel, self.me.clone(), recipients, message, sender))
+            .send((self.channel, self.me, recipients, message, sender))
             .await
             .map_err(|_| Error::NetworkClosed)?;
         receiver.await.map_err(|_| Error::NetworkClosed)
@@ -615,7 +615,7 @@ impl<P: PublicKey> Peer<P> {
                                 );
                                 let message = data.slice(SIZE_OF_CHANNEL..);
                                 if let Err(err) = inbox_sender
-                                    .send((channel, (dialer.clone(), message)))
+                                    .send((channel, (dialer, message)))
                                     .await
                                 {
                                     error!(?err, "failed to send message to mailbox");

--- a/p2p/src/utils/requester.rs
+++ b/p2p/src/utils/requester.rs
@@ -49,18 +49,18 @@ pub struct Requester<E: Clock + GClock + Rng, C: Scheme> {
     timeout: Duration,
 
     // Participants to exclude from requests
-    excluded: HashSet<PublicKey>,
+    excluded: HashSet<C::PublicKey>,
 
     // Rate limiter for participants
     rate_limiter:
-        RateLimiter<PublicKey, HashMapStateStore<PublicKey>, E, NoOpMiddleware<E::Instant>>,
+        RateLimiter<C::PublicKey, HashMapStateStore<C::PublicKey>, E, NoOpMiddleware<E::Instant>>,
     // Participants and their performance (lower is better)
-    participants: PrioritySet<PublicKey, u128>,
+    participants: PrioritySet<C::PublicKey, u128>,
 
     // Next ID to use for a request
     id: ID,
     // Outstanding requests (ID -> (participant, start time))
-    requests: HashMap<ID, (PublicKey, SystemTime)>,
+    requests: HashMap<ID, (C::PublicKey, SystemTime)>,
     // Deadlines for outstanding requests (ID -> deadline)
     deadlines: PrioritySet<ID, SystemTime>,
 }
@@ -71,12 +71,12 @@ pub struct Requester<E: Clock + GClock + Rng, C: Scheme> {
 /// this struct in case we want to `resolve` or `timeout` the request. This approach
 /// makes it impossible to forget to remove a handled request if it doesn't warrant
 /// updating the performance of the participant.
-pub struct Request {
+pub struct Request<P: PublicKey> {
     /// Unique identifier for the request.
     pub id: ID,
 
     /// Participant that handled the request.
-    participant: PublicKey,
+    participant: P,
 
     /// Time the request was issued.
     start: SystemTime,
@@ -104,7 +104,7 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
     }
 
     /// Indicate which participants can be sent requests.
-    pub fn reconcile(&mut self, participants: &[PublicKey]) {
+    pub fn reconcile(&mut self, participants: &[C::PublicKey]) {
         self.participants
             .reconcile(participants, self.initial.as_millis());
         self.rate_limiter.shrink_to_fit();
@@ -114,7 +114,7 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
     ///
     /// Participants added to this list will never be removed (even if dropped
     /// during `reconcile`, in case they are re-added later).
-    pub fn block(&mut self, participant: PublicKey) {
+    pub fn block(&mut self, participant: C::PublicKey) {
         self.excluded.insert(participant);
     }
 
@@ -123,7 +123,7 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
     /// If `shuffle` is true, the order of participants is shuffled before
     /// a request is made. This is typically used when a request to the preferred
     /// participant fails.
-    pub fn request(&mut self, shuffle: bool) -> Option<(PublicKey, ID)> {
+    pub fn request(&mut self, shuffle: bool) -> Option<(C::PublicKey, ID)> {
         // Prepare participant iterator
         let participant_iter = if shuffle {
             let mut participants = self.participants.iter().collect::<Vec<_>>();
@@ -165,7 +165,7 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
     }
 
     /// Calculate a participant's new priority using exponential moving average.
-    fn update(&mut self, participant: PublicKey, elapsed: Duration) {
+    fn update(&mut self, participant: C::PublicKey, elapsed: Duration) {
         let Some(past) = self.participants.get(&participant) else {
             return;
         };
@@ -174,7 +174,7 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
     }
 
     /// Drop an outstanding request regardless of who it was intended for.
-    pub fn cancel(&mut self, id: ID) -> Option<Request> {
+    pub fn cancel(&mut self, id: ID) -> Option<Request<C::PublicKey>> {
         let (participant, start) = self.requests.remove(&id)?;
         self.deadlines.remove(&id);
         Some(Request {
@@ -189,7 +189,7 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
     ///
     /// If the request was outstanding, a `Request` is returned that can
     /// either be resolved or timed out.
-    pub fn handle(&mut self, participant: &PublicKey, id: ID) -> Option<Request> {
+    pub fn handle(&mut self, participant: &C::PublicKey, id: ID) -> Option<Request<C::PublicKey>> {
         // Confirm ID exists and is for the participant
         let (expected, _) = self.requests.get(&id)?;
         if expected != participant {
@@ -201,7 +201,7 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
     }
 
     /// Resolve an outstanding request.
-    pub fn resolve(&mut self, request: Request) {
+    pub fn resolve(&mut self, request: Request<C::PublicKey>) {
         // Get elapsed time
         //
         // If we can't compute the elapsed time for some reason (i.e. current time does
@@ -218,7 +218,7 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
     }
 
     /// Timeout an outstanding request.
-    pub fn timeout(&mut self, request: Request) {
+    pub fn timeout(&mut self, request: Request<C::PublicKey>) {
         // Update performance
         self.update(request.participant, self.timeout);
     }

--- a/p2p/src/utils/requester.rs
+++ b/p2p/src/utils/requester.rs
@@ -156,10 +156,10 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
 
             // Record request issuance time
             let now = self.runtime.current();
-            self.requests.insert(id, (participant.clone(), now));
+            self.requests.insert(id, (*participant, now));
             let deadline = now.checked_add(self.timeout).expect("time overflowed");
             self.deadlines.put(id, deadline);
-            return Some((participant.clone(), id));
+            return Some((*participant, id));
         }
         None
     }
@@ -170,7 +170,7 @@ impl<E: Clock + GClock + Rng, C: Scheme> Requester<E, C> {
             return;
         };
         let next = past.saturating_add(elapsed.as_millis()) / 2;
-        self.participants.put(participant.clone(), next);
+        self.participants.put(participant, next);
     }
 
     /// Drop an outstanding request regardless of who it was intended for.

--- a/p2p/src/utils/requester.rs
+++ b/p2p/src/utils/requester.rs
@@ -275,7 +275,7 @@ mod tests {
 
             // Initialize requester
             let other = Ed25519::from_seed(1).public_key();
-            requester.reconcile(&[me.clone(), other.clone()]);
+            requester.reconcile(&[me, other]);
 
             // Get request
             let current = runtime.current();
@@ -380,7 +380,7 @@ mod tests {
             // Initialize requester
             let other1 = Ed25519::from_seed(1).public_key();
             let other2 = Ed25519::from_seed(2).public_key();
-            requester.reconcile(&[me.clone(), other1.clone(), other2.clone()]);
+            requester.reconcile(&[me, other1, other2]);
 
             // Get request
             let (participant, id) = requester.request(false).expect("failed to get participant");
@@ -423,7 +423,7 @@ mod tests {
 
             // Add another participant
             let other3 = Ed25519::from_seed(3).public_key();
-            requester.reconcile(&[me, other1.clone(), other2.clone(), other3.clone()]);
+            requester.reconcile(&[me, other1, other2, other3]);
 
             // Get request (new should be prioritized because lower default time)
             let (participant, id) = requester.request(false).expect("failed to get participant");

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -11,7 +11,7 @@ use chacha20poly1305::{
     aead::{Aead, KeyInit},
     ChaCha20Poly1305,
 };
-use commonware_cryptography::{PublicKey, Scheme};
+use commonware_cryptography::Scheme;
 use commonware_macros::select;
 use commonware_runtime::{Clock, Sink, Spawner, Stream};
 use commonware_utils::SystemTimeExt as _;
@@ -24,7 +24,7 @@ const ENCRYPTION_TAG_LENGTH: usize = 16;
 /// An incoming connection with a verified peer handshake.
 pub struct IncomingConnection<C: Scheme, Si: Sink, St: Stream> {
     config: Config<C>,
-    handshake: IncomingHandshake<Si, St>,
+    handshake: IncomingHandshake<Si, St, C>,
 }
 
 impl<C: Scheme, Si: Sink, St: Stream> IncomingConnection<C, Si, St> {
@@ -51,8 +51,8 @@ impl<C: Scheme, Si: Sink, St: Stream> IncomingConnection<C, Si, St> {
     }
 
     /// The public key of the peer attempting to connect.
-    pub fn peer(&self) -> PublicKey {
-        self.handshake.peer_public_key.clone()
+    pub fn peer(&self) -> C::PublicKey {
+        self.handshake.peer_public_key
     }
 }
 
@@ -94,7 +94,7 @@ impl<Si: Sink, St: Stream> Connection<Si, St> {
         mut config: Config<C>,
         mut sink: Si,
         mut stream: St,
-        peer: PublicKey,
+        peer: C::PublicKey,
     ) -> Result<Self, Error> {
         // Set handshake deadline
         let deadline = runtime.current() + config.handshake_timeout;
@@ -109,7 +109,7 @@ impl<Si: Sink, St: Stream> Connection<Si, St> {
             &mut config.crypto,
             &config.namespace,
             timestamp,
-            peer.clone(),
+            peer,
             ephemeral,
         )?;
 
@@ -183,7 +183,7 @@ impl<Si: Sink, St: Stream> Connection<Si, St> {
             &mut config.crypto,
             &config.namespace,
             timestamp,
-            handshake.peer_public_key.clone(),
+            handshake.peer_public_key,
             ephemeral,
         )?;
 


### PR DESCRIPTION
To avoid a ton of parsing logic, it might be nice to employ `prost`'s `type_attributes`/`field_attributes`: https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.type_attribute

AFAICT it isn't possible to provide generic types here, so it may not be possible outside of crates with hardcoded `Schemes`/`Digests`.