### PR TITLE
[consensus] Add "1k" Run + Move "slow" tests to `ignored`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,9 +17,14 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.rust-version }}
+        key: ${{ runner.os }}-cargo-registry
     - name: Cache cargo index
       uses: actions/cache@v4
       with:
         path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.rust-version }}
+        key: ${{ runner.os }}-cargo-index
+    - name: Maintain cargo cache
+      shell: bash
+      run: |
+        cargo install --locked cargo-cache >/dev/null 2>&1 || true
+        cargo cache --autoclean 3G

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ runs:
       run: |
         echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
         echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-        echo "SCCACHE_CACHE_SIZE=6G"
+        echo "SCCACHE_CACHE_SIZE=6G" >> "$GITHUB_ENV"
     - name: Cache cargo registry
       uses: actions/cache@v4
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,6 +22,7 @@ runs:
         key: ${{ runner.os }}-cargo-index
     - name: Get Rust version
       id: rust-version
+      shell: bash
       run: echo "rust_version=$(rustc +nightly --version)" >> "$GITHUB_OUTPUT"
     - name: Cache cargo-cache
       id: cargo-cache-cache

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,5 +23,5 @@ runs:
     - name: Maintain cargo cache
       shell: bash
       run: |
-        cargo install --locked cargo-cache >/dev/null 2>&1 || true
-        cargo cache --autoclean -- --limit 3G
+        cargo install --locked cargo-cache
+        cargo cache --autoclean

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ runs:
   using: 'composite'
   steps:
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.8
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Configure sccache
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,5 +23,5 @@ runs:
     - name: Maintain cargo cache
       shell: bash
       run: |
-        cargo install --locked cargo-cache
+        cargo install cargo-cache
         cargo cache --autoclean

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Get Rust version
       id: rust-version
       shell: bash
-      run: echo "rust_version=$(rustc +nightly --version)" >> "$GITHUB_OUTPUT"
+      run: echo "rust_version=$(rustc --version)" >> "$GITHUB_OUTPUT"
     - name: Cache cargo-cache
       id: cargo-cache-cache
       uses: actions/cache@v4

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,6 +9,7 @@ runs:
       run: |
         echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
         echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "SCCACHE_CACHE_SIZE=6G"
     - name: Cache cargo registry
       uses: actions/cache@v4
       with:
@@ -23,4 +24,4 @@ runs:
       shell: bash
       run: |
         cargo install --locked cargo-cache >/dev/null 2>&1 || true
-        cargo cache --autoclean 3G
+        cargo cache --autoclean --limit 3G

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,6 +4,8 @@ runs:
   steps:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.8
+      with:
+        cache-mode: 'local'
     - name: Configure sccache
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,4 +24,4 @@ runs:
       shell: bash
       run: |
         cargo install --locked cargo-cache >/dev/null 2>&1 || true
-        cargo cache --autoclean --limit 3G
+        cargo cache --autoclean -- --limit 3G

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,8 +20,17 @@ runs:
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index
+    - name: Get Rust version
+      id: rust-version
+      run: echo "rust_version=$(rustc +nightly --version)" >> "$GITHUB_OUTPUT"
+    - name: Cache cargo-cache
+      id: cargo-cache-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/cargo-cache
+        key: ${{ runner.os }}-cargo-cache-${{ steps.rust-version.outputs.rust_version }}
     - name: Maintain cargo cache
       shell: bash
       run: |
-        cargo install cargo-cache
+        cargo install cargo-cache || true
         cargo cache --autoclean

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,8 +23,3 @@ runs:
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.rust-version }}
-    - name: Cache cargo target
-      uses: actions/cache@v4
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.rust-version }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,8 +4,6 @@ runs:
   steps:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.8
-      with:
-        cache-mode: 'local'
     - name: Configure sccache
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,11 +15,11 @@ runs:
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry
-    - name: Cache cargo index
+    - name: Cache cargo git
       uses: actions/cache@v4
       with:
         path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index
+        key: ${{ runner.os }}-cargo-git
     - name: Get Rust version
       id: rust-version
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.8
+    - name: Configure sccache
+      shell: bash
+      run: |
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
     - name: Cache cargo registry
       uses: actions/cache@v4
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,8 +1,4 @@
 name: 'Setup'
-inputs:
-  rust-version:
-    description: 'The version of Rust to use in cache keys'
-    required: true
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,13 +40,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install nightly Rust toolchain
         run: rustup toolchain install nightly
-      - name: Get Rust version
-        id: rust-version
-        run: echo "rust_version=$(rustc +nightly --version)" >> "$GITHUB_OUTPUT"
       - name: Run setup
         uses: ./.github/actions/setup
-        with:
-          rust-version: ${{ steps.rust-version.outputs.rust_version}}
       - name: Compile benchmarks
         run: cargo bench --no-run
       - name: Run benchmark

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate coverage report
-      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      run: cargo llvm-cov --include-ignored --all-features --workspace --lcov --output-path lcov.info
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate coverage report
-      run: cargo llvm-cov --include-ignored --all-features --workspace --lcov --output-path lcov.info
+      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info -- --include-ignored
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Coverage 
+name: Coverage
 
 on:
   push:
@@ -14,13 +14,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Get Rust version
-      id: rust-version
-      run: echo "rust_version=$(rustc --version)" >> "$GITHUB_OUTPUT"
     - name: Run setup
       uses: ./.github/actions/setup
-      with:
-        rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Remove examples
       # Reduces compilation time on code we exclude from coverage
       run: rm -rf examples

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,13 +10,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Get Rust version
-      id: rust-version
-      run: echo "rust_version=$(rustc --version)" >> "$GITHUB_OUTPUT"
     - name: Run setup
       uses: ./.github/actions/setup
-      with:
-        rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Publish macros
       run: cargo publish --manifest-path macros/Cargo.toml
       continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Run ignored tests
-      run: cargo test --verbose --ignored
+      run: cargo test --verbose -- --ignored
 
   Dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ env:
   UDEPS_VERSION: 0.1.50
 
 jobs:
-  All:
+  Lint:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -30,6 +30,19 @@ jobs:
       run: cargo doc --no-deps --document-private-items
       env:
         RUSTDOCFLAGS: "-D warnings"
+
+  All:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Get Rust version
+      id: rust-version
+      run: echo "rust_version=$(rustc --version)" >> "$GITHUB_OUTPUT"
+    - name: Run setup
+      uses: ./.github/actions/setup
+      with:
+        rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Run tests
       run: cargo test --verbose
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,21 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
+  Ignored:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Get Rust version
+      id: rust-version
+      run: echo "rust_version=$(rustc --version)" >> "$GITHUB_OUTPUT"
+    - name: Run setup
+      uses: ./.github/actions/setup
+      with:
+        rust-version: ${{ steps.rust-version.outputs.rust_version}}
+    - name: Run ignored tests
+      run: cargo test --verbose --ignored
+
   Dependencies:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       env:
         RUSTDOCFLAGS: "-D warnings"
 
-  All:
+  Fast:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -46,7 +46,7 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
-  Ignored:
+  Slow:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Get Rust version
-      id: rust-version
-      run: echo "rust_version=$(rustc --version)" >> "$GITHUB_OUTPUT"
     - name: Run setup
       uses: ./.github/actions/setup
-      with:
-        rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Lint
       run: cargo clippy --all-targets --all-features -- -D warnings
     - name: Fmt
@@ -36,13 +31,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Get Rust version
-      id: rust-version
-      run: echo "rust_version=$(rustc --version)" >> "$GITHUB_OUTPUT"
     - name: Run setup
       uses: ./.github/actions/setup
-      with:
-        rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Run tests
       run: cargo test --verbose
 
@@ -51,13 +41,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Get Rust version
-      id: rust-version
-      run: echo "rust_version=$(rustc --version)" >> "$GITHUB_OUTPUT"
     - name: Run setup
       uses: ./.github/actions/setup
-      with:
-        rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Run ignored tests
       run: cargo test --verbose -- --ignored
 
@@ -73,8 +58,6 @@ jobs:
       run: echo "rust_version=$(rustc +nightly --version)" >> "$GITHUB_OUTPUT"
     - name: Run setup
       uses: ./.github/actions/setup
-      with:
-        rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Cache cargo-udeps
       id: cargo-udeps-cache
       uses: actions/cache@v4
@@ -92,13 +75,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Get Rust version
-      id: rust-version
-      run: echo "rust_version=$(rustc --version)" >> "$GITHUB_OUTPUT"
     - name: Run setup
       uses: ./.github/actions/setup
-      with:
-        rust-version: ${{ steps.rust-version.outputs.rust_version}}
     - name: Add WASM target
       run: rustup target add wasm32-unknown-unknown
     - name: Build cryptography

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -182,7 +182,8 @@ mod tests {
     fn spawn_validator_engines(
         context: Context,
         identity: poly::Public,
-        pks: &[PublicKey],
+        sequencer_pks: &[PublicKey],
+        validator_pks: &[PublicKey],
         validators: &[(PublicKey, Ed25519, Share)],
         registrations: &mut Registrations<PublicKey>,
         automatons: &mut BTreeMap<PublicKey, mocks::Automaton<PublicKey>>,
@@ -197,10 +198,10 @@ mod tests {
             let context = context.with_label(&validator.to_string());
             let monitor = mocks::Monitor::new(111);
             monitors.insert(validator.clone(), monitor.clone());
-            let sequencers = mocks::Sequencers::<PublicKey>::new(pks.to_vec());
+            let sequencers = mocks::Sequencers::<PublicKey>::new(sequencer_pks.to_vec());
             let validators = mocks::Validators::<PublicKey>::new(
                 identity.clone(),
-                pks.to_vec(),
+                validator_pks.to_vec(),
                 Some(share.clone()),
             );
 
@@ -334,6 +335,7 @@ mod tests {
                 context.with_label("validator"),
                 identity.clone(),
                 &pks,
+                &pks,
                 &validators,
                 &mut registrations,
                 &mut automatons.lock().unwrap(),
@@ -411,6 +413,7 @@ mod tests {
                     context.with_label("validator"),
                     identity.clone(),
                     &pks,
+                    &pks,
                     &validators,
                     &mut registrations,
                     &mut automatons.lock().unwrap(),
@@ -487,6 +490,7 @@ mod tests {
                 context.with_label("validator"),
                 identity.clone(),
                 &pks,
+                &pks,
                 &validators,
                 &mut registrations,
                 &mut automatons.lock().unwrap(),
@@ -556,6 +560,7 @@ mod tests {
                 context.with_label("validator"),
                 identity.clone(),
                 &pks,
+                &pks,
                 &validators,
                 &mut registrations,
                 &mut automatons.lock().unwrap(),
@@ -619,6 +624,7 @@ mod tests {
                 context.with_label("validator"),
                 identity.clone(),
                 &pks,
+                &pks,
                 &validators,
                 &mut registrations,
                 &mut automatons.lock().unwrap(),
@@ -664,6 +670,7 @@ mod tests {
             let monitors = spawn_validator_engines(
                 context.with_label("validator"),
                 identity.clone(),
+                &pks,
                 &pks,
                 &validators,
                 &mut registrations,
@@ -922,9 +929,11 @@ mod tests {
             ));
             let mut reporters =
                 BTreeMap::<PublicKey, mocks::ReporterMailbox<Ed25519, Sha256Digest>>::new();
+            let sequencers = &pks[0..pks.len() / 2];
             spawn_validator_engines(
                 context.with_label("validator"),
                 identity.clone(),
+                sequencers,
                 &pks,
                 &validators,
                 &mut registrations,
@@ -937,7 +946,7 @@ mod tests {
 
             await_reporters(
                 context.with_label("reporter"),
-                reporters.keys().cloned().collect::<Vec<_>>(),
+                sequencers.to_vec(),
                 &reporters,
                 (1_000, 111, false),
             )

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -588,6 +588,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_determinism() {
         // We use slow and lossy links as the deterministic test
         // because it is the most complex test.

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -899,6 +899,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_1k() {
         let num_validators: u32 = 10;
         let quorum: u32 = 3;

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -464,6 +464,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_network_partition() {
         let num_validators: u32 = 4;
         let quorum: u32 = 3;

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -1700,15 +1700,17 @@ mod tests {
         }
     }
 
-    #[test_traced]
-    fn test_conflicter() {
+    fn conflicter(seed: u64) {
         // Create context
         let n = 4;
         let required_containers = 50;
         let activity_timeout = 10;
         let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
-        let executor = deterministic::Runner::timed(Duration::from_secs(30));
+        let cfg = deterministic::Config::new()
+            .with_seed(seed)
+            .with_timeout(Some(Duration::from_secs(30)));
+        let executor = deterministic::Runner::new(cfg);
         executor.start(|context| async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
@@ -1860,14 +1862,23 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_nuller() {
+    fn test_conflicter() {
+        for seed in 0..5 {
+            conflicter(seed);
+        }
+    }
+
+    fn nuller(seed: u64) {
         // Create context
         let n = 4;
         let required_containers = 50;
         let activity_timeout = 10;
         let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
-        let executor = deterministic::Runner::timed(Duration::from_secs(30));
+        let cfg = deterministic::Config::new()
+            .with_seed(seed)
+            .with_timeout(Some(Duration::from_secs(30)));
+        let executor = deterministic::Runner::new(cfg);
         executor.start(|context| async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
@@ -2011,14 +2022,23 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_outdated() {
+    fn test_nuller() {
+        for seed in 0..5 {
+            nuller(seed);
+        }
+    }
+
+    fn outdated(seed: u64) {
         // Create context
         let n = 4;
         let required_containers = 100;
         let activity_timeout = 10;
         let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
-        let executor = deterministic::Runner::timed(Duration::from_secs(30));
+        let cfg = deterministic::Config::new()
+            .with_seed(seed)
+            .with_timeout(Some(Duration::from_secs(30)));
+        let executor = deterministic::Runner::new(cfg);
         executor.start(|context| async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
@@ -2145,6 +2165,13 @@ mod tests {
                 }
             }
         });
+    }
+
+    #[test_traced]
+    fn test_outdated() {
+        for seed in 0..5 {
+            outdated(seed);
+        }
     }
 
     #[test_traced]

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -1380,6 +1380,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_partition() {
         // Create context
         let n = 10;

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -2175,6 +2175,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_1k() {
         // Create context
         let n = 10;

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -1685,6 +1685,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_determinism() {
         // We use slow and lossy links as the deterministic test
         // because it is the most complex test.

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -1863,6 +1863,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_conflicter() {
         for seed in 0..5 {
             conflicter(seed);
@@ -2023,6 +2024,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_nuller() {
         for seed in 0..5 {
             nuller(seed);
@@ -2169,6 +2171,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_outdated() {
         for seed in 0..5 {
             outdated(seed);

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -1817,8 +1817,7 @@ mod tests {
         }
     }
 
-    #[test_traced]
-    fn test_conflicter() {
+    fn conflicter(seed: u64) {
         // Create context
         let n = 4;
         let threshold = quorum(n);
@@ -1826,7 +1825,10 @@ mod tests {
         let activity_timeout = 10;
         let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
-        let executor = deterministic::Runner::timed(Duration::from_secs(30));
+        let cfg = deterministic::Config::new()
+            .with_seed(seed)
+            .with_timeout(Some(Duration::from_secs(30)));
+        let executor = deterministic::Runner::new(cfg);
         executor.start(|mut context| async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
@@ -1983,7 +1985,13 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_nuller() {
+    fn test_conflicter() {
+        for seed in 0..5 {
+            conflicter(seed);
+        }
+    }
+
+    fn nuller(seed: u64) {
         // Create context
         let n = 4;
         let threshold = quorum(n);
@@ -1991,7 +1999,10 @@ mod tests {
         let activity_timeout = 10;
         let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
-        let executor = deterministic::Runner::timed(Duration::from_secs(30));
+        let cfg = deterministic::Config::new()
+            .with_seed(seed)
+            .with_timeout(Some(Duration::from_secs(30)));
+        let executor = deterministic::Runner::new(cfg);
         executor.start(|mut context| async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
@@ -2140,7 +2151,13 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_outdated() {
+    fn test_nuller() {
+        for seed in 0..5 {
+            nuller(seed);
+        }
+    }
+
+    fn outdated(seed: u64) {
         // Create context
         let n = 4;
         let threshold = quorum(n);
@@ -2148,7 +2165,10 @@ mod tests {
         let activity_timeout = 10;
         let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
-        let executor = deterministic::Runner::timed(Duration::from_secs(30));
+        let cfg = deterministic::Config::new()
+            .with_seed(seed)
+            .with_timeout(Some(Duration::from_secs(30)));
+        let executor = deterministic::Runner::new(cfg);
         executor.start(|mut context| async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
@@ -2280,6 +2300,13 @@ mod tests {
                 }
             }
         });
+    }
+
+    #[test_traced]
+    fn test_outdated() {
+        for seed in 0..5 {
+            outdated(seed);
+        }
     }
 
     #[test_traced]

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -1802,6 +1802,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_determinism() {
         // We use slow and lossy links as the deterministic test
         // because it is the most complex test.

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -2310,6 +2310,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_1k() {
         // Create context
         let n = 10;

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -2281,4 +2281,134 @@ mod tests {
             }
         });
     }
+
+    #[test_traced]
+    fn test_1k() {
+        // Create context
+        let n = 10;
+        let threshold = quorum(n);
+        let required_containers = 1_000;
+        let activity_timeout = 10;
+        let skip_timeout = 5;
+        let namespace = b"consensus".to_vec();
+        let cfg = deterministic::Config::new().with_timeout(Some(Duration::from_secs(5_000)));
+        let executor = deterministic::Runner::new(cfg);
+        executor.start(|mut context| async move {
+            // Create simulated network
+            let (network, mut oracle) = Network::new(
+                context.with_label("network"),
+                Config {
+                    max_size: 1024 * 1024,
+                },
+            );
+
+            // Start network
+            network.start();
+
+            // Register participants
+            let mut schemes = Vec::new();
+            let mut validators = Vec::new();
+            for i in 0..n {
+                let scheme = Ed25519::from_seed(i as u64);
+                let pk = scheme.public_key();
+                schemes.push(scheme);
+                validators.push(pk);
+            }
+            validators.sort();
+            schemes.sort_by_key(|s| s.public_key());
+            let mut registrations = register_validators(&mut oracle, &validators).await;
+
+            // Link all validators
+            let link = Link {
+                latency: 80.0,
+                jitter: 10.0,
+                success_rate: 0.98,
+            };
+            link_validators(&mut oracle, &validators, Action::Link(link), None).await;
+
+            // Derive threshold
+            let (public, shares) = ops::generate_shares(&mut context, None, n, threshold);
+
+            // Create engines
+            let relay = Arc::new(mocks::relay::Relay::new());
+            let mut supervisors = Vec::new();
+            let mut engine_handlers = Vec::new();
+            for (idx, scheme) in schemes.into_iter().enumerate() {
+                // Create scheme context
+                let context = context.with_label(&format!("validator-{}", scheme.public_key()));
+
+                // Configure engine
+                let validator = scheme.public_key();
+                let mut participants = BTreeMap::new();
+                participants.insert(0, (public.clone(), validators.clone(), shares[idx].clone()));
+                let supervisor_config = mocks::supervisor::Config {
+                    namespace: namespace.clone(),
+                    participants,
+                };
+                let supervisor = mocks::supervisor::Supervisor::new(supervisor_config);
+                supervisors.push(supervisor.clone());
+                let application_cfg = mocks::application::Config {
+                    hasher: Sha256::default(),
+                    relay: relay.clone(),
+                    participant: validator.clone(),
+                    propose_latency: (100.0, 50.0),
+                    verify_latency: (50.0, 40.0),
+                };
+                let (actor, application) = mocks::application::Application::new(
+                    context.with_label("application"),
+                    application_cfg,
+                );
+                actor.start();
+                let cfg = config::Config {
+                    crypto: scheme,
+                    automaton: application.clone(),
+                    relay: application.clone(),
+                    reporter: supervisor.clone(),
+                    supervisor,
+                    partition: validator.to_string(),
+                    compression: Some(3),
+                    mailbox_size: 1024,
+                    namespace: namespace.clone(),
+                    leader_timeout: Duration::from_secs(1),
+                    notarization_timeout: Duration::from_secs(2),
+                    nullify_retry: Duration::from_secs(10),
+                    fetch_timeout: Duration::from_secs(1),
+                    activity_timeout,
+                    skip_timeout,
+                    max_fetch_count: 1,
+                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_concurrent: 1,
+                    replay_concurrency: 1,
+                };
+                let engine = Engine::new(context.with_label("engine"), cfg);
+
+                // Start engine
+                let (voter, resolver) = registrations
+                    .remove(&validator)
+                    .expect("validator should be registered");
+                engine_handlers.push(engine.start(voter, resolver));
+            }
+
+            // Wait for all engines to finish
+            let mut finalizers = Vec::new();
+            for supervisor in supervisors.iter_mut() {
+                let (mut latest, mut monitor) = supervisor.subscribe().await;
+                finalizers.push(context.with_label("finalizer").spawn(move |_| async move {
+                    while latest < required_containers {
+                        latest = monitor.next().await.expect("event missing");
+                    }
+                }));
+            }
+            join_all(finalizers).await;
+
+            // Check supervisors for correct activity
+            for supervisor in supervisors.iter() {
+                // Ensure no faults
+                {
+                    let faults = supervisor.faults.lock().unwrap();
+                    assert!(faults.is_empty());
+                }
+            }
+        })
+    }
 }

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -1986,6 +1986,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_conflicter() {
         for seed in 0..5 {
             conflicter(seed);
@@ -2152,6 +2153,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_nuller() {
         for seed in 0..5 {
             nuller(seed);
@@ -2304,6 +2306,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_outdated() {
         for seed in 0..5 {
             outdated(seed);

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -1485,6 +1485,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_partition() {
         // Create context
         let n = 10;

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -2291,7 +2291,7 @@ mod tests {
         let activity_timeout = 10;
         let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
-        let cfg = deterministic::Config::new().with_timeout(Some(Duration::from_secs(5_000)));
+        let cfg = deterministic::Config::new();
         let executor = deterministic::Runner::new(cfg);
         executor.start(|mut context| async move {
             // Create simulated network

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -440,6 +440,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_determinism_one() {
         for i in 0..10 {
             run_deterministic_test(i, Mode::One);
@@ -447,6 +448,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_determinism_some() {
         for i in 0..10 {
             run_deterministic_test(i, Mode::Some);
@@ -454,6 +456,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_determinism_all() {
         for i in 0..10 {
             run_deterministic_test(i, Mode::All);

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -868,11 +868,13 @@ mod tests {
     }
 
     #[test_traced]
+    #[ignore]
     fn test_archive_many_keys_and_restart() {
         test_archive_keys_and_restart(100_000); // 391 sections
     }
 
     #[test_traced]
+    #[ignore]
     fn test_determinism() {
         let state1 = test_archive_keys_and_restart(5_000); // 20 sections
         let state2 = test_archive_keys_and_restart(5_000);


### PR DESCRIPTION
I was getting annoyed with our CI latency, so I put some elbow grease in and:
* broke tests into "lint", "slow", "fast" (all run concurrently now)
* added a caching layer around `rustc` via `sccache`
* changed how we cache cargo data

As a result:
* `Lint` is ~40% faster
* `Fast` takes ~5 minutes (old tests used to take ~20 minutes or so to get any feedback)


*****

This pull request introduces several updates to the CI workflows and test suite. The changes focus on improving caching mechanisms, simplifying workflow configurations, and enhancing test coverage and determinism. Additionally, new test cases and configurations have been added to the consensus module.

### CI Workflow Improvements:

* [`.github/actions/setup/action.yml`](diffhunk://#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530L2-R37): Removed the `rust-version` input and introduced `sccache` for caching Rust builds. Updated cache keys to remove dependency on Rust version and added a step to maintain the cargo cache.
* `.github/workflows/benchmark.yml`, `.github/workflows/coverage.yml`, `.github/workflows/publish.yml`, and `.github/workflows/tests.yml`: Simplified workflows by removing the explicit Rust version retrieval step and its usage in cache keys. [[1]](diffhunk://#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0L43-L49) [[2]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L17-L23) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L13-L19) [[4]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL13-L24)

### Workflow Enhancements:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR28-R48): Split the `All` job into `Lint`, `Fast`, and `Slow` jobs for better granularity. Added a dedicated job for running ignored tests. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR28-R48) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL67-L73)

### Test Suite Enhancements:

* [`consensus/src/ordered_broadcast/mod.rs`](diffhunk://#diff-d46da4034254bb485fd2e475b8278c7e2c6fc7e5965e08284814399eb7fbbaf6R467): Added new test cases (`test_1k`) and marked complex tests (`test_network_partition`, `test_determinism`) as ignored to improve test organization and focus. Updated function signatures to distinguish between sequencer and validator public keys. [[1]](diffhunk://#diff-d46da4034254bb485fd2e475b8278c7e2c6fc7e5965e08284814399eb7fbbaf6R467) [[2]](diffhunk://#diff-d46da4034254bb485fd2e475b8278c7e2c6fc7e5965e08284814399eb7fbbaf6R902-R958) [[3]](diffhunk://#diff-d46da4034254bb485fd2e475b8278c7e2c6fc7e5965e08284814399eb7fbbaf6R592)
* [`consensus/src/simplex/mod.rs`](diffhunk://#diff-743aab9a5d2251ca57cf9d9257328f2d2f29229ee44fa452cb56e5b350028a71L1703-R1715): Refactored tests into reusable functions (`conflicter`, `nuller`, `outdated`) and added loops to run them with different seeds for better determinism. Marked certain tests as ignored to reduce runtime in default test runs. [[1]](diffhunk://#diff-743aab9a5d2251ca57cf9d9257328f2d2f29229ee44fa452cb56e5b350028a71L1703-R1715) [[2]](diffhunk://#diff-743aab9a5d2251ca57cf9d9257328f2d2f29229ee44fa452cb56e5b350028a71L1863-R1884) [[3]](diffhunk://#diff-743aab9a5d2251ca57cf9d9257328f2d2f29229ee44fa452cb56e5b350028a71L2014-R2045)

### Minor Improvements:

* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L33-R28): Enhanced the coverage report generation by including ignored tests in the coverage calculation.