### PR TITLE
[commonware-storage] move registry outside of config structs and into the init() methods

### DIFF
--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -353,10 +353,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -580,10 +579,9 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
-                    let journal = Journal::init(runtime.clone(), cfg)
+                    let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                         .await
                         .expect("unable to create journal");
                     let cfg = config::Config {
@@ -794,10 +792,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -929,10 +926,9 @@ mod tests {
                 actor.run().await;
             });
             let cfg = JConfig {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: validator.to_string(),
             };
-            let journal = Journal::init(runtime.clone(), cfg)
+            let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                 .await
                 .expect("unable to create journal");
             let cfg = config::Config {
@@ -1080,10 +1076,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1265,10 +1260,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1439,10 +1433,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1606,10 +1599,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1830,10 +1822,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -2017,10 +2008,9 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
-                    let journal = Journal::init(runtime.clone(), cfg)
+                    let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                         .await
                         .expect("unable to create journal");
                     let cfg = config::Config {
@@ -2202,10 +2192,9 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
-                    let journal = Journal::init(runtime.clone(), cfg)
+                    let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                         .await
                         .expect("unable to create journal");
                     let cfg = config::Config {

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -390,10 +390,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -626,10 +625,9 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
-                    let journal = Journal::init(runtime.clone(), cfg)
+                    let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                         .await
                         .expect("unable to create journal");
                     let cfg = config::Config {
@@ -851,10 +849,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -988,10 +985,9 @@ mod tests {
                 actor.run().await;
             });
             let cfg = JConfig {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: validator.to_string(),
             };
-            let journal = Journal::init(runtime.clone(), cfg)
+            let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                 .await
                 .expect("unable to create journal");
             let cfg = config::Config {
@@ -1145,10 +1141,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1336,10 +1331,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1516,10 +1510,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1689,10 +1682,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1918,10 +1910,9 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -2110,10 +2101,9 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
-                    let journal = Journal::init(runtime.clone(), cfg)
+                    let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                         .await
                         .expect("unable to create journal");
                     let cfg = config::Config {
@@ -2294,10 +2284,9 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
-                    let journal = Journal::init(runtime.clone(), cfg)
+                    let journal = Journal::init(runtime.clone(), &mut Registry::default(), cfg)
                         .await
                         .expect("unable to create journal");
                     let cfg = config::Config {

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -215,10 +215,11 @@ fn main() {
         );
 
         // Initialize storage
+        let mut storage_registry = Registry::default();
         let journal = Journal::init(
             runtime.clone(),
+            storage_registry.sub_registry_with_prefix("journal"),
             Config {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: String::from("log"),
             },
         )

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -192,10 +192,11 @@ fn main() {
         );
 
         // Initialize storage
+        let mut storage_registry = Registry::default();
         let journal = Journal::init(
             runtime.clone(),
+            storage_registry.sub_registry_with_prefix("journal"),
             Config {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: String::from("log"),
             },
         )

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -14,6 +14,7 @@ use commonware_cryptography::Hasher;
 use commonware_runtime::{Blob, Storage as RStorage};
 use commonware_utils::SizedSerialize;
 use futures::future::try_join_all;
+use prometheus_client::registry::Registry;
 use tracing::warn;
 
 /// A MMR backed by a fixed-item-length journal.
@@ -45,8 +46,12 @@ impl<B: Blob, E: RStorage<B>, H: Hasher> Storage<H> for Mmr<B, E, H> {
 
 impl<B: Blob, E: RStorage<B>, H: Hasher> Mmr<B, E, H> {
     /// Initialize a new `Mmr` instance.
-    pub async fn init(context: E, journal_cfg: JConfig) -> Result<Self, Error> {
-        let mut journal = Journal::<B, E, H::Digest>::init(context, journal_cfg).await?;
+    pub async fn init(
+        context: E,
+        registry: &mut Registry,
+        journal_cfg: JConfig,
+    ) -> Result<Self, Error> {
+        let mut journal = Journal::<B, E, H::Digest>::init(context, registry, journal_cfg).await?;
         let mut journal_size = journal.size().await?;
         if journal_size == 0 {
             return Ok(Self {
@@ -163,7 +168,6 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic::Executor, Runner};
     use prometheus_client::registry::Registry;
-    use std::sync::{Arc, Mutex};
 
     fn test_digest(v: u8) -> Digest {
         hash(&v.to_be_bytes())
@@ -172,13 +176,13 @@ mod tests {
     #[test_traced]
     fn test_journaled_mmr() {
         let (executor, context, _) = Executor::default();
+        let mut registry = Registry::default();
         executor.start(async move {
             let cfg = JConfig {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: "test_partition".into(),
                 items_per_blob: 7,
             };
-            let mut mmr = Mmr::<_, _, Sha256>::init(context.clone(), cfg.clone())
+            let mut mmr = Mmr::<_, _, Sha256>::init(context.clone(), &mut registry, cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(mmr.size().await.unwrap(), 0);
@@ -244,12 +248,12 @@ mod tests {
     fn test_journaled_mmr_recovery() {
         let (executor, context, _) = Executor::default();
         executor.start(async move {
+            let mut registry = Registry::default();
             let cfg = JConfig {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: "test_partition".into(),
                 items_per_blob: 7,
             };
-            let mut mmr = Mmr::<_, _, Sha256>::init(context.clone(), cfg.clone())
+            let mut mmr = Mmr::<_, _, Sha256>::init(context.clone(), &mut registry, cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(mmr.size().await.unwrap(), 0);
@@ -284,7 +288,7 @@ mod tests {
                 .expect("Failed to corrupt blob");
             blob.close().await.expect("Failed to close blob");
 
-            let mmr = Mmr::<_, _, Sha256>::init(context.clone(), cfg.clone())
+            let mmr = Mmr::<_, _, Sha256>::init(context.clone(), &mut registry, cfg.clone())
                 .await
                 .unwrap();
             // Since we didn't corrupt the leaf, the MMR is able to replay the leaf and recover to
@@ -293,7 +297,7 @@ mod tests {
 
             // Make sure closing it and re-opening it persists the recovered state.
             mmr.close().await.unwrap();
-            let mmr = Mmr::<_, _, Sha256>::init(context.clone(), cfg.clone())
+            let mmr = Mmr::<_, _, Sha256>::init(context.clone(), &mut registry, cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(mmr.size().await.unwrap(), 498);
@@ -319,7 +323,7 @@ mod tests {
                 .expect("Failed to corrupt blob");
             blob.close().await.expect("Failed to close blob");
 
-            let mmr = Mmr::<_, _, Sha256>::init(context.clone(), cfg.clone())
+            let mmr = Mmr::<_, _, Sha256>::init(context.clone(), &mut registry, cfg.clone())
                 .await
                 .unwrap();
             // Since the leaf was corrupted, it should not have been recovered, and the journal's


### PR DESCRIPTION
This PR changes the ownership of registry from the storage classes themselves to the user of those classes, allowing users to create appropriately prefixed sub-registries for each component.