### PR TITLE
ci: use ubuntu-22.04 runner for benchmark job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
   publish:
     name: Publish
     needs: has-new-commit # Only run if there are new commits
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-22.04
     timeout-minutes: 720
     strategy:
       max-parallel: 1 # Run one package at a time


### PR DESCRIPTION
Replaces the invalid `ubuntu-latest-8` runner with the supported `ubuntu-22.04`
image, ensuring the benchmark workflow runs reliably on an officially
maintained GitHub-hosted environment.