### PR TITLE
fix: incorrect logging syntax in `warn!`

### DIFF
--- a/deployer/src/ec2/utils.rs
+++ b/deployer/src/ec2/utils.rs
@@ -106,7 +106,7 @@ pub async fn poll_service_active(key_file: &str, ip: &str, service: &str) -> Res
             return Ok(());
         }
         if service == "binary" && parsed == "failed" {
-            warn!(service, "service failed to start (check logs and update)");
+            warn!(service = service, "service failed to start (check logs and update)");
             return Ok(());
         }
         warn!(error = ?String::from_utf8_lossy(&output.stderr), service, "active status check failed");


### PR DESCRIPTION
Fixed an issue where `warn!(service, "...")` was missing the required key-value format.
Now using `warn!(service = service, "...")` as expected by `tracing::warn!`.  
