### PR TITLE
[cryptography] Always Implement and Drop `Zeroize`

### DIFF
--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -159,7 +159,7 @@ mod tests {
         let validators: Vec<(PublicKey, Ed25519, Share)> = schemes
             .iter()
             .enumerate()
-            .map(|(i, scheme)| (scheme.public_key(), scheme.clone(), shares_vec[i]))
+            .map(|(i, scheme)| (scheme.public_key(), scheme.clone(), shares_vec[i].clone()))
             .collect();
         let pks = validators
             .iter()
@@ -197,7 +197,7 @@ mod tests {
             monitors.insert(validator.clone(), monitor.clone());
             let sequencers = mocks::Sequencers::<PublicKey>::new(pks.to_vec());
             let validators =
-                mocks::Validators::<PublicKey>::new(identity.clone(), pks.to_vec(), *share);
+                mocks::Validators::<PublicKey>::new(identity.clone(), pks.to_vec(), share.clone());
 
             let automaton = mocks::Automaton::<PublicKey>::new(invalid_when);
             automatons.insert(validator.clone(), automaton.clone());
@@ -357,7 +357,9 @@ mod tests {
                     let validators: Vec<(PublicKey, Ed25519, Share)> = schemes
                         .iter()
                         .enumerate()
-                        .map(|(i, scheme)| (scheme.public_key(), scheme.clone(), shares_vec[i]))
+                        .map(|(i, scheme)| {
+                            (scheme.public_key(), scheme.clone(), shares_vec[i].clone())
+                        })
                         .collect();
                     let pks = validators
                         .iter()

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -95,7 +95,7 @@ mod tests {
             let scheme = schemes[0].clone();
             let validator = scheme.public_key();
             let mut participants = BTreeMap::new();
-            participants.insert(0, (public.clone(), validators.clone(), shares[0]));
+            participants.insert(0, (public.clone(), validators.clone(), shares[0].clone()));
             let supervisor_config = mocks::supervisor::Config {
                 namespace: namespace.clone(),
                 participants,

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -322,7 +322,7 @@ mod tests {
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx]));
+                participants.insert(0, (public.clone(), validators.clone(), shares[idx].clone()));
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,
@@ -576,7 +576,8 @@ mod tests {
                         // Configure engine
                         let validator = scheme.public_key();
                         let mut participants = BTreeMap::new();
-                        participants.insert(0, (public.clone(), validators.clone(), shares[idx]));
+                        participants
+                            .insert(0, (public.clone(), validators.clone(), shares[idx].clone()));
                         let supervisor_config = mocks::supervisor::Config {
                             namespace: namespace.clone(),
                             participants,
@@ -749,7 +750,14 @@ mod tests {
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx_scheme]));
+                participants.insert(
+                    0,
+                    (
+                        public.clone(),
+                        validators.clone(),
+                        shares[idx_scheme].clone(),
+                    ),
+                );
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,
@@ -870,7 +878,7 @@ mod tests {
 
             // Configure engine
             let mut participants = BTreeMap::new();
-            participants.insert(0, (public.clone(), validators.clone(), shares[0]));
+            participants.insert(0, (public.clone(), validators.clone(), shares[0].clone()));
             let supervisor_config = mocks::supervisor::Config {
                 namespace: namespace.clone(),
                 participants,
@@ -999,7 +1007,14 @@ mod tests {
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx_scheme]));
+                participants.insert(
+                    0,
+                    (
+                        public.clone(),
+                        validators.clone(),
+                        shares[idx_scheme].clone(),
+                    ),
+                );
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,
@@ -1200,7 +1215,14 @@ mod tests {
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx_scheme]));
+                participants.insert(
+                    0,
+                    (
+                        public.clone(),
+                        validators.clone(),
+                        shares[idx_scheme].clone(),
+                    ),
+                );
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,
@@ -1375,7 +1397,7 @@ mod tests {
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx]));
+                participants.insert(0, (public.clone(), validators.clone(), shares[idx].clone()));
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,
@@ -1535,7 +1557,7 @@ mod tests {
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx]));
+                participants.insert(0, (public.clone(), validators.clone(), shares[idx].clone()));
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,
@@ -1723,7 +1745,7 @@ mod tests {
                 // Configure engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx]));
+                participants.insert(0, (public.clone(), validators.clone(), shares[idx].clone()));
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,
@@ -1877,7 +1899,14 @@ mod tests {
                 // Start engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx_scheme]));
+                participants.insert(
+                    0,
+                    (
+                        public.clone(),
+                        validators.clone(),
+                        shares[idx_scheme].clone(),
+                    ),
+                );
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,
@@ -2039,7 +2068,14 @@ mod tests {
                 // Start engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx_scheme]));
+                participants.insert(
+                    0,
+                    (
+                        public.clone(),
+                        validators.clone(),
+                        shares[idx_scheme].clone(),
+                    ),
+                );
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,
@@ -2193,7 +2229,14 @@ mod tests {
                 // Start engine
                 let validator = scheme.public_key();
                 let mut participants = BTreeMap::new();
-                participants.insert(0, (public.clone(), validators.clone(), shares[idx_scheme]));
+                participants.insert(
+                    0,
+                    (
+                        public.clone(),
+                        validators.clone(),
+                        shares[idx_scheme].clone(),
+                    ),
+                );
                 let supervisor_config = mocks::supervisor::Config {
                     namespace: namespace.clone(),
                     participants,

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -20,7 +20,7 @@ sha2 = { workspace = true }
 rayon = { workspace = true }
 ed25519-consensus = "2.1.0"
 blst = { version = "0.3.13", features = ["no-threads"] }
-zeroize = "1.5.7"
+zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 
 # Enable "js" feature when WASM is target

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -39,7 +39,7 @@ fn benchmark_dkg_recovery(c: &mut Criterion) {
                         let (_, commitment, shares) =
                             Dealer::new(&mut rng, None, contributors.clone());
                         player
-                            .share(dealer.clone(), commitment.clone(), shares[0])
+                            .share(dealer.clone(), commitment.clone(), shares[0].clone())
                             .unwrap();
                         commitments.insert(idx as u32, commitment);
                     }

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -42,7 +42,11 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
             for (player_idx, player) in players.iter_mut().enumerate() {
                 player
-                    .share(dealer.clone(), commitment.clone(), shares[player_idx])
+                    .share(
+                        dealer.clone(),
+                        commitment.clone(),
+                        shares[player_idx].clone(),
+                    )
                     .unwrap();
             }
             commitments.insert(dealer_idx as u32, commitment);
@@ -79,11 +83,11 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
                             for (idx, dealer) in contributors.iter().take(t as usize).enumerate() {
                                 let (_, commitment, shares) = Dealer::new(
                                     &mut rng,
-                                    Some(outputs[idx].share),
+                                    Some(outputs[idx].share.clone()),
                                     contributors.clone(),
                                 );
                                 player
-                                    .share(dealer.clone(), commitment.clone(), shares[0])
+                                    .share(dealer.clone(), commitment.clone(), shares[0].clone())
                                     .unwrap();
                                 commitments.insert(idx as u32, commitment);
                             }

--- a/cryptography/src/bls12381/dkg/mod.rs
+++ b/cryptography/src/bls12381/dkg/mod.rs
@@ -250,7 +250,11 @@ mod tests {
                 // Process share
                 let player_obj = players.get_mut(player).unwrap();
                 player_obj
-                    .share(dealer.clone(), commitment.clone(), shares[player_idx])
+                    .share(
+                        dealer.clone(),
+                        commitment.clone(),
+                        shares[player_idx].clone(),
+                    )
                     .unwrap();
 
                 // Collect ack
@@ -322,8 +326,11 @@ mod tests {
         let mut reshare_dealers = HashMap::new();
         for con in contributors.iter().take(dealers_1 as usize) {
             let output = outputs.get(con).unwrap();
-            let (dealer, commitment, shares) =
-                Dealer::new(&mut rng, Some(output.share), reshare_players.clone());
+            let (dealer, commitment, shares) = Dealer::new(
+                &mut rng,
+                Some(output.share.clone()),
+                reshare_players.clone(),
+            );
             reshare_shares.insert(con.clone(), (commitment, shares));
             reshare_dealers.insert(con.clone(), dealer);
         }
@@ -360,7 +367,11 @@ mod tests {
                 // Process share
                 let player_obj = reshare_player_objs.get_mut(player).unwrap();
                 player_obj
-                    .share(dealer.clone(), commitment.clone(), shares[player_idx])
+                    .share(
+                        dealer.clone(),
+                        commitment.clone(),
+                        shares[player_idx].clone(),
+                    )
                     .unwrap();
 
                 // Collect ack
@@ -478,7 +489,7 @@ mod tests {
         );
 
         // Send invalid commitment to player
-        let result = player.share(contributors[0].clone(), public, shares[0]);
+        let result = player.share(contributors[0].clone(), public, shares[0].clone());
         assert!(matches!(result, Err(Error::ShareWrongCommitment)));
     }
 
@@ -514,11 +525,11 @@ mod tests {
 
         // Send valid commitment to player
         player
-            .share(contributors[0].clone(), commitment, shares[0])
+            .share(contributors[0].clone(), commitment, shares[0].clone())
             .unwrap();
 
         // Send alternative commitment to player
-        let result = player.share(contributors[0].clone(), other_commitment, shares[0]);
+        let result = player.share(contributors[0].clone(), other_commitment, shares[0].clone());
         assert!(matches!(result, Err(Error::MismatchedCommitment)));
     }
 
@@ -554,11 +565,15 @@ mod tests {
 
         // Send valid share to player
         player
-            .share(contributors[0].clone(), commitment.clone(), shares[0])
+            .share(
+                contributors[0].clone(),
+                commitment.clone(),
+                shares[0].clone(),
+            )
             .unwrap();
 
         // Send alternative share to player
-        let result = player.share(contributors[0].clone(), commitment, other_shares[0]);
+        let result = player.share(contributors[0].clone(), commitment, other_shares[0].clone());
         assert!(matches!(result, Err(Error::MismatchedShare)));
     }
 
@@ -590,11 +605,15 @@ mod tests {
 
         // Send valid share to player
         player
-            .share(contributors[0].clone(), commitment.clone(), shares[0])
+            .share(
+                contributors[0].clone(),
+                commitment.clone(),
+                shares[0].clone(),
+            )
             .unwrap();
 
         // Send alternative share to player
-        let result = player.share(contributors[0].clone(), commitment, shares[0]);
+        let result = player.share(contributors[0].clone(), commitment, shares[0].clone());
         assert!(matches!(result, Err(Error::DuplicateShare)));
     }
 
@@ -625,7 +644,11 @@ mod tests {
         );
 
         // Send misdirected share to player
-        let result = player.share(contributors[0].clone(), commitment.clone(), shares[1]);
+        let result = player.share(
+            contributors[0].clone(),
+            commitment.clone(),
+            shares[1].clone(),
+        );
         assert!(matches!(result, Err(Error::MisdirectedShare)));
     }
 
@@ -657,7 +680,7 @@ mod tests {
 
         // Send share from invalid dealer
         let dealer = Ed25519::from_seed(n as u64).public_key();
-        let result = player.share(dealer.clone(), commitment.clone(), shares[0]);
+        let result = player.share(dealer.clone(), commitment.clone(), shares[0].clone());
         assert!(matches!(result, Err(Error::DealerInvalid)));
 
         // Create arbiter
@@ -698,7 +721,7 @@ mod tests {
         );
 
         // Send invalid commitment to player
-        let result = player.share(contributors[0].clone(), public.clone(), shares[0]);
+        let result = player.share(contributors[0].clone(), public.clone(), shares[0].clone());
         assert!(matches!(result, Err(Error::CommitmentWrongDegree)));
 
         // Create arbiter
@@ -739,7 +762,7 @@ mod tests {
             contributors[0].clone(),
             commitment,
             vec![0, 1, 2, 3],
-            vec![shares[4]],
+            vec![shares[4].clone()],
         )
         .unwrap();
     }
@@ -769,7 +792,7 @@ mod tests {
             // Create dealer
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
             commitments.push(commitment.clone());
-            reveals.push(shares[q]);
+            reveals.push(shares[q].clone());
 
             // Add commitment to arbiter
             let acks: Vec<u32> = (0..q as u32).collect();
@@ -822,7 +845,7 @@ mod tests {
             contributors[0].clone(),
             commitment.clone(),
             vec![0, 1, 2, 3],
-            vec![shares[4]],
+            vec![shares[4].clone()],
         )
         .unwrap();
 
@@ -831,7 +854,7 @@ mod tests {
             contributors[0].clone(),
             commitment,
             vec![0, 1, 2, 3],
-            vec![shares[4]],
+            vec![shares[4].clone()],
         );
         assert!(matches!(result, Err(Error::DuplicateCommitment)));
     }
@@ -861,7 +884,7 @@ mod tests {
             contributors[0].clone(),
             commitment,
             vec![0, 1, 2, 3],
-            vec![shares[3]],
+            vec![shares[3].clone()],
         );
         assert!(matches!(result, Err(Error::AlreadyActive)));
     }
@@ -963,7 +986,7 @@ mod tests {
             contributors[0].clone(),
             commitment,
             vec![0, 1, 2],
-            vec![shares[3], shares[4]],
+            vec![shares[3].clone(), shares[4].clone()],
         );
         assert!(matches!(result, Err(Error::TooManyReveals)));
     }
@@ -997,7 +1020,7 @@ mod tests {
             contributors[0].clone(),
             commitment,
             vec![0, 1, 2, 3],
-            vec![shares[4]],
+            vec![shares[4].clone()],
         );
         assert!(matches!(result, Err(Error::ShareWrongCommitment)));
     }
@@ -1023,7 +1046,7 @@ mod tests {
         let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
 
         // Swap share value
-        let mut share = shares[3];
+        let mut share = shares[3].clone();
         share.index = 4;
 
         // Add commitment to arbiter
@@ -1117,7 +1140,7 @@ mod tests {
         let mut arb = Arbiter::new(None, contributors.clone(), contributors.clone(), 1);
 
         // Swap share value
-        let mut share = shares[3];
+        let mut share = shares[3].clone();
         share.index = 10;
 
         // Add commitment to arbiter
@@ -1290,7 +1313,7 @@ mod tests {
         for (i, con) in contributors.iter().enumerate().take(q - 1) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
             player
-                .share(con.clone(), commitment.clone(), shares[0])
+                .share(con.clone(), commitment.clone(), shares[0].clone())
                 .unwrap();
             commitments.insert(i as u32, commitment);
         }
@@ -1300,7 +1323,7 @@ mod tests {
         let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
         commitments.insert(last, commitment);
         let mut reveals = HashMap::new();
-        reveals.insert(last, shares[0]);
+        reveals.insert(last, shares[0].clone());
         player.finalize(commitments, reveals).unwrap();
     }
 
@@ -1333,7 +1356,7 @@ mod tests {
         for (i, con) in contributors.iter().enumerate().take(q - 1) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
             player
-                .share(con.clone(), commitment.clone(), shares[0])
+                .share(con.clone(), commitment.clone(), shares[0].clone())
                 .unwrap();
             commitments.insert(i as u32, commitment);
         }
@@ -1374,7 +1397,7 @@ mod tests {
         for (i, con) in contributors.iter().enumerate().take(2) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
             player
-                .share(con.clone(), commitment.clone(), shares[0])
+                .share(con.clone(), commitment.clone(), shares[0].clone())
                 .unwrap();
             commitments.insert(i as u32, commitment);
         }
@@ -1413,7 +1436,7 @@ mod tests {
         for (i, con) in contributors.iter().enumerate().take(q - 1) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
             player
-                .share(con.clone(), commitment.clone(), shares[0])
+                .share(con.clone(), commitment.clone(), shares[0].clone())
                 .unwrap();
             commitments.insert(i as u32, commitment);
         }
@@ -1423,7 +1446,7 @@ mod tests {
         let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
         commitments.insert(last, commitment);
         let mut reveals = HashMap::new();
-        reveals.insert(last, shares[1]);
+        reveals.insert(last, shares[1].clone());
         let result = player.finalize(commitments, reveals);
         assert!(matches!(result, Err(Error::MisdirectedShare)));
     }
@@ -1457,7 +1480,7 @@ mod tests {
         for (i, con) in contributors.iter().enumerate().take(q - 1) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
             player
-                .share(con.clone(), commitment.clone(), shares[0])
+                .share(con.clone(), commitment.clone(), shares[0].clone())
                 .unwrap();
             commitments.insert(i as u32, commitment);
         }
@@ -1467,7 +1490,7 @@ mod tests {
         let (commitment, shares) = ops::generate_shares(&mut rng, None, n as u32, 1);
         commitments.insert(last, commitment);
         let mut reveals = HashMap::new();
-        reveals.insert(last, shares[0]);
+        reveals.insert(last, shares[0].clone());
         let result = player.finalize(commitments, reveals);
         assert!(matches!(result, Err(Error::CommitmentWrongDegree)));
     }
@@ -1501,7 +1524,7 @@ mod tests {
         for (i, con) in contributors.iter().enumerate().take(q - 1) {
             let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
             player
-                .share(con.clone(), commitment.clone(), shares[0])
+                .share(con.clone(), commitment.clone(), shares[0].clone())
                 .unwrap();
             commitments.insert(i as u32, commitment);
         }
@@ -1511,7 +1534,7 @@ mod tests {
         let (_, commitment, shares) = Dealer::new(&mut rng, None, contributors.clone());
         commitments.insert(last, commitment);
         let mut reveals = HashMap::new();
-        let mut share = shares[1];
+        let mut share = shares[1].clone();
         share.index = 0;
         reveals.insert(last, share);
         let result = player.finalize(commitments, reveals);

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -60,15 +60,31 @@ pub trait Point: Element {
     fn map(&mut self, dst: DST, message: &[u8]);
 }
 
-/// A scalar representing an element of the BLS12-381 finite field.
+/// Wrapper around [`blst_fr`] that represents an element of the BLS12‑381
+/// scalar field `F_r`.
+///
+/// The new‑type is marked `#[repr(transparent)]`, so it has exactly the same
+/// memory layout as the underlying `blst_fr`, allowing safe passage across
+/// the C FFI boundary without additional transmutation.
+///
+/// All arithmetic is performed modulo the prime
+/// `r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`,
+/// the order of the BLS12‑381 G1/G2 groups.
 #[derive(Clone, Copy, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Scalar(blst_fr);
 
-/// Length of a scalar in bytes.
+/// Number of bytes required to encode a scalar in its canonical
+/// little‑endian form (`32 × 8 = 256 bits`).
+///
+/// Because `r` is only 255 bits wide, the most‑significant byte is always in
+/// the range `0x00‥=0x7f`, leaving the top bit clear.
 const SCALAR_LENGTH: usize = 32;
 
-/// Length of a scalar in bits.
+/// Effective bit‑length of the field modulus `r` (`⌈log_2 r⌉ = 255`).
+///
+/// Useful for constant‑time exponentiation loops and for validating that a
+/// decoded integer lies in the range `0 ≤ x < r`.
 const SCALAR_BITS: usize = 255;
 
 /// This constant serves as the multiplicative identity (i.e., "one") in the

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -368,6 +368,12 @@ impl Debug for Share {
     }
 }
 
+impl Zeroize for Share {
+    fn zeroize(&mut self) {
+        self.private.zeroize();
+    }
+}
+
 impl G1 {
     /// Encodes the G1 element into a slice.
     fn as_slice(&self) -> [u8; Self::SIZE] {

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -70,8 +70,6 @@ pub trait Point: Element {
 /// All arithmetic is performed modulo the prime
 /// `r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`,
 /// the order of the BLS12‑381 G1/G2 groups.
-//
-// `bl`
 #[derive(Clone, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Scalar(blst_fr);

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -139,7 +139,7 @@ impl<C: Element> Poly<C> {
     ///
     /// It panics if the index is out of range.
     pub fn get(&self, i: u32) -> C {
-        self.0[i as usize]
+        self.0[i as usize].clone()
     }
 
     /// Set the given element at the specified index.
@@ -238,7 +238,7 @@ impl<C: Element> Poly<C> {
                         num.mul(xj);
 
                         // Compute `xj - xi` and include it in the denominator product
-                        let mut tmp = *xj;
+                        let mut tmp = xj.clone();
                         tmp.sub(xi);
                         den.mul(&tmp);
                     }
@@ -253,7 +253,7 @@ impl<C: Element> Poly<C> {
             num.mul(&inv);
 
             // Scale `yi` by `l_i(0)` to contribute to the constant term
-            let mut yi_scaled = **yi;
+            let mut yi_scaled = (*yi).clone();
             yi_scaled.mul(&num);
 
             // Add `yi * l_i(0)` to the running sum
@@ -379,7 +379,7 @@ pub mod tests {
                 for i in 0..larger.degree() + 1 {
                     let i = i as usize;
                     if i < (smaller.degree() + 1) as usize {
-                        let mut coeff_sum = p1.0[i];
+                        let mut coeff_sum = p1.0[i].clone();
                         coeff_sum.add(&p2.0[i]);
                         assert_eq!(res.0[i], coeff_sum);
                     } else {
@@ -402,7 +402,7 @@ pub mod tests {
         for degree in 0..100u32 {
             for num_evals in 0..100u32 {
                 let poly = new(degree);
-                let expected = poly.0[0];
+                let expected = poly.0[0].clone();
 
                 let shares = (0..num_evals).map(|i| poly.evaluate(i)).collect::<Vec<_>>();
                 let recovered_constant = Poly::recover(num_evals, &shares).unwrap();
@@ -435,14 +435,14 @@ pub mod tests {
                 let evaluation = p1.evaluate(idx).value;
 
                 let coeffs = p1.0;
-                let mut sum = coeffs[0];
+                let mut sum = coeffs[0].clone();
                 for (i, coeff) in coeffs
                     .into_iter()
                     .enumerate()
                     .take((d + 1) as usize)
                     .skip(1)
                 {
-                    let xi = pow(x, i);
+                    let xi = pow(x.clone(), i);
                     let mut var = coeff;
                     var.mul(&xi);
                     sum.add(&var);

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -35,6 +35,7 @@ use std::{
     hash::{Hash, Hasher},
     ops::Deref,
 };
+use zeroize::Zeroize;
 
 const CURVE_NAME: &str = "bls12381";
 
@@ -170,6 +171,13 @@ impl Debug for PrivateKey {
 impl Display for PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex(&self.raw))
+    }
+}
+
+impl Zeroize for PrivateKey {
+    fn zeroize(&mut self) {
+        self.raw.zeroize();
+        self.key.zeroize();
     }
 }
 

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -97,7 +97,7 @@ impl Signer for Bls12381 {
 }
 
 /// BLS12-381 private key.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Zeroize, ZeroizeOnDrop)]
 pub struct PrivateKey {
     raw: [u8; group::PRIVATE_KEY_LENGTH],
     key: group::Private,
@@ -173,21 +173,6 @@ impl Display for PrivateKey {
         write!(f, "{}", hex(&self.raw))
     }
 }
-
-impl Zeroize for PrivateKey {
-    fn zeroize(&mut self) {
-        self.raw.zeroize();
-        self.key.zeroize();
-    }
-}
-
-impl Drop for PrivateKey {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
-
-impl ZeroizeOnDrop for PrivateKey {}
 
 /// BLS12-381 public key.
 #[derive(Clone, Eq, PartialEq)]

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -35,7 +35,7 @@ use std::{
     hash::{Hash, Hasher},
     ops::Deref,
 };
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const CURVE_NAME: &str = "bls12381";
 
@@ -180,6 +180,14 @@ impl Zeroize for PrivateKey {
         self.key.zeroize();
     }
 }
+
+impl Drop for PrivateKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for PrivateKey {}
 
 /// BLS12-381 public key.
 #[derive(Clone, Eq, PartialEq)]

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -76,14 +76,14 @@ impl Signer for Bls12381 {
     }
 
     fn from(private_key: PrivateKey) -> Option<Self> {
-        let private = private_key.key;
+        let private = private_key.key.clone();
         let mut public = group::Public::one();
         public.mul(&private);
         Some(Self { private, public })
     }
 
     fn private_key(&self) -> PrivateKey {
-        PrivateKey::from(self.private)
+        PrivateKey::from(self.private.clone())
     }
 
     fn public_key(&self) -> PublicKey {

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const CURVE_NAME: &str = "ed25519";
 const PRIVATE_KEY_LENGTH: usize = 32;
@@ -57,7 +57,7 @@ impl Signer for Ed25519 {
     }
 
     fn from(private_key: PrivateKey) -> Option<Self> {
-        let signer = private_key.key;
+        let signer = private_key.key.clone();
         let verifier = signer.verification_key();
         Some(Self { signer, verifier })
     }
@@ -212,6 +212,14 @@ impl Zeroize for PrivateKey {
         self.key.zeroize();
     }
 }
+
+impl Drop for PrivateKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for PrivateKey {}
 
 /// Ed25519 Public Key.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+use zeroize::Zeroize;
 
 const CURVE_NAME: &str = "ed25519";
 const PRIVATE_KEY_LENGTH: usize = 32;
@@ -202,6 +203,13 @@ impl Debug for PrivateKey {
 impl Display for PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex(&self.raw))
+    }
+}
+
+impl Zeroize for PrivateKey {
+    fn zeroize(&mut self) {
+        self.raw.zeroize();
+        self.key.zeroize();
     }
 }
 

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -122,7 +122,7 @@ impl BatchScheme for Ed25519Batch {
 }
 
 /// Ed25519 Private Key.
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct PrivateKey {
     raw: [u8; PRIVATE_KEY_LENGTH],
     key: ed25519_consensus::SigningKey,
@@ -205,21 +205,6 @@ impl Display for PrivateKey {
         write!(f, "{}", hex(&self.raw))
     }
 }
-
-impl Zeroize for PrivateKey {
-    fn zeroize(&mut self) {
-        self.raw.zeroize();
-        self.key.zeroize();
-    }
-}
-
-impl Drop for PrivateKey {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
-
-impl ZeroizeOnDrop for PrivateKey {}
 
 /// Ed25519 Public Key.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -16,7 +16,7 @@ use std::{
     hash::{Hash, Hasher},
     ops::Deref,
 };
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const CURVE_NAME: &str = "secp256r1";
 const PRIVATE_KEY_LENGTH: usize = 32;
@@ -63,7 +63,7 @@ impl CommonwareSigner for Secp256r1 {
     }
 
     fn from(private_key: PrivateKey) -> Option<Self> {
-        let signer = private_key.key;
+        let signer = private_key.key.clone();
         let verifier = signer.verifying_key().to_owned();
         Some(Self { signer, verifier })
     }
@@ -171,8 +171,18 @@ impl Zeroize for PrivateKey {
     fn zeroize(&mut self) {
         self.raw.zeroize();
         // `ZeroizeOnDrop` is implemented for `SigningKey` and can't be called directly.
+        //
+        // Reference: https://github.com/RustCrypto/signatures/blob/a83c494216b6f3dacba5d4e4376785e2ea142044/ecdsa/src/signing.rs#L487-L493
     }
 }
+
+impl Drop for PrivateKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for PrivateKey {}
 
 /// Secp256r1 Public Key.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -90,9 +90,13 @@ impl CommonwareSigner for Secp256r1 {
 }
 
 /// Secp256r1 Private Key.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Zeroize, ZeroizeOnDrop)]
 pub struct PrivateKey {
     raw: [u8; PRIVATE_KEY_LENGTH],
+    // `ZeroizeOnDrop` is implemented for `SigningKey` and can't be called directly.
+    //
+    // Reference: https://github.com/RustCrypto/signatures/blob/a83c494216b6f3dacba5d4e4376785e2ea142044/ecdsa/src/signing.rs#L487-L493
+    #[zeroize(skip)]
     key: SigningKey,
 }
 
@@ -167,22 +171,10 @@ impl Display for PrivateKey {
     }
 }
 
-impl Zeroize for PrivateKey {
-    fn zeroize(&mut self) {
-        self.raw.zeroize();
-        // `ZeroizeOnDrop` is implemented for `SigningKey` and can't be called directly.
-        //
-        // Reference: https://github.com/RustCrypto/signatures/blob/a83c494216b6f3dacba5d4e4376785e2ea142044/ecdsa/src/signing.rs#L487-L493
-    }
-}
-
-impl Drop for PrivateKey {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
-
-impl ZeroizeOnDrop for PrivateKey {}
+// impl Zeroize for PrivateKey {
+//     fn zeroize(&mut self) {
+//         self.raw.zeroize();
+// }
 
 /// Secp256r1 Public Key.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -16,6 +16,7 @@ use std::{
     hash::{Hash, Hasher},
     ops::Deref,
 };
+use zeroize::Zeroize;
 
 const CURVE_NAME: &str = "secp256r1";
 const PRIVATE_KEY_LENGTH: usize = 32;
@@ -163,6 +164,13 @@ impl Debug for PrivateKey {
 impl Display for PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex(&self.raw))
+    }
+}
+
+impl Zeroize for PrivateKey {
+    fn zeroize(&mut self) {
+        self.raw.zeroize();
+        // `ZeroizeOnDrop` is implemented for `SigningKey` and can't be called directly.
     }
 }
 

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -171,11 +171,6 @@ impl Display for PrivateKey {
     }
 }
 
-// impl Zeroize for PrivateKey {
-//     fn zeroize(&mut self) {
-//         self.raw.zeroize();
-// }
-
 /// Secp256r1 Public Key.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PublicKey {

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -157,7 +157,7 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
 
         // Create dealer
         let mut dealer_obj = if should_deal {
-            let previous = previous.map(|previous| previous.share);
+            let previous = previous.map(|previous| previous.share.clone());
             let (dealer, commitment, shares) =
                 Dealer::new(&mut self.context, previous, self.contributors.clone());
             Some((dealer, commitment, shares, HashMap::new()))
@@ -179,7 +179,7 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
             let mut sent = 0;
             for (idx, player) in self.contributors.iter().enumerate() {
                 // Send to self
-                let mut share = shares[idx];
+                let mut share = shares[idx].clone();
                 if idx == me_idx as usize {
                     player_obj
                         .share(me.clone(), commitment.clone(), share)
@@ -347,7 +347,7 @@ impl<E: Clock + Rng + Spawner, C: Scheme> Contributor<E, C> {
             let mut reveals = Vec::new();
             for idx in 0..self.contributors.len() as u32 {
                 if !acks.contains_key(&idx) {
-                    reveals.push(shares[idx as usize]);
+                    reveals.push(shares[idx as usize].clone());
                 }
             }
             debug!(


### PR DESCRIPTION
It turns out just implementing `Zeroize` doesn't actually do anything. You need to implement `Drop` and call `.zeroize()`.

## TODO
- [x] Implement for bls12381::Share/Scalar