### PR TITLE
[commonware-storage/mmr] remove reusable hasher from mem::Mmr to avoid interior mutability concerns

### DIFF
--- a/storage/src/mmr/benches/append.rs
+++ b/storage/src/mmr/benches/append.rs
@@ -16,9 +16,10 @@ fn bench_append(c: &mut Criterion) {
         // Append elements to MMR
         c.bench_function(&format!("{}/n={}", module_path!(), n), |b| {
             b.iter(|| {
+                let mut h = Sha256::new();
                 let mut mmr = Mmr::<Sha256>::new();
                 for digest in &elements {
-                    mmr.add(digest);
+                    mmr.add(&mut h, digest);
                 }
             })
         });

--- a/storage/src/mmr/benches/append_additional.rs
+++ b/storage/src/mmr/benches/append_additional.rs
@@ -23,15 +23,17 @@ fn bench_append_additional(c: &mut Criterion) {
             c.bench_function(&format!("{}/start={} add={}", module_path!(), n, a), |b| {
                 b.iter_batched(
                     || {
+                        let mut h = Sha256::new();
                         let mut mmr = Mmr::<Sha256>::new();
                         for digest in &elements {
-                            mmr.add(digest);
+                            mmr.add(&mut h, digest);
                         }
                         mmr
                     },
                     |mut mmr| {
+                        let mut h = Sha256::new();
                         for digest in &additional {
-                            mmr.add(digest);
+                            mmr.add(&mut h, digest);
                         }
                     },
                     criterion::BatchSize::SmallInput,

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -13,13 +13,14 @@ fn bench_prove_many_elements(c: &mut Criterion) {
         let mut positions = Vec::with_capacity(n);
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
+        let mut hasher = Sha256::new();
         for i in 0..n {
             let element = Sha256::random(&mut sampler);
-            let pos = mmr.add(&element);
+            let pos = mmr.add(&mut hasher, &element);
             positions.push((i, pos));
             elements.push(element);
         }
-        let root_hash = mmr.root();
+        let root_hash = mmr.root(&mut hasher);
 
         // Generate SAMPLE_SIZE random starts without replacement and create/verify range proofs
         for range in [2, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000] {

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -12,12 +12,13 @@ fn bench_prove_single_element(c: &mut Criterion) {
         let mut mmr = Mmr::<Sha256>::new();
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
+        let mut hasher = Sha256::new();
         for _ in 0..n {
             let element = Sha256::random(&mut sampler);
-            let pos = mmr.add(&element);
+            let pos = mmr.add(&mut hasher, &element);
             elements.push((pos, element));
         }
-        let root_hash = mmr.root();
+        let root_hash = mmr.root(&mut hasher);
 
         // Select SAMPLE_SIZE random elements without replacement and create/verify proofs
         c.bench_function(

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -349,11 +349,12 @@ mod tests {
             let mut mmr = Mmr::<Sha256>::new();
             let element = Digest::from(*b"01234567012345670123456701234567");
             let mut leaves: Vec<u64> = Vec::new();
+            let mut hasher = Sha256::default();
             for _ in 0..11 {
-                leaves.push(mmr.add(&element));
+                leaves.push(mmr.add(&mut hasher, &element));
             }
 
-            let root_hash = mmr.root();
+            let root_hash = mmr.root(&mut hasher);
             let mut hasher = Sha256::default();
 
             // confirm the proof of inclusion for each leaf successfully verifies
@@ -441,12 +442,13 @@ mod tests {
             let mut mmr: Mmr<Sha256> = Mmr::default();
             let mut elements = Vec::<Digest>::new();
             let mut element_positions = Vec::<u64>::new();
+            let mut hasher = Sha256::default();
             for i in 0..49 {
                 elements.push(test_digest(i));
-                element_positions.push(mmr.add(elements.last().unwrap()));
+                element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
             }
             // test range proofs over all possible ranges of at least 2 elements
-            let root_hash = mmr.root();
+            let root_hash = mmr.root(&mut hasher);
             let mut hasher = Sha256::default();
 
             for i in 0..elements.len() {
@@ -608,9 +610,10 @@ mod tests {
         let mut mmr: Mmr<Sha256> = Mmr::default();
         let mut elements = Vec::<Digest>::new();
         let mut element_positions = Vec::<u64>::new();
+        let mut hasher = Sha256::default();
         for i in 0..49 {
             elements.push(test_digest(i));
-            element_positions.push(mmr.add(elements.last().unwrap()));
+            element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
         }
 
         // forget the max # of elements
@@ -626,7 +629,7 @@ mod tests {
         }
 
         // test range proofs over all possible ranges of at least 2 elements
-        let root_hash = mmr.root();
+        let root_hash = mmr.root(&mut hasher);
         let mut hasher = Sha256::default();
         for i in 0..elements.len() {
             for j in i + 1..elements.len() {
@@ -649,11 +652,11 @@ mod tests {
         // add a few more nodes, forget again, and test again to make sure repeated forgetting works
         for i in 0..37 {
             elements.push(test_digest(i));
-            element_positions.push(mmr.add(elements.last().unwrap()));
+            element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
         }
         assert_eq!(mmr.forget_max(), 126);
         assert_eq!(mmr.oldest_remembered_node_pos(), 126);
-        let updated_root_hash = mmr.root();
+        let updated_root_hash = mmr.root(&mut hasher);
         for i in 0..elements.len() {
             if element_positions[i] > 126 {
                 elements = elements[i..elements.len()].to_vec();
@@ -690,9 +693,10 @@ mod tests {
             let mut mmr: Mmr<Sha256> = Mmr::default();
             let mut elements = Vec::<Digest>::new();
             let mut element_positions = Vec::<u64>::new();
+            let mut hasher = Sha256::default();
             for i in 0..25 {
                 elements.push(test_digest(i));
-                element_positions.push(mmr.add(elements.last().unwrap()));
+                element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
             }
 
             // Generate proofs over all possible ranges of elements and confirm each


### PR DESCRIPTION
This PR requires the caller to provide a reusable hasher for efficiency rather than maintaining one inside the MMR. This avoids interior mutability issues that (for example) required making methods such as root() mutable.