### PR TITLE
[runtime] Add support for `spawn_blocking`

### DIFF
--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -91,7 +91,7 @@ fn main() {
 
     // Initialize runtime
     let cfg = tokio::Config {
-        threads: config.worker_threads,
+        worker_threads: config.worker_threads,
         ..Default::default()
     };
     let (executor, context) = tokio::Executor::init(cfg);

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -65,6 +65,8 @@ struct Work {
 struct Metrics {
     tasks_spawned: Family<Work, Counter>,
     tasks_running: Family<Work, Gauge>,
+    blocking_tasks_spawned: Family<Work, Counter>,
+    blocking_tasks_running: Family<Work, Gauge>,
     task_polls: Family<Work, Counter>,
 
     network_bandwidth: Counter,
@@ -80,8 +82,10 @@ impl Metrics {
     pub fn init(registry: &mut Registry) -> Self {
         let metrics = Self {
             task_polls: Family::default(),
-            tasks_running: Family::default(),
             tasks_spawned: Family::default(),
+            tasks_running: Family::default(),
+            blocking_tasks_spawned: Family::default(),
+            blocking_tasks_running: Family::default(),
             network_bandwidth: Counter::default(),
             open_blobs: Gauge::default(),
             storage_reads: Counter::default(),
@@ -98,6 +102,16 @@ impl Metrics {
             "tasks_running",
             "Number of tasks currently running",
             metrics.tasks_running.clone(),
+        );
+        registry.register(
+            "blocking_tasks_spawned",
+            "Total number of blocking tasks spawned",
+            metrics.blocking_tasks_spawned.clone(),
+        );
+        registry.register(
+            "blocking_tasks_running",
+            "Number of blocking tasks currently running",
+            metrics.blocking_tasks_running.clone(),
         );
         registry.register(
             "task_polls",
@@ -892,13 +906,13 @@ impl crate::Spawner for Context {
         };
         self.executor
             .metrics
-            .tasks_spawned
+            .blocking_tasks_spawned
             .get_or_create(&work)
             .inc();
         let gauge = self
             .executor
             .metrics
-            .tasks_running
+            .blocking_tasks_running
             .get_or_create(&work)
             .clone();
 

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -902,11 +902,11 @@ impl crate::Spawner for Context {
             .get_or_create(&work)
             .clone();
 
-        // Create a future that runs the closure when polled
-        let future = async move { f() };
+        // Initialize the blocking task
+        let (f, handle) = Handle::init_blocking(f, gauge, false);
 
-        // Use Handle::init with catch_panics = false
-        let (f, handle) = Handle::init(future, gauge, false);
+        // Spawn the task
+        let f = async move { f() };
         Tasks::register(&self.executor.tasks, &self.label, false, Box::pin(f));
         handle
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -132,6 +132,10 @@ pub trait Spawner: Clone + Send + Sync + 'static {
     /// This method is designed for synchronous, potentially long-running operations that should
     /// not block the asynchronous event loop. The task starts executing immediately, and the
     /// returned handle can be awaited to retrieve the result.
+    ///
+    /// # Warning
+    ///
+    /// Blocking tasks cannot be aborted.
     fn spawn_blocking<F, T>(self, f: F) -> Handle<T>
     where
         F: FnOnce() -> T + Send + 'static,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -837,6 +837,14 @@ mod tests {
         });
     }
 
+    fn test_spawn_blocking(runner: impl Runner, context: impl Spawner) {
+        runner.start(async move {
+            let handle = context.spawn_blocking(|| 42);
+            let result = handle.await;
+            assert_eq!(result, Ok(42));
+        });
+    }
+
     fn test_metrics(runner: impl Runner, context: impl Spawner + Metrics) {
         runner.start(async move {
             // Assert label
@@ -991,14 +999,6 @@ mod tests {
         test_spawn_duplicate(executor, context);
     }
 
-    fn test_spawn_blocking(runner: impl Runner, context: impl Spawner) {
-        runner.start(async move {
-            let handle = context.spawn_blocking(|| 42);
-            let result = handle.await;
-            assert_eq!(result, Ok(42));
-        });
-    }
-
     #[test]
     fn test_deterministic_spawn_blocking() {
         let (executor, context, _) = deterministic::Executor::default();
@@ -1014,24 +1014,6 @@ mod tests {
                 panic!("blocking task panicked");
             });
             handle.await.unwrap();
-        });
-    }
-
-    #[test]
-    fn test_tokio_spawn_blocking() {
-        let (executor, context) = tokio::Executor::default();
-        test_spawn_blocking(executor, context);
-    }
-
-    #[test]
-    fn test_tokio_spawn_blocking_panic() {
-        let (executor, context) = tokio::Executor::default();
-        executor.start(async move {
-            let handle = context.spawn_blocking(|| {
-                panic!("blocking task panicked");
-            });
-            let result = handle.await;
-            assert_eq!(result, Err(Error::Exited));
         });
     }
 
@@ -1161,6 +1143,24 @@ mod tests {
     fn test_tokio_spawn_duplicate() {
         let (executor, context) = tokio::Executor::default();
         test_spawn_duplicate(executor, context);
+    }
+
+    #[test]
+    fn test_tokio_spawn_blocking() {
+        let (executor, context) = tokio::Executor::default();
+        test_spawn_blocking(executor, context);
+    }
+
+    #[test]
+    fn test_tokio_spawn_blocking_panic() {
+        let (executor, context) = tokio::Executor::default();
+        executor.start(async move {
+            let handle = context.spawn_blocking(|| {
+                panic!("blocking task panicked");
+            });
+            let result = handle.await;
+            assert_eq!(result, Err(Error::Exited));
+        });
     }
 
     #[test]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -870,6 +870,10 @@ mod tests {
             });
 
             // Abort the task
+            //
+            // If there was an `.await` prior to sending a message over the oneshot, this test
+            // could deadlock (depending on the runtime implementation) because the blocking task
+            // would never yield (preventing send from being called).
             handle.abort();
             sender.send(()).unwrap();
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1002,12 +1002,6 @@ mod tests {
     }
 
     #[test]
-    fn test_tokio_spawn_blocking() {
-        let (executor, context) = tokio::Executor::default();
-        test_spawn_blocking(executor, context);
-    }
-
-    #[test]
     #[should_panic(expected = "blocking task panicked")]
     fn test_deterministic_spawn_blocking_panic() {
         let (executor, context, _) = deterministic::Executor::default();
@@ -1017,6 +1011,12 @@ mod tests {
             });
             handle.await.unwrap();
         });
+    }
+
+    #[test]
+    fn test_tokio_spawn_blocking() {
+        let (executor, context) = tokio::Executor::default();
+        test_spawn_blocking(executor, context);
     }
 
     #[test]

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -420,11 +420,10 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the blocking task using the new function
-        let executor = self.executor.clone();
-        let (f, handle) = Handle::init_blocking(f, gauge, executor.cfg.catch_panics);
+        let (f, handle) = Handle::init_blocking(f, gauge, self.executor.cfg.catch_panics);
 
         // Spawn the blocking task
-        executor.runtime.spawn_blocking(f);
+        self.executor.runtime.spawn_blocking(f);
         handle
     }
 

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -194,7 +194,7 @@ pub struct Config {
 
     /// Maximum buffer size for operations on blobs.
     ///
-    /// `tokio` defaults this value to 2MB.
+    /// Tokio sets the default value to 2MB.
     pub maximum_buffer_size: usize,
 }
 

--- a/runtime/src/tokio.rs
+++ b/runtime/src/tokio.rs
@@ -393,17 +393,12 @@ impl crate::Spawner for Context {
             .get_or_create(&work)
             .clone();
 
-        // Spawn the blocking task
+        // Initialize the blocking task using the new function
         let executor = self.executor.clone();
-        let join_handle = executor.runtime.spawn_blocking(f);
+        let (f, handle) = Handle::init_blocking(f, gauge, executor.cfg.catch_panics);
 
-        // Set up the task
-        let catch_panics = self.executor.cfg.catch_panics;
-        let future = async move { join_handle.await.unwrap() };
-        let (f, handle) = Handle::init(future, gauge, catch_panics);
-
-        // Spawn the async task
-        executor.runtime.spawn(f);
+        // Spawn the blocking task
+        executor.runtime.spawn_blocking(f);
         handle
     }
 

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -130,7 +130,7 @@ where
         )
     }
 
-    pub fn init_blocking<F>(f: F, running: Gauge, catch_panic: bool) -> (impl FnOnce(), Self)
+    pub(crate) fn init_blocking<F>(f: F, running: Gauge, catch_panic: bool) -> (impl FnOnce(), Self)
     where
         F: FnOnce() -> T + Send + 'static,
     {

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -185,6 +185,9 @@ where
         )
     }
 
+    /// Abort the task (if abortable).
+    ///
+    /// Blocking tasks cannot be aborted.
     pub fn abort(&self) {
         // Abort the task (if abortable)
         let Some(aborter) = &self.aborter else {

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -15,7 +15,7 @@ use prometheus_client::metrics::gauge::Gauge;
 use std::{
     any::Any,
     future::Future,
-    panic::{resume_unwind, AssertUnwindSafe},
+    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
     pin::Pin,
     sync::{Arc, Once},
     task::{Context, Poll},
@@ -60,7 +60,7 @@ pub struct Handle<T>
 where
     T: Send + 'static,
 {
-    aborter: AbortHandle,
+    aborter: Option<AbortHandle>,
     receiver: oneshot::Receiver<Result<T, Error>>,
 
     running: Gauge,
@@ -121,7 +121,62 @@ where
         (
             abortable.map(|_| ()),
             Self {
-                aborter,
+                aborter: Some(aborter),
+                receiver,
+
+                running,
+                once,
+            },
+        )
+    }
+
+    pub fn init_blocking<F>(f: F, running: Gauge, catch_panic: bool) -> (impl FnOnce(), Self)
+    where
+        F: FnOnce() -> T + Send + 'static,
+    {
+        // Increment the running tasks gauge
+        running.inc();
+
+        // Create a oneshot channel for communication
+        let (sender, receiver) = oneshot::channel();
+
+        // Create a Once instance to ensure the gauge is decremented only once
+        let once = Arc::new(Once::new());
+
+        // Wrap the closure with panic handling
+        let f = {
+            let once = once.clone();
+            let running = running.clone();
+            move || {
+                // Run blocking task
+                let result = catch_unwind(AssertUnwindSafe(f));
+
+                // Decrement running counter
+                once.call_once(|| {
+                    running.dec();
+                });
+
+                // Handle result
+                let result = match result {
+                    Ok(value) => Ok(value),
+                    Err(err) => {
+                        if !catch_panic {
+                            resume_unwind(err);
+                        }
+                        let err = extract_panic_message(&*err);
+                        error!(?err, "blocking task panicked");
+                        Err(Error::Exited)
+                    }
+                };
+                let _ = sender.send(result);
+            }
+        };
+
+        // Return the task and handle
+        (
+            f,
+            Self {
+                aborter: None,
                 receiver,
 
                 running,
@@ -131,8 +186,11 @@ where
     }
 
     pub fn abort(&self) {
-        // Stop task
-        self.aborter.abort();
+        // Abort the task (if abortable)
+        let Some(aborter) = &self.aborter else {
+            return;
+        };
+        aborter.abort();
 
         // Decrement running counter
         self.once.call_once(|| {
@@ -148,9 +206,27 @@ where
     type Output = Result<T, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.receiver)
-            .poll(cx)
-            .map(|res| res.map_err(|_| Error::Closed).and_then(|r| r))
+        match Pin::new(&mut self.receiver).poll(cx) {
+            Poll::Ready(Ok(Ok(value))) => {
+                self.once.call_once(|| {
+                    self.running.dec();
+                });
+                Poll::Ready(Ok(value))
+            }
+            Poll::Ready(Ok(Err(err))) => {
+                self.once.call_once(|| {
+                    self.running.dec();
+                });
+                Poll::Ready(Err(err))
+            }
+            Poll::Ready(Err(_)) => {
+                self.once.call_once(|| {
+                    self.running.dec();
+                });
+                Poll::Ready(Err(Error::Closed))
+            }
+            Poll::Pending => Poll::Pending,
+        }
     }
 }
 

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -137,11 +137,9 @@ where
         // Increment the running tasks gauge
         running.inc();
 
-        // Create a oneshot channel for communication
-        let (sender, receiver) = oneshot::channel();
-
-        // Create a Once instance to ensure the gauge is decremented only once
+        // Initialize channel to handle result
         let once = Arc::new(Once::new());
+        let (sender, receiver) = oneshot::channel();
 
         // Wrap the closure with panic handling
         let f = {
@@ -185,11 +183,9 @@ where
         )
     }
 
-    /// Abort the task (if abortable).
-    ///
-    /// Blocking tasks cannot be aborted.
+    /// Abort the task (if not blocking).
     pub fn abort(&self) {
-        // Abort the task (if abortable)
+        // Get aborter and abort
         let Some(aborter) = &self.aborter else {
             return;
         };


### PR DESCRIPTION
- [x] don't put blocking task in a non-blocking task (should be able to use direct)
- [x] add separate metrics for blocking tasks