### PR TITLE
[runtime] Make Listener an associated type of Network trait

### DIFF
--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -207,7 +207,7 @@ mod tests {
     use commonware_cryptography::{Ed25519, Signer};
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        deterministic, tokio, Clock, Listener, Metrics, Network as RNetwork, Runner, Spawner,
+        deterministic, tokio, Clock, Metrics, Network as RNetwork, Runner, Spawner,
     };
     use governor::{clock::ReasonablyRealtime, Quota};
     use rand::{CryptoRng, Rng};
@@ -231,8 +231,8 @@ mod tests {
     ///
     /// We set a unique `base_port` for each test to avoid "address already in use"
     /// errors when tests are run immediately after each other.
-    async fn run_network<L: Listener>(
-        context: impl Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork<L> + Metrics,
+    async fn run_network(
+        context: impl Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metrics,
         max_message_size: usize,
         base_port: u16,
         n: usize,

--- a/p2p/src/authenticated/network.rs
+++ b/p2p/src/authenticated/network.rs
@@ -9,12 +9,11 @@ use super::{
 use crate::Channel;
 use commonware_cryptography::Scheme;
 use commonware_macros::select;
-use commonware_runtime::{Clock, Handle, Listener, Metrics, Network as RNetwork, Spawner};
+use commonware_runtime::{Clock, Handle, Metrics, Network as RNetwork, Spawner};
 use commonware_stream::public_key;
 use commonware_utils::union;
 use governor::{clock::ReasonablyRealtime, Quota};
 use rand::{CryptoRng, Rng};
-use std::marker::PhantomData;
 use tracing::{debug, info, warn};
 
 /// Unique suffix for all messages signed by the tracker.
@@ -25,8 +24,7 @@ const STREAM_SUFFIX: &[u8] = b"_STREAM";
 
 /// Implementation of an `authenticated` network.
 pub struct Network<
-    L: Listener,
-    E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork<L> + Metrics,
+    E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metrics,
     C: Scheme,
 > {
     context: E,
@@ -37,15 +35,10 @@ pub struct Network<
     tracker_mailbox: tracker::Mailbox<E, C>,
     router: router::Actor<E, C::PublicKey>,
     router_mailbox: router::Mailbox<C::PublicKey>,
-
-    _phantom_l: PhantomData<L>,
 }
 
-impl<
-        L: Listener,
-        E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork<L> + Metrics,
-        C: Scheme,
-    > Network<L, E, C>
+impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metrics, C: Scheme>
+    Network<E, C>
 {
     /// Create a new instance of an `authenticated` network.
     ///
@@ -92,8 +85,6 @@ impl<
                 tracker_mailbox,
                 router,
                 router_mailbox,
-
-                _phantom_l: PhantomData,
             },
             oracle,
         )

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -8,9 +8,7 @@ use crate::{Channel, Message, Recipients};
 use bytes::Bytes;
 use commonware_codec::{DecodeExt, FixedSize};
 use commonware_macros::select;
-use commonware_runtime::{
-    deterministic::Listener, Clock, Handle, Listener as _, Metrics, Network as RNetwork, Spawner,
-};
+use commonware_runtime::{Clock, Handle, Listener as _, Metrics, Network as RNetwork, Spawner};
 use commonware_stream::utils::codec::{recv_frame, send_frame};
 use commonware_utils::Array;
 use futures::{
@@ -37,7 +35,7 @@ pub struct Config {
 }
 
 /// Implementation of a simulated network.
-pub struct Network<E: RNetwork<Listener> + Spawner + Rng + Clock + Metrics, P: Array> {
+pub struct Network<E: RNetwork + Spawner + Rng + Clock + Metrics, P: Array> {
     context: E,
 
     // Maximum size of a message that can be sent over the network
@@ -67,7 +65,7 @@ pub struct Network<E: RNetwork<Listener> + Spawner + Rng + Clock + Metrics, P: A
     sent_messages: Family<metrics::Message, Counter>,
 }
 
-impl<E: RNetwork<Listener> + Spawner + Rng + Clock + Metrics, P: Array> Network<E, P> {
+impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: Array> Network<E, P> {
     /// Create a new simulated network with a given runtime and configuration.
     ///
     /// Returns a tuple containing the network instance and the oracle that can
@@ -488,7 +486,7 @@ impl<P: Array> Peer<P> {
     ///
     /// The peer will listen for incoming connections on the given `socket` address.
     /// `max_size` is the maximum size of a message that can be sent to the peer.
-    fn new<E: Spawner + RNetwork<Listener> + Metrics>(
+    fn new<E: Spawner + RNetwork + Metrics>(
         context: &mut E,
         public_key: P,
         socket: SocketAddr,
@@ -636,7 +634,7 @@ struct Link {
 }
 
 impl Link {
-    fn new<E: Spawner + RNetwork<Listener> + Metrics, P: Array>(
+    fn new<E: Spawner + RNetwork + Metrics, P: Array>(
         context: &mut E,
         dialer: P,
         socket: SocketAddr,

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1223,8 +1223,10 @@ impl Networking {
     }
 }
 
-impl crate::Network<Listener> for Context {
-    async fn bind(&self, socket: SocketAddr) -> Result<Listener, Error> {
+impl crate::Network for Context {
+    type Listener = Listener;
+
+    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, Error> {
         self.networking.bind(socket)
     }
 

--- a/runtime/src/telemetry/metrics/server.rs
+++ b/runtime/src/telemetry/metrics/server.rs
@@ -29,7 +29,7 @@ where
 }
 
 /// Serve metrics over HTTP (on all methods and paths) for the given address.
-pub async fn serve<L: Listener, C: Metrics + Network<L>>(context: C, address: SocketAddr) {
+pub async fn serve<C: Metrics + Network>(context: C, address: SocketAddr) {
     let mut listener = context
         .bind(address)
         .await

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -463,7 +463,9 @@ impl GClock for Context {
 
 impl ReasonablyRealtime for Context {}
 
-impl crate::Network<Listener> for Context {
+impl crate::Network for Context {
+    type Listener = Listener;
+
     async fn bind(&self, socket: SocketAddr) -> Result<Listener, Error> {
         TcpListener::bind(socket)
             .await
@@ -474,7 +476,16 @@ impl crate::Network<Listener> for Context {
             })
     }
 
-    async fn dial(&self, socket: SocketAddr) -> Result<(Sink, Stream), Error> {
+    async fn dial(
+        &self,
+        socket: SocketAddr,
+    ) -> Result<
+        (
+            <<Self as crate::Network>::Listener as crate::Listener>::Sink,
+            <<Self as crate::Network>::Listener as crate::Listener>::Stream,
+        ),
+        Error,
+    > {
         // Create a new TCP stream
         let stream = TcpStream::connect(socket)
             .await


### PR DESCRIPTION
A network is not actually generic over some listener -- the network implementation chooses the listener implementation -- so we should use an associated type here.