### PR TITLE
[consensus] Separate `skip_timeout` and `acitvity_timeout`

### DIFF
--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -30,5 +30,6 @@ pub struct Config<
     pub notarization_timeout: Duration,
     pub nullify_retry: Duration,
     pub activity_timeout: View,
+    pub skip_timeout: View,
     pub replay_concurrency: usize,
 }

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -52,8 +52,15 @@ pub struct Config<
     pub nullify_retry: Duration,
 
     /// Number of views behind finalized tip to track
-    /// activity derived from validator messages.
+    /// and persist activity derived from validator messages.
     pub activity_timeout: View,
+
+    /// Move to nullify immediately if the selected leader has been inactive
+    /// for this many views.
+    ///
+    /// This number should be less than or equal to `activity_timeout` (how
+    /// many views we are tracking).
+    pub skip_timeout: View,
 
     /// Timeout to wait for a peer to respond to a request.
     pub fetch_timeout: Duration,
@@ -103,6 +110,14 @@ impl<
         assert!(
             self.activity_timeout > 0,
             "activity timeout must be greater than zero"
+        );
+        assert!(
+            self.skip_timeout > 0,
+            "skip timeout must be greater than zero"
+        );
+        assert!(
+            self.skip_timeout <= self.activity_timeout,
+            "skip timeout must be less than or equal to activity timeout"
         );
         assert!(
             self.fetch_timeout > Duration::default(),

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -65,6 +65,7 @@ impl<
                 notarization_timeout: cfg.notarization_timeout,
                 nullify_retry: cfg.nullify_retry,
                 activity_timeout: cfg.activity_timeout,
+                skip_timeout: cfg.skip_timeout,
                 replay_concurrency: cfg.replay_concurrency,
             },
         );

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -285,6 +285,7 @@ mod tests {
         let max_exceptions = 4;
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -372,6 +373,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -493,6 +495,7 @@ mod tests {
         let n = 5;
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
 
         // Random restarts every x seconds
@@ -596,6 +599,7 @@ mod tests {
                         nullify_retry: Duration::from_secs(10),
                         fetch_timeout: Duration::from_secs(1),
                         activity_timeout,
+skip_timeout,
                         max_fetch_count: 1,
                         max_fetch_size: 1024 * 512,
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -708,6 +712,7 @@ mod tests {
         let n = 4;
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, context, _) = Executor::timed(Duration::from_secs(360));
         executor.start(async move {
@@ -806,6 +811,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1, // force many fetches
                     max_fetch_size: 1024 * 1024,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -940,6 +946,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -992,6 +999,7 @@ mod tests {
         let n = 5;
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -1090,6 +1098,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1175,6 +1184,7 @@ mod tests {
         let n = 5;
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -1273,6 +1283,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1358,6 +1369,7 @@ mod tests {
         let n = 5;
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, context, _) = Executor::timed(Duration::from_secs(120));
         executor.start(async move {
@@ -1445,6 +1457,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1523,6 +1536,7 @@ mod tests {
         let n = 10;
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, context, _) = Executor::timed(Duration::from_secs(900));
         executor.start(async move {
@@ -1607,6 +1621,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1737,6 +1752,7 @@ mod tests {
         let n = 5;
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let cfg = deterministic::Config {
             seed,
@@ -1829,6 +1845,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1913,6 +1930,7 @@ mod tests {
         let n = 4;
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -2015,6 +2033,7 @@ mod tests {
                         nullify_retry: Duration::from_secs(10),
                         fetch_timeout: Duration::from_secs(1),
                         activity_timeout,
+                        skip_timeout,
                         max_fetch_count: 1,
                         max_fetch_size: 1024 * 512,
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -2097,6 +2116,7 @@ mod tests {
         let n = 4;
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -2196,6 +2216,7 @@ mod tests {
                         nullify_retry: Duration::from_secs(10),
                         fetch_timeout: Duration::from_secs(1),
                         activity_timeout,
+                        skip_timeout,
                         max_fetch_count: 1,
                         max_fetch_size: 1024 * 512,
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -675,6 +675,7 @@ pub struct Actor<
     notarization_timeout: Duration,
     nullify_retry: Duration,
     activity_timeout: View,
+    skip_timeout: View,
 
     mailbox_receiver: mpsc::Receiver<Message<D>>,
 
@@ -684,6 +685,7 @@ pub struct Actor<
 
     current_view: Gauge,
     tracked_views: Gauge,
+    skipped_views: Counter,
     received_messages: Family<metrics::PeerMessage, Counter>,
     broadcast_messages: Family<metrics::Message, Counter>,
     notarization_latency: Histogram,
@@ -720,12 +722,14 @@ impl<
         // Initialize metrics
         let current_view = Gauge::<i64, AtomicI64>::default();
         let tracked_views = Gauge::<i64, AtomicI64>::default();
+        let skipped_views = Counter::default();
         let received_messages = Family::<metrics::PeerMessage, Counter>::default();
         let broadcast_messages = Family::<metrics::Message, Counter>::default();
         let notarization_latency = Histogram::new(LATENCY.into_iter());
         let finalization_latency = Histogram::new(LATENCY.into_iter());
         context.register("current_view", "current view", current_view.clone());
         context.register("tracked_views", "tracked views", tracked_views.clone());
+        context.register("skipped_views", "skipped views", skipped_views.clone());
         context.register(
             "received_messages",
             "received messages",
@@ -774,6 +778,7 @@ impl<
                 nullify_retry: cfg.nullify_retry,
 
                 activity_timeout: cfg.activity_timeout,
+                skip_timeout: cfg.skip_timeout,
 
                 mailbox_receiver,
 
@@ -783,6 +788,7 @@ impl<
 
                 current_view,
                 tracked_views,
+                skipped_views,
                 received_messages,
                 broadcast_messages,
                 notarization_latency,
@@ -1339,14 +1345,14 @@ impl<
             return;
         }
 
-        // Check if we should fast exit this view
+        // Check if we should skip this view
         let leader = round.leader.as_ref().unwrap().clone();
-        if view < self.activity_timeout || leader == self.crypto.public_key() {
-            // Don't fast exit the view
+        if view < self.skip_timeout || leader == self.crypto.public_key() {
+            // Don't skip the view
             return;
         }
         let mut next = view - 1;
-        while next > view - self.activity_timeout {
+        while next > view - self.skip_timeout {
             let leader_index = match self.supervisor.is_participant(next, &leader) {
                 Some(index) => index,
                 None => {
@@ -1371,6 +1377,7 @@ impl<
 
         // Reduce leader deadline to now
         debug!(view, ?leader, "skipping leader timeout due to inactivity");
+        self.skipped_views.inc();
         self.views.get_mut(&view).unwrap().leader_deadline = Some(self.context.current());
     }
 

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -32,5 +32,6 @@ pub struct Config<
     pub notarization_timeout: Duration,
     pub nullify_retry: Duration,
     pub activity_timeout: View,
+    pub skip_timeout: View,
     pub replay_concurrency: usize,
 }

--- a/consensus/src/threshold_simplex/config.rs
+++ b/consensus/src/threshold_simplex/config.rs
@@ -52,8 +52,15 @@ pub struct Config<
     pub nullify_retry: Duration,
 
     /// Number of views behind finalized tip to track
-    /// activity derived from validator messages.
+    /// and persist activity derived from validator messages.
     pub activity_timeout: View,
+
+    /// Move to nullify immediately if the selected leader has been inactive
+    /// for this many views.
+    ///
+    /// This number should be less than or equal to `activity_timeout` (how
+    /// many views we are tracking).
+    pub skip_timeout: View,
 
     /// Timeout to wait for a peer to respond to a request.
     pub fetch_timeout: Duration,
@@ -103,6 +110,14 @@ impl<
         assert!(
             self.activity_timeout > 0,
             "activity timeout must be greater than zero"
+        );
+        assert!(
+            self.skip_timeout > 0,
+            "skip timeout must be greater than zero"
+        );
+        assert!(
+            self.skip_timeout <= self.activity_timeout,
+            "skip timeout must be less than or equal to activity timeout"
         );
         assert!(
             self.fetch_timeout > Duration::default(),

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -79,6 +79,7 @@ impl<
                 notarization_timeout: cfg.notarization_timeout,
                 nullify_retry: cfg.nullify_retry,
                 activity_timeout: cfg.activity_timeout,
+                skip_timeout: cfg.skip_timeout,
                 replay_concurrency: cfg.replay_concurrency,
             },
         );

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -318,6 +318,7 @@ mod tests {
         let max_exceptions = 4;
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, mut context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -409,6 +410,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -532,6 +534,7 @@ mod tests {
         let threshold = quorum(n).expect("unable to calculate threshold");
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
 
         // Derive threshold
@@ -643,6 +646,7 @@ mod tests {
                         nullify_retry: Duration::from_secs(10),
                         fetch_timeout: Duration::from_secs(1),
                         activity_timeout,
+skip_timeout,
                         max_fetch_count: 1,
                         max_fetch_size: 1024 * 512,
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -759,6 +763,7 @@ mod tests {
         let threshold = quorum(n).expect("unable to calculate threshold");
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, mut context, _) = Executor::timed(Duration::from_secs(360));
         executor.start(async move {
@@ -861,6 +866,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1, // force many fetches
                     max_fetch_size: 1024 * 1024,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -997,6 +1003,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1051,6 +1058,7 @@ mod tests {
         let threshold = quorum(n).expect("unable to calculate threshold");
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, mut context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -1153,6 +1161,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1240,6 +1249,7 @@ mod tests {
         let threshold = quorum(n).expect("unable to calculate threshold");
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, mut context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -1342,6 +1352,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1429,6 +1440,7 @@ mod tests {
         let threshold = quorum(n).expect("unable to calculate threshold");
         let required_containers = 100;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, mut context, _) = Executor::timed(Duration::from_secs(120));
         executor.start(async move {
@@ -1520,6 +1532,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1600,6 +1613,7 @@ mod tests {
         let threshold = quorum(n).expect("unable to calculate threshold");
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, mut context, _) = Executor::timed(Duration::from_secs(900));
         executor.start(async move {
@@ -1691,6 +1705,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1822,6 +1837,7 @@ mod tests {
         let threshold = quorum(n).expect("unable to calculate threshold");
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let cfg = deterministic::Config {
             seed,
@@ -1918,6 +1934,7 @@ mod tests {
                     nullify_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout,
+                    skip_timeout,
                     max_fetch_count: 1,
                     max_fetch_size: 1024 * 512,
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -2004,6 +2021,7 @@ mod tests {
         let threshold = quorum(n).expect("unable to calculate threshold");
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, mut context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -2109,6 +2127,7 @@ mod tests {
                         nullify_retry: Duration::from_secs(10),
                         fetch_timeout: Duration::from_secs(1),
                         activity_timeout,
+                        skip_timeout,
                         max_fetch_count: 1,
                         max_fetch_size: 1024 * 512,
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -2188,6 +2207,7 @@ mod tests {
         let threshold = quorum(n).expect("unable to calculate threshold");
         let required_containers = 50;
         let activity_timeout = 10;
+        let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
         let (executor, mut context, _) = Executor::timed(Duration::from_secs(30));
         executor.start(async move {
@@ -2290,6 +2310,7 @@ mod tests {
                         nullify_retry: Duration::from_secs(10),
                         fetch_timeout: Duration::from_secs(1),
                         activity_timeout,
+                        skip_timeout,
                         max_fetch_count: 1,
                         max_fetch_size: 1024 * 512,
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -260,6 +260,7 @@ fn main() {
                 nullify_retry: Duration::from_secs(10),
                 fetch_timeout: Duration::from_secs(1),
                 activity_timeout: 10,
+                skip_timeout: 5,
                 max_fetch_count: 32,
                 max_fetch_size: 1024 * 512,
                 fetch_concurrent: 2,

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -228,6 +228,7 @@ fn main() {
                 nullify_retry: Duration::from_secs(10),
                 fetch_timeout: Duration::from_secs(1),
                 activity_timeout: 10,
+                skip_timeout: 5,
                 max_fetch_count: 32,
                 max_fetch_size: 1024 * 512,
                 fetch_concurrent: 2,


### PR DESCRIPTION
Related: https://github.com/commonwarexyz/alto/issues/15

This PR allows us to retain a healthy buffer of view artifacts near tip without losing responsiveness to offline participants (that we would otherwise try to skip).