### PR TITLE
[storage/index] Optimize `Translator` Usage

### DIFF
--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -25,6 +25,9 @@ use std::hash::{BuildHasher, Hash};
 /// distributed, the performance of [Index] will degrade substantially.
 pub trait Translator: Clone + BuildHasher {
     /// The type of the internal representation of keys.
+    ///
+    /// Although `Translator` is a [BuildHasher], the `Key` type must still implement [Hash] for compatibility
+    /// with the [std::collections::HashMap] used internally by [Index].
     type Key: Eq + Hash;
 
     /// Transform a key into its internal representation.

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -21,10 +21,11 @@ use std::hash::{BuildHasher, Hash};
 ///
 /// # Warning
 ///
-/// If invoking `transform` on keys results in many conflicts, the performance of `Index` will
-/// degrade substantially.
+/// The output of `transform` is used as the key in a hash table. If the output is not uniformly
+/// distributed, the performance of [Index] will degrade substantially.
 pub trait Translator: Clone + BuildHasher {
-    type Key: Eq + Hash + Send + Sync + Clone;
+    /// The type of the internal representation of keys.
+    type Key: Eq + Hash;
 
     /// Transform a key into its internal representation.
     fn transform(&self, key: &[u8]) -> Self::Key;

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -15,7 +15,7 @@ mod storage;
 pub use storage::{Index, RemoveValueIterator, UpdateValueIterator, ValueIterator};
 pub mod translator;
 
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 
 /// Translate keys into an internal representation used by `Index`.
 ///
@@ -23,7 +23,7 @@ use std::hash::Hash;
 ///
 /// If invoking `transform` on keys results in many conflicts, the performance of `Index` will
 /// degrade substantially.
-pub trait Translator: Clone {
+pub trait Translator: Clone + BuildHasher {
     type Key: Eq + Hash + Send + Sync + Clone;
 
     /// Transform a key into its internal representation.

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -205,7 +205,7 @@ impl<V> Record<V> {
 /// An index that maps translated keys to values.
 pub struct Index<T: Translator, V> {
     translator: T,
-    map: HashMap<T::Key, Record<V>>,
+    map: HashMap<T::Key, Record<V>, T>,
 
     collisions: Counter,
     keys_pruned: Counter,
@@ -215,8 +215,8 @@ impl<T: Translator, V> Index<T, V> {
     /// Create a new index.
     pub fn init(context: impl Metrics, translator: T) -> Self {
         let s = Self {
-            translator,
-            map: HashMap::new(),
+            translator: translator.clone(),
+            map: HashMap::with_capacity_and_hasher(0, translator),
             collisions: Counter::default(),
             keys_pruned: Counter::default(),
         };

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -9,6 +9,11 @@ use std::{
     mem::swap,
 };
 
+/// The initial capacity of the hashmap. This is a guess at the number of unique keys we will
+/// encounter. The hashmap will grow as needed, but this is a good starting point (covering
+/// the entire [super::translator::OneCap] range).
+const INITIAL_CAPACITY: usize = 256;
+
 /// Each key is mapped to a `Record` that contains a linked list of potential values for the key.
 ///
 /// In the common case of a single value associated with a key, the value is stored within the
@@ -216,7 +221,7 @@ impl<T: Translator, V> Index<T, V> {
     pub fn init(context: impl Metrics, translator: T) -> Self {
         let s = Self {
             translator: translator.clone(),
-            map: HashMap::with_capacity_and_hasher(0, translator),
+            map: HashMap::with_capacity_and_hasher(INITIAL_CAPACITY, translator),
             collisions: Counter::default(),
             keys_pruned: Counter::default(),
         };

--- a/storage/src/index/translator.rs
+++ b/storage/src/index/translator.rs
@@ -29,6 +29,7 @@ macro_rules! define_cap_translator {
     };
 }
 
+define_cap_translator!(OneCap, 1);
 define_cap_translator!(TwoCap, 2);
 define_cap_translator!(FourCap, 4);
 define_cap_translator!(EightCap, 8);
@@ -36,6 +37,15 @@ define_cap_translator!(EightCap, 8);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_one_cap() {
+        let translator = OneCap;
+        assert_eq!(translator.transform(b""), [0]);
+        assert_eq!(translator.transform(b"a"), [b'a']);
+        assert_eq!(translator.transform(b"ab"), [b'a']);
+        assert_eq!(translator.transform(b"abc"), [b'a']);
+    }
 
     #[test]
     fn test_two_cap() {

--- a/storage/src/index/translator.rs
+++ b/storage/src/index/translator.rs
@@ -24,7 +24,7 @@ pub struct IdentityHasher {
 impl Hasher for IdentityHasher {
     #[inline]
     fn write(&mut self, _: &[u8]) {
-        unreachable!("we should only ever call type-specific write methods");
+        unimplemented!("we should only ever call type-specific write methods");
     }
 
     #[inline]

--- a/storage/src/index/translator.rs
+++ b/storage/src/index/translator.rs
@@ -69,7 +69,7 @@ fn cap<const N: usize>(key: &[u8]) -> [u8; N] {
 
 macro_rules! define_cap_translator {
     ($name:ident, $size:expr, $int:ty) => {
-        #[doc = concat!("Translator that caps the key to ", stringify!($size), " byte(s) and returns it packed in a " ,stringify!($int), ". HashMap uses an identity hasher, so no extra hashing work.")]
+        #[doc = concat!("Translator that caps the key to ", stringify!($size), " byte(s) and returns it packed in a ", stringify!($int), ".")]
         #[derive(Clone, Default)]
         pub struct $name;
 

--- a/storage/src/index/translator.rs
+++ b/storage/src/index/translator.rs
@@ -69,13 +69,7 @@ fn cap<const N: usize>(key: &[u8]) -> [u8; N] {
 
 macro_rules! define_cap_translator {
     ($name:ident, $size:expr, $int:ty) => {
-        #[doc = concat!(
-                                    "Translator that caps the key to ",
-                                    stringify!($size),
-                                    " byte(s) and returns it packed in a ",
-                                    stringify!($int),
-                                    ". HashMap uses an identity hasher, so no extra hashing work."
-                                )]
+        #[doc = concat!("Translator that caps the key to ", stringify!($size), " byte(s) and returns it packed in a " ,stringify!($int), ". HashMap uses an identity hasher, so no extra hashing work.")]
         #[derive(Clone, Default)]
         pub struct $name;
 

--- a/storage/src/index/translator.rs
+++ b/storage/src/index/translator.rs
@@ -105,6 +105,7 @@ define_cap_translator!(EightCap, 8, u64);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::hash::Hasher;
 
     #[test]
     fn test_one_cap() {
@@ -149,5 +150,12 @@ mod tests {
             t.transform(b"abcdefghijk").to_le_bytes(),
             [b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h']
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "we should only ever call type-specific write methods")]
+    fn identity_hasher_panics_on_write_slice() {
+        let mut h = UintIdentity::default();
+        h.write(b"not an int");
     }
 }


### PR DESCRIPTION
This pull request refactors the `Translator` trait and its usage in the `Index` structure to improve performance and flexibility by incorporating the `BuildHasher` trait. Additionally, it introduces a new `IdentityHasher` implementation and updates the `cap` translators to use minimal integer types. Below are the key changes grouped by theme:

### Translator Trait Enhancements:
* Updated the `Translator` trait to implement `BuildHasher` and revised its documentation to clarify the performance implications of non-uniform key distributions. The `Key` type now must implement `Hash` for compatibility with `HashMap`. (`storage/src/index/mod.rs`, [storage/src/index/mod.rsL18-R31](diffhunk://#diff-2dd4d6b8fcf070743f9f820bdd9f212fee2852197f80474e097c2394179ce46dL18-R31))

### Index Structure Updates:
* Modified the `Index` structure to include the `Translator` as the hasher for its internal `HashMap`. This change ensures that the `HashMap` uses the `IdentityHasher` provided by the `Translator`. (`storage/src/index/storage.rs`, [storage/src/index/storage.rsL208-R208](diffhunk://#diff-243f4106360c326c987804cdb0538080bfd6bc162301e961dd2dde2b56f6b1aeL208-R208))
* Updated the `init` method of `Index` to initialize the `HashMap` with the `Translator` as its custom hasher. (`storage/src/index/storage.rs`, [storage/src/index/storage.rsL218-R219](diffhunk://#diff-243f4106360c326c987804cdb0538080bfd6bc162301e961dd2dde2b56f6b1aeL218-R219))

### IdentityHasher Implementation:
* Introduced the `IdentityHasher`, a custom hasher that avoids re-hashing already hashed keys, improving efficiency when used with `HashMap`. This implementation is specialized for `u8`, `u16`, `u32`, and `u64` types. (`storage/src/index/translator.rs`, [storage/src/index/translator.rsR1-R54](diffhunk://#diff-15bd611e82988a69f521d94373e5229884e34b4037433b35443c91848a5633ecR1-R54))

### Cap Translators Refactoring:
* Refactored the `cap` translators to use minimal integer types (`u8`, `u16`, `u32`, `u64`) for capped keys, reducing memory usage. Each translator now implements `BuildHasher` with the `IdentityHasher`. (`storage/src/index/translator.rs`, [storage/src/index/translator.rsR69-R154](diffhunk://#diff-15bd611e82988a69f521d94373e5229884e34b4037433b35443c91848a5633ecR69-R154))

### Tests Update:
* Updated and expanded the tests for the `cap` translators to validate the new implementation using minimal integer types and the `IdentityHasher`. (`storage/src/index/translator.rs`, [storage/src/index/translator.rsR69-R154](diffhunk://#diff-15bd611e82988a69f521d94373e5229884e34b4037433b35443c91848a5633ecR69-R154))