### PR TITLE
[commonware-storage/mmr] make get_node() return a Digest instead of &Digest

### DIFF
--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -37,8 +37,11 @@ impl<H: CHasher> Storage<H> for Mmr<H> {
         Ok(self.size())
     }
 
-    async fn get_node(&self, position: u64) -> Result<Option<&H::Digest>, Error> {
-        Ok(self.nodes.get(self.pos_to_index(position)))
+    async fn get_node(&self, position: u64) -> Result<Option<H::Digest>, Error> {
+        match self.nodes.get(self.pos_to_index(position)) {
+            Some(node) => Ok(Some(node.clone())),
+            None => Ok(None),
+        }
     }
 }
 
@@ -233,7 +236,7 @@ mod tests {
             let mut mmr_hasher = Hasher::new(&mut hasher);
             for leaf in leaves.iter().by_ref() {
                 let hash = mmr_hasher.leaf_hash(*leaf, &element);
-                assert_eq!(mmr.get_node(*leaf).await.unwrap().unwrap(), &hash);
+                assert_eq!(mmr.get_node(*leaf).await.unwrap().unwrap(), hash);
             }
 
             // verify height=1 hashes

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -34,7 +34,7 @@ pub trait Storage<H: CHasher> {
     fn get_node(
         &self,
         position: u64,
-    ) -> impl Future<Output = Result<Option<&H::Digest>, Error>> + Send;
+    ) -> impl Future<Output = Result<Option<H::Digest>, Error>> + Send;
 }
 
 impl<H: CHasher> PartialEq for Proof<H> {
@@ -246,7 +246,7 @@ impl<H: CHasher> Proof<H> {
         let hash_results = try_join_all(node_futures).await?;
         for hash_result in hash_results {
             match hash_result {
-                Some(hash) => hashes.push(hash.clone()),
+                Some(hash) => hashes.push(hash),
                 // Implementations should check to make sure the range is provable before calling
                 // this function, so this case should not happen in general.
                 None => return Err(Error::ElementPruned),
@@ -293,7 +293,7 @@ fn peak_hash_from_range<'a, H: CHasher>(
             elements,
             sibling_hashes,
         ) {
-            Ok(h) => left_hash = Some(h.clone()),
+            Ok(h) => left_hash = Some(h),
             Err(_) => return Err(()),
         }
     }
@@ -308,7 +308,7 @@ fn peak_hash_from_range<'a, H: CHasher>(
             elements,
             sibling_hashes,
         ) {
-            Ok(h) => right_hash = Some(h.clone()),
+            Ok(h) => right_hash = Some(h),
             Err(_) => return Err(()),
         }
     }


### PR DESCRIPTION
Make get_node() return a full digest instead of a reference, since there is no reference to return for disk-backed MMRs.