### PR TITLE
[runtime] Generalize auditor to work over any payload

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -842,7 +842,7 @@ impl crate::Spawner for Context {
     }
 
     fn stopped(&self) -> Signal {
-        self.executor.auditor.event(b"stop", |_| {});
+        self.executor.auditor.event(b"stopped", |_| {});
         self.executor.signal.clone()
     }
 }
@@ -1195,22 +1195,30 @@ impl crate::Stream for Stream {
 
 impl RngCore for Context {
     fn next_u32(&mut self) -> u32 {
-        self.executor.auditor.event(b"next_u32", |_| {});
+        self.executor.auditor.event(b"rand", |hasher| {
+            hasher.update(b"next_u32");
+        });
         self.executor.rng.lock().unwrap().next_u32()
     }
 
     fn next_u64(&mut self) -> u64 {
-        self.executor.auditor.event(b"next_u64", |_| {});
+        self.executor.auditor.event(b"rand", |hasher| {
+            hasher.update(b"next_u64");
+        });
         self.executor.rng.lock().unwrap().next_u64()
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.executor.auditor.event(b"fill_bytes", |_| {});
+        self.executor.auditor.event(b"rand", |hasher| {
+            hasher.update(b"fill_bytes");
+        });
         self.executor.rng.lock().unwrap().fill_bytes(dest)
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.executor.auditor.event(b"try_fill_bytes", |_| {});
+        self.executor.auditor.event(b"rand", |hasher| {
+            hasher.update(b"try_fill_bytes");
+        });
         self.executor.rng.lock().unwrap().try_fill_bytes(dest)
     }
 }

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -137,194 +137,20 @@ impl Default for Auditor {
 }
 
 impl Auditor {
-    fn process_task(&self, task: u128, label: &str) {
+    /// Record that an event happened.
+    /// This auditor's hash will be updated with the event's `label` and
+    /// whatever other data is passed in the `payload` closure.
+    pub(crate) fn event<F>(&self, label: &'static [u8], payload: F)
+    where
+        F: FnOnce(&mut Sha256),
+    {
         let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"process_task");
-        hasher.update(task.to_be_bytes());
-        hasher.update(label.as_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
 
-    fn stop(&self, value: i32) {
-        let mut hash = self.hash.lock().unwrap();
         let mut hasher = Sha256::new();
         hasher.update(&*hash);
-        hasher.update(b"stop");
-        hasher.update(value.to_be_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
+        hasher.update(label);
+        payload(&mut hasher);
 
-    fn stopped(&self) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"stopped");
-        *hash = hasher.finalize().to_vec();
-    }
-
-    fn bind(&self, address: SocketAddr) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"bind");
-        hasher.update(address.to_string().as_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
-
-    fn dial(&self, dialer: SocketAddr, listener: SocketAddr) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"dial");
-        hasher.update(dialer.to_string().as_bytes());
-        hasher.update(listener.to_string().as_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
-
-    fn accept(&self, listener: SocketAddr, dialer: SocketAddr) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"accept");
-        hasher.update(listener.to_string().as_bytes());
-        hasher.update(dialer.to_string().as_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
-
-    fn send(&self, sender: SocketAddr, receiver: SocketAddr, message: &[u8]) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"send");
-        hasher.update(sender.to_string().as_bytes());
-        hasher.update(receiver.to_string().as_bytes());
-        hasher.update(message);
-        *hash = hasher.finalize().to_vec();
-    }
-
-    fn recv(&self, receiver: SocketAddr, sender: SocketAddr, message: &[u8]) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"recv");
-        hasher.update(receiver.to_string().as_bytes());
-        hasher.update(sender.to_string().as_bytes());
-        hasher.update(message);
-        *hash = hasher.finalize().to_vec();
-    }
-
-    fn rand(&self, method: String) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"rand");
-        hasher.update(method.as_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
-
-    pub(crate) fn open(&self, partition: &str, name: &[u8]) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"open");
-        hasher.update(partition.as_bytes());
-        hasher.update(name);
-        *hash = hasher.finalize().to_vec();
-    }
-
-    pub(crate) fn remove(&self, partition: &str, name: Option<&[u8]>) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"remove");
-        hasher.update(partition.as_bytes());
-        if let Some(name) = name {
-            hasher.update(name);
-        }
-        *hash = hasher.finalize().to_vec();
-    }
-
-    pub(crate) fn scan(&self, partition: &str) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"scan");
-        hasher.update(partition.as_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
-
-    pub(crate) fn read_at(&self, partition: &str, name: &[u8], buf: usize, offset: u64) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"read_at");
-        hasher.update(partition.as_bytes());
-        hasher.update(name);
-        hasher.update(buf.to_be_bytes());
-        hasher.update(offset.to_be_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
-
-    pub(crate) fn write_at(&self, partition: &str, name: &[u8], buf: &[u8], offset: u64) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"write_at");
-        hasher.update(partition.as_bytes());
-        hasher.update(name);
-        hasher.update(buf);
-        hasher.update(offset.to_be_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
-
-    pub(crate) fn truncate(&self, partition: &str, name: &[u8], size: u64) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"truncate");
-        hasher.update(partition.as_bytes());
-        hasher.update(name);
-        hasher.update(size.to_be_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
-
-    pub(crate) fn sync(&self, partition: &str, name: &[u8]) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"sync");
-        hasher.update(partition.as_bytes());
-        hasher.update(name);
-        *hash = hasher.finalize().to_vec();
-    }
-
-    pub(crate) fn close(&self, partition: &str, name: &[u8]) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"close");
-        hasher.update(partition.as_bytes());
-        hasher.update(name);
-        *hash = hasher.finalize().to_vec();
-    }
-
-    fn register(&self, name: &str, help: &str) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"register");
-        hasher.update(name.as_bytes());
-        hasher.update(help.as_bytes());
-        *hash = hasher.finalize().to_vec();
-    }
-
-    fn encode(&self) {
-        let mut hash = self.hash.lock().unwrap();
-        let mut hasher = Sha256::new();
-        hasher.update(&*hash);
-        hasher.update(b"encode");
         *hash = hasher.finalize().to_vec();
     }
 
@@ -538,7 +364,10 @@ impl crate::Runner for Runner {
             trace!(iter, tasks = tasks.len(), "starting loop");
             for task in tasks {
                 // Record task for auditing
-                executor.auditor.process_task(task.id, &task.label);
+                executor.auditor.event(b"process_task", |hasher| {
+                    hasher.update(task.id.to_be_bytes());
+                    hasher.update(task.label.as_bytes());
+                });
                 trace!(id = task.id, "processing task");
 
                 // Record task poll
@@ -1006,12 +835,14 @@ impl crate::Spawner for Context {
     }
 
     fn stop(&self, value: i32) {
-        self.executor.auditor.stop(value);
+        self.executor.auditor.event(b"stop", |hasher| {
+            hasher.update(value.to_be_bytes());
+        });
         self.executor.signaler.lock().unwrap().signal(value);
     }
 
     fn stopped(&self) -> Signal {
-        self.executor.auditor.stopped();
+        self.executor.auditor.event(b"stop", |_| {});
         self.executor.signal.clone()
     }
 }
@@ -1049,7 +880,10 @@ impl crate::Metrics for Context {
         let help = help.into();
 
         // Register metric
-        self.executor.auditor.register(&name, &help);
+        self.executor.auditor.event(b"register", |hasher| {
+            hasher.update(name.as_bytes());
+            hasher.update(help.as_bytes());
+        });
         let prefixed_name = {
             let prefix = &self.label;
             if prefix.is_empty() {
@@ -1066,7 +900,7 @@ impl crate::Metrics for Context {
     }
 
     fn encode(&self) -> String {
-        self.executor.auditor.encode();
+        self.executor.auditor.event(b"encode", |_| {});
         let mut buffer = String::new();
         encode(&mut buffer, &self.executor.registry.lock().unwrap()).expect("encoding failed");
         buffer
@@ -1189,7 +1023,9 @@ impl Networking {
     }
 
     fn bind(&self, socket: SocketAddr) -> Result<Listener, Error> {
-        self.auditor.bind(socket);
+        self.auditor.event(b"bind", |hasher| {
+            hasher.update(socket.to_string().as_bytes());
+        });
 
         // If the IP is localhost, ensure the port is not in the ephemeral range
         // so that it can be used for binding in the dial method
@@ -1226,7 +1062,10 @@ impl Networking {
                 .expect("ephemeral port range exhausted");
             dialer
         };
-        self.auditor.dial(dialer, socket);
+        self.auditor.event(b"dial", |hasher| {
+            hasher.update(dialer.to_string().as_bytes());
+            hasher.update(socket.to_string().as_bytes());
+        });
 
         // Get listener
         let mut sender = {
@@ -1286,7 +1125,10 @@ impl crate::Listener for Listener {
 
     async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), Error> {
         let (socket, sender, receiver) = self.listener.next().await.ok_or(Error::ReadFailed)?;
-        self.auditor.accept(self.address, socket);
+        self.auditor.event(b"accept", |hasher| {
+            hasher.update(self.address.to_string().as_bytes());
+            hasher.update(socket.to_string().as_bytes());
+        });
         Ok((
             socket,
             Sink {
@@ -1317,7 +1159,11 @@ pub struct Sink {
 
 impl crate::Sink for Sink {
     async fn send(&mut self, msg: &[u8]) -> Result<(), Error> {
-        self.auditor.send(self.me, self.peer, msg);
+        self.auditor.event(b"send", |hasher| {
+            hasher.update(self.me.to_string().as_bytes());
+            hasher.update(self.peer.to_string().as_bytes());
+            hasher.update(msg);
+        });
         self.sender.send(msg).await.map_err(|_| Error::SendFailed)?;
         self.metrics.network_bandwidth.inc_by(msg.len() as u64);
         Ok(())
@@ -1338,29 +1184,33 @@ impl crate::Stream for Stream {
             .recv(buf)
             .await
             .map_err(|_| Error::RecvFailed)?;
-        self.auditor.recv(self.me, self.peer, buf);
+        self.auditor.event(b"recv", |hasher| {
+            hasher.update(self.me.to_string().as_bytes());
+            hasher.update(self.peer.to_string().as_bytes());
+            hasher.update(buf);
+        });
         Ok(())
     }
 }
 
 impl RngCore for Context {
     fn next_u32(&mut self) -> u32 {
-        self.executor.auditor.rand("next_u32".to_string());
+        self.executor.auditor.event(b"next_u32", |_| {});
         self.executor.rng.lock().unwrap().next_u32()
     }
 
     fn next_u64(&mut self) -> u64 {
-        self.executor.auditor.rand("next_u64".to_string());
+        self.executor.auditor.event(b"next_u64", |_| {});
         self.executor.rng.lock().unwrap().next_u64()
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.executor.auditor.rand("fill_bytes".to_string());
+        self.executor.auditor.event(b"fill_bytes", |_| {});
         self.executor.rng.lock().unwrap().fill_bytes(dest)
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.executor.auditor.rand("try_fill_bytes".to_string());
+        self.executor.auditor.event(b"try_fill_bytes", |_| {});
         self.executor.rng.lock().unwrap().try_fill_bytes(dest)
     }
 }

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -1,6 +1,5 @@
-use sha2::digest::Update;
-
 use crate::{deterministic::Auditor, Error};
+use sha2::digest::Update;
 use std::sync::Arc;
 
 #[derive(Clone)]


### PR DESCRIPTION
This PR replaces the various helper functions inside `Auditor` with `event`, which allows for any method to add its result to the auditor without needing its own helper.