### PR TITLE
[storage/index] Fix `drop_in_place` Panic (Remove `unsafe`)

### DIFF
--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -167,7 +167,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher> Any<E, K, V,
             let op: Operation<K, V> = log.read(i).await?;
             match op.to_type() {
                 Type::Deleted(key) => {
-                    let mut loc_iter = snapshot.remove_iter(&key);
+                    let mut loc_iter = snapshot.mut_iter(&key);
                     while let Some(loc) = loc_iter.next() {
                         let op = log.read(*loc).await?;
                         if op.to_key() == key {
@@ -205,7 +205,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher> Any<E, K, V,
         value: Option<&V>,
         new_loc: u64,
     ) -> Result<bool, Error> {
-        let mut loc_iter = snapshot.update_iter(&key);
+        let mut loc_iter = snapshot.mut_iter(&key);
         for loc in &mut loc_iter {
             let op = log.read(*loc).await?;
             if op.to_key() == key {
@@ -234,7 +234,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher> Any<E, K, V,
 
     /// Get the value of `key` in the db, or None if it has no value.
     pub async fn get(&self, key: &K) -> Result<Option<V>, Error> {
-        for loc in self.snapshot.get_iter(key) {
+        for loc in self.snapshot.iter(key) {
             let op = self.log.read(*loc).await?;
             match op.to_type() {
                 Type::Update(k, v) => {
@@ -295,24 +295,30 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher> Any<E, K, V,
     /// The operation is reflected in the snapshot, but will be subject to rollback until the next
     /// successful `commit`.
     pub async fn delete(&mut self, hasher: &mut H, key: K) -> Result<(), Error> {
-        let mut loc_iter = self.snapshot.remove_iter(&key);
-        for loc in &mut loc_iter {
-            let op = self.log.read(*loc).await?;
-            match op.to_type() {
-                Type::Update(k, _) => {
-                    if k == key {
-                        loc_iter.remove();
-                        self.apply_op(hasher, Operation::delete(key)).await?;
-                        return Ok(());
+        let mut op_found = false;
+        {
+            let mut loc_iter = self.snapshot.mut_iter(&key);
+            for loc in &mut loc_iter {
+                let op = self.log.read(*loc).await?;
+                match op.to_type() {
+                    Type::Update(k, _) => {
+                        if k == key {
+                            loc_iter.remove();
+                            op_found = true;
+                            break;
+                        }
+                    }
+                    _ => {
+                        unreachable!(
+                            "snapshot should only reference update operations. key={}",
+                            key
+                        );
                     }
                 }
-                _ => {
-                    unreachable!(
-                        "snapshot should only reference update operations. key={}",
-                        key
-                    );
-                }
             }
+        }
+        if op_found {
+            self.apply_op(hasher, Operation::delete(key)).await?;
         }
 
         // The key wasn't in the snapshot, so this is a no-op.
@@ -442,7 +448,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher> Any<E, K, V,
     ) -> Result<(), Error> {
         let key = op.to_key();
         let new_loc = self.op_count();
-        let loc_iter = self.snapshot.update_iter(&key);
+        let loc_iter = self.snapshot.mut_iter(&key);
         let mut loc_found = false;
         for loc in loc_iter {
             if *loc == old_loc {
@@ -899,7 +905,7 @@ mod test {
 
             // Simulate a failed commit and test that the log replay doesn't leave behind old data.
             let db = open_db(context.clone(), &mut hasher).await;
-            let iter = db.snapshot.get_iter(&k);
+            let iter = db.snapshot.iter(&k);
             assert_eq!(iter.cloned().collect::<Vec<_>>().len(), 1);
             assert_eq!(db.root(&mut hasher), root);
         });

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -227,14 +227,9 @@ impl<T: Translator, E: Storage + Metrics, K: Array, VC: CodecConfig + Copy, V: C
         // Store interval
         self.intervals.insert(index..=index);
 
-        // Store item
-        self.keys.insert(&key, index);
-
-        // Cleanup tracked keys
-        //
-        // We call this after insertion to avoid unnecessary underlying map
-        // operations.
-        self.keys.remove(&key, |index| *index < oldest_allowed);
+        // Insert and prune any useless keys
+        self.keys
+            .insert_and_prune(&key, index, |v| *v < oldest_allowed);
 
         // Update pending writes
         let pending_writes = self.pending.entry(section).or_default();
@@ -284,7 +279,7 @@ impl<T: Translator, E: Storage + Metrics, K: Array, VC: CodecConfig + Copy, V: C
         self.gets.inc();
 
         // Fetch index
-        let iter = self.keys.get_iter(key);
+        let iter = self.keys.iter(key);
         let min_allowed = self.oldest_allowed.unwrap_or(0);
         for index in iter {
             // Continue if index is no longer allowed due to pruning.

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -279,7 +279,7 @@ impl<T: Translator, E: Storage + Metrics, K: Array, VC: CodecConfig + Copy, V: C
         self.gets.inc();
 
         // Fetch index
-        let iter = self.keys.iter(key);
+        let iter = self.keys.get(key);
         let min_allowed = self.oldest_allowed.unwrap_or(0);
         for index in iter {
             // Continue if index is no longer allowed due to pruning.

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -378,17 +378,16 @@ mod tests {
             index.insert(b"key", i);
         }
 
-        // Remove middle: [3, 0]
+        // Remove middle: [0, 1]
         {
             let mut cursor = index.get_mut(b"key").unwrap();
             assert_eq!(*cursor.next().unwrap(), 0); // head
             assert_eq!(*cursor.next().unwrap(), 3); // middle
             cursor.delete();
+            assert_eq!(*cursor.next().unwrap(), 2); // middle
+            cursor.delete();
         }
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![0, 2, 1]
-        );
+        assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![0, 1]);
     }
 
     #[test_traced]

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -77,31 +77,31 @@ mod tests {
         assert!(index.is_empty());
     }
 
-    // #[test_traced]
-    // fn test_index_many_keys() {
-    //     let mut context = deterministic::Context::default();
-    //     let mut index = Index::init(context.clone(), TwoCap);
+    #[test_traced]
+    fn test_index_many_keys() {
+        let mut context = deterministic::Context::default();
+        let mut index = Index::init(context.clone(), TwoCap);
 
-    //     // Insert enough keys to generate some collisions, then confirm each value we inserted
-    //     // remains retrievable.
-    //     let mut expected = HashMap::new();
-    //     const NUM_KEYS: usize = 2000; // enough to generate some collisions
-    //     while expected.len() < NUM_KEYS {
-    //         let mut key_array = [0u8; 32];
-    //         context.fill(&mut key_array);
-    //         let key = key_array.to_vec();
+        // Insert enough keys to generate some collisions, then confirm each value we inserted
+        // remains retrievable.
+        let mut expected = HashMap::new();
+        const NUM_KEYS: usize = 2000; // enough to generate some collisions
+        while expected.len() < NUM_KEYS {
+            let mut key_array = [0u8; 32];
+            context.fill(&mut key_array);
+            let key = key_array.to_vec();
 
-    //         let loc = expected.len() as u64;
-    //         index.insert(&key, loc);
-    //         expected.insert(key, loc);
-    //     }
+            let loc = expected.len() as u64;
+            index.insert(&key, loc);
+            expected.insert(key, loc);
+        }
 
-    //     for (key, loc) in expected.iter() {
-    //         let mut values = index.get_iter(key);
-    //         let res = values.find(|i| *i == loc);
-    //         assert!(res.is_some());
-    //     }
-    // }
+        for (key, loc) in expected.iter() {
+            let mut values = index.get_iter(key);
+            let res = values.find(|i| *i == loc);
+            assert!(res.is_some());
+        }
+    }
 
     #[test_traced]
     fn test_index_key_lengths_and_collisions() {
@@ -397,55 +397,55 @@ mod tests {
         );
     }
 
-    // #[test_traced]
-    // fn test_index_many_conflicts() {
-    //     let context = deterministic::Context::default();
-    //     let mut index = Index::init(context.clone(), OneCap);
+    #[test_traced]
+    fn test_index_many_conflicts() {
+        let context = deterministic::Context::default();
+        let mut index = Index::init(context.clone(), OneCap);
 
-    //     // Add 1000 entries to the same key (pruning 100 behind)
-    //     let key = b"key";
-    //     for i in 0..1000 {
-    //         index.insert(key, i);
+        // Add 1000 entries to the same key (pruning 100 behind)
+        let key = b"key";
+        for i in 0..1000 {
+            index.insert(key, i);
 
-    //         if i < 100 {
-    //             continue;
-    //         }
-    //         let lower_bound = i - 100;
-    //         index.remove(key, |v| *v < lower_bound);
-    //         assert_eq!(
-    //             (lower_bound..=i).rev().collect::<Vec<_>>(),
-    //             index.get_iter(key).copied().collect::<Vec<_>>()
-    //         );
-    //     }
+            if i < 100 {
+                continue;
+            }
+            let lower_bound = i - 100;
+            index.remove(key, |v| *v < lower_bound);
+            assert_eq!(
+                (lower_bound..=i).rev().collect::<Vec<_>>(),
+                index.get_iter(key).copied().collect::<Vec<_>>()
+            );
+        }
 
-    //     // Remove everything
-    //     index.remove(key, |v| *v < 1000);
-    //     assert!(index.get_iter(key).collect::<Vec<_>>().is_empty());
+        // Remove everything
+        index.remove(key, |v| *v < 1000);
+        assert!(index.get_iter(key).collect::<Vec<_>>().is_empty());
 
-    //     // Add again
-    //     for i in 1000..2000 {
-    //         index.insert(key, i);
-    //         if i < 1100 {
-    //             continue;
-    //         }
-    //         let lower_bound = i - 100;
-    //         index.remove(key, |v| *v < lower_bound);
-    //         assert_eq!(
-    //             (lower_bound..=i).rev().collect::<Vec<_>>(),
-    //             index.get_iter(key).copied().collect::<Vec<_>>()
-    //         );
-    //     }
-    // }
+        // Add again
+        for i in 1000..2000 {
+            index.insert(key, i);
+            if i < 1100 {
+                continue;
+            }
+            let lower_bound = i - 100;
+            index.remove(key, |v| *v < lower_bound);
+            assert_eq!(
+                (lower_bound..=i).rev().collect::<Vec<_>>(),
+                index.get_iter(key).copied().collect::<Vec<_>>()
+            );
+        }
+    }
 
-    // #[test_traced]
-    // fn test_index_chain_workload() {
-    //     let mut context = deterministic::Context::default();
-    //     let mut index = Index::init(context.clone(), OneCap);
+    #[test_traced]
+    fn test_index_chain_workload() {
+        let mut context = deterministic::Context::default();
+        let mut index = Index::init(context.clone(), OneCap);
 
-    //     for i in 0..10_000u64 {
-    //         let key = context.gen_range(0..u8::MAX);
-    //         index.insert(&key.to_be_bytes(), i);
-    //         index.remove(&key.to_be_bytes(), |v| *v < i.saturating_sub(25));
-    //     }
-    // }
+        for i in 0..10_000u64 {
+            let key = context.gen_range(0..u8::MAX);
+            index.insert(&key.to_be_bytes(), i);
+            index.remove(&key.to_be_bytes(), |v| *v < i.saturating_sub(25));
+        }
+    }
 }

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -77,31 +77,31 @@ mod tests {
         assert!(index.is_empty());
     }
 
-    #[test_traced]
-    fn test_index_many_keys() {
-        let mut context = deterministic::Context::default();
-        let mut index = Index::init(context.clone(), TwoCap);
+    // #[test_traced]
+    // fn test_index_many_keys() {
+    //     let mut context = deterministic::Context::default();
+    //     let mut index = Index::init(context.clone(), TwoCap);
 
-        // Insert enough keys to generate some collisions, then confirm each value we inserted
-        // remains retrievable.
-        let mut expected = HashMap::new();
-        const NUM_KEYS: usize = 2000; // enough to generate some collisions
-        while expected.len() < NUM_KEYS {
-            let mut key_array = [0u8; 32];
-            context.fill(&mut key_array);
-            let key = key_array.to_vec();
+    //     // Insert enough keys to generate some collisions, then confirm each value we inserted
+    //     // remains retrievable.
+    //     let mut expected = HashMap::new();
+    //     const NUM_KEYS: usize = 2000; // enough to generate some collisions
+    //     while expected.len() < NUM_KEYS {
+    //         let mut key_array = [0u8; 32];
+    //         context.fill(&mut key_array);
+    //         let key = key_array.to_vec();
 
-            let loc = expected.len() as u64;
-            index.insert(&key, loc);
-            expected.insert(key, loc);
-        }
+    //         let loc = expected.len() as u64;
+    //         index.insert(&key, loc);
+    //         expected.insert(key, loc);
+    //     }
 
-        for (key, loc) in expected.iter() {
-            let mut values = index.get_iter(key);
-            let res = values.find(|i| *i == loc);
-            assert!(res.is_some());
-        }
-    }
+    //     for (key, loc) in expected.iter() {
+    //         let mut values = index.get_iter(key);
+    //         let res = values.find(|i| *i == loc);
+    //         assert!(res.is_some());
+    //     }
+    // }
 
     #[test_traced]
     fn test_index_key_lengths_and_collisions() {
@@ -397,45 +397,45 @@ mod tests {
         );
     }
 
-    #[test_traced]
-    fn test_index_many_conflicts() {
-        let context = deterministic::Context::default();
-        let mut index = Index::init(context.clone(), OneCap);
+    // #[test_traced]
+    // fn test_index_many_conflicts() {
+    //     let context = deterministic::Context::default();
+    //     let mut index = Index::init(context.clone(), OneCap);
 
-        // Add 1000 entries to the same key (pruning 100 behind)
-        let key = b"key";
-        for i in 0..1000 {
-            index.insert(key, i);
+    //     // Add 1000 entries to the same key (pruning 100 behind)
+    //     let key = b"key";
+    //     for i in 0..1000 {
+    //         index.insert(key, i);
 
-            if i < 100 {
-                continue;
-            }
-            let lower_bound = i - 100;
-            index.remove(key, |v| *v < lower_bound);
-            assert_eq!(
-                (lower_bound..=i).rev().collect::<Vec<_>>(),
-                index.get_iter(key).copied().collect::<Vec<_>>()
-            );
-        }
+    //         if i < 100 {
+    //             continue;
+    //         }
+    //         let lower_bound = i - 100;
+    //         index.remove(key, |v| *v < lower_bound);
+    //         assert_eq!(
+    //             (lower_bound..=i).rev().collect::<Vec<_>>(),
+    //             index.get_iter(key).copied().collect::<Vec<_>>()
+    //         );
+    //     }
 
-        // Remove everything
-        index.remove(key, |v| *v < 1000);
-        assert!(index.get_iter(key).collect::<Vec<_>>().is_empty());
+    //     // Remove everything
+    //     index.remove(key, |v| *v < 1000);
+    //     assert!(index.get_iter(key).collect::<Vec<_>>().is_empty());
 
-        // Add again
-        for i in 1000..2000 {
-            index.insert(key, i);
-            if i < 1100 {
-                continue;
-            }
-            let lower_bound = i - 100;
-            index.remove(key, |v| *v < lower_bound);
-            assert_eq!(
-                (lower_bound..=i).rev().collect::<Vec<_>>(),
-                index.get_iter(key).copied().collect::<Vec<_>>()
-            );
-        }
-    }
+    //     // Add again
+    //     for i in 1000..2000 {
+    //         index.insert(key, i);
+    //         if i < 1100 {
+    //             continue;
+    //         }
+    //         let lower_bound = i - 100;
+    //         index.remove(key, |v| *v < lower_bound);
+    //         assert_eq!(
+    //             (lower_bound..=i).rev().collect::<Vec<_>>(),
+    //             index.get_iter(key).copied().collect::<Vec<_>>()
+    //         );
+    //     }
+    // }
 
     // #[test_traced]
     // fn test_index_chain_workload() {

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -37,12 +37,11 @@ pub trait Translator: Clone + BuildHasher {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::index::translator::TwoCap;
+    use crate::index::translator::{OneCap, TwoCap};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Metrics};
     use rand::Rng;
     use std::collections::HashMap;
-    use translator::OneCap;
 
     #[test_traced]
     fn test_index_basic() {
@@ -437,4 +436,16 @@ mod tests {
             );
         }
     }
+
+    // #[test_traced]
+    // fn test_index_chain_workload() {
+    //     let mut context = deterministic::Context::default();
+    //     let mut index = Index::init(context.clone(), OneCap);
+
+    //     for i in 0..10_000u64 {
+    //         let key = context.gen_range(0..u8::MAX);
+    //         index.insert(&key.to_be_bytes(), i);
+    //         index.remove(&key.to_be_bytes(), |v| *v < i.saturating_sub(25));
+    //     }
+    // }
 }

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -403,13 +403,13 @@ mod tests {
         // Remove middle: []
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 0); // head
+            assert_eq!(*cursor.next().unwrap(), 0);
             cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 3); // middle
+            assert_eq!(*cursor.next().unwrap(), 3);
             cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 2); // tail
+            assert_eq!(*cursor.next().unwrap(), 2);
             cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 1); // tail
+            assert_eq!(*cursor.next().unwrap(), 1);
             cursor.delete();
             assert_eq!(cursor.next(), None);
             assert!(cursor.empty());
@@ -429,19 +429,21 @@ mod tests {
         // Remove middle: [4, 5]
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 0); // head
+            assert_eq!(*cursor.next().unwrap(), 0);
             cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 3); // middle
+            assert_eq!(*cursor.next().unwrap(), 3);
             cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 2); // tail
+            assert_eq!(*cursor.next().unwrap(), 2);
             cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 1); // tail
+            assert_eq!(*cursor.next().unwrap(), 1);
             cursor.delete();
             assert_eq!(cursor.next(), None);
             cursor.insert(4);
             cursor.insert(5);
             assert!(!cursor.empty());
         }
+
+        // Ensure remaining values are correct
         assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![4, 5]);
     }
 

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -495,7 +495,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn dangling_vec_pointer() {
+    fn test_dangling_item() {
         let ctx = deterministic::Context::default();
         let mut ix = Index::<TwoCap, i32>::init(ctx, TwoCap);
         let kb = b"k";

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -373,4 +373,27 @@ mod tests {
         assert!(iter.next().is_none());
         assert!(context.encode().contains("collisions_total 5"));
     }
+
+    #[test_traced]
+    fn test_index_remove_middle_then_next() {
+        let context = deterministic::Context::default();
+        let mut index = Index::init(context.clone(), TwoCap);
+
+        // Build list: [3, 2, 1, 0]
+        for i in 0..4 {
+            index.insert(b"key", i);
+        }
+
+        // Remove middle: [3, 0]
+        let mut iter = index.remove_iter(b"key");
+        assert_eq!(*iter.next().unwrap(), 3); // head (kept)
+        assert_eq!(*iter.next().unwrap(), 2); // middle (removed)
+        iter.remove();
+        assert_eq!(*iter.next().unwrap(), 1); // middle (removed)
+        iter.remove();
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![3, 0]
+        );
+    }
 }

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -493,4 +493,25 @@ mod tests {
         assert!(ctx.encode().contains("collisions_total 2"));
         assert!(ctx.encode().contains("pruned_total 2"));
     }
+
+    #[test_traced]
+    fn dangling_vec_pointer() {
+        let ctx = deterministic::Context::default();
+        let mut ix = Index::<TwoCap, i32>::init(ctx, TwoCap);
+        let kb = b"k";
+
+        // Create a Vec with two elements
+        ix.insert(kb, 1);
+        ix.insert(kb, 2);
+
+        // Create a dangling pointer to the second element
+        let mut it = ix.mut_iter(kb);
+        let dangling = it.next().unwrap(); // &mut 2
+
+        // Remove the item we have a reference to
+        it.remove();
+
+        // Attempt to mutate the reference
+        *dangling = 99;
+    }
 }

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -118,25 +118,19 @@ impl<'a, T: Translator, V> std::iter::Iterator for MutableIterator<'a, T, V> {
 }
 
 impl<T: Translator, V> MutableIterator<'_, T, V> {
-    /// Insert a new value at the start of the iterator.
-    ///
-    /// This operation will prevent the iterator from being used again (although
-    /// it is possible to call `insert()` multiple times).
+    /// Insert a new value at the translated key.
     ///
     /// If you want to instead update some existing value, use `next()` to get a mutable reference
     /// and then update it directly.
     ///
-    /// This is more efficient than calling `index::insert()` after iteration.
-    pub fn insert(&mut self, v: V) {
+    /// This is more efficient than calling `index::insert()` after dropping
+    /// `MutableIterator`.
+    pub fn insert(self, v: V) {
         self.values.push(v);
         let values_len = self.values.len();
         if values_len > 1 {
             self.collisions.inc();
         }
-
-        // Stop the iterator.
-        self.idx = 0;
-        self.last_idx = None;
     }
 
     /// Remove the last value returned by `next()` (swapping it with the most recently added value for the


### PR DESCRIPTION
Replaces: #861 

When testing `alto`, I saw:

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000c0c94e3f5bb0 in core::ptr::drop_in_place<alloc::boxed::Box<commonware_storage::index::storage::Record<u64>>> ()
[Current thread is 1 (Thread 0xfd436476ee40 (LWP 4177))]
```

I have no idea which `archive` this was in (or what the pattern is to reproduce it) but it appears our `unsafe` code isn't right.

## TODO

- [x] Make `insert()` consume mutable iterator