### PR TITLE
[commonware-runtime/commonware-storage benches] reuse large journal across benchmarks, fix Runner naming

### DIFF
--- a/runtime/src/benchmarks/tokio.rs
+++ b/runtime/src/benchmarks/tokio.rs
@@ -1,7 +1,7 @@
 //! Implements a [criterion]-compatible executor for the [tokio] runtime.
 
 use super::context;
-use crate::{tokio, Runner};
+use crate::{tokio, Runner as TokioRunner};
 use criterion::async_executor::AsyncExecutor;
 use futures::Future;
 
@@ -15,7 +15,7 @@ use futures::Future;
 /// use std::time::Duration;
 ///
 /// fn my_benchmark(c: &mut Criterion) {
-///     let executor = tokio::Executor::default();
+///     let executor = tokio::Runner::default();
 ///     c.bench_function("sleep_benchmark", |b| {
 ///         b.to_async(&executor).iter_batched(|| (),
 ///         |_| async {
@@ -28,28 +28,28 @@ use futures::Future;
 /// }
 /// ```
 #[derive(Clone)]
-pub struct Executor {
+pub struct Runner {
     cfg: tokio::Config,
 }
 
-impl Executor {
+impl Runner {
     /// Create a new bencher with the given configuration
     pub fn new(cfg: tokio::Config) -> Self {
         Self { cfg }
     }
 }
 
-impl Default for Executor {
+impl Default for Runner {
     fn default() -> Self {
         Self::new(tokio::Config::default())
     }
 }
 
-impl AsyncExecutor for &Executor {
+impl AsyncExecutor for &Runner {
     fn block_on<T>(&self, future: impl Future<Output = T>) -> T {
-        let executor = tokio::Runner::new(self.cfg.clone());
+        let runner = tokio::Runner::new(self.cfg.clone());
 
-        let result = executor.start(|ctx| {
+        let result = runner.start(|ctx| {
             // Create and store our context
             context::set(ctx);
 

--- a/runtime/src/benchmarks/tokio.rs
+++ b/runtime/src/benchmarks/tokio.rs
@@ -1,7 +1,7 @@
 //! Implements a [criterion]-compatible executor for the [tokio] runtime.
 
 use super::context;
-use crate::{tokio, Runner as TokioRunner};
+use crate::{tokio, Runner as _};
 use criterion::async_executor::AsyncExecutor;
 use futures::Future;
 

--- a/storage/src/journal/benches/fixed_append.rs
+++ b/storage/src/journal/benches/fixed_append.rs
@@ -1,4 +1,4 @@
-use crate::append_random_data;
+use crate::{append_random_data, get_journal};
 use commonware_runtime::benchmarks::{context, tokio};
 use criterion::{criterion_group, Criterion};
 use std::time::{Duration, Instant};
@@ -13,7 +13,7 @@ const ITEMS_PER_BLOB: u64 = 10_000;
 const ITEM_SIZE: usize = 32;
 
 fn bench_fixed_append(c: &mut Criterion) {
-    let executor = tokio::Executor::default();
+    let runner = tokio::Runner::default();
     for items_to_write in [1_000, 10_000, 100_000, 1_000_000] {
         c.bench_function(
             &format!(
@@ -23,23 +23,19 @@ fn bench_fixed_append(c: &mut Criterion) {
                 ITEM_SIZE
             ),
             |b| {
-                b.to_async(&executor).iter_custom(|iters| async move {
+                b.to_async(&runner).iter_custom(|iters| async move {
                     let ctx = context::get::<commonware_runtime::tokio::Context>();
                     let mut duration = Duration::ZERO;
+                    let mut j = get_journal::<ITEM_SIZE>(ctx, PARTITION, ITEMS_PER_BLOB).await;
                     for _ in 0..iters {
                         let start = Instant::now();
-                        let j = append_random_data::<ITEM_SIZE>(
-                            ctx.clone(),
-                            PARTITION,
-                            ITEMS_PER_BLOB,
-                            items_to_write,
-                        )
-                        .await;
+                        append_random_data(&mut j, items_to_write).await;
                         duration += start.elapsed();
 
                         // Destroy the journal after appending to avoid polluting the next iteration
-                        j.destroy().await.unwrap();
                     }
+                    j.destroy().await.unwrap();
+
                     duration
                 });
             },

--- a/storage/src/journal/benches/fixed_read_random.rs
+++ b/storage/src/journal/benches/fixed_read_random.rs
@@ -2,7 +2,7 @@ use super::{append_random_data, get_journal};
 use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::{Config, Context, Runner},
-    Runner as RunnerTrait,
+    Runner as _,
 };
 use commonware_storage::journal::fixed::Journal;
 use commonware_utils::array::FixedBytes;

--- a/storage/src/journal/benches/fixed_read_random.rs
+++ b/storage/src/journal/benches/fixed_read_random.rs
@@ -8,11 +8,8 @@ use commonware_storage::journal::fixed::Journal;
 use commonware_utils::array::FixedBytes;
 use criterion::{black_box, criterion_group, Criterion};
 use futures::future::try_join_all;
-use rand::{rngs::OsRng, rngs::StdRng, Rng, RngCore, SeedableRng};
-use std::{
-    env,
-    time::{Duration, Instant},
-};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::time::{Duration, Instant};
 
 /// Partition name to use in the journal config.
 const PARTITION: &str = "test_partition";
@@ -51,24 +48,11 @@ async fn bench_run_concurrent(
 }
 
 fn bench_fixed_read_random(c: &mut Criterion) {
-    // Create a runtime config we can use across all benchmarks, allowing the
-    // same test file to be re-used. First we generate a random directory to
-    // avoid conflicts.
-    let rng = OsRng.next_u64();
-    let storage_directory =
-        env::temp_dir().join(format!("commonware_storage_journal_bench_{}", rng));
+    // Create a config we can use across all benchmarks (with a fixed `storage_directory`), allowing the
+    // same test file to be re-used.
+    let cfg = Config::default();
 
-    // Same config as tokio::Config::default() as of 4/2025.
-    let cfg = Config {
-        worker_threads: 2,
-        max_blocking_threads: 512,
-        catch_panics: true,
-        read_timeout: Duration::from_secs(60),
-        write_timeout: Duration::from_secs(30),
-        tcp_nodelay: None,
-        storage_directory,
-        maximum_buffer_size: 2 * 1024 * 1024, // 2 MB
-    };
+    // Generate a large temp journal with random data.
     let runner = Runner::new(cfg.clone());
     runner.start(|ctx| async move {
         // Create a large temp journal with random data.
@@ -77,8 +61,8 @@ fn bench_fixed_read_random(c: &mut Criterion) {
         j.close().await.unwrap();
     });
 
+    // Run the benchmarks
     let runner = tokio::Runner::new(cfg.clone());
-
     for mode in ["serial", "concurrent"] {
         for items_to_read in [100, 1_000, 10_000, 100_000] {
             c.bench_function(
@@ -93,8 +77,6 @@ fn bench_fixed_read_random(c: &mut Criterion) {
                     b.to_async(&runner).iter_custom(|iters| async move {
                         let ctx = context::get::<commonware_runtime::tokio::Context>();
                         let j = get_journal(ctx.clone(), PARTITION, ITEMS_PER_BLOB).await;
-
-                        // Run the benchmark
                         let mut duration = Duration::ZERO;
                         for _ in 0..iters {
                             let start = Instant::now();

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -1,4 +1,4 @@
-use super::append_random_data;
+use super::{append_random_data, get_journal};
 use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::Context,
@@ -20,7 +20,8 @@ const ITEM_SIZE: usize = 32;
 
 /// Replay all items in the given `journal`.
 async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, items_to_read: u64) {
-    let concurrency = (items_to_read / ITEMS_PER_BLOB) as usize;
+    let concurrency = std::cmp::max(1, (items_to_read / ITEMS_PER_BLOB) as usize);
+
     let stream = journal
         .replay(concurrency)
         .await
@@ -39,21 +40,16 @@ async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, items_
 /// Benchmark the replaying of items from a journal containing exactly that
 /// number of items.
 fn bench_fixed_replay(c: &mut Criterion) {
-    let executor = tokio::Executor::default();
+    let runner = tokio::Runner::default();
     for items in [1_000, 10_000, 100_000, 500_000] {
         c.bench_function(
             &format!("{}/items={} size={}", module_path!(), items, ITEM_SIZE),
             |b| {
-                b.to_async(&executor).iter_custom(|iters| async move {
+                b.to_async(&runner).iter_custom(|iters| async move {
                     // Append random data to the journal
                     let ctx = context::get::<commonware_runtime::tokio::Context>();
-                    let mut j = append_random_data::<ITEM_SIZE>(
-                        ctx.clone(),
-                        PARTITION,
-                        ITEMS_PER_BLOB,
-                        items,
-                    )
-                    .await;
+                    let mut j = get_journal::<ITEM_SIZE>(ctx, PARTITION, ITEMS_PER_BLOB).await;
+                    append_random_data::<ITEM_SIZE>(&mut j, items).await;
                     let sz = j.size().await.unwrap();
                     assert_eq!(sz, items);
 

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -21,7 +21,6 @@ const ITEM_SIZE: usize = 32;
 /// Replay all items in the given `journal`.
 async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, items_to_read: u64) {
     let concurrency = std::cmp::max(1, (items_to_read / ITEMS_PER_BLOB) as usize);
-
     let stream = journal
         .replay(concurrency)
         .await

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -340,6 +340,7 @@ impl<E: Storage + Metrics, A: Array> Journal<E, A> {
         &mut self,
         concurrency: usize,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + '_, Error> {
+        assert!(concurrency > 0);
         // Collect all blobs to replay
         let mut blobs = Vec::with_capacity(self.blobs.len());
         let newest_blob_index = self.newest_blob().0;


### PR DESCRIPTION
- Write random-read benchmark journal only once to improve overall runtime.

- Rename commonware_runtime::benchmarks::tokio::Executor to Runner.

- Also fixed recently introduced hang in the replay benchmark due to the concurrency value rounding down to 0.