### PR TITLE
[commonware-storage/index] allow the mutable iterator to delete & insert efficiently

### DIFF
--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -167,27 +167,20 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
             let op: Operation<K, V> = log.read(i).await?;
             match op.to_type() {
                 Type::Deleted(key) => {
-                    snapshot.remove(&key, |loc| *loc == i);
-                }
-                Type::Update(key, _) => {
-                    // If the key is already in the snapshot, then update its location.
-                    let mut snapshot_updated = false;
-                    for loc in snapshot.get_mut(&key) {
+                    let mut loc_iter = snapshot.delete_iter(&key);
+                    while let Some(loc) = loc_iter.next() {
                         let op = log.read(*loc).await?;
                         if op.to_key() == key {
-                            snapshot_updated = true;
-                            *loc = i;
+                            loc_iter.remove();
                             break;
                         }
                     }
-                    if !snapshot_updated {
-                        // The key was not already in the snapshot, so add it.
-                        snapshot.insert(&key, i);
-                    }
                 }
-                Type::Commit(loc) => {
-                    inactivity_floor_loc = loc;
+                Type::Update(key, _) => {
+                    _ = Any::<B, E, K, V, H>::update_loc(&mut snapshot, &mut log, key, None, i)
+                        .await?;
                 }
+                Type::Commit(loc) => inactivity_floor_loc = loc,
             }
         }
 
@@ -202,6 +195,50 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
         Ok(db)
     }
 
+    /// Update the location of `key` to `new_loc` in the snapshot, or insert it if the key isn't
+    /// already present.  If a `value` is provided, then it is used to see if the key is already
+    /// assigned that value, in which case this is a no-op, and `false` is returned.
+    async fn update_loc(
+        snapshot: &mut Index<EightCap, u64>,
+        log: &mut Journal<B, E, Operation<K, V>>,
+        key: K,
+        value: Option<&V>,
+        new_loc: u64,
+    ) -> Result<bool, Error> {
+        let mut loc_iter = snapshot.update_iter(&key);
+
+        let found_loc = {
+            let mut found = None;
+            for loc in &mut loc_iter {
+                let op = log.read(*loc).await?;
+                if op.to_key() == key {
+                    if let Some(v) = value {
+                        if op.to_value().unwrap() == *v {
+                            // The key value is the same as the previous one: treat as a no-op.
+                            return Ok(false);
+                        }
+                    }
+                    found = Some(loc);
+                    break;
+                }
+            }
+            found
+        };
+
+        match found_loc {
+            Some(loc) => {
+                // The key was already in the snapshot, so update its location.
+                *loc = new_loc;
+            }
+            None => {
+                // The key wasn't in the snapshot, so add it.
+                loc_iter.insert(new_loc);
+            }
+        }
+
+        Ok(true)
+    }
+
     /// Return a digest of the operation.
     pub fn op_digest(hasher: &mut H, op: &Operation<K, V>) -> H::Digest {
         hasher.update(op);
@@ -210,9 +247,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
 
     /// Get the value of `key` in the db, or None if it has no value.
     pub async fn get(&self, key: &K) -> Result<Option<V>, Error> {
-        let loc_iter = self.snapshot.get(key);
-
-        for loc in loc_iter {
+        for loc in self.snapshot.get_iter(key) {
             let op = self.log.read(*loc).await?;
             match op.to_type() {
                 Type::Update(k, v) => {
@@ -221,7 +256,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
                     }
                 }
                 _ => {
-                    panic!(
+                    unreachable!(
                         "snapshot should only reference update operations. key={}",
                         key
                     );
@@ -250,37 +285,19 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
     /// next successful `commit`.
     pub async fn update(&mut self, hasher: &mut H, key: K, value: V) -> Result<(), Error> {
         let new_loc = self.op_count();
-
-        // Update the snapshot if the key is already in it.
-        let mut snapshot_updated = false;
-        let loc_iter = self.snapshot.get_mut(&key);
-        for loc in loc_iter {
-            let op = self.log.read(*loc).await?;
-            match op.to_type() {
-                Type::Update(k, v) => {
-                    if k == key {
-                        if v == value {
-                            // Trying to assign the same value is a no-op.
-                            return Ok(());
-                        }
-                        *loc = new_loc;
-                        snapshot_updated = true;
-                        break;
-                    }
-                }
-                _ => {
-                    panic!(
-                        "snapshot should only reference update operations. key={}",
-                        key
-                    );
-                }
-            }
+        if !Any::<B, E, K, V, H>::update_loc(
+            &mut self.snapshot,
+            &mut self.log,
+            key.clone(),
+            Some(&value),
+            new_loc,
+        )
+        .await?
+        {
+            // Don't apply the operation if the update was a no-op
+            return Ok(());
         }
 
-        if !snapshot_updated {
-            // The key was not already in the snapshot, so add it.
-            self.snapshot.insert(&key, new_loc);
-        }
         let op = Operation::update(key, value);
         self.apply_op(hasher, op).await?;
 
@@ -291,18 +308,19 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
     /// The operation is reflected in the snapshot, but will be subject to rollback until the next
     /// successful `commit`.
     pub async fn delete(&mut self, hasher: &mut H, key: K) -> Result<(), Error> {
-        let mut old_loc: Option<u64> = None;
-        for loc in self.snapshot.get(&key) {
+        let mut loc_iter = self.snapshot.delete_iter(&key);
+        for loc in &mut loc_iter {
             let op = self.log.read(*loc).await?;
             match op.to_type() {
                 Type::Update(k, _) => {
                     if k == key {
-                        old_loc = Some(*loc);
-                        break;
+                        loc_iter.remove();
+                        self.apply_op(hasher, Operation::delete(key)).await?;
+                        return Ok(());
                     }
                 }
                 _ => {
-                    panic!(
+                    unreachable!(
                         "snapshot should only reference update operations. key={}",
                         key
                     );
@@ -310,14 +328,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
             }
         }
 
-        let Some(old_loc) = old_loc else {
-            // The key wasn't in the snapshot, so this is a no-op.
-            return Ok(());
-        };
-
-        self.snapshot.remove(&key, |loc| *loc == old_loc);
-        self.apply_op(hasher, Operation::delete(key)).await?;
-
+        // The key wasn't in the snapshot, so this is a no-op.
         Ok(())
     }
 
@@ -396,7 +407,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
     /// recoverable upon return from this function.
     pub async fn commit(&mut self, hasher: &mut H) -> Result<(), Error> {
         // Raise the inactivity floor by the # of uncommitted operations, plus 1 to account for the
-        // floor op that will be appended.
+        // commit op that will be appended.
         self.raise_inactivity_floor(hasher, self.uncommitted_ops + 1)
             .await?;
         self.uncommitted_ops = 0;
@@ -444,9 +455,9 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
     ) -> Result<(), Error> {
         let key = op.to_key();
         let new_loc = self.op_count();
-        let iter = self.snapshot.get_mut(&key);
+        let loc_iter = self.snapshot.update_iter(&key);
         let mut loc_found = false;
-        for loc in iter {
+        for loc in loc_iter {
             if *loc == old_loc {
                 loc_found = true;
                 *loc = new_loc;
@@ -861,7 +872,7 @@ mod test {
                 .await
                 .unwrap();
 
-            // Journaled MMR recovery should redb the orphaned leaf & its parents, then log
+            // Journaled MMR recovery should read the orphaned leaf & its parents, then log
             // replaying will restore the rest.
             let mut db = open_db(context.clone(), &mut hasher).await;
             assert_eq!(db.root(&mut hasher), root);
@@ -900,9 +911,45 @@ mod test {
 
             // Simulate a failed commit and test that the log replay doesn't leave behind old data.
             let db = open_db(context.clone(), &mut hasher).await;
-            let iter = db.snapshot.get(&k);
+            let iter = db.snapshot.get_iter(&k);
             assert_eq!(iter.cloned().collect::<Vec<_>>().len(), 1);
             assert_eq!(db.root(&mut hasher), root);
+        });
+    }
+
+    #[test_traced("WARN")]
+    pub fn test_any_multiple_commits_delete_gets_replayed() {
+        let (executor, context, _) = Executor::default();
+        executor.start(async move {
+            let mut hasher = Sha256::new();
+            let mut db = open_db(context.clone(), &mut hasher).await;
+
+            let mut map = HashMap::<Digest, Digest>::default();
+            const ELEMENTS: u64 = 10;
+            // insert & commit multiple batches to ensure repeated inactivity floor raising.
+            for j in 0u64..ELEMENTS {
+                for i in 0u64..ELEMENTS {
+                    let k = hash(&(j * 1000 + i).to_be_bytes());
+                    let v = hash(&(i * 1000).to_be_bytes());
+                    db.update(&mut hasher, k, v).await.unwrap();
+                    map.insert(k, v);
+                }
+                db.commit(&mut hasher).await.unwrap();
+            }
+            let k = hash(&((ELEMENTS - 1) * 1000 + (ELEMENTS - 1)).to_be_bytes());
+
+            // Do one last delete operation which will be above the inactivity
+            // floor, to make sure it gets replayed on restart.
+            db.delete(&mut hasher, k).await.unwrap();
+            db.commit(&mut hasher).await.unwrap();
+            assert!(db.get(&k).await.unwrap().is_none());
+
+            // Close & reopen the db, making sure the re-opened db has exactly the same state.
+            let root_hash = db.root(&mut hasher);
+            db.close().await.unwrap();
+            let db = open_db(context.clone(), &mut hasher).await;
+            assert_eq!(root_hash, db.root(&mut hasher));
+            assert!(db.get(&k).await.unwrap().is_none());
         });
     }
 }

--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -167,7 +167,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
             let op: Operation<K, V> = log.read(i).await?;
             match op.to_type() {
                 Type::Deleted(key) => {
-                    let mut loc_iter = snapshot.delete_iter(&key);
+                    let mut loc_iter = snapshot.remove_iter(&key);
                     while let Some(loc) = loc_iter.next() {
                         let op = log.read(*loc).await?;
                         if op.to_key() == key {
@@ -295,7 +295,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
     /// The operation is reflected in the snapshot, but will be subject to rollback until the next
     /// successful `commit`.
     pub async fn delete(&mut self, hasher: &mut H, key: K) -> Result<(), Error> {
-        let mut loc_iter = self.snapshot.delete_iter(&key);
+        let mut loc_iter = self.snapshot.remove_iter(&key);
         for loc in &mut loc_iter {
             let op = self.log.read(*loc).await?;
             match op.to_type() {

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -291,7 +291,7 @@ impl<T: Translator, K: Array, B: Blob, E: Storage<B> + Metrics> Archive<T, K, B,
         self.gets.inc();
 
         // Fetch index
-        let iter = self.keys.get(key);
+        let iter = self.keys.get_iter(key);
         let min_allowed = self.oldest_allowed.unwrap_or(0);
         for index in iter {
             // Continue if index is no longer allowed due to pruning.
@@ -342,7 +342,7 @@ impl<T: Translator, K: Array, B: Blob, E: Storage<B> + Metrics> Archive<T, K, B,
     }
 
     async fn has_key(&self, key: &[u8]) -> Result<bool, Error> {
-        let iter = self.keys.get(key);
+        let iter = self.keys.get_iter(key);
         let min_allowed = self.oldest_allowed.unwrap_or(0);
         for index in iter {
             // Continue if index is no longer allowed due to pruning.

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -50,18 +50,20 @@ mod tests {
         index.insert(key, 1);
         index.insert(key, 2);
         assert_eq!(index.len(), 1);
-        let buffer = context.encode();
-        assert!(buffer.contains("collisions_total 1"));
+        assert!(context.encode().contains("collisions_total 1"));
 
         // Make sure we can remove keys with a predicate
         index.insert(key, 3);
         index.insert(key, 4);
         index.remove(key, |i| *i == 3);
-        assert_eq!(index.get(key).copied().collect::<Vec<_>>(), vec![1, 4, 2]);
+        assert_eq!(
+            index.get_iter(key).copied().collect::<Vec<_>>(),
+            vec![4, 2, 1]
+        );
         index.remove(key, |_| true);
         // Try removing all of a keys values.
         assert_eq!(
-            index.get(key).copied().collect::<Vec<_>>(),
+            index.get_iter(key).copied().collect::<Vec<_>>(),
             Vec::<u64>::new()
         );
         assert!(index.is_empty());
@@ -91,7 +93,7 @@ mod tests {
         }
 
         for (key, loc) in expected.iter() {
-            let mut values = index.get(key);
+            let mut values = index.get_iter(key);
             let res = values.find(|i| *i == loc);
             assert!(res.is_some());
         }
@@ -108,36 +110,43 @@ mod tests {
         index.insert(b"abc", 3); // Longer than cap (3 bytes -> "ab")
 
         // Check that "a" maps to "a\0"
-        assert_eq!(index.get(b"a").copied().collect::<Vec<_>>(), vec![1]);
+        assert_eq!(index.get_iter(b"a").copied().collect::<Vec<_>>(), vec![1]);
 
         // Check that "ab" and "abc" map to "ab" due to TwoCap truncation
-        let mut values = index.get(b"ab").copied().collect::<Vec<_>>();
+        let mut values = index.get_iter(b"ab").copied().collect::<Vec<_>>();
         values.sort();
         assert_eq!(values, vec![2, 3]);
 
-        let mut values = index.get(b"abc").copied().collect::<Vec<_>>();
+        let mut values = index.get_iter(b"abc").copied().collect::<Vec<_>>();
         values.sort();
         assert_eq!(values, vec![2, 3]);
 
         // Insert another value for "ab"
         index.insert(b"ab", 4);
         // Expected order: head=2 (first "ab"), then 4 (new "ab"), then 3 (from "abc")
-        assert_eq!(index.get(b"ab").copied().collect::<Vec<_>>(), vec![2, 4, 3]);
+
+        assert_eq!(
+            index.get_iter(b"ab").copied().collect::<Vec<_>>(),
+            vec![4, 3, 2]
+        );
 
         // Remove a specific value
         index.remove(b"ab", |v| *v == 4);
-        assert_eq!(index.get(b"ab").copied().collect::<Vec<_>>(), vec![2, 3]);
+        assert_eq!(
+            index.get_iter(b"ab").copied().collect::<Vec<_>>(),
+            vec![3, 2]
+        );
 
         // Remove all values for "ab"
         index.remove(b"ab", |_| true);
         assert_eq!(
-            index.get(b"ab").copied().collect::<Vec<_>>(),
+            index.get_iter(b"ab").copied().collect::<Vec<_>>(),
             Vec::<u64>::new()
         );
         assert_eq!(index.len(), 1); // Only "a" remains
 
         // Check that "a" is still present
-        assert_eq!(index.get(b"a").copied().collect::<Vec<_>>(), vec![1]);
+        assert_eq!(index.get_iter(b"a").copied().collect::<Vec<_>>(), vec![1]);
     }
 
     #[test_traced]
@@ -149,13 +158,10 @@ mod tests {
         index.insert(b"key", 2);
         index.insert(b"key", 3);
 
-        // Values should be: head=1 (first insertion), then 3 (last insertion), then 2 (middle insertion)
-        //
-        // While we make no guarantees about the order of values to external clients, we should
-        // take note if the internal order is different than expected (as it may be indicative of some bug).
+        // Values should be in stack order (last in first).
         assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![1, 3, 2]
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![3, 2, 1]
         );
     }
 
@@ -170,11 +176,14 @@ mod tests {
 
         // Remove value 2
         index.remove(b"key", |v| *v == 2);
-        assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![1, 3]);
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![3, 1]
+        );
 
         // Remove head value 1
         index.remove(b"key", |v| *v == 1);
-        assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![3]);
+        assert_eq!(index.get_iter(b"key").copied().collect::<Vec<_>>(), vec![3]);
     }
 
     #[test_traced]
@@ -187,21 +196,21 @@ mod tests {
         index.insert(b"\0\0", 2); // Maps to [0, 0]
 
         // All keys map to [0, 0], so all values should be returned
-        let mut values = index.get(b"").copied().collect::<Vec<_>>();
+        let mut values = index.get_iter(b"").copied().collect::<Vec<_>>();
         values.sort();
         assert_eq!(values, vec![0, 1, 2]);
 
-        let mut values = index.get(b"\0").copied().collect::<Vec<_>>();
+        let mut values = index.get_iter(b"\0").copied().collect::<Vec<_>>();
         values.sort();
         assert_eq!(values, vec![0, 1, 2]);
 
-        let mut values = index.get(b"\0\0").copied().collect::<Vec<_>>();
+        let mut values = index.get_iter(b"\0\0").copied().collect::<Vec<_>>();
         values.sort();
         assert_eq!(values, vec![0, 1, 2]);
 
         // Remove a specific value
         index.remove(b"", |v| *v == 1);
-        let mut values = index.get(b"").copied().collect::<Vec<_>>();
+        let mut values = index.get_iter(b"").copied().collect::<Vec<_>>();
         values.sort();
         assert_eq!(values, vec![0, 2]);
     }
@@ -215,14 +224,142 @@ mod tests {
         index.insert(b"key", 2);
         index.insert(b"key", 3);
 
-        for value in index.get_mut(b"key") {
+        for value in index.update_iter(b"key") {
             // Mutate the value
             *value += 10;
         }
 
         assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![11, 13, 12]
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![13, 12, 11]
         );
+
+        // Mutations should work with a delete iterator too
+        for value in index.update_iter(b"key") {
+            // Mutate the value
+            *value *= 10;
+        }
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![130, 120, 110]
+        );
+    }
+
+    #[test_traced]
+    fn test_index_delete_through_iterator() {
+        let (_, context, _) = Executor::default();
+        let mut index = Index::init(context.clone(), TwoCap);
+
+        index.insert(b"key", 1);
+        index.insert(b"key", 2);
+        index.insert(b"key", 3);
+
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![3, 2, 1]
+        );
+        assert!(context.encode().contains("pruned_total 0"));
+
+        // Test deleting first value from the list.
+        let mut iter = index.delete_iter(b"key");
+        assert_eq!(*iter.next().unwrap(), 3);
+        iter.remove();
+        assert!(context.encode().contains("pruned_total 1"));
+
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![2, 1]
+        );
+
+        index.insert(b"key", 3);
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![3, 2, 1]
+        );
+
+        // Test deleting from the middle.
+        let mut iter = index.delete_iter(b"key");
+        assert_eq!(*iter.next().unwrap(), 3);
+        assert_eq!(*iter.next().unwrap(), 2);
+        iter.remove();
+        assert!(context.encode().contains("pruned_total 2"));
+
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![3, 1]
+        );
+        index.insert(b"key", 2);
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![2, 3, 1]
+        );
+
+        // Test deleting last value.
+        let mut iter = index.delete_iter(b"key");
+        assert_eq!(*iter.next().unwrap(), 2);
+        assert_eq!(*iter.next().unwrap(), 3);
+        assert_eq!(*iter.next().unwrap(), 1);
+        iter.remove();
+        assert!(context.encode().contains("pruned_total 3"));
+
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+
+        // Test deleting all values.
+        let mut iter = index.delete_iter(b"key");
+        while let Some(_) = iter.next() {
+            iter.remove();
+        }
+        iter.remove(); // should be a no-op
+        assert_eq!(index.len(), 0);
+        assert!(context.encode().contains("pruned_total 5"));
+
+        // Deleting from an empty iterator should be a no-op and shouldn't panic
+        let mut iter = index.delete_iter(b"key");
+        iter.remove();
+
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            Vec::<u64>::new()
+        );
+        assert!(context.encode().contains("pruned_total 5"));
+    }
+
+    #[test_traced]
+    fn test_index_insert_through_iterator() {
+        let (_, context, _) = Executor::default();
+        let mut index = Index::init(context.clone(), TwoCap);
+
+        {
+            let mut iter = index.update_iter(b"key");
+            iter.insert(1);
+            iter.insert(2);
+            index.insert(b"key", 3);
+            assert!(context.encode().contains("collisions_total 2"));
+        }
+
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![3, 2, 1]
+        );
+        assert_eq!(index.len(), 1);
+
+        // Try inserting into an iterator while iterating.
+        let mut iter = index.update_iter(b"key");
+        iter.insert(42);
+        iter.insert(43);
+        assert_eq!(*iter.next().unwrap(), 43);
+        assert_eq!(*iter.next().unwrap(), 42);
+        assert!(context.encode().contains("collisions_total 4"));
+
+        // since we've advanced beyond the head, newly inserted elements won't be returned by next()
+        iter.insert(100);
+        assert_eq!(*iter.next().unwrap(), 3);
+        assert_eq!(*iter.next().unwrap(), 2);
+        assert_eq!(*iter.next().unwrap(), 1);
+        assert!(iter.next().is_none());
+        assert!(context.encode().contains("collisions_total 5"));
     }
 }


### PR DESCRIPTION
- updates storage::index with unsafe iterators allowing them to insert and update values during iteration (UpdateValueIterator and DeleteValueIterator respectively). 

- storage::index's insert operation is now guaranteed to always insert the new element at the head of the list for more predictable ordering and providing a more LRU-like behavior.

- updates storage::adb::any to use these constructs in order to reduce hashmap lookups for delete and update operations.

- fix bug in storage::adb::any pertaining to replaying of delete operations that could result in an incorrect snapshot on restart, and added test to prevent regression.

Addresses the concerns from this issue: https://github.com/commonwarexyz/monorepo/issues/682