### PR TITLE
[p2p] Improve peer discovery for peers that change their IP Address

### DIFF
--- a/p2p/src/authenticated/actors/peer/actor.rs
+++ b/p2p/src/authenticated/actors/peer/actor.rs
@@ -119,7 +119,13 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Ver
             let mailbox = self.mailbox.clone();
             let rate_limits = rate_limits.clone();
             move |context| async move {
-                let mut deadline = context.current() + self.gossip_bit_vec_frequency;
+                // Allow tracker to initialize the peer
+                tracker.initialize(peer.clone(), mailbox.clone()).await;
+
+                // Set the initial deadline to now to start gossiping immediately
+                let mut deadline = context.current();
+
+                // Enter into the main loop
                 loop {
                     select! {
                         _ = context.sleep_until(deadline) => {

--- a/p2p/src/authenticated/actors/tracker/record.rs
+++ b/p2p/src/authenticated/actors/tracker/record.rs
@@ -159,7 +159,7 @@ impl<C: Verifier> Record<C> {
         matches!(self.address, Address::Blocked)
     }
 
-    /// Returns true if we don't need additional [`PeerInfo`] about this peer.
+    /// Returns `true` if we don't need additional [`PeerInfo`] about this peer.
     ///
     /// Similar to `peer_info().is_some()`, but also include the `Blocked` case since we don't
     /// want to track blocked peers despite not recording their information.
@@ -168,6 +168,20 @@ impl<C: Verifier> Record<C> {
             Address::Unknown | Address::Bootstrapper(_) => false,
             Address::Myself(_)
             | Address::Blocked
+            | Address::Discovered(_)
+            | Address::Persistent(_) => true,
+        }
+    }
+
+    /// Returns `true` if we want to attempt to refresh the peer information if not connected to
+    /// this peer.
+    ///
+    /// `false` only for `Myself` and `Blocked` peers.
+    pub fn refreshable(&self) -> bool {
+        match self.address {
+            Address::Myself(_) | Address::Blocked => false,
+            Address::Unknown
+            | Address::Bootstrapper(_)
             | Address::Discovered(_)
             | Address::Persistent(_) => true,
         }

--- a/p2p/src/authenticated/actors/tracker/set.rs
+++ b/p2p/src/authenticated/actors/tracker/set.rs
@@ -3,9 +3,6 @@ use std::collections::HashMap;
 
 /// Represents a set of peers and their knowledge of each other.
 pub struct Set<P: Array> {
-    /// The index at which this peer set applies.
-    pub index: u64,
-
     /// The list of peers, sorted.
     pub sorted: Vec<P>,
 
@@ -17,7 +14,8 @@ pub struct Set<P: Array> {
 }
 
 impl<P: Array> Set<P> {
-    pub fn new(index: u64, mut peers: Vec<P>) -> Self {
+    /// Creates a new set for the given index.
+    pub fn new(mut peers: Vec<P>) -> Self {
         // Insert peers in sorted order
         peers.sort();
         let mut order = HashMap::new();
@@ -29,13 +27,15 @@ impl<P: Array> Set<P> {
         let knowledge = BitVec::zeroes(peers.len());
 
         Self {
-            index,
             sorted: peers,
             order,
             knowledge,
         }
     }
 
+    /// Marks a peer as found in the set.
+    ///
+    /// Returns `true` if the peer is in the set, `false` otherwise.
     pub fn found(&mut self, peer: &P) -> bool {
         if let Some(idx) = self.order.get(peer) {
             self.knowledge.set(*idx);
@@ -53,7 +53,7 @@ mod tests {
     #[test]
     fn test_set_initialization() {
         let peers = vec![U64::new(3), U64::new(1), U64::new(2)];
-        let set = Set::new(0, peers);
+        let set = Set::new(peers);
         assert_eq!(set.sorted, vec![U64::new(1), U64::new(2), U64::new(3)]);
         assert_eq!(set.order.get(&U64::new(1)), Some(&0));
         assert_eq!(set.order.get(&U64::new(2)), Some(&1));
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn test_found() {
         let peers = vec![U64::new(1), U64::new(2), U64::new(3)];
-        let mut set = Set::new(0, peers);
+        let mut set = Set::new(peers);
         assert!(set.found(&U64::new(2)));
         assert_eq!(set.knowledge, BitVec::from(vec![false, true, false]));
         assert!(!set.found(&U64::new(4))); // Peer not in set


### PR DESCRIPTION
Fixes #914 with the following techniques:

- Send our own `PeerInfo` immediately to peers upon connection
  - This behavior is documented but was previously missing
  - This helps to update directly-connected peers who might have previously had outdated information
  - This introduces a new ingress message type, `Initialize`, to the `Tracker`
- After this message, send a `BitVec` to a peer immediately; do not begin the connection for waiting for an initial `gossip_bit_vec_frequency` timeout period
- When constructing a `BitVec`, if we have peer information for a peer but are not connected to them, mark their position in the bitvec as `0`
  - To avoid adding additional data structures, we use the lack of an active reservation as a proxy for connection. This seems fine since there is nothing too bad about not "unsetting" the bit


TODO:
- [ ] Don't `want()` info that we haven't attempted to dial