### PR TITLE
[deployer] Consider `failed` status the same as `inactive`

### DIFF
--- a/deployer/src/ec2/utils.rs
+++ b/deployer/src/ec2/utils.rs
@@ -91,16 +91,14 @@ pub async fn poll_service_active(key_file: &str, ip: &str, service: &str) -> Res
             .arg(format!("systemctl is-active {}", service))
             .output()
             .await?;
-        if output.status.success() {
-            let parsed = String::from_utf8_lossy(&output.stdout);
-            let parsed = parsed.trim();
-            if parsed == "active" {
-                return Ok(());
-            }
-            if service == "binary" && parsed == "failed" {
-                warn!(service, "service failed to start (check logs and update)");
-                return Ok(());
-            }
+        let parsed = String::from_utf8_lossy(&output.stdout);
+        let parsed = parsed.trim();
+        if parsed == "active" {
+            return Ok(());
+        }
+        if service == "binary" && parsed == "failed" {
+            warn!(service, "service failed to start (check logs and update)");
+            return Ok(());
         }
         warn!(error = ?String::from_utf8_lossy(&output.stderr), service, "active status check failed");
         sleep(RETRY_INTERVAL).await;
@@ -122,16 +120,14 @@ pub async fn poll_service_inactive(key_file: &str, ip: &str, service: &str) -> R
             .arg(format!("systemctl is-active {}", service))
             .output()
             .await?;
-        if output.status.success() {
-            let parsed = String::from_utf8_lossy(&output.stdout);
-            let parsed = parsed.trim();
-            if parsed == "inactive" {
-                return Ok(());
-            }
-            if service == "binary" && parsed == "failed" {
-                warn!(service, "service was never active");
-                return Ok(());
-            }
+        let parsed = String::from_utf8_lossy(&output.stdout);
+        let parsed = parsed.trim();
+        if parsed == "inactive" {
+            return Ok(());
+        }
+        if service == "binary" && parsed == "failed" {
+            warn!(service, "service was never active");
+            return Ok(());
         }
         warn!(error = ?String::from_utf8_lossy(&output.stderr), service, "inactive status check failed");
         sleep(RETRY_INTERVAL).await;

--- a/deployer/src/ec2/utils.rs
+++ b/deployer/src/ec2/utils.rs
@@ -97,8 +97,8 @@ pub async fn poll_service_active(key_file: &str, ip: &str, service: &str) -> Res
             if parsed == "active" {
                 return Ok(());
             }
-            if parsed == "failed" {
-                warn!(service, "service failed to start");
+            if service == "binary" && parsed == "failed" {
+                warn!(service, "service failed to start (check logs and update)");
                 return Ok(());
             }
         }
@@ -128,7 +128,7 @@ pub async fn poll_service_inactive(key_file: &str, ip: &str, service: &str) -> R
             if parsed == "inactive" {
                 return Ok(());
             }
-            if parsed == "failed" {
+            if service == "binary" && parsed == "failed" {
                 warn!(service, "service was never active");
                 return Ok(());
             }

--- a/deployer/src/ec2/utils.rs
+++ b/deployer/src/ec2/utils.rs
@@ -114,7 +114,9 @@ pub async fn poll_service_inactive(key_file: &str, ip: &str, service: &str) -> R
             .arg(format!("systemctl is-active {}", service))
             .output()
             .await?;
-        if String::from_utf8_lossy(&output.stdout).trim() == "inactive" {
+        let parsed = String::from_utf8_lossy(&output.stdout);
+        let parsed = parsed.trim();
+        if parsed == "inactive" || parsed == "failed" {
             return Ok(());
         }
         warn!(error = ?String::from_utf8_lossy(&output.stderr), service, "inactive status check failed");


### PR DESCRIPTION
If the deployment of a binary fails, it may be in `failed` status after `stop` is called.