### PR TITLE
[storage] Optimize `journal::replay()`

### DIFF
--- a/consensus/src/ordered_broadcast/config.rs
+++ b/consensus/src/ordered_broadcast/config.rs
@@ -76,6 +76,9 @@ pub struct Config<
     /// Upon replaying a journal, the number of entries to replay concurrently.
     pub journal_replay_concurrency: usize,
 
+    /// The number of bytes to look ahead when replaying a journal.
+    pub journal_replay_lookahead: usize,
+
     /// Compression level for the journal.
     pub journal_compression: Option<u8>,
 }

--- a/consensus/src/ordered_broadcast/config.rs
+++ b/consensus/src/ordered_broadcast/config.rs
@@ -76,7 +76,7 @@ pub struct Config<
     /// Upon replaying a journal, the number of entries to replay concurrently.
     pub journal_replay_concurrency: usize,
 
-    /// The number of bytes to look ahead when replaying a journal.
+    /// The number of bytes to buffer when replaying a journal.
     pub journal_replay_buffer: usize,
 
     /// Compression level for the journal.

--- a/consensus/src/ordered_broadcast/config.rs
+++ b/consensus/src/ordered_broadcast/config.rs
@@ -77,7 +77,7 @@ pub struct Config<
     pub journal_replay_concurrency: usize,
 
     /// The number of bytes to look ahead when replaying a journal.
-    pub journal_replay_lookahead: usize,
+    pub journal_replay_buffer: usize,
 
     /// Compression level for the journal.
     pub journal_compression: Option<u8>,

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -141,7 +141,7 @@ pub struct Engine<
     journal_replay_concurrency: usize,
 
     // The number of bytes to look ahead when replaying a journal.
-    journal_replay_lookahead: usize,
+    journal_replay_buffer: usize,
 
     // A prefix for the journal names.
     // The rest of the name is the hex-encoded public keys of the relevant sequencer.
@@ -234,7 +234,7 @@ impl<
             pending_verifies: FuturesPool::default(),
             journal_heights_per_section: cfg.journal_heights_per_section,
             journal_replay_concurrency: cfg.journal_replay_concurrency,
-            journal_replay_lookahead: cfg.journal_replay_lookahead,
+            journal_replay_buffer: cfg.journal_replay_buffer,
             journal_name_prefix: cfg.journal_name_prefix,
             journal_compression: cfg.journal_compression,
             journals: BTreeMap::new(),
@@ -974,10 +974,7 @@ impl<
 
             // Prepare the stream
             let stream = journal
-                .replay(
-                    self.journal_replay_concurrency,
-                    self.journal_replay_lookahead,
-                )
+                .replay(self.journal_replay_concurrency, self.journal_replay_buffer)
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -140,6 +140,9 @@ pub struct Engine<
     // The number of concurrent operations when replaying journals.
     journal_replay_concurrency: usize,
 
+    // The number of bytes to look ahead when replaying a journal.
+    journal_replay_lookahead: usize,
+
     // A prefix for the journal names.
     // The rest of the name is the hex-encoded public keys of the relevant sequencer.
     journal_name_prefix: String,
@@ -231,6 +234,7 @@ impl<
             pending_verifies: FuturesPool::default(),
             journal_heights_per_section: cfg.journal_heights_per_section,
             journal_replay_concurrency: cfg.journal_replay_concurrency,
+            journal_replay_lookahead: cfg.journal_replay_lookahead,
             journal_name_prefix: cfg.journal_name_prefix,
             journal_compression: cfg.journal_compression,
             journals: BTreeMap::new(),
@@ -960,7 +964,7 @@ impl<
             compression: self.journal_compression,
             codec_config: (),
         };
-        let mut journal = Journal::<_, Node<C, D>>::init(self.context.with_label("journal"), cfg)
+        let journal = Journal::<_, Node<C, D>>::init(self.context.with_label("journal"), cfg)
             .await
             .expect("unable to init journal");
 
@@ -970,7 +974,10 @@ impl<
 
             // Prepare the stream
             let stream = journal
-                .replay(self.journal_replay_concurrency)
+                .replay(
+                    self.journal_replay_concurrency,
+                    self.journal_replay_lookahead,
+                )
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -140,7 +140,7 @@ pub struct Engine<
     // The number of concurrent operations when replaying journals.
     journal_replay_concurrency: usize,
 
-    // The number of bytes to look ahead when replaying a journal.
+    // The number of bytes to buffer when replaying a journal.
     journal_replay_buffer: usize,
 
     // A prefix for the journal names.

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -234,7 +234,7 @@ mod tests {
                     priority_proposals: false,
                     journal_heights_per_section: 10,
                     journal_replay_concurrency: 1,
-                    journal_replay_lookahead: 4096,
+                    journal_replay_buffer: 4096,
                     journal_name_prefix: format!("ordered-broadcast-seq/{}/", validator),
                     journal_compression: Some(3),
                 },
@@ -830,7 +830,7 @@ mod tests {
                         priority_proposals: false,
                         journal_heights_per_section: 10,
                         journal_replay_concurrency: 1,
-                        journal_replay_lookahead: 4096,
+                        journal_replay_buffer: 4096,
                         journal_name_prefix: format!("ordered-broadcast-seq/{}/", validator),
                         journal_compression: Some(3),
                     },
@@ -879,7 +879,7 @@ mod tests {
                         priority_proposals: false,
                         journal_heights_per_section: 10,
                         journal_replay_concurrency: 1,
-                        journal_replay_lookahead: 4096,
+                        journal_replay_buffer: 4096,
                         journal_name_prefix: format!(
                             "ordered-broadcast-seq/{}/",
                             sequencer.public_key()

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -234,6 +234,7 @@ mod tests {
                     priority_proposals: false,
                     journal_heights_per_section: 10,
                     journal_replay_concurrency: 1,
+                    journal_replay_lookahead: 4096,
                     journal_name_prefix: format!("ordered-broadcast-seq/{}/", validator),
                     journal_compression: Some(3),
                 },
@@ -829,6 +830,7 @@ mod tests {
                         priority_proposals: false,
                         journal_heights_per_section: 10,
                         journal_replay_concurrency: 1,
+                        journal_replay_lookahead: 4096,
                         journal_name_prefix: format!("ordered-broadcast-seq/{}/", validator),
                         journal_compression: Some(3),
                     },
@@ -877,6 +879,7 @@ mod tests {
                         priority_proposals: false,
                         journal_heights_per_section: 10,
                         journal_replay_concurrency: 1,
+                        journal_replay_lookahead: 4096,
                         journal_name_prefix: format!(
                             "ordered-broadcast-seq/{}/",
                             sequencer.public_key()

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -327,7 +327,7 @@ pub struct Actor<
     partition: String,
     compression: Option<u8>,
     replay_concurrency: usize,
-    replay_lookahead: usize,
+    replay_buffer: usize,
     journal: Option<Journal<E, Voter<C::Signature, D>>>,
 
     genesis: Option<D>,
@@ -419,7 +419,7 @@ impl<
                 partition: cfg.partition,
                 compression: cfg.compression,
                 replay_concurrency: cfg.replay_concurrency,
-                replay_lookahead: cfg.replay_lookahead,
+                replay_buffer: cfg.replay_buffer,
                 journal: None,
 
                 genesis: None,
@@ -1695,7 +1695,7 @@ impl<
         let mut observed_view = 1;
         {
             let stream = journal
-                .replay(self.replay_concurrency, self.replay_lookahead)
+                .replay(self.replay_concurrency, self.replay_buffer)
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -327,6 +327,7 @@ pub struct Actor<
     partition: String,
     compression: Option<u8>,
     replay_concurrency: usize,
+    replay_lookahead: usize,
     journal: Option<Journal<E, Voter<C::Signature, D>>>,
 
     genesis: Option<D>,
@@ -418,6 +419,7 @@ impl<
                 partition: cfg.partition,
                 compression: cfg.compression,
                 replay_concurrency: cfg.replay_concurrency,
+                replay_lookahead: cfg.replay_lookahead,
                 journal: None,
 
                 genesis: None,
@@ -1678,7 +1680,7 @@ impl<
         self.enter_view(1);
 
         // Initialize journal
-        let mut journal = Journal::<_, Voter<C::Signature, D>>::init(
+        let journal = Journal::<_, Voter<C::Signature, D>>::init(
             self.context.with_label("journal"),
             JConfig {
                 partition: self.partition.clone(),
@@ -1693,7 +1695,7 @@ impl<
         let mut observed_view = 1;
         {
             let stream = journal
-                .replay(self.replay_concurrency)
+                .replay(self.replay_concurrency, self.replay_lookahead)
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -34,7 +34,7 @@ pub struct Config<
     pub activity_timeout: View,
     pub skip_timeout: View,
     pub replay_concurrency: usize,
-    pub replay_lookahead: usize,
+    pub replay_buffer: usize,
 }
 
 #[cfg(test)]
@@ -125,7 +125,7 @@ mod tests {
                 activity_timeout: 10,
                 skip_timeout: 10,
                 replay_concurrency: 1,
-                replay_lookahead: 1024 * 1024,
+                replay_buffer: 1024 * 1024,
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -34,6 +34,7 @@ pub struct Config<
     pub activity_timeout: View,
     pub skip_timeout: View,
     pub replay_concurrency: usize,
+    pub replay_lookahead: usize,
 }
 
 #[cfg(test)]
@@ -124,6 +125,7 @@ mod tests {
                 activity_timeout: 10,
                 skip_timeout: 10,
                 replay_concurrency: 1,
+                replay_lookahead: 1024 * 1024,
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -44,6 +44,9 @@ pub struct Config<
     /// Number of views to replay concurrently during startup.
     pub replay_concurrency: usize,
 
+    /// Number of bytes to look ahead when replaying during startup.
+    pub replay_lookahead: usize,
+
     /// Amount of time to wait for a leader to propose a payload
     /// in a view.
     pub leader_timeout: Duration,

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -45,7 +45,7 @@ pub struct Config<
     pub replay_concurrency: usize,
 
     /// Number of bytes to look ahead when replaying during startup.
-    pub replay_lookahead: usize,
+    pub replay_buffer: usize,
 
     /// Amount of time to wait for a leader to propose a payload
     /// in a view.

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -44,7 +44,7 @@ pub struct Config<
     /// Number of views to replay concurrently during startup.
     pub replay_concurrency: usize,
 
-    /// Number of bytes to look ahead when replaying during startup.
+    /// Number of bytes to buffer when replaying during startup.
     pub replay_buffer: usize,
 
     /// Amount of time to wait for a leader to propose a payload

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -65,7 +65,7 @@ impl<
                 activity_timeout: cfg.activity_timeout,
                 skip_timeout: cfg.skip_timeout,
                 replay_concurrency: cfg.replay_concurrency,
-                replay_lookahead: cfg.replay_lookahead,
+                replay_buffer: cfg.replay_buffer,
             },
         );
 

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -65,6 +65,7 @@ impl<
                 activity_timeout: cfg.activity_timeout,
                 skip_timeout: cfg.skip_timeout,
                 replay_concurrency: cfg.replay_concurrency,
+                replay_lookahead: cfg.replay_lookahead,
             },
         );
 

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -324,7 +324,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
                 let (voter, resolver) = registrations
@@ -568,7 +568,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
-                        replay_lookahead: 1024 * 1024,
+                        replay_buffer: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     let (voter_network, resolver_network) = registrations
@@ -736,7 +736,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -854,7 +854,7 @@ mod tests {
                 fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                 fetch_concurrent: 1,
                 replay_concurrency: 1,
-                replay_lookahead: 1024 * 1024,
+                replay_buffer: 1024 * 1024,
             };
             let (voter, resolver) = registrations
                 .remove(&validator)
@@ -975,7 +975,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1170,7 +1170,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1327,7 +1327,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1477,7 +1477,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1655,7 +1655,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1821,7 +1821,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
-                        replay_lookahead: 1024 * 1024,
+                        replay_buffer: 1024 * 1024,
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -1988,7 +1988,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
-                        replay_lookahead: 1024 * 1024,
+                        replay_buffer: 1024 * 1024,
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2151,7 +2151,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
-                        replay_lookahead: 1024 * 1024,
+                        replay_buffer: 1024 * 1024,
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2286,7 +2286,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -139,14 +139,13 @@ mod tests {
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{deterministic, Clock, Metrics, Runner, Spawner};
-    use commonware_utils::{quorum, Array};
+    use commonware_utils::{quorum, Array, NZU32};
     use engine::Engine;
     use futures::{future::join_all, StreamExt};
     use governor::Quota;
     use rand::Rng as _;
     use std::{
         collections::{BTreeMap, HashMap},
-        num::NonZeroU32,
         sync::{Arc, Mutex},
         time::Duration,
     };
@@ -321,7 +320,7 @@ mod tests {
                     skip_timeout,
                     max_fetch_count: 1,
                     max_participants: n as usize,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -565,7 +564,7 @@ mod tests {
                         skip_timeout,
                         max_participants: n as usize,
                         max_fetch_count: 1,
-                        fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                        fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
@@ -733,7 +732,7 @@ mod tests {
                     skip_timeout,
                     max_fetch_count: 1, // force many fetches
                     max_participants: n as usize,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -851,7 +850,7 @@ mod tests {
                 skip_timeout,
                 max_fetch_count: 1,
                 max_participants: n as usize,
-                fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                 fetch_concurrent: 1,
                 replay_concurrency: 1,
                 replay_buffer: 1024 * 1024,
@@ -972,7 +971,7 @@ mod tests {
                     skip_timeout,
                     max_participants: n as usize,
                     max_fetch_count: 1,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1167,7 +1166,7 @@ mod tests {
                     skip_timeout,
                     max_fetch_count: 1,
                     max_participants: n as usize,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1324,7 +1323,7 @@ mod tests {
                     skip_timeout,
                     max_fetch_count: 1,
                     max_participants: n as usize,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1474,7 +1473,7 @@ mod tests {
                     skip_timeout,
                     max_fetch_count: 1,
                     max_participants: n as usize,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1652,7 +1651,7 @@ mod tests {
                     skip_timeout,
                     max_fetch_count: 1,
                     max_participants: n as usize,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1818,7 +1817,7 @@ mod tests {
                         skip_timeout,
                         max_fetch_count: 1,
                         max_participants: n as usize,
-                        fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                        fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
@@ -1985,7 +1984,7 @@ mod tests {
                         skip_timeout,
                         max_fetch_count: 1,
                         max_participants: n as usize,
-                        fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                        fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
@@ -2148,7 +2147,7 @@ mod tests {
                         skip_timeout,
                         max_fetch_count: 1,
                         max_participants: n as usize,
-                        fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                        fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
@@ -2283,7 +2282,7 @@ mod tests {
                     skip_timeout,
                     max_fetch_count: 1,
                     max_participants: n as usize,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -324,6 +324,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
                 let (voter, resolver) = registrations
@@ -567,6 +568,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
+                        replay_lookahead: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     let (voter_network, resolver_network) = registrations
@@ -734,6 +736,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -851,6 +854,7 @@ mod tests {
                 fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                 fetch_concurrent: 1,
                 replay_concurrency: 1,
+                replay_lookahead: 1024 * 1024,
             };
             let (voter, resolver) = registrations
                 .remove(&validator)
@@ -971,6 +975,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1165,6 +1170,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1321,6 +1327,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1470,6 +1477,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1647,6 +1655,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1812,6 +1821,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
+                        replay_lookahead: 1024 * 1024,
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -1978,6 +1988,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
+                        replay_lookahead: 1024 * 1024,
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2140,6 +2151,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
+                        replay_lookahead: 1024 * 1024,
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2274,6 +2286,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -514,7 +514,7 @@ pub struct Actor<
     partition: String,
     compression: Option<u8>,
     replay_concurrency: usize,
-    replay_lookahead: usize,
+    replay_buffer: usize,
     journal: Option<Journal<E, Voter<D>>>,
 
     genesis: Option<D>,
@@ -611,7 +611,7 @@ impl<
                 partition: cfg.partition,
                 compression: cfg.compression,
                 replay_concurrency: cfg.replay_concurrency,
-                replay_lookahead: cfg.replay_lookahead,
+                replay_buffer: cfg.replay_buffer,
                 journal: None,
 
                 genesis: None,
@@ -1815,7 +1815,7 @@ impl<
         // Rebuild from journal
         {
             let stream = journal
-                .replay(self.replay_concurrency, self.replay_lookahead)
+                .replay(self.replay_concurrency, self.replay_buffer)
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -35,7 +35,7 @@ pub struct Config<
     pub activity_timeout: View,
     pub skip_timeout: View,
     pub replay_concurrency: usize,
-    pub replay_lookahead: usize,
+    pub replay_buffer: usize,
 }
 
 #[cfg(test)]
@@ -132,7 +132,7 @@ mod tests {
                 activity_timeout: 10,
                 skip_timeout: 10,
                 replay_concurrency: 1,
-                replay_lookahead: 1024 * 1024,
+                replay_buffer: 1024 * 1024,
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -35,6 +35,7 @@ pub struct Config<
     pub activity_timeout: View,
     pub skip_timeout: View,
     pub replay_concurrency: usize,
+    pub replay_lookahead: usize,
 }
 
 #[cfg(test)]
@@ -131,6 +132,7 @@ mod tests {
                 activity_timeout: 10,
                 skip_timeout: 10,
                 replay_concurrency: 1,
+                replay_lookahead: 1024 * 1024,
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 

--- a/consensus/src/threshold_simplex/config.rs
+++ b/consensus/src/threshold_simplex/config.rs
@@ -44,6 +44,9 @@ pub struct Config<
     /// Number of views to replay concurrently during startup.
     pub replay_concurrency: usize,
 
+    /// Number of bytes to look ahead when replaying during startup.
+    pub replay_lookahead: usize,
+
     /// Amount of time to wait for a leader to propose a payload
     /// in a view.
     pub leader_timeout: Duration,

--- a/consensus/src/threshold_simplex/config.rs
+++ b/consensus/src/threshold_simplex/config.rs
@@ -45,7 +45,7 @@ pub struct Config<
     pub replay_concurrency: usize,
 
     /// Number of bytes to look ahead when replaying during startup.
-    pub replay_lookahead: usize,
+    pub replay_buffer: usize,
 
     /// Amount of time to wait for a leader to propose a payload
     /// in a view.

--- a/consensus/src/threshold_simplex/config.rs
+++ b/consensus/src/threshold_simplex/config.rs
@@ -44,7 +44,7 @@ pub struct Config<
     /// Number of views to replay concurrently during startup.
     pub replay_concurrency: usize,
 
-    /// Number of bytes to look ahead when replaying during startup.
+    /// Number of bytes to buffer when replaying during startup.
     pub replay_buffer: usize,
 
     /// Amount of time to wait for a leader to propose a payload

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -79,7 +79,7 @@ impl<
                 activity_timeout: cfg.activity_timeout,
                 skip_timeout: cfg.skip_timeout,
                 replay_concurrency: cfg.replay_concurrency,
-                replay_lookahead: cfg.replay_lookahead,
+                replay_buffer: cfg.replay_buffer,
             },
         );
 

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -79,6 +79,7 @@ impl<
                 activity_timeout: cfg.activity_timeout,
                 skip_timeout: cfg.skip_timeout,
                 replay_concurrency: cfg.replay_concurrency,
+                replay_lookahead: cfg.replay_lookahead,
             },
         );
 

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -357,6 +357,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -619,6 +620,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
+                        replay_lookahead: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -798,6 +800,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -915,6 +918,7 @@ mod tests {
                 fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                 fetch_concurrent: 1,
                 replay_concurrency: 1,
+                replay_lookahead: 1024 * 1024,
             };
             let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1047,6 +1051,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1263,6 +1268,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1424,6 +1430,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1581,6 +1588,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1763,6 +1771,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1938,6 +1947,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
+                        replay_lookahead: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(voter, resolver);
@@ -2110,6 +2120,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
+                        replay_lookahead: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(voter, resolver);
@@ -2278,6 +2289,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
+                        replay_lookahead: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(voter, resolver);
@@ -2412,6 +2424,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
+                    replay_lookahead: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -357,7 +357,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -620,7 +620,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
-                        replay_lookahead: 1024 * 1024,
+                        replay_buffer: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -800,7 +800,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -918,7 +918,7 @@ mod tests {
                 fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                 fetch_concurrent: 1,
                 replay_concurrency: 1,
-                replay_lookahead: 1024 * 1024,
+                replay_buffer: 1024 * 1024,
             };
             let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1051,7 +1051,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1268,7 +1268,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1430,7 +1430,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1588,7 +1588,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1771,7 +1771,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1947,7 +1947,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
-                        replay_lookahead: 1024 * 1024,
+                        replay_buffer: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(voter, resolver);
@@ -2120,7 +2120,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
-                        replay_lookahead: 1024 * 1024,
+                        replay_buffer: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(voter, resolver);
@@ -2289,7 +2289,7 @@ mod tests {
                         fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
-                        replay_lookahead: 1024 * 1024,
+                        replay_buffer: 1024 * 1024,
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(voter, resolver);
@@ -2424,7 +2424,7 @@ mod tests {
                     fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
-                    replay_lookahead: 1024 * 1024,
+                    replay_buffer: 1024 * 1024,
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -170,14 +170,13 @@ mod tests {
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{deterministic, Clock, Metrics, Runner, Spawner};
-    use commonware_utils::{quorum, Array};
+    use commonware_utils::{quorum, Array, NZU32};
     use engine::Engine;
     use futures::{future::join_all, StreamExt};
     use governor::Quota;
     use rand::{rngs::StdRng, Rng as _, SeedableRng as _};
     use std::{
         collections::{BTreeMap, HashMap},
-        num::NonZeroU32,
         sync::{Arc, Mutex},
         time::Duration,
     };
@@ -354,7 +353,7 @@ mod tests {
                     activity_timeout,
                     skip_timeout,
                     max_fetch_count: 1,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -617,7 +616,7 @@ mod tests {
                         activity_timeout,
                         skip_timeout,
                         max_fetch_count: 1,
-                        fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                        fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
@@ -797,7 +796,7 @@ mod tests {
                     activity_timeout,
                     skip_timeout,
                     max_fetch_count: 1, // force many fetches
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -915,7 +914,7 @@ mod tests {
                 activity_timeout,
                 skip_timeout,
                 max_fetch_count: 1,
-                fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                 fetch_concurrent: 1,
                 replay_concurrency: 1,
                 replay_buffer: 1024 * 1024,
@@ -1048,7 +1047,7 @@ mod tests {
                     activity_timeout,
                     skip_timeout,
                     max_fetch_count: 1,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1265,7 +1264,7 @@ mod tests {
                     activity_timeout,
                     skip_timeout,
                     max_fetch_count: 1,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1427,7 +1426,7 @@ mod tests {
                     activity_timeout,
                     skip_timeout,
                     max_fetch_count: 1,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1585,7 +1584,7 @@ mod tests {
                     activity_timeout,
                     skip_timeout,
                     max_fetch_count: 1,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1768,7 +1767,7 @@ mod tests {
                     activity_timeout,
                     skip_timeout,
                     max_fetch_count: 1,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
@@ -1944,7 +1943,7 @@ mod tests {
                         activity_timeout,
                         skip_timeout,
                         max_fetch_count: 1,
-                        fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                        fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
@@ -2117,7 +2116,7 @@ mod tests {
                         activity_timeout,
                         skip_timeout,
                         max_fetch_count: 1,
-                        fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                        fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
@@ -2286,7 +2285,7 @@ mod tests {
                         activity_timeout,
                         skip_timeout,
                         max_fetch_count: 1,
-                        fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                        fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
                         replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
@@ -2421,7 +2420,7 @@ mod tests {
                     activity_timeout,
                     skip_timeout,
                     max_fetch_count: 1,
-                    fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                    fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
                     replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -229,7 +229,7 @@ fn main() {
                 namespace: consensus_namespace,
                 mailbox_size: 1024,
                 replay_concurrency: 1,
-                replay_lookahead: 1024 * 1024,
+                replay_buffer: 1024 * 1024,
                 leader_timeout: Duration::from_secs(1),
                 notarization_timeout: Duration::from_secs(2),
                 nullify_retry: Duration::from_secs(10),

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -229,6 +229,7 @@ fn main() {
                 namespace: consensus_namespace,
                 mailbox_size: 1024,
                 replay_concurrency: 1,
+                replay_lookahead: 1024 * 1024,
                 leader_timeout: Duration::from_secs(1),
                 notarization_timeout: Duration::from_secs(2),
                 nullify_retry: Duration::from_secs(10),

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -11,12 +11,9 @@ use commonware_cryptography::{
 use commonware_p2p::authenticated;
 use commonware_runtime::{tokio, Metrics, Network, Runner};
 use commonware_stream::public_key::{self, Connection};
-use commonware_utils::{from_hex, quorum, union};
+use commonware_utils::{from_hex, quorum, union, NZU32};
 use governor::Quota;
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    num::NonZeroU32,
-};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::{str::FromStr, time::Duration};
 
 fn main() {
@@ -188,13 +185,13 @@ fn main() {
         // for this channel.
         let (voter_sender, voter_receiver) = network.register(
             0,
-            Quota::per_second(NonZeroU32::new(10).unwrap()),
+            Quota::per_second(NZU32!(10)),
             256, // 256 messages in flight
             Some(3),
         );
         let (resolver_sender, resolver_receiver) = network.register(
             1,
-            Quota::per_second(NonZeroU32::new(10).unwrap()),
+            Quota::per_second(NZU32!(10)),
             256, // 256 messages in flight
             Some(3),
         );
@@ -238,7 +235,7 @@ fn main() {
                 skip_timeout: 5,
                 max_fetch_count: 32,
                 fetch_concurrent: 2,
-                fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
             },
         );
 

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -61,9 +61,9 @@ use commonware_p2p::authenticated::{self, Network};
 use commonware_runtime::tokio;
 use commonware_runtime::Metrics;
 use commonware_runtime::Runner as _;
+use commonware_utils::NZU32;
 use governor::Quota;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::num::NonZeroU32;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use tracing::info;
@@ -176,7 +176,7 @@ fn main() {
         const COMPRESSION_LEVEL: Option<i32> = Some(3);
         let (chat_sender, chat_receiver) = network.register(
             handler::CHANNEL,
-            Quota::per_second(NonZeroU32::new(128).unwrap()),
+            Quota::per_second(NZU32!(128)),
             MAX_MESSAGE_BACKLOG,
             COMPRESSION_LEVEL,
         );

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -8,7 +8,7 @@ use commonware_deployer::ec2::{Hosts, METRICS_PORT};
 use commonware_flood::Config;
 use commonware_p2p::{authenticated, Receiver, Recipients, Sender};
 use commonware_runtime::{tokio, Metrics, Runner, Spawner};
-use commonware_utils::{from_hex_formatted, union};
+use commonware_utils::{from_hex_formatted, union, NZU32};
 use futures::future::try_join_all;
 use governor::Quota;
 use prometheus_client::metrics::counter::Counter;
@@ -16,7 +16,6 @@ use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
 use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    num::NonZeroU32,
     str::FromStr,
     sync::atomic::AtomicU64,
 };
@@ -126,7 +125,7 @@ fn main() {
         // Register flood channel
         let (mut flood_sender, mut flood_receiver) = network.register(
             0,
-            Quota::per_second(NonZeroU32::new(u32::MAX).unwrap()),
+            Quota::per_second(NZU32!(u32::MAX)),
             config.message_backlog,
             None,
         );

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -204,7 +204,7 @@ fn main() {
             compression: Some(3),
             mailbox_size: 1024,
             replay_concurrency: 1,
-            replay_lookahead: 1024 * 1024,
+            replay_buffer: 1024 * 1024,
             leader_timeout: Duration::from_secs(1),
             notarization_timeout: Duration::from_secs(2),
             nullify_retry: Duration::from_secs(10),

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -204,6 +204,7 @@ fn main() {
             compression: Some(3),
             mailbox_size: 1024,
             replay_concurrency: 1,
+            replay_lookahead: 1024 * 1024,
             leader_timeout: Duration::from_secs(1),
             notarization_timeout: Duration::from_secs(2),
             nullify_retry: Duration::from_secs(10),

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -52,12 +52,9 @@ use commonware_consensus::simplex;
 use commonware_cryptography::{Ed25519, Sha256, Signer};
 use commonware_p2p::authenticated::{self, Network};
 use commonware_runtime::{tokio, Metrics, Runner};
-use commonware_utils::union;
+use commonware_utils::{union, NZU32};
 use governor::Quota;
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    num::NonZeroU32,
-};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::{str::FromStr, time::Duration};
 
 /// Unique namespace to avoid message replay attacks.
@@ -170,13 +167,13 @@ fn main() {
         // for this channel.
         let (voter_sender, voter_receiver) = network.register(
             0,
-            Quota::per_second(NonZeroU32::new(10).unwrap()),
+            Quota::per_second(NZU32!(10)),
             256, // 256 messages in flight
             Some(3),
         );
         let (resolver_sender, resolver_receiver) = network.register(
             1,
-            Quota::per_second(NonZeroU32::new(10).unwrap()),
+            Quota::per_second(NZU32!(10)),
             256, // 256 messages in flight
             Some(3),
         );
@@ -214,7 +211,7 @@ fn main() {
             max_fetch_count: 32,
             max_participants: participants.len(),
             fetch_concurrent: 2,
-            fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+            fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
         };
         let engine = simplex::Engine::new(context.with_label("engine"), cfg);
 

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -82,12 +82,9 @@ use clap::{value_parser, Arg, Command};
 use commonware_cryptography::{Ed25519, Signer};
 use commonware_p2p::authenticated::{self, Network};
 use commonware_runtime::{tokio, Metrics, Runner};
-use commonware_utils::quorum;
+use commonware_utils::{quorum, NZU32};
 use governor::Quota;
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    num::NonZeroU32,
-};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::{str::FromStr, time::Duration};
 use tracing::info;
 
@@ -257,7 +254,7 @@ fn main() {
             let forger = matches.get_flag("forger");
             let (contributor_sender, contributor_receiver) = network.register(
                 handlers::DKG_CHANNEL,
-                Quota::per_second(NonZeroU32::new(10).unwrap()),
+                Quota::per_second(NZU32!(10)),
                 DEFAULT_MESSAGE_BACKLOG,
                 COMPRESSION_LEVEL,
             );
@@ -277,7 +274,7 @@ fn main() {
             // Create vrf
             let (vrf_sender, vrf_receiver) = network.register(
                 handlers::VRF_CHANNEL,
-                Quota::per_second(NonZeroU32::new(10).unwrap()),
+                Quota::per_second(NZU32!(10)),
                 DEFAULT_MESSAGE_BACKLOG,
                 None,
             );
@@ -292,7 +289,7 @@ fn main() {
         } else {
             let (arbiter_sender, arbiter_receiver) = network.register(
                 handlers::DKG_CHANNEL,
-                Quota::per_second(NonZeroU32::new(10).unwrap()),
+                Quota::per_second(NZU32!(10)),
                 DEFAULT_MESSAGE_BACKLOG,
                 COMPRESSION_LEVEL,
             );

--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -526,9 +526,9 @@ mod tests {
     use crate::authenticated::{actors::peer, config::Bootstrapper};
     use commonware_cryptography::{Ed25519, Signer};
     use commonware_runtime::{deterministic, Clock, Runner};
+    use commonware_utils::NZU32;
     use governor::Quota;
     use std::net::{IpAddr, Ipv4Addr};
-    use std::num::NonZeroU32;
     use std::time::Duration;
 
     fn test_config<C: Scheme>(
@@ -544,7 +544,7 @@ mod tests {
             mailbox_size: 32,
             synchrony_bound: Duration::from_secs(10),
             tracked_peer_sets: 2,
-            allowed_connection_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
+            allowed_connection_rate_per_peer: Quota::per_second(NZU32!(1)),
             peer_gossip_max_count: 32,
             max_peer_set_size: 1 << 16, // 2^16
         }

--- a/p2p/src/authenticated/config.rs
+++ b/p2p/src/authenticated/config.rs
@@ -1,6 +1,7 @@
 use commonware_cryptography::Scheme;
+use commonware_utils::NZU32;
 use governor::Quota;
-use std::{net::SocketAddr, num::NonZeroU32, time::Duration};
+use std::{net::SocketAddr, time::Duration};
 
 /// Known peer and its accompanying address that will be dialed on startup.
 pub type Bootstrapper<P> = (P, SocketAddr);
@@ -126,16 +127,16 @@ impl<C: Scheme> Config<C> {
             synchrony_bound: Duration::from_secs(5),
             max_handshake_age: Duration::from_secs(10),
             handshake_timeout: Duration::from_secs(5),
-            allowed_connection_rate_per_peer: Quota::per_minute(NonZeroU32::new(1).unwrap()),
-            allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(256).unwrap()),
+            allowed_connection_rate_per_peer: Quota::per_minute(NZU32!(1)),
+            allowed_incoming_connection_rate: Quota::per_second(NZU32!(256)),
             dial_frequency: Duration::from_secs(60),
-            dial_rate: Quota::per_minute(NonZeroU32::new(30).unwrap()),
+            dial_rate: Quota::per_minute(NZU32!(30)),
             tracked_peer_sets: 4,
             max_peer_set_size: 1 << 16, // 2^16
             gossip_bit_vec_frequency: Duration::from_secs(50),
-            allowed_bit_vec_rate: Quota::per_second(NonZeroU32::new(2).unwrap()),
+            allowed_bit_vec_rate: Quota::per_second(NZU32!(2)),
             peer_gossip_max_count: 32,
-            allowed_peers_rate: Quota::per_second(NonZeroU32::new(2).unwrap()),
+            allowed_peers_rate: Quota::per_second(NZU32!(2)),
         }
     }
 
@@ -165,16 +166,16 @@ impl<C: Scheme> Config<C> {
             synchrony_bound: Duration::from_secs(5),
             max_handshake_age: Duration::from_secs(10),
             handshake_timeout: Duration::from_secs(5),
-            allowed_connection_rate_per_peer: Quota::per_second(NonZeroU32::new(1).unwrap()),
-            allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(256).unwrap()),
+            allowed_connection_rate_per_peer: Quota::per_second(NZU32!(1)),
+            allowed_incoming_connection_rate: Quota::per_second(NZU32!(256)),
             dial_frequency: Duration::from_secs(5),
-            dial_rate: Quota::per_second(NonZeroU32::new(30).unwrap()),
+            dial_rate: Quota::per_second(NZU32!(30)),
             tracked_peer_sets: 4,
             max_peer_set_size: 1 << 16, // 2^16
             gossip_bit_vec_frequency: Duration::from_secs(5),
-            allowed_bit_vec_rate: Quota::per_second(NonZeroU32::new(5).unwrap()),
+            allowed_bit_vec_rate: Quota::per_second(NZU32!(5)),
             peer_gossip_max_count: 32,
-            allowed_peers_rate: Quota::per_second(NonZeroU32::new(5).unwrap()),
+            allowed_peers_rate: Quota::per_second(NZU32!(5)),
         }
     }
 
@@ -198,16 +199,16 @@ impl<C: Scheme> Config<C> {
             synchrony_bound: Duration::from_secs(5),
             max_handshake_age: Duration::from_secs(10),
             handshake_timeout: Duration::from_secs(5),
-            allowed_connection_rate_per_peer: Quota::per_second(NonZeroU32::new(1_024).unwrap()),
-            allowed_incoming_connection_rate: Quota::per_second(NonZeroU32::new(1_024).unwrap()),
+            allowed_connection_rate_per_peer: Quota::per_second(NZU32!(1_024)),
+            allowed_incoming_connection_rate: Quota::per_second(NZU32!(1_024)),
             dial_frequency: Duration::from_secs(1),
-            dial_rate: Quota::per_second(NonZeroU32::new(1_024).unwrap()),
+            dial_rate: Quota::per_second(NZU32!(1_024)),
             tracked_peer_sets: 4,
             max_peer_set_size: 1 << 8, // 2^8
             gossip_bit_vec_frequency: Duration::from_secs(1),
-            allowed_bit_vec_rate: Quota::per_second(NonZeroU32::new(5).unwrap()),
+            allowed_bit_vec_rate: Quota::per_second(NZU32!(5)),
             peer_gossip_max_count: 32,
-            allowed_peers_rate: Quota::per_second(NonZeroU32::new(5).unwrap()),
+            allowed_peers_rate: Quota::per_second(NZU32!(5)),
         }
     }
 }

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -96,9 +96,9 @@
 //! use commonware_p2p::{authenticated::{self, Network}, Sender, Recipients};
 //! use commonware_cryptography::{Ed25519, Signer, Verifier};
 //! use commonware_runtime::{tokio, Spawner, Runner, Metrics};
+//! use commonware_utils::NZU32;
 //! use governor::Quota;
 //! use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-//! use std::num::NonZeroU32;
 //!
 //! // Configure context
 //! let runtime_cfg = tokio::Config::default();

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -156,7 +156,7 @@
 //!     const COMPRESSION_LEVEL: Option<i32> = Some(3);
 //!     let (mut sender, receiver) = network.register(
 //!         0,
-//!         Quota::per_second(NonZeroU32::new(1).unwrap()),
+//!         Quota::per_second(NZU32!(1)),
 //!         MAX_MESSAGE_BACKLOG,
 //!         COMPRESSION_LEVEL,
 //!     );
@@ -209,12 +209,12 @@ mod tests {
     use commonware_runtime::{
         deterministic, tokio, Clock, Metrics, Network as RNetwork, Runner, Spawner,
     };
+    use commonware_utils::NZU32;
     use governor::{clock::ReasonablyRealtime, Quota};
     use rand::{CryptoRng, Rng};
     use std::collections::HashSet;
     use std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
-        num::NonZeroU32,
         time::Duration,
     };
 
@@ -279,7 +279,7 @@ mod tests {
             // Register basic application
             let (mut sender, mut receiver) = network.register(
                 0,
-                Quota::per_second(NonZeroU32::new(5).unwrap()), // Ensure we hit the rate limit
+                Quota::per_second(NZU32!(5)), // Ensure we hit the rate limit
                 DEFAULT_MESSAGE_BACKLOG,
                 None,
             );
@@ -531,7 +531,7 @@ mod tests {
                 // Register basic application
                 let (mut sender, mut receiver) = network.register(
                     0,
-                    Quota::per_second(NonZeroU32::new(10).unwrap()),
+                    Quota::per_second(NZU32!(10)),
                     DEFAULT_MESSAGE_BACKLOG,
                     None,
                 );
@@ -609,7 +609,7 @@ mod tests {
             // Register basic application
             let (mut sender, _) = network.register(
                 0,
-                Quota::per_second(NonZeroU32::new(10).unwrap()),
+                Quota::per_second(NZU32!(10)),
                 DEFAULT_MESSAGE_BACKLOG,
                 compression,
             );

--- a/p2p/src/utils/requester/requester.rs
+++ b/p2p/src/utils/requester/requester.rs
@@ -259,8 +259,8 @@ mod tests {
     use commonware_cryptography::{Ed25519, Signer};
     use commonware_runtime::deterministic;
     use commonware_runtime::Runner;
+    use commonware_utils::NZU32;
     use governor::Quota;
-    use std::num::NonZeroU32;
     use std::time::Duration;
 
     #[test]
@@ -274,7 +274,7 @@ mod tests {
             let timeout = Duration::from_secs(5);
             let config = Config {
                 public_key: scheme.public_key(),
-                rate_limit: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                rate_limit: Quota::per_second(NZU32!(1)),
                 initial: Duration::from_millis(100),
                 timeout,
             };
@@ -382,7 +382,7 @@ mod tests {
             let timeout = Duration::from_secs(5);
             let config = Config {
                 public_key: scheme.public_key(),
-                rate_limit: Quota::per_second(NonZeroU32::new(1).unwrap()),
+                rate_limit: Quota::per_second(NZU32!(1)),
                 initial: Duration::from_millis(100),
                 timeout,
             };

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -85,6 +85,7 @@ mod tests {
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{deterministic, Clock, Metrics, Runner};
+    use commonware_utils::NZU32;
     use futures::{SinkExt, StreamExt};
     use std::time::Duration;
 
@@ -170,9 +171,7 @@ mod tests {
                 mailbox_size: MAILBOX_SIZE,
                 requester_config: commonware_p2p::utils::requester::Config {
                     public_key: scheme.public_key(),
-                    rate_limit: governor::Quota::per_second(
-                        std::num::NonZeroU32::new(RATE_LIMIT).unwrap(),
-                    ),
+                    rate_limit: governor::Quota::per_second(NZU32!(RATE_LIMIT)),
                     initial: INITIAL_DURATION,
                     timeout: TIMEOUT,
                 },

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -38,9 +38,7 @@ mod network;
 mod storage;
 pub mod telemetry;
 mod utils;
-pub use utils::{
-    create_pool, reschedule, Handle, RwLock, RwLockReadGuard, RwLockWriteGuard, Signal, Signaler,
-};
+pub use utils::*;
 
 /// Prefix for runtime metrics.
 const METRICS_PREFIX: &str = "runtime";

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -491,17 +491,17 @@ impl<B: Blob> Buffer<B> {
     ///
     /// # Panics
     ///
-    /// Panics if `lookahead` is zero.
-    pub fn new(blob: B, size: u64, lookahead: usize) -> Self {
-        assert!(lookahead > 0, "Buffer size must be greater than zero");
+    /// Panics if `buffer_size` is zero.
+    pub fn new(blob: B, blob_size: u64, buffer_size: usize) -> Self {
+        assert!(buffer_size > 0, "Buffer size must be greater than zero");
         Self {
             blob,
-            buffer: vec![0; lookahead],
+            buffer: vec![0; buffer_size],
             blob_position: 0,
-            blob_size: size,
+            blob_size,
             buffer_position: 0,
             buffer_valid_len: 0,
-            buffer_size: lookahead,
+            buffer_size,
         }
     }
 
@@ -526,7 +526,6 @@ impl<B: Blob> Buffer<B> {
 
         // Calculate how many bytes remain in the blob
         let blob_remaining = self.blob_size.saturating_sub(self.blob_position);
-
         if blob_remaining == 0 {
             return Err(Error::BlobInsufficientLength);
         }
@@ -569,8 +568,8 @@ impl<B: Blob> Buffer<B> {
             return Err(Error::BlobInsufficientLength);
         }
 
+        // Read until we have enough bytes
         let mut bytes_read = 0;
-
         while bytes_read < size {
             // Check if we need to refill
             if self.buffer_position >= self.buffer_valid_len {
@@ -611,7 +610,6 @@ impl<B: Blob> Buffer<B> {
 
         // We need to do a more complex operation: copy remaining data to beginning,
         // then refill the rest of the buffer
-
         let remaining = self.buffer_remaining();
         if remaining > 0 {
             // Copy the remaining data to the beginning of the buffer
@@ -628,7 +626,6 @@ impl<B: Blob> Buffer<B> {
         let read_pos = self.blob_position + remaining as u64;
         let bytes_blob_remaining = self.blob_size.saturating_sub(read_pos);
         let read_size = std::cmp::min(self.buffer_size - remaining, bytes_blob_remaining as usize);
-
         if read_size > 0 {
             match self
                 .blob

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -531,7 +531,7 @@ impl<B: Blob> Buffer<B> {
         }
 
         // Calculate how much to read (minimum of buffer size and remaining bytes)
-        let bytes_to_read = std::cmp::min(self.buffer_size, blob_remaining as usize);
+        let bytes_to_read = std::cmp::min(self.buffer_size as u64, blob_remaining) as usize;
 
         // Read the data - we only need a single read operation since we know exactly how much data is available
         self.blob
@@ -585,7 +585,7 @@ impl<B: Blob> Buffer<B> {
         }
 
         // Check if enough total bytes are available
-        let total_available = self.buffer_remaining() + self.blob_remaining() as usize;
+        let total_available = (self.buffer_remaining() as u64 + self.blob_remaining()) as usize;
         if total_available < size {
             return Err(Error::BlobInsufficientLength);
         }
@@ -607,7 +607,8 @@ impl<B: Blob> Buffer<B> {
         // Read more data into the buffer after the remaining data
         let read_pos = self.blob_position + remaining as u64;
         let bytes_blob_remaining = self.blob_size.saturating_sub(read_pos);
-        let read_size = std::cmp::min(self.buffer_size - remaining, bytes_blob_remaining as usize);
+        let read_size =
+            std::cmp::min((self.buffer_size - remaining) as u64, bytes_blob_remaining) as usize;
         if read_size > 0 {
             match self
                 .blob
@@ -621,6 +622,7 @@ impl<B: Blob> Buffer<B> {
             }
         }
 
+        // If we could not fill the buffer, return an error
         if self.buffer_valid_len < size {
             return Err(Error::BlobInsufficientLength);
         }

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -427,17 +427,17 @@ impl<T> RwLock<T> {
 /// of a full scan of contents.
 pub struct Buffer<B: Blob> {
     /// The underlying blob to read from.
-    blob: B,
+    pub blob: B,
     /// The buffer storing the data read from the blob.
     buffer: Vec<u8>,
     /// The current position in the blob from where the buffer was filled.
-    blob_position: u64,
+    pub blob_position: u64,
     /// The size of the blob.
     blob_size: u64,
     /// The current position within the buffer for reading.
-    buffer_position: usize,
+    pub buffer_position: usize,
     /// The valid data length in the buffer.
-    buffer_valid_len: usize,
+    pub buffer_valid_len: usize,
     /// The maximum size of the buffer.
     buffer_size: usize,
 }

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -534,30 +534,12 @@ impl<B: Blob> Buffer<B> {
         let bytes_to_read = std::cmp::min(self.buffer_size, blob_remaining as usize);
 
         // Read the data - we only need a single read operation since we know exactly how much data is available
-        if bytes_to_read < self.buffer_size {
-            // Partial buffer read
-            let read_buffer = &mut self.buffer[0..bytes_to_read];
-            match self.blob.read_at(read_buffer, self.blob_position).await {
-                Ok(()) => {
-                    self.buffer_valid_len = bytes_to_read;
-                    Ok(bytes_to_read)
-                }
-                Err(e) => Err(e),
-            }
-        } else {
-            // Full buffer read
-            match self
-                .blob
-                .read_at(&mut self.buffer, self.blob_position)
-                .await
-            {
-                Ok(()) => {
-                    self.buffer_valid_len = self.buffer_size;
-                    Ok(self.buffer_size)
-                }
-                Err(e) => Err(e),
-            }
-        }
+        self.blob
+            .read_at(&mut self.buffer[..bytes_to_read], self.blob_position)
+            .await?;
+        self.buffer_valid_len = bytes_to_read;
+
+        Ok(bytes_to_read)
     }
 
     /// Reads exactly `size` bytes into the provided buffer.

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -17,6 +17,12 @@ const PENDING_WRITES: usize = 1_000;
 /// Section-mask that yields reasonably small blobs for local testing.
 const SECTION_MASK: u64 = 0xffff_ffff_ffff_ff00u64;
 
+/// Number of blobs to read concurrently during replay.
+const REPLAY_CONCURRENCY: usize = 1;
+
+/// Number of bytes to look ahead when replaying.
+const REPLAY_LOOKAHEAD: usize = 1024 * 1024; // 1MB
+
 /// Fixed-length key and value types.
 pub type Key = FixedBytes<64>;
 pub type Val = FixedBytes<32>;
@@ -35,7 +41,8 @@ pub async fn get_archive(ctx: Context, compression: Option<u8>) -> ArchiveType {
         codec_config: (),
         section_mask: SECTION_MASK,
         pending_writes: PENDING_WRITES,
-        replay_concurrency: 1,
+        replay_concurrency: REPLAY_CONCURRENCY,
+        replay_lookahead: REPLAY_LOOKAHEAD,
     };
     Archive::init(ctx, cfg).await.unwrap()
 }

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -20,7 +20,7 @@ const SECTION_MASK: u64 = 0xffff_ffff_ffff_ff00u64;
 /// Number of blobs to read concurrently during replay.
 const REPLAY_CONCURRENCY: usize = 1;
 
-/// Number of bytes to look ahead when replaying.
+/// Number of bytes to buffer when replaying.
 const REPLAY_BUFFER: usize = 1024 * 1024; // 1MB
 
 /// Fixed-length key and value types.

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -21,7 +21,7 @@ const SECTION_MASK: u64 = 0xffff_ffff_ffff_ff00u64;
 const REPLAY_CONCURRENCY: usize = 1;
 
 /// Number of bytes to look ahead when replaying.
-const REPLAY_LOOKAHEAD: usize = 1024 * 1024; // 1MB
+const REPLAY_BUFFER: usize = 1024 * 1024; // 1MB
 
 /// Fixed-length key and value types.
 pub type Key = FixedBytes<64>;
@@ -42,7 +42,7 @@ pub async fn get_archive(ctx: Context, compression: Option<u8>) -> ArchiveType {
         section_mask: SECTION_MASK,
         pending_writes: PENDING_WRITES,
         replay_concurrency: REPLAY_CONCURRENCY,
-        replay_lookahead: REPLAY_LOOKAHEAD,
+        replay_buffer: REPLAY_BUFFER,
     };
     Archive::init(ctx, cfg).await.unwrap()
 }

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -129,6 +129,7 @@
 //!         section_mask: 0xffff_ffff_ffff_0000u64,
 //!         pending_writes: 10,
 //!         replay_concurrency: 4,
+//!         replay_lookahead: 4096,
 //!     };
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
 //!
@@ -189,6 +190,9 @@ pub struct Config<T: Translator, C> {
 
     /// The number of blobs to replay concurrently on initialization.
     pub replay_concurrency: usize,
+
+    /// The buffer size to use when replaying a blob.
+    pub replay_lookahead: usize,
 }
 
 #[cfg(test)]
@@ -226,6 +230,7 @@ mod tests {
                 codec_config: (),
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -324,6 +329,7 @@ mod tests {
                 compression: Some(3),
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -350,6 +356,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let result = Archive::<_, _, FixedBytes<64>, i32>::init(context, cfg.clone()).await;
@@ -373,6 +380,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -412,6 +420,7 @@ mod tests {
                     compression: None,
                     pending_writes: 10,
                     replay_concurrency: 4,
+                    replay_lookahead: 4096,
                     section_mask: DEFAULT_SECTION_MASK,
                 },
             )
@@ -436,6 +445,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -494,6 +504,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let archive = Archive::init(context.clone(), cfg.clone())
@@ -537,6 +548,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -599,6 +611,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -655,6 +668,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: 0xffff_ffff_ffff_ffffu64, // no mask
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -740,6 +754,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -797,6 +812,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask,
             };
             let mut archive =
@@ -894,6 +910,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
+                replay_lookahead: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -129,7 +129,7 @@
 //!         section_mask: 0xffff_ffff_ffff_0000u64,
 //!         pending_writes: 10,
 //!         replay_concurrency: 4,
-//!         replay_lookahead: 4096,
+//!         replay_buffer: 4096,
 //!     };
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
 //!
@@ -192,7 +192,7 @@ pub struct Config<T: Translator, C> {
     pub replay_concurrency: usize,
 
     /// The buffer size to use when replaying a blob.
-    pub replay_lookahead: usize,
+    pub replay_buffer: usize,
 }
 
 #[cfg(test)]
@@ -230,7 +230,7 @@ mod tests {
                 codec_config: (),
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -329,7 +329,7 @@ mod tests {
                 compression: Some(3),
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -356,7 +356,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let result = Archive::<_, _, FixedBytes<64>, i32>::init(context, cfg.clone()).await;
@@ -380,7 +380,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -420,7 +420,7 @@ mod tests {
                     compression: None,
                     pending_writes: 10,
                     replay_concurrency: 4,
-                    replay_lookahead: 4096,
+                    replay_buffer: 4096,
                     section_mask: DEFAULT_SECTION_MASK,
                 },
             )
@@ -445,7 +445,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -504,7 +504,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let archive = Archive::init(context.clone(), cfg.clone())
@@ -548,7 +548,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -611,7 +611,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -668,7 +668,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: 0xffff_ffff_ffff_ffffu64, // no mask
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -754,7 +754,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -812,7 +812,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask,
             };
             let mut archive =
@@ -910,7 +910,7 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 replay_concurrency: 4,
-                replay_lookahead: 4096,
+                replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -99,7 +99,7 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
     /// by replaying the journal.
     pub async fn init(context: E, cfg: Config<T, V::Cfg>) -> Result<Self, Error> {
         // Initialize journal
-        let mut journal = Journal::<E, Record<K, V>>::init(
+        let journal = Journal::<E, Record<K, V>>::init(
             context.with_label("journal"),
             JConfig {
                 partition: cfg.partition,
@@ -115,7 +115,9 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
         let mut intervals = RangeInclusiveSet::new();
         {
             debug!("initializing archive");
-            let stream = journal.replay(cfg.replay_concurrency).await?;
+            let stream = journal
+                .replay(cfg.replay_concurrency, cfg.replay_lookahead)
+                .await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 // Extract key from record

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -116,7 +116,7 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
         {
             debug!("initializing archive");
             let stream = journal
-                .replay(cfg.replay_concurrency, cfg.replay_lookahead)
+                .replay(cfg.replay_concurrency, cfg.replay_buffer)
                 .await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -60,9 +60,15 @@ fn bench_fixed_replay(c: &mut Criterion) {
 
         // Run the benchmarks
         let runner = tokio::Runner::new(cfg.clone());
-        for buffer in [0, 16_384, 65_536, 262_144, 1_048_576] {
+        for buffer in [128, 16_384, 65_536, 262_144, 1_048_576] {
             c.bench_function(
-                &format!("{}/items={} size={}", module_path!(), items, ITEM_SIZE),
+                &format!(
+                    "{}/items={} buffer={} size={}",
+                    module_path!(),
+                    items,
+                    buffer,
+                    ITEM_SIZE
+                ),
                 |b| {
                     b.to_async(&runner).iter_custom(|iters| async move {
                         let ctx = context::get::<commonware_runtime::tokio::Context>();

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -22,12 +22,12 @@ const ITEM_SIZE: usize = 32;
 /// Replay all items in the given `journal`.
 async fn bench_run(
     journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
-    lookahead: usize,
+    buffer: usize,
     items_to_read: u64,
 ) {
     let concurrency = std::cmp::max(1, (items_to_read / ITEMS_PER_BLOB) as usize);
     let stream = journal
-        .replay(concurrency, lookahead)
+        .replay(concurrency, buffer)
         .await
         .expect("failed to replay journal");
     pin_mut!(stream);
@@ -60,7 +60,7 @@ fn bench_fixed_replay(c: &mut Criterion) {
 
         // Run the benchmarks
         let runner = tokio::Runner::new(cfg.clone());
-        for lookahead in [0, 16_384, 65_536, 262_144, 1_048_576] {
+        for buffer in [0, 16_384, 65_536, 262_144, 1_048_576] {
             c.bench_function(
                 &format!("{}/items={} size={}", module_path!(), items, ITEM_SIZE),
                 |b| {
@@ -70,7 +70,7 @@ fn bench_fixed_replay(c: &mut Criterion) {
                         let mut duration = Duration::ZERO;
                         for _ in 0..iters {
                             let start = Instant::now();
-                            bench_run(&j, lookahead, items).await;
+                            bench_run(&j, buffer, items).await;
                             duration += start.elapsed();
                         }
 

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -60,7 +60,7 @@ fn bench_fixed_replay(c: &mut Criterion) {
 
         // Run the benchmarks
         let runner = tokio::Runner::new(cfg.clone());
-        for lookahead in [0, 1_024, 4_096, 16_384, 32_768, 65_536, 131_072, 262_144] {
+        for lookahead in [0, 16_384, 65_536, 262_144, 1_048_576] {
             c.bench_function(
                 &format!("{}/items={} size={}", module_path!(), items, ITEM_SIZE),
                 |b| {

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -1,7 +1,8 @@
 use super::{append_random_data, get_journal};
 use commonware_runtime::{
     benchmarks::{context, tokio},
-    tokio::Context,
+    tokio::{Config, Context, Runner},
+    Runner as _,
 };
 use commonware_storage::journal::fixed::Journal;
 use commonware_utils::array::FixedBytes;
@@ -19,10 +20,14 @@ const ITEMS_PER_BLOB: u64 = 100_000;
 const ITEM_SIZE: usize = 32;
 
 /// Replay all items in the given `journal`.
-async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, items_to_read: u64) {
+async fn bench_run(
+    journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
+    lookahead: usize,
+    items_to_read: u64,
+) {
     let concurrency = std::cmp::max(1, (items_to_read / ITEMS_PER_BLOB) as usize);
     let stream = journal
-        .replay(concurrency)
+        .replay(concurrency, lookahead)
         .await
         .expect("failed to replay journal");
     pin_mut!(stream);
@@ -39,34 +44,48 @@ async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, items_
 /// Benchmark the replaying of items from a journal containing exactly that
 /// number of items.
 fn bench_fixed_replay(c: &mut Criterion) {
-    let runner = tokio::Runner::default();
     for items in [1_000, 10_000, 100_000, 500_000] {
-        c.bench_function(
-            &format!("{}/items={} size={}", module_path!(), items, ITEM_SIZE),
-            |b| {
-                b.to_async(&runner).iter_custom(|iters| async move {
-                    // Append random data to the journal
-                    let ctx = context::get::<commonware_runtime::tokio::Context>();
-                    let mut j = get_journal::<ITEM_SIZE>(ctx, PARTITION, ITEMS_PER_BLOB).await;
-                    append_random_data::<ITEM_SIZE>(&mut j, items).await;
-                    let sz = j.size().await.unwrap();
-                    assert_eq!(sz, items);
+        // Create a config we can use across all benchmarks (with a fixed `storage_directory`), allowing the
+        // same test file to be re-used.
+        let cfg = Config::default();
 
-                    // Run the benchmark
-                    let mut duration = Duration::ZERO;
-                    for _ in 0..iters {
-                        let start = Instant::now();
-                        bench_run(&mut j, items).await;
-                        duration += start.elapsed();
-                    }
+        // Generate a large temp journal with random data.
+        let runner = Runner::new(cfg.clone());
+        runner.start(|ctx| async move {
+            // Create a large temp journal with random data.
+            let mut j = get_journal(ctx, PARTITION, ITEMS_PER_BLOB).await;
+            append_random_data::<ITEM_SIZE>(&mut j, items).await;
+            j.close().await.unwrap();
+        });
 
-                    // Destroy the journal after appending to avoid polluting the next iteration
-                    j.destroy().await.unwrap();
+        // Run the benchmarks
+        let runner = tokio::Runner::new(cfg.clone());
+        for lookahead in [0, 1_024, 4_096, 16_384, 32_768, 65_536, 131_072, 262_144] {
+            c.bench_function(
+                &format!("{}/items={} size={}", module_path!(), items, ITEM_SIZE),
+                |b| {
+                    b.to_async(&runner).iter_custom(|iters| async move {
+                        let ctx = context::get::<commonware_runtime::tokio::Context>();
+                        let j = get_journal(ctx.clone(), PARTITION, ITEMS_PER_BLOB).await;
+                        let mut duration = Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = Instant::now();
+                            bench_run(&j, lookahead, items).await;
+                            duration += start.elapsed();
+                        }
 
-                    duration
-                });
-            },
-        );
+                        duration
+                    });
+                },
+            );
+        }
+
+        // Clean up the temp journal
+        let runner = Runner::new(cfg);
+        runner.start(|context| async move {
+            let j = get_journal::<ITEM_SIZE>(context, PARTITION, ITEMS_PER_BLOB).await;
+            j.destroy().await.unwrap();
+        });
     }
 }
 

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -60,7 +60,7 @@ fn bench_fixed_replay(c: &mut Criterion) {
 
         // Run the benchmarks
         let runner = tokio::Runner::new(cfg.clone());
-        for buffer in [128, 16_384, 65_536, 262_144, 1_048_576] {
+        for buffer in [128, 16_384, 65_536, 1_048_576] {
             c.bench_function(
                 &format!(
                     "{}/items={} buffer={} size={}",

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -385,7 +385,6 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
                         // Try to read the full item (data + checksum)
                         let mut buf = vec![0u8; Self::CHUNK_SIZE];
                         let item_pos = items_per_blob * *index + offset / Self::CHUNK_SIZE_U64;
-
                         match reader.read_exact(&mut buf, Self::CHUNK_SIZE).await {
                             Ok(()) => {
                                 let next_offset = offset + Self::CHUNK_SIZE_U64;
@@ -396,11 +395,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
                                     Err(err) => Some((Err(err), (index, reader, next_offset))),
                                 }
                             }
-                            Err(err) => {
-                                // If we hit the end of the blob and can't read a complete item,
-                                // we've reached the end or encountered an error
-                                Some((Err(Error::Runtime(err)), (index, reader, size)))
-                            }
+                            Err(err) => Some((Err(Error::Runtime(err)), (index, reader, size))),
                         }
                     },
                 )

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -346,7 +346,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
     pub async fn replay(
         &self,
         concurrency: usize,
-        lookahead: usize,
+        buffer: usize,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + '_, Error> {
         assert!(concurrency > 0);
         // Collect all blobs to replay
@@ -371,7 +371,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
         Ok(stream::iter(blobs)
             .map(move |(index, blob, size)| async move {
                 // Create buffered reader
-                let reader = Buffer::new(blob, size, lookahead);
+                let reader = Buffer::new(blob, size, buffer);
 
                 // Read over the blob in chunks of `CHUNK_SIZE` bytes
                 stream::unfold(

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -51,7 +51,7 @@
 use super::Error;
 use bytes::BufMut;
 use commonware_codec::{Codec, DecodeExt, FixedSize};
-use commonware_runtime::{Blob, Error as RError, Metrics, Storage};
+use commonware_runtime::{Blob, Buffer, Error as RError, Metrics, Storage};
 use commonware_utils::hex;
 use futures::stream::{self, Stream, StreamExt};
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
@@ -344,23 +344,24 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
     /// dramatically speed up the replay process if the underlying storage supports concurrent reads
     /// across different blobs.
     pub async fn replay(
-        &mut self,
+        &self,
         concurrency: usize,
+        lookahead: usize,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + '_, Error> {
         assert!(concurrency > 0);
         // Collect all blobs to replay
         let mut blobs = Vec::with_capacity(self.blobs.len());
         let (newest_blob_index, _) = self.newest_blob();
-        for (index, (blob, len)) in self.blobs.iter() {
+        for (index, (blob, size)) in self.blobs.iter() {
             let len = {
                 if index == newest_blob_index {
-                    *len
+                    *size
                 } else {
                     self.cfg.items_per_blob * Self::CHUNK_SIZE_U64
                 }
             };
             if len > 0 {
-                blobs.push((index, blob, len));
+                blobs.push((index, blob.clone(), *size));
             }
         }
 
@@ -368,30 +369,38 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
         // much memory with buffered data)
         let items_per_blob = self.cfg.items_per_blob;
         Ok(stream::iter(blobs)
-            .map(move |(index, blob, len)| async move {
+            .map(move |(index, blob, size)| async move {
+                // Create buffered reader
+                let reader = Buffer::new(blob, size, lookahead);
+
+                // Read over the blob in chunks of `CHUNK_SIZE` bytes.
                 stream::unfold(
-                    (index, blob, 0u64),
-                    move |(index, blob, offset)| async move {
+                    (index, reader, 0u64),
+                    move |(index, mut reader, offset)| async move {
                         // Check if we are at the end of the blob
-                        if offset == len {
+                        if offset >= size {
                             return None;
                         }
-                        // Get next item
+
+                        // Try to read the full item (data + checksum)
                         let mut buf = vec![0u8; Self::CHUNK_SIZE];
-                        let item = blob.read_at(&mut buf, offset).await.map_err(Error::Runtime);
-                        let next_offset = offset + Self::CHUNK_SIZE_U64;
-                        match item {
-                            Ok(_) => match Self::verify_integrity(&buf) {
-                                Ok(item) => Some((
-                                    Ok((
-                                        items_per_blob * *index + offset / Self::CHUNK_SIZE_U64,
-                                        item,
-                                    )),
-                                    (index, blob, next_offset),
-                                )),
-                                Err(err) => Some((Err(err), (index, blob, next_offset))),
-                            },
-                            Err(err) => Some((Err(err), (index, blob, len))),
+                        let item_pos = items_per_blob * *index + offset / Self::CHUNK_SIZE_U64;
+
+                        match reader.read_exact(&mut buf, Self::CHUNK_SIZE).await {
+                            Ok(()) => {
+                                let next_offset = offset + Self::CHUNK_SIZE_U64;
+                                match Self::verify_integrity(&buf) {
+                                    Ok(item) => {
+                                        Some((Ok((item_pos, item)), (index, reader, next_offset)))
+                                    }
+                                    Err(err) => Some((Err(err), (index, reader, next_offset))),
+                                }
+                            }
+                            Err(err) => {
+                                // If we hit the end of the blob and can't read a complete item,
+                                // we've reached the end or encountered an error
+                                Some((Err(Error::Runtime(err)), (index, reader, size)))
+                            }
                         }
                     },
                 )
@@ -612,7 +621,10 @@ mod tests {
             // will be empty, and there will be no retained items.
             assert_eq!(journal.oldest_retained_pos().await.unwrap(), None);
 
-            let stream = journal.replay(1).await.expect("failed to replay journal");
+            let stream = journal
+                .replay(1, 1024)
+                .await
+                .expect("failed to replay journal");
             pin_mut!(stream);
             let mut items = Vec::new();
             while let Some(result) = stream.next().await {
@@ -659,7 +671,10 @@ mod tests {
 
             // Replay should return all items
             {
-                let stream = journal.replay(10).await.expect("failed to replay journal");
+                let stream = journal
+                    .replay(10, 1024)
+                    .await
+                    .expect("failed to replay journal");
                 let mut items = Vec::new();
                 pin_mut!(stream);
                 while let Some(result) = stream.next().await {
@@ -700,7 +715,7 @@ mod tests {
             blob.close().await.expect("Failed to close blob");
 
             // Re-initialize the journal to simulate a restart
-            let mut journal = Journal::init(context.clone(), cfg.clone())
+            let journal = Journal::init(context.clone(), cfg.clone())
                 .await
                 .expect("Failed to re-initialize journal");
             let err = journal.read(corrupted_item_pos).await.unwrap_err();
@@ -708,7 +723,10 @@ mod tests {
 
             // Replay all items, making sure the checksum mismatch error is handled correctly
             {
-                let stream = journal.replay(10).await.expect("failed to replay journal");
+                let stream = journal
+                    .replay(10, 1024)
+                    .await
+                    .expect("failed to replay journal");
                 let mut items = Vec::new();
                 pin_mut!(stream);
                 let mut error_count = 0;
@@ -746,7 +764,7 @@ mod tests {
             blob.close().await.expect("Failed to close blob");
 
             // Re-initialize the journal to simulate a restart
-            let mut journal = Journal::init(context.clone(), cfg.clone())
+            let journal = Journal::init(context.clone(), cfg.clone())
                 .await
                 .expect("Failed to re-initialize journal");
             let err = journal.read(corrupted_item_pos).await.unwrap_err();
@@ -754,7 +772,10 @@ mod tests {
 
             // Replay all items, making sure the partial read error is handled correctly
             {
-                let stream = journal.replay(10).await.expect("failed to replay journal");
+                let stream = journal
+                    .replay(10, 1024)
+                    .await
+                    .expect("failed to replay journal");
                 let mut items = Vec::new();
                 pin_mut!(stream);
                 let mut error_count = 0;

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -373,7 +373,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
                 // Create buffered reader
                 let reader = Buffer::new(blob, size, lookahead);
 
-                // Read over the blob in chunks of `CHUNK_SIZE` bytes.
+                // Read over the blob in chunks of `CHUNK_SIZE` bytes
                 stream::unfold(
                     (index, reader, 0u64),
                     move |(index, mut reader, offset)| async move {

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -369,7 +369,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     pub async fn replay(
         &self,
         concurrency: usize,
-        lookahead: usize,
+        buffer: usize,
     ) -> Result<impl Stream<Item = Result<(u64, u32, u32, V), Error>> + '_, Error> {
         // Collect all blobs to replay
         let codec_config = self.cfg.codec_config.clone();
@@ -393,7 +393,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
             .map(
                 move |(section, blob, aligned_len, size, codec_config, compressed)| async move {
                     // Created buffered reader
-                    let reader = Buffer::new(blob, size, lookahead);
+                    let reader = Buffer::new(blob, size, buffer);
 
                     // Read over the blob
                     stream::unfold(

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -93,6 +93,36 @@ pub fn modulo(bytes: &[u8], n: u64) -> u64 {
     result
 }
 
+/// A macro to create a `NonZeroUsize` from a value, panicking if the value is zero.
+#[macro_export]
+macro_rules! NZUsize {
+    ($val:expr) => {
+        // This will panic at runtime if $val is zero.
+        // For literals, the compiler *might* optimize, but the check is still conceptually there.
+        std::num::NonZeroUsize::new($val).expect("value must be non-zero")
+    };
+}
+
+/// A macro to create a `NonZeroU32` from a value, panicking if the value is zero.
+#[macro_export]
+macro_rules! NZU32 {
+    ($val:expr) => {
+        // This will panic at runtime if $val is zero.
+        // For literals, the compiler *might* optimize, but the check is still conceptually there.
+        std::num::NonZeroU32::new($val).expect("value must be non-zero")
+    };
+}
+
+/// A macro to create a `NonZeroU64` from a value, panicking if the value is zero.
+#[macro_export]
+macro_rules! NZU64 {
+    ($val:expr) => {
+        // This will panic at runtime if $val is zero.
+        // For literals, the compiler *might* optimize, but the check is still conceptually there.
+        std::num::NonZeroU64::new($val).expect("value must be non-zero")
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -298,5 +328,18 @@ mod tests {
             let utils_modulo = modulo(&bytes, n);
             assert_eq!(big_modulo, BigUint::from(utils_modulo));
         }
+    }
+
+    #[test]
+    fn test_non_zero_macros() {
+        // Test case 0: zero value
+        assert!(std::panic::catch_unwind(|| NZUsize!(0)).is_err());
+        assert!(std::panic::catch_unwind(|| NZU32!(0)).is_err());
+        assert!(std::panic::catch_unwind(|| NZU64!(0)).is_err());
+
+        // Test case 1: non-zero value
+        assert_eq!(NZUsize!(1).get(), 1);
+        assert_eq!(NZU32!(2).get(), 2);
+        assert_eq!(NZU64!(3).get(), 3);
     }
 }


### PR DESCRIPTION
Resolves: #897 
Future Work: #902

## Results

_Reproduce by running the command (from inside `storage`): `cargo bench --bench journal -- journal::fixed_replay`._

### `main`
```
journal::fixed_replay/items=1000 size=32
                        time:   [11.362 ms 11.393 ms 11.428 ms]
journal::fixed_replay/items=10000 size=32
                        time:   [111.57 ms 112.68 ms 113.72 ms]
journal::fixed_replay/items=100000 size=32
                        time:   [1.1191 s 1.1302 s 1.1427 s]
journal::fixed_replay/items=500000 size=32
                        time:   [5.5083 s 5.5745 s 5.6678 s]
```

### `diff` (-99%)
```
journal::fixed_replay/items=1000 buffer=128 size=32
                        time:   [3.2873 ms 3.2919 ms 3.2979 ms]
journal::fixed_replay/items=1000 buffer=16384 size=32
                        time:   [155.12 µs 155.63 µs 156.25 µs]
journal::fixed_replay/items=1000 buffer=65536 size=32
                        time:   [123.50 µs 123.82 µs 124.03 µs]
journal::fixed_replay/items=1000 buffer=1048576 size=32
                        time:   [127.67 µs 128.02 µs 128.49 µs]
journal::fixed_replay/items=10000 buffer=128 size=32
                        time:   [32.720 ms 32.818 ms 32.918 ms]
journal::fixed_replay/items=10000 buffer=16384 size=32
                        time:   [1.4659 ms 1.4760 ms 1.4895 ms]
journal::fixed_replay/items=10000 buffer=65536 size=32
                        time:   [1.1765 ms 1.1800 ms 1.1862 ms]
journal::fixed_replay/items=10000 buffer=1048576 size=32
                        time:   [1.0822 ms 1.0890 ms 1.0998 ms]
journal::fixed_replay/items=100000 buffer=128 size=32
                        time:   [327.79 ms 329.47 ms 331.07 ms]
journal::fixed_replay/items=100000 buffer=16384 size=32
                        time:   [14.638 ms 14.674 ms 14.745 ms]
journal::fixed_replay/items=100000 buffer=65536 size=32
                        time:   [11.550 ms 11.584 ms 11.619 ms]
journal::fixed_replay/items=100000 buffer=1048576 size=32
                        time:   [10.691 ms 10.783 ms 10.975 ms]
journal::fixed_replay/items=500000 buffer=128 size=32
                        time:   [1.6123 s 1.6352 s 1.6552 s]
journal::fixed_replay/items=500000 buffer=16384 size=32
                        time:   [73.261 ms 73.406 ms 73.555 ms]
journal::fixed_replay/items=500000 buffer=65536 size=32
                        time:   [58.329 ms 58.443 ms 58.601 ms]
journal::fixed_replay/items=500000 buffer=1048576 size=32
                        time:   [55.060 ms 56.339 ms 57.447 ms]
```

