### PR TITLE
[commonware-storage/mmr] proof generation function that returns only the required elelement positions

### DIFF
--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -3,10 +3,10 @@
 //!
 //! # Terminology
 //!
-//! An MMR is a list of perfect binary trees of strictly decreasing height. The roots of these trees
-//! are called the "peaks" of the MMR. Each "element" stored in the MMR is represented by some leaf
-//! node in one of these perfect trees, storing a positioned hash of the element. Non-leaf nodes
-//! store a positioned hash of their children.
+//! An MMR is a list of perfect binary trees (aka "mountains") of strictly decreasing height. The
+//! roots of these trees are called the "peaks" of the MMR. Each "element" stored in the MMR is
+//! represented by some leaf node in one of these perfect trees, storing a positioned hash of the
+//! element. Non-leaf nodes store a positioned hash of their children.
 //!
 //! The "size" of an MMR is the total number of nodes summed over all trees.
 //!


### PR DESCRIPTION
This PR separates out the process of generating the positions of the required elements from the process of fetching those elements.  It also improves precision of some of the language in the comments.