### PR TITLE
[consensus] Improve "Old" Message Handling

### DIFF
--- a/consensus/src/threshold_simplex/actors/resolver/ingress.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/ingress.rs
@@ -24,7 +24,7 @@ pub struct Mailbox {
 }
 
 impl Mailbox {
-    pub(super) fn new(sender: mpsc::Sender<Message>) -> Self {
+    pub(crate) fn new(sender: mpsc::Sender<Message>) -> Self {
         Self { sender }
     }
 

--- a/consensus/src/threshold_simplex/actors/resolver/mod.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/mod.rs
@@ -5,7 +5,9 @@ use crate::Supervisor;
 pub use actor::Actor;
 use commonware_cryptography::Scheme;
 use governor::Quota;
-pub use ingress::{Mailbox, Message};
+pub use ingress::Mailbox;
+#[cfg(test)]
+pub use ingress::Message;
 use std::time::Duration;
 
 pub struct Config<C: Scheme, S: Supervisor> {

--- a/consensus/src/threshold_simplex/actors/resolver/mod.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/mod.rs
@@ -5,7 +5,7 @@ use crate::Supervisor;
 pub use actor::Actor;
 use commonware_cryptography::Scheme;
 use governor::Quota;
-pub use ingress::Mailbox;
+pub use ingress::{Mailbox, Message};
 use std::time::Duration;
 
 pub struct Config<C: Scheme, S: Supervisor> {

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -2559,6 +2559,8 @@ impl<
                         Message::Notarization{ notarization }  => {
                             view = notarization.message.proposal.as_ref().unwrap().view;
                             if !self.interesting(view, false) {
+                                // It is possible that we receive a notarization for a view
+                                // that we have pruned. We should ignore this.
                                 debug!(view, "backfilled notarization is not interesting");
                                 continue;
                             }
@@ -2568,6 +2570,8 @@ impl<
                         Message::Nullification { nullification } => {
                             view = nullification.view;
                             if !self.interesting(view, false) {
+                                // It is possible that we receive a notarization for a view
+                                // that we have pruned. We should ignore this.
                                 debug!(view, "backfilled nullification is not interesting");
                                 continue;
                             }

--- a/consensus/src/threshold_simplex/actors/voter/ingress.rs
+++ b/consensus/src/threshold_simplex/actors/voter/ingress.rs
@@ -18,7 +18,7 @@ pub struct Mailbox<D: Array> {
 }
 
 impl<D: Array> Mailbox<D> {
-    pub(super) fn new(sender: mpsc::Sender<Message<D>>) -> Self {
+    pub(crate) fn new(sender: mpsc::Sender<Message<D>>) -> Self {
         Self { sender }
     }
 

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -164,7 +164,7 @@ mod tests {
                 skip_timeout: 10,
                 replay_concurrency: 1,
             };
-            let (mut actor, mut mailbox) = Actor::new(context.clone(), journal, cfg);
+            let (actor, mut mailbox) = Actor::new(context.clone(), journal, cfg);
 
             // Create a dummy backfiller mailbox (not used in this path)
             let (backfiller_sender, mut backfiller_receiver) = mpsc::channel(1);

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -35,3 +35,150 @@ pub struct Config<
     pub skip_timeout: View,
     pub replay_concurrency: usize,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::threshold_simplex::{
+        actors::resolver,
+        mocks,
+        wire::{self, backfiller},
+        Prover, View, CONFLICTING_FINALIZE, CONFLICTING_NOTARIZE, FINALIZE, NOTARIZE,
+        NULLIFY_AND_FINALIZE,
+    };
+    use bytes::Bytes;
+    use commonware_cryptography::{
+        bls12381::{
+            dkg::ops,
+            primitives::{
+                group::{self, Share, Signature},
+                poly::{self, Public},
+            },
+        },
+        sha256::Digest,
+        Ed25519, Scheme as CryptoScheme, Sha256, Signer,
+    };
+    use commonware_macros::test_traced;
+    use commonware_p2p::simulated::{Config as NConfig, Network};
+    use commonware_runtime::{
+        deterministic::{self, Context as DeterministicContext, Executor},
+        Blob, Clock, Metrics, Runner, Spawner, Storage,
+    };
+    use commonware_storage::journal::variable::{Config as JConfig, Journal};
+    use commonware_utils::{quorum, Array};
+    use futures::{
+        channel::mpsc::{self, UnboundedReceiver},
+        StreamExt,
+    };
+    use prost::Message;
+    use std::time::Duration;
+    use std::{
+        collections::BTreeMap,
+        sync::{atomic::AtomicI64, Arc},
+    };
+
+    // Mock Committer (no-op)
+    #[derive(Clone)]
+    struct MockCommitter;
+    impl Committer for MockCommitter {
+        type Digest = <Sha256 as commonware_cryptography::Hasher>::Digest;
+        async fn prepared(&mut self, _proof: Bytes, _payload: Self::Digest) {}
+        async fn finalized(&mut self, _proof: Bytes, _payload: Self::Digest) {}
+    }
+
+    // Test for late notarization causing a panic
+    #[test_traced]
+    fn test_late_notarization_panic() {
+        let n = 5;
+        let threshold = quorum(n).expect("unable to calculate threshold");
+        let namespace = b"consensus".to_vec();
+        let (executor, mut context, _) = Executor::timed(Duration::from_secs(10));
+        executor.start(async move {
+            // Create simulated network
+            let (network, mut oracle) = Network::new(
+                context.with_label("network"),
+                NConfig {
+                    max_size: 1024 * 1024,
+                },
+            );
+            network.start();
+
+            // Get participants
+            let mut schemes = Vec::new();
+            let mut validators = Vec::new();
+            for i in 0..n {
+                let scheme = Ed25519::from_seed(i as u64);
+                let pk = scheme.public_key();
+                schemes.push(scheme);
+                validators.push(pk);
+            }
+            validators.sort();
+            schemes.sort_by_key(|s| s.public_key());
+
+            // Derive threshold
+            let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
+            let pk = poly::public(&public);
+            let prover = Prover::<Digest>::new(*pk, &namespace);
+
+            // Initialize voter actor
+            let (done_sender, mut done_receiver) = mpsc::unbounded();
+            let scheme = schemes[0].clone();
+            let validator = scheme.public_key();
+            let mut participants = BTreeMap::new();
+            participants.insert(0, (public.clone(), validators.clone(), shares[0]));
+            let supervisor_config = mocks::supervisor::Config {
+                prover: prover.clone(),
+                participants,
+            };
+            let supervisor = mocks::supervisor::Supervisor::new(supervisor_config);
+            let relay = Arc::new(mocks::relay::Relay::new());
+            let application_cfg = mocks::application::Config {
+                hasher: Sha256::default(),
+                relay: relay.clone(),
+                participant: validator.clone(),
+                tracker: done_sender.clone(),
+                propose_latency: (10.0, 5.0),
+                verify_latency: (10.0, 5.0),
+            };
+            let (actor, application) = mocks::application::Application::new(
+                context.with_label("application"),
+                application_cfg,
+            );
+            actor.start();
+            let cfg = JConfig {
+                partition: "test".to_string(),
+            };
+            let journal = Journal::init(context.with_label("journal"), cfg)
+                .await
+                .expect("unable to create journal");
+
+            let cfg = Config {
+                crypto: scheme,
+                automaton: application.clone(),
+                relay: application.clone(),
+                committer: MockCommitter,
+                supervisor,
+
+                namespace,
+                mailbox_size: 10,
+                leader_timeout: Duration::from_secs(5),
+                notarization_timeout: Duration::from_secs(5),
+                nullify_retry: Duration::from_secs(5),
+                activity_timeout: 10,
+                skip_timeout: 10,
+                replay_concurrency: 1,
+            };
+            let (mut actor, mut mailbox) = Actor::new(context.clone(), journal, cfg);
+
+            // Create a dummy backfiller mailbox (not used in this path)
+            let (backfiller_sender, backfiller_receiver) = mpsc::channel(1);
+            let backfiller = resolver::Mailbox::new(backfiller_sender);
+
+            // Create a dummy network mailbox
+            let (voter_sender, voter_receiver) = oracle.register(validator, 0).await.unwrap();
+
+            // Run the actor, expecting it to panic
+            actor.start(backfiller, voter_sender, voter_receiver);
+        });
+    }
+}

--- a/consensus/src/threshold_simplex/mocks/mod.rs
+++ b/consensus/src/threshold_simplex/mocks/mod.rs
@@ -3,5 +3,6 @@
 pub mod application;
 pub mod conflicter;
 pub mod nuller;
+pub mod outdated;
 pub mod relay;
 pub mod supervisor;

--- a/consensus/src/threshold_simplex/mocks/outdated.rs
+++ b/consensus/src/threshold_simplex/mocks/outdated.rs
@@ -1,0 +1,216 @@
+//! Byzantine participant that sends conflicting notarize/finalize messages.
+
+use crate::{
+    threshold_simplex::{
+        encoder::{
+            finalize_namespace, notarize_namespace, nullify_message, nullify_namespace,
+            proposal_message, seed_message, seed_namespace,
+        },
+        wire::{self, Proposal},
+        View,
+    },
+    ThresholdSupervisor,
+};
+use bytes::Bytes;
+use commonware_cryptography::{
+    bls12381::primitives::{group, ops},
+    Hasher,
+};
+use commonware_p2p::{Receiver, Recipients, Sender};
+use commonware_runtime::{Clock, Handle, Spawner};
+use prost::Message;
+use rand::{CryptoRng, Rng};
+use std::{collections::HashMap, marker::PhantomData};
+use tracing::debug;
+
+pub struct Config<
+    S: ThresholdSupervisor<Seed = group::Signature, Index = View, Share = group::Share>,
+> {
+    pub supervisor: S,
+    pub namespace: Vec<u8>,
+    pub view_delta: u64,
+}
+
+pub struct Outdated<
+    E: Clock + Rng + CryptoRng + Spawner,
+    H: Hasher,
+    S: ThresholdSupervisor<Seed = group::Signature, Index = View, Share = group::Share>,
+> {
+    context: E,
+    supervisor: S,
+    _hasher: PhantomData<H>,
+
+    seed_namespace: Vec<u8>,
+    notarize_namespace: Vec<u8>,
+    nullify_namespace: Vec<u8>,
+    finalize_namespace: Vec<u8>,
+
+    history: HashMap<u64, Proposal>,
+    view_delta: u64,
+}
+
+impl<
+        E: Clock + Rng + CryptoRng + Spawner,
+        H: Hasher,
+        S: ThresholdSupervisor<Seed = group::Signature, Index = View, Share = group::Share>,
+    > Outdated<E, H, S>
+{
+    pub fn new(context: E, cfg: Config<S>) -> Self {
+        Self {
+            context,
+            supervisor: cfg.supervisor,
+            _hasher: PhantomData,
+
+            seed_namespace: seed_namespace(&cfg.namespace),
+            notarize_namespace: notarize_namespace(&cfg.namespace),
+            nullify_namespace: nullify_namespace(&cfg.namespace),
+            finalize_namespace: finalize_namespace(&cfg.namespace),
+
+            history: HashMap::new(),
+            view_delta: cfg.view_delta,
+        }
+    }
+
+    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
+        self.context.spawn_ref()(self.run(voter_network))
+    }
+
+    async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {
+        let (mut sender, mut receiver) = voter_network;
+        while let Ok((s, msg)) = receiver.recv().await {
+            // Parse message
+            let msg = match wire::Voter::decode(msg) {
+                Ok(msg) => msg,
+                Err(err) => {
+                    debug!(?err, sender = ?s, "failed to decode message");
+                    continue;
+                }
+            };
+            let payload = match msg.payload {
+                Some(payload) => payload,
+                None => {
+                    debug!(sender = ?s, "message missing payload");
+                    continue;
+                }
+            };
+
+            // Process message
+            match payload {
+                wire::voter::Payload::Nullify(nullify) => {
+                    // Get our index
+                    let view = nullify.view;
+                    let share = self.supervisor.share(view).unwrap();
+
+                    // Nullify provided view
+                    let view = view.saturating_sub(self.view_delta);
+                    let message = nullify_message(view);
+                    let view_signature =
+                        ops::partial_sign_message(share, Some(&self.nullify_namespace), &message)
+                            .serialize();
+                    let message = seed_message(view);
+                    let seed_signature =
+                        ops::partial_sign_message(share, Some(&self.seed_namespace), &message)
+                            .serialize();
+                    let n = wire::Nullify {
+                        view,
+                        view_signature,
+                        seed_signature,
+                    };
+                    let msg = wire::Voter {
+                        payload: Some(wire::voter::Payload::Nullify(n)),
+                    }
+                    .encode_to_vec()
+                    .into();
+                    sender.send(Recipients::All, msg, true).await.unwrap();
+                }
+                wire::voter::Payload::Notarize(notarize) => {
+                    // Get our index
+                    let proposal = match notarize.proposal {
+                        Some(proposal) => proposal,
+                        None => {
+                            debug!(sender = ?s, "notarize missing proposal");
+                            continue;
+                        }
+                    };
+                    let Ok(payload) = H::Digest::try_from(&proposal.payload) else {
+                        debug!(sender = ?s, "invalid payload");
+                        continue;
+                    };
+                    let view = proposal.view;
+                    let share = self.supervisor.share(view).unwrap();
+
+                    // Store proposal
+                    self.history.insert(view, proposal.clone());
+
+                    // Notarize old digest
+                    let view = view.saturating_sub(self.view_delta);
+                    let Some(proposal) = self.history.get(&view) else {
+                        continue;
+                    };
+                    let parent = proposal.parent;
+                    let message = proposal_message(proposal.view, parent, &payload);
+                    let proposal_signature =
+                        ops::partial_sign_message(share, Some(&self.notarize_namespace), &message)
+                            .serialize();
+                    let message = seed_message(view);
+                    let seed_signature: Bytes =
+                        ops::partial_sign_message(share, Some(&self.seed_namespace), &message)
+                            .serialize()
+                            .into();
+                    let n = wire::Notarize {
+                        proposal: Some(proposal.clone()),
+                        proposal_signature,
+                        seed_signature: seed_signature.to_vec(),
+                    };
+                    let msg = wire::Voter {
+                        payload: Some(wire::voter::Payload::Notarize(n)),
+                    }
+                    .encode_to_vec()
+                    .into();
+                    sender.send(Recipients::All, msg, true).await.unwrap();
+                }
+                wire::voter::Payload::Finalize(finalize) => {
+                    // Get our index
+                    let proposal = match finalize.proposal {
+                        Some(proposal) => proposal,
+                        None => {
+                            debug!(sender = ?s, "notarize missing proposal");
+                            continue;
+                        }
+                    };
+                    let Ok(payload) = H::Digest::try_from(&proposal.payload) else {
+                        debug!(sender = ?s, "invalid payload");
+                        continue;
+                    };
+                    let view = proposal.view;
+                    let share = self.supervisor.share(view).unwrap();
+
+                    // Store proposal
+                    self.history.insert(view, proposal.clone());
+
+                    // Finalize old digest
+                    let view = view.saturating_sub(self.view_delta);
+                    let Some(proposal) = self.history.get(&view) else {
+                        continue;
+                    };
+                    let parent = proposal.parent;
+                    let message = proposal_message(view, parent, &payload);
+                    let proposal_signature =
+                        ops::partial_sign_message(share, Some(&self.finalize_namespace), &message)
+                            .serialize();
+                    let f = wire::Finalize {
+                        proposal: Some(proposal.clone()),
+                        proposal_signature,
+                    };
+                    let msg = wire::Voter {
+                        payload: Some(wire::voter::Payload::Finalize(f)),
+                    }
+                    .encode_to_vec()
+                    .into();
+                    sender.send(Recipients::All, msg, true).await.unwrap();
+                }
+                _ => continue,
+            }
+        }
+    }
+}

--- a/consensus/src/threshold_simplex/mocks/outdated.rs
+++ b/consensus/src/threshold_simplex/mocks/outdated.rs
@@ -103,6 +103,7 @@ impl<
 
                     // Nullify provided view
                     let view = view.saturating_sub(self.view_delta);
+                    debug!(?view, "nullifying outdated view");
                     let message = nullify_message(view);
                     let view_signature =
                         ops::partial_sign_message(share, Some(&self.nullify_namespace), &message)
@@ -147,6 +148,7 @@ impl<
                     let Some(proposal) = self.history.get(&view) else {
                         continue;
                     };
+                    debug!(?view, "notarizing outdated proposal");
                     let parent = proposal.parent;
                     let message = proposal_message(proposal.view, parent, &payload);
                     let proposal_signature =
@@ -193,6 +195,7 @@ impl<
                     let Some(proposal) = self.history.get(&view) else {
                         continue;
                     };
+                    debug!(?view, "finalizing outdated proposal");
                     let parent = proposal.parent;
                     let message = proposal_message(view, parent, &payload);
                     let proposal_signature =

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -2376,4 +2376,169 @@ skip_timeout,
             assert!(count_nullify_and_finalize > 0);
         });
     }
+
+    #[test_traced]
+    fn test_outdated() {
+        // Create context
+        let n = 4;
+        let threshold = quorum(n).expect("unable to calculate threshold");
+        let required_containers = 100;
+        let activity_timeout = 10;
+        let skip_timeout = 5;
+        let namespace = b"consensus".to_vec();
+        let (executor, mut context, _) = Executor::timed(Duration::from_secs(30));
+        executor.start(async move {
+            // Create simulated network
+            let (network, mut oracle) = Network::new(
+                context.with_label("network"),
+                Config {
+                    max_size: 1024 * 1024,
+                },
+            );
+
+            // Start network
+            network.start();
+
+            // Register participants
+            let mut schemes = Vec::new();
+            let mut validators = Vec::new();
+            for i in 0..n {
+                let scheme = Ed25519::from_seed(i as u64);
+                let pk = scheme.public_key();
+                schemes.push(scheme);
+                validators.push(pk);
+            }
+            validators.sort();
+            schemes.sort_by_key(|s| s.public_key());
+            let mut registrations = register_validators(&mut oracle, &validators).await;
+
+            // Link all validators
+            let link = Link {
+                latency: 10.0,
+                jitter: 1.0,
+                success_rate: 1.0,
+            };
+            link_validators(&mut oracle, &validators, Action::Link(link), None).await;
+
+            // Derive threshold
+            let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
+            let pk = poly::public(&public);
+            let prover = Prover::new(*pk, &namespace);
+
+            // Create engines
+            let relay = Arc::new(mocks::relay::Relay::new());
+            let mut supervisors = Vec::new();
+            let (done_sender, mut done_receiver) = mpsc::unbounded();
+            for (idx_scheme, scheme) in schemes.into_iter().enumerate() {
+                // Create scheme context
+                let context = context.with_label(&format!("validator-{}", scheme.public_key()));
+
+                // Start engine
+                let validator = scheme.public_key();
+                let mut participants = BTreeMap::new();
+                participants.insert(0, (public.clone(), validators.clone(), shares[idx_scheme]));
+                let supervisor_config = mocks::supervisor::Config {
+                    prover: prover.clone(),
+                    participants,
+                };
+                let supervisor = mocks::supervisor::Supervisor::new(supervisor_config);
+                let (voter, resolver) = registrations
+                    .remove(&validator)
+                    .expect("validator should be registered");
+                if idx_scheme == 0 {
+                    let cfg = mocks::outdated::Config {
+                        supervisor,
+                        namespace: namespace.clone(),
+                        view_delta: activity_timeout + 10,
+                    };
+                    let engine: mocks::outdated::Outdated<_, Sha256, _> =
+                        mocks::outdated::Outdated::new(context.with_label("byzantine_engine"), cfg);
+                    engine.start(voter);
+                } else {
+                    supervisors.push(supervisor.clone());
+                    let application_cfg = mocks::application::Config {
+                        hasher: Sha256::default(),
+                        relay: relay.clone(),
+                        participant: validator.clone(),
+                        tracker: done_sender.clone(),
+                        propose_latency: (10.0, 5.0),
+                        verify_latency: (10.0, 5.0),
+                    };
+                    let (actor, application) = mocks::application::Application::new(
+                        context.with_label("application"),
+                        application_cfg,
+                    );
+                    actor.start();
+                    let cfg = JConfig {
+                        partition: validator.to_string(),
+                    };
+                    let journal = Journal::init(context.with_label("journal"), cfg)
+                        .await
+                        .expect("unable to create journal");
+                    let cfg = config::Config {
+                        crypto: scheme,
+                        automaton: application.clone(),
+                        relay: application.clone(),
+                        committer: application,
+                        supervisor,
+                        mailbox_size: 1024,
+                        namespace: namespace.clone(),
+                        leader_timeout: Duration::from_secs(1),
+                        notarization_timeout: Duration::from_secs(2),
+                        nullify_retry: Duration::from_secs(10),
+                        fetch_timeout: Duration::from_secs(1),
+                        activity_timeout,
+                        skip_timeout,
+                        max_fetch_count: 1,
+                        max_fetch_size: 1024 * 512,
+                        fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                        fetch_concurrent: 1,
+                        replay_concurrency: 1,
+                    };
+                    let engine = Engine::new(context.with_label("engine"), journal, cfg);
+                    engine.start(voter, resolver);
+                }
+            }
+
+            // Wait for all engines to finish
+            let mut completed = HashSet::new();
+            let mut finalized = HashMap::new();
+            loop {
+                let (validator, event) = done_receiver.next().await.unwrap();
+                if let mocks::application::Progress::Finalized(proof, digest) = event {
+                    let (view, _, payload, _, _) = prover.deserialize_finalization(proof).unwrap();
+                    if digest != payload {
+                        panic!(
+                            "finalization mismatch digest: {:?}, payload: {:?}",
+                            digest, payload
+                        );
+                    }
+                    if let Some(previous) = finalized.insert(view, digest) {
+                        if previous != digest {
+                            panic!(
+                                "finalization mismatch at {:?} previous: {:?}, current: {:?}",
+                                view, previous, digest
+                            );
+                        }
+                    }
+                    if (finalized.len() as u64) < required_containers {
+                        continue;
+                    }
+                    completed.insert(validator);
+                }
+                if completed.len() == (n - 1) as usize {
+                    break;
+                }
+            }
+
+            // Check supervisors for correct activity
+            for supervisor in supervisors.iter() {
+                // No faults
+                {
+                    let faults = supervisor.faults.lock().unwrap();
+                    assert_eq!(faults.len(), 0);
+                }
+            }
+        });
+    }
 }


### PR DESCRIPTION
Related: #712 

## TODO:
- [ ] Standardize placement of `interesting()` check
- [ ] Why call `notify()` if not an interesting view?
- [ ] Should we just log (and drop) in journal for writing before pruned?
- [ ] Add view() to some trait implemented by all types (call interesting on this)