### PR TITLE
[runtime] Separate networking into its own module

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,6 +34,7 @@ cfg_if::cfg_if! {
         pub mod benchmarks;
     }
 }
+mod network;
 mod storage;
 pub mod telemetry;
 mod utils;

--- a/runtime/src/network/metered.rs
+++ b/runtime/src/network/metered.rs
@@ -47,6 +47,7 @@ impl Metrics {
     }
 }
 
+/// Sends using the `inner` sink and tracks metrics for it.
 pub struct Sink<S: crate::Sink> {
     inner: S,
     metrics: Arc<Metrics>,
@@ -60,6 +61,7 @@ impl<S: crate::Sink> crate::Sink for Sink<S> {
     }
 }
 
+/// Receives from the `inner` stream and tracks metrics for it.
 pub struct Stream<S: crate::Stream> {
     inner: S,
     metrics: Arc<Metrics>,
@@ -73,6 +75,8 @@ impl<S: crate::Stream> crate::Stream for Stream<S> {
     }
 }
 
+/// Listens for incoming connections using the `inner` listener
+/// and tracks metrics for it.
 pub struct Listener<L: crate::Listener> {
     inner: L,
     metrics: Arc<Metrics>,

--- a/runtime/src/network/metered.rs
+++ b/runtime/src/network/metered.rs
@@ -1,0 +1,45 @@
+use std::net::SocketAddr;
+
+#[derive(Debug, Clone)]
+struct Network {}
+
+impl crate::Network for Network {
+    type Listener = Listener;
+
+    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, crate::Error> {
+        todo!()
+    }
+
+    async fn dial(&self, socket: SocketAddr) -> Result<(Sink, Stream), crate::Error> {
+        todo!()
+    }
+}
+
+struct Listener {}
+
+impl crate::Listener for Listener {
+    type Stream = Stream;
+    type Sink = Sink;
+
+    async fn accept(
+        &mut self,
+    ) -> Result<(std::net::SocketAddr, Self::Sink, Self::Stream), crate::Error> {
+        todo!()
+    }
+}
+
+struct Sink {}
+
+impl crate::Sink for Sink {
+    async fn send(&mut self, data: &[u8]) -> Result<(), crate::Error> {
+        todo!()
+    }
+}
+
+struct Stream {}
+
+impl crate::Stream for Stream {
+    async fn recv(&mut self, buf: &mut [u8]) -> Result<(), crate::Error> {
+        todo!()
+    }
+}

--- a/runtime/src/network/metered.rs
+++ b/runtime/src/network/metered.rs
@@ -104,18 +104,19 @@ impl<L: crate::Listener> crate::Listener for Listener<L> {
     async fn accept(
         &mut self,
     ) -> Result<(std::net::SocketAddr, Self::Sink, Self::Stream), crate::Error> {
-        self.inner.accept().await.map(|(addr, sink, stream)| {
-            self.metrics.inbound_connections.inc();
-            let sink = Sink {
+        let (addr, sink, stream) = self.inner.accept().await?;
+        self.metrics.inbound_connections.inc();
+        Ok((
+            addr,
+            Sink {
                 inner: sink,
                 metrics: self.metrics.clone(),
-            };
-            let stream = Stream {
+            },
+            Stream {
                 inner: stream,
                 metrics: self.metrics.clone(),
-            };
-            (addr, sink, stream)
-        })
+            },
+        ))
     }
 }
 

--- a/runtime/src/network/metered.rs
+++ b/runtime/src/network/metered.rs
@@ -1,45 +1,146 @@
-use std::net::SocketAddr;
+use crate::{SinkOf, StreamOf};
+use prometheus_client::{metrics::counter::Counter, registry::Registry};
+use std::{net::SocketAddr, sync::Arc};
 
-#[derive(Debug, Clone)]
-struct Network {}
+#[derive(Debug)]
+struct Metrics {
+    inbound_connections: Counter,
+    outbound_connections: Counter,
+    inbound_bandwidth: Counter,
+    outbound_bandwidth: Counter,
+}
 
-impl crate::Network for Network {
-    type Listener = Listener;
-
-    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, crate::Error> {
-        todo!()
-    }
-
-    async fn dial(&self, socket: SocketAddr) -> Result<(Sink, Stream), crate::Error> {
-        todo!()
+impl Metrics {
+    fn new(registry: &mut Registry) -> Self {
+        let metrics = Self {
+            inbound_connections: Counter::default(),
+            outbound_connections: Counter::default(),
+            inbound_bandwidth: Counter::default(),
+            outbound_bandwidth: Counter::default(),
+        };
+        registry.register(
+            "inbound_connections",
+            "Number of connections created by dialing us",
+            metrics.inbound_connections.clone(),
+        );
+        registry.register(
+            "outbound_connections",
+            "Number of connections created by dialing others",
+            metrics.outbound_connections.clone(),
+        );
+        registry.register(
+            "inbound_bandwidth",
+            "Bandwidth used by receiving data from others",
+            metrics.inbound_bandwidth.clone(),
+        );
+        registry.register(
+            "outbound_bandwidth",
+            "Bandwidth used by sending data to others",
+            metrics.outbound_bandwidth.clone(),
+        );
+        metrics
     }
 }
 
-struct Listener {}
+#[derive(Debug, Clone)]
+pub(crate) struct Network<N: crate::Network> {
+    inner: N,
+    metrics: Arc<Metrics>,
+}
 
-impl crate::Listener for Listener {
-    type Stream = Stream;
-    type Sink = Sink;
+impl<N: crate::Network> Network<N> {
+    pub(crate) fn new(inner: N, registry: &mut Registry) -> Self {
+        let metrics = Metrics::new(registry);
+        Self {
+            inner,
+            metrics: Arc::new(metrics),
+        }
+    }
+}
+
+impl<N: crate::Network> crate::Network for Network<N> {
+    type Listener = Listener<N::Listener>;
+
+    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, crate::Error> {
+        let inner = self.inner.bind(socket).await?;
+        Ok(Listener {
+            inner,
+            metrics: self.metrics.clone(),
+        })
+    }
+
+    async fn dial(
+        &self,
+        socket: SocketAddr,
+    ) -> Result<(SinkOf<Self>, StreamOf<Self>), crate::Error> {
+        let (sink, stream) = self.inner.dial(socket).await?;
+        self.metrics.outbound_connections.inc();
+
+        let sink = sink;
+        let sink = Sink {
+            inner: sink,
+            metrics: self.metrics.clone(),
+        };
+
+        let stream = stream;
+        let stream = Stream {
+            inner: stream,
+            metrics: self.metrics.clone(),
+        };
+
+        Ok((sink, stream))
+    }
+}
+
+pub(crate) struct Listener<L: crate::Listener> {
+    inner: L,
+    metrics: Arc<Metrics>,
+}
+
+impl<L: crate::Listener> crate::Listener for Listener<L> {
+    type Sink = Sink<L::Sink>;
+    type Stream = Stream<L::Stream>;
 
     async fn accept(
         &mut self,
     ) -> Result<(std::net::SocketAddr, Self::Sink, Self::Stream), crate::Error> {
-        todo!()
+        self.inner.accept().await.map(|(addr, sink, stream)| {
+            self.metrics.inbound_connections.inc();
+            let sink = Sink {
+                inner: sink,
+                metrics: self.metrics.clone(),
+            };
+            let stream = Stream {
+                inner: stream,
+                metrics: self.metrics.clone(),
+            };
+            (addr, sink, stream)
+        })
     }
 }
 
-struct Sink {}
+pub(crate) struct Sink<S: crate::Sink> {
+    inner: S,
+    metrics: Arc<Metrics>,
+}
 
-impl crate::Sink for Sink {
+impl<S: crate::Sink> crate::Sink for Sink<S> {
     async fn send(&mut self, data: &[u8]) -> Result<(), crate::Error> {
-        todo!()
+        self.inner.send(data).await?;
+        self.metrics.outbound_bandwidth.inc_by(data.len() as u64);
+        Ok(())
     }
 }
 
-struct Stream {}
+pub(crate) struct Stream<S: crate::Stream> {
+    inner: S,
+    metrics: Arc<Metrics>,
+}
 
-impl crate::Stream for Stream {
+impl<S: crate::Stream> crate::Stream for Stream<S> {
     async fn recv(&mut self, buf: &mut [u8]) -> Result<(), crate::Error> {
-        todo!()
+        self.inner.recv(buf).await?;
+        self.metrics.inbound_bandwidth.inc_by(buf.len() as u64);
+        Ok(())
     }
 }

--- a/runtime/src/network/metered.rs
+++ b/runtime/src/network/metered.rs
@@ -43,13 +43,13 @@ impl Metrics {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct Network<N: crate::Network> {
+pub struct Network<N: crate::Network> {
     inner: N,
     metrics: Arc<Metrics>,
 }
 
 impl<N: crate::Network> Network<N> {
-    pub(crate) fn new(inner: N, registry: &mut Registry) -> Self {
+    pub fn new(inner: N, registry: &mut Registry) -> Self {
         let metrics = Metrics::new(registry);
         Self {
             inner,
@@ -92,7 +92,7 @@ impl<N: crate::Network> crate::Network for Network<N> {
     }
 }
 
-pub(crate) struct Listener<L: crate::Listener> {
+pub struct Listener<L: crate::Listener> {
     inner: L,
     metrics: Arc<Metrics>,
 }
@@ -119,7 +119,7 @@ impl<L: crate::Listener> crate::Listener for Listener<L> {
     }
 }
 
-pub(crate) struct Sink<S: crate::Sink> {
+pub struct Sink<S: crate::Sink> {
     inner: S,
     metrics: Arc<Metrics>,
 }
@@ -132,7 +132,7 @@ impl<S: crate::Sink> crate::Sink for Sink<S> {
     }
 }
 
-pub(crate) struct Stream<S: crate::Stream> {
+pub struct Stream<S: crate::Stream> {
     inner: S,
     metrics: Arc<Metrics>,
 }

--- a/runtime/src/network/metered.rs
+++ b/runtime/src/network/metered.rs
@@ -5,9 +5,13 @@ use std::{net::SocketAddr, sync::Arc};
 #[derive(Debug)]
 /// Tracks network metrics.
 struct Metrics {
+    /// Number of connections created by dialing us.
     inbound_connections: Counter,
+    /// Number of connections created by dialing others.
     outbound_connections: Counter,
+    /// Bandwidth used by receiving data from others.
     inbound_bandwidth: Counter,
+    /// Bandwidth used by sending data to others.
     outbound_bandwidth: Counter,
 }
 
@@ -43,6 +47,8 @@ impl Metrics {
     }
 }
 
+/// A metered network implementation which wraps another
+/// [crate::Network] and tracks metrics for it.
 #[derive(Debug, Clone)]
 pub struct Network<N: crate::Network> {
     inner: N,
@@ -104,9 +110,7 @@ impl<L: crate::Listener> crate::Listener for Listener<L> {
     type Sink = Sink<L::Sink>;
     type Stream = Stream<L::Stream>;
 
-    async fn accept(
-        &mut self,
-    ) -> Result<(std::net::SocketAddr, Self::Sink, Self::Stream), crate::Error> {
+    async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), crate::Error> {
         let (addr, sink, stream) = self.inner.accept().await?;
         self.metrics.inbound_connections.inc();
         Ok((

--- a/runtime/src/network/mod.rs
+++ b/runtime/src/network/mod.rs
@@ -1,0 +1,1 @@
+mod tokio;

--- a/runtime/src/network/mod.rs
+++ b/runtime/src/network/mod.rs
@@ -1,1 +1,2 @@
+mod metered;
 mod tokio;

--- a/runtime/src/network/mod.rs
+++ b/runtime/src/network/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod metered;
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod tokio;

--- a/runtime/src/network/mod.rs
+++ b/runtime/src/network/mod.rs
@@ -1,2 +1,2 @@
-mod metered;
-mod tokio;
+pub(crate) mod metered;
+pub(crate) mod tokio;

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -96,11 +96,20 @@ impl axum::serve::Listener for Listener {
 
 #[derive(Clone, Debug)]
 pub(crate) struct Config {
-    /// If given, enables/disables TCP_NODELAY on connections
+    /// Whether or not to disable Nagle's algorithm.
+    ///
+    /// The algorithm combines a series of small network packets into a single packet
+    /// before sending to reduce overhead of sending multiple small packets which might not
+    /// be efficient on slow, congested networks. However, to do so the algorithm introduces
+    /// a slight delay as it waits to accumulate more data. Latency-sensitive networks should
+    /// consider disabling it to send the packets as soon as possible to reduce latency.
+    ///
+    /// Note: Make sure that your compile target has and allows this configuration otherwise
+    /// panics or unexpected behaviours are possible.
     pub(crate) tcp_nodelay: Option<bool>,
-    /// Read timeout for connections
+    /// Read timeout for connections, after which the connection will be closed
     pub(crate) read_timeout: Duration,
-    /// Write timeout for connections
+    /// Write timeout for connections, after which the connection will be closed
     pub(crate) write_timeout: Duration,
 }
 

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -18,6 +18,7 @@ pub struct Sink {
 
 impl crate::Sink for Sink {
     async fn send(&mut self, msg: &[u8]) -> Result<(), Error> {
+        // Time out if we take too long to write
         timeout(self.write_timeout, self.sink.write_all(msg))
             .await
             .map_err(|_| Error::Timeout)?
@@ -34,7 +35,7 @@ pub struct Stream {
 
 impl crate::Stream for Stream {
     async fn recv(&mut self, buf: &mut [u8]) -> Result<(), Error> {
-        // Wait for the stream to be readable
+        // Time out if we take too long to read
         timeout(self.read_timeout, self.stream.read_exact(buf))
             .await
             .map_err(|_| Error::Timeout)?
@@ -80,21 +81,8 @@ impl crate::Listener for Listener {
     }
 }
 
-impl axum::serve::Listener for Listener {
-    type Io = TcpStream;
-    type Addr = SocketAddr;
-
-    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
-        let (stream, addr) = self.listener.accept().await.unwrap();
-        (stream, addr)
-    }
-
-    fn local_addr(&self) -> std::io::Result<Self::Addr> {
-        self.listener.local_addr()
-    }
-}
-
 #[derive(Clone, Debug)]
+/// Configuration for the tokio [Network] implementation of the [crate::Network] trait.
 pub(crate) struct Config {
     /// Whether or not to disable Nagle's algorithm.
     ///

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -178,6 +178,15 @@ pub(crate) struct Network {
     metrics: Arc<Metrics>,
 }
 
+impl Network {
+    pub(crate) fn new(cfg: Config, reg: &mut Registry) -> Self {
+        Self {
+            cfg,
+            metrics: Arc::new(Metrics::new(reg)),
+        }
+    }
+}
+
 impl crate::Network for Network {
     type Listener = Listener;
 

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -102,11 +102,11 @@ impl crate::Stream for Stream {
 #[derive(Clone, Debug)]
 pub(crate) struct Config {
     /// If given, enables/disables TCP_NODELAY on the socket
-    tcp_nodelay: Option<bool>,
+    pub(crate) tcp_nodelay: Option<bool>,
     /// Read timeout for sockets created by this listener
-    read_timeout: Duration,
+    pub(crate) read_timeout: Duration,
     /// Write timeout for sockets created by this listener
-    write_timeout: Duration,
+    pub(crate) write_timeout: Duration,
 }
 
 impl Default for Config {

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -1,0 +1,214 @@
+use crate::Error;
+use prometheus_client::{metrics::counter::Counter, registry::Registry};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+    net::{
+        tcp::{OwnedReadHalf, OwnedWriteHalf},
+        TcpListener, TcpStream,
+    },
+    time::timeout,
+};
+use tracing::warn;
+
+#[derive(Debug)]
+struct Metrics {
+    inbound_connections: Counter,
+    outbound_connections: Counter,
+    inbound_bandwidth: Counter,
+    outbound_bandwidth: Counter,
+}
+
+impl Metrics {
+    fn new(registry: &mut Registry) -> Self {
+        let metrics = Self {
+            inbound_connections: Counter::default(),
+            outbound_connections: Counter::default(),
+            inbound_bandwidth: Counter::default(),
+            outbound_bandwidth: Counter::default(),
+        };
+        registry.register(
+            "inbound_connections",
+            "Number of connections created by dialing us",
+            metrics.inbound_connections.clone(),
+        );
+        registry.register(
+            "outbound_connections",
+            "Number of connections created by dialing others",
+            metrics.outbound_connections.clone(),
+        );
+        registry.register(
+            "inbound_bandwidth",
+            "Bandwidth used by receiving data from others",
+            metrics.inbound_bandwidth.clone(),
+        );
+        registry.register(
+            "outbound_bandwidth",
+            "Bandwidth used by sending data to others",
+            metrics.outbound_bandwidth.clone(),
+        );
+        metrics
+    }
+}
+
+/// Implementation of [crate::Listener] using the [tokio] runtime.
+pub struct Listener {
+    /// If given, enables/disables TCP_NODELAY on the socket
+    tcp_nodelay: Option<bool>,
+    /// Write timeout for sockets created by this listener
+    write_timeout: Duration,
+    /// Read timeout for sockets created by this listener
+    read_timeout: Duration,
+    metrics: Arc<Metrics>,
+    listener: TcpListener,
+}
+
+impl crate::Listener for Listener {
+    type Sink = Sink;
+    type Stream = Stream;
+
+    async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), Error> {
+        // Accept a new TCP stream
+        let (stream, addr) = self.listener.accept().await.map_err(|_| Error::Closed)?;
+        self.metrics.inbound_connections.inc();
+
+        // Set TCP_NODELAY if configured
+        if let Some(tcp_nodelay) = self.tcp_nodelay {
+            if let Err(err) = stream.set_nodelay(tcp_nodelay) {
+                warn!(?err, "failed to set TCP_NODELAY");
+            }
+        }
+
+        // Return the sink and stream
+        let (stream, sink) = stream.into_split();
+        Ok((
+            addr,
+            Sink {
+                write_timeout: self.write_timeout,
+                metrics: self.metrics.clone(),
+                sink,
+            },
+            Stream {
+                read_timeout: self.read_timeout,
+                metrics: self.metrics.clone(),
+                stream,
+            },
+        ))
+    }
+}
+
+impl axum::serve::Listener for Listener {
+    type Io = TcpStream;
+    type Addr = SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        let (stream, addr) = self.listener.accept().await.unwrap();
+        (stream, addr)
+    }
+
+    fn local_addr(&self) -> std::io::Result<Self::Addr> {
+        self.listener.local_addr()
+    }
+}
+
+/// Implementation of [crate::Sink] for the `tokio` runtime.
+pub struct Sink {
+    write_timeout: Duration,
+    metrics: Arc<Metrics>,
+    sink: OwnedWriteHalf,
+}
+
+impl crate::Sink for Sink {
+    async fn send(&mut self, msg: &[u8]) -> Result<(), Error> {
+        let len = msg.len();
+        timeout(self.write_timeout, self.sink.write_all(msg))
+            .await
+            .map_err(|_| Error::Timeout)?
+            .map_err(|_| Error::SendFailed)?;
+        self.metrics.outbound_bandwidth.inc_by(len as u64);
+        Ok(())
+    }
+}
+
+/// Implementation of [crate::Stream] for the `tokio` runtime.
+pub struct Stream {
+    read_timeout: Duration,
+    metrics: Arc<Metrics>,
+    stream: OwnedReadHalf,
+}
+
+impl crate::Stream for Stream {
+    async fn recv(&mut self, buf: &mut [u8]) -> Result<(), Error> {
+        // Wait for the stream to be readable
+        timeout(self.read_timeout, self.stream.read_exact(buf))
+            .await
+            .map_err(|_| Error::Timeout)?
+            .map_err(|_| Error::RecvFailed)?;
+
+        // Record metrics
+        self.metrics.inbound_bandwidth.inc_by(buf.len() as u64);
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Network {
+    /// If given, enables/disables TCP_NODELAY on the socket
+    tcp_nodelay: Option<bool>,
+    /// Write timeout for sockets created by this listener
+    write_timeout: Duration,
+    /// Read timeout for sockets created by this listener
+    read_timeout: Duration,
+    metrics: Arc<Metrics>,
+}
+
+impl crate::Network for Network {
+    type Listener = Listener;
+
+    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, crate::Error> {
+        TcpListener::bind(socket)
+            .await
+            .map_err(|_| Error::BindFailed)
+            .map(|listener| Listener {
+                tcp_nodelay: self.tcp_nodelay,
+                write_timeout: self.write_timeout,
+                read_timeout: self.read_timeout,
+                metrics: Arc::new(Metrics::new(&mut Registry::default())), // TODO danlaine: pass registry
+                listener,
+            })
+    }
+
+    async fn dial(
+        &self,
+        socket: SocketAddr,
+    ) -> Result<(crate::SinkOf<Self>, crate::StreamOf<Self>), crate::Error> {
+        // Create a new TCP stream
+        let stream = TcpStream::connect(socket)
+            .await
+            .map_err(|_| Error::ConnectionFailed)?;
+        self.metrics.outbound_connections.inc();
+
+        // Set TCP_NODELAY if configured
+        if let Some(tcp_nodelay) = self.tcp_nodelay {
+            if let Err(err) = stream.set_nodelay(tcp_nodelay) {
+                warn!(?err, "failed to set TCP_NODELAY");
+            }
+        }
+
+        // Return the sink and stream
+        let (stream, sink) = stream.into_split();
+        Ok((
+            Sink {
+                write_timeout: self.write_timeout,
+                metrics: self.metrics.clone(),
+                sink,
+            },
+            Stream {
+                read_timeout: self.read_timeout,
+                metrics: self.metrics.clone(),
+                stream,
+            },
+        ))
+    }
+}

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -106,11 +106,44 @@ pub(crate) struct Config {
     ///
     /// Note: Make sure that your compile target has and allows this configuration otherwise
     /// panics or unexpected behaviours are possible.
-    pub(crate) tcp_nodelay: Option<bool>,
+    tcp_nodelay: Option<bool>,
     /// Read timeout for connections, after which the connection will be closed
-    pub(crate) read_timeout: Duration,
+    read_timeout: Duration,
     /// Write timeout for connections, after which the connection will be closed
-    pub(crate) write_timeout: Duration,
+    write_timeout: Duration,
+}
+
+impl Config {
+    // Setters
+    /// See [Config]
+    pub fn with_tcp_nodelay(mut self, tcp_nodelay: Option<bool>) -> Self {
+        self.tcp_nodelay = tcp_nodelay;
+        self
+    }
+    /// See [Config]
+    pub fn with_read_timeout(mut self, read_timeout: Duration) -> Self {
+        self.read_timeout = read_timeout;
+        self
+    }
+    /// See [Config]
+    pub fn with_write_timeout(mut self, write_timeout: Duration) -> Self {
+        self.write_timeout = write_timeout;
+        self
+    }
+
+    // Getters
+    /// See [Config]
+    pub fn tcp_nodelay(&self) -> Option<bool> {
+        self.tcp_nodelay
+    }
+    /// See [Config]
+    pub fn read_timeout(&self) -> Duration {
+        self.read_timeout
+    }
+    /// See [Config]
+    pub fn write_timeout(&self) -> Duration {
+        self.write_timeout
+    }
 }
 
 impl Default for Config {

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -275,7 +275,7 @@ impl crate::Runner for Runner {
             runtime_registry,
         );
 
-        let network = TokioNetwork::new(TokioNetworkConfig {
+        let network = TokioNetwork::from(TokioNetworkConfig {
             read_timeout: self.cfg.read_timeout,
             write_timeout: self.cfg.write_timeout,
             tcp_nodelay: self.cfg.tcp_nodelay.clone(),

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -278,7 +278,7 @@ impl crate::Runner for Runner {
         let network = TokioNetwork::from(TokioNetworkConfig {
             read_timeout: self.cfg.read_timeout,
             write_timeout: self.cfg.write_timeout,
-            tcp_nodelay: self.cfg.tcp_nodelay.clone(),
+            tcp_nodelay: self.cfg.tcp_nodelay,
         });
         let network = MeteredNetwork::new(network, runtime_registry);
 

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -134,17 +134,17 @@ impl Config {
     }
     /// See [Config]
     pub fn with_read_timeout(mut self, d: Duration) -> Self {
-        self.network_cfg.read_timeout = d;
+        self.network_cfg = self.network_cfg.with_read_timeout(d);
         self
     }
     /// See [Config]
     pub fn with_write_timeout(mut self, d: Duration) -> Self {
-        self.network_cfg.write_timeout = d;
+        self.network_cfg = self.network_cfg.with_write_timeout(d);
         self
     }
     /// See [Config]
     pub fn with_tcp_nodelay(mut self, n: Option<bool>) -> Self {
-        self.network_cfg.tcp_nodelay = n;
+        self.network_cfg = self.network_cfg.with_tcp_nodelay(n);
         self
     }
     /// See [Config]
@@ -173,15 +173,15 @@ impl Config {
     }
     /// See [Config]
     pub fn read_timeout(&self) -> Duration {
-        self.network_cfg.read_timeout
+        self.network_cfg.read_timeout()
     }
     /// See [Config]
     pub fn write_timeout(&self) -> Duration {
-        self.network_cfg.write_timeout
+        self.network_cfg.write_timeout()
     }
     /// See [Config]
     pub fn tcp_nodelay(&self) -> Option<bool> {
-        self.network_cfg.tcp_nodelay
+        self.network_cfg.tcp_nodelay()
     }
     /// See [Config]
     pub fn storage_directory(&self) -> &PathBuf {

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -34,13 +34,6 @@ struct Metrics {
     tasks_running: Family<Work, Gauge>,
     blocking_tasks_spawned: Family<Work, Counter>,
     blocking_tasks_running: Family<Work, Gauge>,
-
-    // As nice as it would be to track each of these by socket address,
-    // it quickly becomes an OOM attack vector.
-    inbound_connections: Counter,
-    outbound_connections: Counter,
-    inbound_bandwidth: Counter,
-    outbound_bandwidth: Counter,
 }
 
 impl Metrics {
@@ -50,10 +43,6 @@ impl Metrics {
             tasks_running: Family::default(),
             blocking_tasks_spawned: Family::default(),
             blocking_tasks_running: Family::default(),
-            inbound_connections: Counter::default(),
-            outbound_connections: Counter::default(),
-            inbound_bandwidth: Counter::default(),
-            outbound_bandwidth: Counter::default(),
         };
         registry.register(
             "tasks_spawned",
@@ -74,26 +63,6 @@ impl Metrics {
             "blocking_tasks_running",
             "Number of blocking tasks currently running",
             metrics.blocking_tasks_running.clone(),
-        );
-        registry.register(
-            "inbound_connections",
-            "Number of connections created by dialing us",
-            metrics.inbound_connections.clone(),
-        );
-        registry.register(
-            "outbound_connections",
-            "Number of connections created by dialing others",
-            metrics.outbound_connections.clone(),
-        );
-        registry.register(
-            "inbound_bandwidth",
-            "Bandwidth used by receiving data from others",
-            metrics.inbound_bandwidth.clone(),
-        );
-        registry.register(
-            "outbound_bandwidth",
-            "Bandwidth used by sending data to others",
-            metrics.outbound_bandwidth.clone(),
         );
         metrics
     }


### PR DESCRIPTION
This PR:

* Adds a new `mod network` inside `commonware_runtime`
* Adds 2 `commonware_runtime::Network` implementations
* One is in `metered.rs`. It wraps another `Network` to track metrics.
* The other is `tokio.rs` which uses tokio for network IO.
* Adds a `network` field to `Context` which is a `MeteredNetwork<TokioNetwork>` and has the same functionality as before