### PR TITLE
[commonware-storage/mmr/mutable] move mmr-based kv store from the mmr module to a new adb module

### DIFF
--- a/storage/src/adb/mod.rs
+++ b/storage/src/adb/mod.rs
@@ -1,0 +1,18 @@
+//! A collection of authenticated databases (ADB).
+
+use commonware_utils::array::prefixed_u64::U64;
+use thiserror::Error;
+
+pub mod any;
+pub mod operation;
+
+/// Errors that can occur when interacting with an authenticated database.
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("mmr error: {0}")]
+    MmrError(#[from] crate::mmr::Error),
+    #[error("metadata error: {0}")]
+    MetadataError(#[from] crate::metadata::Error<U64>),
+    #[error("journal error: {0}")]
+    JournalError(#[from] crate::journal::Error),
+}

--- a/storage/src/adb/operation.rs
+++ b/storage/src/adb/operation.rs
@@ -1,5 +1,7 @@
-//! An `Array` implementation for operations applied to a `MutableMmr` K/V store, making them
-//! storable in a `fixed::Journal`.
+//! Operations that can be applied to an authenticated database.
+//!
+//! The `Operation` enum implements the `Array` trait, allowing for a persistent log of operations
+//! based on a `crate::Journal`.
 
 use commonware_codec::{Codec, Error as CodecError, Reader, SizedCodec, Writer};
 use commonware_utils::Array;
@@ -28,7 +30,7 @@ pub enum Error<K: Array, V: Array> {
     InvalidCommitOp,
 }
 
-/// The types of operations that can change the state of the store.
+/// The types of operations that can change the state of a database.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum Type<K: Array, V: Array> {
     /// Indicates the key no longer has a value.
@@ -42,7 +44,7 @@ pub enum Type<K: Array, V: Array> {
     Commit(u64),
 }
 
-/// An `Array` implementation for operations applied to a `MutableMmr` K/V store.
+/// An `Array` implementation for operations applied to an authenticated database.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(transparent)]
 pub struct Operation<K: Array, V: Array> {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -5,6 +5,7 @@
 //! `commonware-storage` is **ALPHA** software and is not yet recommended for production use. Developers should
 //! expect breaking changes and occasional instability.
 
+pub mod adb;
 pub mod archive;
 pub mod bmt;
 pub mod index;

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -72,11 +72,9 @@ use thiserror::Error;
 
 pub mod bitmap;
 mod hasher;
-mod iterator;
+pub mod iterator;
 pub mod journaled;
 pub mod mem;
-pub mod mutable;
-pub mod operation;
 pub mod verification;
 
 /// Errors that can occur when interacting with an MMR.


### PR DESCRIPTION
- adb module stands for "authenticated database"

- renamed the "mutable mmr" to the `Any` variant of an authenticated database based on its authentication capabilities (being able to prove a key had any of its historically assigned values).