### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -61,7 +61,7 @@ pub trait Element:
     fn mul(&mut self, rhs: &Scalar);
 }
 
-/// A point on a a curve.
+/// A point on a curve.
 pub trait Point: Element {
     /// Maps the provided data to a group element.
     fn map(&mut self, dst: DST, message: &[u8]);


### PR DESCRIPTION
 remove redundant word in comment