### PR TITLE
[storage/mmr/verification] remove async from verification::Storage trait's size() fn

### DIFF
--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -39,8 +39,8 @@ impl<H: CHasher + Send + Sync> Storage<H::Digest> for BitmapStorage<'_, H> {
         }
     }
 
-    async fn size(&self) -> Result<u64, Error> {
-        Ok(self.last_chunk_mmr.size())
+    fn size(&self) -> u64 {
+        self.last_chunk_mmr.size()
     }
 }
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -61,8 +61,8 @@ pub struct Mmr<E: RStorage + Clock + Metrics, H: Hasher> {
 }
 
 impl<E: RStorage + Clock + Metrics, H: Hasher> Storage<H::Digest> for Mmr<E, H> {
-    async fn size(&self) -> Result<u64, Error> {
-        Ok(self.size())
+    fn size(&self) -> u64 {
+        self.size()
     }
 
     async fn get_node(&self, position: u64) -> Result<Option<H::Digest>, Error> {

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -44,8 +44,8 @@ impl<H: CHasher> Default for Mmr<H> {
 }
 
 impl<H: CHasher> Storage<H::Digest> for Mmr<H> {
-    async fn size(&self) -> Result<u64, Error> {
-        Ok(self.size())
+    fn size(&self) -> u64 {
+        self.size()
     }
 
     async fn get_node(&self, position: u64) -> Result<Option<H::Digest>, Error> {


### PR DESCRIPTION
This is an artifact over previously relying on blob.size().