### PR TITLE
Update Codecov action to v5

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Generate coverage report
       run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         files: lcov.info
         fail_ci_if_error: true


### PR DESCRIPTION
Bump `codecov/codecov-action` from v4 to v5 to use the new Codecov Wrapper, keeping the workflow on the latest supported major version.
[Codecov GitHub Action – v5 release notes](https://github.com/codecov/codecov-action#v5-release)