### PR TITLE
[commonware-storage/mmr/bitmap] pruning support for the authenticated bitmap

### DIFF
--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -31,10 +31,10 @@ pub struct Mmr<H: CHasher> {
 
     // The position of the oldest element still retained by the MMR, or the size of the MMR if there
     // are no retained nodes because the MMR is empty or it has been fully pruned.
-    oldest_retained_pos: u64,
+    pub(crate) oldest_retained_pos: u64,
 
     // The auxiliary map from node position to the digest of any pinned node.
-    pinned_nodes: HashMap<u64, H::Digest>,
+    pub(crate) pinned_nodes: HashMap<u64, H::Digest>,
 }
 
 impl<H: CHasher> Default for Mmr<H> {


### PR DESCRIPTION
Support the ability to prune historical bits from the bitmap and the tree nodes over them, except those that must be maintained to support authentication of any retained bit.