### PR TITLE
[release] v0.0.50

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-bridge"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "chrono",
  "clap",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "paste",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "blst",
  "bytes",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "chrono",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bimap",
  "bytes",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "async-lock",
  "axum",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-vrf"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.49", path = "broadcast" }
-commonware-codec = { version = "0.0.49", path = "codec" }
-commonware-consensus = { version = "0.0.49", path = "consensus" }
-commonware-cryptography = { version = "0.0.49", path = "cryptography" }
-commonware-deployer = { version = "0.0.49", path = "deployer", default-features = false }
-commonware-macros = { version = "0.0.49", path = "macros" }
-commonware-p2p = { version = "0.0.49", path = "p2p" }
-commonware-resolver = { version = "0.0.49", path = "resolver" }
-commonware-runtime = { version = "0.0.49", path = "runtime" }
-commonware-storage = { version = "0.0.49", path = "storage" }
-commonware-stream = { version = "0.0.49", path = "stream" }
-commonware-utils = { version = "0.0.49", path = "utils" }
+commonware-broadcast = { version = "0.0.50", path = "broadcast" }
+commonware-codec = { version = "0.0.50", path = "codec" }
+commonware-consensus = { version = "0.0.50", path = "consensus" }
+commonware-cryptography = { version = "0.0.50", path = "cryptography" }
+commonware-deployer = { version = "0.0.50", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.50", path = "macros" }
+commonware-p2p = { version = "0.0.50", path = "p2p" }
+commonware-resolver = { version = "0.0.50", path = "resolver" }
+commonware-runtime = { version = "0.0.50", path = "runtime" }
+commonware-storage = { version = "0.0.50", path = "storage" }
+commonware-stream = { version = "0.0.50", path = "stream" }
+commonware-utils = { version = "0.0.50", path = "utils" }
 thiserror = "2.0.12"
 bytes = "1.7.1"
 sha2 = "0.10.8"

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-broadcast"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Disseminate data over a wide-area network."
 readme = "README.md"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-codec"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Serialize structured data."
 readme = "README.md"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-consensus"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Order opaque messages in a Byzantine environment."
 readme = "README.md"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify signatures."
 readme = "README.md"

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-deployer"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Deploy infrastructure across cloud providers."
 readme = "README.md"

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-bridge"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Send succinct consensus certificates between two networks."
 readme = "README.md"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-flood"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Spam peers deployed to AWS EC2 with random messages."
 readme = "README.md"

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-log"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Commit to a secret log and agree to its hash."
 readme = "README.md"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-vrf"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-macros"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Augment the development of primitives with procedural macros."
 readme = "README.md"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-resolver"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Resolve data identified by a fixed-length key."
 readme = "README.md"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-runtime"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Execute asynchronous tasks with a configurable scheduler."
 readme = "README.md"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-storage"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Persist and retrieve data from an abstract store."
 readme = "README.md"

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-stream"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Exchange messages over arbitrary transport."
 readme = "README.md"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-utils"
 edition = "2021"
 publish = true
-version = "0.0.49"
+version = "0.0.50"
 license = "MIT OR Apache-2.0"
 description = "Leverage common functionality across multiple primitives."
 readme = "README.md"


### PR DESCRIPTION
# commonware v0.0.50 – Release Notes

## 🚀 Highlights

### `runtime::network` Refactor

* Layered modules: `network::{deterministic, audited, metered, tokio}`.
* `Context` & Tokio runtime now compose these layers ⇒ auditing hooks, per-connection metrics, time-outs.
* New helper type alias: `ListenerOf<N>`; `SinkOf` / `StreamOf` unchanged.

### `storage::index` Overhaul

* Added Prometheus **`keys`** and **`items`** gauges; removed `collisions` counter.
* `Index::len()/is_empty()` → **`keys()`** (breaking).
* `Cursor` rewritten—safer phase machine.

### `storage::adb` `Operation` enum

* Replaced opaque byte blob with explicit `Operation::{Deleted, Update, Commit}`.
* Helpers `to_key()` / `to_value()` now return `Option<&…>`; `Type` enum removed (breaking).

---

## ⚙️ CI / Tooling

| Change              | Detail                                                                                                                               |
| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
| **Caching**         | Switch to `mozilla-actions/sccache@v0.0.9` (`SCCACHE_CACHE_SIZE=6G`); new `cargo-cache --autoclean`; static registry/git cache keys. |
| **Workflows**       | `tests.yml` split into **Lint**, **Fast**, **Slow**, **Dependencies**; auto-detect Rust version.                                     |
| **Coverage**        | `codecov-action@v5`; pass `--include-ignored`.                                                                                       |
| **Bench / Publish** | Updated to new reusable Setup action.                                                                                                |

---

## ✨ Improvements

* **Metrics**: network bandwidth & task gauges; index now exports `keys`, `items`, `pruned_total`.
* **Runtime**: deterministic runner gains audited + metered layers; Tokio runtime delegates networking to metered wrapper.
* **Storage**: `Journal`, `MMR`, bitmap now expose sync `size()`; CRC handling fixed.
* **Tests**: large stress suites (`test_1k`, partitions) gated by `#[ignore]`; deterministic tests parameterised by seed.

---

## ⚠️ Breaking changes

1. `Index::len()`/`is_empty()` removed → use `keys()`.
2. `Operation` API changed; old `Type` enum gone.
3. Several long-running tests now `#[ignore]`; CI updated.

---

## Migration checklist

* Replace `len()` with `keys()` wherever the index is queried.
* Update any code matching on `Type` to the new `Operation` enum.
* If you consume `collisions` metric, switch (or drop) in favour of `keys`/`items`.

```
 .github/actions/setup/action.yml       |  34 ++-
 .github/workflows/benchmark.yml        |   5 -
 .github/workflows/coverage.yml         |  11 +-
 .github/workflows/publish.yml          |   5 -
 .github/workflows/tests.yml            |  32 +--
 Cargo.lock                             |  34 +--
 Cargo.toml                             |  24 +-
 broadcast/Cargo.toml                   |   2 +-
 codec/Cargo.toml                       |   2 +-
 consensus/Cargo.toml                   |   2 +-
 consensus/src/ordered_broadcast/mod.rs |  72 +++++-
 consensus/src/simplex/mod.rs           | 172 +++++++++++++-
 consensus/src/threshold_simplex/mod.rs | 177 +++++++++++++-
 cryptography/Cargo.toml                |   2 +-
 deployer/Cargo.toml                    |   2 +-
 examples/bridge/Cargo.toml             |   2 +-
 examples/chat/Cargo.toml               |   2 +-
 examples/flood/Cargo.toml              |   2 +-
 examples/log/Cargo.toml                |   2 +-
 examples/vrf/Cargo.toml                |   2 +-
 macros/Cargo.toml                      |   2 +-
 p2p/Cargo.toml                         |   2 +-
 p2p/src/authenticated/mod.rs           |   3 +
 resolver/Cargo.toml                    |   2 +-
 runtime/Cargo.toml                     |   2 +-
 runtime/src/deterministic.rs           | 234 +++----------------
 runtime/src/lib.rs                     |   7 +
 runtime/src/network/audited.rs         | 180 +++++++++++++++
 runtime/src/network/deterministic.rs   | 143 ++++++++++++
 runtime/src/network/metered.rs         | 162 +++++++++++++
 runtime/src/network/mod.rs             |   5 +
 runtime/src/network/tokio.rs           | 210 +++++++++++++++++
 runtime/src/tokio/runtime.rs           | 226 ++----------------
 storage/Cargo.toml                     |   2 +-
 storage/src/adb/any.rs                 |  90 +++++---
 storage/src/adb/operation.rs           | 250 ++++++++------------
 storage/src/archive/mod.rs             |   2 +
 storage/src/archive/storage.rs         |   2 +-
 storage/src/index/mod.rs               | 326 +++++++++++++++++++++++---
 storage/src/index/storage.rs           | 407 +++++++++++++++++----------------
 storage/src/journal/fixed.rs           |   9 +-
 storage/src/mmr/bitmap.rs              |   4 +-
 storage/src/mmr/journaled.rs           |   4 +-
 storage/src/mmr/mem.rs                 |   4 +-
 storage/src/mmr/verification.rs        |  11 +-
 stream/Cargo.toml                      |   2 +-
 utils/Cargo.toml                       |   2 +-
 47 files changed, 1937 insertions(+), 942 deletions(-)
```