### PR TITLE
spelling and grammar errors

### DIFF
--- a/examples/log/src/gui.rs
+++ b/examples/log/src/gui.rs
@@ -38,7 +38,7 @@ enum Event<I> {
     Tick,
 }
 
-/// Appends logs to provided vectors.
+/// Appends logs to the provided vectors.
 pub struct Writer {
     progress: Arc<Mutex<Vec<String>>>,
     logs: Arc<Mutex<Vec<String>>>,

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -206,7 +206,7 @@ impl<
         );
         let mut dialer_task = dialer.start(self.tracker_mailbox, spawner_mailbox);
 
-        // Wait for first actor to exit
+        // Wait for the first actor to exit
         info!("network started");
         let err = select! {
             tracker = &mut tracker_task => {


### PR DESCRIPTION
logs to provided - logs to the provided

for first - for the first