### PR TITLE
[stream] Simplify nonce logic

### DIFF
--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -55,16 +55,16 @@
 //! Each peer maintains a pair of ChaCha20-Poly1305 nonces (12 bytes), one for itself and one for
 //! the other. Each nonce is constructed using a counter that starts at either 1 for the dialer, or
 //! 0 for the dialee. For each message sent, the relevant counter is incremented by 2, ensuring that
-//! the two counters have disjoint nonce spaces. The nonce is the least-significant 12 bytes of the
-//! counter, encoded big-endian.
+//! the two counters have disjoint nonce spaces.
 //!
-//! This provides 2^95 unique nonces per sender, sufficient for over 1 trillion years at 1 billion
-//! messages/second—far exceeding practical limits. Maintaining long-lived connections to reliable
-//! peers enhances network stability by removing the overhead of connection churn. In an unlikely
-//! case of overflow, the connection would terminate, and a new handshake would be required.
+//! The nonce is the least-significant 12 bytes of the counter, encoded big-endian. This provides 2^95 unique nonces
+//! per sender, sufficient for over 1 trillion years at 1 billion messages/second—far exceeding practical limits. This approach
+//! ensures well-behaving peers, as long as they both stay online, remain connected indefinitely (maximizing the stability
+//! of any p2p construction). In an unlikely case of overflow, the connection would terminate, and a new handshake would be required.
 //!
-//! This construction saves bandwidth, as the nonce does not need to be sent as part of the message.
-//! It also prevents nonce-reuse, which would otherwise allow for messages to be decrypted.
+//! This simple coordination prevents nonce reuse (which would allow for messages to be decrypted) and saves a small amount of
+//! bandwidth (no need to send the nonce alongside the encrypted message). This "pedantic" construction of the nonce
+//! also avoids accidental reuse of a nonce over long-lived connections (when setting it to be a small hash as in XChaCha20-Poly1305).
 
 use commonware_cryptography::Scheme;
 use std::time::Duration;

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -48,35 +48,22 @@
 //!
 //! ## Encryption
 //!
-//! During the handshake (described above), a shared x25519 secret is established using a Diffie-Hellman Key Exchange. This
-//! x25519 secret is then used to create a ChaCha20-Poly1305 cipher for encrypting all messages exchanged with the peer.
+//! During the handshake (described above), a shared x25519 secret is established using a
+//! Diffie-Hellman Key Exchange. This x25519 secret is then used to create a ChaCha20-Poly1305
+//! cipher for encrypting all messages exchanged with the peer.
 //!
-//! ChaCha20-Poly1305 nonces (12 bytes) are constructed such that the first bit indicates whether the sender is a dialer (1) or
-//! dialee (0). The rest of the first byte (next 7 bits) is unused (set to 0). The next 2 bytes are a `u16` iterator.
-//! The next 8 bytes are a `u64` sequence number. When the sequence reaches `u64::MAX`, the iterator is incremented and the
-//! sequence is reset to 0. This technique provides each sender with a channel duration of `2^80` frames
-//! (and automatically terminates when this number of frames has been sent). In the blockchain context, validators often maintain
-//! long-lived connections with each other and avoiding connection re-establishment (to reset iterator/sequence with a new cipher)
-//! is desirable. The final byte is unused (set to 0).
+//! Each peer maintains a pair of ChaCha20-Poly1305 nonces (12 bytes), one for itself and one for
+//! the other. Each nonce is constructed using a counter that starts at either 1 for the dialer, or
+//! 0 for the dialee. For each message sent, the relevant counter is incremented by 2, ensuring that
+//! the two counters have disjoint nonce spaces. The nonce is the least-significant 12 bytes of the
+//! counter, encoded big-endian.
 //!
-//! ```text
-//! +---+---+---+---+---+---+---+---+---+---+---+---+
-//! | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |10 |11 |
-//! +---+---+---+---+---+---+---+---+---+---+---+---+
-//! | D |It(u16)|         Sequence(u64)         | U |
-//! +---+---+---+---+---+---+---+---+---+---+---+---+
+//! This provides 2^95 unique nonces per sender, sufficient for over 1 trillion years at 1 billion
+//! messages/second—far exceeding practical limits. In an unlikely case of overflow, the connection
+//! would terminate, and a new handshake would be required.
 //!
-//! D = Dialer/Dialee, U = Unused, It = Iterator
-//! ```
-//!
-//! _We use a combination of `u64` (sequence) and `u16` (iterator) instead of implementing `u80/u88` because
-//! CPUs provide native support for `u64` operations (which will always be faster than an implementation of a
-//! "wrapping add" over arbitrary bytes). With this technique, almost all operations (other than iterator
-//! increments every `2^64` frames) are just a basic `u64` increment._
-//!
-//! This simple coordination prevents nonce reuse (which would allow for messages to be decrypted) and saves a small amount of
-//! bandwidth (no need to send the nonce alongside the encrypted message). This "pedantic" construction of the nonce
-//! also avoids accidentally reusing a nonce over long-lived connections when setting it to be a small hash (as in XChaCha-Poly1305).
+//! This construction saves bandwidth, as the nonce does not need to be sent as part of the message.
+//! It also prevents nonce-reuse, which would otherwise allow for messages to be decrypted.
 
 use commonware_cryptography::Scheme;
 use std::time::Duration;

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -59,8 +59,9 @@
 //! counter, encoded big-endian.
 //!
 //! This provides 2^95 unique nonces per sender, sufficient for over 1 trillion years at 1 billion
-//! messages/second—far exceeding practical limits. In an unlikely case of overflow, the connection
-//! would terminate, and a new handshake would be required.
+//! messages/second—far exceeding practical limits. Maintaining long-lived connections to reliable
+//! peers enhances network stability by removing the overhead of connection churn. In an unlikely
+//! case of overflow, the connection would terminate, and a new handshake would be required.
 //!
 //! This construction saves bandwidth, as the nonce does not need to be sent as part of the message.
 //! It also prevents nonce-reuse, which would otherwise allow for messages to be decrypted.

--- a/stream/src/public_key/nonce.rs
+++ b/stream/src/public_key/nonce.rs
@@ -24,10 +24,11 @@ impl Info {
     /// An error is returned if-and-only-if the nonce overflows 96 bits.
     pub fn inc(&mut self) -> Result<(), Error> {
         const OVERFLOW: u128 = 1 << 96;
-        self.counter += 2;
-        if self.counter >= OVERFLOW {
+        let new_counter = self.counter + 2; // Overflow check not necessary unless counter was improperly initialized
+        if new_counter >= OVERFLOW {
             return Err(Error::NonceOverflow);
         }
+        self.counter = new_counter;
         Ok(())
     }
 
@@ -107,19 +108,19 @@ mod tests {
 
     #[test]
     fn test_inc_overflow_even() {
-        let mut nonce = Info {
-            counter: (1 << 96) - 2,
-        };
+        let initial = (1 << 96) - 2;
+        let mut nonce = Info { counter: initial };
 
         assert!(nonce.inc().is_err());
+        assert_eq!(nonce.counter, initial);
     }
 
     #[test]
     fn test_inc_overflow_odd() {
-        let mut nonce = Info {
-            counter: (1 << 96) - 1,
-        };
+        let initial = (1 << 96) - 1;
+        let mut nonce = Info { counter: initial };
 
         assert!(nonce.inc().is_err());
+        assert_eq!(nonce.counter, initial);
     }
 }

--- a/stream/src/public_key/nonce.rs
+++ b/stream/src/public_key/nonce.rs
@@ -19,12 +19,12 @@ const OVERFLOW_VALUE: u128 = 1 << 96;
 impl Info {
     /// Creates a new `Info` struct.
     ///
-    /// The `sender_is_dialer` parameter indicates whether the sender is the dialer or not.
+    /// The `dialer` parameter indicates whether the sender is the dialer or not.
     /// For example, if the client was the dialer, this is set to true for your own nonces, but
     /// false for the peer's nonces.
-    pub fn new(sender_is_dialer: bool) -> Self {
+    pub fn new(dialer: bool) -> Self {
         Self {
-            counter: if sender_is_dialer { 1 } else { 0 },
+            counter: if dialer { 1 } else { 0 },
         }
     }
 


### PR DESCRIPTION
- Just put everything in to a `u128`
- Initialized to `1` or `0` based on boolean
- Increments by 2 (preserving the least-significant bit)
- Overflows past 12 bytes (Nonce is 12 bytes long)
- Deserializes least significant 12 bytes

Simpler and more maintainable. Might be faster, might not be. Increases the overflow bound by 2^15 as many increments. Previously if you incremented the nonce every single nanosecond, you would only be able to do-so for 38 million years. Now this should be good for about 1.2 trillion years. 91 times the age of the universe should be enough for anyone