### PR TITLE
[release] 4-21-25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-bridge"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "clap",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "chrono",
  "clap",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "paste",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "blst",
  "bytes",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "chrono",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bimap",
  "bytes",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "axum",
  "bytes",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-vrf"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.44", path = "broadcast" }
-commonware-codec = { version = "0.0.44", path = "codec" }
-commonware-consensus = { version = "0.0.44", path = "consensus" }
-commonware-cryptography = { version = "0.0.44", path = "cryptography" }
-commonware-deployer = { version = "0.0.44", path = "deployer", default-features = false }
-commonware-macros = { version = "0.0.44", path = "macros" }
-commonware-p2p = { version = "0.0.44", path = "p2p" }
-commonware-resolver = { version = "0.0.44", path = "resolver" }
-commonware-runtime = { version = "0.0.44", path = "runtime" }
-commonware-storage = { version = "0.0.44", path = "storage" }
-commonware-stream = { version = "0.0.44", path = "stream" }
-commonware-utils = { version = "0.0.44", path = "utils" }
+commonware-broadcast = { version = "0.0.45", path = "broadcast" }
+commonware-codec = { version = "0.0.45", path = "codec" }
+commonware-consensus = { version = "0.0.45", path = "consensus" }
+commonware-cryptography = { version = "0.0.45", path = "cryptography" }
+commonware-deployer = { version = "0.0.45", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.45", path = "macros" }
+commonware-p2p = { version = "0.0.45", path = "p2p" }
+commonware-resolver = { version = "0.0.45", path = "resolver" }
+commonware-runtime = { version = "0.0.45", path = "runtime" }
+commonware-storage = { version = "0.0.45", path = "storage" }
+commonware-stream = { version = "0.0.45", path = "stream" }
+commonware-utils = { version = "0.0.45", path = "utils" }
 thiserror = "2.0.12"
 bytes = "1.7.1"
 sha2 = "0.10.8"

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-broadcast"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Disseminate data over a wide-area network."
 readme = "README.md"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-codec"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Serialize structured data."
 readme = "README.md"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-consensus"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Order opaque messages in a Byzantine environment."
 readme = "README.md"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify signatures."
 readme = "README.md"

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-deployer"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Deploy infrastructure across cloud providers."
 readme = "README.md"

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-bridge"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Send succinct consensus certificates between two networks."
 readme = "README.md"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-flood"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Spam peers deployed to AWS EC2 with random messages."
 readme = "README.md"

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-log"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Commit to a secret log and agree to its hash."
 readme = "README.md"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-vrf"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-macros"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Augment the development of primitives with procedural macros."
 readme = "README.md"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-resolver"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Resolve data identified by a fixed-length key."
 readme = "README.md"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-runtime"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Execute asynchronous tasks with a configurable scheduler."
 readme = "README.md"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-storage"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Persist and retrieve data from an abstract store."
 readme = "README.md"

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-stream"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Exchange messages over arbitrary transport."
 readme = "README.md"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-utils"
 edition = "2021"
 publish = true
-version = "0.0.44"
+version = "0.0.45"
 license = "MIT OR Apache-2.0"
 description = "Leverage common functionality across multiple primitives."
 readme = "README.md"


### PR DESCRIPTION
```
git diff 3300f012094d9f5586af11d31354a903cee8dd88 --stat

 .github/workflows/benchmark.yml                    |    2 +-
 Cargo.lock                                         |  138 +-
 Cargo.toml                                         |   25 +-
 broadcast/Cargo.toml                               |    2 +-
 broadcast/src/buffered/config.rs                   |    6 +-
 broadcast/src/buffered/engine.rs                   |   18 +-
 broadcast/src/buffered/ingress.rs                  |    4 +-
 broadcast/src/buffered/mocks.rs                    |   18 +-
 broadcast/src/buffered/mod.rs                      |    3 +-
 broadcast/src/lib.rs                               |    6 +-
 codec/Cargo.toml                                   |    2 +-
 codec/src/codec.rs                                 |  163 +-
 codec/src/error.rs                                 |   66 +-
 codec/src/extensions.rs                            |   74 +
 codec/src/lib.rs                                   |  189 +-
 codec/src/types/bytes.rs                           |   77 +
 codec/src/types/map.rs                             |  295 +++
 codec/src/types/mod.rs                             |    6 +
 codec/src/types/net.rs                             |   85 +-
 codec/src/types/primitives.rs                      |  209 +-
 codec/src/types/tuple.rs                           |   63 +
 codec/src/types/vec.rs                             |   74 +
 consensus/Cargo.toml                               |    8 +-
 consensus/build.rs                                 |   23 -
 consensus/src/lib.rs                               |   48 +-
 consensus/src/ordered_broadcast/ack_manager.rs     |  171 +-
 consensus/src/ordered_broadcast/config.rs          |    8 +-
 consensus/src/ordered_broadcast/engine.rs          |  274 +--
 .../src/ordered_broadcast/mocks/application.rs     |   79 -
 consensus/src/ordered_broadcast/mocks/automaton.rs |    3 +-
 consensus/src/ordered_broadcast/mocks/mod.rs       |    4 +-
 consensus/src/ordered_broadcast/mocks/monitor.rs   |    3 +-
 .../mocks/{committer.rs => reporter.rs}            |  137 +-
 .../src/ordered_broadcast/mocks/sequencers.rs      |    7 +-
 .../src/ordered_broadcast/mocks/validators.rs      |    7 +-
 consensus/src/ordered_broadcast/mod.rs             |  147 +-
 consensus/src/ordered_broadcast/namespace.rs       |   16 -
 consensus/src/ordered_broadcast/parsed.rs          |  182 --
 consensus/src/ordered_broadcast/prover.rs          |  105 -
 consensus/src/ordered_broadcast/serializer.rs      |   34 -
 consensus/src/ordered_broadcast/tip_manager.rs     |   38 +-
 consensus/src/ordered_broadcast/types.rs           | 1559 +++++++++++++++
 consensus/src/ordered_broadcast/wire.proto         |   56 -
 consensus/src/simplex/actors/resolver/actor.rs     |  157 +-
 consensus/src/simplex/actors/resolver/ingress.rs   |   22 +-
 consensus/src/simplex/actors/resolver/mod.rs       |    6 +-
 consensus/src/simplex/actors/voter/actor.rs        | 1505 +++++----------
 consensus/src/simplex/actors/voter/ingress.rs      |   38 +-
 consensus/src/simplex/actors/voter/mod.rs          |  229 ++-
 consensus/src/simplex/config.rs                    |   34 +-
 consensus/src/simplex/encoder.rs                   |   32 -
 consensus/src/simplex/engine.rs                    |   38 +-
 consensus/src/simplex/mocks/application.rs         |   82 +-
 consensus/src/simplex/mocks/conflicter.rs          |  181 +-
 consensus/src/simplex/mocks/mod.rs                 |    1 +
 consensus/src/simplex/mocks/nuller.rs              |   91 +-
 consensus/src/simplex/mocks/outdated.rs            |  127 ++
 consensus/src/simplex/mocks/supervisor.rs          |  252 ++-
 consensus/src/simplex/mod.rs                       | 1329 ++++++-------
 consensus/src/simplex/prover.rs                    |  553 ------
 consensus/src/simplex/types.rs                     | 1819 ++++++++++++++++++
 consensus/src/simplex/verifier.rs                  |  320 ----
 consensus/src/simplex/wire.proto                   |   76 -
 .../src/threshold_simplex/actors/resolver/actor.rs |  144 +-
 .../threshold_simplex/actors/resolver/ingress.rs   |   21 +-
 .../src/threshold_simplex/actors/resolver/mod.rs   |    3 +-
 .../src/threshold_simplex/actors/voter/actor.rs    | 1394 +++++---------
 .../src/threshold_simplex/actors/voter/ingress.rs  |   37 +-
 .../src/threshold_simplex/actors/voter/mod.rs      |  259 ++-
 consensus/src/threshold_simplex/config.rs          |   26 +-
 consensus/src/threshold_simplex/encoder.rs         |   41 -
 consensus/src/threshold_simplex/engine.rs          |   27 +-
 .../src/threshold_simplex/mocks/application.rs     |   80 +-
 .../src/threshold_simplex/mocks/conflicter.rs      |  165 +-
 consensus/src/threshold_simplex/mocks/mod.rs       |    1 +
 consensus/src/threshold_simplex/mocks/nuller.rs    |   93 +-
 consensus/src/threshold_simplex/mocks/outdated.rs  |  110 ++
 .../src/threshold_simplex/mocks/supervisor.rs      |  288 ++-
 consensus/src/threshold_simplex/mod.rs             | 1356 ++++++-------
 consensus/src/threshold_simplex/prover.rs          |  700 -------
 consensus/src/threshold_simplex/types.rs           | 2022 ++++++++++++++++++++
 consensus/src/threshold_simplex/verifier.rs        |  219 ---
 consensus/src/threshold_simplex/wire.proto         |   78 -
 cryptography/Cargo.toml                            |    9 +-
 cryptography/src/bls12381/benches/dkg_recovery.rs  |    2 +-
 .../src/bls12381/benches/dkg_reshare_recovery.rs   |    2 +-
 .../benches/threshold_signature_recover.rs         |    4 +-
 cryptography/src/bls12381/dkg/arbiter.rs           |   11 +-
 cryptography/src/bls12381/dkg/dealer.rs            |    2 +-
 cryptography/src/bls12381/dkg/mod.rs               |   87 +-
 cryptography/src/bls12381/dkg/ops.rs               |    6 +-
 cryptography/src/bls12381/dkg/player.rs            |    6 +-
 cryptography/src/bls12381/mod.rs                   |   41 +-
 cryptography/src/bls12381/primitives/group.rs      |  351 +++-
 cryptography/src/bls12381/primitives/mod.rs        |    4 +-
 cryptography/src/bls12381/primitives/ops.rs        |  169 +-
 cryptography/src/bls12381/primitives/poly.rs       |  202 +-
 cryptography/src/bls12381/scheme.rs                |  309 ++-
 cryptography/src/ed25519/scheme.rs                 |  178 +-
 cryptography/src/lib.rs                            |   64 +-
 cryptography/src/secp256r1/scheme.rs               |  255 +--
 cryptography/src/sha256/mod.rs                     |   70 +-
 deployer/Cargo.toml                                |    2 +-
 docs/blogs/adb-any.html                            |  109 ++
 docs/imgs/adb-any.png                              |  Bin 0 -> 67978 bytes
 docs/index.html                                    |    6 +
 examples/bridge/Cargo.toml                         |    6 +-
 examples/bridge/README.md                          |   18 +-
 examples/bridge/build.rs                           |    8 -
 examples/bridge/src/application/actor.rs           |  216 +--
 examples/bridge/src/application/ingress.rs         |   34 +-
 examples/bridge/src/application/mod.rs             |   10 +-
 examples/bridge/src/application/supervisor.rs      |   12 +-
 examples/bridge/src/bin/dealer.rs                  |   20 +-
 examples/bridge/src/bin/indexer.rs                 |  135 +-
 examples/bridge/src/bin/validator.rs               |   47 +-
 examples/bridge/src/lib.rs                         |   26 +-
 examples/bridge/src/types/block.rs                 |  109 ++
 examples/bridge/src/types/inbound.rs               |  278 +++
 examples/bridge/src/types/mod.rs                   |    3 +
 examples/bridge/src/types/outbound.rs              |  128 ++
 examples/bridge/src/wire.proto                     |   38 -
 examples/chat/Cargo.toml                           |    2 +-
 examples/chat/README.md                            |    2 +-
 examples/chat/src/main.rs                          |    2 +-
 examples/flood/Cargo.toml                          |    3 +-
 examples/flood/Dockerfile                          |    1 -
 examples/flood/src/bin/flood.rs                    |    7 +-
 examples/log/Cargo.toml                            |    2 +-
 examples/log/README.md                             |    2 +-
 examples/log/src/application/actor.rs              |   37 +-
 examples/log/src/application/ingress.rs            |   24 +-
 examples/log/src/application/mod.rs                |   11 +-
 examples/log/src/application/supervisor.rs         |   43 +-
 examples/log/src/main.rs                           |   62 +-
 examples/vrf/Cargo.toml                            |    6 +-
 examples/vrf/README.md                             |    2 +-
 examples/vrf/build.rs                              |    6 -
 examples/vrf/src/handlers/arbiter.rs               |  118 +-
 examples/vrf/src/handlers/contributor.rs           |  193 +-
 examples/vrf/src/handlers/mod.rs                   |    4 +-
 examples/vrf/src/handlers/utils.rs                 |   23 +-
 examples/vrf/src/handlers/vrf.rs                   |   33 +-
 examples/vrf/src/handlers/wire.rs                  |  393 ++++
 examples/vrf/src/main.rs                           |    5 +-
 examples/vrf/src/wire.proto                        |   54 -
 macros/Cargo.toml                                  |    2 +-
 p2p/Cargo.toml                                     |    3 +-
 p2p/src/authenticated/actors/peer/actor.rs         |   16 +-
 p2p/src/authenticated/actors/peer/ingress.rs       |   14 +-
 p2p/src/authenticated/actors/peer/mod.rs           |    2 +
 p2p/src/authenticated/actors/spawner/actor.rs      |    6 +
 p2p/src/authenticated/actors/spawner/mod.rs        |    2 +
 p2p/src/authenticated/actors/tracker/actor.rs      |  113 +-
 p2p/src/authenticated/actors/tracker/ingress.rs    |   36 +-
 p2p/src/authenticated/actors/tracker/mod.rs        |    1 +
 p2p/src/authenticated/actors/tracker/record.rs     |   16 +-
 p2p/src/authenticated/actors/tracker/set.rs        |   66 +-
 p2p/src/authenticated/config.rs                    |    9 +
 p2p/src/authenticated/network.rs                   |    3 +
 p2p/src/authenticated/types.rs                     |  185 +-
 p2p/src/simulated/network.rs                       |   11 +-
 resolver/Cargo.toml                                |    6 +-
 resolver/build.rs                                  |    7 -
 resolver/src/p2p/engine.rs                         |   45 +-
 resolver/src/p2p/fetcher.rs                        |    8 +-
 resolver/src/p2p/mocks/key.rs                      |   52 +-
 resolver/src/p2p/mod.rs                            |    4 +-
 resolver/src/p2p/wire.proto                        |   20 -
 resolver/src/p2p/wire.rs                           |  136 ++
 runtime/Cargo.toml                                 |    5 +-
 runtime/src/benchmarks/context.rs                  |   37 +
 runtime/src/benchmarks/mod.rs                      |    4 +
 runtime/src/benchmarks/tokio.rs                    |   62 +
 runtime/src/deterministic.rs                       |  530 ++---
 runtime/src/lib.rs                                 |   49 +-
 runtime/src/storage/audited.rs                     |  205 ++
 runtime/src/storage/memory.rs                      |  168 ++
 runtime/src/storage/metered.rs                     |  246 +++
 runtime/src/storage/mod.rs                         |  329 ++++
 runtime/src/storage/tokio.rs                       |  242 +++
 runtime/src/tokio/runtime.rs                       |  286 +--
 runtime/src/utils.rs                               |   53 +-
 storage/Cargo.toml                                 |    2 +-
 storage/src/adb/any.rs                             |  203 +-
 storage/src/adb/operation.rs                       |  147 +-
 storage/src/archive/mod.rs                         |    7 +-
 storage/src/archive/storage.rs                     |   34 +-
 storage/src/bmt/mod.rs                             |   11 +-
 storage/src/index/mod.rs                           |  200 +-
 storage/src/index/storage.rs                       |  274 ++-
 storage/src/journal/fixed.rs                       |   36 +-
 storage/src/journal/variable.rs                    |   20 +-
 storage/src/metadata/storage.rs                    |   24 +-
 storage/src/mmr/bitmap.rs                          |  421 ++--
 storage/src/mmr/hasher.rs                          |    7 +-
 storage/src/mmr/journaled.rs                       |   78 +-
 storage/src/mmr/mem.rs                             |   63 +-
 storage/src/mmr/verification.rs                    |   86 +-
 stream/Cargo.toml                                  |    2 +-
 stream/src/public_key/connection.rs                |    2 +-
 stream/src/public_key/handshake.rs                 |   33 +-
 stream/src/public_key/x25519.rs                    |   23 +-
 utils/Cargo.toml                                   |    2 +-
 utils/src/array/fixed_bytes.rs                     |   89 +-
 utils/src/array/mod.rs                             |   31 +-
 utils/src/array/prefixed_u64.rs                    |   81 +-
 utils/src/array/u64.rs                             |   74 +-
 utils/src/bitvec.rs                                |  999 ++++++++++
 utils/src/lib.rs                                   |   77 +-
 210 files changed, 16982 insertions(+), 11425 deletions(-)
```