### PR TITLE
[commonware-storage/mutable] make operation type an Array

### DIFF
--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -22,7 +22,7 @@ pub trait Codec: Sized {
         let len = self.len_encoded();
         let mut buffer = WriteBuffer::new(len);
         self.write(&mut buffer);
-        assert!(buffer.len() == len);
+        assert_eq!(buffer.len(), len);
         buffer.into()
     }
 

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -76,7 +76,7 @@ mod iterator;
 pub mod journaled;
 pub mod mem;
 pub mod mutable;
-pub mod operation_array;
+pub mod operation;
 pub mod verification;
 
 /// Errors that can occur when interacting with an MMR.

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -76,6 +76,7 @@ mod iterator;
 pub mod journaled;
 pub mod mem;
 pub mod mutable;
+pub mod operation_array;
 pub mod verification;
 
 /// Errors that can occur when interacting with an MMR.

--- a/storage/src/mmr/mutable.rs
+++ b/storage/src/mmr/mutable.rs
@@ -11,7 +11,7 @@
 use crate::mmr::{
     iterator::{leaf_num_to_pos, leaf_pos_to_num},
     mem::Mmr,
-    operation_array::{Operation, Type},
+    operation::{Operation, Type},
     verification::Proof,
     Error,
 };

--- a/storage/src/mmr/mutable.rs
+++ b/storage/src/mmr/mutable.rs
@@ -11,6 +11,7 @@
 use crate::mmr::{
     iterator::{leaf_num_to_pos, leaf_pos_to_num},
     mem::Mmr,
+    operation_array::{Operation, Type},
     verification::Proof,
     Error,
 };
@@ -18,26 +19,6 @@ use commonware_cryptography::Hasher as CHasher;
 use commonware_utils::Array;
 use std::collections::{HashMap, VecDeque};
 use tracing::debug;
-
-/// The types of operations that change a key's state in the store.
-#[derive(Clone)]
-pub enum Type<V: Array> {
-    /// Indicates the key no longer has a value.
-    Deleted,
-
-    /// Indicates the key now has the wrapped value.
-    Update(V),
-}
-
-/// An operation applied to the store.
-#[derive(Clone)]
-pub struct Operation<K: Array, V: Array> {
-    /// The key whose state is changed by this operation.
-    pub key: K,
-
-    /// The new state of the key.
-    pub op_type: Type<V>,
-}
 
 /// A structure from which the current state of the store can be fully recovered.
 pub struct StoreState<K: Array, V: Array, H: CHasher> {
@@ -112,11 +93,11 @@ impl<K: Array, V: Array, H: CHasher> MutableMmr<K, V, H> {
             let digest = Self::op_digest(hasher, op);
             store.ops.add(hasher, &digest);
 
-            match op.op_type {
-                Type::Deleted => store.snapshot.remove(&op.key),
+            match op.to_type() {
+                Type::Deleted => store.snapshot.remove(&op.to_key()),
                 Type::Update(_) => {
                     let loc = store_state.pruned_loc + i as u64;
-                    store.snapshot.insert(op.key.clone(), loc)
+                    store.snapshot.insert(op.to_key(), loc)
                 }
             };
         }
@@ -124,23 +105,9 @@ impl<K: Array, V: Array, H: CHasher> MutableMmr<K, V, H> {
         Ok(store)
     }
 
-    const DELETE_CONTEXT: u8 = 0;
-    const UPDATE_CONTEXT: u8 = 1;
-
     /// Return a digest of the operation.
-    ///
-    /// The first byte of the digest material is an operation type byte: 0 for Delete and 1 for
-    /// Update. For an update, the value is appended next, followed by the key. For deletion, the
-    /// key is appended without any value.
     pub fn op_digest(hasher: &mut H, op: &Operation<K, V>) -> H::Digest {
-        match op.op_type {
-            Type::Deleted => hasher.update(&[Self::DELETE_CONTEXT]),
-            Type::Update(ref value) => {
-                hasher.update(&[Self::UPDATE_CONTEXT]);
-                hasher.update(value);
-            }
-        }
-        hasher.update(&op.key);
+        hasher.update(op);
         hasher.finalize()
     }
 
@@ -151,13 +118,13 @@ impl<K: Array, V: Array, H: CHasher> MutableMmr<K, V, H> {
     }
 
     /// Get the value of `key` in the store, or None if it has no value.
-    pub fn get(&self, key: &K) -> Option<&V> {
+    pub fn get(&self, key: &K) -> Option<V> {
         let loc = self.snapshot.get(key)?;
         let i = self.loc_to_op_index(*loc);
-        let op = &self.log[i];
-        match &op.op_type {
+        let op_type = self.log[i].to_type();
+        match op_type {
             Type::Deleted => panic!("deleted key should not be in snapshot: {}", key),
-            Type::Update(ref v) => Some(v),
+            Type::Update(v) => Some(v),
         }
     }
 
@@ -174,7 +141,8 @@ impl<K: Array, V: Array, H: CHasher> MutableMmr<K, V, H> {
         // Update the snapshot.
         if let Some(loc) = self.snapshot.get_mut(&key) {
             let i = *loc - self.pruned_loc;
-            let last_value = match self.log[i as usize].op_type {
+            let op_type = self.log[i as usize].to_type();
+            let last_value = match op_type {
                 Type::Deleted => panic!("deleted key should not be in snapshot: {}", key),
                 Type::Update(ref v) => v,
             };
@@ -209,7 +177,7 @@ impl<K: Array, V: Array, H: CHasher> MutableMmr<K, V, H> {
 
     /// Update the operations MMR with the given operation, and append the operation to the log.
     fn apply_op(&mut self, hasher: &mut H, key: K, op_type: Type<V>) {
-        let op = Operation { key, op_type };
+        let op = Operation::new(key, op_type);
 
         // Update the ops MMR.
         let digest = Self::op_digest(hasher, &op);
@@ -297,12 +265,13 @@ impl<K: Array, V: Array, H: CHasher> MutableMmr<K, V, H> {
             }
             let op = &self.log[i];
             let op_count = self.op_count();
-            if let Some(loc) = self.snapshot.get_mut(&op.key) {
+            let key = op.to_key();
+            if let Some(loc) = self.snapshot.get_mut(&key) {
                 if *loc == self.inactivity_floor_loc {
                     // This operation is active, move it to tip to allow us to continue raising the
                     // inactivity floor.
                     *loc = op_count;
-                    self.apply_op(hasher, op.key.clone(), op.op_type.clone());
+                    self.apply_op(hasher, key, op.to_type());
                 }
             }
             self.inactivity_floor_loc += 1;
@@ -352,22 +321,22 @@ mod test {
         assert!(store.get(&d2).is_none());
 
         store.update(&mut hasher, d1, d2);
-        assert_eq!(store.get(&d1).unwrap(), &d2);
+        assert_eq!(store.get(&d1).unwrap(), d2);
         assert!(store.get(&d2).is_none());
 
         store.update(&mut hasher, d2, d1);
-        assert_eq!(store.get(&d1).unwrap(), &d2);
-        assert_eq!(store.get(&d2).unwrap(), &d1);
+        assert_eq!(store.get(&d1).unwrap(), d2);
+        assert_eq!(store.get(&d2).unwrap(), d1);
 
         store.delete(&mut hasher, d1);
         assert!(store.get(&d1).is_none());
-        assert_eq!(store.get(&d2).unwrap(), &d1);
+        assert_eq!(store.get(&d2).unwrap(), d1);
 
         store.update(&mut hasher, d1, d1);
-        assert_eq!(store.get(&d1).unwrap(), &d1);
+        assert_eq!(store.get(&d1).unwrap(), d1);
 
         store.update(&mut hasher, d2, d2);
-        assert_eq!(store.get(&d2).unwrap(), &d2);
+        assert_eq!(store.get(&d2).unwrap(), d2);
 
         assert_eq!(store.log.len(), 5); // 4 updates, 1 deletion.
         assert_eq!(store.snapshot.len(), 2);
@@ -522,7 +491,7 @@ mod test {
                     let Some(store_value) = store.get(&k) else {
                         panic!("key not found in store: {}", k);
                     };
-                    assert_eq!(map_value, store_value);
+                    assert_eq!(*map_value, store_value);
                 } else {
                     assert!(store.get(&k).is_none());
                 }

--- a/storage/src/mmr/operation_array.rs
+++ b/storage/src/mmr/operation_array.rs
@@ -1,0 +1,220 @@
+//! An `Array` implementation for operations applied to a `MutableMmr` K/V store, making them
+//! storable in a `fixed::Journal`.
+
+use commonware_codec::{Codec, Error as CodecError, Reader, SizedCodec, Writer};
+use commonware_utils::Array;
+use std::{
+    cmp::{Ord, PartialOrd},
+    fmt::{Debug, Display},
+    hash::Hash,
+    ops::Deref,
+};
+use thiserror::Error;
+
+/// Errors returned by `Operation` functions.
+#[derive(Error, Debug)]
+pub enum Error<K: Array, V: Array> {
+    #[error("invalid length")]
+    InvalidLength,
+    #[error("invalid key: {0}")]
+    InvalidKey(<K as Array>::Error),
+    #[error("invalid value: {0}")]
+    InvalidValue(<V as Array>::Error),
+}
+
+/// The types of operations that change a key's state in the store.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum Type<V: Array> {
+    /// Indicates the key no longer has a value.
+    Deleted,
+
+    /// Indicates the key now has the wrapped value.
+    Update(V),
+}
+
+/// An `Array` implementation for operations applied to a `MutableMmr` K/V store.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[repr(transparent)]
+pub struct Operation<K: Array, V: Array> {
+    pub data: Vec<u8>,
+    _phantom: std::marker::PhantomData<(K, V)>,
+}
+
+impl<K: Array, V: Array> Operation<K, V> {
+    const DELETE_CONTEXT: u8 = 0;
+    const UPDATE_CONTEXT: u8 = 1;
+
+    /// Create a new operation from `key` and `op_type`.
+    pub fn new(key: K, op_type: Type<V>) -> Self {
+        let mut data = Vec::with_capacity(Self::LEN_ENCODED);
+        data.extend_from_slice(&key);
+        match op_type {
+            Type::Deleted => {
+                data.push(Self::DELETE_CONTEXT);
+                data.extend(vec![0u8; V::LEN_ENCODED]);
+            }
+            Type::Update(value) => {
+                data.push(Self::UPDATE_CONTEXT);
+                data.extend_from_slice(&value);
+            }
+        }
+
+        Self {
+            data,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn to_key(&self) -> K {
+        K::try_from(&self.data[..K::LEN_ENCODED]).unwrap()
+    }
+
+    pub fn to_type(&self) -> Type<V> {
+        if self.data[K::LEN_ENCODED] == 0 {
+            return Type::Deleted;
+        }
+
+        Type::Update(V::try_from(&self.data[K::LEN_ENCODED + 1..]).unwrap())
+    }
+
+    pub fn to_op(&self) -> V {
+        match self.to_type() {
+            Type::Deleted => panic!("No value for delete operation"),
+            Type::Update(v) => v,
+        }
+    }
+}
+
+impl<K: Array, V: Array> Codec for Operation<K, V> {
+    fn write(&self, writer: &mut impl Writer) {
+        writer.write_fixed(&self.data);
+    }
+
+    fn read(reader: &mut impl Reader) -> Result<Self, CodecError> {
+        let value = reader.read_n_bytes(Self::LEN_ENCODED)?;
+        Self::try_from(value.as_ref()).map_err(|e| CodecError::Wrapped("Operation", e.into()))
+    }
+
+    fn len_encoded(&self) -> usize {
+        Self::LEN_ENCODED
+    }
+}
+
+impl<K: Array, V: Array> SizedCodec for Operation<K, V> {
+    const LEN_ENCODED: usize = K::LEN_ENCODED + 1 + V::LEN_ENCODED;
+}
+
+impl<K: Array, V: Array> Array for Operation<K, V> {
+    type Error = Error<K, V>;
+}
+
+impl<K: Array, V: Array> TryFrom<&[u8]> for Operation<K, V> {
+    type Error = Error<K, V>;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != Self::LEN_ENCODED {
+            return Err(Error::InvalidLength);
+        }
+        let mut data = Vec::with_capacity(Self::LEN_ENCODED);
+        data.extend_from_slice(&value[..K::LEN_ENCODED]);
+        let _ = K::try_from(data.as_slice()).map_err(|e| Error::InvalidKey(e))?;
+
+        if value[K::LEN_ENCODED] == 0 {
+            // Delete op_type
+            data.push(Self::DELETE_CONTEXT);
+        } else {
+            data.push(Self::UPDATE_CONTEXT);
+            let value_vec = value[K::LEN_ENCODED + 1..].to_vec();
+            let _ = V::try_from(value_vec).map_err(|e| Error::InvalidValue(e))?;
+        }
+        data.extend_from_slice(&value[K::LEN_ENCODED + 1..]);
+
+        Ok(Self {
+            data,
+            _phantom: std::marker::PhantomData,
+        })
+    }
+}
+
+impl<K: Array, V: Array> TryFrom<&Vec<u8>> for Operation<K, V> {
+    type Error = Error<K, V>;
+
+    fn try_from(value: &Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl<K: Array, V: Array> TryFrom<Vec<u8>> for Operation<K, V> {
+    type Error = Error<K, V>;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl<K: Array, V: Array> AsRef<[u8]> for Operation<K, V> {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl<K: Array, V: Array> Deref for Operation<K, V> {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl<K: Array, V: Array> Display for Operation<K, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.to_type() {
+            Type::Deleted => write!(f, "[Key:{} <deleted>]", self.to_key()),
+            Type::Update(value) => write!(f, "[Key:{} Value:{}]", self.to_key(), value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_utils::array::U64;
+
+    #[test]
+    fn test_operation_array_basic() {
+        let key = U64::new(1234);
+        let value = U64::new(56789);
+        let update_op = Operation::new(key.clone(), Type::Update(value.clone()));
+
+        let try_from = Operation::try_from(update_op.as_ref()).unwrap();
+        assert_eq!(key, try_from.to_key());
+        assert_eq!(Type::Update(value.clone()), try_from.to_type());
+
+        let vec = update_op.to_vec();
+
+        let from_vec_ref = Operation::<U64, U64>::try_from(&vec).unwrap();
+        assert_eq!(Type::Update(value.clone()), from_vec_ref.to_type());
+
+        let from_vec = Operation::<U64, U64>::try_from(vec).unwrap();
+        assert_eq!(Type::Update(value.clone()), from_vec.to_type());
+
+        let key2 = U64::new(42);
+        let delete_op = Operation::<U64, U64>::new(key2.clone(), Type::Deleted);
+        let try_from = Operation::<U64, U64>::try_from(delete_op.as_ref()).unwrap();
+        assert_eq!(key2, try_from.to_key());
+        assert_eq!(Type::Deleted, try_from.to_type());
+    }
+
+    #[test]
+    fn test_operation_array_codec() {
+        let key = U64::new(1234);
+        let value = U64::new(5678);
+        let update_op = Operation::new(key, Type::Update(value));
+
+        let encoded = update_op.encode();
+        assert_eq!(encoded.len(), Operation::<U64, U64>::LEN_ENCODED);
+        assert_eq!(encoded, update_op.as_ref());
+
+        let decoded = Operation::decode(encoded).unwrap();
+        assert_eq!(update_op, decoded);
+    }
+}


### PR DESCRIPTION
Moves Operation and Type types to their own module where they implement the Array trait so that we can persist them using a fixed-item-length journal.