### PR TITLE
[p2p] encode u32 channel as varint

### DIFF
--- a/p2p/src/authenticated/types.rs
+++ b/p2p/src/authenticated/types.rs
@@ -242,20 +242,20 @@ pub struct Data {
 
 impl EncodeSize for Data {
     fn encode_size(&self) -> usize {
-        self.channel.encode_size() + self.message.encode_size()
+        varint::size(self.channel) + self.message.encode_size()
     }
 }
 
 impl Write for Data {
     fn write(&self, buf: &mut impl BufMut) {
-        self.channel.write(buf);
+        varint::write(self.channel, buf);
         self.message.write(buf);
     }
 }
 
 impl<R: RangeConfig> Read<R> for Data {
     fn read_cfg(buf: &mut impl Buf, range: &R) -> Result<Self, Error> {
-        let channel = u32::read(buf)?;
+        let channel = varint::read::<u32>(buf)?;
         let message = Bytes::read_cfg(buf, range)?;
         Ok(Data { channel, message })
     }


### PR DESCRIPTION
In most examples, channel is a low number. Since channel is sent with each message, we may save a decent amount of bandwidth (up to 3 bytes for every single network message)