### PR TITLE
[runtime/storage] remove `Blob::len()`; add blob length to `Storage::open` return type

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1467,7 +1467,7 @@ mod tests {
         executor.start(|context| async move {
             let (blob, len) = context.open(partition, name).await.unwrap();
             assert_eq!(len, data.len() as u64);
-            let mut buf = vec![0; data.len() as usize];
+            let mut buf = vec![0; data.len()];
             blob.read_at(&mut buf, 0).await.unwrap();
             assert_eq!(buf, data);
         });

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -270,8 +270,8 @@ pub trait Storage: Clone + Send + Sync + 'static {
     /// The readable/writeable storage buffer that can be opened by this Storage.
     type Blob: Blob;
 
-    /// Open an existing blob in a given partition or create a new one.
-    /// Returns the Blob and its length.
+    /// Open an existing blob in a given partition or create a new one, returning
+    /// the blob and its length.
     ///
     /// Multiple instances of the same blob can be opened concurrently, however,
     /// writing to the same blob concurrently may lead to undefined behavior.
@@ -666,7 +666,6 @@ mod tests {
                     .expect("Failed to open blob");
 
                 // Write data at different offsets
-
                 blob.write_at(data1, 0)
                     .await
                     .expect("Failed to write data1");

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
 use commonware_utils::hex;
+use tracing::debug;
 
 /// In-memory storage implementation for the commonware runtime.
 #[derive(Clone)]
@@ -144,6 +145,11 @@ impl crate::Blob for Blob {
                 hex(&self.name),
             ))?;
         *content = new_content;
+        debug!(
+            "Updated partition {} with content len: {:?}",
+            self.partition,
+            content.len()
+        );
         Ok(())
     }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,8 +1,6 @@
+use commonware_utils::hex;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
-
-use commonware_utils::hex;
-use tracing::debug;
 
 /// In-memory storage implementation for the commonware runtime.
 #[derive(Clone)]
@@ -145,11 +143,6 @@ impl crate::Blob for Blob {
                 hex(&self.name),
             ))?;
         *content = new_content;
-        debug!(
-            "Updated partition {} with content len: {:?}",
-            self.partition,
-            content.len()
-        );
         Ok(())
     }
 

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -624,7 +624,7 @@ impl CryptoRng for Context {}
 impl crate::Storage for Context {
     type Blob = <Storage<TokioStorage> as crate::Storage>::Blob;
 
-    async fn open(&self, partition: &str, name: &[u8]) -> Result<Self::Blob, Error> {
+    async fn open(&self, partition: &str, name: &[u8]) -> Result<(Self::Blob, u64), Error> {
         self.storage.open(partition, name).await
     }
 

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -448,7 +448,7 @@ mod tests {
 
             // Corrupt the value
             let section = index & DEFAULT_SECTION_MASK;
-            let blob = context
+            let (blob, _) = context
                 .open("test_partition", &section.to_be_bytes())
                 .await
                 .unwrap();

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -135,7 +135,7 @@ pub struct Journal<E: Storage + Metrics> {
 
     oldest_allowed: Option<u64>,
 
-    blobs: BTreeMap<u64, E::Blob>,
+    blobs: BTreeMap<u64, (E::Blob, u64)>,
 
     tracked: Gauge,
     synced: Counter,
@@ -350,9 +350,8 @@ impl<E: Storage + Metrics> Journal<E> {
     ) -> Result<impl Stream<Item = Result<(u64, u32, u32, Bytes), Error>> + '_, Error> {
         // Collect all blobs to replay
         let mut blobs = Vec::with_capacity(self.blobs.len());
-        for (section, blob) in self.blobs.iter() {
-            let len = blob.len().await?;
-            let aligned_len = compute_next_offset(len)?;
+        for (section, (blob, len)) in self.blobs.iter() {
+            let aligned_len = compute_next_offset(*len)?;
             blobs.push((*section, blob, aligned_len));
         }
 
@@ -467,10 +466,15 @@ impl<E: Storage + Metrics> Journal<E> {
         buf.put_u32(checksum);
 
         // Append item to blob
-        let cursor = blob.len().await?;
+        let cursor = blob.1;
         let offset = compute_next_offset(cursor)?;
-        blob.write_at(&buf, offset as u64 * ITEM_ALIGNMENT).await?;
+        blob.0
+            .write_at(&buf, offset as u64 * ITEM_ALIGNMENT)
+            .await?;
         trace!(blob = section, previous_len = len, offset, "appended item");
+
+        // Update blob length
+        blob.1 += len as u64;
         Ok(offset)
     }
 
@@ -485,7 +489,7 @@ impl<E: Storage + Metrics> Journal<E> {
         prefix: u32,
     ) -> Result<Option<Bytes>, Error> {
         self.prune_guard(section, false)?;
-        let blob = match self.blobs.get(&section) {
+        let (blob, _) = match self.blobs.get(&section) {
             Some(blob) => blob,
             None => return Ok(None),
         };
@@ -505,7 +509,7 @@ impl<E: Storage + Metrics> Journal<E> {
         exact: Option<u32>,
     ) -> Result<Option<Bytes>, Error> {
         self.prune_guard(section, false)?;
-        let blob = match self.blobs.get(&section) {
+        let (blob, _) = match self.blobs.get(&section) {
             Some(blob) => blob,
             None => return Ok(None),
         };
@@ -526,7 +530,7 @@ impl<E: Storage + Metrics> Journal<E> {
     /// If the `section` does not exist, no error will be returned.
     pub async fn sync(&self, section: u64) -> Result<(), Error> {
         self.prune_guard(section, false)?;
-        let blob = match self.blobs.get(&section) {
+        let (blob, _) = match self.blobs.get(&section) {
             Some(blob) => blob,
             None => return Ok(()),
         };
@@ -547,7 +551,7 @@ impl<E: Storage + Metrics> Journal<E> {
             }
 
             // Remove and close blob
-            let blob = self.blobs.remove(&section).unwrap();
+            let (blob, _) = self.blobs.remove(&section).unwrap();
             blob.close().await?;
 
             // Remove blob from storage
@@ -566,7 +570,7 @@ impl<E: Storage + Metrics> Journal<E> {
 
     /// Closes all open sections.
     pub async fn close(self) -> Result<(), Error> {
-        for (section, blob) in self.blobs.into_iter() {
+        for (section, (blob, _)) in self.blobs.into_iter() {
             blob.close().await?;
             debug!(blob = section, "closed blob");
         }
@@ -575,7 +579,7 @@ impl<E: Storage + Metrics> Journal<E> {
 
     /// Close and remove any underlying blobs created by the journal.
     pub async fn destroy(self) -> Result<(), Error> {
-        for (i, blob) in self.blobs.into_iter() {
+        for (i, (blob, _)) in self.blobs.into_iter() {
             blob.close().await?;
             debug!(blob = i, "destroyed blob");
             self.context
@@ -867,7 +871,7 @@ mod tests {
 
             // Manually create a blob with an invalid name (not 8 bytes)
             let invalid_blob_name = b"invalid"; // Less than 8 bytes
-            let blob = context
+            let (blob, _) = context
                 .open(&cfg.partition, invalid_blob_name)
                 .await
                 .expect("Failed to create blob with invalid name");
@@ -895,7 +899,7 @@ mod tests {
             // Manually create a blob with incomplete size data
             let section = 1u64;
             let blob_name = section.to_be_bytes();
-            let blob = context
+            let (blob, _) = context
                 .open(&cfg.partition, &blob_name)
                 .await
                 .expect("Failed to create blob");
@@ -953,7 +957,7 @@ mod tests {
             // Manually create a blob with missing item data
             let section = 1u64;
             let blob_name = section.to_be_bytes();
-            let blob = context
+            let (blob, _) = context
                 .open(&cfg.partition, &blob_name)
                 .await
                 .expect("Failed to create blob");
@@ -1017,7 +1021,7 @@ mod tests {
             // Manually create a blob with missing checksum
             let section = 1u64;
             let blob_name = section.to_be_bytes();
-            let blob = context
+            let (blob, _) = context
                 .open(&cfg.partition, &blob_name)
                 .await
                 .expect("Failed to create blob");
@@ -1080,7 +1084,7 @@ mod tests {
             // Manually create a blob with incorrect checksum
             let section = 1u64;
             let blob_name = section.to_be_bytes();
-            let blob = context
+            let (blob, _) = context
                 .open(&cfg.partition, &blob_name)
                 .await
                 .expect("Failed to create blob");
@@ -1179,11 +1183,10 @@ mod tests {
             journal.close().await.expect("Failed to close journal");
 
             // Manually corrupt the end of the second blob
-            let blob = context
+            let (blob, blob_len) = context
                 .open(&cfg.partition, &2u64.to_be_bytes())
                 .await
                 .expect("Failed to open blob");
-            let blob_len = blob.len().await.expect("Failed to get blob length");
             blob.truncate(blob_len - 4)
                 .await
                 .expect("Failed to corrupt blob");
@@ -1221,9 +1224,7 @@ mod tests {
 
     // Define `MockBlob` that returns an offset length that should overflow
     #[derive(Clone)]
-    struct MockBlob {
-        len: u64,
-    }
+    struct MockBlob {}
 
     impl Blob for MockBlob {
         async fn read_at(&self, _buf: &mut [u8], _offset: u64) -> Result<(), RError> {
@@ -1256,8 +1257,8 @@ mod tests {
     impl Storage for MockStorage {
         type Blob = MockBlob;
 
-        async fn open(&self, _partition: &str, _name: &[u8]) -> Result<MockBlob, RError> {
-            Ok(MockBlob { len: self.len })
+        async fn open(&self, _partition: &str, _name: &[u8]) -> Result<(MockBlob, u64), RError> {
+            Ok((MockBlob {}, self.len))
         }
 
         async fn remove(&self, _partition: &str, _name: Option<&[u8]>) -> Result<(), RError> {

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -1226,11 +1226,6 @@ mod tests {
     }
 
     impl Blob for MockBlob {
-        async fn len(&self) -> Result<u64, commonware_runtime::Error> {
-            // Return a length that will cause offset overflow
-            Ok(self.len)
-        }
-
         async fn read_at(&self, _buf: &mut [u8], _offset: u64) -> Result<(), RError> {
             Ok(())
         }

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -308,7 +308,7 @@ mod tests {
             metadata.close().await.unwrap();
 
             // Corrupt the metadata store
-            let blob = context.open("test", b"left").await.unwrap();
+            let (blob, _) = context.open("test", b"left").await.unwrap();
             blob.write_at(b"corrupted", 0).await.unwrap();
             blob.close().await.unwrap();
 
@@ -354,10 +354,10 @@ mod tests {
             metadata.close().await.unwrap();
 
             // Corrupt the metadata store
-            let blob = context.open("test", b"left").await.unwrap();
+            let (blob, _) = context.open("test", b"left").await.unwrap();
             blob.write_at(b"corrupted", 0).await.unwrap();
             blob.close().await.unwrap();
-            let blob = context.open("test", b"right").await.unwrap();
+            let (blob, _) = context.open("test", b"right").await.unwrap();
             blob.write_at(b"corrupted", 0).await.unwrap();
             blob.close().await.unwrap();
 
@@ -408,8 +408,7 @@ mod tests {
             metadata.close().await.unwrap();
 
             // Corrupt the metadata store
-            let blob = context.open("test", b"left").await.unwrap();
-            let blob_len = blob.len().await.unwrap();
+            let (blob, blob_len) = context.open("test", b"left").await.unwrap();
             blob.truncate(blob_len - 8).await.unwrap();
             blob.close().await.unwrap();
 
@@ -455,7 +454,7 @@ mod tests {
             metadata.close().await.unwrap();
 
             // Corrupt the metadata store
-            let blob = context.open("test", b"left").await.unwrap();
+            let (blob, _) = context.open("test", b"left").await.unwrap();
             blob.truncate(5).await.unwrap();
             blob.close().await.unwrap();
 

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -408,8 +408,8 @@ mod tests {
             metadata.close().await.unwrap();
 
             // Corrupt the metadata store
-            let (blob, blob_len) = context.open("test", b"left").await.unwrap();
-            blob.truncate(blob_len - 8).await.unwrap();
+            let (blob, len) = context.open("test", b"left").await.unwrap();
+            blob.truncate(len - 8).await.unwrap();
             blob.close().await.unwrap();
 
             // Reopen the metadata store

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -20,7 +20,7 @@ pub struct Metadata<E: Clock + Storage + Metrics, K: Array> {
     // Data is stored in a BTreeMap to enable deterministic serialization.
     data: BTreeMap<K, Bytes>,
     cursor: usize,
-    blobs: [(E::Blob, u128); 2],
+    blobs: [(E::Blob, u64, u128); 2],
 
     syncs: Counter,
     keys: Gauge,
@@ -30,12 +30,12 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
     /// Initialize a new `Metadata` instance.
     pub async fn init(context: E, cfg: Config) -> Result<Self, Error<K>> {
         // Open dedicated blobs
-        let left = context.open(&cfg.partition, BLOB_NAMES[0]).await?;
-        let right = context.open(&cfg.partition, BLOB_NAMES[1]).await?;
+        let (left, left_len) = context.open(&cfg.partition, BLOB_NAMES[0]).await?;
+        let (right, right_len) = context.open(&cfg.partition, BLOB_NAMES[1]).await?;
 
         // Find latest blob (check which includes a hash of the other)
-        let left_result = Self::load(0, &left).await?;
-        let right_result = Self::load(1, &right).await?;
+        let left_result = Self::load(0, &left, left_len).await?;
+        let right_result = Self::load(1, &right, right_len).await?;
 
         // Set checksums
         let mut left_timestamp = 0;
@@ -72,7 +72,10 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
 
             data,
             cursor,
-            blobs: [(left, left_timestamp), (right, right_timestamp)],
+            blobs: [
+                (left, left_len, left_timestamp),
+                (right, right_len, right_timestamp),
+            ],
 
             syncs,
             keys,
@@ -82,9 +85,9 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
     async fn load(
         index: usize,
         blob: &E::Blob,
+        len: u64,
     ) -> Result<Option<(u128, BTreeMap<K, Bytes>)>, Error<K>> {
         // Get blob length
-        let len = blob.len().await?;
         if len == 0 {
             // Empty blob
             return Ok(None);
@@ -187,7 +190,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
     /// Get the timestamp of the last update to `Metadata` (if a previous
     /// update exists).
     pub fn last_update(&self) -> Option<SystemTime> {
-        let timestamp = self.blobs[self.cursor].1;
+        let timestamp = self.blobs[self.cursor].2;
         if timestamp == 0 {
             return None;
         }
@@ -201,7 +204,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
     /// Atomically commit the current state of `Metadata`.
     pub async fn sync(&mut self) -> Result<(), Error<K>> {
         // Compute next timestamp
-        let past_timestamp = &self.blobs[self.cursor].1;
+        let past_timestamp = &self.blobs[self.cursor].2;
         let mut next_timestamp = self.context.current().epoch().as_nanos();
         if next_timestamp <= *past_timestamp {
             // While it is possible that extremely high-frequency updates to `Metadata` (more than
@@ -238,10 +241,12 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         let next_blob = &mut self.blobs[next_cursor];
 
         // Write and truncate blob
+        let buf_len = buf.len() as u64;
         next_blob.0.write_at(&buf, 0).await?;
-        next_blob.0.truncate(buf.len() as u64).await?;
+        next_blob.0.truncate(buf_len).await?;
         next_blob.0.sync().await?;
-        next_blob.1 = next_timestamp;
+        next_blob.1 = buf_len;
+        next_blob.2 = next_timestamp;
 
         // Switch blobs
         self.cursor = next_cursor;
@@ -253,7 +258,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
     pub async fn close(mut self) -> Result<(), Error<K>> {
         // Sync and close blobs
         self.sync().await?;
-        for (blob, _) in self.blobs.into_iter() {
+        for (blob, _, _) in self.blobs.into_iter() {
             blob.close().await?;
         }
         Ok(())

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -30,12 +30,12 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
     /// Initialize a new `Metadata` instance.
     pub async fn init(context: E, cfg: Config) -> Result<Self, Error<K>> {
         // Open dedicated blobs
-        let (left, left_len) = context.open(&cfg.partition, BLOB_NAMES[0]).await?;
-        let (right, right_len) = context.open(&cfg.partition, BLOB_NAMES[1]).await?;
+        let (left_blob, left_len) = context.open(&cfg.partition, BLOB_NAMES[0]).await?;
+        let (right_blob, right_len) = context.open(&cfg.partition, BLOB_NAMES[1]).await?;
 
         // Find latest blob (check which includes a hash of the other)
-        let left_result = Self::load(0, &left, left_len).await?;
-        let right_result = Self::load(1, &right, right_len).await?;
+        let left_result = Self::load(0, &left_blob, left_len).await?;
+        let right_result = Self::load(1, &right_blob, right_len).await?;
 
         // Set checksums
         let mut left_timestamp = 0;
@@ -73,8 +73,8 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
             data,
             cursor,
             blobs: [
-                (left, left_len, left_timestamp),
-                (right, right_len, right_timestamp),
+                (left_blob, left_len, left_timestamp),
+                (right_blob, right_len, right_timestamp),
             ],
 
             syncs,

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -684,11 +684,10 @@ mod tests {
             // 497. Simulate a partial write by corrupting the last parent's checksum by truncating
             // the last blob by a single byte.
             let partition: String = "journal_partition".into();
-            let blob = context
+            let (blob, len) = context
                 .open(&partition, &71u64.to_be_bytes())
                 .await
                 .expect("Failed to open blob");
-            let len = blob.len().await.expect("Failed to get blob length");
             assert_eq!(len, 36); // N+4 = 36 bytes per node, 1 node in the last blob
 
             // truncate the blob by one byte to corrupt the checksum of the last parent node.
@@ -720,11 +719,10 @@ mod tests {
                 .remove(&partition, Some(&71u64.to_be_bytes()))
                 .await
                 .expect("Failed to remove blob");
-            let blob = context
+            let (blob, len) = context
                 .open(&partition, &70u64.to_be_bytes())
                 .await
                 .expect("Failed to open blob");
-            let len = blob.len().await.expect("Failed to get blob length");
             assert_eq!(len, 36 * 7); // this blob should be full.
 
             // The last leaf should be in slot 5 of this blob, truncate last byte of its checksum.


### PR DESCRIPTION
TODO:
- [x] Remove unnecessary logging