### PR TITLE
[commonware-storage/mmr] Simplify & improve MMR pruning behavior

### DIFF
--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -188,7 +188,7 @@ impl<B: Blob, E: Storage<B> + Metrics, A: Array> Journal<B, E, A> {
     pub async fn sync(&mut self) -> Result<(), Error> {
         self.synced.inc();
         let newest_blob = self.newest_blob();
-        debug!("syncing blob {}", newest_blob.0);
+        debug!(blob = newest_blob.0, "syncing blob");
         self.newest_blob().1.sync().await.map_err(Error::Runtime)
     }
 
@@ -227,7 +227,7 @@ impl<B: Blob, E: Storage<B> + Metrics, A: Array> Journal<B, E, A> {
             let next_blob_index = newest_blob.0 + 1;
             // Always sync the previous blob before creating a new one
             newest_blob.1.sync().await?;
-            debug!("creating next blob {}", next_blob_index);
+            debug!(blob = next_blob_index, "creating next blob");
             let next_blob = self
                 .context
                 .open(&self.cfg.partition, &next_blob_index.to_be_bytes())

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -408,45 +408,19 @@ impl<B: Blob, E: Storage<B> + Metrics, A: Array> Journal<B, E, A> {
         panic!("no blobs found");
     }
 
-    /// Return the potential new outcomes for `oldest_retained_pos` that will result from calling
-    /// `prune` with `min_item_pos` to facilitate recovery should the prune operation fail. The
-    /// result will be empty if the `min_item_pos` is within the oldest blob (and hence no blob will
-    /// be pruned).
-    ///
-    /// The `prune` function works by atomically deleting chunks of `items_per_blob` items at a
-    /// time. This method exposes the potential outcomes, with the last value corresponding to a
-    /// successfully completed call.
-    pub fn prune_pos_outcomes(&self, min_item_pos: u64) -> Vec<u64> {
-        let mut oldest_blob = self.oldest_blob().0;
-        let mut prune_to_blob = min_item_pos / self.cfg.items_per_blob;
-        // We will never prune the newest blob.
-        let (newest_blob, _) = self.newest_blob();
-        if prune_to_blob > newest_blob {
-            prune_to_blob = newest_blob;
-        }
-
-        let mut outcomes = Vec::new();
-        while oldest_blob != prune_to_blob {
-            oldest_blob += 1;
-            outcomes.push(oldest_blob * self.cfg.items_per_blob);
-        }
-
-        outcomes
-    }
-
     /// Allow the journal to prune items older than `min_item_pos`. The journal may not prune all
     /// such items in order to preserve blob boundaries, but the amount of such items will always be
-    /// less than the configured number of items per blob.
+    /// less than the configured number of items per blob. The result will contain the actual
+    /// pruning position.
     ///
-    /// Use the last value of `prune_pos_outcomes` to get the actual pruning boundary position that
-    /// will result for a successful call with a given value of `min_item_pos`. Note that pruning
-    /// will not be atomic if there is more than one outcome in this result.
-    pub async fn prune(&mut self, min_item_pos: u64) -> Result<(), Error> {
+    /// Note that this operation may NOT be atomic, however it's guaranteed not to leave gaps in the
+    /// event of failure as items are always pruned in order from oldest to newest.
+    pub async fn prune(&mut self, min_item_pos: u64) -> Result<u64, Error> {
         let oldest_blob = self.oldest_blob().0;
         let mut new_oldest_blob = min_item_pos / self.cfg.items_per_blob;
         if new_oldest_blob <= oldest_blob {
             // nothing to prune
-            return Ok(());
+            return Ok(new_oldest_blob * self.cfg.items_per_blob);
         }
         // Make sure we never prune the most recent blob
         new_oldest_blob = std::cmp::min(new_oldest_blob, self.newest_blob().0);
@@ -463,7 +437,7 @@ impl<B: Blob, E: Storage<B> + Metrics, A: Array> Journal<B, E, A> {
             self.tracked.dec();
         }
 
-        Ok(())
+        Ok(new_oldest_blob * self.cfg.items_per_blob)
     }
 
     /// Close the journal

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -410,7 +410,7 @@ impl<B: Blob, E: Storage<B> + Metrics, A: Array> Journal<B, E, A> {
 
     /// Return the potential new outcomes for `oldest_retained_pos` that will result from calling
     /// `prune` with `min_item_pos` to facilitate recovery should the prune operation fail. The
-    /// result will be empty if the `min_item_pos` is within the oldest blob (and hence no blob can
+    /// result will be empty if the `min_item_pos` is within the oldest blob (and hence no blob will
     /// be pruned).
     ///
     /// The `prune` function works by atomically deleting chunks of `items_per_blob` items at a
@@ -449,10 +449,7 @@ impl<B: Blob, E: Storage<B> + Metrics, A: Array> Journal<B, E, A> {
             return Ok(());
         }
         // Make sure we never prune the most recent blob
-        let newest_blob = self.newest_blob();
-        if new_oldest_blob > newest_blob.0 {
-            new_oldest_blob = newest_blob.0;
-        }
+        new_oldest_blob = std::cmp::min(new_oldest_blob, self.newest_blob().0);
 
         for index in oldest_blob..new_oldest_blob {
             let blob = self.blobs.remove(&index).unwrap();

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -18,9 +18,9 @@ struct BitmapStorage<'a, H: CHasher> {
 impl<H: CHasher + Send + Sync> Storage<H::Digest> for BitmapStorage<'_, H> {
     async fn get_node(&self, pos: u64) -> Result<Option<H::Digest>, Error> {
         if pos < self.mmr.size() {
-            self.mmr.get_node(pos).await
+            Ok(self.mmr.get_node(pos))
         } else {
-            self.last_chunk_mmr.get_node(pos).await
+            Ok(self.last_chunk_mmr.get_node(pos))
         }
     }
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -141,7 +141,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, H: Hasher> Mmr<B, E, H> {
                 Mmr::<B, E, H>::get_from_metadata_or_journal(&metadata, &journal, pos).await?;
             old_nodes_to_add.insert(pos, old_node);
         }
-        mem_mmr.add_old_nodes(old_nodes_to_add);
+        mem_mmr.add_pinned_nodes(old_nodes_to_add);
 
         let mut s = Self {
             mem_mmr,
@@ -240,8 +240,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, H: Hasher> Mmr<B, E, H> {
 
         // Now that old_nodes is recomputed, it's safe to prune the mem_mmr and reinstate them.
         self.mem_mmr.prune_all();
-        self.mem_mmr.add_old_nodes(old_nodes);
-
+        self.mem_mmr.add_pinned_nodes(old_nodes);
         Ok(())
     }
 
@@ -328,7 +327,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, H: Hasher> Mmr<B, E, H> {
             // involving more than one iteration.
             debug!("syncing old_nodes required for pruning outcome: {}", pos);
             let old_nodes = self.sync_metadata(pos).await?;
-            self.mem_mmr.add_old_nodes(old_nodes);
+            self.mem_mmr.add_pinned_nodes(old_nodes);
         }
 
         // Now that recovery from any outcome is assured, it's safe to start pruning.
@@ -339,7 +338,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, H: Hasher> Mmr<B, E, H> {
         self.metadata.clear();
         let old_nodes = self.sync_metadata(successful_outcome_pos).await?;
         self.mem_mmr.prune_all();
-        self.mem_mmr.add_old_nodes(old_nodes);
+        self.mem_mmr.add_pinned_nodes(old_nodes);
 
         Ok(())
     }

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -79,8 +79,7 @@ impl<H: CHasher> Mmr<H> {
             return mmr;
         }
 
-        let required_positions =
-            Proof::<H>::nodes_required_for_proving(mmr.size(), oldest_retained_pos);
+        let required_positions = Proof::<H>::nodes_to_pin(mmr.size(), oldest_retained_pos);
         assert_eq!(pinned_nodes.len(), required_positions.len());
         for (i, pos) in required_positions.into_iter().enumerate() {
             mmr.pinned_nodes.insert(pos, pinned_nodes[i]);
@@ -300,7 +299,7 @@ impl<H: CHasher> Mmr<H> {
     /// Get the nodes (position + digest) that need to be pinned (those required for proof
     /// generation) in an MMR pruned to position `prune_pos`.
     pub(crate) fn nodes_to_pin(&self, prune_pos: u64) -> HashMap<u64, H::Digest> {
-        let positions = Proof::<H>::nodes_required_for_proving(self.size(), prune_pos);
+        let positions = Proof::<H>::nodes_to_pin(self.size(), prune_pos);
         positions
             .into_iter()
             .map(|pos| (pos, *self.get_node_unchecked(pos)))
@@ -310,7 +309,7 @@ impl<H: CHasher> Mmr<H> {
     /// Get the digests of nodes that need to be pinned (those required for proof generation) in an
     /// MMR pruned to position `prune_pos`.
     pub(crate) fn node_digests_to_pin(&self, start_pos: u64) -> Vec<H::Digest> {
-        let positions = Proof::<H>::nodes_required_for_proving(self.size(), start_pos);
+        let positions = Proof::<H>::nodes_to_pin(self.size(), start_pos);
         positions
             .into_iter()
             .map(|pos| *self.get_node_unchecked(pos))

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -122,7 +122,7 @@ impl<H: CHasher> Mmr<H> {
         index as u64 + self.oldest_retained_pos
     }
 
-    /// Returns the requested node, assuming it is either unpruned or known to exist in the
+    /// Returns the requested node, assuming it is either retained or known to exist in the
     /// pinned_nodes map.
     pub fn get_node_unchecked(&self, pos: u64) -> &H::Digest {
         if pos < self.oldest_retained_pos {
@@ -279,7 +279,7 @@ impl<H: CHasher> Mmr<H> {
     }
 
     /// Prune all nodes and pin the O(log2(n)) number of them required for proof generation going
-    /// forward.
+    /// forward.ad
     pub fn prune_all(&mut self) {
         if !self.nodes.is_empty() {
             self.prune_to_pos(self.index_to_pos(self.nodes.len()));
@@ -291,13 +291,13 @@ impl<H: CHasher> Mmr<H> {
     pub fn prune_to_pos(&mut self, pos: u64) {
         // Recompute the set of older nodes to retain.
         self.pinned_nodes = self.nodes_to_pin(pos);
-        let unpruned_nodes = self.pos_to_index(pos);
-        self.nodes.drain(0..unpruned_nodes);
+        let retained_nodes = self.pos_to_index(pos);
+        self.nodes.drain(0..retained_nodes);
         self.oldest_retained_pos = pos;
     }
 
     /// Get the nodes (position + digest) that need to be pinned (those required for proof
-    /// generation) in an MMR pruned to position `prune_pos`.
+    /// generation) in this MMR when pruned to position `prune_pos`.
     pub(crate) fn nodes_to_pin(&self, prune_pos: u64) -> HashMap<u64, H::Digest> {
         let positions = Proof::<H>::nodes_to_pin(self.size(), prune_pos);
         positions
@@ -306,8 +306,8 @@ impl<H: CHasher> Mmr<H> {
             .collect()
     }
 
-    /// Get the digests of nodes that need to be pinned (those required for proof generation) in an
-    /// MMR pruned to position `prune_pos`.
+    /// Get the digests of nodes that need to be pinned (those required for proof generation) in
+    /// this MMR when pruned to position `prune_pos`.
     pub(crate) fn node_digests_to_pin(&self, start_pos: u64) -> Vec<H::Digest> {
         let positions = Proof::<H>::nodes_to_pin(self.size(), start_pos);
         positions

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -184,10 +184,8 @@ impl<H: CHasher> Mmr<H> {
             }
             new_size -= 1;
         }
-
-        while self.size() != new_size {
-            self.nodes.pop_back();
-        }
+        let num_to_drain = (self.size() - new_size) as usize;
+        self.nodes.drain(self.nodes.len() - num_to_drain..);
 
         Ok(self.size())
     }
@@ -279,7 +277,7 @@ impl<H: CHasher> Mmr<H> {
     }
 
     /// Prune all nodes and pin the O(log2(n)) number of them required for proof generation going
-    /// forward.ad
+    /// forward.
     pub fn prune_all(&mut self) {
         if !self.nodes.is_empty() {
             self.prune_to_pos(self.index_to_pos(self.nodes.len()));
@@ -318,8 +316,8 @@ impl<H: CHasher> Mmr<H> {
 
     /// Utility used by stores that build on the mem MMR to pin extra nodes if needed. It's up to
     /// the caller to ensure that this set of pinned nodes is valid for their use case.
-    pub(crate) fn add_pinned_nodes(&mut self, old_nodes: HashMap<u64, H::Digest>) {
-        for (pos, node) in old_nodes.into_iter() {
+    pub(crate) fn add_pinned_nodes(&mut self, pinned_nodes: HashMap<u64, H::Digest>) {
+        for (pos, node) in pinned_nodes.into_iter() {
             self.pinned_nodes.insert(pos, node);
         }
     }

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -67,7 +67,7 @@
 //! )
 //! ```
 
-use commonware_utils::array;
+use commonware_utils::array::prefixed_u64::U64;
 use thiserror::Error;
 
 pub mod bitmap;
@@ -84,7 +84,7 @@ pub enum Error {
     #[error("an element required for this operation has been pruned: {0}")]
     ElementPruned(u64),
     #[error("metadata error: {0}")]
-    MetadataError(#[from] crate::metadata::Error<array::U64>),
+    MetadataError(#[from] crate::metadata::Error<U64>),
     #[error("journal error: {0}")]
     JournalError(#[from] crate::journal::Error),
     #[error("missing node: {0}")]

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -81,14 +81,14 @@ pub mod verification;
 /// Errors that can occur when interacting with an MMR.
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("an element required for this operation has been pruned")]
-    ElementPruned,
+    #[error("an element required for this operation has been pruned: {0}")]
+    ElementPruned(u64),
     #[error("metadata error: {0}")]
     MetadataError(#[from] crate::metadata::Error<array::U64>),
     #[error("journal error: {0}")]
     JournalError(#[from] crate::journal::Error),
-    #[error("missing peak: {0}")]
-    MissingPeak(u64),
+    #[error("missing node: {0}")]
+    MissingNode(u64),
     #[error("MMR is empty")]
     Empty,
     #[error("missing hashes in proof")]

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -199,11 +199,11 @@ impl<H: CHasher> Proof<H> {
 
     /// Return the list of pruned (pos < `start_pos`) node positions that are still required for
     /// proving any retained node.
-    pub fn nodes_required_for_proving(size: u64, start_pos: u64) -> Vec<u64> {
+    pub fn nodes_to_pin(size: u64, start_pos: u64) -> Vec<u64> {
         let mut positions = Vec::<u64>::new();
-        for peak in PeakIterator::new(size) {
-            if peak.0 >= start_pos {
-                let iter = PathIterator::new(start_pos, peak.0, peak.1);
+        for (pos, height) in PeakIterator::new(size) {
+            if pos >= start_pos {
+                let iter = PathIterator::new(start_pos, pos, height);
                 for (_, sibling_pos) in iter {
                     if sibling_pos < start_pos {
                         positions.push(sibling_pos);
@@ -211,7 +211,7 @@ impl<H: CHasher> Proof<H> {
                 }
                 break;
             }
-            positions.push(peak.0);
+            positions.push(pos);
         }
 
         positions

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -198,7 +198,7 @@ impl<H: CHasher> Proof<H> {
     }
 
     /// Return the list of pruned (pos < `start_pos`) node positions that are still required for
-    /// proving any unpruned node.
+    /// proving any retained node.
     pub fn nodes_required_for_proving(size: u64, start_pos: u64) -> Vec<u64> {
         let mut positions = Vec::<u64>::new();
         for peak in PeakIterator::new(size) {
@@ -403,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_element() {
+    fn test_verification_verify_element() {
         let (executor, _, _) = Executor::default();
         executor.start(async move {
             // create an 11 element MMR over which we'll test single-element inclusion proofs
@@ -496,7 +496,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_range() {
+    fn test_verification_verify_range() {
         let (executor, _, _) = Executor::default();
         executor.start(async move {
             // create a new MMR and add a non-trivial amount (49) of elements
@@ -663,7 +663,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unpruned_nodes_all_provable() {
+    fn test_verification_retained_nodes_provable_after_pruning() {
         let (executor, _, _) = Executor::default();
         executor.start(async move {
             // create a new MMR and add a non-trivial amount (49) of elements
@@ -676,7 +676,7 @@ mod tests {
                 element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
             }
 
-            // Confirm we can successfully prove all unpruned elements in the MMR after pruning.
+            // Confirm we can successfully prove all retained elements in the MMR after pruning.
             let root = mmr.root(&mut hasher);
             for i in 1..mmr.size() {
                 mmr.prune_to_pos(i);
@@ -701,7 +701,7 @@ mod tests {
     }
 
     #[test]
-    fn test_range_proofs_after_pruning() {
+    fn test_verification_ranges_provable_after_pruning() {
         let (executor, _, _) = Executor::default();
         executor.start(async move {
             // create a new MMR and add a non-trivial amount (49) of elements
@@ -779,7 +779,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proof_serialization() {
+    fn test_verification_proof_serialization() {
         let (executor, _, _) = Executor::default();
         executor.start(async move {
             assert_eq!(

--- a/utils/src/array/mod.rs
+++ b/utils/src/array/mod.rs
@@ -13,6 +13,7 @@ pub mod fixed_bytes;
 pub use fixed_bytes::FixedBytes;
 pub mod u64;
 pub use u64::U64;
+pub mod prefixed_u64;
 
 /// Errors returned by the `Array` trait's functions.
 #[derive(Error, Debug, PartialEq)]

--- a/utils/src/array/prefixed_u64.rs
+++ b/utils/src/array/prefixed_u64.rs
@@ -1,0 +1,174 @@
+//! A `u64` array type with a prefix byte to allow for multiple key contexts.
+
+use crate::Array;
+use commonware_codec::{Codec, Error as CodecError, Reader, SizedCodec, Writer};
+use std::{
+    cmp::{Ord, PartialOrd},
+    fmt::{Debug, Display},
+    hash::Hash,
+    ops::Deref,
+};
+use thiserror::Error;
+
+// Errors returned by `U64` functions.
+#[derive(Error, Debug, PartialEq)]
+pub enum Error {
+    #[error("invalid length")]
+    InvalidLength,
+}
+
+/// An `Array` implementation for prefixed `U64`
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+#[repr(transparent)]
+pub struct U64([u8; u64::LEN_ENCODED + 1]);
+
+impl U64 {
+    pub fn new(prefix: u8, value: u64) -> Self {
+        let mut arr = [0; u64::LEN_ENCODED + 1];
+        arr[0] = prefix;
+        arr[1..].copy_from_slice(&u64::to_be_bytes(value));
+
+        Self(arr)
+    }
+
+    pub fn to_u64(&self) -> u64 {
+        u64::from_be_bytes(self.0[1..].try_into().unwrap())
+    }
+
+    pub fn prefix(&self) -> u8 {
+        self.0[0]
+    }
+}
+
+impl Codec for U64 {
+    fn write(&self, writer: &mut impl Writer) {
+        self.0.write(writer);
+    }
+
+    fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
+        <[u8; Self::LEN_ENCODED]>::read(reader).map(Self)
+    }
+
+    fn len_encoded(&self) -> usize {
+        Self::LEN_ENCODED
+    }
+}
+
+impl SizedCodec for U64 {
+    const LEN_ENCODED: usize = u64::LEN_ENCODED + 1;
+}
+
+impl Array for U64 {
+    type Error = Error;
+}
+
+impl From<[u8; U64::LEN_ENCODED]> for U64 {
+    fn from(value: [u8; U64::LEN_ENCODED]) -> Self {
+        Self(value)
+    }
+}
+
+impl TryFrom<&[u8]> for U64 {
+    type Error = Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != U64::LEN_ENCODED {
+            return Err(Error::InvalidLength);
+        }
+        let array: [u8; U64::LEN_ENCODED] = value.try_into().map_err(|_| Error::InvalidLength)?;
+        Ok(Self(array))
+    }
+}
+
+impl TryFrom<&Vec<u8>> for U64 {
+    type Error = Error;
+
+    fn try_from(value: &Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl TryFrom<Vec<u8>> for U64 {
+    type Error = Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.len() != U64::LEN_ENCODED {
+            return Err(Error::InvalidLength);
+        }
+
+        // If the length is correct, we can safely convert the vector into a boxed slice without any
+        // copies.
+        let boxed_slice = value.into_boxed_slice();
+        let boxed_array: Box<[u8; U64::LEN_ENCODED]> =
+            boxed_slice.try_into().map_err(|_| Error::InvalidLength)?;
+        Ok(Self(*boxed_array))
+    }
+}
+
+impl AsRef<[u8]> for U64 {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Deref for U64 {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Debug for U64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}",
+            self.0[0],
+            u64::from_be_bytes(self.0[1..].try_into().unwrap())
+        )
+    }
+}
+
+impl Display for U64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prefixed_u64() {
+        let prefix = 69u8;
+        let value = 42u64;
+        let array = U64::new(prefix, value);
+        let try_from = U64::try_from(array.as_ref()).unwrap();
+        assert_eq!(value, try_from.to_u64());
+        assert_eq!(prefix, try_from.prefix());
+        let from = U64::from(array.0);
+        assert_eq!(value, from.to_u64());
+        assert_eq!(prefix, from.prefix());
+
+        let vec = array.to_vec();
+        let from_vec = U64::try_from(&vec).unwrap();
+        assert_eq!(value, from_vec.to_u64());
+        assert_eq!(prefix, from_vec.prefix());
+        let from_vec = U64::try_from(vec).unwrap();
+        assert_eq!(value, from_vec.to_u64());
+        assert_eq!(prefix, from_vec.prefix());
+    }
+
+    #[test]
+    fn test_prefixed_u64_codec() {
+        let original = U64::new(69, 42u64);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), U64::LEN_ENCODED);
+        assert_eq!(encoded, original.as_ref());
+
+        let decoded = U64::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+}


### PR DESCRIPTION
- Store an additional O(log2(n)) historical nodes, which we refer to as _pinned_, to guarantee any current & future retained node is provable after pruning. This allows removing of the "min provable position" related ugliness.

- `prune_all` behavior is changed to prune everything instead of leaving behind a single digest, simplifying boundary conditions.

- improve consistency of terminology/naming