### PR TITLE
[commonware-runtime/storage] wrap blob io errors instead of swallowing them

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -18,6 +18,7 @@
 //! expect breaking changes and occasional instability.
 
 use prometheus_client::registry::Metric;
+use std::io::Error as IoError;
 use std::{
     future::Future,
     net::SocketAddr,
@@ -42,7 +43,7 @@ pub use utils::{create_pool, reschedule, Handle, Signal, Signaler};
 const METRICS_PREFIX: &str = "runtime";
 
 /// Errors that can occur when interacting with the runtime.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum Error {
     #[error("exited")]
     Exited,
@@ -68,16 +69,16 @@ pub enum Error {
     PartitionMissing(String),
     #[error("partition corrupt: {0}")]
     PartitionCorrupt(String),
-    #[error("blob open failed: {0}/{1}")]
-    BlobOpenFailed(String, String),
+    #[error("blob open failed: {0}/{1} error: {2}")]
+    BlobOpenFailed(String, String, IoError),
     #[error("blob missing: {0}/{1}")]
     BlobMissing(String, String),
-    #[error("blob truncate failed: {0}/{1}")]
-    BlobTruncateFailed(String, String),
-    #[error("blob sync failed: {0}/{1}")]
-    BlobSyncFailed(String, String),
-    #[error("blob close failed: {0}/{1}")]
-    BlobCloseFailed(String, String),
+    #[error("blob truncate failed: {0}/{1} error: {2}")]
+    BlobTruncateFailed(String, String, IoError),
+    #[error("blob sync failed: {0}/{1} error: {2}")]
+    BlobSyncFailed(String, String, IoError),
+    #[error("blob close failed: {0}/{1} error: {2}")]
+    BlobCloseFailed(String, String, IoError),
     #[error("blob insufficient length")]
     BlobInsufficientLength,
     #[error("offset overflow")]
@@ -391,7 +392,7 @@ mod tests {
                 }
             });
             handle.abort();
-            assert_eq!(handle.await, Err(Error::Closed));
+            assert!(matches!(handle.await, Err(Error::Closed)));
         });
     }
 
@@ -409,7 +410,7 @@ mod tests {
             let result = context.spawn(|_| async move {
                 panic!("blah");
             });
-            assert_eq!(result.await, Err(Error::Exited));
+            assert!(matches!(result.await, Err(Error::Exited)));
             Result::<(), Error>::Ok(())
         });
 
@@ -821,7 +822,7 @@ mod tests {
         runner.start(async move {
             let handle = context.spawn_ref();
             let result = handle(async move { 42 }).await;
-            assert_eq!(result, Ok(42));
+            assert!(matches!(result, Ok(42)));
         });
     }
 
@@ -829,12 +830,12 @@ mod tests {
         runner.start(async move {
             let handle = context.spawn_ref();
             let result = handle(async move { 42 }).await;
-            assert_eq!(result, Ok(42));
+            assert!(matches!(result, Ok(42)));
 
             // Ensure context is consumed
             let handle = context.spawn_ref();
             let result = handle(async move { 42 }).await;
-            assert_eq!(result, Ok(42));
+            assert!(matches!(result, Ok(42)));
         });
     }
 
@@ -842,7 +843,7 @@ mod tests {
         runner.start(async move {
             let handle = context.spawn_ref();
             let result = handle(async move { 42 }).await;
-            assert_eq!(result, Ok(42));
+            assert!(matches!(result, Ok(42)));
 
             // Ensure context is consumed
             context.spawn(|_| async move { 42 });
@@ -853,7 +854,7 @@ mod tests {
         runner.start(async move {
             let handle = context.spawn_blocking(|| 42);
             let result = handle.await;
-            assert_eq!(result, Ok(42));
+            assert!(matches!(result, Ok(42)));
         });
     }
 
@@ -889,7 +890,7 @@ mod tests {
             sender.send(()).unwrap();
 
             // Wait for the task to complete
-            assert_eq!(handle.await, Ok(100_000_000));
+            assert!(matches!(handle.await, Ok(100_000_000)));
         });
     }
 
@@ -1323,7 +1324,7 @@ mod tests {
                 panic!("blocking task panicked");
             });
             let result = handle.await;
-            assert_eq!(result, Err(Error::Exited));
+            assert!(matches!(result, Err(Error::Exited)));
         });
     }
 

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -175,7 +175,7 @@ mod tests {
                 // Take the waiter and drop it.
                 sink.channel.lock().unwrap().waiter.take();
             },);
-            assert_eq!(v, Err(Error::RecvFailed));
+            assert!(matches!(v, Err(Error::RecvFailed)));
         });
     }
 
@@ -203,7 +203,7 @@ mod tests {
 
             // Try to send a message (longer than the requested amount), but the receiver is dropped.
             let result = sink.send(b"hello world").await;
-            assert_eq!(result, Err(Error::SendFailed));
+            assert!(matches!(result, Err(Error::SendFailed)));
         });
     }
 

--- a/runtime/src/storage/tokio.rs
+++ b/runtime/src/storage/tokio.rs
@@ -88,7 +88,7 @@ impl crate::Storage for Storage {
             .truncate(false)
             .open(&path)
             .await
-            .map_err(|_| Error::BlobOpenFailed(partition.into(), hex(name)))?;
+            .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e))?;
 
         // Set the maximum buffer size
         file.set_max_buf_size(self.cfg.maximum_buffer_size);
@@ -194,7 +194,7 @@ impl crate::Blob for Blob {
         file.0
             .set_len(len)
             .await
-            .map_err(|_| Error::BlobTruncateFailed(self.partition.clone(), hex(&self.name)))?;
+            .map_err(|e| Error::BlobTruncateFailed(self.partition.clone(), hex(&self.name), e))?;
 
         // Update the virtual file size
         file.1 = len;
@@ -206,7 +206,7 @@ impl crate::Blob for Blob {
         file.0
             .sync_all()
             .await
-            .map_err(|_| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name)))
+            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
     }
 
     async fn close(self) -> Result<(), Error> {
@@ -214,11 +214,11 @@ impl crate::Blob for Blob {
         file.0
             .sync_all()
             .await
-            .map_err(|_| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name)))?;
+            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))?;
         file.0
             .shutdown()
             .await
-            .map_err(|_| Error::BlobCloseFailed(self.partition.clone(), hex(&self.name)))
+            .map_err(|e| Error::BlobCloseFailed(self.partition.clone(), hex(&self.name), e))
     }
 }
 


### PR DESCRIPTION
Instead of swallowing IO errors from blob file IO, wrap/propgate them to enable easier failure diagnosis.

This required removing PartialEq trait from the commonware-runtime Error enum, but as I understand it, PartialEq for errors is non-idiomatic, and using maches! macro is preferrable to ==.