### PR TITLE
[utils] fix `quorum` calculation for unaligned `n`

### DIFF
--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -503,7 +503,7 @@ mod tests {
         let finalized = Arc::new(Mutex::new(HashMap::new()));
         let completed = Arc::new(Mutex::new(HashSet::new()));
         let supervised = Arc::new(Mutex::new(Vec::new()));
-        let (mut executor, mut context, _) = Executor::timed(Duration::from_secs(30));
+        let (mut executor, mut context, _) = Executor::timed(Duration::from_secs(60));
         while completed.lock().unwrap().len() != n as usize {
             let namespace = namespace.clone();
             let shutdowns = shutdowns.clone();
@@ -542,7 +542,7 @@ mod tests {
                 // Link all validators
                 let link = Link {
                     latency: 50.0,
-                    jitter: 50.0,
+                    jitter: 40.0,
                     success_rate: 1.0,
                 };
                 link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -598,7 +598,7 @@ mod tests {
                         nullify_retry: Duration::from_secs(10),
                         fetch_timeout: Duration::from_secs(1),
                         activity_timeout,
-skip_timeout,
+                        skip_timeout,
                         max_fetch_count: 1,
                         max_fetch_size: 1024 * 512,
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
@@ -1755,7 +1755,7 @@ skip_timeout,
         let namespace = b"consensus".to_vec();
         let cfg = deterministic::Config {
             seed,
-            timeout: Some(Duration::from_secs(3_000)),
+            timeout: Some(Duration::from_secs(5_000)),
             ..deterministic::Config::default()
         };
         let (executor, context, auditor) = Executor::init(cfg);

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -542,7 +542,7 @@ mod tests {
                 // Link all validators
                 let link = Link {
                     latency: 50.0,
-                    jitter: 40.0,
+                    jitter: 25.0,
                     success_rate: 1.0,
                 };
                 link_validators(&mut oracle, &validators, Action::Link(link), None).await;

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -546,7 +546,7 @@ mod tests {
         let finalized = Arc::new(Mutex::new(HashMap::new()));
         let completed = Arc::new(Mutex::new(HashSet::new()));
         let supervised = Arc::new(Mutex::new(Vec::new()));
-        let (mut executor, mut context, _) = Executor::timed(Duration::from_secs(10 * 60));
+        let (mut executor, mut context, _) = Executor::timed(Duration::from_secs(600));
         while completed.lock().unwrap().len() != n as usize {
             let namespace = namespace.clone();
             let shutdowns = shutdowns.clone();

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -546,7 +546,7 @@ mod tests {
         let finalized = Arc::new(Mutex::new(HashMap::new()));
         let completed = Arc::new(Mutex::new(HashSet::new()));
         let supervised = Arc::new(Mutex::new(Vec::new()));
-        let (mut executor, mut context, _) = Executor::timed(Duration::from_secs(300));
+        let (mut executor, mut context, _) = Executor::timed(Duration::from_secs(10 * 60));
         while completed.lock().unwrap().len() != n as usize {
             let namespace = namespace.clone();
             let shutdowns = shutdowns.clone();
@@ -1840,7 +1840,7 @@ skip_timeout,
         let namespace = b"consensus".to_vec();
         let cfg = deterministic::Config {
             seed,
-            timeout: Some(Duration::from_secs(3_000)),
+            timeout: Some(Duration::from_secs(5_000)),
             ..deterministic::Config::default()
         };
         let (executor, mut context, auditor) = Executor::init(cfg);

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -41,7 +41,7 @@ pub fn from_hex_formatted(hex: &str) -> Option<Vec<u8>> {
 }
 
 /// Compute the maximum number of `f` (faults) that can be tolerated for a given set of `n`
-/// participants. This is the maximum integer `f` such that `n > 3*f`.
+/// participants. This is the maximum integer `f` such that `n >= 3*f + 1`.
 ///
 /// If the value of `n` is too small to tolerate any faults, this function returns `None`.
 pub fn max_faults(n: u32) -> Option<u32> {
@@ -53,7 +53,7 @@ pub fn max_faults(n: u32) -> Option<u32> {
 }
 
 /// Compute the quorum size for a given set of `n` participants. This is the minimum integer `q`
-/// such that `3*q > 2*n`. It is also equal to `n - f`, where `f` is the maximum number of faults.
+/// such that `3*q >= 2*n + 1`. It is also equal to `n - f`, where `f` is the maximum number of faults.
 ///
 /// If the value of `n` is too small to tolerate any faults, this function returns `None`.
 pub fn quorum(n: u32) -> Option<u32> {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -193,6 +193,8 @@ mod tests {
             assert_eq!(quorum(n), eq);
             if let (Some(f), Some(q)) = (ef, eq) {
                 assert_eq!(n, f + q);
+            } else {
+                assert!(ef.is_none() && eq.is_none());
             }
         }
     }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -53,7 +53,7 @@ pub fn max_faults(n: u32) -> Option<u32> {
 }
 
 /// Compute the quorum size for a given set of `n` participants. This is the minimum integer `q`
-/// such that `3*q > 2*n`. It is also equal to `n - f`, where `f` is the maximum number of faults
+/// such that `3*q > 2*n`. It is also equal to `n - f`, where `f` is the maximum number of faults.
 ///
 /// If the value of `n` is too small to tolerate any faults, this function returns `None`.
 pub fn quorum(n: u32) -> Option<u32> {
@@ -172,33 +172,29 @@ mod tests {
     }
 
     #[test]
-    fn test_max_faults() {
-        assert_eq!(max_faults(0), None);
-        assert_eq!(max_faults(1), None);
-        assert_eq!(max_faults(2), None);
-        assert_eq!(max_faults(3), None);
-        assert_eq!(max_faults(4), Some(1));
-        assert_eq!(max_faults(5), Some(1));
-        assert_eq!(max_faults(6), Some(1));
-        assert_eq!(max_faults(7), Some(2));
-        assert_eq!(max_faults(8), Some(2));
-        assert_eq!(max_faults(9), Some(2));
-        assert_eq!(max_faults(10), Some(3));
-    }
+    fn test_quorum_and_max_faults() {
+        // n, expected_f, expected_q
+        let test_cases = [
+            (0, None, None),
+            (1, None, None),
+            (2, None, None),
+            (3, None, None),
+            (4, Some(1), Some(3)),
+            (5, Some(1), Some(4)),
+            (6, Some(1), Some(5)),
+            (7, Some(2), Some(5)),
+            (8, Some(2), Some(6)),
+            (9, Some(2), Some(7)),
+            (10, Some(3), Some(7)),
+        ];
 
-    #[test]
-    fn test_quorum() {
-        assert_eq!(quorum(0), None);
-        assert_eq!(quorum(1), None);
-        assert_eq!(quorum(2), None);
-        assert_eq!(quorum(3), None);
-        assert_eq!(quorum(4), Some(3));
-        assert_eq!(quorum(5), Some(4));
-        assert_eq!(quorum(6), Some(5));
-        assert_eq!(quorum(7), Some(5));
-        assert_eq!(quorum(8), Some(6));
-        assert_eq!(quorum(9), Some(7));
-        assert_eq!(quorum(10), Some(7));
+        for (n, ef, eq) in test_cases {
+            assert_eq!(max_faults(n), ef);
+            assert_eq!(quorum(n), eq);
+            if let (Some(f), Some(q)) = (ef, eq) {
+                assert_eq!(n, f + q);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Previously the quorum calculation could return values that were `<= (n*2/3)`