### PR TITLE
Implement historical peaks storage for MMR provability guarantees

### DIFF
--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -83,4 +83,12 @@ pub enum Error {
     JournalError(#[from] crate::journal::Error),
     #[error("missing peak: {0}")]
     MissingPeak(u64),
+    #[error("no historical peaks found for provable_pos: {0}")]
+    NoHistoricalPeaks(u64),
+    #[error("element {0} is not provable with historical peaks from provable_pos: {1}")]
+    ElementNotProvable(u64, u64),
+    #[error("invalid digest")]
+    InvalidDigest,
+    #[error("not implemented: {0}")]
+    NotImplemented(&'static str),
 }


### PR DESCRIPTION
This commit implements the storage of historical peaks in the MMR metadata
to guarantee the stability of provability guarantees provided by the prune
method. When pruning the MMR, we now store the current peaks with a special
encoding that includes the provable_pos, allowing us to retrieve these
historical peaks later.

The implementation includes:
1. Storing historical peaks during pruning with a special key encoding
2. A method to retrieve historical peaks for a given provable_pos
3. A skeleton for generating proofs using historical peaks
4. New error types to support these operations

This addresses the TODO comment in the prune method about persisting
historical peaks required to guarantee the stability of provability
guarantees.