### PR TITLE
[runtime] separate spawner into separate struct

### DIFF
--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -279,7 +279,6 @@ struct SpawnerConfig {
 impl Spawner {
     fn new(label: String, cfg: SpawnerConfig, reg: &mut Registry, runtime: Arc<Runtime>) -> Self {
         let (signaler, signal) = Signaler::new();
-
         Self {
             cfg,
             label,
@@ -292,18 +291,6 @@ impl Spawner {
     }
 
     fn with_label(&self, label: String) -> Self {
-        let label = {
-            let prefix = self.label.clone();
-            if prefix.is_empty() {
-                label
-            } else {
-                format!("{}_{}", prefix, label)
-            }
-        };
-        assert!(
-            !label.starts_with(METRICS_PREFIX),
-            "using runtime label is not allowed"
-        );
         Self {
             cfg: self.cfg.clone(),
             label,

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -186,7 +186,6 @@ impl Executor {
 
         // Initialize runtime
         let metrics = Arc::new(Metrics::init(runtime_registry));
-
         let runtime = Builder::new_multi_thread()
             .worker_threads(cfg.worker_threads)
             .max_blocking_threads(cfg.max_blocking_threads)


### PR DESCRIPTION
* Replace `Executor` reference with `Runtime` reference inside `Runner` -- it only used `self.executor` for `self.executor.runtime` before.
* Moves state from `Context` to new `Spawner` struct, which lives inside `Context`.
* Makes `impl crate::Spawner for Context` a pass-through implementation to the inner `Spawner`