### PR TITLE
[utils] `Array` must implement `FixedCodec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ version = "0.0.42"
 dependencies = [
  "blst",
  "bytes",
+ "commonware-codec",
  "commonware-utils",
  "criterion",
  "ed25519-consensus",
@@ -1046,6 +1047,7 @@ version = "0.0.42"
 dependencies = [
  "bimap",
  "bytes",
+ "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
  "commonware-p2p",
@@ -1130,6 +1132,7 @@ name = "commonware-utils"
 version = "0.0.42"
 dependencies = [
  "bytes",
+ "commonware-codec",
  "futures",
  "num-bigint",
  "prost",

--- a/codec/src/buffer.rs
+++ b/codec/src/buffer.rs
@@ -54,6 +54,11 @@ impl ReadBuffer {
         Ok(())
     }
 
+    #[inline]
+    pub fn chunk(&self) -> &[u8] {
+        self.inner.chunk()
+    }
+
     /// Advance the buffer by `cnt` bytes
     #[inline]
     pub fn advance(&mut self, cnt: usize) {

--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -4,7 +4,7 @@ use crate::{
     buffer::{ReadBuffer, WriteBuffer},
     error::Error,
 };
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 
 /// Trait for types that can be encoded to and decoded from bytes
 pub trait Codec: Sized {
@@ -68,7 +68,7 @@ pub trait SizedCodec: Codec {
 }
 
 /// Trait for codec read operations
-pub trait Reader {
+pub trait Reader: Buf {
     /// Reads a u8 value
     fn read_u8(&mut self) -> Result<u8, Error>;
 
@@ -188,6 +188,20 @@ pub trait Writer {
 
     /// Writes a vector with a length prefix
     fn write_vec<T: Codec>(&mut self, values: &[T]);
+}
+
+impl Buf for ReadBuffer {
+    fn remaining(&self) -> usize {
+        self.remaining()
+    }
+
+    fn chunk(&self) -> &[u8] {
+        self.chunk()
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        self.advance(cnt)
+    }
 }
 
 // Implement Reader for ReadBuffer

--- a/codec/src/error.rs
+++ b/codec/src/error.rs
@@ -20,5 +20,5 @@ pub enum Error {
     Invalid(&'static str, &'static str), // context, message
 
     #[error("Invalid: Err({1})")]
-    Wrapped(&'static str, Box<dyn std::error::Error>),
+    Wrapped(&'static str, Box<dyn std::error::Error + Send + Sync>),
 }

--- a/codec/src/error.rs
+++ b/codec/src/error.rs
@@ -5,16 +5,20 @@ use thiserror::Error;
 /// Error type for codec operations
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("unexpected end of buffer")]
+    #[error("Unexpected End-of-Buffer")]
     EndOfBuffer,
-    #[error("extra data found: {0} bytes")]
+    #[error("Extra Data: {0} bytes")]
     ExtraData(usize),
-    #[error("invalid data in {0}: {1}")]
-    InvalidData(String, String), // context, message
-    #[error("length exceeded: {0} > {1}")]
+    #[error("Length Exceeded: {0} > {1}")]
     LengthExceeded(usize, usize), // found, max
-    #[error("invalid varint")]
+    #[error("Invalid Varint")]
     InvalidVarint,
-    #[error("invalid bool")]
+    #[error("Invalid Bool")]
     InvalidBool,
+
+    #[error("Invalid. Context({0}), Message({1})")]
+    Invalid(&'static str, &'static str), // context, message
+
+    #[error("Invalid: Err({1})")]
+    Wrapped(&'static str, Box<dyn std::error::Error>),
 }

--- a/codec/src/error.rs
+++ b/codec/src/error.rs
@@ -15,10 +15,8 @@ pub enum Error {
     InvalidVarint,
     #[error("Invalid Bool")]
     InvalidBool,
-
     #[error("Invalid. Context({0}), Message({1})")]
-    Invalid(&'static str, &'static str), // context, message
-
-    #[error("Invalid: Err({1})")]
+    Invalid(&'static str, &'static str),
+    #[error("Invalid. Context({0}), Error({1})")]
     Wrapped(&'static str, Box<dyn std::error::Error + Send + Sync>),
 }

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/cryptography"
 documentation = "https://docs.rs/commonware-cryptography"
 
 [dependencies]
+commonware-codec = { workspace = true }
 commonware-utils = { workspace = true }
 bytes = { workspace = true }
 thiserror = { workspace = true }

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -100,10 +100,7 @@ impl Codec for PrivateKey {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        let raw = <[u8; group::PRIVATE_KEY_LENGTH]>::read(reader)?;
-        let key = group::Private::deserialize(&raw)
-            .ok_or(CodecError::Invalid(CURVE_NAME, "Invalid private key"))?;
-        Ok(Self { raw, key })
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))
     }
 
     fn len_encoded(&self) -> usize {
@@ -211,10 +208,7 @@ impl Codec for PublicKey {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        let raw = <[u8; group::PUBLIC_KEY_LENGTH]>::read(reader)?;
-        let key = group::Public::deserialize(&raw)
-            .ok_or(CodecError::Invalid(CURVE_NAME, "Invalid public key"))?;
-        Ok(Self { raw, key })
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))
     }
 
     fn len_encoded(&self) -> usize {
@@ -322,10 +316,7 @@ impl Codec for Signature {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        let raw = <[u8; group::SIGNATURE_LENGTH]>::read(reader)?;
-        let signature = group::Signature::deserialize(&raw)
-            .ok_or(CodecError::Invalid(CURVE_NAME, "Invalid signature"))?;
-        Ok(Self { raw, signature })
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))
     }
 
     fn len_encoded(&self) -> usize {

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -33,7 +33,7 @@ use std::{
     ops::Deref,
 };
 
-const CURVE_NAME: &str = "BLS12-381";
+const CURVE_NAME: &str = "bls12381";
 
 /// BLS12-381 implementation of the `Scheme` trait.
 ///

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -24,6 +24,7 @@ use super::primitives::{
     ops,
 };
 use crate::{Array, Error, Scheme};
+use commonware_codec::{Codec, Error as CodecError, Reader, SizedCodec, Writer};
 use commonware_utils::{hex, SizedSerialize};
 use rand::{CryptoRng, Rng};
 use std::{
@@ -89,6 +90,29 @@ impl Scheme for Bls12381 {
 pub struct PrivateKey {
     raw: [u8; group::PRIVATE_KEY_LENGTH],
     key: group::Private,
+}
+
+impl Codec for PrivateKey {
+    fn write(&self, writer: &mut impl Writer) {
+        self.raw.write(writer);
+    }
+
+    fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
+        let raw = <[u8; group::PRIVATE_KEY_LENGTH]>::read(reader)?;
+        let key = group::Private::deserialize(&raw).ok_or(CodecError::InvalidData(
+            "Bls12381".into(),
+            "Invalid private key".into(),
+        ))?;
+        Ok(Self { raw, key })
+    }
+
+    fn len_encoded(&self) -> usize {
+        group::PRIVATE_KEY_LENGTH
+    }
+}
+
+impl SizedCodec for PrivateKey {
+    const LEN_ENCODED: usize = group::PRIVATE_KEY_LENGTH;
 }
 
 impl Array for PrivateKey {
@@ -181,6 +205,29 @@ pub struct PublicKey {
     key: group::Public,
 }
 
+impl Codec for PublicKey {
+    fn write(&self, writer: &mut impl Writer) {
+        self.raw.write(writer);
+    }
+
+    fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
+        let raw = <[u8; group::PUBLIC_KEY_LENGTH]>::read(reader)?;
+        let key = group::Public::deserialize(&raw).ok_or(CodecError::InvalidData(
+            "Bls12381".into(),
+            "Invalid public key".into(),
+        ))?;
+        Ok(Self { raw, key })
+    }
+
+    fn len_encoded(&self) -> usize {
+        group::PUBLIC_KEY_LENGTH
+    }
+}
+
+impl SizedCodec for PublicKey {
+    const LEN_ENCODED: usize = group::PUBLIC_KEY_LENGTH;
+}
+
 impl Array for PublicKey {
     type Error = Error;
 }
@@ -269,6 +316,29 @@ impl Display for PublicKey {
 pub struct Signature {
     raw: [u8; group::SIGNATURE_LENGTH],
     signature: group::Signature,
+}
+
+impl Codec for Signature {
+    fn write(&self, writer: &mut impl Writer) {
+        self.raw.write(writer);
+    }
+
+    fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
+        let raw = <[u8; group::SIGNATURE_LENGTH]>::read(reader)?;
+        let signature = group::Signature::deserialize(&raw).ok_or(CodecError::InvalidData(
+            "Bls12381".into(),
+            "Invalid signature".into(),
+        ))?;
+        Ok(Self { raw, signature })
+    }
+
+    fn len_encoded(&self) -> usize {
+        group::SIGNATURE_LENGTH
+    }
+}
+
+impl SizedCodec for Signature {
+    const LEN_ENCODED: usize = group::SIGNATURE_LENGTH;
 }
 
 impl Array for Signature {

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -426,6 +426,39 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_codec_private_key() {
+        let original =
+            parse_private_key("0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3")
+                .unwrap();
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), PrivateKey::SERIALIZED_LEN);
+        let decoded = PrivateKey::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_codec_public_key() {
+        let original =
+            parse_public_key("0xa491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a")
+                .unwrap();
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), PublicKey::SERIALIZED_LEN);
+        let decoded = PublicKey::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_codec_signature() {
+        let original =
+            parse_signature("0x882730e5d03f6b42c3abc26d3372625034e1d871b65a8a6b900a56dae22da98abbe1b68f85e49fe7652a55ec3d0591c20767677e33e5cbb1207315c41a9ac03be39c2e7668edc043d6cb1d9fd93033caa8a1c5b0e84bedaeb6c64972503a43eb")
+                .unwrap();
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), Signature::SERIALIZED_LEN);
+        let decoded = Signature::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
     fn test_sign() {
         let cases = [
             vector_sign_1(),

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -33,6 +33,8 @@ use std::{
     ops::Deref,
 };
 
+const CURVE_NAME: &str = "BLS12-381";
+
 /// BLS12-381 implementation of the `Scheme` trait.
 ///
 /// This implementation uses the `blst` crate for BLS12-381 operations. This
@@ -99,10 +101,8 @@ impl Codec for PrivateKey {
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
         let raw = <[u8; group::PRIVATE_KEY_LENGTH]>::read(reader)?;
-        let key = group::Private::deserialize(&raw).ok_or(CodecError::InvalidData(
-            "Bls12381".into(),
-            "Invalid private key".into(),
-        ))?;
+        let key = group::Private::deserialize(&raw)
+            .ok_or(CodecError::Invalid(CURVE_NAME, "Invalid private key"))?;
         Ok(Self { raw, key })
     }
 
@@ -212,10 +212,8 @@ impl Codec for PublicKey {
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
         let raw = <[u8; group::PUBLIC_KEY_LENGTH]>::read(reader)?;
-        let key = group::Public::deserialize(&raw).ok_or(CodecError::InvalidData(
-            "Bls12381".into(),
-            "Invalid public key".into(),
-        ))?;
+        let key = group::Public::deserialize(&raw)
+            .ok_or(CodecError::Invalid(CURVE_NAME, "Invalid public key"))?;
         Ok(Self { raw, key })
     }
 
@@ -325,10 +323,8 @@ impl Codec for Signature {
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
         let raw = <[u8; group::SIGNATURE_LENGTH]>::read(reader)?;
-        let signature = group::Signature::deserialize(&raw).ok_or(CodecError::InvalidData(
-            "Bls12381".into(),
-            "Invalid signature".into(),
-        ))?;
+        let signature = group::Signature::deserialize(&raw)
+            .ok_or(CodecError::Invalid(CURVE_NAME, "Invalid signature"))?;
         Ok(Self { raw, signature })
     }
 

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -125,9 +125,7 @@ impl Codec for PrivateKey {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        let raw = <[u8; PRIVATE_KEY_LENGTH]>::read(reader)?;
-        let key = ed25519_consensus::SigningKey::from(raw);
-        Ok(Self { raw, key })
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))
     }
 
     fn len_encoded(&self) -> usize {
@@ -243,10 +241,7 @@ impl Codec for PublicKey {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        let raw = <[u8; PUBLIC_KEY_LENGTH]>::read(reader)?;
-        let key = ed25519_consensus::VerificationKey::try_from(raw)
-            .map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))?;
-        Ok(Self { raw, key })
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))
     }
 
     fn len_encoded(&self) -> usize {
@@ -336,9 +331,7 @@ impl Codec for Signature {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        let raw = <[u8; SIGNATURE_LENGTH]>::read(reader)?;
-        let signature = ed25519_consensus::Signature::from(raw);
-        Ok(Self { raw, signature })
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))
     }
 
     fn len_encoded(&self) -> usize {

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -8,7 +8,7 @@ use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
-const CURVE_NAME: &str = "Ed25519";
+const CURVE_NAME: &str = "ed25519";
 const PRIVATE_KEY_LENGTH: usize = 32;
 const PUBLIC_KEY_LENGTH: usize = 32;
 const SIGNATURE_LENGTH: usize = 64;

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -532,6 +532,50 @@ mod tests {
     }
 
     #[test]
+    fn test_codec_private_key() {
+        let private_key = parse_private_key(
+            "
+            9d61b19deffd5a60ba844af492ec2cc4
+            4449c5697b326919703bac031cae7f60
+            ",
+        );
+        let encoded = private_key.encode();
+        assert_eq!(encoded.len(), PRIVATE_KEY_LENGTH);
+        let decoded = PrivateKey::decode(encoded).unwrap();
+        assert_eq!(private_key, decoded);
+    }
+
+    #[test]
+    fn test_codec_public_key() {
+        let public_key = parse_public_key(
+            "
+            d75a980182b10ab7d54bfed3c964073a
+            0ee172f3daa62325af021a68f707511a
+            ",
+        );
+        let encoded = public_key.encode();
+        assert_eq!(encoded.len(), PUBLIC_KEY_LENGTH);
+        let decoded = PublicKey::decode(encoded).unwrap();
+        assert_eq!(public_key, decoded);
+    }
+
+    #[test]
+    fn test_codec_signature() {
+        let signature = parse_signature(
+            "
+            e5564300c360ac729086e2cc806e828a
+            84877f1eb8e5d974d873e06522490155
+            5fb8821590a33bacc61e39701cf9b46b
+            d25bf5f0595bbe24655141438e7a100b
+            ",
+        );
+        let encoded = signature.encode();
+        assert_eq!(encoded.len(), SIGNATURE_LENGTH);
+        let decoded = Signature::decode(encoded).unwrap();
+        assert_eq!(signature, decoded);
+    }
+
+    #[test]
     fn rfc8032_test_vector_1() {
         let (private_key, public_key, message, signature) = vector_1();
         test_sign_and_verify(private_key, public_key, &message, signature)

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -8,6 +8,7 @@ use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
+const CURVE_NAME: &str = "Ed25519";
 const PRIVATE_KEY_LENGTH: usize = 32;
 const PUBLIC_KEY_LENGTH: usize = 32;
 const SIGNATURE_LENGTH: usize = 64;
@@ -243,8 +244,8 @@ impl Codec for PublicKey {
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
         let raw = <[u8; PUBLIC_KEY_LENGTH]>::read(reader)?;
-        let key = ed25519_consensus::VerificationKey::try_from(&raw[..])
-            .map_err(|_| CodecError::InvalidData("Ed25519".into(), "Invalid public key".into()))?;
+        let key = ed25519_consensus::VerificationKey::try_from(raw)
+            .map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))?;
         Ok(Self { raw, key })
     }
 

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -95,10 +95,7 @@ impl Codec for PrivateKey {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        let raw = <[u8; PRIVATE_KEY_LENGTH]>::read(reader)?;
-        let key = SigningKey::from_slice(&raw)
-            .map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))?;
-        Ok(Self { raw, key })
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))
     }
 
     fn len_encoded(&self) -> usize {
@@ -206,10 +203,7 @@ impl Codec for PublicKey {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        let raw = <[u8; PUBLIC_KEY_LENGTH]>::read(reader)?;
-        let key = VerifyingKey::from_sec1_bytes(&raw)
-            .map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))?;
-        Ok(Self { raw, key })
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))
     }
 
     fn len_encoded(&self) -> usize {
@@ -306,17 +300,7 @@ impl Codec for Signature {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        let raw = <[u8; SIGNATURE_LENGTH]>::read(reader)?;
-        let signature = p256::ecdsa::Signature::from_slice(&raw)
-            .map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))?;
-        if signature.s().is_high().into() {
-            // Reject any signatures with a `s` value in the upper half of the curve order.
-            return Err(CodecError::Wrapped(
-                CURVE_NAME,
-                Error::InvalidSignature.into(),
-            ));
-        }
-        Ok(Self { raw, signature })
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped(CURVE_NAME, err.into()))
     }
 
     fn len_encoded(&self) -> usize {

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -98,7 +98,7 @@ impl Codec for Digest {
     }
 
     fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
-        <[u8; DIGEST_LENGTH]>::read(reader).map(Self)
+        Self::read_from(reader).map_err(|err| CodecError::Wrapped("Digest", err.into()))
     }
 
     fn len_encoded(&self) -> usize {

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -21,6 +21,7 @@
 //! ```
 
 use crate::{Array, Error, Hasher};
+use commonware_codec::{Codec, Error as CodecError, Reader, SizedCodec, Writer};
 use commonware_utils::{hex, SizedSerialize};
 use rand::{CryptoRng, Rng};
 use sha2::{Digest as _, Sha256 as ISha256};
@@ -90,6 +91,24 @@ impl Hasher for Sha256 {
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct Digest([u8; DIGEST_LENGTH]);
+
+impl Codec for Digest {
+    fn write(&self, writer: &mut impl Writer) {
+        self.0.write(writer);
+    }
+
+    fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
+        <[u8; DIGEST_LENGTH]>::read(reader).map(Self)
+    }
+
+    fn len_encoded(&self) -> usize {
+        DIGEST_LENGTH
+    }
+}
+
+impl SizedCodec for Digest {
+    const LEN_ENCODED: usize = DIGEST_LENGTH;
+}
 
 impl Array for Digest {
     type Error = Error;
@@ -200,5 +219,20 @@ mod tests {
     #[test]
     fn test_sha256_len() {
         assert_eq!(Digest::SERIALIZED_LEN, DIGEST_LENGTH);
+    }
+
+    #[test]
+    fn test_codec() {
+        let msg = b"hello world";
+        let mut hasher = Sha256::new();
+        hasher.update(msg);
+        let digest = hasher.finalize();
+
+        let encoded = digest.encode();
+        assert_eq!(encoded.len(), DIGEST_LENGTH);
+        assert_eq!(encoded, digest.as_ref());
+
+        let decoded = Digest::decode(encoded).unwrap();
+        assert_eq!(digest, decoded);
     }
 }

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/resolver"
 documentation = "https://docs.rs/commonware-resolver"
 
 [dependencies]
+commonware-codec = { workspace = true }
 commonware-cryptography = { workspace = true }
 commonware-macros = { workspace = true }
 commonware-p2p = { workspace = true }

--- a/resolver/src/p2p/mocks/key.rs
+++ b/resolver/src/p2p/mocks/key.rs
@@ -1,3 +1,4 @@
+use commonware_codec::{Codec, Error as CodecError, Reader, SizedCodec, Writer};
 use commonware_utils::{Array, SizedSerialize};
 use std::{fmt, ops::Deref};
 use thiserror::Error;
@@ -51,6 +52,24 @@ impl TryFrom<Vec<u8>> for Key {
 
 impl SizedSerialize for Key {
     const SERIALIZED_LEN: usize = 1;
+}
+
+impl Codec for Key {
+    fn write(&self, writer: &mut impl Writer) {
+        self.0.write(writer);
+    }
+
+    fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
+        u8::read(reader).map(Self)
+    }
+
+    fn len_encoded(&self) -> usize {
+        Self::SERIALIZED_LEN
+    }
+}
+
+impl SizedCodec for Key {
+    const LEN_ENCODED: usize = Self::SERIALIZED_LEN;
 }
 
 impl Array for Key {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/utils"
 documentation = "https://docs.rs/commonware-utils"
 
 [dependencies]
+commonware-codec = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 prost = { workspace = true }

--- a/utils/src/array/fixed_bytes.rs
+++ b/utils/src/array/fixed_bytes.rs
@@ -1,4 +1,5 @@
 use crate::{hex, Array, SizedSerialize};
+use commonware_codec::{Codec, Error as CodecError, Reader, SizedCodec, Writer};
 use std::{
     cmp::{Ord, PartialOrd},
     fmt::{Debug, Display},
@@ -24,6 +25,25 @@ impl<const N: usize> FixedBytes<N> {
     pub fn new(value: [u8; N]) -> Self {
         Self(value)
     }
+}
+
+impl<const N: usize> Codec for FixedBytes<N> {
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_fixed(&self.0);
+    }
+
+    fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
+        let value = reader.read_fixed()?;
+        Ok(Self(value))
+    }
+
+    fn len_encoded(&self) -> usize {
+        N
+    }
+}
+
+impl<const N: usize> SizedCodec for FixedBytes<N> {
+    const LEN_ENCODED: usize = N;
 }
 
 impl<const N: usize> Array for FixedBytes<N> {

--- a/utils/src/array/fixed_bytes.rs
+++ b/utils/src/array/fixed_bytes.rs
@@ -110,6 +110,15 @@ mod tests {
     use bytes::{Buf, BytesMut};
 
     #[test]
+    fn test_codec() {
+        let original = FixedBytes::new([1, 2, 3, 4]);
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), original.len());
+        let decoded = FixedBytes::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
     fn test_bytes_creation_and_conversion() {
         let value = [1, 2, 3, 4];
         let bytes = FixedBytes::new(value);

--- a/utils/src/array/mod.rs
+++ b/utils/src/array/mod.rs
@@ -1,5 +1,6 @@
 use crate::SizedSerialize;
 use bytes::Buf;
+use commonware_codec::{Codec, SizedCodec};
 use std::{
     cmp::{Ord, PartialOrd},
     error::Error as StdError,
@@ -48,6 +49,8 @@ pub trait Array:
     + for<'a> TryFrom<&'a Vec<u8>, Error = <Self as Array>::Error>
     + TryFrom<Vec<u8>, Error = <Self as Array>::Error>
     + SizedSerialize
+    + Codec
+    + SizedCodec
 {
     /// Errors returned when parsing an invalid byte sequence.
     type Error: StdError + Send + Sync + 'static;

--- a/utils/src/array/mod.rs
+++ b/utils/src/array/mod.rs
@@ -56,7 +56,7 @@ pub trait Array:
     type Error: StdError + Send + Sync + 'static;
 
     /// Attempts to read an array from the provided buffer.
-    fn read_from<B: Buf>(buf: &mut B) -> Result<Self, Error<<Self as Array>::Error>> {
+    fn read_from(buf: &mut impl Buf) -> Result<Self, Error<<Self as Array>::Error>> {
         let len = Self::SERIALIZED_LEN;
         if buf.remaining() < len {
             return Err(Error::InsufficientBytes);


### PR DESCRIPTION
A change that allows other crates to start using `Codec` and `FixedCodec` more easily since `Array` implements `Codec` and `FixedCodec`. Eventually we will remove the use of `SizedSerialize` and several other parts of the `Array` trait. For example, we should remove the requirement of `Array` to implement `TryFrom` for `Vec<u8>` and `&Vec<u8>`.
`&Vec<u8>` is redundant since `Vec<u8>` dereferences to `&[u8]`, and `Vec<u8>` is handled by converting to Bytes (transfers ownership to `Bytes` without making a copy).

Will make #593 easier

Also the first step in #622 