### PR TITLE
[p2p] Fix bug with tracker bitvec

### DIFF
--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -467,10 +467,10 @@ impl<E: Spawner + Rng + Clock + GClock + Metrics, C: Scheme> Actor<E, C> {
         // Parse bit vector bytes
         let bits: BitVec<u8, Lsb0> = BitVec::from_vec(bit_vec.bits);
 
-        // Ensure bit vector is the correct length
-        let required_bytes = (set.order.len() / 8 + 1) * 8;
-        if bits.len() != required_bytes {
-            return Err(Error::BitVecLengthMismatch(required_bytes, bits.len()));
+        // Calculate the required number of bits (padded to the nearest byte)
+        let required_bits = ((set.order.len() + 7) / 8) * 8;
+        if bits.len() != required_bits {
+            return Err(Error::BitVecLengthMismatch(required_bits, bits.len()));
         }
 
         // Compile peers to send


### PR DESCRIPTION
- Instead of rounding up to the nearest multiple of 8, `required_bytes` was adding an extra whole byte for multiples of 8
- The naming is also wrong, it's actually the number of required bits, so I changed the name :)