### PR TITLE
[runtime] nit: remove unneded ` from [doc::links]

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -394,7 +394,7 @@ enum State {
     Context(Context),
 }
 
-/// Implementation of [`crate::Runner`] for the `deterministic` runtime.
+/// Implementation of [crate::Runner] for the `deterministic` runtime.
 pub struct Runner {
     state: State,
 }
@@ -722,8 +722,8 @@ impl Tasks {
     }
 }
 
-/// Implementation of [`crate::Spawner`], [`crate::Clock`],
-/// [`crate::Network`], and [`crate::Storage`] for the `deterministic`
+/// Implementation of [crate::Spawner], [crate::Clock],
+/// [crate::Network], and [crate::Storage] for the `deterministic`
 /// runtime.
 pub struct Context {
     label: String,
@@ -1128,7 +1128,7 @@ type Dialable = mpsc::UnboundedSender<(
     mocks::Stream, // Dialer -> Listener
 )>;
 
-/// Implementation of [`crate::Network`] for the `deterministic` runtime.
+/// Implementation of [crate::Network] for the `deterministic` runtime.
 ///
 /// When a dialer connects to a listener, the listener is given a new ephemeral port
 /// from the range `32768..61000`. To keep things simple, it is not possible to
@@ -1233,7 +1233,7 @@ impl crate::Network<Listener, Sink, Stream> for Context {
     }
 }
 
-/// Implementation of [`crate::Listener`] for the `deterministic` runtime.
+/// Implementation of [crate::Listener] for the `deterministic` runtime.
 pub struct Listener {
     metrics: Arc<Metrics>,
     auditor: Arc<Auditor>,
@@ -1264,7 +1264,7 @@ impl crate::Listener<Sink, Stream> for Listener {
     }
 }
 
-/// Implementation of [`crate::Sink`] for the `deterministic` runtime.
+/// Implementation of [crate::Sink] for the `deterministic` runtime.
 pub struct Sink {
     metrics: Arc<Metrics>,
     auditor: Arc<Auditor>,
@@ -1282,7 +1282,7 @@ impl crate::Sink for Sink {
     }
 }
 
-/// Implementation of [`crate::Stream`] for the `deterministic` runtime.
+/// Implementation of [crate::Stream] for the `deterministic` runtime.
 pub struct Stream {
     auditor: Arc<Auditor>,
     me: SocketAddr,

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -180,7 +180,7 @@ pub struct Executor {
     signal: Signal,
 }
 
-/// Implementation of [`crate::Runner`] for the `tokio` runtime.
+/// Implementation of [crate::Runner] for the `tokio` runtime.
 pub struct Runner {
     cfg: Config,
 }
@@ -248,8 +248,8 @@ impl crate::Runner for Runner {
     }
 }
 
-/// Implementation of [`crate::Spawner`], [`crate::Clock`],
-/// [`crate::Network`], and [`crate::Storage`] for the `tokio`
+/// Implementation of [crate::Spawner], [crate::Clock],
+/// [crate::Network], and [crate::Storage] for the `tokio`
 /// runtime.
 pub struct Context {
     label: String,
@@ -501,7 +501,7 @@ impl crate::Network<Listener, Sink, Stream> for Context {
     }
 }
 
-/// Implementation of [`crate::Listener`] for the `tokio` runtime.
+/// Implementation of [crate::Listener] for the `tokio` runtime.
 pub struct Listener {
     context: Context,
     listener: TcpListener,
@@ -548,7 +548,7 @@ impl axum::serve::Listener for Listener {
     }
 }
 
-/// Implementation of [`crate::Sink`] for the `tokio` runtime.
+/// Implementation of [crate::Sink] for the `tokio` runtime.
 pub struct Sink {
     context: Context,
     sink: OwnedWriteHalf,
@@ -573,7 +573,7 @@ impl crate::Sink for Sink {
     }
 }
 
-/// Implementation of [`crate::Stream`] for the `tokio` runtime.
+/// Implementation of [crate::Stream] for the `tokio` runtime.
 pub struct Stream {
     context: Context,
     stream: OwnedReadHalf,

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -373,10 +373,10 @@ pub fn create_pool<S: Spawner + Metrics>(
 /// ```
 pub struct RwLock<T>(async_lock::RwLock<T>);
 
-/// Shared guard returned by [`RwLock::read`].
+/// Shared guard returned by [RwLock::read].
 pub type RwLockReadGuard<'a, T> = async_lock::RwLockReadGuard<'a, T>;
 
-/// Exclusive guard returned by [`RwLock::write`].
+/// Exclusive guard returned by [RwLock::write].
 pub type RwLockWriteGuard<'a, T> = async_lock::RwLockWriteGuard<'a, T>;
 
 impl<T> RwLock<T> {


### PR DESCRIPTION
These backticks aren't needed, and I don't see them used this way in other libraries.