### PR TITLE
[commonware-storage/mmr] change mmr element type to &[u8]

### DIFF
--- a/storage/src/mmr/hasher.rs
+++ b/storage/src/mmr/hasher.rs
@@ -13,9 +13,9 @@ impl<'a, H: CHasher> Hasher<'a, H> {
     }
 
     /// Computes the hash for a leaf given its position and the element it represents.
-    pub(crate) fn leaf_hash(&mut self, pos: u64, element: &H::Digest) -> H::Digest {
+    pub(crate) fn leaf_hash(&mut self, pos: u64, element: &[u8]) -> H::Digest {
         self.update_with_pos(pos);
-        self.update_with_hash(element);
+        self.update_with_element(element);
         self.finalize_reset()
     }
 
@@ -51,6 +51,9 @@ impl<'a, H: CHasher> Hasher<'a, H> {
     }
     pub(crate) fn update_with_hash(&mut self, hash: &H::Digest) {
         self.hasher.update(hash.as_ref());
+    }
+    pub(crate) fn update_with_element(&mut self, element: &[u8]) {
+        self.hasher.update(element);
     }
     pub(crate) fn finalize_reset(&mut self) -> H::Digest {
         self.hasher.finalize()

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -239,7 +239,7 @@ impl<E: RStorage + Clock + Metrics, H: Hasher> Mmr<E, H> {
 
     /// Add an element to the MMR and return its position in the MMR. Elements added to the MMR
     /// aren't persisted to disk until `sync` is called.
-    pub fn add(&mut self, h: &mut H, element: &H::Digest) -> u64 {
+    pub fn add(&mut self, h: &mut H, element: &[u8]) -> u64 {
         self.mem_mmr.add(h, element)
     }
 

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -149,7 +149,7 @@ impl<H: CHasher> Mmr<H> {
     }
 
     /// Add an element to the MMR and return its position in the MMR.
-    pub fn add(&mut self, hasher: &mut H, element: &H::Digest) -> u64 {
+    pub fn add(&mut self, hasher: &mut H, element: &[u8]) -> u64 {
         let element_pos = self.index_to_pos(self.nodes.len());
         let hash = Hasher::new(hasher).leaf_hash(element_pos, element);
         self.add_leaf_digest(hasher, hash);


### PR DESCRIPTION
Change the MMR element type from Digest to &[u8] since any type that can be represented as a byte slice will work, not just digests.  This will allow applications to avoid unnecessary hashing of elements to convert them to digests before adding them to the MMR.