### PR TITLE
[consensus/threshold-simplex] Employ aggregate verification when possible

### DIFF
--- a/broadcast/src/linked/engine.rs
+++ b/broadcast/src/linked/engine.rs
@@ -815,7 +815,7 @@ impl<
         };
         let public_key = poly::public(identity);
         ops::verify_message(
-            &public_key,
+            public_key,
             Some(&self.ack_namespace),
             &serializer::ack(&parent_chunk, parent.epoch),
             &parent.threshold,

--- a/broadcast/src/linked/mod.rs
+++ b/broadcast/src/linked/mod.rs
@@ -225,7 +225,7 @@ mod tests {
             let (collector, collector_mailbox) =
                 mocks::collector::Collector::<Ed25519, Sha256Digest>::new(
                     namespace,
-                    poly::public(&identity),
+                    *poly::public(&identity),
                 );
             context.with_label("collector").spawn(|_| collector.run());
             collectors.insert(validator.clone(), collector_mailbox);

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -470,18 +470,18 @@ impl<
                 let eval = Eval::deserialize(&notarize.message.seed_signature).unwrap();
                 seed.push(eval);
             }
-            let proposal_signature =
-                self.context
-                    .with_label("notarization_recovery")
-                    .spawn(move |_| async move {
-                        threshold_signature_recover(threshold, notarization)
-                            .unwrap()
-                            .serialize()
-                    });
+            let proposal_signature = self
+                .context
+                .with_label("notarization_recovery")
+                .spawn_blocking(move || {
+                    threshold_signature_recover(threshold, notarization)
+                        .unwrap()
+                        .serialize()
+                });
             let seed_signature =
                 self.context
                     .with_label("seed_recovery")
-                    .spawn(move |_| async move {
+                    .spawn_blocking(move || {
                         threshold_signature_recover(threshold, seed)
                             .unwrap()
                             .serialize()
@@ -531,18 +531,18 @@ impl<
             let eval = Eval::deserialize(&nullify.seed_signature).unwrap();
             seed.push(eval);
         }
-        let view_signature =
-            self.context
-                .with_label("nullification_recovery")
-                .spawn(move |_| async move {
-                    threshold_signature_recover(threshold, nullification)
-                        .unwrap()
-                        .serialize()
-                });
+        let view_signature = self
+            .context
+            .with_label("nullification_recovery")
+            .spawn_blocking(move || {
+                threshold_signature_recover(threshold, nullification)
+                    .unwrap()
+                    .serialize()
+            });
         let seed_signature = self
             .context
             .with_label("seed_recovery")
-            .spawn(move |_| async move {
+            .spawn_blocking(move || {
                 threshold_signature_recover(threshold, seed)
                     .unwrap()
                     .serialize()

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -357,7 +357,7 @@ mod tests {
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace);
+            let prover = Prover::new(*pk, &namespace);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -540,7 +540,6 @@ mod tests {
         // Derive threshold
         let mut rng = StdRng::seed_from_u64(0);
         let (public, shares) = ops::generate_shares(&mut rng, None, n, threshold);
-        let pk = poly::public(&public);
 
         // Random restarts every x seconds
         let shutdowns: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
@@ -594,7 +593,8 @@ mod tests {
                 link_validators(&mut oracle, &validators, Action::Link(link), None).await;
 
                 // Create engines
-                let prover = Prover::new(pk, &namespace);
+                let pk = poly::public(&public);
+                let prover = Prover::new(*pk, &namespace);
                 let relay = Arc::new(mocks::relay::Relay::new());
                 let mut supervisors = HashMap::new();
                 let (done_sender, mut done_receiver) = mpsc::unbounded();
@@ -808,7 +808,7 @@ skip_timeout,
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace);
+            let prover = Prover::new(*pk, &namespace);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1103,7 +1103,7 @@ skip_timeout,
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace);
+            let prover = Prover::new(*pk, &namespace);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1288,7 +1288,7 @@ skip_timeout,
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace);
+            let prover = Prover::new(*pk, &namespace);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1479,7 +1479,7 @@ skip_timeout,
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace);
+            let prover = Prover::new(*pk, &namespace);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1652,7 +1652,7 @@ skip_timeout,
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace);
+            let prover = Prover::new(*pk, &namespace);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -1881,7 +1881,7 @@ skip_timeout,
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace);
+            let prover = Prover::new(*pk, &namespace);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -2060,7 +2060,7 @@ skip_timeout,
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace);
+            let prover = Prover::new(*pk, &namespace);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());
@@ -2246,7 +2246,7 @@ skip_timeout,
             // Derive threshold
             let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
             let pk = poly::public(&public);
-            let prover = Prover::new(pk, &namespace);
+            let prover = Prover::new(*pk, &namespace);
 
             // Create engines
             let relay = Arc::new(mocks::relay::Relay::new());

--- a/consensus/src/threshold_simplex/prover.rs
+++ b/consensus/src/threshold_simplex/prover.rs
@@ -452,7 +452,7 @@ mod tests {
     fn generate_threshold() -> (group::Public, poly::Public, Vec<Share>) {
         let mut sampler = StdRng::seed_from_u64(0);
         let (public, shares) = generate_shares(&mut sampler, None, 4, 3);
-        (poly::public(&public), public, shares)
+        (*poly::public(&public), public, shares)
     }
 
     fn generate_keypair() -> (group::Private, group::Public) {

--- a/consensus/src/threshold_simplex/verifier.rs
+++ b/consensus/src/threshold_simplex/verifier.rs
@@ -64,8 +64,14 @@ pub fn verify_notarization<
     let notarization_message = (Some(notarization_namespace), notarization_message.as_ref());
     let seed_message = seed_message(proposal.view);
     let seed_message = (Some(seed_namespace), seed_message.as_ref());
-    let messages = [notarization_message, seed_message];
-    if aggregate_verify_multiple_messages(public_key, &messages, &signature, 1).is_err() {
+    if aggregate_verify_multiple_messages(
+        public_key,
+        &[notarization_message, seed_message],
+        &signature,
+        1,
+    )
+    .is_err()
+    {
         debug!(reason = "invalid signature", "dropping notarization");
         return false;
     }
@@ -111,8 +117,14 @@ pub fn verify_nullification<S: ThresholdSupervisor<Index = View, Identity = poly
     );
     let seed_message = seed_message(nullification.view);
     let seed_message = (Some(seed_namespace), seed_message.as_ref());
-    let messages = [nullification_message, seed_message];
-    if aggregate_verify_multiple_messages(public_key, &messages, &signature, 1).is_err() {
+    if aggregate_verify_multiple_messages(
+        public_key,
+        &[nullification_message, seed_message],
+        &signature,
+        1,
+    )
+    .is_err()
+    {
         debug!(reason = "invalid signature", "dropping nullification");
         return false;
     }
@@ -173,8 +185,14 @@ pub fn verify_finalization<
     let finalization_message = (Some(finalization_namespace), finalization_message.as_ref());
     let seed_message = seed_message(proposal.view);
     let seed_message = (Some(seed_namespace), seed_message.as_ref());
-    let messages = [finalization_message, seed_message];
-    if aggregate_verify_multiple_messages(public_key, &messages, &signature, 1).is_err() {
+    if aggregate_verify_multiple_messages(
+        public_key,
+        &[finalization_message, seed_message],
+        &signature,
+        1,
+    )
+    .is_err()
+    {
         debug!(reason = "invalid signature", "dropping finalization");
         return false;
     }

--- a/consensus/src/threshold_simplex/verifier.rs
+++ b/consensus/src/threshold_simplex/verifier.rs
@@ -50,7 +50,10 @@ pub fn verify_notarization<
     let Some(notarization_signature) =
         group::Signature::deserialize(&notarization.proposal_signature)
     else {
-        debug!(reason = "invalid signature", "dropping notarization");
+        debug!(
+            reason = "invalid notarization signature",
+            "dropping notarization"
+        );
         return false;
     };
     let Some(seed_signature) = group::Signature::deserialize(&notarization.seed_signature) else {
@@ -72,7 +75,10 @@ pub fn verify_notarization<
     )
     .is_err()
     {
-        debug!(reason = "invalid signature", "dropping notarization");
+        debug!(
+            reason = "signature verification failed",
+            "dropping notarization"
+        );
         return false;
     }
     debug!(view = proposal.view, "notarization verified");
@@ -100,7 +106,10 @@ pub fn verify_nullification<S: ThresholdSupervisor<Index = View, Identity = poly
     let Some(nullification_signature) =
         group::Signature::deserialize(&nullification.view_signature)
     else {
-        debug!(reason = "invalid signature", "dropping nullification");
+        debug!(
+            reason = "invalid nullification signature",
+            "dropping nullification"
+        );
         return false;
     };
     let Some(seed_signature) = group::Signature::deserialize(&nullification.seed_signature) else {
@@ -125,7 +134,10 @@ pub fn verify_nullification<S: ThresholdSupervisor<Index = View, Identity = poly
     )
     .is_err()
     {
-        debug!(reason = "invalid signature", "dropping nullification");
+        debug!(
+            reason = "signature verification failed",
+            "dropping nullification"
+        );
         return false;
     }
     debug!(view = nullification.view, "nullification verified");
@@ -171,7 +183,10 @@ pub fn verify_finalization<
     let Some(finalization_signature) =
         group::Signature::deserialize(&finalization.proposal_signature)
     else {
-        debug!(reason = "invalid signature", "dropping finalization");
+        debug!(
+            reason = "invalid finalization signature",
+            "dropping finalization"
+        );
         return false;
     };
     let Some(seed_signature) = group::Signature::deserialize(&finalization.seed_signature) else {
@@ -193,7 +208,10 @@ pub fn verify_finalization<
     )
     .is_err()
     {
-        debug!(reason = "invalid signature", "dropping finalization");
+        debug!(
+            reason = "signature verification failed",
+            "dropping finalization"
+        );
         return false;
     }
     debug!(view = proposal.view, "finalization verified");

--- a/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
@@ -4,14 +4,17 @@ use rand::{thread_rng, Rng};
 
 fn benchmark_aggregate_verify_multiple_messages(c: &mut Criterion) {
     let namespace = b"namespace";
-    for n in [10, 100, 1000, 10000, 50000].into_iter() {
+    for n in [2, 10, 100, 1000, 10000, 50000].into_iter() {
         let mut msgs = Vec::with_capacity(n);
         for _ in 0..n {
             let mut msg = [0u8; 32];
             thread_rng().fill(&mut msg);
             msgs.push(msg);
         }
-        let msgs = msgs.iter().map(|msg| msg.as_ref()).collect::<Vec<_>>();
+        let msgs = msgs
+            .iter()
+            .map(|msg| (Some(&namespace[..]), msg.as_ref()))
+            .collect::<Vec<_>>();
         for concurrency in [1, 2, 4, 8].into_iter() {
             c.bench_function(
                 &format!("{}/conc={} msgs={}", module_path!(), concurrency, n,),
@@ -20,8 +23,8 @@ fn benchmark_aggregate_verify_multiple_messages(c: &mut Criterion) {
                         || {
                             let (private, public) = ops::keypair(&mut thread_rng());
                             let mut signatures = Vec::with_capacity(n);
-                            for msg in msgs.iter() {
-                                let signature = ops::sign_message(&private, Some(namespace), msg);
+                            for (namespace, msg) in msgs.iter() {
+                                let signature = ops::sign_message(&private, *namespace, msg);
                                 signatures.push(signature);
                             }
                             (public, ops::aggregate_signatures(&signatures))
@@ -29,7 +32,6 @@ fn benchmark_aggregate_verify_multiple_messages(c: &mut Criterion) {
                         |(public, signature)| {
                             ops::aggregate_verify_multiple_messages(
                                 &public,
-                                Some(namespace),
                                 &msgs,
                                 &signature,
                                 concurrency,

--- a/cryptography/src/bls12381/dkg/mod.rs
+++ b/cryptography/src/bls12381/dkg/mod.rs
@@ -307,7 +307,7 @@ mod tests {
         let signature =
             threshold_signature_recover(t, partials).expect("unable to recover signature");
         let public_key = public(&outputs.iter().next().unwrap().1.public);
-        verify_proof_of_possession(&public_key, &signature).expect("invalid proof of possession");
+        verify_proof_of_possession(public_key, &signature).expect("invalid proof of possession");
 
         // Create reshare players (assume no overlap)
         let mut reshare_players = Vec::new();
@@ -418,7 +418,7 @@ mod tests {
         let signature =
             threshold_signature_recover(t, partials).expect("unable to recover signature");
         let public_key = public(&outputs[0].public);
-        verify_proof_of_possession(&public_key, &signature).expect("invalid proof of possession");
+        verify_proof_of_possession(public_key, &signature).expect("invalid proof of possession");
     }
 
     #[test]

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -51,7 +51,7 @@ mod tests {
         // Generate and verify the threshold sig
         let threshold_sig = threshold_signature_recover(t, partials).unwrap();
         let threshold_pub = public(&group);
-        verify_message(&threshold_pub, namespace, msg, &threshold_sig).unwrap();
+        verify_message(threshold_pub, namespace, msg, &threshold_sig).unwrap();
     }
 
     #[test]
@@ -87,7 +87,7 @@ mod tests {
         let threshold_sig = threshold_signature_recover(t, partials).unwrap();
         let threshold_pub = public(&group);
         assert!(matches!(
-            verify_message(&threshold_pub, namespace, msg, &threshold_sig).unwrap_err(),
+            verify_message(threshold_pub, namespace, msg, &threshold_sig).unwrap_err(),
             Error::InvalidSignature
         ));
     }
@@ -187,6 +187,6 @@ mod tests {
         // Generate and verify the threshold sig
         let threshold_sig = threshold_signature_recover(t, partials).unwrap();
         let threshold_pub = public(&group);
-        verify_message(&threshold_pub, namespace, msg, &threshold_sig).unwrap();
+        verify_message(threshold_pub, namespace, msg, &threshold_sig).unwrap();
     }
 }

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -207,12 +207,16 @@ pub fn partial_aggregate_signatures(
 /// This function assumes a group check was already performed on each `signature`.
 pub fn partial_verify_multiple_messages(
     public: &poly::Public,
+    partial_signer: u32,
     messages: &[(Option<&[u8]>, &[u8])],
     signatures: &[PartialSignature],
 ) -> Result<(), Error> {
     // Aggregate the partial signatures
     let (index, signature) =
         partial_aggregate_signatures(signatures).ok_or(Error::InvalidSignature)?;
+    if partial_signer != index {
+        return Err(Error::InvalidSignature);
+    }
     let public = public.evaluate(index).value;
 
     // Sum the hashed messages

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -713,7 +713,11 @@ mod tests {
         // Aggregate the signatures
         let aggregate_sig = aggregate_signatures(&signatures);
 
-        // Verify the aggregated signature
+        // Verify the aggregated signature without parallelism
+        aggregate_verify_multiple_messages(&public, &messages, &aggregate_sig, 1)
+            .expect("Aggregated signature should be valid");
+
+        // Verify the aggregated signature with parallelism
         aggregate_verify_multiple_messages(&public, &messages, &aggregate_sig, 4)
             .expect("Aggregated signature should be valid");
 
@@ -748,12 +752,19 @@ mod tests {
         // Aggregate the signatures
         let aggregate_sig = aggregate_signatures(&signatures);
 
-        // Verify the aggregated signature
+        // Construct wrong messages
         let wrong_messages: Vec<(Option<&[u8]>, &[u8])> = vec![
             (namespace, b"Message 1"),
             (namespace, b"Message 2"),
             (namespace, b"Message 4"),
         ];
+
+        // Verify the aggregated signature without parallelism
+        let result =
+            aggregate_verify_multiple_messages(&public, &wrong_messages, &aggregate_sig, 1);
+        assert!(matches!(result, Err(Error::InvalidSignature)));
+
+        // Verify the aggregated signature with parallelism
         let result =
             aggregate_verify_multiple_messages(&public, &wrong_messages, &aggregate_sig, 4);
         assert!(matches!(result, Err(Error::InvalidSignature)));
@@ -777,9 +788,16 @@ mod tests {
         // Aggregate the signatures
         let aggregate_sig = aggregate_signatures(&signatures);
 
-        // Verify the aggregated signature
+        // Construct wrong messages
         let wrong_messages: Vec<(Option<&[u8]>, &[u8])> =
             vec![(namespace, b"Message 1"), (namespace, b"Message 2")];
+
+        // Verify the aggregated signature without parallelism
+        let result =
+            aggregate_verify_multiple_messages(&public, &wrong_messages, &aggregate_sig, 1);
+        assert!(matches!(result, Err(Error::InvalidSignature)));
+
+        // Verify the aggregated signature with parallelism
         let result =
             aggregate_verify_multiple_messages(&public, &wrong_messages, &aggregate_sig, 4);
         assert!(matches!(result, Err(Error::InvalidSignature)));

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -261,34 +261,47 @@ pub fn aggregate_verify_multiple_public_keys(
 /// this optimization to cause this function to return that an aggregate signature is valid when it really isn't.
 pub fn aggregate_verify_multiple_messages(
     public: &group::Public,
-    namespace: Option<&[u8]>,
-    messages: &[&[u8]],
+    messages: &[(Option<&[u8]>, &[u8])],
     signature: &group::Signature,
     concurrency: usize,
 ) -> Result<(), Error> {
-    // Build a thread pool with the specified concurrency
-    let pool = ThreadPoolBuilder::new()
-        .num_threads(concurrency)
-        .build()
-        .expect("Unable to build thread pool");
+    let hm_sum = if concurrency == 1 {
+        // Avoid pool overhead when concurrency is 1
+        let mut hm_sum = group::Signature::zero();
+        for (namespace, msg) in messages {
+            let mut hm = group::Signature::zero();
+            match namespace {
+                Some(namespace) => hm.map(MESSAGE, &union_unique(namespace, msg)),
+                None => hm.map(MESSAGE, msg),
+            };
+            hm_sum.add(&hm);
+        }
+        hm_sum
+    } else {
+        // Build a thread pool with the specified concurrency
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(concurrency)
+            .build()
+            .expect("Unable to build thread pool");
 
-    // Perform hashing to curve and summation of messages in parallel
-    let hm_sum = pool.install(|| {
-        messages
-            .par_iter()
-            .map(|msg| {
-                let mut hm = group::Signature::zero();
-                match namespace {
-                    Some(namespace) => hm.map(MESSAGE, &union_unique(namespace, msg)),
-                    None => hm.map(MESSAGE, msg),
-                };
-                hm
-            })
-            .reduce(group::Signature::zero, |mut sum, hm| {
-                sum.add(&hm);
-                sum
-            })
-    });
+        // Perform hashing to curve and summation of messages in parallel
+        pool.install(|| {
+            messages
+                .par_iter()
+                .map(|(namespace, msg)| {
+                    let mut hm = group::Signature::zero();
+                    match namespace {
+                        Some(namespace) => hm.map(MESSAGE, &union_unique(namespace, msg)),
+                        None => hm.map(MESSAGE, msg),
+                    };
+                    hm
+                })
+                .reduce(group::Signature::zero, |mut sum, hm| {
+                    sum.add(&hm);
+                    sum
+                })
+        })
+    };
 
     // Verify the signature
     if !equal(public, signature, &hm_sum) {
@@ -375,11 +388,11 @@ mod tests {
         let threshold_pub = poly::public(&public);
 
         // Verify PoP
-        verify_proof_of_possession(&threshold_pub, &threshold_sig)
+        verify_proof_of_possession(threshold_pub, &threshold_sig)
             .expect("signature should be valid");
 
         // Verify PoP using blst
-        blst_verify_proof_of_possession(&threshold_pub, &threshold_sig)
+        blst_verify_proof_of_possession(threshold_pub, &threshold_sig)
             .expect("signature should be valid");
     }
 
@@ -470,12 +483,12 @@ mod tests {
         let threshold_pub = poly::public(&public);
 
         // Verify the signature
-        verify_message(&threshold_pub, Some(namespace), msg, &threshold_sig)
+        verify_message(threshold_pub, Some(namespace), msg, &threshold_sig)
             .expect("signature should be valid");
 
         // Verify the signature using blst
         let payload = union_unique(namespace, msg);
-        blst_verify_message(&threshold_pub, &payload, &threshold_sig)
+        blst_verify_message(threshold_pub, &payload, &threshold_sig)
             .expect("signature should be valid");
     }
 
@@ -624,24 +637,28 @@ mod tests {
     fn test_aggregate_verify_multiple_messages() {
         // Generate signatures
         let (private, public) = keypair(&mut thread_rng());
-        let messages: Vec<&[u8]> = vec![b"Message 1", b"Message 2", b"Message 3"];
         let namespace = Some(&b"test"[..]);
+        let messages: Vec<(Option<&[u8]>, &[u8])> = vec![
+            (namespace, b"Message 1"),
+            (namespace, b"Message 2"),
+            (namespace, b"Message 3"),
+        ];
         let signatures: Vec<_> = messages
             .iter()
-            .map(|msg| sign_message(&private, namespace, msg))
+            .map(|(namespace, msg)| sign_message(&private, *namespace, msg))
             .collect();
 
         // Aggregate the signatures
         let aggregate_sig = aggregate_signatures(&signatures);
 
         // Verify the aggregated signature
-        aggregate_verify_multiple_messages(&public, namespace, &messages, &aggregate_sig, 4)
+        aggregate_verify_multiple_messages(&public, &messages, &aggregate_sig, 4)
             .expect("Aggregated signature should be valid");
 
         // Verify the aggregated signature using blst
         let messages = messages
             .iter()
-            .map(|msg| union_unique(b"test", msg))
+            .map(|(namespace, msg)| union_unique(namespace.unwrap(), msg))
             .collect::<Vec<_>>();
         let messages = messages
             .iter()
@@ -655,25 +672,28 @@ mod tests {
     fn test_aggregate_verify_wrong_messages() {
         // Generate signatures
         let (private, public) = keypair(&mut thread_rng());
-        let messages: Vec<&[u8]> = vec![b"Message 1", b"Message 2", b"Message 3"];
         let namespace = Some(&b"test"[..]);
+        let messages: Vec<(Option<&[u8]>, &[u8])> = vec![
+            (namespace, b"Message 1"),
+            (namespace, b"Message 2"),
+            (namespace, b"Message 3"),
+        ];
         let signatures: Vec<_> = messages
             .iter()
-            .map(|msg| sign_message(&private, namespace, msg))
+            .map(|(namespace, msg)| sign_message(&private, *namespace, msg))
             .collect();
 
         // Aggregate the signatures
         let aggregate_sig = aggregate_signatures(&signatures);
 
         // Verify the aggregated signature
-        let wrong_messages: Vec<&[u8]> = vec![b"Message 1", b"Message 2", b"Message 4"];
-        let result = aggregate_verify_multiple_messages(
-            &public,
-            namespace,
-            &wrong_messages,
-            &aggregate_sig,
-            4,
-        );
+        let wrong_messages: Vec<(Option<&[u8]>, &[u8])> = vec![
+            (namespace, b"Message 1"),
+            (namespace, b"Message 2"),
+            (namespace, b"Message 4"),
+        ];
+        let result =
+            aggregate_verify_multiple_messages(&public, &wrong_messages, &aggregate_sig, 4);
         assert!(matches!(result, Err(Error::InvalidSignature)));
     }
 
@@ -681,25 +701,25 @@ mod tests {
     fn test_aggregate_verify_wrong_message_count() {
         // Generate signatures
         let (private, public) = keypair(&mut thread_rng());
-        let messages: Vec<&[u8]> = vec![b"Message 1", b"Message 2", b"Message 3"];
         let namespace = Some(&b"test"[..]);
+        let messages: Vec<(Option<&[u8]>, &[u8])> = vec![
+            (namespace, b"Message 1"),
+            (namespace, b"Message 2"),
+            (namespace, b"Message 3"),
+        ];
         let signatures: Vec<_> = messages
             .iter()
-            .map(|msg| sign_message(&private, namespace, msg))
+            .map(|(namespace, msg)| sign_message(&private, *namespace, msg))
             .collect();
 
         // Aggregate the signatures
         let aggregate_sig = aggregate_signatures(&signatures);
 
         // Verify the aggregated signature
-        let wrong_messages: Vec<&[u8]> = vec![b"Message 1", b"Message 2"];
-        let result = aggregate_verify_multiple_messages(
-            &public,
-            namespace,
-            &wrong_messages,
-            &aggregate_sig,
-            4,
-        );
+        let wrong_messages: Vec<(Option<&[u8]>, &[u8])> =
+            vec![(namespace, b"Message 1"), (namespace, b"Message 2")];
+        let result =
+            aggregate_verify_multiple_messages(&public, &wrong_messages, &aggregate_sig, 4);
         assert!(matches!(result, Err(Error::InvalidSignature)));
     }
 }

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -268,8 +268,8 @@ impl<C: Element> Poly<C> {
 }
 
 /// Returns the public key of the polynomial (constant term).
-pub fn public(public: &Public) -> group::Public {
-    *public.constant()
+pub fn public(public: &Public) -> &group::Public {
+    public.constant()
 }
 
 #[cfg(test)]

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -121,7 +121,7 @@ fn main() {
     let identity = from_hex(identity).expect("Identity not well-formed");
     let identity: Poly<group::Public> =
         Poly::deserialize(&identity, threshold).expect("Identity not well-formed");
-    let public = poly::public(&identity);
+    let public = *poly::public(&identity);
     let share = matches
         .get_one::<String>("share")
         .expect("Please provide share");


### PR DESCRIPTION
## Motivation

On my machine, it takes ~641 µs to verify a single BLS12-381 signature but only ~733 µs to verify an aggregate signature over two BLS12-381 from the same public key.

```
bls12381::signature_verification/ns_len=9 msg_len=32
                        time:   [617.53 µs 625.76 µs 641.84 µs]

bls12381::aggregate_verify_multiple_messages/conc=1 msgs=2
                        time:   [732.63 µs 733.84 µs 735.53 µs]
```