### PR TITLE
[deployer] Revert loki configuration change

### DIFF
--- a/deployer/src/ec2/services.rs
+++ b/deployer/src/ec2/services.rs
@@ -130,7 +130,7 @@ schema_config:
       schema: v13
       index:
         prefix: index_
-        period: 12h
+        period: 24h
 storage_config:
   tsdb_shipper:
     active_index_directory: /loki/index


### PR DESCRIPTION
```
 msg="validating config" err="CONFIG ERROR: invalid schema config: validating period_config: tsdb must always have periodic config for index set to 24h"
 ```