### PR TITLE
[cryptography] Fix Exports of `PrivateKey`, `PublicKey`, `Signature`

### DIFF
--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -9,7 +9,7 @@
 pub mod dkg;
 pub mod primitives;
 mod scheme;
-pub use scheme::Bls12381;
+pub use scheme::{Bls12381, PrivateKey, PublicKey, Signature};
 
 #[cfg(test)]
 mod tests {

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -84,6 +84,7 @@ impl Scheme for Bls12381 {
     }
 }
 
+/// BLS12-381 private key.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PrivateKey {
     raw: [u8; group::PRIVATE_KEY_LENGTH],
@@ -165,6 +166,7 @@ impl Display for PrivateKey {
     }
 }
 
+/// BLS12-381 public key.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PublicKey {
     raw: [u8; group::PUBLIC_KEY_LENGTH],
@@ -246,6 +248,7 @@ impl Display for PublicKey {
     }
 }
 
+/// BLS12-381 signature.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Signature {
     raw: [u8; group::SIGNATURE_LENGTH],

--- a/cryptography/src/ed25519/mod.rs
+++ b/cryptography/src/ed25519/mod.rs
@@ -26,5 +26,4 @@
 
 mod scheme;
 
-pub use scheme::Ed25519;
-pub use scheme::Ed25519Batch;
+pub use scheme::{Ed25519, Ed25519Batch, PrivateKey, PublicKey, Signature};

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -110,6 +110,7 @@ impl BatchScheme for Ed25519Batch {
     }
 }
 
+/// Ed25519 Private Key.
 #[derive(Clone, Debug)]
 pub struct PrivateKey {
     raw: [u8; PRIVATE_KEY_LENGTH],
@@ -199,6 +200,7 @@ impl Display for PrivateKey {
     }
 }
 
+/// Ed25519 Public Key.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PublicKey {
     raw: [u8; PUBLIC_KEY_LENGTH],
@@ -262,6 +264,7 @@ impl Display for PublicKey {
     }
 }
 
+/// Ed25519 Signature.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Signature {
     raw: [u8; SIGNATURE_LENGTH],

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -15,11 +15,9 @@ use thiserror::Error;
 pub mod bls12381;
 pub use bls12381::Bls12381;
 pub mod ed25519;
-pub use ed25519::Ed25519;
-pub use ed25519::Ed25519Batch;
+pub use ed25519::{Ed25519, Ed25519Batch};
 pub mod sha256;
-pub use sha256::hash;
-pub use sha256::Sha256;
+pub use sha256::{hash, Sha256};
 pub mod secp256r1;
 pub use secp256r1::Secp256r1;
 

--- a/cryptography/src/secp256r1/mod.rs
+++ b/cryptography/src/secp256r1/mod.rs
@@ -25,4 +25,4 @@
 
 mod scheme;
 
-pub use scheme::Secp256r1;
+pub use scheme::{PrivateKey, PublicKey, Secp256r1, Signature};

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -80,6 +80,7 @@ impl Scheme for Secp256r1 {
     }
 }
 
+/// Secp256r1 Private Key.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PrivateKey {
     raw: [u8; PRIVATE_KEY_LENGTH],
@@ -161,6 +162,7 @@ impl Display for PrivateKey {
     }
 }
 
+/// Secp256r1 Public Key.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PublicKey {
     raw: [u8; PUBLIC_KEY_LENGTH],
@@ -231,6 +233,7 @@ impl Display for PublicKey {
     }
 }
 
+/// Secp256r1 Signature.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Signature {
     raw: [u8; SIGNATURE_LENGTH],

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -1,4 +1,24 @@
 //! SHA-256 implementation of the `Hasher` trait.
+//!
+//! This implementation uses the `sha2` crate to generate SHA-256 digests.
+//!
+//! # Example
+//! ```rust
+//! use commonware_cryptography::{Hasher, Sha256};
+//!
+//! // Create a new SHA-256 hasher
+//! let mut hasher = Sha256::new();
+//!
+//! // Update the hasher with some messages
+//! hasher.update(b"hello,");
+//! hasher.update(b"world!");
+//!
+//! // Finalize the hasher to get the digest
+//! let digest = hasher.finalize();
+//!
+//! // Print the digest
+//! println!("digest: {:?}", digest);
+//! ```
 
 use crate::{Array, Error, Hasher};
 use commonware_utils::{hex, SizedSerialize};


### PR DESCRIPTION
Related: #447 

Because these types aren't exported, the docs look like this:
<img width="468" alt="image" src="https://github.com/user-attachments/assets/57c19866-17a2-4ad8-b43e-5d7b1224f486" />

It may also be nice to take advantage of certain functionality specific to an implementation (not currently done but could be).