### PR TITLE
[commonware-storage/mmr] add rewind function to fixed-item journal

### DIFF
--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -35,4 +35,6 @@ pub enum Error {
     ItemPruned(u64),
     #[error("invalid item: {0}")]
     InvalidItem(u64),
+    #[error("invalid rewind: {0}")]
+    InvalidRewind(u64),
 }


### PR DESCRIPTION
The MMR will need to be able to rewind the journal to back up to a valid state after a partial write failure.