### PR TITLE
[runtime] Alternative approach to `spawn_ref`

### DIFF
--- a/broadcast/src/linked/signer/actor.rs
+++ b/broadcast/src/linked/signer/actor.rs
@@ -235,10 +235,8 @@ impl<
     /// - Messages from the network:
     ///   - Nodes
     ///   - Acks
-    pub fn start(self, chunk_network: (NetS, NetR), ack_network: (NetS, NetR)) -> Handle<()> {
-        self.context
-            .clone()
-            .spawn(|_| self.run(chunk_network, ack_network))
+    pub fn start(mut self, chunk_network: (NetS, NetR), ack_network: (NetS, NetR)) -> Handle<()> {
+        self.context.spawn_ref()(self.run(chunk_network, ack_network))
     }
 
     async fn run(mut self, chunk_network: (NetS, NetR), ack_network: (NetS, NetR)) {

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -316,7 +316,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
             .await;
     }
 
-    pub fn start(self) -> Handle<()> {
+    pub fn start(mut self) -> Handle<()> {
         self.context.spawn_ref()(self.run())
     }
 

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -317,7 +317,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
     }
 
     pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -56,7 +56,7 @@ impl<
     }
 
     pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(voter_network))
+        self.context.spawn_ref()(self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -55,7 +55,7 @@ impl<
         }
     }
 
-    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
         self.context.spawn_ref()(self.run(voter_network))
     }
 

--- a/consensus/src/simplex/mocks/nuller.rs
+++ b/consensus/src/simplex/mocks/nuller.rs
@@ -50,7 +50,7 @@ impl<E: Spawner, C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = C
         }
     }
 
-    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
         self.context.spawn_ref()(self.run(voter_network))
     }
 

--- a/consensus/src/simplex/mocks/nuller.rs
+++ b/consensus/src/simplex/mocks/nuller.rs
@@ -51,7 +51,7 @@ impl<E: Spawner, C: Scheme, H: Hasher, S: Supervisor<Index = View, PublicKey = C
     }
 
     pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(voter_network))
+        self.context.spawn_ref()(self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/application.rs
+++ b/consensus/src/threshold_simplex/mocks/application.rs
@@ -316,7 +316,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
     }
 
     pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/consensus/src/threshold_simplex/mocks/application.rs
+++ b/consensus/src/threshold_simplex/mocks/application.rs
@@ -315,7 +315,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
             .await;
     }
 
-    pub fn start(self) -> Handle<()> {
+    pub fn start(mut self) -> Handle<()> {
         self.context.spawn_ref()(self.run())
     }
 

--- a/consensus/src/threshold_simplex/mocks/conflicter.rs
+++ b/consensus/src/threshold_simplex/mocks/conflicter.rs
@@ -60,7 +60,7 @@ impl<
         }
     }
 
-    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
         self.context.spawn_ref()(self.run(voter_network))
     }
 

--- a/consensus/src/threshold_simplex/mocks/conflicter.rs
+++ b/consensus/src/threshold_simplex/mocks/conflicter.rs
@@ -61,7 +61,7 @@ impl<
     }
 
     pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(voter_network))
+        self.context.spawn_ref()(self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/nuller.rs
+++ b/consensus/src/threshold_simplex/mocks/nuller.rs
@@ -60,7 +60,7 @@ impl<
     }
 
     pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(voter_network))
+        self.context.spawn_ref()(self.run(voter_network))
     }
 
     async fn run(self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/nuller.rs
+++ b/consensus/src/threshold_simplex/mocks/nuller.rs
@@ -59,7 +59,7 @@ impl<
         }
     }
 
-    pub fn start(self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
         self.context.spawn_ref()(self.run(voter_network))
     }
 

--- a/examples/log/src/application/actor.rs
+++ b/examples/log/src/application/actor.rs
@@ -43,7 +43,7 @@ impl<R: Rng + Spawner, C: Scheme, H: Hasher> Application<R, C, H> {
 
     /// Run the application actor.
     pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/examples/log/src/application/actor.rs
+++ b/examples/log/src/application/actor.rs
@@ -42,7 +42,7 @@ impl<R: Rng + Spawner, C: Scheme, H: Hasher> Application<R, C, H> {
     }
 
     /// Run the application actor.
-    pub fn start(self) -> Handle<()> {
+    pub fn start(mut self) -> Handle<()> {
         self.context.spawn_ref()(self.run())
     }
 

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -268,7 +268,7 @@ impl<E: Clock + Spawner, C: Scheme> Arbiter<E, C> {
     }
 
     pub fn start(
-        self,
+        mut self,
         sender: impl Sender<PublicKey = C::PublicKey>,
         receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) -> Handle<()> {

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -272,7 +272,7 @@ impl<E: Clock + Spawner, C: Scheme> Arbiter<E, C> {
         sender: impl Sender<PublicKey = C::PublicKey>,
         receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(sender, receiver))
+        self.context.spawn_ref()(self.run(sender, receiver))
     }
 
     async fn run(

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -504,7 +504,7 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
     }
 
     pub fn start(
-        self,
+        mut self,
         sender: impl Sender<PublicKey = C::PublicKey>,
         receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) {

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -508,7 +508,7 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
         sender: impl Sender<PublicKey = C::PublicKey>,
         receiver: impl Receiver<PublicKey = C::PublicKey>,
     ) {
-        self.context.clone().spawn(|_| self.run(sender, receiver));
+        self.context.spawn_ref()(self.run(sender, receiver));
     }
 
     async fn run(

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -162,7 +162,7 @@ impl<E: Clock + Spawner, P: Array> Vrf<E, P> {
         sender: impl Sender<PublicKey = P>,
         receiver: impl Receiver<PublicKey = P>,
     ) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(sender, receiver))
+        self.context.spawn_ref()(self.run(sender, receiver))
     }
 
     async fn run(

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -158,7 +158,7 @@ impl<E: Clock + Spawner, P: Array> Vrf<E, P> {
     }
 
     pub fn start(
-        self,
+        mut self,
         sender: impl Sender<PublicKey = P>,
         receiver: impl Receiver<PublicKey = P>,
     ) -> Handle<()> {

--- a/p2p/src/authenticated/actors/router/actor.rs
+++ b/p2p/src/authenticated/actors/router/actor.rs
@@ -77,7 +77,7 @@ impl<E: Spawner + Metrics, P: Array> Actor<E, P> {
     }
 
     pub fn start(self, routing: Channels<P>) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(routing))
+        self.context.spawn_ref()(self.run(routing))
     }
 
     async fn run(mut self, routing: Channels<P>) {

--- a/p2p/src/authenticated/actors/router/actor.rs
+++ b/p2p/src/authenticated/actors/router/actor.rs
@@ -76,7 +76,7 @@ impl<E: Spawner + Metrics, P: Array> Actor<E, P> {
         }
     }
 
-    pub fn start(self, routing: Channels<P>) -> Handle<()> {
+    pub fn start(mut self, routing: Channels<P>) -> Handle<()> {
         self.context.spawn_ref()(self.run(routing))
     }
 

--- a/p2p/src/authenticated/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/actors/spawner/actor.rs
@@ -76,8 +76,7 @@ impl<
     }
 
     pub fn start(self, tracker: tracker::Mailbox<E, P>, router: router::Mailbox<P>) -> Handle<()> {
-        let spawn_ref = self.context.spawn_ref();
-        spawn_ref(self.run(tracker, router))
+        self.context.spawn_ref()(self.run(tracker, router))
     }
 
     async fn run(mut self, tracker: tracker::Mailbox<E, P>, router: router::Mailbox<P>) {

--- a/p2p/src/authenticated/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/actors/spawner/actor.rs
@@ -76,7 +76,8 @@ impl<
     }
 
     pub fn start(self, tracker: tracker::Mailbox<E, P>, router: router::Mailbox<P>) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run(tracker, router))
+        let spawn_ref = self.context.spawn_ref();
+        spawn_ref(self.run(tracker, router))
     }
 
     async fn run(mut self, tracker: tracker::Mailbox<E, P>, router: router::Mailbox<P>) {

--- a/p2p/src/authenticated/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/actors/spawner/actor.rs
@@ -75,7 +75,11 @@ impl<
         )
     }
 
-    pub fn start(self, tracker: tracker::Mailbox<E, P>, router: router::Mailbox<P>) -> Handle<()> {
+    pub fn start(
+        mut self,
+        tracker: tracker::Mailbox<E, P>,
+        router: router::Mailbox<P>,
+    ) -> Handle<()> {
         self.context.spawn_ref()(self.run(tracker, router))
     }
 

--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -552,7 +552,7 @@ impl<E: Spawner + Rng + Clock + GClock + Metrics, C: Scheme> Actor<E, C> {
         ))
     }
 
-    pub fn start(self) -> Handle<()> {
+    pub fn start(mut self) -> Handle<()> {
         self.context.spawn_ref()(self.run())
     }
 

--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -553,7 +553,7 @@ impl<E: Spawner + Rng + Clock + GClock + Metrics, C: Scheme> Actor<E, C> {
     }
 
     pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -152,7 +152,7 @@ impl<
     ///
     /// After the network is started, it is not possible to add more channels.
     pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(self) {

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -151,7 +151,7 @@ impl<
     /// Starts the network.
     ///
     /// After the network is started, it is not possible to add more channels.
-    pub fn start(self) -> Handle<()> {
+    pub fn start(mut self) -> Handle<()> {
         self.context.spawn_ref()(self.run())
     }
 

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -346,7 +346,7 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock + Metrics, P: A
     /// It is not necessary to invoke this method before modifying the network topology, however,
     /// no messages will be sent until this method is called.
     pub fn start(self) -> Handle<()> {
-        self.context.clone().spawn(|_| self.run())
+        self.context.spawn_ref()(self.run())
     }
 
     async fn run(mut self) {

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -345,7 +345,7 @@ impl<E: RNetwork<Listener, Sink, Stream> + Spawner + Rng + Clock + Metrics, P: A
     ///
     /// It is not necessary to invoke this method before modifying the network topology, however,
     /// no messages will be sent until this method is called.
-    pub fn start(self) -> Handle<()> {
+    pub fn start(mut self) -> Handle<()> {
         self.context.spawn_ref()(self.run())
     }
 

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -511,6 +511,7 @@ impl Executor {
             },
             Context {
                 label: String::new(),
+                spawned: false,
                 executor,
                 networking: Arc::new(Networking::new(metrics, auditor.clone())),
             },
@@ -713,9 +714,9 @@ impl crate::Runner for Runner {
 /// Implementation of [`crate::Spawner`], [`crate::Clock`],
 /// [`crate::Network`], and [`crate::Storage`] for the `deterministic`
 /// runtime.
-#[derive(Clone)]
 pub struct Context {
     label: String,
+    spawned: bool,
     executor: Arc<Executor>,
     networking: Arc<Networking>,
 }
@@ -783,11 +784,23 @@ impl Context {
             },
             Self {
                 label: String::new(),
+                spawned: false,
                 executor,
                 networking: Arc::new(Networking::new(metrics, auditor.clone())),
             },
             auditor,
         )
+    }
+}
+
+impl Clone for Context {
+    fn clone(&self) -> Self {
+        Self {
+            label: self.label.clone(),
+            spawned: false,
+            executor: self.executor.clone(),
+            networking: self.networking.clone(),
+        }
     }
 }
 
@@ -798,6 +811,9 @@ impl crate::Spawner for Context {
         Fut: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        // Ensure a context only spawns one task
+        assert!(!self.spawned, "already spawned");
+
         // Get metrics
         let label = self.label.clone();
         let work = Work {
@@ -825,11 +841,15 @@ impl crate::Spawner for Context {
         handle
     }
 
-    fn spawn_ref<F, T>(&self) -> impl FnOnce(F) -> Handle<T> + 'static
+    fn spawn_ref<F, T>(&mut self) -> impl FnOnce(F) -> Handle<T> + 'static
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        // Ensure a context only spawns one task
+        assert!(!self.spawned, "already spawned");
+        self.spawned = true;
+
         // Get metrics
         let work = Work {
             label: self.label.clone(),
@@ -885,6 +905,7 @@ impl crate::Metrics for Context {
         );
         Self {
             label,
+            spawned: false,
             executor: self.executor.clone(),
             networking: self.networking.clone(),
         }

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -825,6 +825,37 @@ impl crate::Spawner for Context {
         handle
     }
 
+    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T>
+    where
+        Fut: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        // Get metrics
+        let work = Work {
+            label: self.label.clone(),
+        };
+        self.executor
+            .metrics
+            .tasks_spawned
+            .get_or_create(&work)
+            .inc();
+        let gauge = self
+            .executor
+            .metrics
+            .tasks_running
+            .get_or_create(&work)
+            .clone();
+
+        // Set up the task
+        move |f: Fut| {
+            let (f, handle) = Handle::init(f, gauge, false);
+
+            // Spawn the task
+            Tasks::register(&self.executor.tasks, &self.label, false, Box::pin(f));
+            handle
+        }
+    }
+
     fn stop(&self, value: i32) {
         self.executor.auditor.stop(value);
         self.executor.signaler.lock().unwrap().signal(value);

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -825,7 +825,7 @@ impl crate::Spawner for Context {
         handle
     }
 
-    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T>
+    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T> + 'static
     where
         Fut: Future<Output = T> + Send + 'static,
         T: Send + 'static,
@@ -847,11 +847,13 @@ impl crate::Spawner for Context {
             .clone();
 
         // Set up the task
+        let label = self.label.clone();
+        let executor = self.executor.clone();
         move |f: Fut| {
             let (f, handle) = Handle::init(f, gauge, false);
 
             // Spawn the task
-            Tasks::register(&self.executor.tasks, &self.label, false, Box::pin(f));
+            Tasks::register(&executor.tasks, &label, false, Box::pin(f));
             handle
         }
     }

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -825,9 +825,9 @@ impl crate::Spawner for Context {
         handle
     }
 
-    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T> + 'static
+    fn spawn_ref<F, T>(&self) -> impl FnOnce(F) -> Handle<T> + 'static
     where
-        Fut: Future<Output = T> + Send + 'static,
+        F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
         // Get metrics
@@ -849,7 +849,7 @@ impl crate::Spawner for Context {
         // Set up the task
         let label = self.label.clone();
         let executor = self.executor.clone();
-        move |f: Fut| {
+        move |f: F| {
             let (f, handle) = Handle::init(f, gauge, false);
 
             // Spawn the task

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,8 +117,8 @@ pub trait Spawner: Clone + Send + Sync + 'static {
     /// does not await the handle).
     ///
     /// In some cases, it may be useful to spawn a task without consuming the context (e.g. starting
-    /// an actor that already holds a context). It is up to the caller to ensure context reuse
-    /// does not lead to unexpected behavior.
+    /// an actor that already holds a context). Once used this way, the context should not be used
+    /// to spawn additional tasks.
     fn spawn_ref<F, T>(&self) -> impl FnOnce(F) -> Handle<T> + 'static
     where
         F: Future<Output = T> + Send + 'static,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,6 +111,11 @@ pub trait Spawner: Clone + Send + Sync + 'static {
         Fut: Future<Output = T> + Send + 'static,
         T: Send + 'static;
 
+    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T>
+    where
+        Fut: Future<Output = T> + Send + 'static,
+        T: Send + 'static;
+
     /// Signals the runtime to stop execution and that all outstanding tasks
     /// should perform any required cleanup and exit. This method is idempotent and
     /// can be called multiple times.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -788,6 +788,14 @@ mod tests {
         });
     }
 
+    fn test_spawn_ref(runner: impl Runner, context: impl Spawner) {
+        runner.start(async move {
+            let handle = context.spawn_ref();
+            let result = handle(async move { 42 }).await;
+            assert_eq!(result, Ok(42));
+        });
+    }
+
     fn test_metrics(runner: impl Runner, context: impl Spawner + Metrics) {
         runner.start(async move {
             // Assert label
@@ -925,6 +933,12 @@ mod tests {
     }
 
     #[test]
+    fn test_deterministic_spawn_ref() {
+        let (executor, context, _) = deterministic::Executor::default();
+        test_spawn_ref(executor, context);
+    }
+
+    #[test]
     fn test_deterministic_metrics() {
         let (executor, context, _) = deterministic::Executor::default();
         test_metrics(executor, context);
@@ -1030,6 +1044,12 @@ mod tests {
     fn test_tokio_shutdown() {
         let (executor, context) = tokio::Executor::default();
         test_shutdown(executor, context);
+    }
+
+    #[test]
+    fn test_tokio_spawn_ref() {
+        let (executor, context) = tokio::Executor::default();
+        test_spawn_ref(executor, context);
     }
 
     #[test]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub trait Spawner: Clone + Send + Sync + 'static {
         Fut: Future<Output = T> + Send + 'static,
         T: Send + 'static;
 
-    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T>
+    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T> + 'static
     where
         Fut: Future<Output = T> + Send + 'static,
         T: Send + 'static;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,9 +111,17 @@ pub trait Spawner: Clone + Send + Sync + 'static {
         Fut: Future<Output = T> + Send + 'static,
         T: Send + 'static;
 
-    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T> + 'static
+    /// Enqueue a task to be executed (without consuming the context).
+    ///
+    /// Unlike a future, a spawned task will start executing immediately (even if the caller
+    /// does not await the handle).
+    ///
+    /// In some cases, it may be useful to spawn a task without consuming the context (e.g. starting
+    /// an actor that already holds a context). It is up to the caller to ensure context reuse
+    /// does not lead to unexpected behavior.
+    fn spawn_ref<F, T>(&self) -> impl FnOnce(F) -> Handle<T> + 'static
     where
-        Fut: Future<Output = T> + Send + 'static,
+        F: Future<Output = T> + Send + 'static,
         T: Send + 'static;
 
     /// Signals the runtime to stop execution and that all outstanding tasks

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,8 +117,8 @@ pub trait Spawner: Clone + Send + Sync + 'static {
     /// does not await the handle).
     ///
     /// In some cases, it may be useful to spawn a task without consuming the context (e.g. starting
-    /// an actor that already holds a context). Once used this way, the context should not be used
-    /// to spawn additional tasks.
+    /// an actor that already holds a context). If a task is spawned from a context with this function
+    /// multiple times (or with `spawn` after this), the runtime will panic to prevent accidental misuse.
     fn spawn_ref<F, T>(&mut self) -> impl FnOnce(F) -> Handle<T> + 'static
     where
         F: Future<Output = T> + Send + 'static,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,8 +117,12 @@ pub trait Spawner: Clone + Send + Sync + 'static {
     /// does not await the handle).
     ///
     /// In some cases, it may be useful to spawn a task without consuming the context (e.g. starting
-    /// an actor that already holds a context). If a task is spawned from a context with this function
-    /// multiple times (or with `spawn` after this), the runtime will panic to prevent accidental misuse.
+    /// an actor that already has a reference to context).
+    ///
+    /// # Warning
+    ///
+    /// If this function is used to spawn multiple tasks from the same context, the runtime will panic
+    /// to prevent accidental misuse.
     fn spawn_ref<F, T>(&mut self) -> impl FnOnce(F) -> Handle<T> + 'static
     where
         F: Future<Output = T> + Send + 'static,

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -316,7 +316,7 @@ impl crate::Spawner for Context {
         handle
     }
 
-    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T>
+    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T> + 'static
     where
         Fut: Future<Output = T> + Send + 'static,
         T: Send + 'static,
@@ -338,11 +338,12 @@ impl crate::Spawner for Context {
             .clone();
 
         // Set up the task
+        let executor = self.executor.clone();
         move |f: Fut| {
-            let (f, handle) = Handle::init(f, gauge, self.executor.cfg.catch_panics);
+            let (f, handle) = Handle::init(f, gauge, executor.cfg.catch_panics);
 
             // Spawn the task
-            self.executor.runtime.spawn(f);
+            executor.runtime.spawn(f);
             handle
         }
     }

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -316,9 +316,9 @@ impl crate::Spawner for Context {
         handle
     }
 
-    fn spawn_ref<Fut, T>(&self) -> impl FnOnce(Fut) -> Handle<T> + 'static
+    fn spawn_ref<F, T>(&self) -> impl FnOnce(F) -> Handle<T> + 'static
     where
-        Fut: Future<Output = T> + Send + 'static,
+        F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
         // Get metrics
@@ -339,7 +339,7 @@ impl crate::Spawner for Context {
 
         // Set up the task
         let executor = self.executor.clone();
-        move |f: Fut| {
+        move |f: F| {
             let (f, handle) = Handle::init(f, gauge, executor.cfg.catch_panics);
 
             // Spawn the task


### PR DESCRIPTION
Replaces: #521 

While context reuse won't cause any issues atm, we should prevent it now for the day it does.