### PR TITLE
[commonware-storage/mmr] Make get_node() in the MMR Storage trait async

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -16,13 +16,13 @@ commonware-cryptography = {workspace = true}
 cfg-if = { workspace = true }
 thiserror = { workspace = true }
 commonware-utils = { workspace = true }
+futures = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bytes = { workspace = true }
 commonware-runtime = { workspace = true }
 commonware-macros = { workspace = true }
 prometheus-client = { workspace = true }
-futures = { workspace = true }
 futures-util = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -72,6 +72,6 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("a required element has been pruned: {0}")]
-    ElementPruned(u64),
+    #[error("an element required for this operation has been pruned")]
+    ElementPruned,
 }


### PR DESCRIPTION
get_node needs to be async to support backing an MMR with a Journal