### PR TITLE
[storage] Remove `any::Type`

### DIFF
--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -413,7 +413,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
                         let old_loc = *loc;
                         cursor.delete();
                         drop(cursor);
-                        self.apply_op(hasher, Operation::delete(key)).await?;
+                        self.apply_op(hasher, Operation::delete(&key)).await?;
                         return Ok(Some(old_loc));
                     }
                 }

--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -385,7 +385,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
             UpdateResult::Updated(_, _) => (),
         }
 
-        let op = Operation::update(key, value);
+        let op = Operation::update(&key, value);
         self.apply_op(hasher, op).await?;
 
         Ok(res)

--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -159,7 +159,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         let mut rewind_leaf_num = log_size;
         while rewind_leaf_num > 0 {
             let op: Operation<K, V> = log.read(rewind_leaf_num - 1).await?;
-            match &op {
+            match op {
                 Operation::Commit(_) => {
                     break; // floor is our commit indicator
                 }
@@ -401,9 +401,9 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         // Iterate over all conflicting keys in the snapshot.
         while let Some(loc) = cursor.next() {
             let op = self.log.read(*loc).await?;
-            match &op {
+            match op {
                 Operation::Update(k, _) => {
-                    if *k == key {
+                    if k == key {
                         // The key is in the snapshot, so delete it.
                         //
                         // If there are no longer any conflicting keys in the cursor, it will

--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -385,7 +385,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
             UpdateResult::Updated(_, _) => (),
         }
 
-        let op = Operation::update(&key, value);
+        let op = Operation::update(&key, &value);
         self.apply_op(hasher, op).await?;
 
         Ok(res)

--- a/storage/src/adb/operation.rs
+++ b/storage/src/adb/operation.rs
@@ -4,15 +4,12 @@
 //! based on a `crate::Journal`.
 
 use bytes::{Buf, BufMut};
-use commonware_codec::{
-    util::at_least, DecodeExt, Error as CodecError, FixedSize, Read, ReadExt, Write,
-};
+use commonware_codec::{util::at_least, Error as CodecError, FixedSize, Read, ReadExt, Write};
 use commonware_utils::Array;
 use std::{
     cmp::{Ord, PartialOrd},
     fmt::{Debug, Display},
     hash::Hash,
-    ops::Deref,
 };
 use thiserror::Error;
 
@@ -49,7 +46,7 @@ pub enum Error {
 
 /// An `Array` implementation for operations applied to an authenticated database.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub(super) enum Operation<K: Array, V: Array> {
+pub enum Operation<K: Array, V: Array> {
     /// Indicates the key no longer has a value.
     Deleted(K),
 
@@ -73,59 +70,10 @@ impl<K: Array, V: Array> Operation<K, V> {
     // A compile-time assertion that operation's array size is large enough to handle the commit
     // operation, which requires 9 bytes.
     const _MIN_OPERATION_LEN: usize = 9;
-    // const _COMMIT_OP_ASSERT: () = assert!(
-    //     Self::SIZE >= Self::_MIN_OPERATION_LEN,
-    //     "array size too small for commit op"
-    // );
-
-    // Create a new operation of the given type.
-    // pub fn new(t: Type<K, V>) -> Self {
-    //     match t {
-    //         Type::Deleted(key) => Self::delete(&key),
-    //         Type::Update(key, value) => Self::update(&key, &value),
-    //         Type::Commit(loc) => Self::commit(loc),
-    //     }
-    // }
-
-    // /// Create a new update operation that makes `key` have value `value`.
-    // pub fn update(key: &K, value: &V) -> Self {
-    //     let mut data = Vec::with_capacity(Self::SIZE);
-    //     data.push(Self::UPDATE_CONTEXT);
-    //     data.extend_from_slice(key);
-    //     data.extend_from_slice(&value);
-
-    //     Self {
-    //         data,
-    //         _phantom: std::marker::PhantomData,
-    //     }
-    // }
-
-    // /// Create a new delete operation that removes any value assigned to `key`.
-    // pub fn delete(key: &K) -> Self {
-    //     let mut data = Vec::with_capacity(Self::SIZE);
-    //     data.push(Self::DELETE_CONTEXT);
-    //     data.extend_from_slice(key);
-    //     data.resize(Self::SIZE, 0);
-
-    //     Self {
-    //         data,
-    //         _phantom: std::marker::PhantomData,
-    //     }
-    // }
-
-    // /// Create a new commit operation that indicates the current floor on inactive operations is
-    // /// `loc`.
-    // pub fn commit(loc: u64) -> Self {
-    //     let mut data = Vec::with_capacity(Self::SIZE);
-    //     data.push(Self::COMMIT_CONTEXT);
-    //     data.extend_from_slice(&loc.to_be_bytes());
-    //     data.resize(Self::SIZE, 0);
-
-    //     Self {
-    //         data,
-    //         _phantom: std::marker::PhantomData,
-    //     }
-    // }
+    const _COMMIT_OP_ASSERT: () = assert!(
+        Self::SIZE >= Self::_MIN_OPERATION_LEN,
+        "array size too small for commit op"
+    );
 
     pub fn to_key(&self) -> K {
         match self {
@@ -134,22 +82,6 @@ impl<K: Array, V: Array> Operation<K, V> {
             Operation::Commit(_) => panic!("Cannot get key from commit operation"),
         }
     }
-
-    // pub fn to_type(&self) -> Type<K, V> {
-    //     let key = K::decode(&self.data[1..K::SIZE + 1]).unwrap();
-    //     match self.data[0] {
-    //         Self::DELETE_CONTEXT => Type::Deleted(key),
-    //         Self::UPDATE_CONTEXT => {
-    //             let value = V::decode(&self.data[K::SIZE + 1..]).unwrap();
-    //             Type::Update(key, value)
-    //         }
-    //         Self::COMMIT_CONTEXT => {
-    //             let loc = u64::from_be_bytes(self.data[1..9].try_into().unwrap());
-    //             Type::Commit(loc)
-    //         }
-    //         _ => unreachable!(),
-    //     }
-    // }
 
     pub fn to_value(&self) -> Option<V> {
         match self {
@@ -177,9 +109,8 @@ impl<K: Array, V: Array> Write for Operation<K, V> {
             Operation::Commit(loc) => {
                 buf.put_u8(Self::COMMIT_CONTEXT);
                 buf.put_slice(&loc.to_be_bytes());
-                // TODO danlaine: fix this
                 // Put 0s for the rest
-                // buf.put_bytes(0, Self::SIZE -1 - u64::SIZE);
+                buf.put_bytes(0, Self::SIZE - 1 - u64::SIZE);
             }
         }
     }
@@ -229,25 +160,6 @@ impl<K: Array, V: Array> Read for Operation<K, V> {
         Ok(op)
     }
 }
-
-// impl<K: Array, V: Array> FixedSize for Operation<K, V> {
-//     const SIZE: usize = u8::SIZE + K::SIZE + V::SIZE;
-// }
-
-// impl<K: Array, V: Array> Array for Operation<K, V> {}
-
-// impl<K: Array, V: Array> AsRef<[u8]> for Operation<K, V> {
-//     fn as_ref(&self) -> &[u8] {
-//         &self.data
-//     }
-// }
-
-// impl<K: Array, V: Array> Deref for Operation<K, V> {
-//     type Target = [u8];
-//     fn deref(&self) -> &[u8] {
-//         &self.data
-//     }
-// }
 
 impl<K: Array, V: Array> Display for Operation<K, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/storage/src/adb/operation.rs
+++ b/storage/src/adb/operation.rs
@@ -72,16 +72,16 @@ impl<K: Array, V: Array> Operation<K, V> {
     pub fn new(t: Type<K, V>) -> Self {
         match t {
             Type::Deleted(key) => Self::delete(&key),
-            Type::Update(key, value) => Self::update(key, value),
+            Type::Update(key, value) => Self::update(&key, value),
             Type::Commit(loc) => Self::commit(loc),
         }
     }
 
     /// Create a new update operation that makes `key` have value `value`.
-    pub fn update(key: K, value: V) -> Self {
+    pub fn update(key: &K, value: V) -> Self {
         let mut data = Vec::with_capacity(Self::SIZE);
         data.push(Self::UPDATE_CONTEXT);
-        data.extend_from_slice(&key);
+        data.extend_from_slice(key);
         data.extend_from_slice(&value);
 
         Self {
@@ -237,7 +237,7 @@ mod tests {
     fn test_operation_array_basic() {
         let key = U64::new(1234);
         let value = U64::new(56789);
-        let update_op = Operation::update(key.clone(), value.clone());
+        let update_op = Operation::update(&key, value.clone());
 
         let from = Operation::decode(update_op.as_ref()).unwrap();
         assert_eq!(key, from.to_key());
@@ -295,7 +295,7 @@ mod tests {
     fn test_operation_array_display() {
         let key = U64::new(1234);
         let value = U64::new(56789);
-        let update_op = Operation::update(key.clone(), value.clone());
+        let update_op = Operation::update(&key, value.clone());
         assert_eq!(
             format!("{}", update_op),
             format!("[key:{} value:{}]", key, value)
@@ -313,7 +313,7 @@ mod tests {
     fn test_operation_array_codec() {
         let key = U64::new(1234);
         let value = U64::new(5678);
-        let update_op = Operation::update(key, value);
+        let update_op = Operation::update(&key, value);
 
         let encoded = update_op.encode();
         assert_eq!(encoded.len(), Operation::<U64, U64>::SIZE);

--- a/storage/src/adb/operation.rs
+++ b/storage/src/adb/operation.rs
@@ -33,9 +33,23 @@ pub enum Error {
     InvalidCommitOp,
 }
 
-/// The types of operations that can change the state of a database.
+// /// The types of operations that can change the state of a database.
+// #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+// pub enum Type<K: Array, V: Array> {
+//     /// Indicates the key no longer has a value.
+//     Deleted(K),
+
+//     /// Indicates the key now has the wrapped value.
+//     Update(K, V),
+
+//     /// Indicates all prior operations are no longer subject to rollback, and the floor on inactive
+//     /// operations has been raised to the wrapped value.
+//     Commit(u64),
+// }
+
+/// An `Array` implementation for operations applied to an authenticated database.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum Type<K: Array, V: Array> {
+pub(super) enum Operation<K: Array, V: Array> {
     /// Indicates the key no longer has a value.
     Deleted(K),
 
@@ -47,14 +61,6 @@ pub enum Type<K: Array, V: Array> {
     Commit(u64),
 }
 
-/// An `Array` implementation for operations applied to an authenticated database.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[repr(transparent)]
-pub struct Operation<K: Array, V: Array> {
-    pub data: Vec<u8>,
-    _phantom: std::marker::PhantomData<(K, V)>,
-}
-
 impl<K: Array, V: Array> Operation<K, V> {
     const DELETE_CONTEXT: u8 = 0;
     const UPDATE_CONTEXT: u8 = 1;
@@ -63,94 +69,114 @@ impl<K: Array, V: Array> Operation<K, V> {
     // A compile-time assertion that operation's array size is large enough to handle the commit
     // operation, which requires 9 bytes.
     const _MIN_OPERATION_LEN: usize = 9;
-    const _COMMIT_OP_ASSERT: () = assert!(
-        Self::SIZE >= Self::_MIN_OPERATION_LEN,
-        "array size too small for commit op"
-    );
+    // const _COMMIT_OP_ASSERT: () = assert!(
+    //     Self::SIZE >= Self::_MIN_OPERATION_LEN,
+    //     "array size too small for commit op"
+    // );
 
     /// Create a new operation of the given type.
-    pub fn new(t: Type<K, V>) -> Self {
-        match t {
-            Type::Deleted(key) => Self::delete(&key),
-            Type::Update(key, value) => Self::update(&key, &value),
-            Type::Commit(loc) => Self::commit(loc),
-        }
-    }
+    // pub fn new(t: Type<K, V>) -> Self {
+    //     match t {
+    //         Type::Deleted(key) => Self::delete(&key),
+    //         Type::Update(key, value) => Self::update(&key, &value),
+    //         Type::Commit(loc) => Self::commit(loc),
+    //     }
+    // }
 
-    /// Create a new update operation that makes `key` have value `value`.
-    pub fn update(key: &K, value: &V) -> Self {
-        let mut data = Vec::with_capacity(Self::SIZE);
-        data.push(Self::UPDATE_CONTEXT);
-        data.extend_from_slice(key);
-        data.extend_from_slice(&value);
+    // /// Create a new update operation that makes `key` have value `value`.
+    // pub fn update(key: &K, value: &V) -> Self {
+    //     let mut data = Vec::with_capacity(Self::SIZE);
+    //     data.push(Self::UPDATE_CONTEXT);
+    //     data.extend_from_slice(key);
+    //     data.extend_from_slice(&value);
 
-        Self {
-            data,
-            _phantom: std::marker::PhantomData,
-        }
-    }
+    //     Self {
+    //         data,
+    //         _phantom: std::marker::PhantomData,
+    //     }
+    // }
 
-    /// Create a new delete operation that removes any value assigned to `key`.
-    pub fn delete(key: &K) -> Self {
-        let mut data = Vec::with_capacity(Self::SIZE);
-        data.push(Self::DELETE_CONTEXT);
-        data.extend_from_slice(key);
-        data.resize(Self::SIZE, 0);
+    // /// Create a new delete operation that removes any value assigned to `key`.
+    // pub fn delete(key: &K) -> Self {
+    //     let mut data = Vec::with_capacity(Self::SIZE);
+    //     data.push(Self::DELETE_CONTEXT);
+    //     data.extend_from_slice(key);
+    //     data.resize(Self::SIZE, 0);
 
-        Self {
-            data,
-            _phantom: std::marker::PhantomData,
-        }
-    }
+    //     Self {
+    //         data,
+    //         _phantom: std::marker::PhantomData,
+    //     }
+    // }
 
-    /// Create a new commit operation that indicates the current floor on inactive operations is
-    /// `loc`.
-    pub fn commit(loc: u64) -> Self {
-        let mut data = Vec::with_capacity(Self::SIZE);
-        data.push(Self::COMMIT_CONTEXT);
-        data.extend_from_slice(&loc.to_be_bytes());
-        data.resize(Self::SIZE, 0);
+    // /// Create a new commit operation that indicates the current floor on inactive operations is
+    // /// `loc`.
+    // pub fn commit(loc: u64) -> Self {
+    //     let mut data = Vec::with_capacity(Self::SIZE);
+    //     data.push(Self::COMMIT_CONTEXT);
+    //     data.extend_from_slice(&loc.to_be_bytes());
+    //     data.resize(Self::SIZE, 0);
 
-        Self {
-            data,
-            _phantom: std::marker::PhantomData,
-        }
-    }
+    //     Self {
+    //         data,
+    //         _phantom: std::marker::PhantomData,
+    //     }
+    // }
 
-    pub fn to_key(&self) -> K {
-        K::decode(&self.data[1..K::SIZE + 1]).unwrap()
-    }
+    // pub fn to_key(&self) -> K {
+    //     K::decode(&self.data[1..K::SIZE + 1]).unwrap()
+    // }
 
-    pub fn to_type(&self) -> Type<K, V> {
-        let key = K::decode(&self.data[1..K::SIZE + 1]).unwrap();
-        match self.data[0] {
-            Self::DELETE_CONTEXT => Type::Deleted(key),
-            Self::UPDATE_CONTEXT => {
-                let value = V::decode(&self.data[K::SIZE + 1..]).unwrap();
-                Type::Update(key, value)
-            }
-            Self::COMMIT_CONTEXT => {
-                let loc = u64::from_be_bytes(self.data[1..9].try_into().unwrap());
-                Type::Commit(loc)
-            }
-            _ => unreachable!(),
-        }
-    }
+    // pub fn to_type(&self) -> Type<K, V> {
+    //     let key = K::decode(&self.data[1..K::SIZE + 1]).unwrap();
+    //     match self.data[0] {
+    //         Self::DELETE_CONTEXT => Type::Deleted(key),
+    //         Self::UPDATE_CONTEXT => {
+    //             let value = V::decode(&self.data[K::SIZE + 1..]).unwrap();
+    //             Type::Update(key, value)
+    //         }
+    //         Self::COMMIT_CONTEXT => {
+    //             let loc = u64::from_be_bytes(self.data[1..9].try_into().unwrap());
+    //             Type::Commit(loc)
+    //         }
+    //         _ => unreachable!(),
+    //     }
+    // }
 
-    pub fn to_value(&self) -> Option<V> {
-        match self.data[0] {
-            Self::DELETE_CONTEXT => None,
-            Self::UPDATE_CONTEXT => Some(V::decode(&self.data[K::SIZE + 1..]).unwrap()),
-            Self::COMMIT_CONTEXT => None,
-            _ => unreachable!(),
-        }
-    }
+    // pub fn to_value(&self) -> Option<V> {
+    //     match self.data[0] {
+    //         Self::DELETE_CONTEXT => None,
+    //         Self::UPDATE_CONTEXT => Some(V::decode(&self.data[K::SIZE + 1..]).unwrap()),
+    //         Self::COMMIT_CONTEXT => None,
+    //         _ => unreachable!(),
+    //     }
+    // }
 }
 
 impl<K: Array, V: Array> Write for Operation<K, V> {
     fn write(&self, buf: &mut impl BufMut) {
-        assert!(self.data.len() == Self::SIZE);
-        buf.put_slice(&self.data);
+        match &self {
+            Operation::Deleted(k) => {
+                buf.put_u8(Self::DELETE_CONTEXT);
+                k.write(buf);
+                // Put 0s for the value
+                buf.put_bytes(0, V::SIZE);
+
+            },
+            Operation::Update(k, v) => {
+                buf.put_u8(Self::UPDATE_CONTEXT);
+                k.write(buf);
+                v.write(buf);
+            },
+            Operation::Commit(loc) => {
+                buf.put_u8(Self::COMMIT_CONTEXT);
+                buf.put_slice(&loc.to_be_bytes());
+                // TODO danlaine: fix this
+                // Put 0s for the rest
+                // buf.put_bytes(0, Self::SIZE -1 - u64::SIZE);
+
+            },
+        }
     }
 }
 
@@ -198,31 +224,31 @@ impl<K: Array, V: Array> Read for Operation<K, V> {
     }
 }
 
-impl<K: Array, V: Array> FixedSize for Operation<K, V> {
-    const SIZE: usize = u8::SIZE + K::SIZE + V::SIZE;
-}
+// impl<K: Array, V: Array> FixedSize for Operation<K, V> {
+//     const SIZE: usize = u8::SIZE + K::SIZE + V::SIZE;
+// }
 
-impl<K: Array, V: Array> Array for Operation<K, V> {}
+// impl<K: Array, V: Array> Array for Operation<K, V> {}
 
-impl<K: Array, V: Array> AsRef<[u8]> for Operation<K, V> {
-    fn as_ref(&self) -> &[u8] {
-        &self.data
-    }
-}
+// impl<K: Array, V: Array> AsRef<[u8]> for Operation<K, V> {
+//     fn as_ref(&self) -> &[u8] {
+//         &self.data
+//     }
+// }
 
-impl<K: Array, V: Array> Deref for Operation<K, V> {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        &self.data
-    }
-}
+// impl<K: Array, V: Array> Deref for Operation<K, V> {
+//     type Target = [u8];
+//     fn deref(&self) -> &[u8] {
+//         &self.data
+//     }
+// }
 
 impl<K: Array, V: Array> Display for Operation<K, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.to_type() {
-            Type::Deleted(key) => write!(f, "[key:{} <deleted>]", key),
-            Type::Update(key, value) => write!(f, "[key:{} value:{}]", key, value),
-            Type::Commit(loc) => write!(f, "[commit with inactivity floor: {}]", loc),
+        match self {
+            Operation::Deleted(key) => write!(f, "[key:{} <deleted>]", key),
+            Operation::Update(key, value) => write!(f, "[key:{} value:{}]", key, value),
+            Operation::Commit(loc) => write!(f, "[commit with inactivity floor: {}]", loc),
         }
     }
 }

--- a/storage/src/adb/operation.rs
+++ b/storage/src/adb/operation.rs
@@ -71,7 +71,7 @@ impl<K: Array, V: Array> Operation<K, V> {
     /// Create a new operation of the given type.
     pub fn new(t: Type<K, V>) -> Self {
         match t {
-            Type::Deleted(key) => Self::delete(key),
+            Type::Deleted(key) => Self::delete(&key),
             Type::Update(key, value) => Self::update(key, value),
             Type::Commit(loc) => Self::commit(loc),
         }
@@ -91,10 +91,10 @@ impl<K: Array, V: Array> Operation<K, V> {
     }
 
     /// Create a new delete operation that removes any value assigned to `key`.
-    pub fn delete(key: K) -> Self {
+    pub fn delete(key: &K) -> Self {
         let mut data = Vec::with_capacity(Self::SIZE);
         data.push(Self::DELETE_CONTEXT);
-        data.extend_from_slice(&key);
+        data.extend_from_slice(key);
         data.resize(Self::SIZE, 0);
 
         Self {
@@ -257,7 +257,7 @@ mod tests {
         assert_eq!(update_op, from);
 
         let key2 = U64::new(42);
-        let delete_op = Operation::<U64, U64>::delete(key2.clone());
+        let delete_op = Operation::<U64, U64>::delete(&key2);
         let from = Operation::<U64, U64>::decode(delete_op.as_ref()).unwrap();
         assert_eq!(key2, from.to_key());
         assert_eq!(None, from.to_value());
@@ -302,7 +302,7 @@ mod tests {
         );
 
         let key2 = U64::new(42);
-        let delete_op = Operation::<U64, U64>::delete(key2.clone());
+        let delete_op = Operation::<U64, U64>::delete(&key2);
         assert_eq!(
             format!("{}", delete_op),
             format!("[key:{} <deleted>]", key2)

--- a/storage/src/adb/operation.rs
+++ b/storage/src/adb/operation.rs
@@ -72,13 +72,13 @@ impl<K: Array, V: Array> Operation<K, V> {
     pub fn new(t: Type<K, V>) -> Self {
         match t {
             Type::Deleted(key) => Self::delete(&key),
-            Type::Update(key, value) => Self::update(&key, value),
+            Type::Update(key, value) => Self::update(&key, &value),
             Type::Commit(loc) => Self::commit(loc),
         }
     }
 
     /// Create a new update operation that makes `key` have value `value`.
-    pub fn update(key: &K, value: V) -> Self {
+    pub fn update(key: &K, value: &V) -> Self {
         let mut data = Vec::with_capacity(Self::SIZE);
         data.push(Self::UPDATE_CONTEXT);
         data.extend_from_slice(key);
@@ -237,7 +237,7 @@ mod tests {
     fn test_operation_array_basic() {
         let key = U64::new(1234);
         let value = U64::new(56789);
-        let update_op = Operation::update(&key, value.clone());
+        let update_op = Operation::update(&key, &value);
 
         let from = Operation::decode(update_op.as_ref()).unwrap();
         assert_eq!(key, from.to_key());
@@ -295,7 +295,7 @@ mod tests {
     fn test_operation_array_display() {
         let key = U64::new(1234);
         let value = U64::new(56789);
-        let update_op = Operation::update(&key, value.clone());
+        let update_op = Operation::update(&key, &value);
         assert_eq!(
             format!("{}", update_op),
             format!("[key:{} value:{}]", key, value)
@@ -313,7 +313,7 @@ mod tests {
     fn test_operation_array_codec() {
         let key = U64::new(1234);
         let value = U64::new(5678);
-        let update_op = Operation::update(&key, value);
+        let update_op = Operation::update(&key, &value);
 
         let encoded = update_op.encode();
         assert_eq!(encoded.len(), Operation::<U64, U64>::SIZE);

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -50,7 +50,7 @@
 
 use super::Error;
 use bytes::BufMut;
-use commonware_codec::{Codec, Decode, DecodeExt, Encode, FixedSize};
+use commonware_codec::{Decode, DecodeExt, Encode, FixedSize};
 use commonware_runtime::{Blob, Error as RError, Metrics, Storage};
 use commonware_utils::hex;
 use futures::stream::{self, Stream, StreamExt};

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -50,9 +50,9 @@
 
 use super::Error;
 use bytes::BufMut;
-use commonware_codec::{Decode, DecodeExt, FixedSize};
+use commonware_codec::{Codec, Decode, DecodeExt, Encode, FixedSize};
 use commonware_runtime::{Blob, Error as RError, Metrics, Storage};
-use commonware_utils::{hex, Array};
+use commonware_utils::hex;
 use futures::stream::{self, Stream, StreamExt};
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use std::collections::BTreeMap;
@@ -73,7 +73,7 @@ pub struct Config {
 }
 
 /// Implementation of `Journal` storage.
-pub struct Journal<E: Storage + Metrics, A: Decode> {
+pub struct Journal<E: Storage + Metrics, A: Codec + FixedSize> {
     context: E,
     cfg: Config,
 
@@ -91,7 +91,7 @@ pub struct Journal<E: Storage + Metrics, A: Decode> {
     _array: PhantomData<A>,
 }
 
-impl<E: Storage + Metrics, A: Array> Journal<E, A> {
+impl<E: Storage + Metrics, A: Codec + FixedSize> Journal<E, A> {
     const CHUNK_SIZE: usize = u32::SIZE + A::SIZE;
     const CHUNK_SIZE_U64: u64 = Self::CHUNK_SIZE as u64;
 
@@ -215,6 +215,7 @@ impl<E: Storage + Metrics, A: Array> Journal<E, A> {
         assert!(*len < self.cfg.items_per_blob * Self::CHUNK_SIZE_U64);
         assert_eq!(*len % Self::CHUNK_SIZE_U64, 0);
         let mut buf: Vec<u8> = Vec::with_capacity(Self::CHUNK_SIZE);
+        let item = item.encode();
         let checksum = crc32fast::hash(&item);
         buf.extend_from_slice(&item);
         buf.put_u32(checksum);

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -73,7 +73,7 @@ pub struct Config {
 }
 
 /// Implementation of `Journal` storage.
-pub struct Journal<E: Storage + Metrics, A: Codec + FixedSize> {
+pub struct Journal<E: Storage + Metrics, A> {
     context: E,
     cfg: Config,
 
@@ -91,7 +91,7 @@ pub struct Journal<E: Storage + Metrics, A: Codec + FixedSize> {
     _array: PhantomData<A>,
 }
 
-impl<E: Storage + Metrics, A: Codec + FixedSize> Journal<E, A> {
+impl<E: Storage + Metrics, A: Encode + Decode<Cfg = ()> + FixedSize> Journal<E, A> {
     const CHUNK_SIZE: usize = u32::SIZE + A::SIZE;
     const CHUNK_SIZE_U64: u64 = Self::CHUNK_SIZE as u64;
 

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -50,7 +50,7 @@
 
 use super::Error;
 use bytes::BufMut;
-use commonware_codec::{DecodeExt, FixedSize};
+use commonware_codec::{Decode, DecodeExt, FixedSize};
 use commonware_runtime::{Blob, Error as RError, Metrics, Storage};
 use commonware_utils::{hex, Array};
 use futures::stream::{self, Stream, StreamExt};
@@ -73,7 +73,7 @@ pub struct Config {
 }
 
 /// Implementation of `Journal` storage.
-pub struct Journal<E: Storage + Metrics, A: Array> {
+pub struct Journal<E: Storage + Metrics, A: Decode> {
     context: E,
     cfg: Config,
 


### PR DESCRIPTION
(Work in progress)

Removes `any::Type` and replaces its usage with `Operation`