### PR TITLE
[cryptography/bls12381] Concurrent `recover`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prometheus-client",
  "rand",
+ "rayon",
  "sha2 0.10.8",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ opentelemetry = "0.28.0"
 opentelemetry-otlp = "0.28.0"
 opentelemetry_sdk =  "0.28.0"
 tracing-opentelemetry = "0.29.0"
+rayon = "1.10.0"
 
 [profile.bench]
 # Because we enable overflow checks in "release," we should benchmark with them.

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -17,10 +17,10 @@ bytes = { workspace = true }
 thiserror = { workspace = true }
 rand = { workspace = true }
 sha2 = { workspace = true }
+rayon = { workspace = true }
 ed25519-consensus = "2.1.0"
 blst = { version = "0.3.13", features = ["no-threads"] }
 zeroize = "1.5.7"
-rayon = "1.10"
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 
 # Enable "js" feature when WASM is target

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -7,9 +7,6 @@ use rand::SeedableRng;
 use std::collections::HashMap;
 use std::hint::black_box;
 
-/// Concurrency isn't used in DKG recovery, so we set it to 1.
-const CONCURRENCY: usize = 1;
-
 fn benchmark_dkg_recovery(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0);
     for &n in &[5, 10, 20, 50, 100, 250, 500, 1000, 1500, 2000] {
@@ -25,13 +22,8 @@ fn benchmark_dkg_recovery(c: &mut Criterion) {
 
                     // Create player
                     let me = contributors[0].clone();
-                    let mut player = Player::new(
-                        me,
-                        None,
-                        contributors.clone(),
-                        contributors.clone(),
-                        CONCURRENCY,
-                    );
+                    let mut player =
+                        Player::new(me, None, contributors.clone(), contributors.clone(), None);
 
                     // Create commitments and send shares to player
                     let mut commitments = HashMap::new();

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -4,6 +4,7 @@ use commonware_utils::quorum;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rayon::ThreadPoolBuilder;
 use std::collections::HashMap;
 use std::hint::black_box;
 
@@ -11,38 +12,54 @@ fn benchmark_dkg_recovery(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0);
     for &n in &[5, 10, 20, 50, 100, 250, 500, 1000, 1500, 2000] {
         let t = quorum(n).unwrap();
-        c.bench_function(&format!("{}/n={} t={}", module_path!(), n, t), |b| {
-            b.iter_batched(
-                || {
-                    // Create contributors
-                    let mut contributors = (0..n)
-                        .map(|i| Ed25519::from_seed(i as u64).public_key())
-                        .collect::<Vec<_>>();
-                    contributors.sort();
+        for concurrency in [1, 2, 4, 8] {
+            c.bench_function(
+                &format!("{}/conc={} n={} t={}", module_path!(), concurrency, n, t),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            // Create contributors
+                            let mut contributors = (0..n)
+                                .map(|i| Ed25519::from_seed(i as u64).public_key())
+                                .collect::<Vec<_>>();
+                            contributors.sort();
 
-                    // Create player
-                    let me = contributors[0].clone();
-                    let mut player =
-                        Player::new(me, None, contributors.clone(), contributors.clone(), None);
+                            // Create thread pool
+                            let pool = ThreadPoolBuilder::new()
+                                .num_threads(concurrency)
+                                .build()
+                                .unwrap();
 
-                    // Create commitments and send shares to player
-                    let mut commitments = HashMap::new();
-                    for (idx, dealer) in contributors.iter().take(t as usize).enumerate() {
-                        let (_, commitment, shares) =
-                            Dealer::new(&mut rng, None, contributors.clone());
-                        player
-                            .share(dealer.clone(), commitment.clone(), shares[0])
-                            .unwrap();
-                        commitments.insert(idx as u32, commitment);
-                    }
-                    (player, commitments)
+                            // Create player
+                            let me = contributors[0].clone();
+                            let mut player = Player::new(
+                                me,
+                                None,
+                                contributors.clone(),
+                                contributors.clone(),
+                                Some(pool),
+                            );
+
+                            // Create commitments and send shares to player
+                            let mut commitments = HashMap::new();
+                            for (idx, dealer) in contributors.iter().take(t as usize).enumerate() {
+                                let (_, commitment, shares) =
+                                    Dealer::new(&mut rng, None, contributors.clone());
+                                player
+                                    .share(dealer.clone(), commitment.clone(), shares[0])
+                                    .unwrap();
+                                commitments.insert(idx as u32, commitment);
+                            }
+                            (player, commitments)
+                        },
+                        |(player, commitments)| {
+                            black_box(player.finalize(commitments, HashMap::new()).unwrap());
+                        },
+                        BatchSize::SmallInput,
+                    );
                 },
-                |(player, commitments)| {
-                    black_box(player.finalize(commitments, HashMap::new()).unwrap());
-                },
-                BatchSize::SmallInput,
             );
-        });
+        }
     }
 }
 

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -5,6 +5,7 @@ use commonware_cryptography::{
 use commonware_utils::quorum;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
+use rayon::ThreadPoolBuilder;
 use std::collections::HashMap;
 use std::hint::black_box;
 
@@ -30,7 +31,7 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
                 None,
                 contributors.clone(),
                 contributors.clone(),
-                1,
+                None,
             );
             players.push(player);
         }
@@ -64,6 +65,12 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
                 |b| {
                     b.iter_batched(
                         || {
+                            // Create pool
+                            let pool = ThreadPoolBuilder::new()
+                                .num_threads(concurrency)
+                                .build()
+                                .unwrap();
+
                             // Create player
                             let me = contributors[0].clone();
                             let mut player = Player::new(
@@ -71,7 +78,7 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
                                 Some(outputs[0].public.clone()),
                                 contributors.clone(),
                                 contributors.clone(),
-                                concurrency,
+                                Some(pool),
                             );
 
                             // Create commitments and send shares to player

--- a/cryptography/src/bls12381/benches/threshold_signature_recover.rs
+++ b/cryptography/src/bls12381/benches/threshold_signature_recover.rs
@@ -2,6 +2,7 @@ use commonware_cryptography::bls12381::{dkg, primitives};
 use commonware_utils::quorum;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
+use rayon::ThreadPoolBuilder;
 use std::hint::black_box;
 
 fn benchmark_threshold_signature_recover(c: &mut Criterion) {
@@ -10,21 +11,43 @@ fn benchmark_threshold_signature_recover(c: &mut Criterion) {
     let msg = b"hello";
     for &n in &[5, 10, 20, 50, 100, 250, 500, 1000, 1500, 2000] {
         let t = quorum(n).unwrap();
-        c.bench_function(&format!("{}/n={} t={}", module_path!(), n, t), |b| {
-            b.iter_batched(
-                || {
-                    let (_, shares) = dkg::ops::generate_shares(&mut rng, None, n, t);
-                    shares
-                        .iter()
-                        .map(|s| primitives::ops::partial_sign_message(s, Some(namespace), msg))
-                        .collect::<Vec<_>>()
+        for concurrency in [1, 2, 4, 8] {
+            c.bench_function(
+                &format!("{}/conc={} n={} t={}", module_path!(), concurrency, n, t),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            // Create partials
+                            let (_, shares) = dkg::ops::generate_shares(&mut rng, None, n, t);
+                            let partials = shares
+                                .iter()
+                                .map(|s| {
+                                    primitives::ops::partial_sign_message(s, Some(namespace), msg)
+                                })
+                                .collect::<Vec<_>>();
+
+                            // Create thread pool
+                            let pool = ThreadPoolBuilder::new()
+                                .num_threads(concurrency)
+                                .build()
+                                .unwrap();
+                            (partials, pool)
+                        },
+                        |(partials, pool)| {
+                            black_box(
+                                primitives::ops::threshold_signature_recover(
+                                    t,
+                                    partials,
+                                    Some(&pool),
+                                )
+                                .unwrap(),
+                            );
+                        },
+                        BatchSize::SmallInput,
+                    );
                 },
-                |partials| {
-                    black_box(primitives::ops::threshold_signature_recover(t, partials).unwrap());
-                },
-                BatchSize::SmallInput,
             );
-        });
+        }
     }
 }
 

--- a/cryptography/src/bls12381/dkg/mod.rs
+++ b/cryptography/src/bls12381/dkg/mod.rs
@@ -197,7 +197,7 @@ mod tests {
     use rand::SeedableRng;
     use std::collections::HashMap;
 
-    fn run_dkg_and_reshare(n_0: u32, dealers_0: u32, n_1: u32, dealers_1: u32, concurrency: usize) {
+    fn run_dkg_and_reshare(n_0: u32, dealers_0: u32, n_1: u32, dealers_1: u32) {
         // Create shared RNG (for reproducibility)
         let mut rng = StdRng::seed_from_u64(0);
 
@@ -226,18 +226,13 @@ mod tests {
                 None,
                 contributors.clone(),
                 contributors.clone(),
-                concurrency,
+                None,
             );
             players.insert(con.clone(), player);
         }
 
         // Create arbiter
-        let mut arb = Arbiter::new(
-            None,
-            contributors.clone(),
-            contributors.clone(),
-            concurrency,
-        );
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Check ready
         assert!(!arb.ready());
@@ -305,7 +300,7 @@ mod tests {
             .map(|s| partial_sign_proof_of_possession(&s.public, &s.share))
             .collect::<Vec<_>>();
         let signature =
-            threshold_signature_recover(t, partials).expect("unable to recover signature");
+            threshold_signature_recover(t, partials, None).expect("unable to recover signature");
         let public_key = public(&outputs.iter().next().unwrap().1.public);
         verify_proof_of_possession(public_key, &signature).expect("invalid proof of possession");
 
@@ -336,7 +331,7 @@ mod tests {
                 Some(output.public.clone()),
                 contributors.clone(),
                 reshare_players.clone(),
-                concurrency,
+                None,
             );
             reshare_player_objs.insert(con.clone(), player);
         }
@@ -346,7 +341,7 @@ mod tests {
             Some(output.public),
             contributors.clone(),
             reshare_players.clone(),
-            concurrency,
+            None,
         );
 
         // Check ready
@@ -416,35 +411,35 @@ mod tests {
             .map(|s| partial_sign_proof_of_possession(&s.public, &s.share))
             .collect::<Vec<_>>();
         let signature =
-            threshold_signature_recover(t, partials).expect("unable to recover signature");
+            threshold_signature_recover(t, partials, None).expect("unable to recover signature");
         let public_key = public(&outputs[0].public);
         verify_proof_of_possession(public_key, &signature).expect("invalid proof of possession");
     }
 
     #[test]
     fn test_dkg_and_reshare_all_active() {
-        run_dkg_and_reshare(5, 5, 10, 5, 4);
+        run_dkg_and_reshare(5, 5, 10, 5);
     }
 
     #[test]
     fn test_dkg_and_reshare_min_active() {
-        run_dkg_and_reshare(4, 3, 4, 3, 4);
+        run_dkg_and_reshare(4, 3, 4, 3);
     }
 
     #[test]
     fn test_dkg_and_reshare_min_active_different_sizes() {
-        run_dkg_and_reshare(5, 3, 10, 3, 4);
+        run_dkg_and_reshare(5, 3, 10, 3);
     }
 
     #[test]
     fn test_dkg_and_reshare_min_active_large() {
-        run_dkg_and_reshare(20, 13, 100, 13, 4);
+        run_dkg_and_reshare(20, 13, 100, 13);
     }
 
     #[test]
     #[should_panic]
     fn test_dkg_and_reshare_insufficient_active() {
-        run_dkg_and_reshare(5, 3, 10, 2, 4);
+        run_dkg_and_reshare(5, 3, 10, 2);
     }
 
     #[test]
@@ -474,7 +469,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send invalid commitment to player
@@ -509,7 +504,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send valid commitment to player
@@ -549,7 +544,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send valid share to player
@@ -585,7 +580,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send valid share to player
@@ -621,7 +616,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send misdirected share to player
@@ -652,7 +647,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send share from invalid dealer
@@ -661,7 +656,7 @@ mod tests {
         assert!(matches!(result, Err(Error::DealerInvalid)));
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Send commitment from invalid dealer
         let result = arb.commitment(dealer, commitment, vec![0, 1, 2, 3], Vec::new());
@@ -694,7 +689,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send invalid commitment to player
@@ -702,7 +697,7 @@ mod tests {
         assert!(matches!(result, Err(Error::CommitmentWrongDegree)));
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Send invalid commitment to arbiter
         let result = arb.commitment(
@@ -732,7 +727,7 @@ mod tests {
         let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Add commitment to arbiter
         arb.commitment(
@@ -759,7 +754,7 @@ mod tests {
         contributors.sort();
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Create dealers
         let mut commitments = Vec::with_capacity(n);
@@ -812,7 +807,7 @@ mod tests {
         let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Add commitment to arbiter
         arb.commitment(
@@ -851,7 +846,7 @@ mod tests {
         let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Add commitment to arbiter
         let result = arb.commitment(
@@ -881,7 +876,7 @@ mod tests {
         let (_, commitment, _) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Add commitment to arbiter
         let result = arb.commitment(
@@ -920,7 +915,7 @@ mod tests {
         let (_, commitment, _) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Disqualify dealer
         arb.disqualify(contributors[0].clone());
@@ -953,7 +948,7 @@ mod tests {
         let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Add commitment to arbiter
         let result = arb.commitment(
@@ -987,7 +982,7 @@ mod tests {
         let (_, shares) = ops::generate_shares(&mut rng, None, n, t);
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Add commitment to arbiter
         let result = arb.commitment(
@@ -1017,7 +1012,7 @@ mod tests {
         let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Swap share value
         let mut share = shares[3];
@@ -1051,7 +1046,7 @@ mod tests {
         let (_, commitment, _) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Add commitment to arbiter
         let result = arb.commitment(
@@ -1081,7 +1076,7 @@ mod tests {
         let (_, commitment, _) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Add commitment to arbiter
         let result = arb.commitment(
@@ -1111,7 +1106,7 @@ mod tests {
         let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
 
         // Create arbiter
-        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
+        let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), None);
 
         // Swap share value
         let mut share = shares[3];
@@ -1278,7 +1273,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send shares to player
@@ -1319,7 +1314,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send shares to player
@@ -1359,7 +1354,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send shares to player
@@ -1397,7 +1392,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send shares to player
@@ -1439,7 +1434,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send shares to player
@@ -1481,7 +1476,7 @@ mod tests {
             None,
             contributors.clone(),
             contributors.clone(),
-            1,
+            None,
         );
 
         // Send shares to player

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -49,7 +49,7 @@ mod tests {
         });
 
         // Generate and verify the threshold sig
-        let threshold_sig = threshold_signature_recover(t, partials).unwrap();
+        let threshold_sig = threshold_signature_recover(t, partials, None).unwrap();
         let threshold_pub = public(&group);
         verify_message(threshold_pub, namespace, msg, &threshold_sig).unwrap();
     }
@@ -84,7 +84,7 @@ mod tests {
         });
 
         // Generate and verify the threshold sig
-        let threshold_sig = threshold_signature_recover(t, partials).unwrap();
+        let threshold_sig = threshold_signature_recover(t, partials, None).unwrap();
         let threshold_pub = public(&group);
         assert!(matches!(
             verify_message(threshold_pub, namespace, msg, &threshold_sig).unwrap_err(),
@@ -119,7 +119,7 @@ mod tests {
 
         // Generate the threshold sig
         assert!(matches!(
-            threshold_signature_recover(t, partials).unwrap_err(),
+            threshold_signature_recover(t, partials, None).unwrap_err(),
             Error::NotEnoughPartialSignatures(4, 3)
         ));
     }
@@ -152,7 +152,7 @@ mod tests {
 
         // Generate the threshold sig
         assert!(matches!(
-            threshold_signature_recover(t, partials).unwrap_err(),
+            threshold_signature_recover(t, partials, None).unwrap_err(),
             Error::DuplicateEval,
         ));
     }
@@ -185,7 +185,7 @@ mod tests {
         });
 
         // Generate and verify the threshold sig
-        let threshold_sig = threshold_signature_recover(t, partials).unwrap();
+        let threshold_sig = threshold_signature_recover(t, partials, None).unwrap();
         let threshold_pub = public(&group);
         verify_message(threshold_pub, namespace, msg, &threshold_sig).unwrap();
     }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,6 +25,7 @@ prometheus-client = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
 opentelemetry = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+rayon = { workspace = true }
 
 
 # Enable "js" feature when WASM is target


### PR DESCRIPTION
Closes: #719 

Experiment with concurrent `recover`.

Preliminary Results:
```
bls12381::threshold_signature_recover/conc=1 n=5 t=3
                        time:   [139.03 µs 139.69 µs 140.43 µs]
bls12381::threshold_signature_recover/conc=2 n=5 t=3
                        time:   [134.71 µs 135.09 µs 135.46 µs]
bls12381::threshold_signature_recover/conc=4 n=5 t=3
                        time:   [136.92 µs 137.16 µs 137.42 µs]
bls12381::threshold_signature_recover/conc=8 n=5 t=3
                        time:   [171.32 µs 171.84 µs 172.32 µs]
bls12381::threshold_signature_recover/conc=1 n=10 t=7
                        time:   [368.30 µs 368.99 µs 369.71 µs]
bls12381::threshold_signature_recover/conc=2 n=10 t=7
                        time:   [255.99 µs 256.43 µs 256.88 µs]
bls12381::threshold_signature_recover/conc=4 n=10 t=7
                        time:   [156.58 µs 157.53 µs 158.53 µs]
bls12381::threshold_signature_recover/conc=8 n=10 t=7
                        time:   [187.69 µs 192.97 µs 201.87 µs]
bls12381::threshold_signature_recover/conc=1 n=20 t=13
                        time:   [757.15 µs 757.82 µs 758.46 µs]
bls12381::threshold_signature_recover/conc=2 n=20 t=13
                        time:   [396.35 µs 396.96 µs 397.58 µs]
bls12381::threshold_signature_recover/conc=4 n=20 t=13
                        time:   [282.42 µs 292.65 µs 306.17 µs]
bls12381::threshold_signature_recover/conc=8 n=20 t=13
                        time:   [254.34 µs 261.92 µs 270.59 µs]
bls12381::threshold_signature_recover/conc=1 n=50 t=33
                        time:   [2.0957 ms 2.1037 ms 2.1119 ms]
bls12381::threshold_signature_recover/conc=2 n=50 t=33
                        time:   [1.1041 ms 1.1067 ms 1.1092 ms]
bls12381::threshold_signature_recover/conc=4 n=50 t=33
                        time:   [615.63 µs 617.47 µs 619.65 µs]
bls12381::threshold_signature_recover/conc=8 n=50 t=33
                        time:   [491.40 µs 495.03 µs 498.77 µs]
bls12381::threshold_signature_recover/conc=1 n=100 t=67
                        time:   [4.8379 ms 4.8532 ms 4.8689 ms]
bls12381::threshold_signature_recover/conc=2 n=100 t=67
                        time:   [2.5518 ms 2.6282 ms 2.7714 ms]
bls12381::threshold_signature_recover/conc=4 n=100 t=67
                        time:   [1.4330 ms 1.4461 ms 1.4637 ms]
bls12381::threshold_signature_recover/conc=8 n=100 t=67
                        time:   [960.65 µs 968.28 µs 976.23 µs]
bls12381::threshold_signature_recover/conc=1 n=250 t=167
                        time:   [16.777 ms 16.814 ms 16.853 ms]
bls12381::threshold_signature_recover/conc=2 n=250 t=167
                        time:   [8.7362 ms 8.7640 ms 8.7908 ms]
bls12381::threshold_signature_recover/conc=4 n=250 t=167
                        time:   [4.5958 ms 4.6404 ms 4.6965 ms]
bls12381::threshold_signature_recover/conc=8 n=250 t=167
                        time:   [2.9515 ms 2.9819 ms 3.0165 ms]
bls12381::threshold_signature_recover/conc=1 n=500 t=333
                        time:   [38.082 ms 38.159 ms 38.242 ms]
bls12381::threshold_signature_recover/conc=2 n=500 t=333
                        time:   [19.496 ms 19.535 ms 19.576 ms]
bls12381::threshold_signature_recover/conc=4 n=500 t=333
                        time:   [10.278 ms 10.332 ms 10.396 ms]
bls12381::threshold_signature_recover/conc=8 n=500 t=333
                        time:   [6.2920 ms 6.4400 ms 6.6847 ms]
bls12381::threshold_signature_recover/conc=1 n=1000 t=667
                        time:   [84.343 ms 84.604 ms 84.918 ms]
bls12381::threshold_signature_recover/conc=2 n=1000 t=667
                        time:   [42.835 ms 42.880 ms 42.931 ms]
bls12381::threshold_signature_recover/conc=4 n=1000 t=667
                        time:   [22.336 ms 22.641 ms 23.102 ms]
bls12381::threshold_signature_recover/conc=8 n=1000 t=667
                        time:   [13.508 ms 13.698 ms 13.980 ms]
bls12381::threshold_signature_recover/conc=1 n=1500 t=999
                        time:   [136.09 ms 136.42 ms 136.84 ms]
bls12381::threshold_signature_recover/conc=2 n=1500 t=999
                        time:   [69.971 ms 70.801 ms 72.274 ms]
bls12381::threshold_signature_recover/conc=4 n=1500 t=999
                        time:   [36.126 ms 36.246 ms 36.397 ms]
bls12381::threshold_signature_recover/conc=8 n=1500 t=999
                        time:   [21.777 ms 21.916 ms 22.084 ms]
bls12381::threshold_signature_recover/conc=1 n=2000 t=1333
                        time:   [196.83 ms 197.63 ms 198.60 ms]
bls12381::threshold_signature_recover/conc=2 n=2000 t=1333
                        time:   [100.71 ms 101.81 ms 103.69 ms]
bls12381::threshold_signature_recover/conc=4 n=2000 t=1333
                        time:   [51.686 ms 52.029 ms 52.463 ms]
bls12381::threshold_signature_recover/conc=8 n=2000 t=1333
                        time:   [30.976 ms 31.200 ms 31.463 ms]
```