### PR TITLE
[resolver] Use Metrics, Not `WARN` Logs to Communicate Errors

### DIFF
--- a/p2p/src/utils/requester/metrics.rs
+++ b/p2p/src/utils/requester/metrics.rs
@@ -1,6 +1,6 @@
 //! Metrics for the requester.
 
-use commonware_runtime::telemetry::metrics::histogram::Buckets;
+use commonware_runtime::telemetry::metrics::{histogram::Buckets, status};
 use commonware_utils::Array;
 use prometheus_client::{
     encoding::EncodeLabelSet,
@@ -26,8 +26,8 @@ impl PeerLabel {
 /// Metrics for the requester.
 #[derive(Debug)]
 pub struct Metrics {
-    /// Number of requests made.
-    pub requests: Counter,
+    /// Number of requests created.
+    pub created: status::Counter,
     /// Number of requests that timed out.
     pub timeouts: Counter,
     /// Number and duration of requests that were resolved.
@@ -40,15 +40,15 @@ impl Metrics {
     /// Create and return a new set of metrics, registered with the given registry.
     pub fn init<M: commonware_runtime::Metrics>(registry: M) -> Self {
         let metrics = Self {
-            requests: Counter::default(),
+            created: status::Counter::default(),
             timeouts: Counter::default(),
             resolves: Histogram::new(Buckets::NETWORK.into_iter()),
             performance: Family::default(),
         };
         registry.register(
             "requests",
-            "Number of requests made",
-            metrics.requests.clone(),
+            "Number of requests created",
+            metrics.created.clone(),
         );
         registry.register(
             "timeouts",

--- a/p2p/src/utils/requester/metrics.rs
+++ b/p2p/src/utils/requester/metrics.rs
@@ -4,7 +4,7 @@ use commonware_runtime::telemetry::metrics::{histogram::Buckets, status};
 use commonware_utils::Array;
 use prometheus_client::{
     encoding::EncodeLabelSet,
-    metrics::{counter::Counter, family::Family, gauge::Gauge, histogram::Histogram},
+    metrics::{family::Family, gauge::Gauge, histogram::Histogram},
 };
 
 /// Label for peer metrics.
@@ -26,11 +26,11 @@ impl PeerLabel {
 /// Metrics for the requester.
 #[derive(Debug)]
 pub struct Metrics {
-    /// Number of requests created.
+    /// Status of all request creation attempts.
     pub created: status::Counter,
-    /// Number of requests that timed out.
-    pub timeouts: Counter,
-    /// Number and duration of requests that were resolved.
+    /// Status of all requests that were successfully created.
+    pub results: status::Counter,
+    /// Number and duration of requests that were successfully resolved.
     pub resolves: Histogram,
     /// Performance of each peer
     pub performance: Family<PeerLabel, Gauge>,
@@ -41,19 +41,19 @@ impl Metrics {
     pub fn init<M: commonware_runtime::Metrics>(registry: M) -> Self {
         let metrics = Self {
             created: status::Counter::default(),
-            timeouts: Counter::default(),
+            results: status::Counter::default(),
             resolves: Histogram::new(Buckets::NETWORK.into_iter()),
             performance: Family::default(),
         };
         registry.register(
-            "requests",
-            "Number of requests created",
+            "created",
+            "Status of all request creation attempts",
             metrics.created.clone(),
         );
         registry.register(
-            "timeouts",
-            "Number of requests that timed out",
-            metrics.timeouts.clone(),
+            "results",
+            "Status of all requests that were successfully created",
+            metrics.results.clone(),
         );
         registry.register(
             "resolves",

--- a/p2p/src/utils/requester/metrics.rs
+++ b/p2p/src/utils/requester/metrics.rs
@@ -29,7 +29,7 @@ pub struct Metrics {
     /// Status of all request creation attempts.
     pub created: status::Counter,
     /// Status of all requests that were successfully created.
-    pub results: status::Counter,
+    pub requests: status::Counter,
     /// Number and duration of requests that were successfully resolved.
     pub resolves: Histogram,
     /// Performance of each peer
@@ -41,7 +41,7 @@ impl Metrics {
     pub fn init<M: commonware_runtime::Metrics>(registry: M) -> Self {
         let metrics = Self {
             created: status::Counter::default(),
-            results: status::Counter::default(),
+            requests: status::Counter::default(),
             resolves: Histogram::new(Buckets::NETWORK.into_iter()),
             performance: Family::default(),
         };
@@ -51,9 +51,9 @@ impl Metrics {
             metrics.created.clone(),
         );
         registry.register(
-            "results",
+            "requests",
             "Status of all requests that were successfully created",
-            metrics.results.clone(),
+            metrics.requests.clone(),
         );
         registry.register(
             "resolves",

--- a/p2p/src/utils/requester/requester.rs
+++ b/p2p/src/utils/requester/requester.rs
@@ -216,14 +216,23 @@ impl<E: Clock + GClock + Rng + Metrics, P: Array> Requester<E, P> {
 
         // Update performance
         self.update(request.participant, elapsed);
+        self.metrics.results.inc(Status::Success);
         self.metrics.resolves.observe(elapsed.as_secs_f64());
     }
 
     /// Timeout an outstanding request.
     pub fn timeout(&mut self, request: Request<P>) {
-        // Update performance
         self.update(request.participant, self.timeout);
-        self.metrics.timeouts.inc();
+        self.metrics.results.inc(Status::Timeout);
+    }
+
+    /// Fail an outstanding request and penalize the request
+    /// participant with the timeout duration.
+    ///
+    /// This is used when we fail to send a request to a participant.
+    pub fn fail(&mut self, request: Request<P>) {
+        self.update(request.participant, self.timeout);
+        self.metrics.results.inc(Status::Failure);
     }
 
     /// Get the next outstanding ID and deadline.

--- a/p2p/src/utils/requester/requester.rs
+++ b/p2p/src/utils/requester/requester.rs
@@ -216,14 +216,14 @@ impl<E: Clock + GClock + Rng + Metrics, P: Array> Requester<E, P> {
 
         // Update performance
         self.update(request.participant, elapsed);
-        self.metrics.results.inc(Status::Success);
+        self.metrics.requests.inc(Status::Success);
         self.metrics.resolves.observe(elapsed.as_secs_f64());
     }
 
     /// Timeout an outstanding request.
     pub fn timeout(&mut self, request: Request<P>) {
         self.update(request.participant, self.timeout);
-        self.metrics.results.inc(Status::Timeout);
+        self.metrics.requests.inc(Status::Timeout);
     }
 
     /// Fail an outstanding request and penalize the request
@@ -232,7 +232,7 @@ impl<E: Clock + GClock + Rng + Metrics, P: Array> Requester<E, P> {
     /// This is used when we fail to send a request to a participant.
     pub fn fail(&mut self, request: Request<P>) {
         self.update(request.participant, self.timeout);
-        self.metrics.results.inc(Status::Failure);
+        self.metrics.requests.inc(Status::Failure);
     }
 
     /// Get the next outstanding ID and deadline.

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -108,7 +108,7 @@ impl<
         let (sender, receiver) = mpsc::channel(cfg.mailbox_size);
         let metrics = metrics::Metrics::init(context.clone());
         let fetcher = Fetcher::new(
-            context.clone(),
+            context.with_label("fetcher"),
             cfg.requester_config,
             cfg.fetch_retry_timeout,
             cfg.priority_requests,

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -28,7 +28,7 @@ use futures::{
 use governor::clock::Clock as GClock;
 use rand::Rng;
 use std::{collections::HashMap, marker::PhantomData};
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, trace};
 
 /// Represents a pending serve operation.
 struct Serve<E: Clock, P: Array> {
@@ -316,7 +316,7 @@ impl<
         // Log result, but do not handle errors
         match result {
             Err(err) => error!(?err, ?peer, ?id, "serve send failed"),
-            Ok(to) if to.is_empty() => warn!(?peer, ?id, "serve send failed"),
+            Ok(to) if to.is_empty() => debug!(?peer, ?id, "serve send failed"),
             Ok(_) => trace!(?peer, ?id, "serve sent"),
         };
     }

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -28,7 +28,7 @@ use futures::{
 use governor::clock::Clock as GClock;
 use rand::Rng;
 use std::{collections::HashMap, marker::PhantomData};
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 
 /// Represents a pending serve operation.
 struct Serve<E: Clock, P: Array> {
@@ -316,7 +316,7 @@ impl<
         // Log result, but do not handle errors
         match result {
             Err(err) => error!(?err, ?peer, ?id, "serve send failed"),
-            Ok(to) if to.is_empty() => debug!(?peer, ?id, "serve send failed"),
+            Ok(to) if to.is_empty() => warn!(?peer, ?id, "serve send failed"),
             Ok(_) => trace!(?peer, ?id, "serve sent"),
         };
     }

--- a/resolver/src/p2p/fetcher.rs
+++ b/resolver/src/p2p/fetcher.rs
@@ -16,7 +16,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use thiserror::Error;
-use tracing::warn;
+use tracing::debug;
 
 /// Errors that can occur when sending network messages.
 #[derive(Error, Debug, PartialEq)]
@@ -104,7 +104,7 @@ impl<E: Clock + GClock + Rng + Metrics, P: Array, Key: Array, NetS: Sender<Publi
         let shuffle = !is_new;
         let Some((peer, id)) = self.requester.request(shuffle) else {
             // If there are no peers, add the key to the pending queue
-            warn!(?key, "requester failed");
+            debug!(?key, "requester failed");
             self.add_pending(key);
             return;
         };
@@ -130,7 +130,7 @@ impl<E: Clock + GClock + Rng + Metrics, P: Array, Key: Array, NetS: Sender<Publi
         match result {
             // If the message was not sent successfully, treat it instantly as a peer timeout
             Err(err) => {
-                warn!(?err, ?peer, "send failed");
+                debug!(?err, ?peer, "send failed");
                 let req = self.requester.handle(&peer, id).unwrap(); // Unwrap is safe
                 self.requester.timeout(req);
                 self.add_pending(key);

--- a/resolver/src/p2p/fetcher.rs
+++ b/resolver/src/p2p/fetcher.rs
@@ -132,7 +132,7 @@ impl<E: Clock + GClock + Rng + Metrics, P: Array, Key: Array, NetS: Sender<Publi
             Err(err) => {
                 debug!(?err, ?peer, "send failed");
                 let req = self.requester.handle(&peer, id).unwrap(); // Unwrap is safe
-                self.requester.timeout(req);
+                self.requester.fail(req);
                 self.add_pending(key);
             }
             // If the message was sent to someone, add the request to the map

--- a/runtime/src/telemetry/metrics/status.rs
+++ b/runtime/src/telemetry/metrics/status.rs
@@ -24,6 +24,8 @@ pub enum Status {
     /// Input was valid, but intentionally not processed.
     /// For example due to a rate limit, being a duplicate, etc.
     Dropped,
+    /// Processing returned no result before some deadline.
+    Timeout,
 }
 
 /// A counter metric with a status label.


### PR DESCRIPTION
On `INFO`, 99% of logs come from `resolver` "failed to send" `WARN` logs (we start making requests before network connections are fully established).

This PR reduces per-request logging largely to `DEBUG` (and adds a metric to better track failed request creation).