### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
All other workflow files in the repo already use actions/checkout@v4. This one was still on v3, so I updated it for consistency.

Also, GitHub recommends using the latest major version. Here's the official migration guide for reference:
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md