### PR TITLE
[Storage] make `Blob` type an associated type of Storage instead of generic param

### DIFF
--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -26,7 +26,7 @@ use commonware_runtime::{
         histogram,
         status::{CounterExt, Status},
     },
-    Blob, Clock, Handle, Metrics, Spawner, Storage,
+    Clock, Handle, Metrics, Spawner, Storage,
 };
 use commonware_storage::journal::{self, variable::Journal};
 use commonware_utils::futures::Pool as FuturesPool;
@@ -53,8 +53,7 @@ struct Verify<C: Scheme, D: Digest, E: Clock> {
 
 /// Instance of the engine.
 pub struct Engine<
-    B: Blob,
-    E: Clock + Spawner + Storage<B> + Metrics,
+    E: Clock + Spawner + Storage + Metrics,
     C: Scheme,
     D: Digest,
     A: Automaton<Context = Context<C::PublicKey>, Digest = D> + Clone,
@@ -149,7 +148,7 @@ pub struct Engine<
     journal_name_prefix: String,
 
     // A map of sequencer public keys to their journals.
-    journals: BTreeMap<C::PublicKey, Journal<B, E>>,
+    journals: BTreeMap<C::PublicKey, Journal<E>>,
 
     ////////////////////////////////////////
     // State
@@ -193,8 +192,7 @@ pub struct Engine<
 }
 
 impl<
-        B: Blob,
-        E: Clock + Spawner + Storage<B> + Metrics,
+        E: Clock + Spawner + Storage + Metrics,
         C: Scheme,
         D: Digest,
         A: Automaton<Context = Context<C::PublicKey>, Digest = D> + Clone,
@@ -210,7 +208,7 @@ impl<
         >,
         NetS: Sender<PublicKey = C::PublicKey>,
         NetR: Receiver<PublicKey = C::PublicKey>,
-    > Engine<B, E, C, D, A, R, Z, M, Su, TSu, NetS, NetR>
+    > Engine<E, C, D, A, R, Z, M, Su, TSu, NetS, NetR>
 {
     /// Creates a new engine with the given context and configuration.
     pub fn new(context: E, cfg: Config<C, D, A, R, Z, M, Su, TSu>) -> Self {

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -17,7 +17,7 @@ use crate::{
 use commonware_cryptography::{sha256::hash, sha256::Digest as Sha256Digest, Scheme};
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Blob, Clock, Handle, Metrics, Spawner, Storage};
+use commonware_runtime::{Clock, Handle, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::Journal;
 use commonware_utils::{quorum, Array};
 use futures::{
@@ -458,8 +458,7 @@ impl<C: Scheme, D: Array, S: Supervisor<Index = View, PublicKey = C::PublicKey>>
 }
 
 pub struct Actor<
-    B: Blob,
-    E: Clock + Rng + Spawner + Storage<B> + Metrics,
+    E: Clock + Rng + Spawner + Storage + Metrics,
     C: Scheme,
     D: Array,
     A: Automaton<Context = Context<D>, Digest = D>,
@@ -475,7 +474,7 @@ pub struct Actor<
     supervisor: S,
 
     replay_concurrency: usize,
-    journal: Option<Journal<B, E>>,
+    journal: Option<Journal<E>>,
 
     genesis: Option<D>,
 
@@ -505,19 +504,18 @@ pub struct Actor<
 }
 
 impl<
-        B: Blob,
-        E: Clock + Rng + Spawner + Storage<B> + Metrics,
+        E: Clock + Rng + Spawner + Storage + Metrics,
         C: Scheme,
         D: Array,
         A: Automaton<Context = Context<D>, Digest = D>,
         R: Relay<Digest = D>,
         F: Committer<Digest = D>,
         S: Supervisor<Index = View, PublicKey = C::PublicKey>,
-    > Actor<B, E, C, D, A, R, F, S>
+    > Actor<E, C, D, A, R, F, S>
 {
     pub fn new(
         context: E,
-        journal: Journal<B, E>,
+        journal: Journal<E>,
         cfg: Config<C, D, A, R, F, S>,
     ) -> (Self, Mailbox<D>) {
         // Assert correctness of timeouts

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -7,7 +7,7 @@ use crate::{Automaton, Committer, Relay, Supervisor};
 use commonware_cryptography::Scheme;
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Sender};
-use commonware_runtime::{Blob, Clock, Handle, Metrics, Spawner, Storage};
+use commonware_runtime::{Clock, Handle, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::Journal;
 use commonware_utils::Array;
 use governor::clock::Clock as GClock;
@@ -16,8 +16,7 @@ use tracing::debug;
 
 /// Instance of `simplex` consensus engine.
 pub struct Engine<
-    B: Blob,
-    E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B> + Metrics,
+    E: Clock + GClock + Rng + CryptoRng + Spawner + Storage + Metrics,
     C: Scheme,
     D: Array,
     A: Automaton<Context = Context<D>, Digest = D>,
@@ -27,25 +26,24 @@ pub struct Engine<
 > {
     context: E,
 
-    voter: voter::Actor<B, E, C, D, A, R, F, S>,
+    voter: voter::Actor<E, C, D, A, R, F, S>,
     voter_mailbox: voter::Mailbox<D>,
     resolver: resolver::Actor<E, C, D, S>,
     resolver_mailbox: resolver::Mailbox,
 }
 
 impl<
-        B: Blob,
-        E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B> + Metrics,
+        E: Clock + GClock + Rng + CryptoRng + Spawner + Storage + Metrics,
         C: Scheme,
         D: Array,
         A: Automaton<Context = Context<D>, Digest = D>,
         R: Relay<Digest = D>,
         F: Committer<Digest = D>,
         S: Supervisor<Index = View, PublicKey = C::PublicKey>,
-    > Engine<B, E, C, D, A, R, F, S>
+    > Engine<E, C, D, A, R, F, S>
 {
     /// Create a new `simplex` consensus engine.
-    pub fn new(context: E, journal: Journal<B, E>, cfg: Config<C, D, A, R, F, S>) -> Self {
+    pub fn new(context: E, journal: Journal<E>, cfg: Config<C, D, A, R, F, S>) -> Self {
         // Ensure configuration is valid
         cfg.assert();
 

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -29,7 +29,7 @@ use commonware_cryptography::{
 };
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Blob, Clock, Handle, Metrics, Spawner, Storage};
+use commonware_runtime::{Clock, Handle, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::Journal;
 use commonware_utils::quorum;
 use futures::{
@@ -675,8 +675,7 @@ impl<
 }
 
 pub struct Actor<
-    B: Blob,
-    E: Clock + Rng + Spawner + Storage<B> + Metrics,
+    E: Clock + Rng + Spawner + Storage + Metrics,
     C: Scheme,
     D: Digest,
     A: Automaton<Digest = D, Context = Context<D>>,
@@ -698,7 +697,7 @@ pub struct Actor<
     supervisor: S,
 
     replay_concurrency: usize,
-    journal: Option<Journal<B, E>>,
+    journal: Option<Journal<E>>,
 
     genesis: Option<D>,
 
@@ -729,8 +728,7 @@ pub struct Actor<
 }
 
 impl<
-        B: Blob,
-        E: Clock + Rng + Spawner + Storage<B> + Metrics,
+        E: Clock + Rng + Spawner + Storage + Metrics,
         C: Scheme,
         D: Digest,
         A: Automaton<Digest = D, Context = Context<D>>,
@@ -743,11 +741,11 @@ impl<
             Share = group::Share,
             PublicKey = C::PublicKey,
         >,
-    > Actor<B, E, C, D, A, R, F, S>
+    > Actor<E, C, D, A, R, F, S>
 {
     pub fn new(
         context: E,
-        journal: Journal<B, E>,
+        journal: Journal<E>,
         cfg: Config<C, D, A, R, F, S>,
     ) -> (Self, Mailbox<D>) {
         // Assert correctness of timeouts

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -10,7 +10,7 @@ use commonware_cryptography::{
 };
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Sender};
-use commonware_runtime::{Blob, Clock, Handle, Metrics, Spawner, Storage};
+use commonware_runtime::{Clock, Handle, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::Journal;
 use governor::clock::Clock as GClock;
 use rand::{CryptoRng, Rng};
@@ -18,8 +18,7 @@ use tracing::debug;
 
 /// Instance of `threshold-simplex` consensus engine.
 pub struct Engine<
-    B: Blob,
-    E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B> + Metrics,
+    E: Clock + GClock + Rng + CryptoRng + Spawner + Storage + Metrics,
     C: Scheme,
     D: Digest,
     A: Automaton<Context = Context<D>, Digest = D>,
@@ -35,15 +34,14 @@ pub struct Engine<
 > {
     context: E,
 
-    voter: voter::Actor<B, E, C, D, A, R, F, S>,
+    voter: voter::Actor<E, C, D, A, R, F, S>,
     voter_mailbox: voter::Mailbox<D>,
     resolver: resolver::Actor<E, C, D, S>,
     resolver_mailbox: resolver::Mailbox,
 }
 
 impl<
-        B: Blob,
-        E: Clock + GClock + Rng + CryptoRng + Spawner + Storage<B> + Metrics,
+        E: Clock + GClock + Rng + CryptoRng + Spawner + Storage + Metrics,
         C: Scheme,
         D: Digest,
         A: Automaton<Context = Context<D>, Digest = D>,
@@ -56,10 +54,10 @@ impl<
             Identity = poly::Public,
             PublicKey = C::PublicKey,
         >,
-    > Engine<B, E, C, D, A, R, F, S>
+    > Engine<E, C, D, A, R, F, S>
 {
     /// Create a new `threshold-simplex` consensus engine.
-    pub fn new(context: E, journal: Journal<B, E>, cfg: Config<C, D, A, R, F, S>) -> Self {
+    pub fn new(context: E, journal: Journal<E>, cfg: Config<C, D, A, R, F, S>) -> Self {
         // Ensure configuration is valid
         cfg.assert();
 

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1324,7 +1324,9 @@ impl Clone for Blob {
     }
 }
 
-impl crate::Storage<Blob> for Context {
+impl crate::Storage for Context {
+    type Blob = Blob;
+
     async fn open(&self, partition: &str, name: &[u8]) -> Result<Blob, Error> {
         self.executor.auditor.open(partition, name);
         let mut partitions = self.executor.partitions.lock().unwrap();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -259,15 +259,18 @@ pub trait Stream: Sync + Send + 'static {
 /// writes, blobs are responsible for maintaining synchronization.
 ///
 /// Storage can be backed by a local filesystem, cloud storage, etc.
-pub trait Storage<B>: Clone + Send + Sync + 'static
-where
-    B: Blob,
-{
+pub trait Storage: Clone + Send + Sync + 'static {
+    type Blob: Blob;
+
     /// Open an existing blob in a given partition or create a new one.
     ///
     /// Multiple instances of the same blob can be opened concurrently, however,
     /// writing to the same blob concurrently may lead to undefined behavior.
-    fn open(&self, partition: &str, name: &[u8]) -> impl Future<Output = Result<B, Error>> + Send;
+    fn open(
+        &self,
+        partition: &str,
+        name: &[u8],
+    ) -> impl Future<Output = Result<Self::Blob, Error>> + Send;
 
     /// Remove a blob from a given partition.
     ///
@@ -483,10 +486,7 @@ mod tests {
         });
     }
 
-    fn test_storage_operations<B>(runner: impl Runner, context: impl Spawner + Storage<B>)
-    where
-        B: Blob,
-    {
+    fn test_storage_operations(runner: impl Runner, context: impl Spawner + Storage) {
         runner.start(async move {
             let partition = "test_partition";
             let name = b"test_blob";
@@ -568,10 +568,7 @@ mod tests {
         });
     }
 
-    fn test_blob_read_write<B>(runner: impl Runner, context: impl Spawner + Storage<B>)
-    where
-        B: Blob,
-    {
+    fn test_blob_read_write(runner: impl Runner, context: impl Spawner + Storage) {
         runner.start(async move {
             let partition = "test_partition";
             let name = b"test_blob_rw";
@@ -632,10 +629,7 @@ mod tests {
         });
     }
 
-    fn test_many_partition_read_write<B>(runner: impl Runner, context: impl Spawner + Storage<B>)
-    where
-        B: Blob,
-    {
+    fn test_many_partition_read_write(runner: impl Runner, context: impl Spawner + Storage) {
         runner.start(async move {
             let partitions = ["partition1", "partition2", "partition3"];
             let name = b"test_blob_rw";
@@ -682,10 +676,7 @@ mod tests {
         });
     }
 
-    fn test_blob_read_past_length<B>(runner: impl Runner, context: impl Spawner + Storage<B>)
-    where
-        B: Blob,
-    {
+    fn test_blob_read_past_length(runner: impl Runner, context: impl Spawner + Storage) {
         runner.start(async move {
             let partition = "test_partition";
             let name = b"test_blob_rw";
@@ -714,12 +705,10 @@ mod tests {
         })
     }
 
-    fn test_blob_clone_and_concurrent_read<B>(
+    fn test_blob_clone_and_concurrent_read(
         runner: impl Runner,
-        context: impl Spawner + Storage<B> + Metrics,
-    ) where
-        B: Blob,
-    {
+        context: impl Spawner + Storage + Metrics,
+    ) {
         runner.start(async move {
             let partition = "test_partition";
             let name = b"test_blob_rw";

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -695,7 +695,9 @@ impl Clone for Blob {
     }
 }
 
-impl crate::Storage<Blob> for Context {
+impl crate::Storage for Context {
+    type Blob = Blob;
+
     async fn open(&self, partition: &str, name: &[u8]) -> Result<Blob, Error> {
         // Acquire the filesystem lock
         let _guard = self.executor.fs.lock().await;

--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -31,7 +31,7 @@ use crate::{
     },
 };
 use commonware_cryptography::Hasher as CHasher;
-use commonware_runtime::{Blob, Clock, Metrics, Storage as RStorage};
+use commonware_runtime::{Clock, Metrics, Storage as RStorage};
 use commonware_utils::Array;
 use futures::{
     future::{try_join_all, TryFutureExt},
@@ -60,10 +60,10 @@ pub struct Config {
 
 /// A key-value ADB based on an MMR over its log of operations, supporting authentication of any
 /// value ever associated with a key.
-pub struct Any<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> {
+pub struct Any<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher> {
     /// An MMR over digests of the operations applied to the db. The number of leaves in this MMR
     /// always equals the number of operations in the unpruned `log`.
-    ops: Mmr<B, E, H>,
+    ops: Mmr<E, H>,
 
     /// A (pruned) log of all operations applied to the db in order of occurrence. The position
     /// of each operation in the log is called its _location_, which is a stable identifier. Pruning
@@ -72,7 +72,7 @@ pub struct Any<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H:
     ///
     /// Invariant: An operation's location is always equal to the number of the MMR leaf storing the
     /// digest of the operation.
-    log: Journal<B, E, Operation<K, V>>,
+    log: Journal<E, Operation<K, V>>,
 
     /// A location before which all operations are "inactive" (that is, operations before this point
     /// are over keys that have been updated by some operation at or after this point).
@@ -86,7 +86,7 @@ pub struct Any<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H:
     uncommitted_ops: u64,
 }
 
-impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> Any<B, E, K, V, H> {
+impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher> Any<E, K, V, H> {
     /// Return an MMR initialized from `cfg`. Any uncommitted operations in the log will be
     /// discarded and the state of the db will be as of the last committed operation.
     pub async fn init(context: E, hasher: &mut H, cfg: Config) -> Result<Self, Error> {
@@ -177,7 +177,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
                     }
                 }
                 Type::Update(key, _) => {
-                    _ = Any::<B, E, K, V, H>::update_loc(&mut snapshot, &mut log, key, None, i)
+                    _ = Any::<E, K, V, H>::update_loc(&mut snapshot, &mut log, key, None, i)
                         .await?;
                 }
                 Type::Commit(loc) => inactivity_floor_loc = loc,
@@ -200,7 +200,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
     /// assigned that value, in which case this is a no-op, and `false` is returned.
     async fn update_loc(
         snapshot: &mut Index<EightCap, u64>,
-        log: &mut Journal<B, E, Operation<K, V>>,
+        log: &mut Journal<E, Operation<K, V>>,
         key: K,
         value: Option<&V>,
         new_loc: u64,
@@ -272,7 +272,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
     /// next successful `commit`.
     pub async fn update(&mut self, hasher: &mut H, key: K, value: V) -> Result<(), Error> {
         let new_loc = self.op_count();
-        if !Any::<B, E, K, V, H>::update_loc(
+        if !Any::<E, K, V, H>::update_loc(
             &mut self.snapshot,
             &mut self.log,
             key.clone(),
@@ -384,7 +384,7 @@ impl<B: Blob, E: RStorage<B> + Clock + Metrics, K: Array, V: Array, H: CHasher> 
 
         let digests = ops
             .iter()
-            .map(|op| Any::<_, E, _, _, _>::op_digest(hasher, op))
+            .map(|op| Any::<E, _, _, _>::op_digest(hasher, op))
             .collect::<Vec<_>>();
 
         proof.verify_range_inclusion(hasher, &digests, start_pos, end_pos, root_hash)
@@ -554,10 +554,10 @@ mod test {
     use std::collections::HashMap;
 
     /// Return an `Any` database initialized with a fixed config.
-    async fn open_db<B: Blob, E: RStorage<B> + Clock + Metrics>(
+    async fn open_db<E: RStorage + Clock + Metrics>(
         context: E,
         hasher: &mut Sha256,
-    ) -> Any<B, E, Digest, Digest, Sha256> {
+    ) -> Any<E, Digest, Digest, Sha256> {
         let cfg = Config {
             mmr_journal_partition: "journal_partition".into(),
             mmr_metadata_partition: "metadata_partition".into(),
@@ -565,7 +565,7 @@ mod test {
             log_journal_partition: "log_journal_partition".into(),
             log_items_per_blob: 7,
         };
-        Any::<B, E, Digest, Digest, Sha256>::init(context, hasher, cfg)
+        Any::<E, Digest, Digest, Sha256>::init(context, hasher, cfg)
             .await
             .unwrap()
     }


### PR DESCRIPTION
The blob type is determined by the storage implementation, so it should be an associated type.