### PR TITLE
[consensus] Combine `Monitor::latest` and `Monitor::subscribe`

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -186,11 +186,8 @@ cfg_if::cfg_if! {
             /// Index is the type used to indicate the in-progress consensus decision.
             type Index;
 
-            /// Latest index known by the consensus implementation.
-            fn latest(&self) -> Self::Index;
-
-            /// Create a channel that will receive updates when the latest index changes.
-            fn subscribe(&mut self) -> mpsc::Receiver<Self::Index>;
+            /// Create a channel that will receive updates when the latest index (also provided) changes.
+            fn subscribe(&mut self) -> impl Future<Output = (Self::Index, mpsc::Receiver<Self::Index>)> + Send;
         }
     }
 }

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -271,10 +271,8 @@ impl<
         let mut pending: Option<(Context<C::PublicKey>, oneshot::Receiver<D>)> = None;
 
         // Initialize the epoch
-        let epoch = self.monitor.latest();
-        assert!(epoch >= self.epoch);
-        self.epoch = epoch;
-        let mut epoch_updates = self.monitor.subscribe();
+        let (latest, mut epoch_updates) = self.monitor.subscribe().await;
+        self.epoch = latest;
 
         // Before starting on the main loop, initialize my own sequencer journal
         // and attempt to rebroadcast if necessary.


### PR DESCRIPTION
Motivation: https://github.com/commonwarexyz/monorepo/pull/647#discussion_r2015432158