### PR TITLE
use XOR for swapping bits

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -31,6 +31,9 @@ tracing-subscriber = { workspace = true }
 rand = { workspace = true }
 criterion = { workspace = true }
 
+[features]
+bench_internal = []
+
 [lib]
 bench = false
 crate-type = ["rlib", "cdylib"]

--- a/storage/src/mmr/benches/bench.rs
+++ b/storage/src/mmr/benches/bench.rs
@@ -2,10 +2,12 @@ use criterion::criterion_main;
 
 mod append;
 mod append_additional;
+mod bitmap;
 mod prove_many_elements;
 mod prove_single_element;
 
 criterion_main!(
+    //bitmap::benches,
     append::benches,
     append_additional::benches,
     prove_many_elements::benches,

--- a/storage/src/mmr/benches/bitmap.rs
+++ b/storage/src/mmr/benches/bitmap.rs
@@ -1,0 +1,97 @@
+#![allow(unused_imports)]
+use commonware_cryptography::{hash, Hasher, Sha256};
+use commonware_runtime::{deterministic::Executor, Runner};
+use commonware_storage::mmr::bitmap::Bitmap;
+use criterion::{criterion_group, Criterion};
+use std::hint::black_box;
+
+// Variant 1
+fn set_bit_original(bitmap: &mut [u8], byte_offset: usize, mask: u8, bit: bool) {
+    if bit {
+        bitmap[byte_offset] |= mask;
+    } else {
+        bitmap[byte_offset] &= !mask;
+    }
+}
+
+// Variant 2: Current branchless XOR
+fn set_bit_xor(bitmap: &mut [u8], byte_offset: usize, mask: u8, bit: bool) {
+    bitmap[byte_offset] ^= ((-(bit as i8) as u8) ^ bitmap[byte_offset]) & mask;
+}
+
+// Variant 3: Superscalar
+fn set_bit_superscalar(bitmap: &mut [u8], byte_offset: usize, mask: u8, bit: bool) {
+    bitmap[byte_offset] = (bitmap[byte_offset] & !mask) | ((-(bit as i8) as u8) & mask);
+}
+
+fn setup_bitmap(hasher: &mut Sha256) -> Bitmap<Sha256> {
+    let mut bitmap = Bitmap::default();
+    let test_digest = hash(b"test");
+    bitmap.append_chunk_unchecked(hasher, &test_digest);
+    bitmap.append_chunk_unchecked(hasher, &test_digest);
+    bitmap.append_byte_unchecked(hasher, 0xF1);
+    bitmap.append(hasher, true);
+    bitmap.append(hasher, false);
+    bitmap.append(hasher, true);
+    bitmap
+}
+
+#[cfg(any(feature = "bench_internal"))]
+fn bench_set_bit_variants(c: &mut Criterion) {
+    use commonware_storage::mmr::bitmap;
+
+    let mut group = c.benchmark_group("set_bit_variants_from_test");
+
+    // Original branching variant
+    group.bench_function("set_bit_original", |b| {
+        let mut bitmap = setup_bitmap(&mut Sha256::new());
+        let mut hasher = Sha256::new();
+        b.iter(|| {
+            for bit_pos in (0..bitmap.bit_count()).rev() {
+                let bit = bitmap.get_bit(bit_pos);
+                let byte_offset = bit_pos as usize / 8;
+                let mask = 1 << (bit_pos % 8);
+                set_bit_original(bitmap.get_bitmap_mut(), byte_offset, mask, black_box(!bit));
+                let _new_root = bitmap.root(&mut hasher);
+            }
+        });
+    });
+
+    // Original branching xor
+    group.bench_function("set_bit_xor", |b| {
+        let mut bitmap = setup_bitmap(&mut Sha256::new());
+        let mut hasher = Sha256::new();
+        b.iter(|| {
+            for bit_pos in (0..bitmap.bit_count()).rev() {
+                let bit = bitmap.get_bit(bit_pos);
+                let byte_offset = bit_pos as usize / 8;
+                let mask = 1 << (bit_pos % 8);
+                set_bit_xor(bitmap.get_bitmap_mut(), byte_offset, mask, black_box(!bit));
+                let _new_root = bitmap.root(&mut hasher);
+            }
+        });
+    });
+
+    // Original branching superscalar
+    group.bench_function("set_bit_superscalar", |b| {
+        let mut bitmap = setup_bitmap(&mut Sha256::new());
+        let mut hasher = Sha256::new();
+        b.iter(|| {
+            for bit_pos in (0..bitmap.bit_count()).rev() {
+                let bit = bitmap.get_bit(bit_pos);
+                let byte_offset = bit_pos as usize / 8;
+                let mask = 1 << (bit_pos % 8);
+                set_bit_superscalar(bitmap.get_bitmap_mut(), byte_offset, mask, black_box(!bit));
+                let _new_root = bitmap.root(&mut hasher);
+            }
+        });
+    });
+}
+
+#[cfg(any(feature = "bench_internal"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(1000);
+
+    targets = bench_set_bit_variants
+}

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -74,7 +74,7 @@ impl<H: CHasher> Bitmap<H> {
 
     /// Return the number of bits currently stored in the bitmap.
     pub fn bit_count(&self) -> u64 {
-        ((self.bitmap.len() * 8) - (Self::CHUNK_SIZE * 8) + self.next_bit) as u64
+        (self.bitmap.len() * 8 - Self::CHUNK_SIZE * 8 + self.next_bit) as u64
     }
 
     /// Return the last chunk of the bitmap as a digest.
@@ -183,7 +183,7 @@ impl<H: CHasher> Bitmap<H> {
         let mask = Self::chunk_byte_bit_mask(bit_offset);
         
         // XOR the bit with the current value of the bitmap at that offset from;
-        // avoids jump
+        // avoids branching
         self.bitmap[byte_offset] ^= ((-(bit as i8) as u8) ^ self.bitmap[byte_offset]) & mask;
 
         if byte_offset >= self.bitmap.len() - Self::CHUNK_SIZE {


### PR DESCRIPTION
Use XOR for swapping bits, avoids branching
from: https://graphics.stanford.edu/~seander/bithacks.html#ConditionalSetOrClearBitsWithoutBranching