### PR TITLE
[consensus] Explore Using Prost Type Attributes to Reduce Parsing Logic

### DIFF
--- a/consensus/build.rs
+++ b/consensus/build.rs
@@ -3,6 +3,7 @@ fn main() -> Result<()> {
     // Proto compilation rules for `simplex` dialect
     let mut config = prost_build::Config::new();
     config.bytes(["Signature.public_key", "Signature.signature"]);
+    config.field_attribute("Proposal.payload", "#[prost(with = \"digest_payload\")]");
     config.compile_protos(&["src/simplex/wire.proto"], &["src/simplex/"])?;
 
     // Proto compilation rules for `threshold_simplex` dialect

--- a/consensus/src/digest_payload.rs
+++ b/consensus/src/digest_payload.rs
@@ -1,0 +1,40 @@
+use bytes::{Buf, BufMut};
+use commonware_cryptography::Sha256 as Digest;
+use prost::DecodeError;
+
+pub fn encode<B>(value: &Digest, buf: &mut B)
+where
+    B: BufMut,
+{
+    buf.put(value[..]);
+}
+
+pub fn decode<B>(buf: &mut B) -> Result<Digest, DecodeError>
+where
+    B: Buf,
+{
+    // Check if there are enough bytes in the buffer to read a digest.
+    let digest_len = size_of::<Digest>();
+    if buf.remaining() < digest_len {
+        return Err(DecodeError::new("insufficient buffer length"));
+    }
+
+    // If there are enough contiguous bytes in the buffer, use them directly.
+    let chunk = buf.chunk();
+    if chunk.len() >= digest_len {
+        let digest = Digest::try_from(&chunk[..digest_len])
+            .map_err(|_| DecodeError::new("invalid digest length"))?;
+        buf.advance(digest_len);
+        return Ok(digest);
+    }
+
+    // Otherwise, copy the bytes into a temporary buffer.
+    let mut temp = vec![0u8; digest_len];
+    buf.copy_to_slice(&mut temp);
+    let digest = Digest::try_from(buf).map_err(|_| DecodeError::new("invalid digest length"))?;
+    Ok(digest)
+}
+
+pub fn encoded_len(value: &Digest) -> usize {
+    size_of::<Digest>()
+}

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -8,6 +8,7 @@
 use bytes::Bytes;
 use commonware_cryptography::Digest;
 
+pub mod digest_payload;
 pub mod simplex;
 pub mod threshold_simplex;
 


### PR DESCRIPTION
To avoid a ton of parsing logic, it might be nice to employ prost's type_attributes/field_attributes: https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.type_attribute

AFAICT it isn't possible to provide generic types here, so it may not be possible outside of crates with hardcoded Schemes/Digests.