### PR TITLE
[deployer] remove unnecessary clone of `ip`

### DIFF
--- a/deployer/src/ec2/update.rs
+++ b/deployer/src/ec2/update.rs
@@ -94,7 +94,6 @@ pub async fn update(config_path: &PathBuf) -> Result<(), Error> {
             let private_key = private_key_path.to_str().unwrap();
             let binary_path = instance_config.binary.clone();
             let config_path = instance_config.config.clone();
-            let ip = ip.clone();
             let future = async move {
                 update_instance(private_key, &ip, &binary_path, &config_path).await?;
                 info!(name, ip, "updated instance");


### PR DESCRIPTION
`ip` is already a `String`, so there's no need to call `.clone()` before moving it into the `async move` block.
The value is automatically moved, making the extra clone redundant.

Removed the unnecessary `clone()` to simplify the code.