### PR TITLE
Fix Clippy warnings: doc overindented list items, manual div_ceil, manual_ok_err

### DIFF
--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -468,7 +468,7 @@ impl<E: Spawner + Rng + Clock + GClock + Metrics, C: Scheme> Actor<E, C> {
         let bits: BitVec<u8, Lsb0> = BitVec::from_vec(bit_vec.bits);
 
         // Calculate the required number of bits (padded to the nearest byte)
-        let required_bits = ((set.order.len() + 7) / 8) * 8;
+        let required_bits = set.order.len().div_ceil(8) * 8;
         if bits.len() != required_bits {
             return Err(Error::BitVecLengthMismatch(required_bits, bits.len()));
         }

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -128,7 +128,7 @@ impl<H: Hasher> Tree<H> {
         // Construct the tree level-by-level
         let mut current_level = levels.last().unwrap();
         while current_level.len() > 1 {
-            let mut next_level = Vec::with_capacity((current_level.len() + 1) / 2);
+            let mut next_level = Vec::with_capacity(current_level.len().div_ceil(2));
             for chunk in current_level.chunks(2) {
                 // Hash the left child
                 hasher.update(&chunk[0]);

--- a/storage/src/mmr/mutable.rs
+++ b/storage/src/mmr/mutable.rs
@@ -198,8 +198,8 @@ impl<K: Array, V: Array, H: CHasher> MutableMmr<K, V, H> {
     /// Generate and return:
     ///  1. a proof of all operations applied to the store in the range starting at (and including)
     ///     location `start_loc`, and ending at the first of either:
-    ///         - the last operation performed, or
-    ///         - the operation `max_ops` from the start.
+    ///     - the last operation performed, or
+    ///     - the operation `max_ops` from the start.
     ///  2. the operations corresponding to the leaves in this range.
     pub async fn proof_to_tip(
         &self,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -28,7 +28,6 @@ pub fn from_hex(hex: &str) -> Option<Vec<u8>> {
     (0..hex.len())
         .step_by(2)
         .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
-
         .collect()
 }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -27,10 +27,8 @@ pub fn from_hex(hex: &str) -> Option<Vec<u8>> {
 
     (0..hex.len())
         .step_by(2)
-        .map(|i| match u8::from_str_radix(&hex[i..i + 2], 16) {
-            Ok(byte) => Some(byte),
-            Err(_) => None,
-        })
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
+
         .collect()
 }
 


### PR DESCRIPTION
**Summary**
- Replaced manual `(x + 1) / 2` and `(x + 7) / 8` with `.div_ceil(...)`, addressing Clippy’s `manual_div_ceil`.
- Fixed doc comments with excessive indentation, resolving `doc_overindented_list_items`.
- Replaced the `Ok(...) => Some(...), Err(...) => None` pattern with `.ok()`, removing `manual_ok_err`.

**Why**
- Keeps the code clean and warning-free under Clippy’s strict checks (`-D warnings`).
- Improves readability (DOC comments), correctness (using built-in div_ceil), and consistency with Rust best practices.

**Testing**
- Verified locally that `cargo clippy --all -- -D warnings` passes with no new warnings.
- No functional changes — purely stylistic and lint-related improvements.
