### PR TITLE
[p2p/authenticated] use `try_send` for `Drop`

### DIFF
--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -418,7 +418,11 @@ impl<E: Spawner + Rng + Clock + GClock + Metrics, C: Scheme> Actor<E, C> {
         // Reserve the connection
         self.connections.insert(peer.clone());
         self.reserved_connections.inc();
-        Some(Reservation::new(peer, Mailbox::new(self.sender.clone())))
+        Some(Reservation::new(
+            self.context.with_label("reservation"),
+            peer,
+            Mailbox::new(self.sender.clone()),
+        ))
     }
 
     pub fn start(mut self) -> Handle<()> {

--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -418,11 +418,7 @@ impl<E: Spawner + Rng + Clock + GClock + Metrics, C: Scheme> Actor<E, C> {
         // Reserve the connection
         self.connections.insert(peer.clone());
         self.reserved_connections.inc();
-        Some(Reservation::new(
-            self.context.clone(),
-            peer,
-            Mailbox::new(self.sender.clone()),
-        ))
+        Some(Reservation::new(peer, Mailbox::new(self.sender.clone())))
     }
 
     pub fn start(mut self) -> Handle<()> {

--- a/p2p/src/authenticated/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/actors/tracker/ingress.rs
@@ -107,7 +107,10 @@ impl<E: Spawner + Metrics, C: Verifier> Mailbox<E, C> {
         }
 
         // If any other error occurs, we should panic!
-        panic!("Unexpected error while trying to send message: {:?}", e);
+        panic!(
+            "unexpected error while trying to release reservation: {:?}",
+            e
+        );
     }
 
     pub async fn release(&mut self, peer: C::PublicKey) {


### PR DESCRIPTION
Based on collected metrics, this would reduce the number of spawned tasks by ~99% in a standard instance.