### PR TITLE
[commonware-storage/mmr] minor refactor of proof verification

### DIFF
--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -89,4 +89,8 @@ pub enum Error {
     MissingPeak(u64),
     #[error("MMR is empty")]
     Empty,
+    #[error("missing hashes in proof")]
+    MissingHashes,
+    #[error("extra hashes in proof")]
+    ExtraHashes,
 }


### PR DESCRIPTION
Separates out peak reconstruction from root hash comparison and introduces specific error types for missing vs extra hashes in the proof data.
