### PR TITLE
docs: replace outdated Commonware interop article link

### DIFF
--- a/docs/blogs/threshold-simplex.html
+++ b/docs/blogs/threshold-simplex.html
@@ -11,7 +11,7 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
-    <meta property="og:url" content="https://commonware.xyz/blogs/many-to-many-interop.html" />
+    <meta property="og:url" content="https://commonware.xyz/blogs/threshold-simplex.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />
     <meta property="og:image" content="https://commonware.xyz/imgs/trusted-bridge.jpeg" />
@@ -23,7 +23,7 @@
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="twitter:domain" content="commonware.xyz" />
-    <meta property="twitter:url" content="https://commonware.xyz/blogs/many-to-many-interop.html" />
+    <meta property="twitter:url" content="https://commonware.xyz/blogs/threshold-simplex.html" />
     <meta property="twitter:title" content="Many-to-Many Interoperability with Threshold Simplex" />
     <meta property="twitter:description" content="Starting with the launch of the second blockchain, connecting any blockchain to any other blockchain without additional trust assumptions has been an elusive dream. Ten years later, application developers must still settle for some version of this." />
     <meta property="twitter:image" content="https://commonware.xyz/imgs/trusted-bridge.jpeg" />


### PR DESCRIPTION
Description
- fix /blogs/many-to-many-interop.html → /blogs/threshold-simplex.html
- docs-only, no code changes

All files verified; link updated.