### PR TITLE
[consensus/threshold-simplex] Report `Seed`

### DIFF
--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -393,6 +393,17 @@ mod tests {
                     assert!(faults.is_empty());
                 }
 
+                // Ensure seeds for all views
+                {
+                    let seeds = supervisor.seeds.lock().unwrap();
+                    for view in 1..latest_complete {
+                        // Ensure seed for every view
+                        if !seeds.contains_key(&view) {
+                            panic!("view: {}", view);
+                        }
+                    }
+                }
+
                 // Ensure no forks
                 let mut exceptions = 0;
                 let mut notarized = HashMap::new();

--- a/consensus/src/threshold_simplex/types.rs
+++ b/consensus/src/threshold_simplex/types.rs
@@ -1578,14 +1578,21 @@ mod tests {
 
         // Create notarization
         let notarization = Notarization::new(proposal, proposal_signature, seed_signature);
-
         let encoded = notarization.encode();
         let decoded = Notarization::<Sha256>::decode(encoded).unwrap();
-
         assert_eq!(notarization, decoded);
 
         // Verify the notarization
         let public_key = poly::public(&commitment);
+        assert!(decoded.verify(NAMESPACE, public_key));
+
+        // Create seed
+        let seed = Seed::new(notarization.view(), notarization.seed_signature);
+        let encoded = seed.encode();
+        let decoded = Seed::decode(encoded).unwrap();
+        assert_eq!(seed, decoded);
+
+        // Verify the seed
         assert!(decoded.verify(NAMESPACE, public_key));
     }
 


### PR DESCRIPTION
This is a convenience `Activity` that helps integrators interested only in a view's seed (which is already part of `Notarization` and `Nullification`.