### PR TITLE
[broadcast::linked] Allow experimental `optional` field in proto3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "bytes",
  "commonware-cryptography",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.2", path = "broadcast" }
+commonware-broadcast = { version = "0.0.3", path = "broadcast" }
 commonware-consensus = { version = "0.0.10", path = "consensus" }
 commonware-cryptography = { version = "0.0.21", path = "cryptography" }
 commonware-macros = { version = "0.0.12", path = "macros" }

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-broadcast"
 edition = "2021"
 publish = true
-version = "0.0.2"
+version = "0.0.3"
 license = "MIT OR Apache-2.0"
 description = "Disseminate data over a wide-area network."
 readme = "README.md"

--- a/broadcast/build.rs
+++ b/broadcast/build.rs
@@ -2,6 +2,7 @@ use std::io::Result;
 fn main() -> Result<()> {
     // Proto compilation rules for `linked` dialect
     let mut config = prost_build::Config::new();
+    config.protoc_arg("--experimental_allow_proto3_optional");
     config.compile_protos(&["src/linked/wire.proto"], &["src/linked/"])?;
     Ok(())
 }


### PR DESCRIPTION
Fixes an issue with the docs and build process
Also bump the version to `0.0.3`