### PR TITLE
[crypotgraphy/bls12381] Migrate to Pippenger's Algorithm (MSM)

### DIFF
--- a/cryptography/src/bls12381/dkg/ops.rs
+++ b/cryptography/src/bls12381/dkg/ops.rs
@@ -136,6 +136,8 @@ pub fn recover_public_with_weights(
                         value: commitment.get(coeff),
                     })
                     .collect::<Vec<_>>();
+
+                // Use precomputed weights for interpolation
                 msm_interpolate(weights, &evals).map_err(|_| Error::PublicKeyInterpolationFailed)
             })
             .collect::<Result<Vec<_>, _>>()

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -971,6 +971,19 @@ mod tests {
         let result_empty_g1 = G1::msm(&empty_points_g1, &empty_scalars);
         assert_eq!(expected_empty_g1, G1::zero(), "G1 MSM empty (naive) failed");
         assert_eq!(result_empty_g1, G1::zero(), "G1 MSM empty failed");
+
+        // Case 8: Random points and scalars (big)
+        let points_g1: Vec<G1> = (0..50_000)
+            .map(|_| {
+                let mut point = G1::one();
+                point.mul(&Scalar::rand(&mut rng));
+                point
+            })
+            .collect();
+        let scalars: Vec<Scalar> = (0..50_000).map(|_| Scalar::rand(&mut rng)).collect();
+        let expected_g1 = naive_msm(&points_g1, &scalars);
+        let result_g1 = G1::msm(&points_g1, &scalars);
+        assert_eq!(expected_g1, result_g1, "G1 MSM basic case failed");
     }
 
     #[test]
@@ -1058,5 +1071,18 @@ mod tests {
         let result_empty_g2 = G2::msm(&empty_points_g2, &empty_scalars);
         assert_eq!(expected_empty_g2, G2::zero(), "G2 MSM empty (naive) failed");
         assert_eq!(result_empty_g2, G2::zero(), "G2 MSM empty failed");
+
+        // Case 8: Random points and scalars (big)
+        let points_g2: Vec<G2> = (0..50_000)
+            .map(|_| {
+                let mut point = G2::one();
+                point.mul(&Scalar::rand(&mut rng));
+                point
+            })
+            .collect();
+        let scalars: Vec<Scalar> = (0..50_000).map(|_| Scalar::rand(&mut rng)).collect();
+        let expected_g2 = naive_msm(&points_g2, &scalars);
+        let result_g2 = G2::msm(&points_g2, &scalars);
+        assert_eq!(expected_g2, result_g2, "G2 MSM basic case failed");
     }
 }

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -701,12 +701,14 @@ pub(super) fn equal(pk: &G1, sig: &G2, hm: &G2) -> bool {
 ///
 /// Filters out pairs where the point is the identity element (infinity).
 /// Returns an error if the lengths of the input slices mismatch.
-pub(crate) fn msm_g1(points: &[G1], scalars: &[Scalar]) -> G1 {
+pub fn msm_g1(points: &[G1], scalars: &[Scalar]) -> G1 {
     // Prepare points (affine) and scalars (raw blst_scalar), filtering identity points
     assert_eq!(points.len(), scalars.len(), "mismatched lengths");
     let mut points_affine_filtered = Vec::with_capacity(points.len());
     let mut scalars_raw_filtered = Vec::with_capacity(scalars.len());
 
+    // Document skipping any paris where both aren't zero
+    // TODO: https://github.com/supranational/blst/blob/cbc7e166a10d7286b91a3a7bea341e708962db13/src/multi_scalar.c#L10-L12
     for (point, scalar) in points.iter().zip(scalars.iter()) {
         // Skip identity points, as scalar * identity = identity
         if *point == G1::zero() {
@@ -756,7 +758,7 @@ pub(crate) fn msm_g1(points: &[G1], scalars: &[Scalar]) -> G1 {
 ///
 /// Filters out pairs where the point is the identity element (infinity).
 /// Returns an error if the lengths of the input slices mismatch.
-pub(crate) fn msm_g2(points: &[G2], scalars: &[Scalar]) -> G2 {
+pub fn msm_g2(points: &[G2], scalars: &[Scalar]) -> G2 {
     // Prepare points (affine) and scalars (raw blst_scalar), filtering identity points
     assert_eq!(points.len(), scalars.len(), "mismatched lengths");
     let mut points_affine_filtered = Vec::with_capacity(points.len());

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -65,6 +65,8 @@ pub trait Element:
 pub trait Point: Element {
     /// Maps the provided data to a group element.
     fn map(&mut self, dst: DST, message: &[u8]);
+
+    fn msm(points: &[Self], scalars: &[Scalar]) -> Self;
 }
 
 /// Wrapper around [`blst_fr`] that represents an element of the BLS12‑381
@@ -515,6 +517,10 @@ impl Point for G1 {
             );
         }
     }
+
+    fn msm(points: &[Self], scalars: &[Scalar]) -> Self {
+        msm_g1(points, scalars)
+    }
 }
 
 impl Debug for G1 {
@@ -647,6 +653,10 @@ impl Point for G2 {
                 0,
             );
         }
+    }
+
+    fn msm(points: &[Self], scalars: &[Scalar]) -> Self {
+        msm_g2(points, scalars)
     }
 }
 

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -410,7 +410,7 @@ impl G1 {
     }
 
     /// Converts the G1 point to its affine representation.
-    pub(crate) fn as_affine(&self) -> blst_p1_affine {
+    pub(crate) fn as_blst_p1_affine(&self) -> blst_p1_affine {
         let mut affine = blst_p1_affine::default();
         unsafe { blst_p1_to_affine(&mut affine, &self.0) };
         affine
@@ -542,7 +542,7 @@ impl Point for G1 {
             }
 
             // Add to filtered vectors
-            points_filtered.push(point.as_affine());
+            points_filtered.push(point.as_blst_p1_affine());
             scalars_filtered.push(scalar.as_blst_scalar());
         }
 
@@ -601,7 +601,7 @@ impl G2 {
     }
 
     /// Converts the G2 point to its affine representation.
-    pub(crate) fn as_affine(&self) -> blst_p2_affine {
+    pub(crate) fn as_blst_p2_affine(&self) -> blst_p2_affine {
         let mut affine = blst_p2_affine::default();
         unsafe { blst_p2_to_affine(&mut affine, &self.0) };
         affine
@@ -731,7 +731,7 @@ impl Point for G2 {
             if *point == G2::zero() || scalar == &Scalar::zero() {
                 continue;
             }
-            points_filtered.push(point.as_affine());
+            points_filtered.push(point.as_blst_p2_affine());
             scalars_filtered.push(scalar.as_blst_scalar());
         }
 

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -17,8 +17,9 @@ use blst::{
     blst_p1_from_affine, blst_p1_in_g1, blst_p1_is_inf, blst_p1_mult, blst_p1_to_affine,
     blst_p1_uncompress, blst_p2, blst_p2_add_or_double, blst_p2_affine, blst_p2_compress,
     blst_p2_from_affine, blst_p2_in_g2, blst_p2_is_inf, blst_p2_mult, blst_p2_to_affine,
-    blst_p2_uncompress, blst_scalar, blst_scalar_from_bendian, blst_scalar_from_fr, blst_sk_check,
-    Pairing, BLS12_381_G1, BLS12_381_G2, BLS12_381_NEG_G1, BLST_ERROR,
+    blst_p2_uncompress, blst_p2s_mult_pippenger, blst_p2s_mult_pippenger_scratch_sizeof,
+    blst_scalar, blst_scalar_from_bendian, blst_scalar_from_fr, blst_sk_check, Pairing,
+    BLS12_381_G1, BLS12_381_G2, BLS12_381_NEG_G1, BLST_ERROR,
 };
 use bytes::{Buf, BufMut};
 use commonware_codec::{
@@ -32,6 +33,7 @@ use rand::RngCore;
 use std::{
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
+    mem::MaybeUninit,
     ptr,
 };
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -236,6 +238,13 @@ impl Scalar {
         }
         slice
     }
+
+    /// Converts the scalar to the raw `blst_scalar` type.
+    pub(crate) fn to_blst_scalar(&self) -> blst_scalar {
+        let mut scalar = blst_scalar::default();
+        unsafe { blst_scalar_from_fr(&mut scalar, &self.0) };
+        scalar
+    }
 }
 
 impl Element for Scalar {
@@ -395,6 +404,18 @@ impl G1 {
         }
         slice
     }
+
+    /// Converts the G1 point to its affine representation.
+    pub(crate) fn to_affine(&self) -> blst_p1_affine {
+        let mut affine = blst_p1_affine::default();
+        unsafe { blst_p1_to_affine(&mut affine, &self.0) };
+        affine
+    }
+
+    /// Creates a G1 point from a raw `blst_p1`.
+    pub(crate) fn from_blst_p1(p: blst_p1) -> Self {
+        Self(p)
+    }
 }
 
 impl Element for G1 {
@@ -515,6 +536,18 @@ impl G2 {
             blst_p2_compress(slice.as_mut_ptr(), &self.0);
         }
         slice
+    }
+
+    /// Converts the G2 point to its affine representation.
+    pub(crate) fn to_affine(&self) -> blst_p2_affine {
+        let mut affine = blst_p2_affine::default();
+        unsafe { blst_p2_to_affine(&mut affine, &self.0) };
+        affine
+    }
+
+    /// Creates a G2 point from a raw `blst_p2`.
+    pub(crate) fn from_blst_p2(p: blst_p2) -> Self {
+        Self(p)
     }
 }
 

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -524,7 +524,8 @@ mod tests {
     use blst::BLST_ERROR;
     use commonware_codec::DecodeExt;
     use commonware_utils::quorum;
-    use group::{G1, G1_MESSAGE, G1_PROOF_OF_POSSESSION};
+    use group::{G1, G1_MESSAGE, G1_PROOF_OF_POSSESSION, G2};
+    use poly::Poly;
     use rand::prelude::*;
 
     #[test]
@@ -1097,5 +1098,87 @@ mod tests {
         let pk = poly::public(&group_poly);
         verify_message(pk, None, b"payload1", &sig_1).unwrap();
         verify_message(pk, None, b"payload2", &sig_2).unwrap();
+    }
+
+    #[test]
+    fn test_msm_interpolate_vs_poly_recover() {
+        let mut rng = StdRng::seed_from_u64(4242);
+        let degree = 5;
+        let threshold = degree + 1;
+        let poly_scalar = poly::new_from(degree, &mut rng);
+
+        // Commit to G2 (Signature group)
+        let poly_g2 = Poly::<G2>::commit(poly_scalar);
+
+        // Generate evaluations (enough to meet threshold)
+        let evals: Vec<_> = (0..threshold).map(|i| poly_g2.evaluate(i)).collect();
+        let eval_refs: Vec<_> = evals.iter().collect(); // Get references
+
+        // Compute weights
+        let indices: Vec<u32> = eval_refs.iter().map(|e| e.index).collect();
+        let weights = poly::compute_weights(indices).expect("Failed to compute weights");
+
+        // Calculate using original polynomial recovery (naive interpolation)
+        let expected_result = poly::Signature::recover_with_weights(&weights, eval_refs.clone())
+            .expect("poly::recover_with_weights failed");
+
+        // Calculate using MSM interpolation
+        let msm_result = msm_interpolate(&weights, eval_refs).expect("msm_interpolate failed");
+
+        // Compare results
+        assert_eq!(
+            expected_result, msm_result,
+            "MSM interpolation result differs from polynomial recovery"
+        );
+
+        // Also check against the known constant term
+        assert_eq!(
+            expected_result,
+            *poly_g2.constant(),
+            "Recovered value does not match original constant term"
+        );
+    }
+
+    #[test]
+    fn test_msm_interpolate_invalid_index() {
+        let mut rng = StdRng::seed_from_u64(5555);
+        let degree = 2;
+        let threshold = degree + 1;
+        let poly_scalar = poly::new_from(degree, &mut rng);
+        let poly_g2 = Poly::<G2>::commit(poly_scalar);
+
+        // Generate threshold evaluations
+        let evals: Vec<_> = (0..threshold).map(|i| poly_g2.evaluate(i)).collect();
+        let eval_refs: Vec<_> = evals.iter().collect();
+
+        // Compute weights for *different* indices
+        let wrong_indices: Vec<u32> = (threshold..threshold * 2).collect();
+        let weights = poly::compute_weights(wrong_indices).expect("Failed to compute weights");
+
+        // Try to interpolate with mismatched weights/evals
+        let result = msm_interpolate::<G2, _>(&weights, eval_refs);
+
+        // Expect InvalidIndex error
+        assert!(
+            matches!(result, Err(Error::InvalidIndex)),
+            "Expected InvalidIndex error for mismatched weights"
+        );
+    }
+
+    #[test]
+    fn test_msm_interpolate_empty() {
+        let weights: BTreeMap<u32, Weight> = BTreeMap::new();
+        let evals: Vec<Eval<G2>> = Vec::new();
+        let eval_refs: Vec<&Eval<G2>> = evals.iter().collect();
+
+        // Interpolate with empty inputs
+        let result = msm_interpolate(&weights, eval_refs).expect("msm_interpolate failed on empty");
+
+        // Expect identity element
+        assert_eq!(
+            result,
+            G2::zero(),
+            "Expected G2 identity for empty interpolation"
+        );
     }
 }

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -305,8 +305,8 @@ where
     let evals = prepare_evaluations(threshold, partials)?;
 
     // Compute weights
-    let indicies = evals.iter().map(|e| e.index).collect::<Vec<_>>();
-    let weights = compute_weights(indicies)?;
+    let indices = evals.iter().map(|e| e.index).collect::<Vec<_>>();
+    let weights = compute_weights(indices)?;
 
     // Perform interpolation with the precomputed weights.
     //

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -249,7 +249,13 @@ where
     let mut scalars = Vec::with_capacity(weights.len());
     for e in evals {
         points.push(e.value.clone());
-        scalars.push(weights.get(&e.index).ok_or(Error::InvalidIndex)?.0.clone());
+        scalars.push(
+            weights
+                .get(&e.index)
+                .ok_or(Error::InvalidIndex)?
+                .as_scalar()
+                .clone(),
+        );
     }
 
     // Perform multi-scalar multiplication

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -321,7 +321,6 @@ where
 pub fn threshold_signature_recover_multiple<'a, I>(
     threshold: u32,
     mut many_evals: Vec<I>,
-    concurrency: usize,
 ) -> Result<Vec<group::Signature>, Error>
 where
     I: IntoIterator<Item = &'a PartialSignature>,
@@ -366,13 +365,11 @@ pub fn threshold_signature_recover_pair<'a, I>(
     threshold: u32,
     first: I,
     second: I,
-    concurrency: usize,
 ) -> Result<(group::Signature, group::Signature), Error>
 where
     I: IntoIterator<Item = &'a PartialSignature>,
 {
-    let mut sigs =
-        threshold_signature_recover_multiple(threshold, vec![first, second], concurrency)?;
+    let mut sigs = threshold_signature_recover_multiple(threshold, vec![first, second])?;
     let second_sig = sigs.pop().unwrap();
     let first_sig = sigs.pop().unwrap();
     Ok((first_sig, second_sig))
@@ -1085,8 +1082,7 @@ mod tests {
             .collect();
 
         // Recover signatures
-        let (sig_1, sig_2) =
-            threshold_signature_recover_pair(t, &partials_1, &partials_2, 1).unwrap();
+        let (sig_1, sig_2) = threshold_signature_recover_pair(t, &partials_1, &partials_2).unwrap();
 
         // Verify with the aggregated public key.
         let pk = poly::public(&group_poly);

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -237,19 +237,22 @@ where
     Ok(())
 }
 
-/// Interpolate the constant term with a *single* MSM instead of a loop.
+/// Interpolate the value of some [Point] with precomputed Barycentric Weights
+/// and multi-scalar multiplication (MSM).
 pub fn msm_interpolate<'a, P, I>(weights: &BTreeMap<u32, Weight>, evals: I) -> Result<P, Error>
 where
     P: Point + 'a,
     I: IntoIterator<Item = &'a Eval<P>>,
 {
-    let mut points = Vec::new();
-    let mut scalars = Vec::new();
-
+    // Populate points and scalars
+    let mut points = Vec::with_capacity(weights.len());
+    let mut scalars = Vec::with_capacity(weights.len());
     for e in evals {
         points.push(e.value.clone());
         scalars.push(weights.get(&e.index).ok_or(Error::InvalidIndex)?.0.clone());
     }
+
+    // Perform multi-scalar multiplication
     Ok(P::msm(&points, &scalars))
 }
 

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -92,7 +92,7 @@ pub fn new_from<R: RngCore>(degree: u32, rng: &mut R) -> Poly<Scalar> {
 }
 
 /// A Barycentric Weight for interpolation at x=0.
-pub struct Weight(Scalar);
+pub struct Weight(pub(crate) Scalar);
 
 /// Prepares at least `t` evaluations for Lagrange interpolation.
 pub fn prepare_evaluations<'a, C, I>(threshold: u32, evals: I) -> Result<Vec<&'a Eval<C>>, Error>

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -92,7 +92,14 @@ pub fn new_from<R: RngCore>(degree: u32, rng: &mut R) -> Poly<Scalar> {
 }
 
 /// A Barycentric Weight for interpolation at x=0.
-pub struct Weight(pub(crate) Scalar);
+pub struct Weight(Scalar);
+
+impl Weight {
+    /// Returns the weight as a [Scalar].
+    pub fn as_scalar(&self) -> &Scalar {
+        &self.0
+    }
+}
 
 /// Prepares at least `t` evaluations for Lagrange interpolation.
 pub fn prepare_evaluations<'a, C, I>(threshold: u32, evals: I) -> Result<Vec<&'a Eval<C>>, Error>


### PR DESCRIPTION
Resolves: #719 
Replaces: #720 
Replaces: #731 

## TODO

- [ ] ~Flip default PublicKey/Signature fields~: https://github.com/commonwarexyz/monorepo/issues/905

## Results

### `bls12381::dkg_reshare_recovery`

```
bls12381::dkg_reshare_recovery/conc=1 n=5 t=4
                        time:   [688.29 µs 694.30 µs 705.34 µs]
                        change: [-27.088% -26.186% -25.131%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=2 n=5 t=4
                        time:   [377.00 µs 378.26 µs 379.67 µs]
                        change: [-24.635% -24.344% -24.030%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=4 n=5 t=4
                        time:   [244.37 µs 246.40 µs 247.75 µs]
                        change: [-22.278% -20.925% -19.671%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=8 n=5 t=4
                        time:   [298.68 µs 301.99 µs 305.24 µs]
                        change: [-20.392% -18.243% -16.064%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=1 n=10 t=7
                        time:   [1.7400 ms 1.7421 ms 1.7452 ms]
                        change: [-38.047% -37.527% -36.903%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=2 n=10 t=7
                        time:   [1.0946 ms 1.0959 ms 1.0978 ms]
                        change: [-33.245% -32.593% -32.040%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=4 n=10 t=7
                        time:   [612.18 µs 615.88 µs 618.15 µs]
                        change: [-33.117% -32.255% -31.521%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=8 n=10 t=7
                        time:   [578.84 µs 585.72 µs 595.70 µs]
                        change: [-29.552% -27.375% -24.421%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=1 n=20 t=14
                        time:   [6.1613 ms 6.1978 ms 6.2304 ms]
                        change: [-44.127% -43.692% -43.244%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=2 n=20 t=14
                        time:   [3.1798 ms 3.2001 ms 3.2157 ms]
                        change: [-44.048% -43.663% -43.299%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=4 n=20 t=14
                        time:   [1.9201 ms 1.9257 ms 1.9303 ms]
                        change: [-42.733% -42.435% -42.144%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=8 n=20 t=14
                        time:   [1.2437 ms 1.2623 ms 1.2833 ms]
                        change: [-41.498% -39.418% -37.379%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=1 n=50 t=34
                        time:   [32.827 ms 33.124 ms 33.582 ms]
                        change: [-51.303% -49.838% -48.610%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=2 n=50 t=34
                        time:   [16.879 ms 16.947 ms 17.029 ms]
                        change: [-49.099% -48.861% -48.599%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=4 n=50 t=34
                        time:   [9.2237 ms 9.2525 ms 9.2855 ms]
                        change: [-49.318% -48.860% -48.465%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=8 n=50 t=34
                        time:   [5.4414 ms 5.5282 ms 5.6235 ms]
                        change: [-55.888% -53.392% -50.966%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=1 n=100 t=67
                        time:   [57.019 ms 57.168 ms 57.334 ms]
                        change: [-78.940% -78.533% -78.140%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=2 n=100 t=67
                        time:   [29.678 ms 29.786 ms 29.883 ms]
                        change: [-78.016% -77.534% -77.154%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=4 n=100 t=67
                        time:   [15.473 ms 15.501 ms 15.532 ms]
                        change: [-76.963% -76.872% -76.788%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=8 n=100 t=67
                        time:   [9.5296 ms 9.7331 ms 10.094 ms]
                        change: [-78.046% -77.219% -76.138%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=1 n=250 t=167
                        time:   [363.06 ms 364.06 ms 365.34 ms]
                        change: [-77.936% -77.353% -76.875%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=2 n=250 t=167
                        time:   [186.58 ms 186.83 ms 187.11 ms]
                        change: [-85.989% -81.712% -77.509%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=4 n=250 t=167
                        time:   [96.666 ms 96.749 ms 96.830 ms]
                        change: [-80.579% -80.331% -80.065%] (p = 0.00 < 0.05)
bls12381::dkg_reshare_recovery/conc=8 n=250 t=167
                        time:   [59.314 ms 59.933 ms 60.577 ms]
                        change: [-78.699% -78.248% -77.856%] (p = 0.00 < 0.05)
```

### `bls12381::threshold_signature_recover`

```
bls12381::threshold_signature_recover/n=5 t=4
                        time:   [377.32 µs 378.53 µs 380.69 µs]
                        change: [-14.140% -13.886% -13.627%] (p = 0.00 < 0.05)
bls12381::threshold_signature_recover/n=10 t=7
                        time:   [577.83 µs 578.55 µs 579.50 µs]
                        change: [-30.290% -26.991% -25.131%] (p = 0.00 < 0.05)
bls12381::threshold_signature_recover/n=20 t=14
                        time:   [1.0528 ms 1.0708 ms 1.1047 ms]
                        change: [-32.196% -30.839% -28.427%] (p = 0.00 < 0.05)
bls12381::threshold_signature_recover/n=50 t=34
                        time:   [1.2326 ms 1.2336 ms 1.2348 ms]
                        change: [-67.869% -67.603% -67.411%] (p = 0.00 < 0.05)
bls12381::threshold_signature_recover/n=100 t=67
                        time:   [2.3946 ms 2.3966 ms 2.3991 ms]
                        change: [-68.152% -68.099% -68.055%] (p = 0.00 < 0.05)
bls12381::threshold_signature_recover/n=250 t=167
                        time:   [6.8772 ms 6.8835 ms 6.8902 ms]
                        change: [-64.808% -64.621% -64.474%] (p = 0.00 < 0.05)
bls12381::threshold_signature_recover/n=500 t=334
                        time:   [16.472 ms 16.515 ms 16.569 ms]
                        change: [-59.719% -59.594% -59.469%] (p = 0.00 < 0.05)
```

Context: https://github.com/supranational/blst/blob/cbc7e166a10d7286b91a3a7bea341e708962db13/bindings/rust/src/pippenger.rs#L133-L163