### PR TITLE
[runtime] Add `Metrics` Trait + Refactor `Spawner::spawn`

### DIFF
--- a/broadcast/src/linked/mocks/application.rs
+++ b/broadcast/src/linked/mocks/application.rs
@@ -53,7 +53,7 @@ impl<D: Array, P: Array> Application<D, P> {
         (Application { mailbox: receiver }, Mailbox { sender })
     }
 
-    pub async fn run(&mut self, mut signer: signer::Mailbox<D>) {
+    pub async fn run(mut self, mut signer: signer::Mailbox<D>) {
         while let Some(msg) = self.mailbox.next().await {
             match msg {
                 Message::Broadcast(payload) => {

--- a/broadcast/src/linked/mod.rs
+++ b/broadcast/src/linked/mod.rs
@@ -219,10 +219,7 @@ mod tests {
                     namespace,
                     poly::public(&identity),
                 );
-            context
-                .clone()
-                .with_label("collector")
-                .spawn(|_| collector.run());
+            context.with_label("collector").spawn(|_| collector.run());
             collectors.insert(validator.clone(), collector_mailbox);
 
             let (signer, signer_mailbox) = signer::Actor::new(
@@ -245,10 +242,7 @@ mod tests {
                 },
             );
 
-            context
-                .clone()
-                .with_label("app")
-                .spawn(|_| app.run(signer_mailbox));
+            context.with_label("app").spawn(|_| app.run(signer_mailbox));
             let ((a1, a2), (b1, b2)) = registrations.remove(validator).unwrap();
             signer.start((a1, a2), (b1, b2));
         }

--- a/broadcast/src/linked/mod.rs
+++ b/broadcast/src/linked/mod.rs
@@ -357,11 +357,7 @@ mod tests {
                 Duration::from_millis(100),
                 Duration::from_secs(5),
             );
-            spawn_proposer(
-                context.with_label("proposer"),
-                mailboxes.clone(),
-                |_| false,
-            );
+            spawn_proposer(context.with_label("proposer"), mailboxes.clone(), |_| false);
             await_collectors(context.with_label("collector"), &collectors, 100).await;
         });
     }
@@ -434,11 +430,7 @@ mod tests {
                         Duration::from_millis(100),
                         Duration::from_secs(5),
                     );
-                    spawn_proposer(
-                        context.with_label("proposer"),
-                        mailboxes.clone(),
-                        |_| false,
-                    );
+                    spawn_proposer(context.with_label("proposer"), mailboxes.clone(), |_| false);
 
                     let collector_pairs: Vec<(
                         PublicKey,
@@ -449,8 +441,9 @@ mod tests {
                         .collect();
                     for (validator, mut mailbox) in collector_pairs {
                         let completed_clone = completed.clone();
-                        context.with_label("collector_unclean").spawn(
-                            |context| async move {
+                        context
+                            .with_label("collector_unclean")
+                            .spawn(|context| async move {
                                 loop {
                                     let tip = mailbox.get_tip(validator.clone()).await.unwrap_or(0);
                                     if tip >= 100 {
@@ -459,8 +452,7 @@ mod tests {
                                     }
                                     context.sleep(Duration::from_millis(100)).await;
                                 }
-                            },
-                        );
+                            });
                     }
                     context.sleep(Duration::from_millis(1000)).await;
                     *shutdowns.lock().unwrap() += 1;
@@ -505,11 +497,7 @@ mod tests {
                 Duration::from_millis(100),
                 Duration::from_secs(1),
             );
-            spawn_proposer(
-                context.with_label("proposer"),
-                mailboxes.clone(),
-                |_| false,
-            );
+            spawn_proposer(context.with_label("proposer"), mailboxes.clone(), |_| false);
             // Simulate partition by removing all links.
             link_validators(&mut oracle, &pks, Action::Unlink, None).await;
             context.sleep(Duration::from_secs(5)).await;
@@ -570,11 +558,7 @@ mod tests {
                 Duration::from_millis(150),
             );
 
-            spawn_proposer(
-                context.with_label("proposer"),
-                mailboxes.clone(),
-                |_| false,
-            );
+            spawn_proposer(context.with_label("proposer"), mailboxes.clone(), |_| false);
             await_collectors(context.with_label("collector"), &collectors, 40).await;
         });
         auditor.state()
@@ -630,11 +614,9 @@ mod tests {
                 Duration::from_secs(5),
             );
 
-            spawn_proposer(
-                context.with_label("proposer"),
-                mailboxes.clone(),
-                |i| i % 10 == 0,
-            );
+            spawn_proposer(context.with_label("proposer"), mailboxes.clone(), |i| {
+                i % 10 == 0
+            });
             await_collectors(context.with_label("collector"), &collectors, 100).await;
         });
     }

--- a/broadcast/src/linked/mod.rs
+++ b/broadcast/src/linked/mod.rs
@@ -85,7 +85,6 @@ mod tests {
     use commonware_runtime::{Clock, Runner, Spawner};
     use futures::channel::oneshot;
     use futures::future::join_all;
-    use prometheus_client::registry::Registry;
     use std::sync::{Arc, Mutex};
     use std::{
         collections::{BTreeMap, HashSet},
@@ -157,7 +156,6 @@ mod tests {
         let (network, mut oracle) = Network::new(
             runtime.clone(),
             commonware_p2p::simulated::Config {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 max_size: 1024 * 1024,
             },
         );
@@ -381,7 +379,6 @@ mod tests {
                     let (network, mut oracle) = Network::new(
                         context.clone(),
                         commonware_p2p::simulated::Config {
-                            registry: Arc::new(Mutex::new(Registry::default())),
                             max_size: 1024 * 1024,
                         },
                     );

--- a/broadcast/src/linked/signer/ack_manager.rs
+++ b/broadcast/src/linked/signer/ack_manager.rs
@@ -155,8 +155,8 @@ mod tests {
 
         /// Generate shares using the default executor.
         pub fn setup_shares(num_validators: u32, quorum: u32) -> Vec<Share> {
-            let (_, mut runtime, _) = Executor::default();
-            let (_identity, shares) = generate_shares(&mut runtime, None, num_validators, quorum);
+            let (_, mut context, _) = Executor::default();
+            let (_identity, shares) = generate_shares(&mut context, None, num_validators, quorum);
             shares
         }
 

--- a/broadcast/src/linked/signer/actor.rs
+++ b/broadcast/src/linked/signer/actor.rs
@@ -13,7 +13,7 @@ use commonware_cryptography::{
 };
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Blob, Clock, Metrics, Spawner, Storage};
+use commonware_runtime::{Blob, Clock, Handle, Metrics, Spawner, Storage};
 use commonware_storage::journal::{self, variable::Journal};
 use futures::{
     channel::{mpsc, oneshot},
@@ -234,7 +234,13 @@ impl<
     /// - Messages from the network:
     ///   - Nodes
     ///   - Acks
-    pub async fn run(mut self, chunk_network: (NetS, NetR), ack_network: (NetS, NetR)) {
+    pub fn start(self, chunk_network: (NetS, NetR), ack_network: (NetS, NetR)) -> Handle<()> {
+        self.runtime
+            .clone()
+            .spawn(|_| self.run(chunk_network, ack_network))
+    }
+
+    async fn run(mut self, chunk_network: (NetS, NetR), ack_network: (NetS, NetR)) {
         let (mut node_sender, mut node_receiver) = chunk_network;
         let (mut ack_sender, mut ack_receiver) = ack_network;
         let mut shutdown = self.runtime.stopped();

--- a/broadcast/src/linked/signer/actor.rs
+++ b/broadcast/src/linked/signer/actor.rs
@@ -235,10 +235,8 @@ impl<
     /// - Messages from the network:
     ///   - Nodes
     ///   - Acks
-    pub fn start(self, chunk_network: (NetS, NetR), ack_network: (NetS, NetR)) -> Handle<()> {
-        self.context
-            .clone()
-            .spawn(|_| self.run(chunk_network, ack_network))
+    pub fn start(mut self, chunk_network: (NetS, NetR), ack_network: (NetS, NetR)) -> Handle<()> {
+        self.context.spawn_ref()(self.run(chunk_network, ack_network))
     }
 
     async fn run(mut self, chunk_network: (NetS, NetR), ack_network: (NetS, NetR)) {

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -102,7 +102,7 @@ pub struct Actor<
     D: Array,
     S: Supervisor<Index = View, PublicKey = C::PublicKey>,
 > {
-    runtime: E,
+    context: E,
     supervisor: S,
     _digest: PhantomData<D>,
 
@@ -137,7 +137,7 @@ impl<
         S: Supervisor<Index = View, PublicKey = C::PublicKey>,
     > Actor<E, C, D, S>
 {
-    pub fn new(runtime: E, cfg: Config<C, S>) -> (Self, Mailbox) {
+    pub fn new(context: E, cfg: Config<C, S>) -> (Self, Mailbox) {
         // Initialize requester
         let config = requester::Config {
             crypto: cfg.crypto.clone(),
@@ -145,19 +145,19 @@ impl<
             initial: cfg.fetch_timeout / 2,
             timeout: cfg.fetch_timeout,
         };
-        let requester = requester::Requester::new(runtime.clone(), config);
+        let requester = requester::Requester::new(context.clone(), config);
 
         // Initialize metrics
         let unfulfilled = Gauge::default();
         let outstanding = Gauge::default();
         let served = Counter::default();
-        runtime.register(
+        context.register(
             "unfulfilled",
             "unfulfilled notarizations/nullifications",
             unfulfilled.clone(),
         );
-        runtime.register("outstanding", "outstanding requests", outstanding.clone());
-        runtime.register(
+        context.register("outstanding", "outstanding requests", outstanding.clone());
+        context.register(
             "served",
             "served notarizations/nullifications",
             served.clone(),
@@ -167,7 +167,7 @@ impl<
         let (sender, receiver) = mpsc::channel(cfg.mailbox_size);
         (
             Self {
-                runtime,
+                context,
                 supervisor: cfg.supervisor,
                 _digest: PhantomData,
 
@@ -216,7 +216,7 @@ impl<
                 .required
                 .iter()
                 .filter(|entry| !self.inflight.contains(entry))
-                .choose_multiple(&mut self.runtime, self.max_fetch_count);
+                .choose_multiple(&mut self.context, self.max_fetch_count);
             if entries.is_empty() {
                 return;
             }
@@ -259,7 +259,7 @@ impl<
                     // learn of new notarizations or nullifications in the meantime.
                     warn!("failed to send request to any validator");
                     let deadline = self
-                        .runtime
+                        .context
                         .current()
                         .checked_add(self.fetch_timeout)
                         .expect("time overflowed");
@@ -304,7 +304,7 @@ impl<
         sender: impl Sender<PublicKey = C::PublicKey>,
         receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) -> Handle<()> {
-        self.runtime
+        self.context
             .clone()
             .spawn(|_| self.run(voter, sender, receiver))
     }
@@ -325,13 +325,13 @@ impl<
 
             // Set timeout for retry
             let retry = match self.retry {
-                Some(retry) => Either::Left(self.runtime.sleep_until(retry)),
+                Some(retry) => Either::Left(self.context.sleep_until(retry)),
                 None => Either::Right(futures::future::pending()),
             };
 
             // Set timeout for next request
             let (request, timeout) = if let Some((request, timeout)) = self.requester.next() {
-                (request, Either::Left(self.runtime.sleep_until(timeout)))
+                (request, Either::Left(self.context.sleep_until(timeout)))
             } else {
                 (0, Either::Right(futures::future::pending()))
             };

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -14,7 +14,7 @@ use crate::{
 use commonware_cryptography::{Array, Scheme};
 use commonware_macros::select;
 use commonware_p2p::{utils::requester, Receiver, Recipients, Sender};
-use commonware_runtime::{Clock, Metrics};
+use commonware_runtime::{Clock, Handle, Metrics, Spawner};
 use futures::{channel::mpsc, future::Either, StreamExt};
 use governor::clock::Clock as GClock;
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
@@ -96,7 +96,7 @@ impl Inflight {
 
 /// Requests are made concurrently to multiple peers.
 pub struct Actor<
-    E: Clock + GClock + Rng + Metrics,
+    E: Clock + GClock + Rng + Metrics + Spawner,
     C: Scheme,
     D: Array,
     S: Supervisor<Index = View, PublicKey = C::PublicKey>,
@@ -130,7 +130,7 @@ pub struct Actor<
 }
 
 impl<
-        E: Clock + GClock + Rng + Metrics,
+        E: Clock + GClock + Rng + Metrics + Spawner,
         C: Scheme,
         D: Array,
         S: Supervisor<Index = View, PublicKey = C::PublicKey>,
@@ -297,7 +297,18 @@ impl<
         }
     }
 
-    pub async fn run(
+    pub fn start(
+        self,
+        voter: voter::Mailbox<D>,
+        sender: impl Sender<PublicKey = C::PublicKey>,
+        receiver: impl Receiver<PublicKey = C::PublicKey>,
+    ) -> Handle<()> {
+        self.runtime
+            .clone()
+            .spawn(|_| self.run(voter, sender, receiver))
+    }
+
+    async fn run(
         mut self,
         mut voter: voter::Mailbox<D>,
         mut sender: impl Sender<PublicKey = C::PublicKey>,

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -6,11 +6,7 @@ pub use actor::Actor;
 use commonware_cryptography::Scheme;
 use governor::Quota;
 pub use ingress::Mailbox;
-use prometheus_client::registry::Registry;
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::time::Duration;
 
 pub struct Config<C: Scheme, S: Supervisor> {
     pub crypto: C,

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -16,7 +16,6 @@ pub struct Config<C: Scheme, S: Supervisor> {
     pub crypto: C,
     pub supervisor: S,
 
-    pub registry: Arc<Mutex<Registry>>,
     pub namespace: Vec<u8>,
     pub mailbox_size: usize,
     pub activity_timeout: u64,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -17,7 +17,7 @@ use crate::{
 use commonware_cryptography::{sha256::hash, sha256::Digest as Sha256Digest, Array, Scheme};
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Blob, Clock, Metrics, Spawner, Storage};
+use commonware_runtime::{Blob, Clock, Handle, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::Journal;
 use commonware_utils::quorum;
 use futures::{
@@ -2022,7 +2022,18 @@ impl<
         };
     }
 
-    pub async fn run(
+    pub fn start(
+        self,
+        backfiller: resolver::Mailbox,
+        sender: impl Sender,
+        receiver: impl Receiver,
+    ) -> Handle<()> {
+        self.runtime
+            .clone()
+            .spawn(|_| self.run(backfiller, sender, receiver))
+    }
+
+    async fn run(
         mut self,
         mut backfiller: resolver::Mailbox,
         mut sender: impl Sender,

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -7,8 +7,6 @@ use crate::{Committer, Relay};
 pub use actor::Actor;
 use commonware_cryptography::{Array, Scheme};
 pub use ingress::{Mailbox, Message};
-use prometheus_client::registry::Registry;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 pub struct Config<
@@ -25,7 +23,6 @@ pub struct Config<
     pub committer: F,
     pub supervisor: S,
 
-    pub registry: Arc<Mutex<Registry>>,
     pub namespace: Vec<u8>,
     pub mailbox_size: usize,
     pub leader_timeout: Duration,

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -2,11 +2,7 @@ use super::{Context, View};
 use crate::{Automaton, Committer, Relay, Supervisor};
 use commonware_cryptography::{Array, Scheme};
 use governor::Quota;
-use prometheus_client::registry::Registry;
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::time::Duration;
 
 /// Configuration for the consensus engine.
 pub struct Config<
@@ -31,9 +27,6 @@ pub struct Config<
 
     /// Supervisor for the consensus engine.
     pub supervisor: S,
-
-    /// Prometheus metrics registry.
-    pub registry: Arc<Mutex<Registry>>,
 
     /// Maximum number of messages to buffer on channels inside the consensus
     /// engine before blocking.

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -7,7 +7,7 @@ use crate::{Automaton, Committer, Relay, Supervisor};
 use commonware_cryptography::{Array, Scheme};
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Sender};
-use commonware_runtime::{Blob, Clock, Spawner, Storage};
+use commonware_runtime::{Blob, Clock, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::Journal;
 use governor::clock::Clock as GClock;
 use rand::{CryptoRng, Rng};
@@ -16,7 +16,7 @@ use tracing::debug;
 /// Instance of `simplex` consensus engine.
 pub struct Engine<
     B: Blob,
-    E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B>,
+    E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B> + Metrics,
     C: Scheme,
     D: Array,
     A: Automaton<Context = Context<D>, Digest = D>,
@@ -34,7 +34,7 @@ pub struct Engine<
 
 impl<
         B: Blob,
-        E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B>,
+        E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B> + Metrics,
         C: Scheme,
         D: Array,
         A: Automaton<Context = Context<D>, Digest = D>,
@@ -58,7 +58,6 @@ impl<
                 relay: cfg.relay,
                 committer: cfg.committer,
                 supervisor: cfg.supervisor.clone(),
-                registry: cfg.registry.clone(),
                 mailbox_size: cfg.mailbox_size,
                 namespace: cfg.namespace.clone(),
                 leader_timeout: cfg.leader_timeout,
@@ -75,7 +74,6 @@ impl<
             resolver::Config {
                 crypto: cfg.crypto,
                 supervisor: cfg.supervisor,
-                registry: cfg.registry,
                 mailbox_size: cfg.mailbox_size,
                 namespace: cfg.namespace,
                 activity_timeout: cfg.activity_timeout,

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -25,7 +25,7 @@ pub struct Engine<
     F: Committer<Digest = D>,
     S: Supervisor<Index = View, PublicKey = C::PublicKey>,
 > {
-    runtime: E,
+    context: E,
 
     voter: voter::Actor<B, E, C, D, A, R, F, S>,
     voter_mailbox: voter::Mailbox<D>,
@@ -45,13 +45,13 @@ impl<
     > Engine<B, E, C, D, A, R, F, S>
 {
     /// Create a new `simplex` consensus engine.
-    pub fn new(runtime: E, journal: Journal<B, E>, cfg: Config<C, D, A, R, F, S>) -> Self {
+    pub fn new(context: E, journal: Journal<B, E>, cfg: Config<C, D, A, R, F, S>) -> Self {
         // Ensure configuration is valid
         cfg.assert();
 
         // Create voter
         let (voter, voter_mailbox) = voter::Actor::new(
-            runtime.with_label("voter"),
+            context.with_label("voter"),
             journal,
             voter::Config {
                 crypto: cfg.crypto.clone(),
@@ -71,7 +71,7 @@ impl<
 
         // Create resolver
         let (resolver, resolver_mailbox) = resolver::Actor::new(
-            runtime.with_label("resolver"),
+            context.with_label("resolver"),
             resolver::Config {
                 crypto: cfg.crypto,
                 supervisor: cfg.supervisor,
@@ -88,7 +88,7 @@ impl<
 
         // Return the engine
         Self {
-            runtime,
+            context,
 
             voter,
             voter_mailbox,
@@ -111,7 +111,7 @@ impl<
             impl Receiver<PublicKey = C::PublicKey>,
         ),
     ) -> Handle<()> {
-        self.runtime
+        self.context
             .clone()
             .spawn(|_| self.run(voter_network, resolver_network))
     }

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -7,7 +7,7 @@ use crate::{Automaton, Committer, Relay, Supervisor};
 use commonware_cryptography::{Array, Scheme};
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Sender};
-use commonware_runtime::{Blob, Clock, Metrics, Spawner, Storage};
+use commonware_runtime::{Blob, Clock, Handle, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::Journal;
 use governor::clock::Clock as GClock;
 use rand::{CryptoRng, Rng};
@@ -50,7 +50,7 @@ impl<
 
         // Create voter
         let (voter, voter_mailbox) = voter::Actor::new(
-            runtime.clone(),
+            runtime.with_label("voter"),
             journal,
             voter::Config {
                 crypto: cfg.crypto.clone(),
@@ -70,7 +70,7 @@ impl<
 
         // Create resolver
         let (resolver, resolver_mailbox) = resolver::Actor::new(
-            runtime.clone(),
+            runtime.with_label("resolver"),
             resolver::Config {
                 crypto: cfg.crypto,
                 supervisor: cfg.supervisor,
@@ -99,7 +99,23 @@ impl<
     /// Start the `simplex` consensus engine.
     ///
     /// This will also rebuild the state of the engine from provided `Journal`.
-    pub async fn run(
+    pub fn start(
+        self,
+        voter_network: (
+            impl Sender<PublicKey = C::PublicKey>,
+            impl Receiver<PublicKey = C::PublicKey>,
+        ),
+        resolver_network: (
+            impl Sender<PublicKey = C::PublicKey>,
+            impl Receiver<PublicKey = C::PublicKey>,
+        ),
+    ) -> Handle<()> {
+        self.runtime
+            .clone()
+            .spawn(|_| self.run(voter_network, resolver_network))
+    }
+
+    async fn run(
         self,
         voter_network: (
             impl Sender<PublicKey = C::PublicKey>,
@@ -112,29 +128,25 @@ impl<
     ) {
         // Start the voter
         let (voter_sender, voter_receiver) = voter_network;
-        let mut voter = self.runtime.spawn("voter", async move {
-            self.voter
-                .run(self.resolver_mailbox, voter_sender, voter_receiver)
-                .await;
-        });
+        let mut voter_task = self
+            .voter
+            .start(self.resolver_mailbox, voter_sender, voter_receiver);
 
         // Start the resolver
         let (resolver_sender, resolver_receiver) = resolver_network;
-        let mut resolver = self.runtime.spawn("resolver", async move {
+        let mut resolver_task =
             self.resolver
-                .run(self.voter_mailbox, resolver_sender, resolver_receiver)
-                .await;
-        });
+                .start(self.voter_mailbox, resolver_sender, resolver_receiver);
 
         // Wait for the resolver or voter to finish
         select! {
-            _ = &mut voter => {
+            _ = &mut voter_task => {
                 debug!("voter finished");
-                resolver.abort();
+                resolver_task.abort();
             },
-            _ = &mut resolver => {
+            _ = &mut resolver_task => {
                 debug!("resolver finished");
-                voter.abort();
+                voter_task.abort();
             },
         }
     }

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -316,8 +316,8 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
             .await;
     }
 
-    pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+    pub fn start(mut self) -> Handle<()> {
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -3,7 +3,7 @@ use crate::{simplex::Context, Automaton as Au, Committer as Co, Proof, Relay as 
 use bytes::{Buf, BufMut, Bytes};
 use commonware_cryptography::{Array, Hasher};
 use commonware_macros::select;
-use commonware_runtime::Clock;
+use commonware_runtime::{Clock, Handle, Spawner};
 use commonware_utils::SizedSerialize;
 use futures::{
     channel::{mpsc, oneshot},
@@ -149,7 +149,7 @@ pub struct Config<H: Hasher, P: Array> {
     pub tracker: mpsc::UnboundedSender<(P, Progress<H::Digest>)>,
 }
 
-pub struct Application<E: Clock + RngCore, H: Hasher, P: Array> {
+pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: Array> {
     runtime: E,
     hasher: H,
     participant: P,
@@ -170,7 +170,7 @@ pub struct Application<E: Clock + RngCore, H: Hasher, P: Array> {
     finalized_views: HashSet<H::Digest>,
 }
 
-impl<E: Clock + RngCore, H: Hasher, P: Array> Application<E, H, P> {
+impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
     pub fn new(runtime: E, cfg: Config<H, P>) -> (Self, Mailbox<H::Digest>) {
         // Register self on relay
         let broadcast = cfg.relay.register(cfg.participant.clone());
@@ -315,7 +315,11 @@ impl<E: Clock + RngCore, H: Hasher, P: Array> Application<E, H, P> {
             .await;
     }
 
-    pub async fn run(mut self) {
+    pub fn start(self) -> Handle<()> {
+        self.runtime.clone().spawn(|_| self.run())
+    }
+
+    async fn run(mut self) {
         // Setup digest tracking
         #[allow(clippy::type_complexity)]
         let mut waiters: HashMap<

--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use commonware_cryptography::{Hasher, Scheme};
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Clock, Spawner};
+use commonware_runtime::{Clock, Handle, Spawner};
 use prost::Message;
 use rand::{CryptoRng, Rng};
 use std::marker::PhantomData;
@@ -55,11 +55,11 @@ impl<
         }
     }
 
-    pub async fn run(
-        mut self,
-        voter_network: (impl Sender, impl Receiver),
-        _backfiller_network: (impl Sender, impl Receiver),
-    ) {
+    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+        self.runtime.clone().spawn(|_| self.run(voter_network))
+    }
+
+    async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {
         let (mut sender, mut receiver) = voter_network;
         while let Ok((s, msg)) = receiver.recv().await {
             // Parse message

--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -55,8 +55,8 @@ impl<
         }
     }
 
-    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(voter_network))
+    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+        self.context.spawn_ref()(self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -27,7 +27,7 @@ pub struct Conflicter<
     H: Hasher,
     S: Supervisor<Index = View, PublicKey = C::PublicKey>,
 > {
-    runtime: E,
+    context: E,
     crypto: C,
     supervisor: S,
     _hasher: PhantomData<H>,
@@ -43,9 +43,9 @@ impl<
         S: Supervisor<Index = View, PublicKey = C::PublicKey>,
     > Conflicter<E, C, H, S>
 {
-    pub fn new(runtime: E, cfg: Config<C, S>) -> Self {
+    pub fn new(context: E, cfg: Config<C, S>) -> Self {
         Self {
-            runtime,
+            context,
             crypto: cfg.crypto,
             supervisor: cfg.supervisor,
             _hasher: PhantomData,
@@ -56,7 +56,7 @@ impl<
     }
 
     pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.runtime.clone().spawn(|_| self.run(voter_network))
+        self.context.clone().spawn(|_| self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {
@@ -122,7 +122,7 @@ impl<
                         .unwrap();
 
                     // Notarize random digest
-                    let payload = H::random(&mut self.runtime);
+                    let payload = H::random(&mut self.context);
                     let msg = proposal_message(view, parent, &payload);
                     let n = wire::Notarize {
                         proposal: Some(wire::Proposal {
@@ -189,7 +189,7 @@ impl<
                         .unwrap();
 
                     // Finalize random digest
-                    let payload = H::random(&mut self.runtime);
+                    let payload = H::random(&mut self.context);
                     let msg = proposal_message(view, parent, &payload);
                     let f = wire::Finalize {
                         proposal: Some(wire::Proposal {

--- a/consensus/src/simplex/mocks/nuller.rs
+++ b/consensus/src/simplex/mocks/nuller.rs
@@ -26,7 +26,7 @@ pub struct Nuller<
     H: Hasher,
     S: Supervisor<Index = View, PublicKey = C::PublicKey>,
 > {
-    runtime: E,
+    context: E,
     crypto: C,
     supervisor: S,
     _hasher: PhantomData<H>,
@@ -38,9 +38,9 @@ pub struct Nuller<
 impl<E: Spawner, C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>>
     Nuller<E, C, H, S>
 {
-    pub fn new(runtime: E, cfg: Config<C, S>) -> Self {
+    pub fn new(context: E, cfg: Config<C, S>) -> Self {
         Self {
-            runtime,
+            context,
             crypto: cfg.crypto,
             supervisor: cfg.supervisor,
             _hasher: PhantomData,
@@ -51,7 +51,7 @@ impl<E: Spawner, C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = C
     }
 
     pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.runtime.clone().spawn(|_| self.run(voter_network))
+        self.context.clone().spawn(|_| self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/nuller.rs
+++ b/consensus/src/simplex/mocks/nuller.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use commonware_cryptography::{Hasher, Scheme};
 use commonware_p2p::{Receiver, Recipients, Sender};
+use commonware_runtime::{Handle, Spawner};
 use prost::Message;
 use std::marker::PhantomData;
 use tracing::debug;
@@ -19,7 +20,13 @@ pub struct Config<C: Scheme, S: Supervisor<Index = View, PublicKey = C::PublicKe
     pub namespace: Vec<u8>,
 }
 
-pub struct Nuller<C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>> {
+pub struct Nuller<
+    E: Spawner,
+    C: Scheme,
+    H: Hasher,
+    S: Supervisor<Index = View, PublicKey = C::PublicKey>,
+> {
+    runtime: E,
     crypto: C,
     supervisor: S,
     _hasher: PhantomData<H>,
@@ -28,9 +35,12 @@ pub struct Nuller<C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = 
     finalize_namespace: Vec<u8>,
 }
 
-impl<C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>> Nuller<C, H, S> {
-    pub fn new(cfg: Config<C, S>) -> Self {
+impl<E: Spawner, C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>>
+    Nuller<E, C, H, S>
+{
+    pub fn new(runtime: E, cfg: Config<C, S>) -> Self {
         Self {
+            runtime,
             crypto: cfg.crypto,
             supervisor: cfg.supervisor,
             _hasher: PhantomData,
@@ -40,11 +50,11 @@ impl<C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>
         }
     }
 
-    pub async fn run(
-        mut self,
-        voter_network: (impl Sender, impl Receiver),
-        _backfiller_network: (impl Sender, impl Receiver),
-    ) {
+    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+        self.runtime.clone().spawn(|_| self.run(voter_network))
+    }
+
+    async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {
         let (mut sender, mut receiver) = voter_network;
         while let Ok((s, msg)) = receiver.recv().await {
             // Parse message

--- a/consensus/src/simplex/mocks/nuller.rs
+++ b/consensus/src/simplex/mocks/nuller.rs
@@ -50,8 +50,8 @@ impl<E: Spawner, C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = C
         }
     }
 
-    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(voter_network))
+    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+        self.context.spawn_ref()(self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -191,7 +191,6 @@ mod tests {
     use engine::Engine;
     use futures::{channel::mpsc, StreamExt};
     use governor::Quota;
-    use prometheus_client::registry::Registry;
     use prover::Prover;
     use rand::Rng;
     use std::{
@@ -352,7 +351,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -364,7 +362,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -578,7 +575,6 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
                     let journal = Journal::init(runtime.clone(), cfg)
@@ -590,7 +586,6 @@ mod tests {
                         relay: application.clone(),
                         committer: application,
                         supervisor,
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         mailbox_size: 1024,
                         namespace: namespace.clone(),
                         leader_timeout: Duration::from_secs(1),
@@ -791,7 +786,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -803,7 +797,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -926,7 +919,6 @@ mod tests {
                 actor.run().await;
             });
             let cfg = JConfig {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: validator.to_string(),
             };
             let journal = Journal::init(runtime.clone(), cfg)
@@ -938,7 +930,6 @@ mod tests {
                 relay: application.clone(),
                 committer: application,
                 supervisor,
-                registry: Arc::new(Mutex::new(Registry::default())),
                 mailbox_size: 1024,
                 namespace: namespace.clone(),
                 leader_timeout: Duration::from_secs(1),
@@ -1076,7 +1067,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1088,7 +1078,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -1260,7 +1249,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1272,7 +1260,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -1433,7 +1420,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1445,7 +1431,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -1599,7 +1584,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1611,7 +1595,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -1822,7 +1805,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1834,7 +1816,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -2008,7 +1989,6 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
                     let journal = Journal::init(runtime.clone(), cfg)
@@ -2020,7 +2000,6 @@ mod tests {
                         relay: application.clone(),
                         committer: application,
                         supervisor,
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         mailbox_size: 1024,
                         namespace: namespace.clone(),
                         leader_timeout: Duration::from_secs(1),
@@ -2192,7 +2171,6 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
                     let journal = Journal::init(runtime.clone(), cfg)
@@ -2204,7 +2182,6 @@ mod tests {
                         relay: application.clone(),
                         committer: application,
                         supervisor,
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         mailbox_size: 1024,
                         namespace: namespace.clone(),
                         leader_timeout: Duration::from_secs(1),

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -293,7 +293,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -520,7 +519,6 @@ mod tests {
                 let (network, mut oracle) = Network::new(
                     runtime.clone(),
                     Config {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         max_size: 1024 * 1024,
                     },
                 );
@@ -723,7 +721,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1009,7 +1006,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1194,7 +1190,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1379,7 +1374,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1546,7 +1540,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1770,7 +1763,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1943,7 +1935,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -2128,7 +2119,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );

--- a/consensus/src/threshold_simplex/actors/resolver/actor.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/actor.rs
@@ -14,7 +14,7 @@ use crate::{
 use commonware_cryptography::{bls12381::primitives::poly, Array, Scheme};
 use commonware_macros::select;
 use commonware_p2p::{utils::requester, Receiver, Recipients, Sender};
-use commonware_runtime::Clock;
+use commonware_runtime::{Clock, Metrics};
 use futures::{channel::mpsc, future::Either, StreamExt};
 use governor::clock::Clock as GClock;
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
@@ -96,7 +96,7 @@ impl Inflight {
 
 /// Requests are made concurrently to multiple peers.
 pub struct Actor<
-    E: Clock + GClock + Rng,
+    E: Clock + GClock + Rng + Metrics,
     C: Scheme,
     D: Array,
     S: ThresholdSupervisor<Index = View, Identity = poly::Public, PublicKey = C::PublicKey>,
@@ -131,7 +131,7 @@ pub struct Actor<
 }
 
 impl<
-        E: Clock + GClock + Rng,
+        E: Clock + GClock + Rng + Metrics,
         C: Scheme,
         D: Array,
         S: ThresholdSupervisor<Index = View, Identity = poly::Public, PublicKey = C::PublicKey>,
@@ -151,20 +151,17 @@ impl<
         let unfulfilled = Gauge::default();
         let outstanding = Gauge::default();
         let served = Counter::default();
-        {
-            let mut registry = cfg.registry.lock().unwrap();
-            registry.register(
-                "unfulfilled",
-                "unfulfilled notarizations/nullifications",
-                unfulfilled.clone(),
-            );
-            registry.register("outstanding", "outstanding requests", outstanding.clone());
-            registry.register(
-                "served",
-                "served notarizations/nullifications",
-                served.clone(),
-            );
-        }
+        runtime.register(
+            "unfulfilled",
+            "unfulfilled notarizations/nullifications",
+            unfulfilled.clone(),
+        );
+        runtime.register("outstanding", "outstanding requests", outstanding.clone());
+        runtime.register(
+            "served",
+            "served notarizations/nullifications",
+            served.clone(),
+        );
 
         // Initialize mailbox
         let (sender, receiver) = mpsc::channel(cfg.mailbox_size);

--- a/consensus/src/threshold_simplex/actors/resolver/mod.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/mod.rs
@@ -6,17 +6,12 @@ pub use actor::Actor;
 use commonware_cryptography::Scheme;
 use governor::Quota;
 pub use ingress::Mailbox;
-use prometheus_client::registry::Registry;
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::time::Duration;
 
 pub struct Config<C: Scheme, S: Supervisor> {
     pub crypto: C,
     pub supervisor: S,
 
-    pub registry: Arc<Mutex<Registry>>,
     pub namespace: Vec<u8>,
     pub mailbox_size: usize,
     pub activity_timeout: u64,

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -26,7 +26,7 @@ use commonware_cryptography::{
 };
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Blob, Clock, Metrics, Spawner, Storage};
+use commonware_runtime::{Blob, Clock, Handle, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::Journal;
 use commonware_utils::quorum;
 use futures::{
@@ -2140,7 +2140,18 @@ impl<
         };
     }
 
-    pub async fn run(
+    pub fn start(
+        self,
+        backfiller: resolver::Mailbox,
+        sender: impl Sender<PublicKey = C::PublicKey>,
+        receiver: impl Receiver<PublicKey = C::PublicKey>,
+    ) -> Handle<()> {
+        self.runtime
+            .clone()
+            .spawn(|_| self.run(backfiller, sender, receiver))
+    }
+
+    async fn run(
         mut self,
         mut backfiller: resolver::Mailbox,
         mut sender: impl Sender<PublicKey = C::PublicKey>,

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -650,7 +650,7 @@ pub struct Actor<
         PublicKey = C::PublicKey,
     >,
 > {
-    runtime: E,
+    context: E,
     crypto: C,
     automaton: A,
     relay: R,
@@ -702,7 +702,7 @@ impl<
     > Actor<B, E, C, D, A, R, F, S>
 {
     pub fn new(
-        runtime: E,
+        context: E,
         journal: Journal<B, E>,
         cfg: Config<C, D, A, R, F, S>,
     ) -> (Self, Mailbox<D>) {
@@ -716,14 +716,14 @@ impl<
         let tracked_views = Gauge::<i64, AtomicI64>::default();
         let received_messages = Family::<metrics::PeerMessage, Counter>::default();
         let broadcast_messages = Family::<metrics::Message, Counter>::default();
-        runtime.register("current_view", "current view", current_view.clone());
-        runtime.register("tracked_views", "tracked views", tracked_views.clone());
-        runtime.register(
+        context.register("current_view", "current view", current_view.clone());
+        context.register("tracked_views", "tracked views", tracked_views.clone());
+        context.register(
             "received_messages",
             "received messages",
             received_messages.clone(),
         );
-        runtime.register(
+        context.register(
             "broadcast_messages",
             "broadcast messages",
             broadcast_messages.clone(),
@@ -734,7 +734,7 @@ impl<
         let mailbox = Mailbox::new(mailbox_sender);
         (
             Self {
-                runtime,
+                context,
                 crypto: cfg.crypto,
                 automaton: cfg.automaton,
                 relay: cfg.relay,
@@ -927,7 +927,7 @@ impl<
         }
 
         // Set nullify retry, if none already set
-        let null_retry = self.runtime.current() + self.nullify_retry;
+        let null_retry = self.context.current() + self.nullify_retry;
         view.nullify_retry = Some(null_retry);
         null_retry
     }
@@ -1300,8 +1300,8 @@ impl<
             .views
             .entry(view)
             .or_insert_with(|| Round::new(self.supervisor.clone(), view));
-        round.leader_deadline = Some(self.runtime.current() + self.leader_timeout);
-        round.advance_deadline = Some(self.runtime.current() + self.notarization_timeout);
+        round.leader_deadline = Some(self.context.current() + self.leader_timeout);
+        round.advance_deadline = Some(self.context.current() + self.notarization_timeout);
         round.set_leader(seed);
         self.view = view;
 
@@ -1342,7 +1342,7 @@ impl<
 
         // Reduce leader deadline to now
         debug!(view, ?leader, "skipping leader timeout due to inactivity");
-        self.views.get_mut(&view).unwrap().leader_deadline = Some(self.runtime.current());
+        self.views.get_mut(&view).unwrap().leader_deadline = Some(self.context.current());
     }
 
     fn interesting(&self, view: View, allow_future: bool) -> bool {
@@ -2146,7 +2146,7 @@ impl<
         sender: impl Sender<PublicKey = C::PublicKey>,
         receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) -> Handle<()> {
-        self.runtime
+        self.context
             .clone()
             .spawn(|_| self.run(backfiller, sender, receiver))
     }
@@ -2322,14 +2322,14 @@ impl<
         debug!(current_view = observed_view, "replayed journal");
         {
             let round = self.views.get_mut(&observed_view).expect("missing round");
-            round.leader_deadline = Some(self.runtime.current());
-            round.advance_deadline = Some(self.runtime.current());
+            round.leader_deadline = Some(self.context.current());
+            round.advance_deadline = Some(self.context.current());
         }
         self.current_view.set(observed_view as i64);
         self.tracked_views.set(self.views.len() as i64);
 
         // Create shutdown tracker
-        let mut shutdown = self.runtime.stopped();
+        let mut shutdown = self.context.stopped();
 
         // Process messages
         let mut pending_propose_context = None;
@@ -2371,7 +2371,7 @@ impl<
                         .expect("unable to close journal");
                     return;
                 },
-                _ = self.runtime.sleep_until(timeout) => {
+                _ = self.context.sleep_until(timeout) => {
                     // Trigger the timeout
                     self.timeout(&mut sender).await;
                     view = self.view;

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -9,8 +9,6 @@ pub use actor::Actor;
 use commonware_cryptography::Scheme;
 use commonware_cryptography::{bls12381::primitives::group, Array};
 pub use ingress::{Mailbox, Message};
-use prometheus_client::registry::Registry;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 pub struct Config<
@@ -27,7 +25,6 @@ pub struct Config<
     pub committer: F,
     pub supervisor: S,
 
-    pub registry: Arc<Mutex<Registry>>,
     pub namespace: Vec<u8>,
     pub mailbox_size: usize,
     pub leader_timeout: Duration,

--- a/consensus/src/threshold_simplex/config.rs
+++ b/consensus/src/threshold_simplex/config.rs
@@ -32,9 +32,6 @@ pub struct Config<
     /// Supervisor for the consensus engine.
     pub supervisor: S,
 
-    /// Prometheus metrics registry.
-    pub registry: Arc<Mutex<Registry>>,
-
     /// Maximum number of messages to buffer on channels inside the consensus
     /// engine before blocking.
     pub mailbox_size: usize,

--- a/consensus/src/threshold_simplex/config.rs
+++ b/consensus/src/threshold_simplex/config.rs
@@ -2,11 +2,7 @@ use super::{Context, View};
 use crate::{Automaton, Committer, Relay, ThresholdSupervisor};
 use commonware_cryptography::{bls12381::primitives::group, Array, Scheme};
 use governor::Quota;
-use prometheus_client::registry::Registry;
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::time::Duration;
 
 /// Configuration for the consensus engine.
 pub struct Config<

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -34,7 +34,7 @@ pub struct Engine<
         PublicKey = C::PublicKey,
     >,
 > {
-    runtime: E,
+    context: E,
 
     voter: voter::Actor<B, E, C, D, A, R, F, S>,
     voter_mailbox: voter::Mailbox<D>,
@@ -60,13 +60,13 @@ impl<
     > Engine<B, E, C, D, A, R, F, S>
 {
     /// Create a new `threshold-simplex` consensus engine.
-    pub fn new(runtime: E, journal: Journal<B, E>, cfg: Config<C, D, A, R, F, S>) -> Self {
+    pub fn new(context: E, journal: Journal<B, E>, cfg: Config<C, D, A, R, F, S>) -> Self {
         // Ensure configuration is valid
         cfg.assert();
 
         // Create voter
         let (voter, voter_mailbox) = voter::Actor::new(
-            runtime.clone(),
+            context.clone(),
             journal,
             voter::Config {
                 crypto: cfg.crypto.clone(),
@@ -86,7 +86,7 @@ impl<
 
         // Create resolver
         let (resolver, resolver_mailbox) = resolver::Actor::new(
-            runtime.clone(),
+            context.clone(),
             resolver::Config {
                 crypto: cfg.crypto,
                 supervisor: cfg.supervisor,
@@ -103,7 +103,7 @@ impl<
 
         // Return the engine
         Self {
-            runtime,
+            context,
 
             voter,
             voter_mailbox,
@@ -126,7 +126,7 @@ impl<
             impl Receiver<PublicKey = C::PublicKey>,
         ),
     ) -> Handle<()> {
-        self.runtime
+        self.context
             .clone()
             .spawn(|_| self.run(voter_network, resolver_network))
     }

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -10,7 +10,7 @@ use commonware_cryptography::{
 };
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Sender};
-use commonware_runtime::{Blob, Clock, Spawner, Storage};
+use commonware_runtime::{Blob, Clock, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::Journal;
 use governor::clock::Clock as GClock;
 use rand::{CryptoRng, Rng};
@@ -19,7 +19,7 @@ use tracing::debug;
 /// Instance of `threshold-simplex` consensus engine.
 pub struct Engine<
     B: Blob,
-    E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B>,
+    E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B> + Metrics,
     C: Scheme,
     D: Array,
     A: Automaton<Context = Context<D>, Digest = D>,
@@ -43,7 +43,7 @@ pub struct Engine<
 
 impl<
         B: Blob,
-        E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B>,
+        E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B> + Metrics,
         C: Scheme,
         D: Array,
         A: Automaton<Context = Context<D>, Digest = D>,
@@ -73,7 +73,6 @@ impl<
                 relay: cfg.relay,
                 committer: cfg.committer,
                 supervisor: cfg.supervisor.clone(),
-                registry: cfg.registry.clone(),
                 mailbox_size: cfg.mailbox_size,
                 namespace: cfg.namespace.clone(),
                 leader_timeout: cfg.leader_timeout,
@@ -90,7 +89,6 @@ impl<
             resolver::Config {
                 crypto: cfg.crypto,
                 supervisor: cfg.supervisor,
-                registry: cfg.registry,
                 mailbox_size: cfg.mailbox_size,
                 namespace: cfg.namespace,
                 activity_timeout: cfg.activity_timeout,

--- a/consensus/src/threshold_simplex/mocks/application.rs
+++ b/consensus/src/threshold_simplex/mocks/application.rs
@@ -150,7 +150,7 @@ pub struct Config<H: Hasher, P: Array> {
 }
 
 pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: Array> {
-    runtime: E,
+    context: E,
     hasher: H,
     participant: P,
 
@@ -171,7 +171,7 @@ pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: Array> {
 }
 
 impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
-    pub fn new(runtime: E, cfg: Config<H, P>) -> (Self, Mailbox<H::Digest>) {
+    pub fn new(context: E, cfg: Config<H, P>) -> (Self, Mailbox<H::Digest>) {
         // Register self on relay
         let broadcast = cfg.relay.register(cfg.participant.clone());
 
@@ -183,7 +183,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
         let (sender, receiver) = mpsc::channel(1024);
         (
             Self {
-                runtime,
+                context,
                 hasher: cfg.hasher,
                 participant: cfg.participant,
 
@@ -223,8 +223,8 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
     /// Backfilling verification dependencies is considered out-of-scope for consensus.
     async fn propose(&mut self, context: Context<H::Digest>) -> H::Digest {
         // Simulate the propose latency
-        let duration = self.propose_latency.sample(&mut self.runtime);
-        self.runtime
+        let duration = self.propose_latency.sample(&mut self.context);
+        self.context
             .sleep(Duration::from_millis(duration as u64))
             .await;
 
@@ -233,7 +233,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
         let mut payload = Vec::with_capacity(payload_len);
         payload.put_u64(context.view);
         payload.extend_from_slice(&context.parent.1);
-        payload.put_u64(self.runtime.gen::<u64>()); // Ensures we always have a unique payload
+        payload.put_u64(self.context.gen::<u64>()); // Ensures we always have a unique payload
         self.hasher.update(&payload);
         let digest = self.hasher.finalize();
 
@@ -252,8 +252,8 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
         mut contents: Bytes,
     ) -> bool {
         // Simulate the verify latency
-        let duration = self.verify_latency.sample(&mut self.runtime);
-        self.runtime
+        let duration = self.verify_latency.sample(&mut self.context);
+        self.context
             .sleep(Duration::from_millis(duration as u64))
             .await;
 
@@ -316,7 +316,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
     }
 
     pub fn start(self) -> Handle<()> {
-        self.runtime.clone().spawn(|_| self.run())
+        self.context.clone().spawn(|_| self.run())
     }
 
     async fn run(mut self) {

--- a/consensus/src/threshold_simplex/mocks/application.rs
+++ b/consensus/src/threshold_simplex/mocks/application.rs
@@ -315,8 +315,8 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
             .await;
     }
 
-    pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+    pub fn start(mut self) -> Handle<()> {
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/consensus/src/threshold_simplex/mocks/conflicter.rs
+++ b/consensus/src/threshold_simplex/mocks/conflicter.rs
@@ -15,7 +15,7 @@ use commonware_cryptography::{
     Hasher,
 };
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Clock, Spawner};
+use commonware_runtime::{Clock, Handle, Spawner};
 use prost::Message;
 use rand::{CryptoRng, Rng};
 use std::marker::PhantomData;
@@ -60,11 +60,11 @@ impl<
         }
     }
 
-    pub async fn run(
-        mut self,
-        voter_network: (impl Sender, impl Receiver),
-        _backfiller_network: (impl Sender, impl Receiver),
-    ) {
+    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+        self.runtime.clone().spawn(|_| self.run(voter_network))
+    }
+
+    async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {
         let (mut sender, mut receiver) = voter_network;
         while let Ok((s, msg)) = receiver.recv().await {
             // Parse message

--- a/consensus/src/threshold_simplex/mocks/conflicter.rs
+++ b/consensus/src/threshold_simplex/mocks/conflicter.rs
@@ -60,8 +60,8 @@ impl<
         }
     }
 
-    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(voter_network))
+    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+        self.context.spawn_ref()(self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/nuller.rs
+++ b/consensus/src/threshold_simplex/mocks/nuller.rs
@@ -59,8 +59,8 @@ impl<
         }
     }
 
-    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(voter_network))
+    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+        self.context.spawn_ref()(self.run(voter_network))
     }
 
     async fn run(self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/nuller.rs
+++ b/consensus/src/threshold_simplex/mocks/nuller.rs
@@ -32,7 +32,7 @@ pub struct Nuller<
     H: Hasher,
     S: ThresholdSupervisor<Seed = group::Signature, Index = View, Share = group::Share>,
 > {
-    runtime: E,
+    context: E,
     supervisor: S,
     _hasher: PhantomData<H>,
 
@@ -47,9 +47,9 @@ impl<
         S: ThresholdSupervisor<Seed = group::Signature, Index = View, Share = group::Share>,
     > Nuller<E, H, S>
 {
-    pub fn new(runtime: E, cfg: Config<S>) -> Self {
+    pub fn new(context: E, cfg: Config<S>) -> Self {
         Self {
-            runtime,
+            context,
             supervisor: cfg.supervisor,
             _hasher: PhantomData,
 
@@ -60,7 +60,7 @@ impl<
     }
 
     pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.runtime.clone().spawn(|_| self.run(voter_network))
+        self.context.clone().spawn(|_| self.run(voter_network))
     }
 
     async fn run(self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/nuller.rs
+++ b/consensus/src/threshold_simplex/mocks/nuller.rs
@@ -15,6 +15,7 @@ use commonware_cryptography::{
     Hasher,
 };
 use commonware_p2p::{Receiver, Recipients, Sender};
+use commonware_runtime::{Handle, Spawner};
 use prost::Message;
 use std::marker::PhantomData;
 use tracing::debug;
@@ -27,9 +28,11 @@ pub struct Config<
 }
 
 pub struct Nuller<
+    E: Spawner,
     H: Hasher,
     S: ThresholdSupervisor<Seed = group::Signature, Index = View, Share = group::Share>,
 > {
+    runtime: E,
     supervisor: S,
     _hasher: PhantomData<H>,
 
@@ -39,12 +42,14 @@ pub struct Nuller<
 }
 
 impl<
+        E: Spawner,
         H: Hasher,
         S: ThresholdSupervisor<Seed = group::Signature, Index = View, Share = group::Share>,
-    > Nuller<H, S>
+    > Nuller<E, H, S>
 {
-    pub fn new(cfg: Config<S>) -> Self {
+    pub fn new(runtime: E, cfg: Config<S>) -> Self {
         Self {
+            runtime,
             supervisor: cfg.supervisor,
             _hasher: PhantomData,
 
@@ -54,11 +59,11 @@ impl<
         }
     }
 
-    pub async fn run(
-        self,
-        voter_network: (impl Sender, impl Receiver),
-        _backfiller_network: (impl Sender, impl Receiver),
-    ) {
+    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+        self.runtime.clone().spawn(|_| self.run(voter_network))
+    }
+
+    async fn run(self, voter_network: (impl Sender, impl Receiver)) {
         let (mut sender, mut receiver) = voter_network;
         while let Ok((s, msg)) = receiver.recv().await {
             // Parse message

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -225,7 +225,6 @@ mod tests {
     use engine::Engine;
     use futures::{channel::mpsc, StreamExt};
     use governor::Quota;
-    use prometheus_client::registry::Registry;
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use std::{
         collections::{BTreeMap, HashMap, HashSet},
@@ -389,7 +388,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -401,7 +399,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -624,7 +621,6 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
                     let journal = Journal::init(runtime.clone(), cfg)
@@ -636,7 +632,6 @@ mod tests {
                         relay: application.clone(),
                         committer: application,
                         supervisor,
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         mailbox_size: 1024,
                         namespace: namespace.clone(),
                         leader_timeout: Duration::from_secs(1),
@@ -848,7 +843,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -860,7 +854,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -985,7 +978,6 @@ mod tests {
                 actor.run().await;
             });
             let cfg = JConfig {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: validator.to_string(),
             };
             let journal = Journal::init(runtime.clone(), cfg)
@@ -997,7 +989,6 @@ mod tests {
                 relay: application.clone(),
                 committer: application,
                 supervisor,
-                registry: Arc::new(Mutex::new(Registry::default())),
                 mailbox_size: 1024,
                 namespace: namespace.clone(),
                 leader_timeout: Duration::from_secs(1),
@@ -1141,7 +1132,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1153,7 +1143,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -1331,7 +1320,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1343,7 +1331,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -1510,7 +1497,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1522,7 +1508,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -1682,7 +1667,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1694,7 +1678,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -1910,7 +1893,6 @@ mod tests {
                     actor.run().await;
                 });
                 let cfg = JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: validator.to_string(),
                 };
                 let journal = Journal::init(runtime.clone(), cfg)
@@ -1922,7 +1904,6 @@ mod tests {
                     relay: application.clone(),
                     committer: application,
                     supervisor,
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     mailbox_size: 1024,
                     namespace: namespace.clone(),
                     leader_timeout: Duration::from_secs(1),
@@ -2101,7 +2082,6 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
                     let journal = Journal::init(runtime.clone(), cfg)
@@ -2113,7 +2093,6 @@ mod tests {
                         relay: application.clone(),
                         committer: application,
                         supervisor,
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         mailbox_size: 1024,
                         namespace: namespace.clone(),
                         leader_timeout: Duration::from_secs(1),
@@ -2284,7 +2263,6 @@ mod tests {
                         actor.run().await;
                     });
                     let cfg = JConfig {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         partition: validator.to_string(),
                     };
                     let journal = Journal::init(runtime.clone(), cfg)
@@ -2296,7 +2274,6 @@ mod tests {
                         relay: application.clone(),
                         committer: application,
                         supervisor,
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         mailbox_size: 1024,
                         namespace: namespace.clone(),
                         leader_timeout: Duration::from_secs(1),

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -326,7 +326,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -565,7 +564,6 @@ mod tests {
                 let (network, mut oracle) = Network::new(
                     runtime.clone(),
                     Config {
-                        registry: Arc::new(Mutex::new(Registry::default())),
                         max_size: 1024 * 1024,
                     },
                 );
@@ -776,7 +774,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1070,7 +1067,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1261,7 +1257,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1452,7 +1447,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1625,7 +1619,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -1854,7 +1847,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -2033,7 +2025,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );
@@ -2218,7 +2209,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     max_size: 1024 * 1024,
                 },
             );

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -218,7 +218,7 @@ mod tests {
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{
         deterministic::{self, Executor},
-        Clock, Runner, Spawner,
+        Clock, Metrics, Runner, Spawner,
     };
     use commonware_storage::journal::variable::{Config as JConfig, Journal};
     use commonware_utils::quorum;
@@ -323,14 +323,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register participants
             let mut schemes = Vec::new();
@@ -364,6 +364,9 @@ mod tests {
             let (done_sender, mut done_receiver) = mpsc::unbounded();
             let mut engine_handlers = Vec::new();
             for (idx, scheme) in schemes.into_iter().enumerate() {
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", scheme.public_key()));
+
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
@@ -382,15 +385,15 @@ mod tests {
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
                 };
-                let (actor, application) =
-                    mocks::application::Application::new(runtime.clone(), application_cfg);
-                runtime.spawn("application", async move {
-                    actor.run().await;
-                });
+                let (actor, application) = mocks::application::Application::new(
+                    runtime.with_label("application"),
+                    application_cfg,
+                );
+                actor.start();
                 let cfg = JConfig {
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.with_label("journal"), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -412,15 +415,13 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                 };
-                let engine = Engine::new(runtime.clone(), journal, cfg);
+                let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
 
                 // Start engine
                 let (voter, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(runtime.spawn("engine", async move {
-                    engine.run(voter, resolver).await;
-                }));
+                engine_handlers.push(engine.start(voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -559,14 +560,14 @@ mod tests {
                 async move {
                 // Create simulated network
                 let (network, mut oracle) = Network::new(
-                    runtime.clone(),
+                    runtime.with_label("network"),
                     Config {
                         max_size: 1024 * 1024,
                     },
                 );
 
                 // Start network
-                runtime.spawn("network", network.run());
+                network.start();
 
                 // Register participants
                 let mut schemes = Vec::new();
@@ -596,6 +597,11 @@ mod tests {
                 let (done_sender, mut done_receiver) = mpsc::unbounded();
                 let mut engine_handlers = Vec::new();
                 for (idx, scheme) in schemes.into_iter().enumerate() {
+                    // Create scheme runtime
+                    let runtime = runtime
+                        .clone()
+                        .with_label(&format!("validator-{}", scheme.public_key()));
+
                     // Configure engine
                     let validator = scheme.public_key();
                     let mut participants = BTreeMap::new();
@@ -616,14 +622,12 @@ mod tests {
                         verify_latency: (10.0, 5.0),
                     };
                     let (actor, application) =
-                        mocks::application::Application::new(runtime.clone(), application_cfg);
-                    runtime.spawn("application", async move {
-                        actor.run().await;
-                    });
+                        mocks::application::Application::new(runtime.with_label("application"), application_cfg);
+                    actor.start();
                     let cfg = JConfig {
                         partition: validator.to_string(),
                     };
-                    let journal = Journal::init(runtime.clone(), cfg)
+                    let journal = Journal::init(runtime.with_label("journal"), cfg)
                         .await
                         .expect("unable to create journal");
                     let cfg = config::Config {
@@ -645,24 +649,17 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                     };
-                    let engine = Engine::new(runtime.clone(), journal, cfg);
+                    let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
 
                     // Start engine
                     let (voter, resolver) = registrations
                         .remove(&validator)
                         .expect("validator should be registered");
-                    engine_handlers.push(runtime.spawn("engine", async move {
-                        engine
-                            .run(
-                                voter,
-                                resolver,
-                            )
-                            .await;
-                    }));
+                    engine_handlers.push(engine.start(voter, resolver));
                 }
 
                 // Wait for all engines to finish
-                runtime.spawn("confirmed", async move {
+                runtime.with_label("confirmed").spawn(move |_| async move {
                     loop {
                         // Parse events
                         let (validator, event) = done_receiver.next().await.unwrap();
@@ -767,14 +764,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register participants
             let mut schemes = Vec::new();
@@ -819,6 +816,9 @@ mod tests {
                     continue;
                 }
 
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", scheme.public_key()));
+
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
@@ -837,15 +837,15 @@ mod tests {
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
                 };
-                let (actor, application) =
-                    mocks::application::Application::new(runtime.clone(), application_cfg);
-                runtime.spawn("application", async move {
-                    actor.run().await;
-                });
+                let (actor, application) = mocks::application::Application::new(
+                    runtime.with_label("application"),
+                    application_cfg,
+                );
+                actor.start();
                 let cfg = JConfig {
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.with_label("journal"), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -867,15 +867,13 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                 };
-                let engine = Engine::new(runtime.clone(), journal, cfg);
+                let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
 
                 // Start engine
                 let (voter, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(runtime.spawn("engine", async move {
-                    engine.run(voter, resolver).await;
-                }));
+                engine_handlers.push(engine.start(voter, resolver));
             }
 
             // Wait for all online engines to finish
@@ -931,86 +929,88 @@ mod tests {
             // Configure engine for first peer
             let scheme = schemes[0].clone();
             let validator = scheme.public_key();
+            {
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", validator));
 
-            // Link first peer to all (except second)
-            link_validators(
-                &mut oracle,
-                &validators,
-                Action::Link(link),
-                Some(|_, i, j| [i, j].contains(&0usize) && ![i, j].contains(&1usize)),
-            )
-            .await;
+                // Link first peer to all (except second)
+                link_validators(
+                    &mut oracle,
+                    &validators,
+                    Action::Link(link),
+                    Some(|_, i, j| [i, j].contains(&0usize) && ![i, j].contains(&1usize)),
+                )
+                .await;
 
-            // Restore network connections for all online peers
-            let link = Link {
-                latency: 10.0,
-                jitter: 2.5,
-                success_rate: 1.0,
-            };
-            link_validators(
-                &mut oracle,
-                &validators,
-                Action::Update(link),
-                Some(|_, i, j| ![i, j].contains(&1usize)),
-            )
-            .await;
+                // Restore network connections for all online peers
+                let link = Link {
+                    latency: 10.0,
+                    jitter: 2.5,
+                    success_rate: 1.0,
+                };
+                link_validators(
+                    &mut oracle,
+                    &validators,
+                    Action::Update(link),
+                    Some(|_, i, j| ![i, j].contains(&1usize)),
+                )
+                .await;
 
-            // Configure engine
-            let mut participants = BTreeMap::new();
-            participants.insert(0, (public.clone(), validators.clone(), shares[0]));
-            let supervisor_config = mocks::supervisor::Config {
-                prover: prover.clone(),
-                participants,
-            };
-            let supervisor = mocks::supervisor::Supervisor::new(supervisor_config);
-            supervisors.push(supervisor.clone());
-            let application_cfg = mocks::application::Config {
-                hasher: Sha256::default(),
-                relay: relay.clone(),
-                participant: validator.clone(),
-                tracker: done_sender.clone(),
-                propose_latency: (10.0, 5.0),
-                verify_latency: (10.0, 5.0),
-            };
-            let (actor, application) =
-                mocks::application::Application::new(runtime.clone(), application_cfg);
-            runtime.spawn("application", async move {
-                actor.run().await;
-            });
-            let cfg = JConfig {
-                partition: validator.to_string(),
-            };
-            let journal = Journal::init(runtime.clone(), cfg)
-                .await
-                .expect("unable to create journal");
-            let cfg = config::Config {
-                crypto: scheme,
-                automaton: application.clone(),
-                relay: application.clone(),
-                committer: application,
-                supervisor,
-                mailbox_size: 1024,
-                namespace: namespace.clone(),
-                leader_timeout: Duration::from_secs(1),
-                notarization_timeout: Duration::from_secs(2),
-                nullify_retry: Duration::from_secs(10),
-                fetch_timeout: Duration::from_secs(1),
-                activity_timeout,
-                max_fetch_count: 1,
-                max_fetch_size: 1024 * 512,
-                fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
-                fetch_concurrent: 1,
-                replay_concurrency: 1,
-            };
-            let engine = Engine::new(runtime.clone(), journal, cfg);
+                // Configure engine
+                let mut participants = BTreeMap::new();
+                participants.insert(0, (public.clone(), validators.clone(), shares[0]));
+                let supervisor_config = mocks::supervisor::Config {
+                    prover: prover.clone(),
+                    participants,
+                };
+                let supervisor = mocks::supervisor::Supervisor::new(supervisor_config);
+                supervisors.push(supervisor.clone());
+                let application_cfg = mocks::application::Config {
+                    hasher: Sha256::default(),
+                    relay: relay.clone(),
+                    participant: validator.clone(),
+                    tracker: done_sender.clone(),
+                    propose_latency: (10.0, 5.0),
+                    verify_latency: (10.0, 5.0),
+                };
+                let (actor, application) = mocks::application::Application::new(
+                    runtime.with_label("application"),
+                    application_cfg,
+                );
+                actor.start();
+                let cfg = JConfig {
+                    partition: validator.to_string(),
+                };
+                let journal = Journal::init(runtime.with_label("journal"), cfg)
+                    .await
+                    .expect("unable to create journal");
+                let cfg = config::Config {
+                    crypto: scheme,
+                    automaton: application.clone(),
+                    relay: application.clone(),
+                    committer: application,
+                    supervisor,
+                    mailbox_size: 1024,
+                    namespace: namespace.clone(),
+                    leader_timeout: Duration::from_secs(1),
+                    notarization_timeout: Duration::from_secs(2),
+                    nullify_retry: Duration::from_secs(10),
+                    fetch_timeout: Duration::from_secs(1),
+                    activity_timeout,
+                    max_fetch_count: 1,
+                    max_fetch_size: 1024 * 512,
+                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_concurrent: 1,
+                    replay_concurrency: 1,
+                };
+                let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
 
-            // Start engine
-            let (voter, resolver) = registrations
-                .remove(&validator)
-                .expect("validator should be registered");
-            engine_handlers.push(runtime.spawn("engine", async move {
-                engine.run(voter, resolver).await;
-            }));
+                // Start engine
+                let (voter, resolver) = registrations
+                    .remove(&validator)
+                    .expect("validator should be registered");
+                engine_handlers.push(engine.start(voter, resolver));
+            }
 
             // Wait for new engine to finalize required
             let mut finalized = HashMap::new();
@@ -1056,14 +1056,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1108,6 +1108,9 @@ mod tests {
                     continue;
                 }
 
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", scheme.public_key()));
+
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
@@ -1126,15 +1129,15 @@ mod tests {
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
                 };
-                let (actor, application) =
-                    mocks::application::Application::new(runtime.clone(), application_cfg);
-                runtime.spawn("application", async move {
-                    actor.run().await;
-                });
+                let (actor, application) = mocks::application::Application::new(
+                    runtime.with_label("application"),
+                    application_cfg,
+                );
+                actor.start();
                 let cfg = JConfig {
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.with_label("journal"), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1156,15 +1159,13 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                 };
-                let engine = Engine::new(runtime.clone(), journal, cfg);
+                let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
 
                 // Start engine
                 let (voter, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(runtime.spawn("engine", async move {
-                    engine.run(voter, resolver).await;
-                }));
+                engine_handlers.push(engine.start(voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -1244,14 +1245,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1285,6 +1286,9 @@ mod tests {
             let (done_sender, mut done_receiver) = mpsc::unbounded();
             let mut engine_handlers = Vec::new();
             for (idx_scheme, scheme) in schemes.into_iter().enumerate() {
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", scheme.public_key()));
+
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
@@ -1314,15 +1318,15 @@ mod tests {
                         verify_latency: (10.0, 5.0),
                     }
                 };
-                let (actor, application) =
-                    mocks::application::Application::new(runtime.clone(), application_cfg);
-                runtime.spawn("application", async move {
-                    actor.run().await;
-                });
+                let (actor, application) = mocks::application::Application::new(
+                    runtime.with_label("application"),
+                    application_cfg,
+                );
+                actor.start();
                 let cfg = JConfig {
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.with_label("journal"), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1344,15 +1348,13 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                 };
-                let engine = Engine::new(runtime.clone(), journal, cfg);
+                let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
 
                 // Start engine
                 let (voter, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(runtime.spawn("engine", async move {
-                    engine.run(voter, resolver).await;
-                }));
+                engine_handlers.push(engine.start(voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -1432,14 +1434,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1473,6 +1475,9 @@ mod tests {
             let (done_sender, mut done_receiver) = mpsc::unbounded();
             let mut engine_handlers = Vec::new();
             for (idx, scheme) in schemes.iter().enumerate() {
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", scheme.public_key()));
+
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
@@ -1491,15 +1496,15 @@ mod tests {
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
                 };
-                let (actor, application) =
-                    mocks::application::Application::new(runtime.clone(), application_cfg);
-                runtime.spawn("application", async move {
-                    actor.run().await;
-                });
+                let (actor, application) = mocks::application::Application::new(
+                    runtime.with_label("application"),
+                    application_cfg,
+                );
+                actor.start();
                 let cfg = JConfig {
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.with_label("journal"), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1521,15 +1526,13 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                 };
-                let engine = Engine::new(runtime.clone(), journal, cfg);
+                let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
 
                 // Start engine
                 let (voter, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(runtime.spawn("engine", async move {
-                    engine.run(voter, resolver).await;
-                }));
+                engine_handlers.push(engine.start(voter, resolver));
             }
 
             // Wait for a few virtual minutes (shouldn't finalize anything)
@@ -1602,14 +1605,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1643,6 +1646,9 @@ mod tests {
             let (done_sender, mut done_receiver) = mpsc::unbounded();
             let mut engine_handlers = Vec::new();
             for (idx, scheme) in schemes.iter().enumerate() {
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", scheme.public_key()));
+
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
@@ -1661,15 +1667,15 @@ mod tests {
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
                 };
-                let (actor, application) =
-                    mocks::application::Application::new(runtime.clone(), application_cfg);
-                runtime.spawn("application", async move {
-                    actor.run().await;
-                });
+                let (actor, application) = mocks::application::Application::new(
+                    runtime.with_label("application"),
+                    application_cfg,
+                );
+                actor.start();
                 let cfg = JConfig {
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.with_label("journal"), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1691,15 +1697,13 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                 };
-                let engine = Engine::new(runtime.clone(), journal, cfg);
+                let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
 
                 // Start engine
                 let (voter, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(runtime.spawn("engine", async move {
-                    engine.run(voter, resolver).await;
-                }));
+                engine_handlers.push(engine.start(voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -1828,14 +1832,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1869,6 +1873,9 @@ mod tests {
             let (done_sender, mut done_receiver) = mpsc::unbounded();
             let mut engine_handlers = Vec::new();
             for (idx, scheme) in schemes.into_iter().enumerate() {
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", scheme.public_key()));
+
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
@@ -1887,15 +1894,15 @@ mod tests {
                     propose_latency: (10.0, 5.0),
                     verify_latency: (10.0, 5.0),
                 };
-                let (actor, application) =
-                    mocks::application::Application::new(runtime.clone(), application_cfg);
-                runtime.spawn("application", async move {
-                    actor.run().await;
-                });
+                let (actor, application) = mocks::application::Application::new(
+                    runtime.with_label("application"),
+                    application_cfg,
+                );
+                actor.start();
                 let cfg = JConfig {
                     partition: validator.to_string(),
                 };
-                let journal = Journal::init(runtime.clone(), cfg)
+                let journal = Journal::init(runtime.with_label("journal"), cfg)
                     .await
                     .expect("unable to create journal");
                 let cfg = config::Config {
@@ -1917,15 +1924,13 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                 };
-                let engine = Engine::new(runtime.clone(), journal, cfg);
+                let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
 
                 // Start engine
                 let (voter, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(runtime.spawn("engine", async move {
-                    engine.run(voter, resolver).await;
-                }));
+                engine_handlers.push(engine.start(voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -2004,14 +2009,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2044,6 +2049,9 @@ mod tests {
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
             for (idx_scheme, scheme) in schemes.into_iter().enumerate() {
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", scheme.public_key()));
+
                 // Start engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
@@ -2062,10 +2070,11 @@ mod tests {
                         namespace: namespace.clone(),
                     };
                     let engine: mocks::conflicter::Conflicter<_, Sha256, _> =
-                        mocks::conflicter::Conflicter::new(runtime.clone(), cfg);
-                    runtime.spawn("byzantine_engine", async move {
-                        engine.run(voter, resolver).await;
-                    });
+                        mocks::conflicter::Conflicter::new(
+                            runtime.with_label("byzantine_engine"),
+                            cfg,
+                        );
+                    engine.start(voter);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2076,15 +2085,15 @@ mod tests {
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),
                     };
-                    let (actor, application) =
-                        mocks::application::Application::new(runtime.clone(), application_cfg);
-                    runtime.spawn("application", async move {
-                        actor.run().await;
-                    });
+                    let (actor, application) = mocks::application::Application::new(
+                        runtime.with_label("application"),
+                        application_cfg,
+                    );
+                    actor.start();
                     let cfg = JConfig {
                         partition: validator.to_string(),
                     };
-                    let journal = Journal::init(runtime.clone(), cfg)
+                    let journal = Journal::init(runtime.with_label("journal"), cfg)
                         .await
                         .expect("unable to create journal");
                     let cfg = config::Config {
@@ -2106,10 +2115,8 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                     };
-                    let engine = Engine::new(runtime.clone(), journal, cfg);
-                    runtime.spawn("engine", async move {
-                        engine.run(voter, resolver).await;
-                    });
+                    let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
+                    engine.start(voter, resolver);
                 }
             }
 
@@ -2186,14 +2193,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2226,6 +2233,9 @@ mod tests {
             let mut supervisors = Vec::new();
             let (done_sender, mut done_receiver) = mpsc::unbounded();
             for (idx_scheme, scheme) in schemes.into_iter().enumerate() {
+                // Create scheme runtime
+                let runtime = runtime.with_label(&format!("validator-{}", scheme.public_key()));
+
                 // Start engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
@@ -2243,10 +2253,9 @@ mod tests {
                         supervisor,
                         namespace: namespace.clone(),
                     };
-                    let engine: mocks::nuller::Nuller<Sha256, _> = mocks::nuller::Nuller::new(cfg);
-                    runtime.spawn("byzantine_engine", async move {
-                        engine.run(voter, resolver).await;
-                    });
+                    let engine: mocks::nuller::Nuller<_, Sha256, _> =
+                        mocks::nuller::Nuller::new(runtime.with_label("byzantine_engine"), cfg);
+                    engine.start(voter);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2257,15 +2266,15 @@ mod tests {
                         propose_latency: (10.0, 5.0),
                         verify_latency: (10.0, 5.0),
                     };
-                    let (actor, application) =
-                        mocks::application::Application::new(runtime.clone(), application_cfg);
-                    runtime.spawn("application", async move {
-                        actor.run().await;
-                    });
+                    let (actor, application) = mocks::application::Application::new(
+                        runtime.with_label("application"),
+                        application_cfg,
+                    );
+                    actor.start();
                     let cfg = JConfig {
                         partition: validator.to_string(),
                     };
-                    let journal = Journal::init(runtime.clone(), cfg)
+                    let journal = Journal::init(runtime.with_label("journal"), cfg)
                         .await
                         .expect("unable to create journal");
                     let cfg = config::Config {
@@ -2287,10 +2296,8 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                     };
-                    let engine = Engine::new(runtime.clone(), journal, cfg);
-                    runtime.spawn("engine", async move {
-                        engine.run(voter, resolver).await;
-                    });
+                    let engine = Engine::new(runtime.with_label("engine"), journal, cfg);
+                    engine.start(voter, resolver);
                 }
             }
 

--- a/examples/bridge/src/application/actor.rs
+++ b/examples/bridge/src/application/actor.rs
@@ -11,7 +11,7 @@ use commonware_cryptography::{
     bls12381::primitives::{group::Element, poly},
     Hasher,
 };
-use commonware_runtime::{Handle, Sink, Spawner, Stream};
+use commonware_runtime::{Sink, Spawner, Stream};
 use commonware_stream::{public_key::Connection, Receiver, Sender};
 use commonware_utils::{hex, Array, SizedSerialize};
 use futures::{channel::mpsc, StreamExt};
@@ -58,11 +58,7 @@ impl<R: Rng + Spawner, H: Hasher, Si: Sink, St: Stream> Application<R, H, Si, St
     }
 
     /// Run the application actor.
-    pub fn start(self) -> Handle<()> {
-        self.runtime.clone().spawn(|_| self.run())
-    }
-
-    async fn run(mut self) {
+    pub async fn run(mut self) {
         let (mut indexer_sender, mut indexer_receiver) = self.indexer.split();
         while let Some(message) = self.mailbox.next().await {
             match message {

--- a/examples/bridge/src/bin/indexer.rs
+++ b/examples/bridge/src/bin/indexer.rs
@@ -124,15 +124,15 @@ fn main() {
         finalizations.insert(network, BTreeMap::new());
     }
 
-    // Create runtime
-    let (executor, runtime) = Executor::default();
+    // Create context
+    let (executor, context) = Executor::default();
     executor.start(async move {
         // Create message handler
         let (handler, mut receiver) = mpsc::unbounded();
 
         // Start handler
         let mut hasher = Sha256::new();
-        runtime.with_label("handler").spawn(|_| async move {
+        context.with_label("handler").spawn(|_| async move {
             while let Some(msg) = receiver.next().await {
                 match msg {
                     Message::PutBlock { incoming, response } => {
@@ -212,7 +212,7 @@ fn main() {
         });
 
         // Start listener
-        let mut listener = runtime.bind(socket).await.expect("failed to bind listener");
+        let mut listener = context.bind(socket).await.expect("failed to bind listener");
         let config = Config {
             crypto: signer,
             namespace: INDEXER_NAMESPACE.to_vec(),
@@ -230,7 +230,7 @@ fn main() {
 
             // Handshake
             let incoming =
-                match IncomingConnection::verify(&runtime, config.clone(), sink, stream).await {
+                match IncomingConnection::verify(&context, config.clone(), sink, stream).await {
                     Ok(partial) => partial,
                     Err(e) => {
                         debug!(error = ?e, "failed to verify incoming handshake");
@@ -242,7 +242,7 @@ fn main() {
                 debug!(?peer, "unauthorized peer");
                 continue;
             }
-            let stream = match Connection::upgrade_listener(runtime.clone(), incoming).await {
+            let stream = match Connection::upgrade_listener(context.clone(), incoming).await {
                 Ok(connection) => connection,
                 Err(e) => {
                     debug!(error = ?e, ?peer, "failed to upgrade connection");
@@ -252,7 +252,7 @@ fn main() {
             info!(?peer, "upgraded connection");
 
             // Spawn message handler
-            runtime.with_label("connection").spawn({
+            context.with_label("connection").spawn({
                 let mut handler = handler.clone();
                 move |_| async move {
                     // Split stream

--- a/examples/bridge/src/bin/indexer.rs
+++ b/examples/bridge/src/bin/indexer.rs
@@ -7,7 +7,7 @@ use commonware_cryptography::{
     sha256::Digest as Sha256Digest,
     Ed25519, Hasher, Scheme, Sha256,
 };
-use commonware_runtime::{tokio::Executor, Listener, Network, Runner, Spawner};
+use commonware_runtime::{tokio::Executor, Listener, Metrics, Network, Runner, Spawner};
 use commonware_stream::{
     public_key::{Config, Connection, IncomingConnection},
     Receiver, Sender,
@@ -132,7 +132,7 @@ fn main() {
 
         // Start handler
         let mut hasher = Sha256::new();
-        runtime.spawn("handler", async move {
+        runtime.with_label("handler").spawn(|_| async move {
             while let Some(msg) = receiver.next().await {
                 match msg {
                     Message::PutBlock { incoming, response } => {
@@ -252,9 +252,9 @@ fn main() {
             info!(?peer, "upgraded connection");
 
             // Spawn message handler
-            runtime.spawn("connection", {
+            runtime.with_label("connection").spawn({
                 let mut handler = handler.clone();
-                async move {
+                move |_| async move {
                     // Split stream
                     let (mut sender, mut receiver) = stream.split();
 

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -170,7 +170,6 @@ fn main() {
     let p2p_cfg = authenticated::Config::aggressive(
         signer.clone(),
         &union(APPLICATION_NAMESPACE, P2P_SUFFIX),
-        Arc::new(Mutex::new(Registry::default())),
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
         bootstrapper_identities.clone(),
         1024 * 1024, // 1MB

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -274,6 +274,6 @@ fn main() {
         );
 
         // Block on application
-        application.start().await.expect("Application failed");
+        application.run().await;
     });
 }

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -19,8 +19,6 @@ use commonware_storage::journal::variable::{Config, Journal};
 use commonware_stream::public_key::{self, Connection};
 use commonware_utils::{from_hex, quorum, union};
 use governor::Quota;
-use prometheus_client::registry::Registry;
-use std::sync::{Arc, Mutex};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     num::NonZeroU32,
@@ -217,7 +215,6 @@ fn main() {
         let journal = Journal::init(
             runtime.clone(),
             Config {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: String::from("log"),
             },
         )
@@ -253,7 +250,6 @@ fn main() {
                 relay: mailbox.clone(),
                 committer: mailbox,
                 supervisor,
-                registry: Arc::new(Mutex::new(Registry::default())),
                 namespace: consensus_namespace,
                 mailbox_size: 1024,
                 replay_concurrency: 1,

--- a/examples/chat/src/handler.rs
+++ b/examples/chat/src/handler.rs
@@ -1,6 +1,6 @@
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Handle, Metrics, Spawner};
+use commonware_runtime::{Metrics, Spawner};
 use commonware_utils::hex;
 use crossterm::{
     event::{self, Event as CEvent, KeyCode},
@@ -40,17 +40,7 @@ enum Focus {
     Messages,
 }
 
-pub fn start(
-    runtime: impl Spawner + Metrics,
-    me: String,
-    logs: Arc<Mutex<Vec<String>>>,
-    sender: impl Sender,
-    receiver: impl Receiver,
-) -> Handle<()> {
-    runtime.spawn(|runtime| run(runtime, me, logs, sender, receiver))
-}
-
-async fn run(
+pub async fn run(
     runtime: impl Spawner + Metrics,
     me: String,
     logs: Arc<Mutex<Vec<String>>>,

--- a/examples/chat/src/handler.rs
+++ b/examples/chat/src/handler.rs
@@ -1,6 +1,6 @@
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::Spawner;
+use commonware_runtime::{Metrics, Spawner};
 use commonware_utils::hex;
 use crossterm::{
     event::{self, Event as CEvent, KeyCode},
@@ -42,9 +42,8 @@ enum Focus {
 }
 
 pub async fn run(
-    runtime: impl Spawner,
+    runtime: impl Spawner + Metrics,
     me: String,
-    runtime_registry: Arc<Mutex<Registry>>,
     p2p_registry: Arc<Mutex<Registry>>,
     logs: Arc<Mutex<Vec<String>>>,
     mut sender: impl Sender,
@@ -136,12 +135,9 @@ pub async fn run(
                 f.render_widget(messages_block, messages_chunks[0]);
 
                 // Display metrics
-                let mut buffer = String::new();
+                let mut buffer = runtime.encode();
                 {
-                    let registry = runtime_registry.lock().unwrap();
-                    encode(&mut buffer, &registry).unwrap();
-                }
-                {
+                    // TODO: No longer needed when runtime includes
                     let registry = p2p_registry.lock().unwrap();
                     encode(&mut buffer, &registry).unwrap();
                 }

--- a/examples/chat/src/handler.rs
+++ b/examples/chat/src/handler.rs
@@ -41,7 +41,7 @@ enum Focus {
 }
 
 pub async fn run(
-    runtime: impl Spawner + Metrics,
+    context: impl Spawner + Metrics,
     me: String,
     logs: Arc<Mutex<Vec<String>>>,
     mut sender: impl Sender,
@@ -56,7 +56,7 @@ pub async fn run(
 
     // Listen for input
     let (mut tx, mut rx) = mpsc::channel(100);
-    runtime.with_label("keyboard").spawn(|_| async move {
+    context.with_label("keyboard").spawn(|_| async move {
         loop {
             match event::poll(Duration::from_millis(500)) {
                 Ok(true) => {}
@@ -133,7 +133,7 @@ pub async fn run(
                 f.render_widget(messages_block, messages_chunks[0]);
 
                 // Display metrics
-                let buffer = runtime.encode();
+                let buffer = context.encode();
                 let metrics_text = Text::from(buffer);
                 let metrics_block = Paragraph::new(metrics_text)
                     .block(

--- a/examples/chat/src/handler.rs
+++ b/examples/chat/src/handler.rs
@@ -8,7 +8,6 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use futures::{channel::mpsc, SinkExt, StreamExt};
-use prometheus_client::{encoding::text::encode, registry::Registry};
 use ratatui::{
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
@@ -44,7 +43,6 @@ enum Focus {
 pub async fn run(
     runtime: impl Spawner + Metrics,
     me: String,
-    p2p_registry: Arc<Mutex<Registry>>,
     logs: Arc<Mutex<Vec<String>>>,
     mut sender: impl Sender,
     mut receiver: impl Receiver,
@@ -135,12 +133,7 @@ pub async fn run(
                 f.render_widget(messages_block, messages_chunks[0]);
 
                 // Display metrics
-                let mut buffer = runtime.encode();
-                {
-                    // TODO: No longer needed when runtime includes
-                    let registry = p2p_registry.lock().unwrap();
-                    encode(&mut buffer, &registry).unwrap();
-                }
+                let buffer = runtime.encode();
                 let metrics_text = Text::from(buffer);
                 let metrics_block = Paragraph::new(metrics_text)
                     .block(

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -58,10 +58,7 @@ mod logger;
 use clap::{value_parser, Arg, Command};
 use commonware_cryptography::{Ed25519, Scheme};
 use commonware_p2p::authenticated::{self, Network};
-use commonware_runtime::{
-    tokio::{self, Executor},
-    Runner, Spawner,
-};
+use commonware_runtime::{tokio::Executor, Runner, Spawner};
 use governor::Quota;
 use prometheus_client::registry::Registry;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -76,12 +73,7 @@ const APPLICATION_NAMESPACE: &[u8] = b"commonware-chat";
 #[doc(hidden)]
 fn main() {
     // Initialize runtime
-    let runtime_registry = Arc::new(Mutex::new(Registry::with_prefix("runtime")));
-    let runtime_cfg = tokio::Config {
-        registry: runtime_registry.clone(),
-        ..Default::default()
-    };
-    let (executor, runtime) = Executor::init(runtime_cfg.clone());
+    let (executor, runtime) = Executor::default();
 
     // Parse arguments
     let matches = Command::new("commonware-chat")
@@ -196,7 +188,6 @@ fn main() {
         handler::run(
             runtime.clone(),
             signer.public_key().to_string(),
-            runtime_registry,
             p2p_registry,
             logs,
             chat_sender,

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -60,7 +60,6 @@ use commonware_cryptography::{Ed25519, Scheme};
 use commonware_p2p::authenticated::{self, Network};
 use commonware_runtime::{tokio::Executor, Runner, Spawner};
 use governor::Quota;
-use prometheus_client::registry::Registry;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::num::NonZeroU32;
 use std::str::FromStr;
@@ -150,11 +149,9 @@ fn main() {
 
     // Configure network
     const MAX_MESSAGE_SIZE: usize = 1024; // 1 KB
-    let p2p_registry = Arc::new(Mutex::new(Registry::with_prefix("p2p")));
     let p2p_cfg = authenticated::Config::aggressive(
         signer.clone(),
         APPLICATION_NAMESPACE,
-        p2p_registry.clone(),
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
         bootstrapper_identities.clone(),
         MAX_MESSAGE_SIZE,
@@ -188,7 +185,6 @@ fn main() {
         handler::run(
             runtime.clone(),
             signer.public_key().to_string(),
-            p2p_registry,
             logs,
             chat_sender,
             chat_receiver,

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -182,16 +182,15 @@ fn main() {
         // Start network
         let network_handler = network.start();
 
-        // Start chat
-        handler::start(
+        // Block on GUI
+        handler::run(
             runtime.with_label("handler"),
             signer.public_key().to_string(),
             logs,
             chat_sender,
             chat_receiver,
         )
-        .await
-        .expect("Chat failed");
+        .await;
 
         // Abort network
         network_handler.abort();

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -72,8 +72,8 @@ const APPLICATION_NAMESPACE: &[u8] = b"commonware-chat";
 
 #[doc(hidden)]
 fn main() {
-    // Initialize runtime
-    let (executor, runtime) = Executor::default();
+    // Initialize context
+    let (executor, context) = Executor::default();
 
     // Parse arguments
     let matches = Command::new("commonware-chat")
@@ -158,10 +158,10 @@ fn main() {
         MAX_MESSAGE_SIZE,
     );
 
-    // Start runtime
+    // Start context
     executor.start(async move {
         // Initialize network
-        let (mut network, mut oracle) = Network::new(runtime.with_label("network"), p2p_cfg);
+        let (mut network, mut oracle) = Network::new(context.with_label("network"), p2p_cfg);
 
         // Provide authorized peers
         //
@@ -184,7 +184,7 @@ fn main() {
 
         // Block on GUI
         handler::run(
-            runtime.with_label("handler"),
+            context.with_label("handler"),
             signer.public_key().to_string(),
             logs,
             chat_sender,

--- a/examples/log/src/application/actor.rs
+++ b/examples/log/src/application/actor.rs
@@ -42,8 +42,8 @@ impl<R: Rng + Spawner, C: Scheme, H: Hasher> Application<R, C, H> {
     }
 
     /// Run the application actor.
-    pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+    pub fn start(mut self) -> Handle<()> {
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/examples/log/src/gui.rs
+++ b/examples/log/src/gui.rs
@@ -3,7 +3,7 @@
 //! This code has nothing to do with the application or consensus and was
 //! implemented to make consensus logging easier to follow.
 
-use commonware_runtime::{Handle, Metrics, Spawner};
+use commonware_runtime::{Metrics, Spawner};
 use crossterm::{
     event::{self, Event as CEvent, KeyCode},
     execute,
@@ -164,11 +164,7 @@ impl<E: Spawner + Metrics> Gui<E> {
         }
     }
 
-    pub fn start(self) -> Handle<()> {
-        self.runtime.clone().spawn(|_| self.run())
-    }
-
-    async fn run(self) {
+    pub async fn run(self) {
         // Setup terminal
         enable_raw_mode().unwrap();
         let mut stdout = stdout();

--- a/examples/log/src/gui.rs
+++ b/examples/log/src/gui.rs
@@ -139,13 +139,13 @@ impl<'a> MakeWriter<'a> for Writer {
 }
 
 pub struct Gui<E: Spawner + Metrics> {
-    runtime: E,
+    context: E,
     progress: Arc<Mutex<Vec<String>>>,
     logs: Arc<Mutex<Vec<String>>>,
 }
 
 impl<E: Spawner + Metrics> Gui<E> {
-    pub fn new(runtime: E) -> Self {
+    pub fn new(context: E) -> Self {
         // Create writer
         let progress = Arc::new(Mutex::new(Vec::new()));
         let logs = Arc::new(Mutex::new(Vec::new()));
@@ -158,7 +158,7 @@ impl<E: Spawner + Metrics> Gui<E> {
             .with_writer(writer)
             .init();
         Self {
-            runtime,
+            context,
             progress,
             logs,
         }
@@ -174,7 +174,7 @@ impl<E: Spawner + Metrics> Gui<E> {
 
         // Listen for input
         let (mut tx, mut rx) = mpsc::channel(100);
-        self.runtime.with_label("keyboard").spawn(|_| async move {
+        self.context.with_label("keyboard").spawn(|_| async move {
             loop {
                 match event::poll(Duration::from_millis(500)) {
                     Ok(true) => {}

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -158,7 +158,6 @@ fn main() {
     let p2p_cfg = authenticated::Config::aggressive(
         signer.clone(),
         &union(APPLICATION_NAMESPACE, b"_P2P"),
-        Arc::new(Mutex::new(Registry::default())),
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
         bootstrapper_identities.clone(),
         1024 * 1024, // 1MB

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -244,6 +244,6 @@ fn main() {
 
         // Block on GUI
         let gui = gui::Gui::new(runtime.with_label("gui"));
-        gui.start().await.expect("GUI failed");
+        gui.run().await;
     });
 }

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -58,8 +58,6 @@ use commonware_runtime::{
 use commonware_storage::journal::variable::{Config, Journal};
 use commonware_utils::union;
 use governor::Quota;
-use prometheus_client::registry::Registry;
-use std::sync::{Arc, Mutex};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     num::NonZeroU32,
@@ -194,7 +192,6 @@ fn main() {
         let journal = Journal::init(
             runtime.clone(),
             Config {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 partition: String::from("log"),
             },
         )
@@ -224,7 +221,6 @@ fn main() {
                 relay: mailbox.clone(),
                 committer: mailbox,
                 supervisor,
-                registry: Arc::new(Mutex::new(Registry::default())),
                 namespace,
                 mailbox_size: 1024,
                 replay_concurrency: 1,

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -268,11 +268,11 @@ impl<E: Clock + Spawner, C: Scheme> Arbiter<E, C> {
     }
 
     pub fn start(
-        self,
+        mut self,
         sender: impl Sender<PublicKey = C::PublicKey>,
         receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(sender, receiver))
+        self.context.spawn_ref()(self.run(sender, receiver))
     }
 
     async fn run(

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -504,11 +504,11 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
     }
 
     pub fn start(
-        self,
+        mut self,
         sender: impl Sender<PublicKey = C::PublicKey>,
         receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) {
-        self.context.clone().spawn(|_| self.run(sender, receiver));
+        self.context.spawn_ref()(self.run(sender, receiver));
     }
 
     async fn run(

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -22,7 +22,7 @@ use tracing::{debug, info, warn};
 /// A DKG/Resharing contributor that can be configured to behave honestly
 /// or deviate as a rogue, lazy, or forger.
 pub struct Contributor<E: Clock + Rng + Spawner, C: Scheme> {
-    runtime: E,
+    context: E,
     crypto: C,
     dkg_phase_timeout: Duration,
     arbiter: C::PublicKey,
@@ -40,7 +40,7 @@ pub struct Contributor<E: Clock + Rng + Spawner, C: Scheme> {
 impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        runtime: E,
+        context: E,
         crypto: C,
         dkg_phase_timeout: Duration,
         arbiter: C::PublicKey,
@@ -58,7 +58,7 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
         let (sender, receiver) = mpsc::channel(32);
         (
             Self {
-                runtime,
+                context,
                 crypto,
                 dkg_phase_timeout,
                 arbiter,
@@ -167,7 +167,7 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
         let mut dealer_obj = if should_deal {
             let previous = previous.map(|previous| previous.share);
             let (dealer, commitment, shares) =
-                Dealer::new(&mut self.runtime, previous, self.contributors.clone());
+                Dealer::new(&mut self.context, previous, self.contributors.clone());
             let serialized_commitment = commitment.serialize();
             Some((
                 dealer,
@@ -220,7 +220,7 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
                     // If we are corrupt, randomly modify the share.
                     serialized_share = group::Share {
                         index: share.index,
-                        private: group::Scalar::rand(&mut self.runtime),
+                        private: group::Scalar::rand(&mut self.context),
                     }
                     .serialize();
                     warn!(round, ?player, "modified share");
@@ -257,10 +257,10 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
         }
 
         // Respond to commitments and wait for acks
-        let t = self.runtime.current() + 2 * self.dkg_phase_timeout;
+        let t = self.context.current() + 2 * self.dkg_phase_timeout;
         loop {
             select! {
-                    _ = self.runtime.sleep_until(t) => {
+                    _ = self.context.sleep_until(t) => {
                         debug!(round, "ack timeout");
                         break;
                     },
@@ -508,7 +508,7 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
         sender: impl Sender<PublicKey = C::PublicKey>,
         receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) {
-        self.runtime.clone().spawn(|_| self.run(sender, receiver));
+        self.context.clone().spawn(|_| self.run(sender, receiver));
     }
 
     async fn run(

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -158,11 +158,11 @@ impl<E: Clock + Spawner, P: Array> Vrf<E, P> {
     }
 
     pub fn start(
-        self,
+        mut self,
         sender: impl Sender<PublicKey = P>,
         receiver: impl Receiver<PublicKey = P>,
     ) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(sender, receiver))
+        self.context.spawn_ref()(self.run(sender, receiver))
     }
 
     async fn run(

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -83,7 +83,7 @@ use commonware_cryptography::{Ed25519, Scheme};
 use commonware_p2p::authenticated::{self, Network};
 use commonware_runtime::{
     tokio::{self, Executor},
-    Runner, Spawner,
+    Metrics, Runner,
 };
 use commonware_utils::quorum;
 use governor::Quota;
@@ -220,7 +220,7 @@ fn main() {
 
     // Start runtime
     executor.start(async move {
-        let (mut network, mut oracle) = Network::new(runtime.clone(), p2p_cfg);
+        let (mut network, mut oracle) = Network::new(runtime.with_label("network"), p2p_cfg);
 
         // Provide authorized peers
         //
@@ -265,7 +265,7 @@ fn main() {
             );
             let arbiter = Ed25519::from_seed(*arbiter).public_key();
             let (contributor, requests) = handlers::Contributor::new(
-                runtime.clone(),
+                runtime.with_label("contributor"),
                 signer,
                 DKG_PHASE_TIMEOUT,
                 arbiter,
@@ -274,10 +274,7 @@ fn main() {
                 lazy,
                 forger,
             );
-            runtime.spawn(
-                "contributor",
-                contributor.run(contributor_sender, contributor_receiver),
-            );
+            contributor.start(contributor_sender, contributor_receiver);
 
             // Create vrf
             let (vrf_sender, vrf_receiver) = network.register(
@@ -287,13 +284,13 @@ fn main() {
                 None,
             );
             let signer = handlers::Vrf::new(
-                runtime.clone(),
+                runtime.with_label("signer"),
                 Duration::from_secs(5),
                 threshold,
                 contributors,
                 requests,
             );
-            runtime.spawn("signer", signer.run(vrf_sender, vrf_receiver));
+            signer.start(vrf_sender, vrf_receiver);
         } else {
             let (arbiter_sender, arbiter_receiver) = network.register(
                 handlers::DKG_CHANNEL,
@@ -302,14 +299,14 @@ fn main() {
                 COMPRESSION_LEVEL,
             );
             let arbiter: handlers::Arbiter<_, Ed25519> = handlers::Arbiter::new(
-                runtime.clone(),
+                runtime.with_label("arbiter"),
                 DKG_FREQUENCY,
                 DKG_PHASE_TIMEOUT,
                 contributors,
                 threshold,
             );
-            runtime.spawn("arbiter", arbiter.run(arbiter_sender, arbiter_receiver));
+            arbiter.start(arbiter_sender, arbiter_receiver);
         }
-        network.run().await;
+        network.start().await.expect("Network failed");
     });
 }

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -87,8 +87,6 @@ use commonware_runtime::{
 };
 use commonware_utils::quorum;
 use governor::Quota;
-use prometheus_client::registry::Registry;
-use std::sync::{Arc, Mutex};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     num::NonZeroU32,
@@ -215,7 +213,6 @@ fn main() {
     let p2p_cfg = authenticated::Config::aggressive(
         signer.clone(),
         APPLICATION_NAMESPACE,
-        Arc::new(Mutex::new(Registry::default())),
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
         bootstrapper_identities.clone(),
         MAX_MESSAGE_SIZE,

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -98,9 +98,9 @@ use tracing::info;
 const APPLICATION_NAMESPACE: &[u8] = b"_COMMONWARE_VRF_";
 
 fn main() {
-    // Initialize runtime
+    // Initialize context
     let runtime_cfg = tokio::Config::default();
-    let (executor, runtime) = Executor::init(runtime_cfg.clone());
+    let (executor, context) = Executor::init(runtime_cfg.clone());
 
     // Parse arguments
     let matches = Command::new("commonware-vrf")
@@ -218,9 +218,9 @@ fn main() {
         MAX_MESSAGE_SIZE,
     );
 
-    // Start runtime
+    // Start context
     executor.start(async move {
-        let (mut network, mut oracle) = Network::new(runtime.with_label("network"), p2p_cfg);
+        let (mut network, mut oracle) = Network::new(context.with_label("network"), p2p_cfg);
 
         // Provide authorized peers
         //
@@ -265,7 +265,7 @@ fn main() {
             );
             let arbiter = Ed25519::from_seed(*arbiter).public_key();
             let (contributor, requests) = handlers::Contributor::new(
-                runtime.with_label("contributor"),
+                context.with_label("contributor"),
                 signer,
                 DKG_PHASE_TIMEOUT,
                 arbiter,
@@ -284,7 +284,7 @@ fn main() {
                 None,
             );
             let signer = handlers::Vrf::new(
-                runtime.with_label("signer"),
+                context.with_label("signer"),
                 Duration::from_secs(5),
                 threshold,
                 contributors,
@@ -299,7 +299,7 @@ fn main() {
                 COMPRESSION_LEVEL,
             );
             let arbiter: handlers::Arbiter<_, Ed25519> = handlers::Arbiter::new(
-                runtime.with_label("arbiter"),
+                context.with_label("arbiter"),
                 DKG_FREQUENCY,
                 DKG_PHASE_TIMEOUT,
                 contributors,

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -12,7 +12,7 @@ use syn::{
 /// Run a test function asynchronously.
 ///
 /// This macro is powered by the [futures](https://docs.rs/futures) crate
-/// and is not bound to a particular executor or runtime.
+/// and is not bound to a particular executor or context.
 ///
 /// # Example
 /// ```rust
@@ -171,7 +171,7 @@ impl Parse for SelectInput {
 /// Select the first future that completes (biased by order).
 ///
 /// This macro is powered by the [futures](https://docs.rs/futures) crate
-/// and is not bound to a particular executor or runtime.
+/// and is not bound to a particular executor or context.
 ///
 /// # Fusing
 ///

--- a/p2p/src/authenticated/actors/router/actor.rs
+++ b/p2p/src/authenticated/actors/router/actor.rs
@@ -76,8 +76,8 @@ impl<E: Spawner + Metrics, P: Array> Actor<E, P> {
         }
     }
 
-    pub fn start(self, routing: Channels<P>) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(routing))
+    pub fn start(mut self, routing: Channels<P>) -> Handle<()> {
+        self.context.spawn_ref()(self.run(routing))
     }
 
     async fn run(mut self, routing: Channels<P>) {

--- a/p2p/src/authenticated/actors/router/actor.rs
+++ b/p2p/src/authenticated/actors/router/actor.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use bytes::Bytes;
 use commonware_runtime::{Handle, Metrics, Spawner};
+use commonware_utils::Array;
 use futures::{channel::mpsc, StreamExt};
 use prometheus_client::metrics::{counter::Counter, family::Family};
 use std::collections::BTreeMap;

--- a/p2p/src/authenticated/actors/router/mod.rs
+++ b/p2p/src/authenticated/actors/router/mod.rs
@@ -1,6 +1,3 @@
-use prometheus_client::registry::Registry;
-use std::sync::{Arc, Mutex};
-
 mod actor;
 mod ingress;
 
@@ -8,6 +5,5 @@ pub use actor::Actor;
 pub use ingress::{Mailbox, Messenger};
 
 pub struct Config {
-    pub registry: Arc<Mutex<Registry>>,
     pub mailbox_size: usize,
 }

--- a/p2p/src/authenticated/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/actors/spawner/actor.rs
@@ -96,7 +96,6 @@ impl<
 
                     // Spawn peer
                     self.context
-                        .clone()
                         .with_label("peer")
                         .spawn(move |context| async move {
                             // Create peer

--- a/p2p/src/authenticated/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/actors/spawner/actor.rs
@@ -75,8 +75,12 @@ impl<
         )
     }
 
-    pub fn start(self, tracker: tracker::Mailbox<E, P>, router: router::Mailbox<P>) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(tracker, router))
+    pub fn start(
+        mut self,
+        tracker: tracker::Mailbox<E, P>,
+        router: router::Mailbox<P>,
+    ) -> Handle<()> {
+        self.context.spawn_ref()(self.run(tracker, router))
     }
 
     async fn run(mut self, tracker: tracker::Mailbox<E, P>, router: router::Mailbox<P>) {

--- a/p2p/src/authenticated/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/actors/spawner/ingress.rs
@@ -1,10 +1,10 @@
 use crate::authenticated::actors::tracker;
 use commonware_cryptography::Array;
-use commonware_runtime::{Clock, Sink, Spawner, Stream};
+use commonware_runtime::{Clock, Metrics, Sink, Spawner, Stream};
 use commonware_stream::public_key::Connection;
 use futures::{channel::mpsc, SinkExt};
 
-pub enum Message<E: Spawner + Clock, Si: Sink, St: Stream, P: Array> {
+pub enum Message<E: Spawner + Clock + Metrics, Si: Sink, St: Stream, P: Array> {
     Spawn {
         peer: P,
         connection: Connection<Si, St>,
@@ -12,11 +12,11 @@ pub enum Message<E: Spawner + Clock, Si: Sink, St: Stream, P: Array> {
     },
 }
 
-pub struct Mailbox<E: Spawner + Clock, Si: Sink, St: Stream, P: Array> {
+pub struct Mailbox<E: Spawner + Clock + Metrics, Si: Sink, St: Stream, P: Array> {
     sender: mpsc::Sender<Message<E, Si, St, P>>,
 }
 
-impl<E: Spawner + Clock, Si: Sink, St: Stream, P: Array> Mailbox<E, Si, St, P> {
+impl<E: Spawner + Clock + Metrics, Si: Sink, St: Stream, P: Array> Mailbox<E, Si, St, P> {
     pub fn new(sender: mpsc::Sender<Message<E, Si, St, P>>) -> Self {
         Self { sender }
     }
@@ -38,7 +38,7 @@ impl<E: Spawner + Clock, Si: Sink, St: Stream, P: Array> Mailbox<E, Si, St, P> {
     }
 }
 
-impl<E: Spawner + Clock, Si: Sink, St: Stream, P: Array> Clone for Mailbox<E, Si, St, P> {
+impl<E: Spawner + Clock + Metrics, Si: Sink, St: Stream, P: Array> Clone for Mailbox<E, Si, St, P> {
     /// Clone the mailbox.
     ///
     /// We manually implement `clone` because the auto-generated `derive` would

--- a/p2p/src/authenticated/actors/spawner/mod.rs
+++ b/p2p/src/authenticated/actors/spawner/mod.rs
@@ -1,6 +1,4 @@
 use governor::Quota;
-use prometheus_client::registry::Registry;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 mod actor;
@@ -10,7 +8,6 @@ pub use actor::Actor;
 pub use ingress::Mailbox;
 
 pub struct Config {
-    pub registry: Arc<Mutex<Registry>>,
     pub mailbox_size: usize,
     pub gossip_bit_vec_frequency: Duration,
     pub allowed_bit_vec_rate: Quota,

--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -552,8 +552,8 @@ impl<E: Spawner + Rng + Clock + GClock + Metrics, C: Scheme> Actor<E, C> {
         ))
     }
 
-    pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+    pub fn start(mut self) -> Handle<()> {
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/p2p/src/authenticated/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/actors/tracker/ingress.rs
@@ -1,13 +1,13 @@
 use crate::authenticated::{actors::peer, wire};
 use commonware_cryptography::Array;
-use commonware_runtime::Spawner;
+use commonware_runtime::{Metrics, Spawner};
 use futures::{
     channel::{mpsc, oneshot},
     SinkExt,
 };
 use std::net::SocketAddr;
 
-pub enum Message<E: Spawner, P: Array> {
+pub enum Message<E: Spawner + Metrics, P: Array> {
     // Used by oracle
     Register {
         index: u64,
@@ -47,11 +47,11 @@ pub enum Message<E: Spawner, P: Array> {
 }
 
 #[derive(Clone)]
-pub struct Mailbox<E: Spawner, P: Array> {
+pub struct Mailbox<E: Spawner + Metrics, P: Array> {
     sender: mpsc::Sender<Message<E, P>>,
 }
 
-impl<E: Spawner, P: Array> Mailbox<E, P> {
+impl<E: Spawner + Metrics, P: Array> Mailbox<E, P> {
     pub(super) fn new(sender: mpsc::Sender<Message<E, P>>) -> Self {
         Self { sender }
     }
@@ -108,11 +108,11 @@ impl<E: Spawner, P: Array> Mailbox<E, P> {
 /// Peers that are not explicitly authorized
 /// will be blocked by commonware-p2p.
 #[derive(Clone)]
-pub struct Oracle<E: Spawner, P: Array> {
+pub struct Oracle<E: Spawner + Metrics, P: Array> {
     sender: mpsc::Sender<Message<E, P>>,
 }
 
-impl<E: Spawner, P: Array> Oracle<E, P> {
+impl<E: Spawner + Metrics, P: Array> Oracle<E, P> {
     pub(super) fn new(sender: mpsc::Sender<Message<E, P>>) -> Self {
         Self { sender }
     }
@@ -133,12 +133,12 @@ impl<E: Spawner, P: Array> Oracle<E, P> {
     }
 }
 
-pub struct Reservation<E: Spawner, P: Array> {
+pub struct Reservation<E: Spawner + Metrics, P: Array> {
     runtime: E,
     closer: Option<(P, Mailbox<E, P>)>,
 }
 
-impl<E: Spawner, P: Array> Reservation<E, P> {
+impl<E: Spawner + Metrics, P: Array> Reservation<E, P> {
     pub fn new(runtime: E, peer: P, mailbox: Mailbox<E, P>) -> Self {
         Self {
             runtime,
@@ -147,11 +147,14 @@ impl<E: Spawner, P: Array> Reservation<E, P> {
     }
 }
 
-impl<E: Spawner, P: Array> Drop for Reservation<E, P> {
+impl<E: Spawner + Metrics, P: Array> Drop for Reservation<E, P> {
     fn drop(&mut self) {
         let (peer, mut mailbox) = self.closer.take().unwrap();
-        self.runtime.spawn("reservation", async move {
-            mailbox.release(peer).await;
-        });
+        self.runtime
+            .clone()
+            .with_label("reservation")
+            .spawn(move |_| async move {
+                mailbox.release(peer).await;
+            });
     }
 }

--- a/p2p/src/authenticated/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/actors/tracker/ingress.rs
@@ -134,14 +134,14 @@ impl<E: Spawner + Metrics, P: Array> Oracle<E, P> {
 }
 
 pub struct Reservation<E: Spawner + Metrics, P: Array> {
-    runtime: E,
+    context: E,
     closer: Option<(P, Mailbox<E, P>)>,
 }
 
 impl<E: Spawner + Metrics, P: Array> Reservation<E, P> {
-    pub fn new(runtime: E, peer: P, mailbox: Mailbox<E, P>) -> Self {
+    pub fn new(context: E, peer: P, mailbox: Mailbox<E, P>) -> Self {
         Self {
-            runtime,
+            context,
             closer: Some((peer, mailbox)),
         }
     }
@@ -150,7 +150,7 @@ impl<E: Spawner + Metrics, P: Array> Reservation<E, P> {
 impl<E: Spawner + Metrics, P: Array> Drop for Reservation<E, P> {
     fn drop(&mut self) {
         let (peer, mut mailbox) = self.closer.take().unwrap();
-        self.runtime
+        self.context
             .clone()
             .with_label("reservation")
             .spawn(move |_| async move {

--- a/p2p/src/authenticated/actors/tracker/mod.rs
+++ b/p2p/src/authenticated/actors/tracker/mod.rs
@@ -3,10 +3,8 @@
 use crate::authenticated::config::Bootstrapper;
 use commonware_cryptography::Scheme;
 use governor::Quota;
-use prometheus_client::registry::Registry;
 use std::net::IpAddr;
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use thiserror::Error;
 
@@ -20,7 +18,6 @@ pub use ingress::{Mailbox, Oracle, Reservation};
 pub struct Config<C: Scheme> {
     pub crypto: C,
     pub namespace: Vec<u8>,
-    pub registry: Arc<Mutex<Registry>>,
     pub address: SocketAddr,
     pub bootstrappers: Vec<Bootstrapper<C::PublicKey>>,
     pub allow_private_ips: bool,

--- a/p2p/src/authenticated/config.rs
+++ b/p2p/src/authenticated/config.rs
@@ -1,12 +1,6 @@
 use commonware_cryptography::Scheme;
 use governor::Quota;
-use prometheus_client::registry::Registry;
-use std::{
-    net::SocketAddr,
-    num::NonZeroU32,
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{net::SocketAddr, num::NonZeroU32, time::Duration};
 
 /// Known peer and its accompanying address that will be dialed on startup.
 pub type Bootstrapper<P> = (P, SocketAddr);
@@ -25,9 +19,6 @@ pub struct Config<C: Scheme> {
 
     /// Prefix for all signed messages to avoid replay attacks.
     pub namespace: Vec<u8>,
-
-    /// Registry for prometheus metrics.
-    pub registry: Arc<Mutex<Registry>>,
 
     /// Address to listen on.
     pub listen: SocketAddr,
@@ -111,7 +102,6 @@ impl<C: Scheme> Config<C> {
     pub fn recommended(
         crypto: C,
         namespace: &[u8],
-        registry: Arc<Mutex<Registry>>,
         listen: SocketAddr,
         bootstrappers: Vec<Bootstrapper<C::PublicKey>>,
         max_message_size: usize,
@@ -119,7 +109,6 @@ impl<C: Scheme> Config<C> {
         Self {
             crypto,
             namespace: namespace.to_vec(),
-            registry,
             listen,
             dialable: listen,
             bootstrappers,
@@ -150,7 +139,6 @@ impl<C: Scheme> Config<C> {
     pub fn aggressive(
         crypto: C,
         namespace: &[u8],
-        registry: Arc<Mutex<Registry>>,
         listen: SocketAddr,
         bootstrappers: Vec<Bootstrapper<C::PublicKey>>,
         max_message_size: usize,
@@ -158,7 +146,6 @@ impl<C: Scheme> Config<C> {
         Self {
             crypto,
             namespace: namespace.to_vec(),
-            registry,
             listen,
             dialable: listen,
             bootstrappers,
@@ -184,7 +171,6 @@ impl<C: Scheme> Config<C> {
     #[cfg(test)]
     pub fn test(
         crypto: C,
-        registry: Arc<Mutex<Registry>>,
         listen: SocketAddr,
         bootstrappers: Vec<Bootstrapper<C::PublicKey>>,
         max_message_size: usize,
@@ -192,7 +178,6 @@ impl<C: Scheme> Config<C> {
         Self {
             crypto,
             namespace: b"test_namespace".to_vec(),
-            registry,
             listen,
             dialable: listen,
             bootstrappers,

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -246,6 +246,9 @@ mod tests {
         // Create networks
         let mut waiters = Vec::new();
         for (i, peer) in peers.iter().enumerate() {
+            // Create peer runtime
+            let runtime = runtime.with_label(&format!("peer-{}", i));
+
             // Derive port
             let port = base_port + i as u16;
 
@@ -266,7 +269,7 @@ mod tests {
                 bootstrappers,
                 max_message_size,
             );
-            let (mut network, mut oracle) = Network::new(runtime.clone(), config);
+            let (mut network, mut oracle) = Network::new(runtime.with_label("network"), config);
 
             // Register peers
             oracle.register(0, addresses.clone()).await;
@@ -280,25 +283,27 @@ mod tests {
             );
 
             // Wait to connect to all peers, and then send messages to everyone
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Send/Receive messages
-            let handler = runtime.spawn("agent", {
+            let handler = runtime.with_label("agent").spawn({
                 let addresses = addresses.clone();
-                let runtime = runtime.clone();
-                async move {
+                move |runtime| async move {
                     // Wait for all peers to send their identity
-                    let acker = runtime.spawn("receiver", async move {
-                        let mut received = HashSet::new();
-                        while received.len() < n - 1 {
-                            // Ensure message equals sender identity
-                            let (sender, message) = receiver.recv().await.unwrap();
-                            assert_eq!(sender.as_ref(), message.as_ref());
+                    let acker = runtime
+                        .clone()
+                        .with_label("receiver")
+                        .spawn(move |_| async move {
+                            let mut received = HashSet::new();
+                            while received.len() < n - 1 {
+                                // Ensure message equals sender identity
+                                let (sender, message) = receiver.recv().await.unwrap();
+                                assert_eq!(sender.as_ref(), message.as_ref());
 
-                            // Add to received set
-                            received.insert(sender);
-                        }
-                    });
+                                // Add to received set
+                                received.insert(sender);
+                            }
+                        });
 
                     // Send identity to all peers
                     let msg = signer.public_key();
@@ -469,6 +474,9 @@ mod tests {
             // Create networks
             let mut waiters = Vec::new();
             for (i, peer) in peers.iter().enumerate() {
+                // Create peer runtime
+                let runtime = runtime.with_label(&format!("peer-{}", i));
+
                 // Derive port
                 let port = base_port + i as u16;
 
@@ -489,7 +497,7 @@ mod tests {
                     bootstrappers,
                     1_024 * 1_024, // 1MB
                 );
-                let (mut network, mut oracle) = Network::new(runtime.clone(), config);
+                let (mut network, mut oracle) = Network::new(runtime.with_label("network"), config);
 
                 // Register peers at separate indices
                 oracle.register(0, vec![addresses[0].clone()]).await;
@@ -509,12 +517,12 @@ mod tests {
                 );
 
                 // Wait to connect to all peers, and then send messages to everyone
-                runtime.spawn("network", network.run());
+                network.start();
 
                 // Send/Receive messages
-                let handler = runtime.spawn("agent", {
-                    let runtime = runtime.clone();
-                    async move {
+                let handler = runtime
+                    .with_label("agent")
+                    .spawn(move |runtime| async move {
                         if i == 0 {
                             // Loop until success
                             let msg = signer.public_key();
@@ -537,8 +545,7 @@ mod tests {
                             let (sender, message) = receiver.recv().await.unwrap();
                             assert_eq!(sender.as_ref(), message.as_ref());
                         }
-                    }
-                });
+                    });
 
                 // Add to waiters
                 waiters.push(handler);
@@ -574,7 +581,7 @@ mod tests {
                 Vec::new(),
                 1_024 * 1_024, // 1MB
             );
-            let (mut network, mut oracle) = Network::new(runtime.clone(), config);
+            let (mut network, mut oracle) = Network::new(runtime.with_label("network"), config);
 
             // Register peers
             oracle.register(0, addresses.clone()).await;
@@ -588,7 +595,7 @@ mod tests {
             );
 
             // Wait to connect to all peers, and then send messages to everyone
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Crate random message
             let mut msg = vec![0u8; 10 * 1024 * 1024]; // 10MB (greater than frame capacity)

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -88,17 +88,12 @@
 //! use commonware_cryptography::{Ed25519, Scheme};
 //! use commonware_runtime::{tokio::{self, Executor}, Spawner, Runner};
 //! use governor::Quota;
-//! use prometheus_client::registry::Registry;
 //! use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 //! use std::num::NonZeroU32;
-//! use std::sync::{Arc, Mutex};
 //!
 //! // Configure runtime
 //! let runtime_cfg = tokio::Config::default();
 //! let (executor, runtime) = Executor::init(runtime_cfg.clone());
-//!
-//! // Configure prometheus registry
-//! let registry = Arc::new(Mutex::new(Registry::with_prefix("p2p")));
 //!
 //! // Generate identity
 //! //
@@ -130,7 +125,6 @@
 //! let p2p_cfg = authenticated::Config::aggressive(
 //!     signer.clone(),
 //!     application_namespace,
-//!     registry,
 //!     SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3000),
 //!     bootstrappers,
 //!     MAX_MESSAGE_SIZE,

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -86,7 +86,7 @@
 //! ```rust
 //! use commonware_p2p::authenticated::{self, Network};
 //! use commonware_cryptography::{Ed25519, Scheme};
-//! use commonware_runtime::{tokio::{self, Executor}, Spawner, Runner};
+//! use commonware_runtime::{tokio::{self, Executor}, Spawner, Runner, Metrics};
 //! use governor::Quota;
 //! use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 //! use std::num::NonZeroU32;
@@ -133,7 +133,7 @@
 //! // Start runtime
 //! executor.start(async move {
 //!     // Initialize network
-//!     let (mut network, mut oracle) = Network::new(runtime.clone(), p2p_cfg);
+//!     let (mut network, mut oracle) = Network::new(runtime.with_label("network"), p2p_cfg);
 //!
 //!     // Register authorized peers
 //!     //
@@ -152,7 +152,7 @@
 //!     );
 //!
 //!     // Run network
-//!     let network_handler = runtime.spawn("network", network.run());
+//!     let network_handler = network.start();
 //!
 //!     // ... Use sender and receiver ...
 //!

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -151,8 +151,8 @@ impl<
     /// Starts the network.
     ///
     /// After the network is started, it is not possible to add more channels.
-    pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+    pub fn start(mut self) -> Handle<()> {
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(self) {

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -14,7 +14,7 @@
 //! ```rust
 //! use commonware_p2p::simulated::{Config, Link, Network};
 //! use commonware_cryptography::{Ed25519, Scheme};
-//! use commonware_runtime::{deterministic::Executor, Spawner, Runner};
+//! use commonware_runtime::{deterministic::Executor, Spawner, Runner, Metrics};
 //!
 //! // Generate peers
 //! let peers = vec![
@@ -33,10 +33,10 @@
 //! let (executor, runtime, _) = Executor::seeded(0);
 //! executor.start(async move {
 //!     // Initialize network
-//!     let (network, mut oracle) = Network::new(runtime.clone(), p2p_cfg);
+//!     let (network, mut oracle) = Network::new(runtime.with_label("network"), p2p_cfg);
 //!
 //!     // Start network
-//!     let network_handler = runtime.spawn("network", network.run());
+//!     let network_handler = network.start();
 //!
 //!     // Register some peers
 //!     let (sender, receiver) = oracle.register(peers[0].clone(), 0).await.unwrap();

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -131,9 +131,7 @@ mod tests {
     use commonware_macros::select;
     use commonware_runtime::{deterministic::Executor, Clock, Runner, Spawner};
     use futures::{channel::mpsc, SinkExt, StreamExt};
-    use prometheus_client::registry::Registry;
     use rand::Rng;
-    use std::sync::{Arc, Mutex};
     use std::{
         collections::{BTreeMap, HashMap},
         time::Duration,
@@ -146,7 +144,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );
@@ -262,7 +259,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );
@@ -303,7 +299,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );
@@ -341,7 +336,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );
@@ -367,7 +361,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );
@@ -407,7 +400,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );
@@ -463,7 +455,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );
@@ -537,7 +528,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );
@@ -590,7 +580,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );
@@ -660,7 +649,6 @@ mod tests {
             let (network, mut oracle) = Network::new(
                 runtime.clone(),
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
                     max_size: 1024 * 1024,
                 },
             );

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -126,7 +126,7 @@ mod tests {
     use bytes::Bytes;
     use commonware_cryptography::{Ed25519, Scheme};
     use commonware_macros::select;
-    use commonware_runtime::{deterministic::Executor, Clock, Runner, Spawner};
+    use commonware_runtime::{deterministic::Executor, Clock, Metrics, Runner, Spawner};
     use futures::{channel::mpsc, SinkExt, StreamExt};
     use rand::Rng;
     use std::{
@@ -139,14 +139,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register agents
             let mut agents = BTreeMap::new();
@@ -156,14 +156,16 @@ mod tests {
                 let (sender, mut receiver) = oracle.register(pk.clone(), 0).await.unwrap();
                 agents.insert(pk, sender);
                 let mut agent_sender = seen_sender.clone();
-                runtime.spawn("agent_receiver", async move {
-                    for _ in 0..size {
-                        receiver.recv().await.unwrap();
-                    }
-                    agent_sender.send(i).await.unwrap();
+                runtime
+                    .with_label("agent_receiver")
+                    .spawn(move |_| async move {
+                        for _ in 0..size {
+                            receiver.recv().await.unwrap();
+                        }
+                        agent_sender.send(i).await.unwrap();
 
-                    // Exiting early here tests the case where the recipient end of an agent is dropped
-                });
+                        // Exiting early here tests the case where the recipient end of an agent is dropped
+                    });
             }
 
             // Randomly link agents
@@ -194,9 +196,9 @@ mod tests {
             }
 
             // Send messages
-            runtime.spawn("agent_sender", {
-                let mut runtime = runtime.clone();
-                async move {
+            runtime
+                .with_label("agent_sender")
+                .spawn(|mut runtime| async move {
                     // Sort agents for deterministic output
                     let keys = agents.keys().collect::<Vec<_>>();
 
@@ -217,8 +219,7 @@ mod tests {
                             assert_eq!(sent.len(), keys.len() - 1);
                         }
                     }
-                }
-            });
+                });
 
             // Wait for all recipients
             let mut results = Vec::new();
@@ -254,14 +255,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register agents
             let mut agents = HashMap::new();
@@ -294,14 +295,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register agents
             let pk = Ed25519::from_seed(0).public_key();
@@ -331,14 +332,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register agents
             let pk = Ed25519::from_seed(0).public_key();
@@ -356,14 +357,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();
@@ -395,14 +396,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();
@@ -450,14 +451,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();
@@ -523,14 +524,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();
@@ -575,14 +576,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Define agents
             let pk1 = Ed25519::from_seed(0).public_key();
@@ -644,14 +645,14 @@ mod tests {
         executor.start(async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
-                runtime.clone(),
+                runtime.with_label("network"),
                 Config {
                     max_size: 1024 * 1024,
                 },
             );
 
             // Start network
-            runtime.spawn("network", network.run());
+            network.start();
 
             // Register agents
             let pk1 = Ed25519::from_seed(0).public_key();

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -15,8 +15,6 @@
 //! use commonware_p2p::simulated::{Config, Link, Network};
 //! use commonware_cryptography::{Ed25519, Scheme};
 //! use commonware_runtime::{deterministic::Executor, Spawner, Runner};
-//! use prometheus_client::registry::Registry;
-//! use std::sync::{Arc, Mutex};
 //!
 //! // Generate peers
 //! let peers = vec![
@@ -28,7 +26,6 @@
 //!
 //! // Configure network
 //! let p2p_cfg = Config {
-//!     registry: Arc::new(Mutex::new(Registry::with_prefix("p2p"))),
 //!     max_size: 1024 * 1024, // 1MB
 //! };
 //!

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -345,8 +345,8 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock + Metrics, P: A
     ///
     /// It is not necessary to invoke this method before modifying the network topology, however,
     /// no messages will be sent until this method is called.
-    pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+    pub fn start(mut self) -> Handle<()> {
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -10,7 +10,7 @@ use commonware_cryptography::Array;
 use commonware_macros::select;
 use commonware_runtime::{
     deterministic::{Listener, Sink, Stream},
-    Clock, Listener as _, Metrics, Network as RNetwork, Spawner,
+    Clock, Handle, Listener as _, Metrics, Network as RNetwork, Spawner,
 };
 use commonware_stream::utils::codec::{recv_frame, send_frame};
 use commonware_utils::SizedSerialize;
@@ -282,14 +282,13 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock + Metrics, P: A
             trace!(?origin, ?recipient, ?delay, "sending message",);
 
             // Send message
-            self.runtime.spawn("messenger", {
-                let runtime = self.runtime.clone();
+            self.runtime.with_label("messenger").spawn({
                 let message = message.clone();
                 let recipient = recipient.clone();
                 let origin = origin.clone();
                 let mut acquired_sender = acquired_sender.clone();
                 let received_messages = self.received_messages.clone();
-                async move {
+                move |runtime| async move {
                     // Mark as sent as soon as soon as execution starts
                     acquired_sender.send(()).await.unwrap();
 
@@ -326,25 +325,32 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock + Metrics, P: A
         }
 
         // Notify sender of successful sends
-        self.runtime.spawn("notifier", async move {
-            // Wait for semaphore to be acquired on all sends
-            for _ in 0..sent.len() {
-                acquired_receiver.next().await.unwrap();
-            }
+        self.runtime
+            .clone()
+            .with_label("notifier")
+            .spawn(|_| async move {
+                // Wait for semaphore to be acquired on all sends
+                for _ in 0..sent.len() {
+                    acquired_receiver.next().await.unwrap();
+                }
 
-            // Notify sender of successful sends
-            if let Err(err) = reply.send(sent) {
-                // This can only happen if the sender exited.
-                error!(?err, "failed to send ack");
-            }
-        });
+                // Notify sender of successful sends
+                if let Err(err) = reply.send(sent) {
+                    // This can only happen if the sender exited.
+                    error!(?err, "failed to send ack");
+                }
+            });
     }
 
     /// Run the simulated network.
     ///
     /// It is not necessary to invoke this method before modifying the network topology, however,
     /// no messages will be sent until this method is called.
-    pub async fn run(mut self) {
+    pub fn start(self) -> Handle<()> {
+        self.runtime.clone().spawn(|_| self.run())
+    }
+
+    async fn run(mut self) {
         loop {
             select! {
                 message = self.ingress.next() => {
@@ -380,7 +386,7 @@ pub struct Sender<P: Array> {
 
 impl<P: Array> Sender<P> {
     fn new(
-        runtime: impl Spawner,
+        runtime: impl Spawner + Metrics,
         me: P,
         channel: Channel,
         max_size: usize,
@@ -389,7 +395,7 @@ impl<P: Array> Sender<P> {
         // Listen for messages
         let (high, mut high_receiver) = mpsc::unbounded();
         let (low, mut low_receiver) = mpsc::unbounded();
-        runtime.spawn("sender", async move {
+        runtime.with_label("sender").spawn(move |_| async move {
             loop {
                 // Wait for task
                 let task;
@@ -486,7 +492,7 @@ impl<P: Array> Peer<P> {
     ///
     /// The peer will listen for incoming connections on the given `socket` address.
     /// `max_size` is the maximum size of a message that can be sent to the peer.
-    fn new<E: Spawner + RNetwork<Listener, Sink, Stream>>(
+    fn new<E: Spawner + RNetwork<Listener, Sink, Stream> + Metrics>(
         runtime: &mut E,
         public_key: P,
         socket: SocketAddr,
@@ -501,7 +507,7 @@ impl<P: Array> Peer<P> {
         let (inbox_sender, mut inbox_receiver) = mpsc::unbounded();
 
         // Spawn router
-        runtime.spawn("router", async move {
+        runtime.with_label("router").spawn(|_| async move {
             // Map of channels to mailboxes (senders to particular channels)
             let mut mailboxes = HashMap::new();
 
@@ -558,19 +564,18 @@ impl<P: Array> Peer<P> {
         });
 
         // Spawn a task that accepts new connections and spawns a task for each connection
-        runtime.spawn("listener", {
-            let runtime = runtime.clone();
+        runtime.with_label("listener").spawn({
             let inbox_sender = inbox_sender.clone();
-            async move {
+            move |runtime| async move {
                 // Initialize listener
                 let mut listener = runtime.bind(socket).await.unwrap();
 
                 // Continually accept new connections
                 while let Ok((_, _, mut stream)) = listener.accept().await {
                     // New connection accepted. Spawn a task for this connection
-                    runtime.spawn("receiver", {
+                    runtime.with_label("receiver").spawn({
                         let mut inbox_sender = inbox_sender.clone();
-                        async move {
+                        move |_| async move {
                             // Receive dialer's public key as a handshake
                             let dialer = match recv_frame(&mut stream, max_size).await {
                                 Ok(data) => data,
@@ -635,7 +640,7 @@ struct Link {
 }
 
 impl Link {
-    fn new<E: Spawner + RNetwork<Listener, Sink, Stream>, P: Array>(
+    fn new<E: Spawner + RNetwork<Listener, Sink, Stream> + Metrics, P: Array>(
         runtime: &mut E,
         dialer: P,
         socket: SocketAddr,
@@ -652,9 +657,10 @@ impl Link {
 
         // Spawn a task that will wait for messages to be sent to the link and then send them
         // over the network.
-        runtime.spawn("link", {
-            let runtime = runtime.clone();
-            async move {
+        runtime
+            .clone()
+            .with_label("link")
+            .spawn(move |runtime| async move {
                 // Dial the peer and handshake by sending it the dialer's public key
                 let (mut sink, _) = runtime.dial(socket).await.unwrap();
                 if let Err(err) = send_frame(&mut sink, &dialer, max_size).await {
@@ -671,8 +677,7 @@ impl Link {
                     let data = data.freeze();
                     send_frame(&mut sink, &data, max_size).await.unwrap();
                 }
-            }
-        });
+            });
 
         result
     }
@@ -705,8 +710,9 @@ mod tests {
             let cfg = Config {
                 max_size: MAX_MESSAGE_SIZE,
             };
-            let (network, mut oracle) = Network::new(runtime.clone(), cfg);
-            runtime.spawn("network", network.run());
+            let network_runtime = runtime.with_label("network");
+            let (network, mut oracle) = Network::new(network_runtime.clone(), cfg);
+            network_runtime.spawn(|_| network.run());
 
             // Create two public keys
             let pk1 = Ed25519::from_seed(1).public_key();

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -22,7 +22,7 @@
 //! println!("Auditor state: {}", auditor.state());
 //! ```
 
-use crate::{mocks, utils::Signaler, Clock, Error, Handle, Signal};
+use crate::{mocks, utils::Signaler, Clock, Error, Handle, Signal, METRICS_PREFIX};
 use commonware_utils::{hex, SystemTimeExt};
 use futures::{
     channel::mpsc,
@@ -55,9 +55,6 @@ const EPHEMERAL_PORT_RANGE: Range<u16> = 32768..61000;
 
 /// Label for root task created during `Runner::start`.
 const ROOT_TASK: &str = "root";
-
-/// Prefix for runtime metrics.
-const METRICS_PREFIX: &str = "runtime";
 
 /// Map of names to blob contents.
 pub type Partition = HashMap<Vec<u8>, Vec<u8>>;
@@ -1319,6 +1316,9 @@ impl crate::Metrics for Context {
         };
         if label == ROOT_TASK {
             panic!("root task cannot be spawned");
+        }
+        if label.starts_with(METRICS_PREFIX) {
+            panic!("using runtime label is not allowed");
         }
         Self {
             label,

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -7,12 +7,12 @@
 //! # Example
 //!
 //! ```rust
-//! use commonware_runtime::{Spawner, Runner, deterministic::Executor};
+//! use commonware_runtime::{Spawner, Runner, deterministic::Executor, Metrics};
 //!
 //! let (executor, runtime, auditor) = Executor::default();
 //! executor.start(async move {
 //!     println!("Parent started");
-//!     let result = runtime.spawn("child", async move {
+//!     let result = runtime.with_label("child").spawn(|_| async move {
 //!         println!("Child started");
 //!         "hello"
 //!     });

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -57,7 +57,7 @@ const EPHEMERAL_PORT_RANGE: Range<u16> = 32768..61000;
 const ROOT_TASK: &str = "root";
 
 /// Prefix for runtime metrics.
-const RUNTIME_METRICS_PREFIX: &str = "runtime";
+const RUNTIME_METRICS_PREFIX: &str = "runtime_deterministic";
 
 /// Map of names to blob contents.
 pub type Partition = HashMap<Vec<u8>, Vec<u8>>;

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -12,7 +12,7 @@
 //! let (executor, context, auditor) = Executor::default();
 //! executor.start(async move {
 //!     println!("Parent started");
-//!     let result = runtime.with_label("child").spawn(|_| async move {
+//!     let result = context.with_label("child").spawn(|_| async move {
 //!         println!("Child started");
 //!         "hello"
 //!     });

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1314,12 +1314,11 @@ impl crate::Metrics for Context {
                 format!("{}_{}", prefix, label)
             }
         };
-        if label == ROOT_TASK {
-            panic!("root task cannot be spawned");
-        }
-        if label.starts_with(METRICS_PREFIX) {
-            panic!("using runtime label is not allowed");
-        }
+        assert_ne!(label, ROOT_TASK, "root task cannot be spawned");
+        assert!(
+            !label.starts_with(METRICS_PREFIX),
+            "using runtime label is not allowed"
+        );
         Self {
             label,
             executor: self.executor.clone(),

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -57,7 +57,7 @@ const EPHEMERAL_PORT_RANGE: Range<u16> = 32768..61000;
 const ROOT_TASK: &str = "root";
 
 /// Prefix for runtime metrics.
-const RUNTIME_METRICS_PREFIX: &str = "runtime_deterministic";
+const METRICS_PREFIX: &str = "runtime";
 
 /// Map of names to blob contents.
 pub type Partition = HashMap<Vec<u8>, Vec<u8>>;
@@ -483,7 +483,7 @@ impl Executor {
 
         // Create a new registry
         let mut registry = Registry::default();
-        let runtime_registry = registry.sub_registry_with_prefix(RUNTIME_METRICS_PREFIX);
+        let runtime_registry = registry.sub_registry_with_prefix(METRICS_PREFIX);
 
         // Initialize runtime
         let metrics = Arc::new(Metrics::init(runtime_registry));
@@ -761,7 +761,7 @@ impl Context {
 
         // Rebuild metrics
         let mut registry = Registry::default();
-        let runtime_registry = registry.sub_registry_with_prefix(RUNTIME_METRICS_PREFIX);
+        let runtime_registry = registry.sub_registry_with_prefix(METRICS_PREFIX);
         let metrics = Arc::new(Metrics::init(runtime_registry));
 
         // Copy state

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -462,7 +462,6 @@ pub struct Executor {
     metrics: Arc<Metrics>,
     auditor: Arc<Auditor>,
     rng: Mutex<StdRng>,
-    prefix: Mutex<String>,
     time: Mutex<SystemTime>,
     tasks: Arc<Tasks>,
     sleeping: Mutex<BinaryHeap<Alarm>>,
@@ -500,7 +499,6 @@ impl Executor {
             metrics: metrics.clone(),
             auditor: auditor.clone(),
             rng: Mutex::new(StdRng::seed_from_u64(cfg.seed)),
-            prefix: Mutex::new(String::new()),
             time: Mutex::new(start_time),
             tasks: Arc::new(Tasks {
                 queue: Mutex::new(Vec::new()),
@@ -518,6 +516,7 @@ impl Executor {
                 executor: executor.clone(),
             },
             Context {
+                label: String::new(),
                 executor,
                 networking: Arc::new(Networking::new(metrics, auditor.clone())),
             },
@@ -607,12 +606,6 @@ impl crate::Runner for Runner {
             // processing a different task required for other tasks to make progress).
             trace!(iter, tasks = tasks.len(), "starting loop");
             for task in tasks {
-                // Set current task prefix
-                {
-                    let mut prefix = self.executor.prefix.lock().unwrap();
-                    prefix.clone_from(&task.label);
-                }
-
                 // Record task for auditing
                 self.executor.auditor.process_task(task.id, &task.label);
 
@@ -728,6 +721,7 @@ impl crate::Runner for Runner {
 /// runtime.
 #[derive(Clone)]
 pub struct Context {
+    label: String,
     executor: Arc<Executor>,
     networking: Arc<Networking>,
 }
@@ -779,7 +773,6 @@ impl Context {
             // New state for the new runtime
             registry: Mutex::new(registry),
             metrics: metrics.clone(),
-            prefix: Mutex::new(String::new()),
             tasks: Arc::new(Tasks {
                 queue: Mutex::new(Vec::new()),
                 counter: Mutex::new(0),
@@ -795,6 +788,7 @@ impl Context {
                 executor: executor.clone(),
             },
             Self {
+                label: String::new(),
                 executor,
                 networking: Arc::new(Networking::new(metrics, auditor.clone())),
             },
@@ -804,24 +798,16 @@ impl Context {
 }
 
 impl crate::Spawner for Context {
-    fn spawn<F, T>(&self, label: &str, f: F) -> Handle<T>
+    fn spawn<F, Fut, T>(self, f: F) -> Handle<T>
     where
-        F: Future<Output = T> + Send + 'static,
+        F: FnOnce(Self) -> Fut + Send + 'static,
+        Fut: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
-        let label = {
-            let prefix = self.executor.prefix.lock().unwrap();
-            if prefix.is_empty() || *prefix == ROOT_TASK {
-                label.to_string()
-            } else {
-                format!("{}_{}", *prefix, label)
-            }
-        };
-        if label == ROOT_TASK {
-            panic!("root task cannot be spawned");
-        }
+        let executor = self.executor.clone();
+        let label = self.label.clone();
         let work = Work {
-            label: label.clone(),
+            label: self.label.clone(),
         };
         self.executor
             .metrics
@@ -834,8 +820,9 @@ impl crate::Spawner for Context {
             .tasks_running
             .get_or_create(&work)
             .clone();
-        let (f, handle) = Handle::init(f, gauge, false);
-        Tasks::register(&self.executor.tasks, &label, false, Box::pin(f));
+        let future = f(self);
+        let (f, handle) = Handle::init(future, gauge, false);
+        Tasks::register(&executor.tasks, &label, false, Box::pin(f));
         handle
     }
 
@@ -1321,6 +1308,25 @@ impl Drop for Blob {
 }
 
 impl crate::Metrics for Context {
+    fn with_label(&self, label: &str) -> Self {
+        let label = {
+            let prefix = self.label.clone();
+            if prefix.is_empty() || prefix == ROOT_TASK {
+                label.to_string()
+            } else {
+                format!("{}_{}", prefix, label)
+            }
+        };
+        if label == ROOT_TASK {
+            panic!("root task cannot be spawned");
+        }
+        Self {
+            label,
+            executor: self.executor.clone(),
+            networking: self.networking.clone(),
+        }
+    }
+
     fn register<N: Into<String>, H: Into<String>>(&self, name: N, help: H, metric: impl Metric) {
         // Prepare args
         let name = name.into();
@@ -1329,7 +1335,7 @@ impl crate::Metrics for Context {
         // Register metric
         self.executor.auditor.register(&name, &help);
         let prefixed_name = {
-            let prefix = self.executor.prefix.lock().unwrap();
+            let prefix = &self.label;
             if prefix.is_empty() {
                 name
             } else {
@@ -1354,7 +1360,7 @@ impl crate::Metrics for Context {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{utils::run_tasks, Blob, Runner, Spawner, Storage};
+    use crate::{utils::run_tasks, Blob, Metrics, Runner, Storage};
     use commonware_macros::test_traced;
     use futures::task::noop_waker;
 
@@ -1455,16 +1461,9 @@ mod tests {
     #[test]
     #[should_panic(expected = "root task cannot be spawned")]
     fn test_spawn_root_task() {
-        let (executor, context, _) = Executor::default();
-        executor.start(async move {
-            let _ = context
-                .spawn(ROOT_TASK, async move {
-                    // This task should never run
-                    panic!("root task should not run");
-                })
-                .await;
-            panic!("root task should not be spawned");
-        });
+        let (_, context, _) = Executor::default();
+        context.with_label(ROOT_TASK);
+        panic!("using root_task should not be possible");
     }
 
     #[test]

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1327,6 +1327,10 @@ impl crate::Metrics for Context {
         }
     }
 
+    fn label(&self) -> String {
+        self.label.clone()
+    }
+
     fn register<N: Into<String>, H: Into<String>>(&self, name: N, help: H, metric: impl Metric) {
         // Prepare args
         let name = name.into();

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -9,7 +9,7 @@
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, deterministic::Executor, Metrics};
 //!
-//! let (executor, runtime, auditor) = Executor::default();
+//! let (executor, context, auditor) = Executor::default();
 //! executor.start(async move {
 //!     println!("Parent started");
 //!     let result = runtime.with_label("child").spawn(|_| async move {
@@ -1369,8 +1369,8 @@ mod tests {
     use futures::task::noop_waker;
 
     fn run_with_seed(seed: u64) -> (String, Vec<usize>) {
-        let (executor, runtime, auditor) = Executor::seeded(seed);
-        let messages = run_tasks(5, executor, runtime);
+        let (executor, context, auditor) = Executor::seeded(seed);
+        let messages = run_tasks(5, executor, context);
         (auditor.state(), messages)
     }
 
@@ -1443,10 +1443,10 @@ mod tests {
     #[test]
     #[should_panic(expected = "runtime timeout")]
     fn test_timeout() {
-        let (executor, runtime, _) = Executor::timed(Duration::from_secs(10));
+        let (executor, context, _) = Executor::timed(Duration::from_secs(10));
         executor.start(async move {
             loop {
-                runtime.sleep(Duration::from_secs(1)).await;
+                context.sleep(Duration::from_secs(1)).await;
             }
         });
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -11,6 +11,7 @@
 //! `commonware-runtime` is **ALPHA** software and is not yet recommended for production use. Developers should
 //! expect breaking changes and occasional instability.
 
+use prometheus_client::registry::Metric;
 use std::{
     future::Future,
     net::SocketAddr,
@@ -237,6 +238,11 @@ pub trait Blob: Clone + Send + Sync + 'static {
 
     /// Close the blob.
     fn close(self) -> impl Future<Output = Result<(), Error>> + Send;
+}
+
+pub trait Metrics: Clone + Send + Sync + 'static {
+    fn register<N: Into<String>, H: Into<String>>(&self, name: N, help: H, metric: impl Metric);
+    fn encode(&self) -> String;
 }
 
 #[cfg(test)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -84,9 +84,9 @@ pub trait Runner {
 }
 
 /// Interface that any task scheduler must implement to spawn
-/// sub-tasks in a given root task.
+/// tasks from a given root task.
 pub trait Spawner: Clone + Send + Sync + 'static {
-    /// Enqueues a task to be executed.
+    /// Enqueue a task to be executed.
     ///
     /// Unlike a future, a spawned task will start executing immediately (even if the caller
     /// does not await the handle).
@@ -118,7 +118,7 @@ pub trait Metrics: Clone + Send + Sync + 'static {
 
     /// Register a metric with the runtime.
     ///
-    /// Any metric registered will automatically include the prefix of the current context's label.
+    /// Any metric registered will automatically include ...
     fn register<N: Into<String>, H: Into<String>>(&self, name: N, help: H, metric: impl Metric);
 
     /// Encode all metrics into a buffer.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -95,8 +95,7 @@ pub trait Runner {
         F::Output: Send + 'static;
 }
 
-/// Interface that any task scheduler must implement to spawn
-/// tasks.
+/// Interface that any task scheduler must implement to spawn tasks.
 pub trait Spawner: Clone + Send + Sync + 'static {
     /// Enqueue a task to be executed.
     ///
@@ -148,7 +147,7 @@ pub trait Metrics: Clone + Send + Sync + 'static {
     /// Create a new instance of `Metrics` with the given label appended to the end
     /// of the current `Metrics` label.
     ///
-    /// This is commonly used to create nested context for `register`.
+    /// This is commonly used to create a nested context for `register`.
     ///
     /// It is not permitted for any implementation to use `METRICS_PREFIX` as the start of a
     /// label (reserved for metrics for the runtime).
@@ -839,7 +838,6 @@ mod tests {
 
             // Encode metrics
             let buffer = context.encode();
-            println!("{}", buffer);
             assert!(buffer.contains("test_total 1"));
 
             // Nested context
@@ -860,7 +858,6 @@ mod tests {
     fn test_metrics_label(runner: impl Runner, context: impl Spawner + Metrics) {
         runner.start(async move {
             context.with_label(METRICS_PREFIX);
-            panic!("should not be possible to create a context with the METRICS_PREFIX");
         })
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -820,7 +820,6 @@ mod tests {
 
             // Ensure context is consumed
             context.spawn(|_| async move { 42 });
-            panic!("should not be possible to spawn a task with the same context");
         });
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -736,7 +736,6 @@ mod tests {
         runner.start(async move {
             // Spawn a task that waits for signal
             let before = context
-                .clone()
                 .with_label("before")
                 .spawn(move |context| async move {
                     let sig = context.stopped().await;
@@ -745,7 +744,6 @@ mod tests {
 
             // Spawn a task after stop is called
             let after = context
-                .clone()
                 .with_label("after")
                 .spawn(move |context| async move {
                     // Wait for stop signal

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,6 +6,12 @@
 //! For testing and simulation, the `deterministic` module provides a runtime
 //! that allows for deterministic execution of tasks (given a fixed seed).
 //!
+//! # Terminology
+//!
+//! Each runtime is typically composed of a `Runner` and a `Context`. The `Runner` is used
+//! to start the execution of a runtime and the `Context` implements any number of the traits
+//! defined in this crate.
+//!
 //! # Status
 //!
 //! `commonware-runtime` is **ALPHA** software and is not yet recommended for production use. Developers should

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn test_send_error() {
         let (mut sink, mut stream) = Channel::init();
-        let (executor, runtime, _) = Executor::default();
+        let (executor, context, _) = Executor::default();
 
         // If the waiter value has a min, but the oneshot receiver is dropped,
         // the send function should return an error when attempting to send the data.
@@ -195,7 +195,7 @@ mod tests {
                 v = stream.recv(&mut buf) => {
                     panic!("unexpected value: {:?}", v);
                 },
-                _ = runtime.sleep(Duration::from_millis(100)) => {
+                _ = context.sleep(Duration::from_millis(100)) => {
                     "timeout"
                 },
             };
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn test_recv_timeout() {
         let (_sink, mut stream) = Channel::init();
-        let (executor, runtime, _) = Executor::default();
+        let (executor, context, _) = Executor::default();
 
         // If there is no data to read, test that the recv function just blocks. A timeout should return first.
         executor.start(async move {
@@ -219,7 +219,7 @@ mod tests {
                 v = stream.recv(&mut buf) => {
                     panic!("unexpected value: {:?}", v);
                 },
-                _ = runtime.sleep(Duration::from_millis(100)) => {
+                _ = context.sleep(Duration::from_millis(100)) => {
                     "timeout"
                 },
             };

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -731,9 +731,10 @@ impl crate::Metrics for Context {
                 format!("{}_{}", prefix, label)
             }
         };
-        if label.starts_with(METRICS_PREFIX) {
-            panic!("using runtime label is not allowed");
-        }
+        assert!(
+            !label.starts_with(METRICS_PREFIX),
+            "using runtime label is not allowed"
+        );
         Self {
             label,
             executor: self.executor.clone(),

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -9,12 +9,12 @@
 //! # Example
 //!
 //! ```rust
-//! use commonware_runtime::{Spawner, Runner, tokio::Executor};
+//! use commonware_runtime::{Spawner, Runner, tokio::Executor, Metrics};
 //!
 //! let (executor, runtime) = Executor::default();
 //! executor.start(async move {
 //!     println!("Parent started");
-//!     let result = runtime.spawn("child", async move {
+//!     let result = runtime.with_label("child").spawn(|_| async move {
 //!         println!("Child started");
 //!         "hello"
 //!     });

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -740,6 +740,10 @@ impl crate::Metrics for Context {
         }
     }
 
+    fn label(&self) -> String {
+        self.label.clone()
+    }
+
     fn register<N: Into<String>, H: Into<String>>(&self, name: N, help: H, metric: impl Metric) {
         let name = name.into();
         let prefixed_name = {

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -53,7 +53,7 @@ use tokio::{
 use tracing::warn;
 
 /// Prefix for runtime metrics.
-const RUNTIME_METRICS_PREFIX: &str = "runtime_tokio";
+const METRICS_PREFIX: &str = "runtime";
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct Work {
@@ -224,7 +224,7 @@ impl Executor {
     pub fn init(cfg: Config) -> (Runner, Context) {
         // Create a new registry
         let mut registry = Registry::default();
-        let runtime_registry = registry.sub_registry_with_prefix(RUNTIME_METRICS_PREFIX);
+        let runtime_registry = registry.sub_registry_with_prefix(METRICS_PREFIX);
 
         // Initialize runtime
         let metrics = Arc::new(Metrics::init(runtime_registry));

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -23,7 +23,7 @@
 //! });
 //! ```
 
-use crate::{utils::Signaler, Clock, Error, Handle, Signal};
+use crate::{utils::Signaler, Clock, Error, Handle, Signal, METRICS_PREFIX};
 use commonware_utils::{from_hex, hex};
 use governor::clock::{Clock as GClock, ReasonablyRealtime};
 use prometheus_client::{
@@ -50,9 +50,6 @@ use tokio::{
     time::timeout,
 };
 use tracing::warn;
-
-/// Prefix for runtime metrics.
-const METRICS_PREFIX: &str = "runtime";
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct Work {
@@ -734,6 +731,9 @@ impl crate::Metrics for Context {
                 format!("{}_{}", prefix, label)
             }
         };
+        if label.starts_with(METRICS_PREFIX) {
+            panic!("using runtime label is not allowed");
+        }
         Self {
             label,
             executor: self.executor.clone(),

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -214,7 +214,7 @@ pub type Signal = Shared<oneshot::Receiver<i32>>;
 ///                      sig = &mut signal => {
 ///                          println!("Received signal: {}", sig.unwrap());
 ///                          break;
-///                      },   
+///                      },
 ///                      _ = context.sleep(Duration::from_secs(1)) => {},
 ///                 };
 ///             }
@@ -263,10 +263,9 @@ pub fn run_tasks(tasks: usize, runner: impl Runner, context: impl Spawner) -> Ve
     runner.start(async move {
         // Randomly schedule tasks
         let mut handles = FuturesUnordered::new();
-        for i in 0..tasks - 1 {
-            handles.push(context.spawn("test", task(i)));
+        for i in 0..=tasks - 1 {
+            handles.push(context.clone().spawn(move |_| task(i)));
         }
-        handles.push(context.spawn("test", task(tasks - 1)));
 
         // Collect output order
         let mut outputs = Vec::new();

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -194,7 +194,7 @@ pub type Signal = Shared<oneshot::Receiver<i32>>;
 ///
 /// ```rust
 /// use commonware_macros::select;
-/// use commonware_runtime::{Clock, Spawner, Runner, Signaler, deterministic::Executor};
+/// use commonware_runtime::{Clock, Spawner, Runner, Signaler, deterministic::Executor, Metrics};
 /// use futures::channel::oneshot;
 /// use std::time::Duration;
 ///
@@ -205,21 +205,18 @@ pub type Signal = Shared<oneshot::Receiver<i32>>;
 ///
 ///     // Loop on the signal until resolved
 ///     let (tx, rx) = oneshot::channel();
-///     context.spawn("task", {
-///         let context = context.clone();
-///         async move {
-///             loop {
-///                 // Wait for signal or sleep
-///                 select! {
-///                      sig = &mut signal => {
-///                          println!("Received signal: {}", sig.unwrap());
-///                          break;
-///                      },
-///                      _ = context.sleep(Duration::from_secs(1)) => {},
-///                 };
-///             }
-///             let _ = tx.send(());
+///     context.with_label("waiter").spawn(|context| async move {
+///         loop {
+///             // Wait for signal or sleep
+///             select! {
+///                  sig = &mut signal => {
+///                      println!("Received signal: {}", sig.unwrap());
+///                      break;
+///                  },
+///                  _ = context.sleep(Duration::from_secs(1)) => {},
+///             };
 ///         }
+///         let _ = tx.send(());
 ///     });
 ///
 ///     // Send signal

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -113,21 +113,17 @@
 //! use commonware_runtime::{Spawner, Runner, deterministic::Executor};
 //! use commonware_storage::archive::{Archive, Config, translator::FourCap};
 //! use commonware_storage::journal::{Error, variable::{Config as JConfig, Journal}};
-//! use prometheus_client::registry::Registry;
-//! use std::sync::{Arc, Mutex};
 //!
 //! let (executor, context, _) = Executor::default();
 //! executor.start(async move {
 //!     // Create a journal
 //!     let cfg = JConfig {
-//!         registry: Arc::new(Mutex::new(Registry::default())),
 //!         partition: "partition".to_string()
 //!     };
-//!     let journal = Journal::init(context, cfg).await.unwrap();
+//!     let journal = Journal::init(context.clone(), cfg).await.unwrap();
 //!
 //!     // Create an archive
 //!     let cfg = Config {
-//!         registry: Arc::new(Mutex::new(Registry::default())),
 //!         key_len: 8,
 //!         translator: FourCap,
 //!         section_mask: 0xffff_ffff_ffff_0000u64,
@@ -135,7 +131,7 @@
 //!         replay_concurrency: 4,
 //!         compression: Some(3),
 //!     };
-//!     let mut archive = Archive::init(journal, cfg).await.unwrap();
+//!     let mut archive = Archive::init(context, journal, cfg).await.unwrap();
 //!
 //!     // Put a key
 //!     archive.put(1, b"test-key", "data".into()).await.unwrap();

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -149,11 +149,7 @@ mod storage;
 pub use storage::{Archive, Identifier};
 pub mod translator;
 
-use prometheus_client::registry::Registry;
-use std::{
-    hash::Hash,
-    sync::{Arc, Mutex},
-};
+use std::hash::Hash;
 use thiserror::Error;
 
 /// Errors that can occur when interacting with the archive.
@@ -192,9 +188,6 @@ pub trait Translator: Clone {
 /// Configuration for `Archive` storage.
 #[derive(Clone)]
 pub struct Config<T: Translator> {
-    /// Registry for metrics.
-    pub registry: Arc<Mutex<Registry>>,
-
     /// Mask to apply to indices to determine section.
     ///
     /// This value is `index & section_mask`.
@@ -233,13 +226,10 @@ mod tests {
     use crate::journal::Error as JournalError;
     use bytes::Bytes;
     use commonware_macros::test_traced;
+    use commonware_runtime::Metrics;
     use commonware_runtime::{deterministic::Executor, Blob, Runner, Storage};
-    use prometheus_client::{encoding::text::encode, registry::Registry};
     use rand::Rng;
-    use std::{
-        collections::BTreeMap,
-        sync::{Arc, Mutex},
-    };
+    use std::collections::BTreeMap;
     use translator::{FourCap, TwoCap};
 
     const DEFAULT_SECTION_MASK: u64 = 0xffff_ffff_ffff_0000u64;
@@ -248,14 +238,10 @@ mod tests {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
         executor.start(async move {
-            // Create a registry for metrics
-            let registry = Arc::new(Mutex::new(Registry::default()));
-
             // Initialize an empty journal
             let journal = Journal::init(
-                context,
+                context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
@@ -264,7 +250,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry,
                 key_len: 7,
                 translator: FourCap,
                 pending_writes: 10,
@@ -272,7 +257,7 @@ mod tests {
                 compression,
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -325,8 +310,7 @@ mod tests {
             assert_eq!(retrieved, data);
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             assert!(buffer.contains("items_tracked 1"));
             assert!(buffer.contains("unnecessary_reads_total 0"));
             assert!(buffer.contains("gets_total 2"));
@@ -337,8 +321,7 @@ mod tests {
             archive.sync().await.expect("Failed to sync data");
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             assert!(buffer.contains("items_tracked 1"));
             assert!(buffer.contains("unnecessary_reads_total 0"));
             assert!(buffer.contains("gets_total 2"));
@@ -366,7 +349,6 @@ mod tests {
             let journal = Journal::init(
                 context.clone(),
                 JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: "test_partition".into(),
                 },
             )
@@ -375,7 +357,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 key_len: 7,
                 translator: FourCap,
                 pending_writes: 10,
@@ -383,7 +364,7 @@ mod tests {
                 compression: Some(3),
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -401,16 +382,14 @@ mod tests {
 
             // Initialize the archive again without compression
             let journal = Journal::init(
-                context,
+                context.clone(),
                 JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: "test_partition".into(),
                 },
             )
             .await
             .expect("Failed to initialize journal");
             let cfg = Config {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 key_len: 7,
                 translator: FourCap,
                 pending_writes: 10,
@@ -418,7 +397,7 @@ mod tests {
                 compression: None,
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let archive = Archive::init(journal, cfg.clone())
+            let archive = Archive::init(context, journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -443,14 +422,10 @@ mod tests {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
         executor.start(async move {
-            // Create a registry for metrics
-            let registry = Arc::new(Mutex::new(Registry::default()));
-
             // Initialize an empty journal
             let journal = Journal::init(
-                context,
+                context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
@@ -459,7 +434,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry,
                 key_len: 8,
                 translator: FourCap,
                 pending_writes: 10,
@@ -467,7 +441,7 @@ mod tests {
                 compression: None,
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -488,8 +462,7 @@ mod tests {
             assert!(matches!(result, Err(Error::InvalidKeyLength)));
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             assert!(buffer.contains("items_tracked 0"));
             assert!(buffer.contains("unnecessary_reads_total 0"));
             assert!(buffer.contains("gets_total 0"));
@@ -505,7 +478,6 @@ mod tests {
             let journal = Journal::init(
                 context.clone(),
                 JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: "test_partition".into(),
                 },
             )
@@ -514,7 +486,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry: Arc::new(Mutex::new(Registry::default())),
                 key_len: 7,
                 translator: FourCap,
                 pending_writes: 10,
@@ -522,7 +493,7 @@ mod tests {
                 compression: None,
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -551,18 +522,17 @@ mod tests {
 
             // Initialize the archive again
             let journal = Journal::init(
-                context,
+                context.clone(),
                 JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: "test_partition".into(),
                 },
             )
             .await
             .expect("Failed to initialize journal");
             let archive = Archive::init(
+                context,
                 journal,
                 Config {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     key_len: 7,
                     translator: FourCap,
                     pending_writes: 10,
@@ -588,14 +558,10 @@ mod tests {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
         executor.start(async move {
-            // Create a registry for metrics
-            let registry = Arc::new(Mutex::new(Registry::default()));
-
             // Initialize an empty journal
             let journal = Journal::init(
-                context,
+                context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
@@ -604,7 +570,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry,
                 key_len: 9,
                 translator: FourCap,
                 pending_writes: 10,
@@ -612,7 +577,7 @@ mod tests {
                 compression: None,
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -646,8 +611,7 @@ mod tests {
             assert_eq!(retrieved, data1);
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             assert!(buffer.contains("items_tracked 1"));
             assert!(buffer.contains("unnecessary_reads_total 0"));
             assert!(buffer.contains("gets_total 2"));
@@ -659,14 +623,10 @@ mod tests {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
         executor.start(async move {
-            // Create a registry for metrics
-            let registry = Arc::new(Mutex::new(Registry::default()));
-
             // Initialize an empty journal
             let journal = Journal::init(
-                context,
+                context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
@@ -675,7 +635,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry,
                 key_len: 11,
                 translator: FourCap,
                 pending_writes: 10,
@@ -683,7 +642,7 @@ mod tests {
                 compression: None,
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let archive = Archive::init(journal, cfg.clone())
+            let archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -704,8 +663,7 @@ mod tests {
             assert!(retrieved.is_none());
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             assert!(buffer.contains("items_tracked 0"));
             assert!(buffer.contains("unnecessary_reads_total 0"));
             assert!(buffer.contains("gets_total 2"));
@@ -717,14 +675,10 @@ mod tests {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
         executor.start(async move {
-            // Create a registry for metrics
-            let registry = Arc::new(Mutex::new(Registry::default()));
-
             // Initialize an empty journal
             let journal = Journal::init(
-                context,
+                context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
@@ -733,7 +687,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry,
                 key_len: 5,
                 translator: FourCap,
                 pending_writes: 10,
@@ -741,7 +694,7 @@ mod tests {
                 compression: None,
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -781,8 +734,7 @@ mod tests {
             assert_eq!(retrieved, data2);
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             assert!(buffer.contains("items_tracked 2"));
             assert!(buffer.contains("unnecessary_reads_total 1"));
             assert!(buffer.contains("gets_total 2"));
@@ -794,14 +746,10 @@ mod tests {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
         executor.start(async move {
-            // Create a registry for metrics
-            let registry = Arc::new(Mutex::new(Registry::default()));
-
             // Initialize an empty journal
             let journal = Journal::init(
-                context,
+                context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
@@ -810,7 +758,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry,
                 key_len: 5,
                 translator: FourCap,
                 pending_writes: 10,
@@ -818,7 +765,7 @@ mod tests {
                 compression: None,
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -864,14 +811,10 @@ mod tests {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
         executor.start(async move {
-            // Create a registry for metrics
-            let registry = Arc::new(Mutex::new(Registry::default()));
-
             // Initialize an empty journal
             let journal = Journal::init(
                 context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
@@ -880,7 +823,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry: registry.clone(),
                 key_len: 9,
                 translator: FourCap,
                 pending_writes: 10,
@@ -888,7 +830,7 @@ mod tests {
                 compression: None,
                 section_mask: 0xffff_ffff_ffff_ffffu64, // no mask
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -909,8 +851,7 @@ mod tests {
             }
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             assert!(buffer.contains("items_tracked 5"));
 
             // Prune sections less than 3
@@ -930,8 +871,7 @@ mod tests {
             }
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             assert!(buffer.contains("items_tracked 3"));
             assert!(buffer.contains("indices_pruned_total 2"));
             assert!(buffer.contains("keys_pruned_total 0")); // no lazy cleanup yet
@@ -955,8 +895,7 @@ mod tests {
                 .expect("Failed to put data");
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             assert!(buffer.contains("items_tracked 4")); // lazily remove one, add one
             assert!(buffer.contains("indices_pruned_total 2"));
             assert!(buffer.contains("keys_pruned_total 1"));
@@ -967,14 +906,10 @@ mod tests {
         // Initialize the deterministic runtime
         let (executor, mut context, auditor) = Executor::default();
         executor.start(async move {
-            // Create a registry for metrics
-            let registry = Arc::new(Mutex::new(Registry::default()));
-
             // Initialize an empty journal
             let journal = Journal::init(
                 context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
@@ -984,7 +919,6 @@ mod tests {
             // Initialize the archive
             let section_mask = 0xffff_ffff_ffff_ff00u64;
             let cfg = Config {
-                registry: registry.clone(),
                 key_len: 32,
                 translator: TwoCap,
                 pending_writes: 10,
@@ -992,7 +926,7 @@ mod tests {
                 compression: None,
                 section_mask,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -1029,8 +963,7 @@ mod tests {
             }
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             let tracked = format!("items_tracked {:?}", num_keys);
             assert!(buffer.contains(&tracked));
             assert!(buffer.contains("keys_pruned_total 0"));
@@ -1039,18 +972,15 @@ mod tests {
             archive.close().await.expect("Failed to close archive");
 
             // Reinitialize the archive
-            let registry = Arc::new(Mutex::new(Registry::default()));
             let journal = Journal::init(
                 context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
             .await
             .expect("Failed to initialize journal");
             let cfg = Config {
-                registry: registry.clone(),
                 key_len: 32,
                 translator: TwoCap,
                 pending_writes: 10,
@@ -1058,7 +988,7 @@ mod tests {
                 compression: None,
                 section_mask,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -1114,8 +1044,7 @@ mod tests {
             }
 
             // Check metrics
-            let mut buffer = String::new();
-            encode(&mut buffer, &cfg.registry.lock().unwrap()).unwrap();
+            let buffer = context.encode();
             let tracked = format!("items_tracked {:?}", num_keys - removed);
             assert!(buffer.contains(&tracked));
             let pruned = format!("indices_pruned_total {}", removed);
@@ -1142,14 +1071,10 @@ mod tests {
         // Initialize the deterministic runtime
         let (executor, context, _) = Executor::default();
         executor.start(async move {
-            // Create a registry for metrics
-            let registry = Arc::new(Mutex::new(Registry::default()));
-
             // Initialize an empty journal
             let journal = Journal::init(
                 context.clone(),
                 JConfig {
-                    registry: registry.clone(),
                     partition: "test_partition".into(),
                 },
             )
@@ -1158,7 +1083,6 @@ mod tests {
 
             // Initialize the archive
             let cfg = Config {
-                registry,
                 key_len: 9,
                 translator: FourCap,
                 pending_writes: 10,
@@ -1166,7 +1090,7 @@ mod tests {
                 compression: None,
                 section_mask: DEFAULT_SECTION_MASK,
             };
-            let mut archive = Archive::init(journal, cfg.clone())
+            let mut archive = Archive::init(context.clone(), journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 
@@ -1213,15 +1137,14 @@ mod tests {
             archive.close().await.expect("Failed to close archive");
 
             let journal = Journal::init(
-                context,
+                context.clone(),
                 JConfig {
-                    registry: Arc::new(Mutex::new(Registry::default())),
                     partition: "test_partition".into(),
                 },
             )
             .await
             .expect("Failed to initialize journal");
-            let archive = Archive::init(journal, cfg.clone())
+            let archive = Archive::init(context, journal, cfg.clone())
                 .await
                 .expect("Failed to initialize archive");
 

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -231,7 +231,7 @@ mod tests {
     const DEFAULT_SECTION_MASK: u64 = 0xffff_ffff_ffff_0000u64;
 
     fn test_archive_put_get(compression: Option<u8>) {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -338,7 +338,7 @@ mod tests {
 
     #[test_traced]
     fn test_archive_compression_then_none() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -415,7 +415,7 @@ mod tests {
 
     #[test_traced]
     fn test_archive_invalid_key_length() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -467,7 +467,7 @@ mod tests {
 
     #[test_traced]
     fn test_archive_record_corruption() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -551,7 +551,7 @@ mod tests {
 
     #[test_traced]
     fn test_archive_duplicate_key() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -616,7 +616,7 @@ mod tests {
 
     #[test_traced]
     fn test_archive_get_nonexistent() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -668,7 +668,7 @@ mod tests {
 
     #[test_traced]
     fn test_archive_overlapping_key() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -739,7 +739,7 @@ mod tests {
 
     #[test_traced]
     fn test_archive_overlapping_key_multiple_sections() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -804,7 +804,7 @@ mod tests {
 
     #[test_traced]
     fn test_archive_prune_keys() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -899,7 +899,7 @@ mod tests {
     }
 
     fn test_archive_keys_and_restart(num_keys: usize) -> String {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, mut context, auditor) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal
@@ -1064,7 +1064,7 @@ mod tests {
 
     #[test_traced]
     fn test_ranges() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Initialize an empty journal

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -1,7 +1,7 @@
 use super::{Config, Error, Translator};
 use crate::journal::variable::Journal;
 use bytes::{Buf, BufMut, Bytes};
-use commonware_runtime::{Blob, Storage};
+use commonware_runtime::{Blob, Metrics, Storage};
 use futures::{pin_mut, StreamExt};
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use rangemap::RangeInclusiveSet;
@@ -32,7 +32,7 @@ struct Record {
 }
 
 /// Implementation of `Archive` storage.
-pub struct Archive<T: Translator, B: Blob, E: Storage<B>> {
+pub struct Archive<T: Translator, B: Blob, E: Storage<B> + Metrics> {
     cfg: Config<T>,
     journal: Journal<B, E>,
 
@@ -58,12 +58,16 @@ pub struct Archive<T: Translator, B: Blob, E: Storage<B>> {
     syncs: Counter,
 }
 
-impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
+impl<T: Translator, B: Blob, E: Storage<B> + Metrics> Archive<T, B, E> {
     /// Initialize a new `Archive` instance.
     ///
     /// The in-memory index for `Archive` is populated during this call
     /// by replaying the journal.
-    pub async fn init(mut journal: Journal<B, E>, cfg: Config<T>) -> Result<Self, Error> {
+    pub async fn init(
+        runtime: E,
+        mut journal: Journal<B, E>,
+        cfg: Config<T>,
+    ) -> Result<Self, Error> {
         // Initialize keys and run corruption check
         let mut indices = BTreeMap::new();
         let mut keys = HashMap::new();
@@ -115,28 +119,25 @@ impl<T: Translator, B: Blob, E: Storage<B>> Archive<T, B, E> {
         let gets = Counter::default();
         let has = Counter::default();
         let syncs = Counter::default();
-        {
-            let mut registry = cfg.registry.lock().unwrap();
-            registry.register(
-                "items_tracked",
-                "Number of items tracked",
-                items_tracked.clone(),
-            );
-            registry.register(
-                "indices_pruned",
-                "Number of indices pruned",
-                indices_pruned.clone(),
-            );
-            registry.register("keys_pruned", "Number of keys pruned", keys_pruned.clone());
-            registry.register(
-                "unnecessary_reads",
-                "Number of unnecessary reads performed during key lookups",
-                unnecessary_reads.clone(),
-            );
-            registry.register("gets", "Number of gets performed", gets.clone());
-            registry.register("has", "Number of has performed", has.clone());
-            registry.register("syncs", "Number of syncs called", syncs.clone());
-        }
+        runtime.register(
+            "items_tracked",
+            "Number of items tracked",
+            items_tracked.clone(),
+        );
+        runtime.register(
+            "indices_pruned",
+            "Number of indices pruned",
+            indices_pruned.clone(),
+        );
+        runtime.register("keys_pruned", "Number of keys pruned", keys_pruned.clone());
+        runtime.register(
+            "unnecessary_reads",
+            "Number of unnecessary reads performed during key lookups",
+            unnecessary_reads.clone(),
+        );
+        runtime.register("gets", "Number of gets performed", gets.clone());
+        runtime.register("has", "Number of has performed", has.clone());
+        runtime.register("syncs", "Number of syncs called", syncs.clone());
         items_tracked.set(indices.len() as i64);
 
         // Return populated archive

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -64,7 +64,7 @@ impl<T: Translator, B: Blob, E: Storage<B> + Metrics> Archive<T, B, E> {
     /// The in-memory index for `Archive` is populated during this call
     /// by replaying the journal.
     pub async fn init(
-        runtime: E,
+        context: E,
         mut journal: Journal<B, E>,
         cfg: Config<T>,
     ) -> Result<Self, Error> {
@@ -119,25 +119,25 @@ impl<T: Translator, B: Blob, E: Storage<B> + Metrics> Archive<T, B, E> {
         let gets = Counter::default();
         let has = Counter::default();
         let syncs = Counter::default();
-        runtime.register(
+        context.register(
             "items_tracked",
             "Number of items tracked",
             items_tracked.clone(),
         );
-        runtime.register(
+        context.register(
             "indices_pruned",
             "Number of indices pruned",
             indices_pruned.clone(),
         );
-        runtime.register("keys_pruned", "Number of keys pruned", keys_pruned.clone());
-        runtime.register(
+        context.register("keys_pruned", "Number of keys pruned", keys_pruned.clone());
+        context.register(
             "unnecessary_reads",
             "Number of unnecessary reads performed during key lookups",
             unnecessary_reads.clone(),
         );
-        runtime.register("gets", "Number of gets performed", gets.clone());
-        runtime.register("has", "Number of has performed", has.clone());
-        runtime.register("syncs", "Number of syncs called", syncs.clone());
+        context.register("gets", "Number of gets performed", gets.clone());
+        context.register("has", "Number of has performed", has.clone());
+        context.register("syncs", "Number of syncs called", syncs.clone());
         items_tracked.set(indices.len() as i64);
 
         // Return populated archive

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -1257,6 +1257,10 @@ mod tests {
     }
 
     impl Metrics for MockStorage {
+        fn with_label(&self, _: &str) -> Self {
+            self.clone()
+        }
+
         fn register<N: Into<String>, H: Into<String>>(&self, _: N, _: H, _: impl Metric) {}
 
         fn encode(&self) -> String {

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -81,14 +81,11 @@
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, deterministic::Executor};
 //! use commonware_storage::journal::variable::{Journal, Config};
-//! use prometheus_client::registry::Registry;
-//! use std::sync::{Arc, Mutex};
 //!
 //! let (executor, context, _) = Executor::default();
 //! executor.start(async move {
 //!     // Create a journal
 //!     let mut journal = Journal::init(context, Config{
-//!         registry: Arc::new(Mutex::new(Registry::default())),
 //!         partition: "partition".to_string()
 //!     }).await.unwrap();
 //!

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -1261,6 +1261,10 @@ mod tests {
             self.clone()
         }
 
+        fn label(&self) -> String {
+            String::new()
+        }
+
         fn register<N: Into<String>, H: Into<String>>(&self, _: N, _: H, _: impl Metric) {}
 
         fn encode(&self) -> String {

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test_traced]
     fn test_put_get_clear() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Create a metadata store
@@ -178,7 +178,7 @@ mod tests {
 
     #[test_traced]
     fn test_multi_sync() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Create a metadata store
@@ -277,7 +277,7 @@ mod tests {
 
     #[test_traced]
     fn test_recover_corrupted_one() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Create a metadata store
@@ -323,7 +323,7 @@ mod tests {
 
     #[test_traced]
     fn test_recover_corrupted_both() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Create a metadata store
@@ -377,7 +377,7 @@ mod tests {
 
     #[test_traced]
     fn test_recover_corrupted_truncate() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Create a metadata store
@@ -424,7 +424,7 @@ mod tests {
 
     #[test_traced]
     fn test_recover_corrupted_short() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Create a metadata store
@@ -470,7 +470,7 @@ mod tests {
 
     #[test_traced]
     fn test_unclean_shutdown() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             let key = 42;
@@ -507,7 +507,7 @@ mod tests {
 
     #[test_traced]
     fn test_value_too_big_error() {
-        // Initialize the deterministic runtime
+        // Initialize the deterministic context
         let (executor, context, _) = Executor::default();
         executor.start(async move {
             // Create a metadata store

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -41,14 +41,11 @@
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, deterministic::Executor};
 //! use commonware_storage::metadata::{Metadata, Config};
-//! use prometheus_client::registry::Registry;
-//! use std::sync::{Arc, Mutex};
 //!
 //! let (executor, context, _) = Executor::default();
 //! executor.start(async move {
 //!     // Create a store
 //!     let mut metadata = Metadata::init(context, Config{
-//!         registry: Arc::new(Mutex::new(Registry::default())),
 //!         partition: "partition".to_string()
 //!     }).await.unwrap();
 //!

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -15,7 +15,7 @@ const SECONDS_IN_NANOSECONDS: u128 = 1_000_000_000;
 
 /// Implementation of `Metadata` storage.
 pub struct Metadata<B: Blob, E: Clock + Storage<B> + Metrics> {
-    runtime: E,
+    context: E,
 
     // Data is stored in a BTreeMap to enable deterministic serialization.
     data: BTreeMap<u32, Bytes>,
@@ -30,10 +30,10 @@ pub struct Metadata<B: Blob, E: Clock + Storage<B> + Metrics> {
 
 impl<B: Blob, E: Clock + Storage<B> + Metrics> Metadata<B, E> {
     /// Initialize a new `Metadata` instance.
-    pub async fn init(runtime: E, cfg: Config) -> Result<Self, Error> {
+    pub async fn init(context: E, cfg: Config) -> Result<Self, Error> {
         // Open dedicated blobs
-        let left = runtime.open(&cfg.partition, BLOB_NAMES[0]).await?;
-        let right = runtime.open(&cfg.partition, BLOB_NAMES[1]).await?;
+        let left = context.open(&cfg.partition, BLOB_NAMES[0]).await?;
+        let right = context.open(&cfg.partition, BLOB_NAMES[1]).await?;
 
         // Find latest blob (check which includes a hash of the other)
         let left_result = Self::load(0, &left).await?;
@@ -64,13 +64,13 @@ impl<B: Blob, E: Clock + Storage<B> + Metrics> Metadata<B, E> {
         // Create metrics
         let syncs = Counter::default();
         let keys = Gauge::default();
-        runtime.register("syncs", "number of syncs of data to disk", syncs.clone());
-        runtime.register("keys", "number of tracked keys", keys.clone());
+        context.register("syncs", "number of syncs of data to disk", syncs.clone());
+        context.register("keys", "number of tracked keys", keys.clone());
 
         // Return metadata
         keys.set(data.len() as i64);
         Ok(Self {
-            runtime,
+            context,
 
             data,
             cursor,
@@ -203,7 +203,7 @@ impl<B: Blob, E: Clock + Storage<B> + Metrics> Metadata<B, E> {
     pub async fn sync(&mut self) -> Result<(), Error> {
         // Compute next timestamp
         let past_timestamp = &self.blobs[self.cursor].1;
-        let mut next_timestamp = self.runtime.current().epoch().as_nanos();
+        let mut next_timestamp = self.context.current().epoch().as_nanos();
         if next_timestamp <= *past_timestamp {
             // While it is possible that extremely high-frequency updates to `Metadata` (more than
             // one update per nanosecond) could cause an eventual overflow of the timestamp, this

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -275,14 +275,11 @@ mod tests {
             let (mut stream_sender, stream) = mocks::Channel::init();
 
             // Send message over stream
-            context
-                .clone()
-                .with_label("stream_sender")
-                .spawn(|_| async move {
-                    send_frame(&mut stream_sender, &handshake_bytes, ONE_MEGABYTE)
-                        .await
-                        .unwrap();
-                });
+            context.with_label("stream_sender").spawn(|_| async move {
+                send_frame(&mut stream_sender, &handshake_bytes, ONE_MEGABYTE)
+                    .await
+                    .unwrap();
+            });
 
             // Call the verify function
             let result = IncomingHandshake::verify(
@@ -329,14 +326,11 @@ mod tests {
             let (mut stream_sender, stream) = mocks::Channel::init();
 
             // Send message over stream
-            context
-                .clone()
-                .with_label("stream_sender")
-                .spawn(|_| async move {
-                    send_frame(&mut stream_sender, &handshake_bytes, ONE_MEGABYTE)
-                        .await
-                        .unwrap();
-                });
+            context.with_label("stream_sender").spawn(|_| async move {
+                send_frame(&mut stream_sender, &handshake_bytes, ONE_MEGABYTE)
+                    .await
+                    .unwrap();
+            });
 
             // Call the verify function
             let result = IncomingHandshake::verify(
@@ -367,14 +361,11 @@ mod tests {
             let (mut stream_sender, stream) = mocks::Channel::init();
 
             // Send invalid data over stream
-            context
-                .clone()
-                .with_label("stream_sender")
-                .spawn(|_| async move {
-                    send_frame(&mut stream_sender, b"mock data", ONE_MEGABYTE)
-                        .await
-                        .unwrap();
-                });
+            context.with_label("stream_sender").spawn(|_| async move {
+                send_frame(&mut stream_sender, b"mock data", ONE_MEGABYTE)
+                    .await
+                    .unwrap();
+            });
 
             // Call the verify function
             let result = IncomingHandshake::verify(

--- a/stream/src/utils/codec.rs
+++ b/stream/src/utils/codec.rs
@@ -67,10 +67,10 @@ mod tests {
     fn test_send_recv_at_max_message_size() {
         let (mut sink, mut stream) = mocks::Channel::init();
 
-        let (executor, mut runtime, _) = Executor::default();
+        let (executor, mut context, _) = Executor::default();
         executor.start(async move {
             let mut buf = [0u8; MAX_MESSAGE_SIZE];
-            runtime.fill(&mut buf);
+            context.fill(&mut buf);
 
             let result = send_frame(&mut sink, &buf, MAX_MESSAGE_SIZE).await;
             assert!(result.is_ok());
@@ -85,12 +85,12 @@ mod tests {
     fn test_send_recv_multiple() {
         let (mut sink, mut stream) = mocks::Channel::init();
 
-        let (executor, mut runtime, _) = Executor::default();
+        let (executor, mut context, _) = Executor::default();
         executor.start(async move {
             let mut buf1 = [0u8; MAX_MESSAGE_SIZE];
             let mut buf2 = [0u8; MAX_MESSAGE_SIZE / 2];
-            runtime.fill(&mut buf1);
-            runtime.fill(&mut buf2);
+            context.fill(&mut buf1);
+            context.fill(&mut buf2);
 
             // Send two messages of different sizes
             let result = send_frame(&mut sink, &buf1, MAX_MESSAGE_SIZE).await;
@@ -112,10 +112,10 @@ mod tests {
     fn test_send_frame() {
         let (mut sink, mut stream) = mocks::Channel::init();
 
-        let (executor, mut runtime, _) = Executor::default();
+        let (executor, mut context, _) = Executor::default();
         executor.start(async move {
             let mut buf = [0u8; MAX_MESSAGE_SIZE];
-            runtime.fill(&mut buf);
+            context.fill(&mut buf);
 
             let result = send_frame(&mut sink, &buf, MAX_MESSAGE_SIZE).await;
             assert!(result.is_ok());
@@ -135,10 +135,10 @@ mod tests {
         const MAX_MESSAGE_SIZE: usize = 1024;
         let (mut sink, _) = mocks::Channel::init();
 
-        let (executor, mut runtime, _) = Executor::default();
+        let (executor, mut context, _) = Executor::default();
         executor.start(async move {
             let mut buf = [0u8; MAX_MESSAGE_SIZE];
-            runtime.fill(&mut buf);
+            context.fill(&mut buf);
 
             let result = send_frame(&mut sink, &buf, MAX_MESSAGE_SIZE - 1).await;
             assert!(matches!(&result, Err(Error::SendTooLarge(n)) if *n == MAX_MESSAGE_SIZE));
@@ -161,11 +161,11 @@ mod tests {
     fn test_read_frame() {
         let (mut sink, mut stream) = mocks::Channel::init();
 
-        let (executor, mut runtime, _) = Executor::default();
+        let (executor, mut context, _) = Executor::default();
         executor.start(async move {
             // Do the writing manually without using send_frame
             let mut buf = [0u8; MAX_MESSAGE_SIZE];
-            runtime.fill(&mut buf);
+            context.fill(&mut buf);
             sink.send(&(MAX_MESSAGE_SIZE as u32).to_be_bytes())
                 .await
                 .unwrap();


### PR DESCRIPTION
Replaces: #510 

## TODO
- [x] Blocked on: #517
- [x] Add comments to `runtime`
- [x] Prevent a task from being spawned that overlaps with `runtime` metrics prefix
- [x] Create issue for adding logging/tracing with this style: https://github.com/commonwarexyz/monorepo/issues/520