### PR TITLE
Implemented common function for default seed

### DIFF
--- a/consensus/src/ordered_broadcast/ack_manager.rs
+++ b/consensus/src/ordered_broadcast/ack_manager.rs
@@ -161,13 +161,14 @@ mod tests {
         use crate::ordered_broadcast::types::Chunk;
         use commonware_codec::{DecodeExt, FixedSize};
         use commonware_cryptography::bls12381::primitives::group::Share;
+        use commonware_utils::default_seed;
         use rand::{rngs::StdRng, SeedableRng as _};
 
         const NAMESPACE: &[u8] = b"1234";
 
         /// Generate shares using a seeded RNG.
         pub fn setup_shares(num_validators: u32, quorum: u32) -> Vec<Share> {
-            let mut rng = StdRng::seed_from_u64(0);
+            let mut rng = StdRng::seed_from_u64(default_seed());
             let (_identity, shares) = generate_shares(&mut rng, None, num_validators, quorum);
             shares
         }

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -71,7 +71,7 @@ mod tests {
         Metrics,
     };
     use commonware_runtime::{Clock, Runner, Spawner};
-    use commonware_utils::quorum;
+    use commonware_utils::{default_seed, quorum};
     use futures::channel::oneshot;
     use futures::future::join_all;
     use rand::{rngs::StdRng, SeedableRng as _};
@@ -356,7 +356,7 @@ mod tests {
     fn test_unclean_shutdown() {
         let num_validators: u32 = 4;
         let quorum: u32 = 3;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
         let (identity, mut shares_vec) =
             ops::generate_shares(&mut rng, None, num_validators, quorum);
         shares_vec.sort_by(|a, b| a.index.cmp(&b.index));

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -164,13 +164,14 @@ pub mod mocks;
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use crate::Monitor;
     use commonware_cryptography::{bls12381::dkg::ops, Ed25519, Sha256, Signer};
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{deterministic, Clock, Metrics, Runner, Spawner};
-    use commonware_utils::{quorum, Array};
+    use commonware_utils::{default_seed, quorum, Array};
     use engine::Engine;
     use futures::{future::join_all, StreamExt};
     use governor::Quota;
@@ -518,7 +519,7 @@ mod tests {
         let namespace = b"consensus".to_vec();
 
         // Derive threshold
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
         let (public, shares) = ops::generate_shares(&mut rng, None, n, threshold);
 
         // Random restarts every x seconds

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::bls12381::dkg::{Dealer, Player};
 use commonware_cryptography::{Ed25519, Signer};
-use commonware_utils::quorum;
+use commonware_utils::{default_seed, quorum};
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -11,7 +11,7 @@ use std::hint::black_box;
 const CONCURRENCY: usize = 1;
 
 fn benchmark_dkg_recovery(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(default_seed());
     for &n in &[5, 10, 20, 50, 100, 250, 500] {
         let t = quorum(n);
         c.bench_function(&format!("{}/n={} t={}", module_path!(), n, t), |b| {

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -2,14 +2,14 @@ use commonware_cryptography::{
     bls12381::dkg::{Dealer, Player},
     Ed25519, Signer,
 };
-use commonware_utils::quorum;
+use commonware_utils::{default_seed, quorum};
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
 use std::collections::HashMap;
 use std::hint::black_box;
 
 fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(default_seed());
     for &n in &[5, 10, 20, 50, 100, 250, 500] {
         // Perform DKG
         //

--- a/cryptography/src/bls12381/benches/threshold_signature_recover.rs
+++ b/cryptography/src/bls12381/benches/threshold_signature_recover.rs
@@ -1,11 +1,11 @@
 use commonware_cryptography::bls12381::{dkg, primitives};
-use commonware_utils::quorum;
+use commonware_utils::{default_seed, quorum};
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
 use std::hint::black_box;
 
 fn benchmark_threshold_signature_recover(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(default_seed());
     let namespace = b"benchmark";
     let msg = b"hello";
     for &n in &[5, 10, 20, 50, 100, 250, 500] {

--- a/cryptography/src/bls12381/dkg/mod.rs
+++ b/cryptography/src/bls12381/dkg/mod.rs
@@ -192,14 +192,14 @@ mod tests {
     };
     use crate::bls12381::primitives::poly::public;
     use crate::{Ed25519, Signer};
-    use commonware_utils::quorum;
+    use commonware_utils::{default_seed, quorum};
     use rand::rngs::StdRng;
     use rand::SeedableRng;
     use std::collections::HashMap;
 
     fn run_dkg_and_reshare(n_0: u32, dealers_0: u32, n_1: u32, dealers_1: u32, concurrency: usize) {
         // Create shared RNG (for reproducibility)
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -462,7 +462,7 @@ mod tests {
     fn test_invalid_commitment() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -497,7 +497,7 @@ mod tests {
     fn test_mismatched_commitment() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -537,7 +537,7 @@ mod tests {
     fn test_mismatched_share() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -581,7 +581,7 @@ mod tests {
     fn test_duplicate_share() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -621,7 +621,7 @@ mod tests {
     fn test_misdirected_share() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -656,7 +656,7 @@ mod tests {
     fn test_invalid_dealer() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -695,7 +695,7 @@ mod tests {
     fn test_invalid_commitment_degree() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -741,7 +741,7 @@ mod tests {
     fn test_reveal() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -772,7 +772,7 @@ mod tests {
         // Initialize test
         let n = 11;
         let q = quorum(n as u32) as usize;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -824,7 +824,7 @@ mod tests {
     fn test_duplicate_commitment() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -863,7 +863,7 @@ mod tests {
     fn test_reveal_duplicate_player() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -893,7 +893,7 @@ mod tests {
     fn test_insufficient_active() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -932,7 +932,7 @@ mod tests {
     fn test_manual_disqualify() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -965,7 +965,7 @@ mod tests {
     fn test_too_many_reveals() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -995,7 +995,7 @@ mod tests {
     fn test_incorrect_reveal() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1029,7 +1029,7 @@ mod tests {
     fn test_reveal_corrupt_share() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1063,7 +1063,7 @@ mod tests {
     fn test_reveal_duplicate_ack() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1093,7 +1093,7 @@ mod tests {
     fn test_reveal_invalid_ack() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1123,7 +1123,7 @@ mod tests {
     fn test_reveal_invalid_share() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1157,7 +1157,7 @@ mod tests {
     fn test_dealer_acks() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1185,7 +1185,7 @@ mod tests {
     fn test_dealer_inactive() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1213,7 +1213,7 @@ mod tests {
     fn test_dealer_insufficient() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1239,7 +1239,7 @@ mod tests {
     fn test_dealer_duplicate_ack() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1265,7 +1265,7 @@ mod tests {
     fn test_dealer_invalid_player() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1289,7 +1289,7 @@ mod tests {
         // Initialize test
         let n = 11;
         let q = quorum(n as u32) as usize;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1332,7 +1332,7 @@ mod tests {
         // Initialize test
         let n = 11;
         let q = quorum(n as u32) as usize;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1373,7 +1373,7 @@ mod tests {
     fn test_player_insufficient_commitments() {
         // Initialize test
         let n = 5;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1412,7 +1412,7 @@ mod tests {
         // Initialize test
         let n = 11;
         let q = quorum(n as u32) as usize;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1456,7 +1456,7 @@ mod tests {
         // Initialize test
         let n = 11;
         let q = quorum(n as u32) as usize;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();
@@ -1500,7 +1500,7 @@ mod tests {
         // Initialize test
         let n = 11;
         let q = quorum(n as u32) as usize;
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create contributors (must be in sorted order)
         let mut contributors = Vec::new();

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -14,6 +14,7 @@ pub use scheme::{Bls12381, PrivateKey, PublicKey, Signature};
 #[cfg(test)]
 mod tests {
     use super::*;
+    use commonware_utils::default_seed;
     use dkg::ops::generate_shares;
     use primitives::group::Private;
     use primitives::ops::{
@@ -26,7 +27,7 @@ mod tests {
     #[test]
     fn test_partial_aggregate_signature() {
         let (n, t) = (5, 4);
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create the private key polynomial and evaluate it at `n`
         // points to generate the shares.
@@ -57,7 +58,7 @@ mod tests {
     #[test]
     fn test_partial_aggregate_signature_bad_namespace() {
         let (n, t) = (5, 4);
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create the private key polynomial and evaluate it at `n`
         // points to generate the shares.
@@ -95,7 +96,7 @@ mod tests {
     #[test]
     fn test_partial_aggregate_signature_insufficient() {
         let (n, t) = (5, 4);
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create the private key polynomial and evaluate it at `n`
         // points to generate the shares
@@ -128,7 +129,7 @@ mod tests {
     #[should_panic(expected = "InvalidSignature")]
     fn test_partial_aggregate_signature_bad_share() {
         let (n, t) = (5, 4);
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
 
         // Create the private key polynomial and evaluate it at `n`
         // points to generate the shares

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -395,7 +395,7 @@ mod tests {
     use crate::bls12381::dkg::ops::generate_shares;
     use blst::BLST_ERROR;
     use commonware_codec::DecodeExt;
-    use commonware_utils::quorum;
+    use commonware_utils::{default_seed, quorum};
     use group::{G1, G1_MESSAGE, G1_PROOF_OF_POSSESSION};
     use rand::prelude::*;
 
@@ -454,7 +454,7 @@ mod tests {
     fn test_threshold_proof_of_possession() {
         // Generate PoP
         let (n, t) = (5, 4);
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
         let (public, shares) = generate_shares(&mut rng, None, n, t);
         let partials: Vec<_> = shares
             .iter()
@@ -545,7 +545,7 @@ mod tests {
     fn test_threshold_message() {
         // Generate signature
         let (n, t) = (5, 4);
-        let mut rng = StdRng::seed_from_u64(0);
+        let mut rng = StdRng::seed_from_u64(default_seed());
         let (public, shares) = generate_shares(&mut rng, None, n, t);
         let msg = &[1, 9, 6, 9];
         let namespace = b"test";

--- a/cryptography/src/sha256/benches/hash_message.rs
+++ b/cryptography/src/sha256/benches/hash_message.rs
@@ -1,9 +1,10 @@
 use commonware_cryptography::{Hasher, Sha256};
+use commonware_utils::default_seed;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
 fn benchmark_hash_message(c: &mut Criterion) {
-    let mut sampler = StdRng::seed_from_u64(0);
+    let mut sampler = StdRng::seed_from_u64(default_seed());
     for message_length in [100, 1000, 10000].into_iter() {
         let mut msg = vec![0u8; message_length];
         sampler.fill_bytes(msg.as_mut_slice());

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -8,7 +8,7 @@ use commonware_deployer::ec2::{Hosts, METRICS_PORT};
 use commonware_flood::Config;
 use commonware_p2p::{authenticated, Receiver, Recipients, Sender};
 use commonware_runtime::{tokio, Metrics, Runner, Spawner};
-use commonware_utils::{from_hex_formatted, union};
+use commonware_utils::{default_seed, from_hex_formatted, union};
 use futures::future::try_join_all;
 use governor::Quota;
 use prometheus_client::metrics::counter::Counter;
@@ -144,7 +144,7 @@ fn main() {
         let flood_sender = context
             .with_label("flood_sender")
             .spawn(move |context| async move {
-                let mut rng = StdRng::seed_from_u64(0);
+                let mut rng = StdRng::seed_from_u64(default_seed());
                 let messages: Counter<u64, AtomicU64> = Counter::default();
                 context.register("messages", "Sent messages", messages.clone());
                 loop {

--- a/storage/src/archive/benches/get.rs
+++ b/storage/src/archive/benches/get.rs
@@ -7,6 +7,7 @@ use commonware_runtime::{
     Runner,
 };
 use commonware_storage::archive::Identifier;
+use commonware_utils::default_seed;
 use criterion::{black_box, criterion_group, Criterion};
 use futures::future::try_join_all;
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -16,7 +17,7 @@ use std::time::Instant;
 const ITEMS: u64 = 250_000;
 
 fn select_keys(keys: &[Key], reads: usize) -> Vec<Key> {
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(default_seed());
     let mut selected_keys = Vec::with_capacity(reads);
     for _ in 0..reads {
         selected_keys.push(keys[rng.gen_range(0..ITEMS as usize)].clone());
@@ -25,7 +26,7 @@ fn select_keys(keys: &[Key], reads: usize) -> Vec<Key> {
 }
 
 fn select_indices(reads: usize) -> Vec<u64> {
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(default_seed());
     let mut selected_indices = Vec::with_capacity(reads);
     for _ in 0..reads {
         selected_indices.push(rng.gen_range(0..ITEMS));

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -5,7 +5,7 @@ use commonware_storage::{
     archive::{Archive, Config},
     index::translator::TwoCap,
 };
-use commonware_utils::array::FixedBytes;
+use commonware_utils::{array::FixedBytes, default_seed};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
 /// Partition used across all archive benchmarks.
@@ -42,7 +42,7 @@ pub async fn get_archive(ctx: Context, compression: Option<u8>) -> ArchiveType {
 
 /// Append `count` random (index,key,value) triples and sync once.
 pub async fn append_random(archive: &mut ArchiveType, count: u64) -> Vec<Key> {
-    let mut rng = StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(default_seed());
     let mut key_buf = [0u8; 64];
     let mut val_buf = [0u8; 32];
 

--- a/storage/src/bmt/benches/build.rs
+++ b/storage/src/bmt/benches/build.rs
@@ -1,5 +1,6 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_storage::bmt::Builder;
+use commonware_utils::default_seed;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -7,7 +8,7 @@ fn bench_new(c: &mut Criterion) {
     for n in [100, 1_000, 5_000, 10_000, 25_000, 50_000, 100_000] {
         // Generate random elements
         let mut elements = Vec::with_capacity(n);
-        let mut sampler = StdRng::seed_from_u64(0);
+        let mut sampler = StdRng::seed_from_u64(default_seed());
         for _ in 0..n {
             let element = Sha256::random(&mut sampler);
             elements.push(element);

--- a/storage/src/bmt/benches/prove_single_element.rs
+++ b/storage/src/bmt/benches/prove_single_element.rs
@@ -1,5 +1,6 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_storage::bmt::Builder;
+use commonware_utils::default_seed;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
@@ -10,7 +11,7 @@ fn bench_prove_single_element(c: &mut Criterion) {
         // Populate Binary Merkle Tree
         let mut builder = Builder::<Sha256>::new(n);
         let mut queries = Vec::with_capacity(n);
-        let mut sampler = StdRng::seed_from_u64(0);
+        let mut sampler = StdRng::seed_from_u64(default_seed());
         for pos in 0..n {
             let element = Sha256::random(&mut sampler);
             builder.add(&element);

--- a/storage/src/journal/benches/bench.rs
+++ b/storage/src/journal/benches/bench.rs
@@ -1,6 +1,6 @@
 use commonware_runtime::tokio::Context;
 use commonware_storage::journal::fixed::{Config as JConfig, Journal};
-use commonware_utils::array::FixedBytes;
+use commonware_utils::{array::FixedBytes, default_seed};
 use criterion::criterion_main;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
@@ -36,7 +36,7 @@ async fn append_random_data<const ITEM_SIZE: usize>(
     items_to_write: u64,
 ) {
     // Append `items_to_write` random items to the journal.
-    let mut rng = StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(default_seed());
     let mut arr = [0; ITEM_SIZE];
     for _ in 0..items_to_write {
         rng.fill_bytes(&mut arr);

--- a/storage/src/journal/benches/fixed_read_random.rs
+++ b/storage/src/journal/benches/fixed_read_random.rs
@@ -5,7 +5,7 @@ use commonware_runtime::{
     Runner as _,
 };
 use commonware_storage::journal::fixed::Journal;
-use commonware_utils::array::FixedBytes;
+use commonware_utils::{array::FixedBytes, default_seed};
 use criterion::{black_box, criterion_group, Criterion};
 use futures::future::try_join_all;
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -26,7 +26,7 @@ const ITEM_SIZE: usize = 32;
 /// Read `items_to_read` random items from the given `journal`, awaiting each
 /// result before continuing.
 async fn bench_run_serial(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, items_to_read: usize) {
-    let mut rng = StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(default_seed());
     for _ in 0..items_to_read {
         let pos = rng.gen_range(0..ITEMS_TO_WRITE);
         black_box(journal.read(pos).await.expect("failed to read data"));
@@ -38,7 +38,7 @@ async fn bench_run_concurrent(
     journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
 ) {
-    let mut rng = StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(default_seed());
     let mut futures = Vec::with_capacity(items_to_read);
     for _ in 0..items_to_read {
         let pos = rng.gen_range(0..ITEMS_TO_WRITE);

--- a/storage/src/mmr/benches/append.rs
+++ b/storage/src/mmr/benches/append.rs
@@ -1,5 +1,6 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_storage::mmr::mem::Mmr;
+use commonware_utils::default_seed;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -7,7 +8,7 @@ fn bench_append(c: &mut Criterion) {
     for n in [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000] {
         // Generate random elements
         let mut elements = Vec::with_capacity(n);
-        let mut sampler = StdRng::seed_from_u64(0);
+        let mut sampler = StdRng::seed_from_u64(default_seed());
         for _ in 0..n {
             let element = Sha256::random(&mut sampler);
             elements.push(element);

--- a/storage/src/mmr/benches/append_additional.rs
+++ b/storage/src/mmr/benches/append_additional.rs
@@ -1,5 +1,6 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_storage::mmr::mem::Mmr;
+use commonware_utils::default_seed;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -7,7 +8,7 @@ fn bench_append_additional(c: &mut Criterion) {
     for n in [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000] {
         // Generate random elements
         let mut elements = Vec::with_capacity(n);
-        let mut sampler = StdRng::seed_from_u64(0);
+        let mut sampler = StdRng::seed_from_u64(default_seed());
         for _ in 0..n {
             let element = Sha256::random(&mut sampler);
             elements.push(element);

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -1,5 +1,6 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_storage::mmr::mem::Mmr;
+use commonware_utils::default_seed;
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -12,7 +13,7 @@ fn bench_prove_many_elements(c: &mut Criterion) {
         let mut mmr = Mmr::<Sha256>::new();
         let mut positions = Vec::with_capacity(n);
         let mut elements = Vec::with_capacity(n);
-        let mut sampler = StdRng::seed_from_u64(0);
+        let mut sampler = StdRng::seed_from_u64(default_seed());
         let mut hasher = Sha256::new();
         for i in 0..n {
             let element = Sha256::random(&mut sampler);

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -1,5 +1,6 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_storage::mmr::mem::Mmr;
+use commonware_utils::default_seed;
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -11,7 +12,7 @@ fn bench_prove_single_element(c: &mut Criterion) {
         // Populate MMR
         let mut mmr = Mmr::<Sha256>::new();
         let mut elements = Vec::with_capacity(n);
-        let mut sampler = StdRng::seed_from_u64(0);
+        let mut sampler = StdRng::seed_from_u64(default_seed());
         let mut hasher = Sha256::new();
         for _ in 0..n {
             let element = Sha256::random(&mut sampler);

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -93,6 +93,13 @@ pub fn modulo(bytes: &[u8], n: u64) -> u64 {
     result
 }
 
+/// Gets the seed from the `COMMONWARE_DEFAULT_SEED` or 0 if not set or parsing as a `u64` fails
+pub fn default_seed() -> u64 {
+    option_env!("COMMONWARE_DEFAULT_SEED")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Addresses https://github.com/commonwarexyz/monorepo/issues/846

I found all instances of `StdRng::seed_from_u64()` and replaced them with a new function in `utils` called `default_seed()` that checks for an environment variable `COMMONWARE_DEFAULT_SEED` and defaults to 0 if not set or parsing to `u64` fails. When compiling without the environment variable set, this should optomize away, but I didn't test it.

Note that there were some instances of seeds that were `42`, but will now be `0`. Namely in `./storage/src/archive/benches/get.rs`.