### PR TITLE
[consensus] primitive types encoded as varints

### DIFF
--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -521,10 +521,10 @@ impl<P: Array, D: Digest> Ack<P, D> {
     /// It contains both the chunk and the epoch to ensure domain separation and prevent
     /// signature reuse across epochs.
     fn payload(chunk: &Chunk<P, D>, epoch: &Epoch) -> Vec<u8> {
-        let var_epoch = UInt(*epoch);
-        let mut message = Vec::with_capacity(chunk.encode_size() + var_epoch.encode_size());
+        let epoch = UInt(*epoch);
+        let mut message = Vec::with_capacity(chunk.encode_size() + epoch.encode_size());
         chunk.write(&mut message);
-        var_epoch.write(&mut message);
+        epoch.write(&mut message);
         message
     }
 

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -1,7 +1,9 @@
 //! Types used in [`ordered_broadcast`](crate::ordered_broadcast).
 
 use bytes::{Buf, BufMut};
-use commonware_codec::{Encode, EncodeSize, Error as CodecError, FixedSize, Read, ReadExt, Write};
+use commonware_codec::{
+    varint::UInt, Encode, EncodeSize, Error as CodecError, Read, ReadExt, Write,
+};
 use commonware_cryptography::{
     bls12381::primitives::{
         group::{Public, Share, Signature},
@@ -215,7 +217,7 @@ impl<P: Array, D: Digest> Chunk<P, D> {
 impl<P: Array, D: Digest> Write for Chunk<P, D> {
     fn write(&self, writer: &mut impl BufMut) {
         self.sequencer.write(writer);
-        self.height.write(writer);
+        UInt(self.height).write(writer);
         self.payload.write(writer);
     }
 }
@@ -223,7 +225,7 @@ impl<P: Array, D: Digest> Write for Chunk<P, D> {
 impl<P: Array, D: Digest> Read for Chunk<P, D> {
     fn read_cfg(reader: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let sequencer = P::read(reader)?;
-        let height = u64::read(reader)?;
+        let height = UInt::read(reader)?.into();
         let payload = D::read(reader)?;
         Ok(Self {
             sequencer,
@@ -233,8 +235,10 @@ impl<P: Array, D: Digest> Read for Chunk<P, D> {
     }
 }
 
-impl<P: Array, D: Digest> FixedSize for Chunk<P, D> {
-    const SIZE: usize = P::SIZE + u64::SIZE + D::SIZE;
+impl<P: Array, D: Digest> EncodeSize for Chunk<P, D> {
+    fn encode_size(&self) -> usize {
+        self.sequencer.encode_size() + UInt(self.height).encode_size() + self.payload.encode_size()
+    }
 }
 
 /// Parent is a message that contains information about the parent (previous height) of a Chunk.
@@ -272,7 +276,7 @@ impl<D: Digest> Parent<D> {
 impl<D: Digest> Write for Parent<D> {
     fn write(&self, writer: &mut impl BufMut) {
         self.digest.write(writer);
-        self.epoch.write(writer);
+        UInt(self.epoch).write(writer);
         self.signature.write(writer);
     }
 }
@@ -280,7 +284,7 @@ impl<D: Digest> Write for Parent<D> {
 impl<D: Digest> Read for Parent<D> {
     fn read_cfg(reader: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let digest = D::read(reader)?;
-        let epoch = Epoch::read(reader)?;
+        let epoch = UInt::read(reader)?.into();
         let signature = Signature::read(reader)?;
         Ok(Self {
             digest,
@@ -290,8 +294,10 @@ impl<D: Digest> Read for Parent<D> {
     }
 }
 
-impl<D: Digest> FixedSize for Parent<D> {
-    const SIZE: usize = D::SIZE + Epoch::SIZE + Signature::SIZE;
+impl<D: Digest> EncodeSize for Parent<D> {
+    fn encode_size(&self) -> usize {
+        self.digest.encode_size() + UInt(self.epoch).encode_size() + self.signature.encode_size()
+    }
 }
 
 /// Node is a message from a sequencer that contains a Chunk and a proof that the parent was correctly broadcasted.
@@ -453,7 +459,7 @@ impl<C: Verifier, D: Digest> Read for Node<C, D> {
 
 impl<C: Verifier, D: Digest> EncodeSize for Node<C, D> {
     fn encode_size(&self) -> usize {
-        Chunk::<C::PublicKey, D>::SIZE + C::Signature::SIZE + self.parent.encode_size()
+        self.chunk.encode_size() + self.signature.encode_size() + self.parent.encode_size()
     }
 }
 
@@ -515,9 +521,10 @@ impl<P: Array, D: Digest> Ack<P, D> {
     /// It contains both the chunk and the epoch to ensure domain separation and prevent
     /// signature reuse across epochs.
     fn payload(chunk: &Chunk<P, D>, epoch: &Epoch) -> Vec<u8> {
-        let mut message = Vec::with_capacity(Chunk::<P, D>::SIZE + Epoch::SIZE);
+        let var_epoch = UInt(*epoch);
+        let mut message = Vec::with_capacity(chunk.encode_size() + var_epoch.encode_size());
         chunk.write(&mut message);
-        epoch.write(&mut message);
+        var_epoch.write(&mut message);
         message
     }
 
@@ -560,7 +567,7 @@ impl<P: Array, D: Digest> Ack<P, D> {
 impl<P: Array, D: Digest> Write for Ack<P, D> {
     fn write(&self, writer: &mut impl BufMut) {
         self.chunk.write(writer);
-        self.epoch.write(writer);
+        UInt(self.epoch).write(writer);
         self.signature.write(writer);
     }
 }
@@ -568,7 +575,7 @@ impl<P: Array, D: Digest> Write for Ack<P, D> {
 impl<P: Array, D: Digest> Read for Ack<P, D> {
     fn read_cfg(reader: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let chunk = Chunk::read(reader)?;
-        let epoch = Epoch::read(reader)?;
+        let epoch = UInt::read(reader)?.into();
         let signature = PartialSignature::read(reader)?;
         Ok(Self {
             chunk,
@@ -578,8 +585,10 @@ impl<P: Array, D: Digest> Read for Ack<P, D> {
     }
 }
 
-impl<P: Array, D: Digest> FixedSize for Ack<P, D> {
-    const SIZE: usize = Chunk::<P, D>::SIZE + Epoch::SIZE + PartialSignature::SIZE;
+impl<P: Array, D: Digest> EncodeSize for Ack<P, D> {
+    fn encode_size(&self) -> usize {
+        self.chunk.encode_size() + UInt(self.epoch).encode_size() + self.signature.encode_size()
+    }
 }
 
 /// Activity is the type associated with the [`Reporter`](crate::Reporter) trait.
@@ -691,8 +700,10 @@ impl<C: Verifier, D: Digest> Read for Proposal<C, D> {
     }
 }
 
-impl<C: Verifier, D: Digest> FixedSize for Proposal<C, D> {
-    const SIZE: usize = Chunk::<C::PublicKey, D>::SIZE + C::Signature::SIZE;
+impl<C: Verifier, D: Digest> EncodeSize for Proposal<C, D> {
+    fn encode_size(&self) -> usize {
+        self.chunk.encode_size() + self.signature.encode_size()
+    }
 }
 
 impl<C: Verifier, D: Digest> Hash for Proposal<C, D> {
@@ -768,7 +779,7 @@ impl<P: Array, D: Digest> Lock<P, D> {
 impl<P: Array, D: Digest> Write for Lock<P, D> {
     fn write(&self, writer: &mut impl BufMut) {
         self.chunk.write(writer);
-        self.epoch.write(writer);
+        UInt(self.epoch).write(writer);
         self.signature.write(writer);
     }
 }
@@ -776,7 +787,7 @@ impl<P: Array, D: Digest> Write for Lock<P, D> {
 impl<P: Array, D: Digest> Read for Lock<P, D> {
     fn read_cfg(reader: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let chunk = Chunk::read(reader)?;
-        let epoch = Epoch::read(reader)?;
+        let epoch = UInt::read(reader)?.into();
         let signature = Signature::read(reader)?;
         Ok(Self {
             chunk,
@@ -786,8 +797,10 @@ impl<P: Array, D: Digest> Read for Lock<P, D> {
     }
 }
 
-impl<P: Array, D: Digest> FixedSize for Lock<P, D> {
-    const SIZE: usize = Chunk::<P, D>::SIZE + Epoch::SIZE + Signature::SIZE;
+impl<P: Array, D: Digest> EncodeSize for Lock<P, D> {
+    fn encode_size(&self) -> usize {
+        self.chunk.encode_size() + UInt(self.epoch).encode_size() + self.signature.encode_size()
+    }
 }
 
 #[cfg(test)]

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -22,6 +22,8 @@ use blst::{
 };
 use bytes::{Buf, BufMut};
 use commonware_codec::{
+    varint::UInt,
+    EncodeSize,
     Error::{self, Invalid},
     FixedSize, Read, ReadExt, Write,
 };
@@ -347,21 +349,23 @@ impl Share {
 
 impl Write for Share {
     fn write(&self, buf: &mut impl BufMut) {
-        self.index.write(buf);
+        UInt(self.index).write(buf);
         self.private.write(buf);
     }
 }
 
 impl Read for Share {
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
-        let index = u32::read(buf)?;
+        let index = UInt::read(buf)?.into();
         let private = Private::read(buf)?;
         Ok(Self { index, private })
     }
 }
 
-impl FixedSize for Share {
-    const SIZE: usize = u32::SIZE + Private::SIZE;
+impl EncodeSize for Share {
+    fn encode_size(&self) -> usize {
+        UInt(self.index).encode_size() + self.private.encode_size()
+    }
 }
 
 impl Display for Share {

--- a/examples/bridge/src/types/inbound.rs
+++ b/examples/bridge/src/types/inbound.rs
@@ -165,8 +165,10 @@ impl<D: Digest> Read for PutFinalization<D> {
     }
 }
 
-impl<D: Digest> FixedSize for PutFinalization<D> {
-    const SIZE: usize = group::Public::SIZE + Finalization::<D>::SIZE;
+impl<D: Digest> EncodeSize for PutFinalization<D> {
+    fn encode_size(&self) -> usize {
+        self.network.encode_size() + self.finalization.encode_size()
+    }
 }
 
 /// Message to retrieve the latest finality certificate from the indexer's storage.

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -197,7 +197,8 @@ mod tests {
     use super::*;
     use crate::index::translator::{FourCap, TwoCap};
     use crate::journal::Error as JournalError;
-    use commonware_codec::{DecodeExt, Error as CodecError};
+    use commonware_codec::varint::UInt;
+    use commonware_codec::{DecodeExt, EncodeSize, Error as CodecError};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
     use commonware_utils::array::FixedBytes;
@@ -398,7 +399,7 @@ mod tests {
                 .open("test_partition", &section.to_be_bytes())
                 .await
                 .unwrap();
-            let value_location = 4 + 8 + 64 + 4;
+            let value_location = 4 /* journal size */ + UInt(1u64).encode_size() as u64 /* index */ + 64 + 4 /* value length */;
             blob.write_at(b"testdaty", value_location).await.unwrap();
             blob.close().await.unwrap();
 


### PR DESCRIPTION
Fixes #765 

Also fixes some other types that should be varint instead in:
- `cryptography`
- `examples`
- `p2p`
- `stream` 