### PR TITLE
[utils/codec] Clean up Array type

### DIFF
--- a/consensus/src/ordered_broadcast/prover.rs
+++ b/consensus/src/ordered_broadcast/prover.rs
@@ -2,19 +2,21 @@
 //!
 //! The proofs contain threshold signatures of validators that have seen and validated a chunk.
 
-use super::{namespace, parsed, serializer, Context, Epoch};
-use crate::Proof;
+use std::marker::PhantomData;
+
 use bytes::{Buf, BufMut};
-use commonware_codec::FixedSize;
+use commonware_codec::{FixedSize, ReadExt};
 use commonware_cryptography::{
     bls12381::primitives::{
         group::{self, Element},
         ops,
     },
-    Digest, Scheme,
+    Digest,
+    Scheme,
 };
-use commonware_utils::Array;
-use std::marker::PhantomData;
+
+use super::{namespace, parsed, serializer, Context, Epoch};
+use crate::Proof;
 
 /// Encode and decode proofs of broadcast.
 ///
@@ -77,9 +79,9 @@ impl<C: Scheme, D: Digest> Prover<C, D> {
         }
 
         // Decode proof
-        let sequencer = C::PublicKey::read_from(&mut proof).ok()?;
+        let sequencer = C::PublicKey::read(&mut proof).ok()?;
         let height = proof.get_u64();
-        let Ok(payload) = D::read_from(&mut proof) else {
+        let Ok(payload) = D::read(&mut proof) else {
             return None;
         };
         let epoch = proof.get_u64();

--- a/consensus/src/ordered_broadcast/tip_manager.rs
+++ b/consensus/src/ordered_broadcast/tip_manager.rs
@@ -1,6 +1,8 @@
-use super::parsed;
-use commonware_cryptography::{Digest, Scheme};
 use std::collections::{hash_map::Entry, HashMap};
+
+use commonware_cryptography::{Digest, Scheme};
+
+use super::parsed;
 
 /// Manages the highest-height chunk for each sequencer.
 #[derive(Default, Debug)]
@@ -55,20 +57,21 @@ impl<C: Scheme, D: Digest> TipManager<C, D> {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::parsed, *};
     use bytes::Bytes;
-    use commonware_codec::FixedSize;
+    use commonware_codec::{FixedSize, ReadExt};
     use commonware_cryptography::{
         ed25519::{self, Ed25519, PublicKey, Signature},
         sha256::{self, Digest},
     };
-    use commonware_utils::Array;
     use rand::SeedableRng;
+
+    use super::{super::parsed, *};
 
     /// Helper functions for TipManager tests.
     mod helpers {
-        use super::*;
         use commonware_cryptography::Signer;
+
+        use super::*;
 
         /// Creates a dummy link for testing.
         pub fn create_dummy_node(
@@ -78,7 +81,7 @@ mod tests {
         ) -> parsed::Node<Ed25519, Digest> {
             let signature = {
                 let mut data = Bytes::from(vec![3u8; Signature::SIZE]);
-                Signature::read_from(&mut data).unwrap()
+                Signature::read(&mut data).unwrap()
             };
             parsed::Node::<Ed25519, Digest> {
                 chunk: parsed::Chunk {

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -1,22 +1,25 @@
-use super::relay::Relay;
-use crate::{simplex::Context, Automaton as Au, Committer as Co, Proof, Relay as Re};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
 use bytes::{Buf, BufMut, Bytes};
-use commonware_codec::FixedSize;
+use commonware_codec::{FixedSize, ReadExt};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_macros::select;
 use commonware_runtime::{Clock, Handle, Spawner};
 use commonware_utils::Array;
 use futures::{
     channel::{mpsc, oneshot},
-    SinkExt, StreamExt,
+    SinkExt,
+    StreamExt,
 };
 use rand::{Rng, RngCore};
 use rand_distr::{Distribution, Normal};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+
+use super::relay::Relay;
+use crate::{simplex::Context, Automaton as Au, Committer as Co, Proof, Relay as Re};
 
 pub enum Message<D: Array> {
     Genesis {
@@ -269,7 +272,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
                 parsed_view, context.view
             ));
         }
-        let Ok(parent) = H::Digest::read_from(&mut contents) else {
+        let Ok(parent) = H::Digest::read(&mut contents) else {
             self.panic("invalid parent");
         };
         if parent != context.parent.1 {

--- a/consensus/src/threshold_simplex/actors/resolver/actor.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/actor.rs
@@ -1,16 +1,11 @@
-use super::{
-    ingress::{Mailbox, Message},
-    Config,
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BTreeSet},
+    marker::PhantomData,
+    time::{Duration, SystemTime},
 };
-use crate::{
-    threshold_simplex::{
-        actors::voter,
-        encoder::{notarize_namespace, nullify_namespace, seed_namespace},
-        verifier::{verify_notarization, verify_nullification},
-        wire, View,
-    },
-    Parsed, ThresholdSupervisor,
-};
+
+use commonware_codec::ReadExt;
 use commonware_cryptography::{bls12381::primitives::poly, Scheme};
 use commonware_macros::select;
 use commonware_p2p::{utils::requester, Receiver, Recipients, Sender};
@@ -21,13 +16,23 @@ use governor::clock::Clock as GClock;
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use prost::Message as _;
 use rand::{seq::IteratorRandom, Rng};
-use std::{
-    cmp::Ordering,
-    collections::{BTreeMap, BTreeSet},
-    marker::PhantomData,
-    time::{Duration, SystemTime},
-};
 use tracing::{debug, warn};
+
+use super::{
+    ingress::{Mailbox, Message},
+    Config,
+};
+use crate::{
+    threshold_simplex::{
+        actors::voter,
+        encoder::{notarize_namespace, nullify_namespace, seed_namespace},
+        verifier::{verify_notarization, verify_nullification},
+        wire,
+        View,
+    },
+    Parsed,
+    ThresholdSupervisor,
+};
 
 /// Task in the required set.
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
@@ -551,7 +556,7 @@ impl<
                                     },
                                 };
                                 let view = proposal.view;
-                                let Ok(payload) = D::try_from(&proposal.payload) else {
+                                let Ok(payload) = D::read(&mut proposal.payload.as_ref()) else {
                                     warn!(view, sender = ?s, "invalid proposal");
                                     self.requester.block(s.clone());
                                     continue;

--- a/consensus/src/threshold_simplex/mocks/application.rs
+++ b/consensus/src/threshold_simplex/mocks/application.rs
@@ -1,22 +1,25 @@
-use super::relay::Relay;
-use crate::{threshold_simplex::Context, Automaton as Au, Committer as Co, Proof, Relay as Re};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
 use bytes::{Buf, BufMut, Bytes};
-use commonware_codec::FixedSize;
+use commonware_codec::{FixedSize, ReadExt};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_macros::select;
 use commonware_runtime::{Clock, Handle, Spawner};
 use commonware_utils::Array;
 use futures::{
     channel::{mpsc, oneshot},
-    SinkExt, StreamExt,
+    SinkExt,
+    StreamExt,
 };
 use rand::{Rng, RngCore};
 use rand_distr::{Distribution, Normal};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+
+use super::relay::Relay;
+use crate::{threshold_simplex::Context, Automaton as Au, Committer as Co, Proof, Relay as Re};
 
 pub enum Message<D: Digest> {
     Genesis {
@@ -269,7 +272,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: Array> Application<E, H, P> {
                 parsed_view, context.view
             ));
         }
-        let Ok(parent) = H::Digest::read_from(&mut contents) else {
+        let Ok(parent) = H::Digest::read(&mut contents) else {
             self.panic("invalid parent");
         };
         if parent != context.parent.1 {

--- a/consensus/src/threshold_simplex/verifier.rs
+++ b/consensus/src/threshold_simplex/verifier.rs
@@ -1,8 +1,4 @@
-use super::{
-    encoder::{nullify_message, proposal_message, seed_message},
-    wire, View,
-};
-use crate::ThresholdSupervisor;
+use commonware_codec::ReadExt;
 use commonware_cryptography::bls12381::primitives::{
     group::{self, Element},
     ops::{aggregate_signatures, aggregate_verify_multiple_messages},
@@ -10,6 +6,13 @@ use commonware_cryptography::bls12381::primitives::{
 };
 use commonware_utils::Array;
 use tracing::debug;
+
+use super::{
+    encoder::{nullify_message, proposal_message, seed_message},
+    wire,
+    View,
+};
+use crate::ThresholdSupervisor;
 
 pub fn verify_notarization<
     D: Array,
@@ -30,7 +33,7 @@ pub fn verify_notarization<
     };
 
     // Ensure payload is well-formed
-    let Ok(payload) = D::try_from(&proposal.payload) else {
+    let Ok(payload) = D::read(&mut proposal.payload.as_ref()) else {
         debug!(reason = "invalid payload", "dropping notarization");
         return false;
     };
@@ -163,7 +166,7 @@ pub fn verify_finalization<
     };
 
     // Ensure payload is well-formed
-    let Ok(payload) = D::try_from(&proposal.payload) else {
+    let Ok(payload) = D::read(&mut proposal.payload.as_ref()) else {
         debug!(reason = "invalid payload", "dropping finalization");
         return false;
     };

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -1,7 +1,9 @@
-use crate::handlers::{
-    utils::{payload, public_hex, ACK_NAMESPACE},
-    wire,
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
 };
+
+use commonware_codec::ReadExt;
 use commonware_cryptography::{
     bls12381::{
         dkg,
@@ -17,11 +19,12 @@ use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{Clock, Handle, Spawner};
 use commonware_utils::hex;
 use prost::Message;
-use std::{
-    collections::{HashMap, HashSet},
-    time::Duration,
-};
 use tracing::{debug, info, warn};
+
+use crate::handlers::{
+    utils::{payload, public_hex, ACK_NAMESPACE},
+    wire,
+};
 
 pub struct Arbiter<E: Clock + Spawner, C: Scheme> {
     context: E,
@@ -142,7 +145,7 @@ impl<E: Clock + Spawner, C: Scheme> Arbiter<E, C> {
                                     break;
                                 };
                                 let payload = payload(round, &sender, &msg.commitment);
-                                let Ok(sig) = C::Signature::try_from(&ack.signature) else {
+                                let Ok(sig) = C::Signature::read(&mut ack.signature.as_ref()) else {
                                     disqualify = true;
                                     break;
                                 };

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -1,11 +1,5 @@
-use super::{
-    config::Config,
-    fetcher::Fetcher,
-    ingress::{Mailbox, Message},
-    metrics,
-};
-use super::{wire, Coordinator, Producer};
-use crate::Consumer;
+use std::{collections::HashMap, marker::PhantomData};
+
 use bytes::Bytes;
 use commonware_codec::{DecodeExt, Encode};
 use commonware_macros::select;
@@ -15,7 +9,10 @@ use commonware_runtime::{
         histogram,
         status::{CounterExt, Status},
     },
-    Clock, Handle, Metrics, Spawner,
+    Clock,
+    Handle,
+    Metrics,
+    Spawner,
 };
 use commonware_utils::{futures::Pool as FuturesPool, Array};
 use futures::{
@@ -25,8 +22,18 @@ use futures::{
 };
 use governor::clock::Clock as GClock;
 use rand::Rng;
-use std::{collections::HashMap, marker::PhantomData};
 use tracing::{debug, error, trace, warn};
+
+use super::{
+    config::Config,
+    fetcher::Fetcher,
+    ingress::{Mailbox, Message},
+    metrics,
+    wire,
+    Coordinator,
+    Producer,
+};
+use crate::Consumer;
 
 /// Represents a pending serve operation.
 struct Serve<E: Clock, P: Array> {

--- a/resolver/src/p2p/mocks/key.rs
+++ b/resolver/src/p2p/mocks/key.rs
@@ -1,7 +1,8 @@
+use std::{fmt, ops::Deref};
+
 use bytes::{Buf, BufMut};
 use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use commonware_utils::Array;
-use std::{fmt, ops::Deref};
 use thiserror::Error;
 
 /// A key that can be used for testing
@@ -67,9 +68,7 @@ impl FixedSize for Key {
     const SIZE: usize = u8::SIZE;
 }
 
-impl Array for Key {
-    type Error = Error;
-}
+impl Array for Key {}
 
 /// Error type for the Array trait
 #[derive(Error, Debug, PartialEq)]

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -41,11 +41,9 @@
 //! ```
 
 use bytes::Buf;
-use commonware_codec::FixedSize;
+use commonware_codec::{FixedSize, ReadExt};
 use commonware_cryptography::Hasher;
-use commonware_utils::Array;
 use thiserror::Error;
-
 /// Errors that can occur when working with a Binary Merkle Tree (BMT).
 #[derive(Error, Debug)]
 pub enum Error {
@@ -285,7 +283,7 @@ impl<H: Hasher> Proof<H> {
         // Deserialize the siblings
         let mut siblings = Vec::with_capacity(num_siblings);
         for _ in 0..num_siblings {
-            let hash = H::Digest::read_from(&mut buf).map_err(|_| Error::InvalidDigest)?;
+            let hash = H::Digest::read(&mut buf).map_err(|_| Error::InvalidDigest)?;
             siblings.push(hash);
         }
         Ok(Self { siblings })
@@ -294,12 +292,13 @@ impl<H: Hasher> Proof<H> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use commonware_cryptography::{
         hash,
         sha256::{Digest, Sha256},
     };
     use commonware_utils::hex;
+
+    use super::*;
 
     fn test_merkle_tree(n: usize) -> Digest {
         // Build tree

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -1,15 +1,17 @@
-use super::{Config, Error};
-use bytes::{BufMut, Bytes};
-use commonware_codec::FixedSize;
-use commonware_runtime::{Blob, Clock, Metrics, Storage};
-use commonware_utils::{Array, SystemTimeExt as _};
-use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use std::{
     collections::BTreeMap,
     marker::PhantomData,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+use bytes::{BufMut, Bytes};
+use commonware_codec::{FixedSize, ReadExt};
+use commonware_runtime::{Blob, Clock, Metrics, Storage};
+use commonware_utils::{Array, SystemTimeExt as _};
+use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use tracing::{trace, warn};
+
+use super::{Config, Error};
 
 const BLOB_NAMES: [&[u8]; 2] = [b"left", b"right"];
 const SECONDS_IN_NANOSECONDS: u128 = 1_000_000_000;
@@ -142,7 +144,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         while cursor < checksum_index {
             // Read key
             let next_cursor = cursor + K::SIZE;
-            let key = K::read_from(&mut buf[cursor..next_cursor].as_ref()).unwrap();
+            let key = K::read(&mut buf[cursor..next_cursor].as_ref()).unwrap();
             cursor = next_cursor;
 
             // Read value length

--- a/utils/src/array/fixed_bytes.rs
+++ b/utils/src/array/fixed_bytes.rs
@@ -1,13 +1,15 @@
-use crate::{hex, Array};
-use bytes::{Buf, BufMut};
-use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use std::{
     cmp::{Ord, PartialOrd},
     fmt::{Debug, Display},
     hash::Hash,
     ops::Deref,
 };
+
+use bytes::{Buf, BufMut};
+use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use thiserror::Error;
+
+use crate::{hex, Array};
 
 /// Errors returned by `Bytes` functions.
 #[derive(Error, Debug, PartialEq)]
@@ -44,9 +46,7 @@ impl<const N: usize> FixedSize for FixedBytes<N> {
     const SIZE: usize = N;
 }
 
-impl<const N: usize> Array for FixedBytes<N> {
-    type Error = Error;
-}
+impl<const N: usize> Array for FixedBytes<N> {}
 
 impl<const N: usize> TryFrom<&[u8]> for FixedBytes<N> {
     type Error = Error;
@@ -99,10 +99,10 @@ impl<const N: usize> Display for FixedBytes<N> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::array::Error as ArrayError;
     use bytes::{Buf, BytesMut};
     use commonware_codec::{DecodeExt, Encode};
+
+    use super::*;
 
     #[test]
     fn test_codec() {
@@ -151,16 +151,16 @@ mod tests {
     #[test]
     fn test_read_from() {
         let mut buf = BytesMut::from(&[1, 2, 3, 4][..]);
-        let bytes = FixedBytes::<4>::read_from(&mut buf).unwrap();
+        let bytes = FixedBytes::<4>::read(&mut buf).unwrap();
         assert_eq!(bytes.as_ref(), &[1, 2, 3, 4]);
         assert_eq!(buf.remaining(), 0);
 
         let mut buf = BytesMut::from(&[1, 2, 3][..]);
-        let result = FixedBytes::<4>::read_from(&mut buf);
-        assert_eq!(result, Err(ArrayError::InsufficientBytes));
+        let result = FixedBytes::<4>::read(&mut buf);
+        assert!(matches!(result, Err(CodecError::EndOfBuffer)));
 
         let mut buf = BytesMut::from(&[1, 2, 3, 4, 5][..]);
-        let bytes = FixedBytes::<4>::read_from(&mut buf).unwrap();
+        let bytes = FixedBytes::<4>::read(&mut buf).unwrap();
         assert_eq!(bytes.as_ref(), &[1, 2, 3, 4]);
         assert_eq!(buf.remaining(), 1);
         assert_eq!(buf[0], 5);

--- a/utils/src/array/mod.rs
+++ b/utils/src/array/mod.rs
@@ -1,5 +1,3 @@
-use bytes::Buf;
-use commonware_codec::{Decode, Encode, FixedSize};
 use std::{
     cmp::{Ord, PartialOrd},
     error::Error as StdError,
@@ -7,6 +5,8 @@ use std::{
     hash::Hash,
     ops::Deref,
 };
+
+use commonware_codec::{Decode, Encode, FixedSize};
 use thiserror::Error;
 
 pub mod fixed_bytes;
@@ -45,32 +45,8 @@ pub trait Array:
     + Display
     + AsRef<[u8]>
     + Deref<Target = [u8]>
-    + for<'a> TryFrom<&'a [u8], Error = <Self as Array>::Error>
-    + for<'a> TryFrom<&'a Vec<u8>, Error = <Self as Array>::Error>
-    + TryFrom<Vec<u8>, Error = <Self as Array>::Error>
     + FixedSize
     + Encode
     + Decode
 {
-    /// Errors returned when parsing an invalid byte sequence.
-    type Error: StdError + Send + Sync + 'static;
-
-    /// Attempts to read an array from the provided buffer.
-    fn read_from(buf: &mut impl Buf) -> Result<Self, Error<<Self as Array>::Error>> {
-        let len = Self::SIZE;
-        if buf.remaining() < len {
-            return Err(Error::InsufficientBytes);
-        }
-
-        let chunk = buf.chunk();
-        if chunk.len() >= len {
-            let array = Self::try_from(&chunk[..len]).map_err(Error::Other)?;
-            buf.advance(len);
-            return Ok(array);
-        }
-
-        let mut temp = vec![0u8; len];
-        buf.copy_to_slice(&mut temp);
-        Self::try_from(temp).map_err(Error::Other)
-    }
 }

--- a/utils/src/array/prefixed_u64.rs
+++ b/utils/src/array/prefixed_u64.rs
@@ -1,15 +1,17 @@
 //! A `u64` array type with a prefix byte to allow for multiple key contexts.
 
-use crate::Array;
-use bytes::{Buf, BufMut};
-use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use std::{
     cmp::{Ord, PartialOrd},
     fmt::{Debug, Display},
     hash::Hash,
     ops::Deref,
 };
+
+use bytes::{Buf, BufMut};
+use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use thiserror::Error;
+
+use crate::Array;
 
 // Errors returned by `U64` functions.
 #[derive(Error, Debug, PartialEq)]
@@ -57,9 +59,7 @@ impl FixedSize for U64 {
     const SIZE: usize = u64::SIZE + 1;
 }
 
-impl Array for U64 {
-    type Error = Error;
-}
+impl Array for U64 {}
 
 impl From<[u8; U64::SIZE]> for U64 {
     fn from(value: [u8; U64::SIZE]) -> Self {

--- a/utils/src/array/u64.rs
+++ b/utils/src/array/u64.rs
@@ -1,13 +1,15 @@
-use crate::Array;
-use bytes::{Buf, BufMut};
-use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use std::{
     cmp::{Ord, PartialOrd},
     fmt::{Debug, Display},
     hash::Hash,
     ops::Deref,
 };
+
+use bytes::{Buf, BufMut};
+use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use thiserror::Error;
+
+use crate::Array;
 
 // Errors returned by `U64` functions.
 #[derive(Error, Debug, PartialEq)]
@@ -47,9 +49,7 @@ impl FixedSize for U64 {
     const SIZE: usize = u64::SIZE;
 }
 
-impl Array for U64 {
-    type Error = Error;
-}
+impl Array for U64 {}
 
 impl From<[u8; U64::SIZE]> for U64 {
     fn from(value: [u8; U64::SIZE]) -> Self {


### PR DESCRIPTION
Simplifies trait bounds of the `Array` type using codec `Encode` and `Decode` as unified interface for encoding and decoding

Closes: #622 