### PR TITLE
[commonware-storage/index] fix unsafe bugs in Update & Remove iterators, and repeated-removal bug in Remove iterator.

### DIFF
--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -296,7 +296,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher> Any<E, K, V,
     /// successful `commit`.
     pub async fn delete(&mut self, hasher: &mut H, key: K) -> Result<(), Error> {
         let mut loc_iter = self.snapshot.remove_iter(&key);
-        for loc in &mut loc_iter {
+        while let Some(loc) = loc_iter.next() {
             let op = self.log.read(*loc).await?;
             match op.to_type() {
                 Type::Update(k, _) => {

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -373,4 +373,28 @@ mod tests {
         assert!(iter.next().is_none());
         assert!(context.encode().contains("collisions_total 5"));
     }
+
+    #[test_traced]
+    fn test_index_remove_middle_then_next() {
+        let context = deterministic::Context::default();
+        let mut index = Index::init(context.clone(), TwoCap);
+
+        // Build list: [3, 2, 1, 0]
+        for i in 0..4 {
+            index.insert(b"key", i);
+        }
+
+        // Remove middle: [3, 0]
+        let mut iter = index.remove_iter(b"key");
+        assert_eq!(*iter.next().unwrap(), 3); // head (kept)
+        assert_eq!(*iter.next().unwrap(), 2); // middle (removed)
+        iter.remove();
+        assert_eq!(*iter.next().unwrap(), 1); // middle (removed)
+        iter.remove();
+        assert_eq!(*iter.next().unwrap(), 0); // middle (removed)
+        assert_eq!(
+            index.get_iter(b"key").copied().collect::<Vec<_>>(),
+            vec![3, 0]
+        );
+    }
 }


### PR DESCRIPTION
- Fixes cases where a Record pointed to by the iterators could end up getting modified through another path, which cargo miri was flagging.

- Fixes buggy logic that couldn't handle repeated remove() calls.

- Copied failing test over from https://github.com/commonwarexyz/monorepo/pull/858, confirmed it's now passing.