### PR TITLE
[deployer] use `$HOME` for deployer artifacts

### DIFF
--- a/deployer/src/ec2/authorize.rs
+++ b/deployer/src/ec2/authorize.rs
@@ -23,15 +23,15 @@ pub async fn authorize(config_path: &PathBuf, ip: Option<String>) -> Result<(), 
     info!(tag = tag.as_str(), "loaded configuration");
 
     // Check deployment status
-    let deployer_directory = deployer_directory(tag);
-    if !deployer_directory.exists() {
+    let tag_directory = deployer_directory(tag);
+    if !tag_directory.exists() {
         return Err(Error::DeploymentDoesNotExist(tag.clone()));
     }
-    let created_file = deployer_directory.join(CREATED_FILE_NAME);
+    let created_file = tag_directory.join(CREATED_FILE_NAME);
     if !created_file.exists() {
         return Err(Error::DeploymentNotComplete(tag.clone()));
     }
-    let destroyed_file = deployer_directory.join(DESTROYED_FILE_NAME);
+    let destroyed_file = tag_directory.join(DESTROYED_FILE_NAME);
     if destroyed_file.exists() {
         return Err(Error::DeploymentAlreadyDestroyed(tag.clone()));
     }

--- a/deployer/src/ec2/authorize.rs
+++ b/deployer/src/ec2/authorize.rs
@@ -23,15 +23,15 @@ pub async fn authorize(config_path: &PathBuf, ip: Option<String>) -> Result<(), 
     info!(tag = tag.as_str(), "loaded configuration");
 
     // Check deployment status
-    let temp_dir = deployer_directory(tag);
-    if !temp_dir.exists() {
+    let deployer_directory = deployer_directory(tag);
+    if !deployer_directory.exists() {
         return Err(Error::DeploymentDoesNotExist(tag.clone()));
     }
-    let created_file = temp_dir.join(CREATED_FILE_NAME);
+    let created_file = deployer_directory.join(CREATED_FILE_NAME);
     if !created_file.exists() {
         return Err(Error::DeploymentNotComplete(tag.clone()));
     }
-    let destroyed_file = temp_dir.join(DESTROYED_FILE_NAME);
+    let destroyed_file = deployer_directory.join(DESTROYED_FILE_NAME);
     if destroyed_file.exists() {
         return Err(Error::DeploymentAlreadyDestroyed(tag.clone()));
     }

--- a/deployer/src/ec2/create.rs
+++ b/deployer/src/ec2/create.rs
@@ -41,12 +41,12 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
     info!(tag = tag.as_str(), "loaded configuration");
 
     // Create a temporary directory for local files
-    let deployer_directory = deployer_directory(tag);
-    if deployer_directory.exists() {
+    let tag_directory = deployer_directory(tag);
+    if tag_directory.exists() {
         return Err(Error::CreationAttempted);
     }
-    std::fs::create_dir_all(&deployer_directory)?;
-    info!(path = ?deployer_directory, "created deployer directory");
+    std::fs::create_dir_all(&tag_directory)?;
+    info!(path = ?tag_directory, "created tag directory");
 
     // Ensure no instance is duplicated or named MONITORING_NAME
     let mut instance_names = HashSet::new();
@@ -63,8 +63,8 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
 
     // Generate SSH key pair
     let key_name = format!("deployer-{}", tag);
-    let private_key_path = deployer_directory.join(format!("id_rsa_{}", tag));
-    let public_key_path = deployer_directory.join(format!("id_rsa_{}.pub", tag));
+    let private_key_path = tag_directory.join(format!("id_rsa_{}", tag));
+    let public_key_path = tag_directory.join(format!("id_rsa_{}.pub", tag));
     let output = Command::new("ssh-keygen")
         .arg("-t")
         .arg("rsa")
@@ -391,35 +391,35 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
     info!("launched binary instances");
 
     // Write systemd service files
-    let prometheus_service_path = deployer_directory.join("prometheus.service");
+    let prometheus_service_path = tag_directory.join("prometheus.service");
     std::fs::write(&prometheus_service_path, PROMETHEUS_SERVICE)?;
-    let loki_service_path = deployer_directory.join("loki.service");
+    let loki_service_path = tag_directory.join("loki.service");
     std::fs::write(&loki_service_path, LOKI_SERVICE)?;
-    let pyroscope_service_path = deployer_directory.join("pyroscope.service");
+    let pyroscope_service_path = tag_directory.join("pyroscope.service");
     std::fs::write(&pyroscope_service_path, PYROSCOPE_SERVICE)?;
-    let tempo_service_path = deployer_directory.join("tempo.service");
+    let tempo_service_path = tag_directory.join("tempo.service");
     std::fs::write(&tempo_service_path, TEMPO_SERVICE)?;
-    let promtail_service_path = deployer_directory.join("promtail.service");
+    let promtail_service_path = tag_directory.join("promtail.service");
     std::fs::write(&promtail_service_path, PROMTAIL_SERVICE)?;
-    let node_exporter_service_path = deployer_directory.join("node_exporter.service");
+    let node_exporter_service_path = tag_directory.join("node_exporter.service");
     std::fs::write(&node_exporter_service_path, NODE_EXPORTER_SERVICE)?;
-    let pyroscope_agent_service_path = deployer_directory.join("pyroscope-agent.service");
+    let pyroscope_agent_service_path = tag_directory.join("pyroscope-agent.service");
     std::fs::write(&pyroscope_agent_service_path, PYROSCOPE_AGENT_SERVICE)?;
-    let pyroscope_agent_timer_path = deployer_directory.join("pyroscope-agent.timer");
+    let pyroscope_agent_timer_path = tag_directory.join("pyroscope-agent.timer");
     std::fs::write(&pyroscope_agent_timer_path, PYROSCOPE_AGENT_TIMER)?;
-    let binary_service_path = deployer_directory.join("binary.service");
+    let binary_service_path = tag_directory.join("binary.service");
     std::fs::write(&binary_service_path, BINARY_SERVICE)?;
-    let memleak_agent_service_path = deployer_directory.join("memleak-agent.service");
+    let memleak_agent_service_path = tag_directory.join("memleak-agent.service");
     std::fs::write(&memleak_agent_service_path, MEMLEAK_AGENT_SERVICE)?;
-    let memleak_agent_script_path = deployer_directory.join("memleak-agent.sh");
+    let memleak_agent_script_path = tag_directory.join("memleak-agent.sh");
     std::fs::write(&memleak_agent_script_path, MEMLEAK_AGENT_SCRIPT)?;
 
     // Write logrotate configuration file
-    let logrotate_conf_path = deployer_directory.join("logrotate.conf");
+    let logrotate_conf_path = tag_directory.join("logrotate.conf");
     std::fs::write(&logrotate_conf_path, LOGROTATE_CONF)?;
 
     // Add BBR configuration file
-    let bbr_conf_path = deployer_directory.join("99-bbr.conf");
+    let bbr_conf_path = tag_directory.join("99-bbr.conf");
     std::fs::write(&bbr_conf_path, BBR_CONF)?;
 
     // Configure monitoring instance
@@ -436,17 +436,17 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
         })
         .collect();
     let prom_config = generate_prometheus_config(&instances);
-    let prom_path = deployer_directory.join("prometheus.yml");
+    let prom_path = tag_directory.join("prometheus.yml");
     std::fs::write(&prom_path, prom_config)?;
-    let datasources_path = deployer_directory.join("datasources.yml");
+    let datasources_path = tag_directory.join("datasources.yml");
     std::fs::write(&datasources_path, DATASOURCES_YML)?;
-    let all_yaml_path = deployer_directory.join("all.yml");
+    let all_yaml_path = tag_directory.join("all.yml");
     std::fs::write(&all_yaml_path, ALL_YML)?;
-    let loki_config_path = deployer_directory.join("loki.yml");
+    let loki_config_path = tag_directory.join("loki.yml");
     std::fs::write(&loki_config_path, LOKI_CONFIG)?;
-    let pyroscope_config_path = deployer_directory.join("pyroscope.yml");
+    let pyroscope_config_path = tag_directory.join("pyroscope.yml");
     std::fs::write(&pyroscope_config_path, PYROSCOPE_CONFIG)?;
-    let tempo_yml_path = deployer_directory.join("tempo.yml");
+    let tempo_yml_path = tag_directory.join("tempo.yml");
     std::fs::write(&tempo_yml_path, TEMPO_CONFIG)?;
     rsync_file(
         private_key,
@@ -572,14 +572,14 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
             .collect(),
     };
     let hosts_yaml = serde_yaml::to_string(&hosts)?;
-    let hosts_path = deployer_directory.join("hosts.yaml");
+    let hosts_path = tag_directory.join("hosts.yaml");
     std::fs::write(&hosts_path, hosts_yaml)?;
 
     // Configure binary instances
     info!("configuring binary instances");
     let mut start_futures = Vec::new();
     for deployment in &deployments {
-        let deployer_directory = deployer_directory.clone();
+        let tag_directory = tag_directory.clone();
         let instance = deployment.instance.clone();
         wait_for_instances_ready(&ec2_clients[&instance.region], &[deployment.id.clone()]).await?;
         let ip = deployment.ip.clone();
@@ -611,7 +611,7 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
             )
             .await?;
             let promtail_config_path =
-                deployer_directory.join(format!("promtail_{}.yml", instance.name));
+                tag_directory.join(format!("promtail_{}.yml", instance.name));
             std::fs::write(
                 &promtail_config_path,
                 promtail_config(
@@ -664,7 +664,7 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
             )
             .await?;
             let pyroscope_agent_script_path =
-                deployer_directory.join(format!("pyroscope-agent_{}.sh", instance.name));
+                tag_directory.join(format!("pyroscope-agent_{}.sh", instance.name));
             std::fs::write(
                 &pyroscope_agent_script_path,
                 generate_pyroscope_script(
@@ -827,7 +827,7 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
     info!("updated monitoring security group");
 
     // Mark deployment as complete
-    File::create(deployer_directory.join(CREATED_FILE_NAME))?;
+    File::create(tag_directory.join(CREATED_FILE_NAME))?;
     info!(
         monitoring = monitoring_ip.as_str(),
         binary = ?all_binary_ips,

--- a/deployer/src/ec2/create.rs
+++ b/deployer/src/ec2/create.rs
@@ -46,7 +46,7 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
         return Err(Error::CreationAttempted);
     }
     std::fs::create_dir_all(&deployer_directory)?;
-    info!(path = ?deployer_directory, "created directory");
+    info!(path = ?deployer_directory, "created deployer directory");
 
     // Ensure no instance is duplicated or named MONITORING_NAME
     let mut instance_names = HashSet::new();

--- a/deployer/src/ec2/create.rs
+++ b/deployer/src/ec2/create.rs
@@ -41,12 +41,12 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
     info!(tag = tag.as_str(), "loaded configuration");
 
     // Create a temporary directory for local files
-    let temp_dir = deployer_directory(tag);
-    if temp_dir.exists() {
+    let deployer_directory = deployer_directory(tag);
+    if deployer_directory.exists() {
         return Err(Error::CreationAttempted);
     }
-    std::fs::create_dir_all(&temp_dir)?;
-    info!(path = ?temp_dir, "created temporary directory");
+    std::fs::create_dir_all(&deployer_directory)?;
+    info!(path = ?deployer_directory, "created directory");
 
     // Ensure no instance is duplicated or named MONITORING_NAME
     let mut instance_names = HashSet::new();
@@ -63,8 +63,8 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
 
     // Generate SSH key pair
     let key_name = format!("deployer-{}", tag);
-    let private_key_path = temp_dir.join(format!("id_rsa_{}", tag));
-    let public_key_path = temp_dir.join(format!("id_rsa_{}.pub", tag));
+    let private_key_path = deployer_directory.join(format!("id_rsa_{}", tag));
+    let public_key_path = deployer_directory.join(format!("id_rsa_{}.pub", tag));
     let output = Command::new("ssh-keygen")
         .arg("-t")
         .arg("rsa")
@@ -391,35 +391,35 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
     info!("launched binary instances");
 
     // Write systemd service files
-    let prometheus_service_path = temp_dir.join("prometheus.service");
+    let prometheus_service_path = deployer_directory.join("prometheus.service");
     std::fs::write(&prometheus_service_path, PROMETHEUS_SERVICE)?;
-    let loki_service_path = temp_dir.join("loki.service");
+    let loki_service_path = deployer_directory.join("loki.service");
     std::fs::write(&loki_service_path, LOKI_SERVICE)?;
-    let pyroscope_service_path = temp_dir.join("pyroscope.service");
+    let pyroscope_service_path = deployer_directory.join("pyroscope.service");
     std::fs::write(&pyroscope_service_path, PYROSCOPE_SERVICE)?;
-    let tempo_service_path = temp_dir.join("tempo.service");
+    let tempo_service_path = deployer_directory.join("tempo.service");
     std::fs::write(&tempo_service_path, TEMPO_SERVICE)?;
-    let promtail_service_path = temp_dir.join("promtail.service");
+    let promtail_service_path = deployer_directory.join("promtail.service");
     std::fs::write(&promtail_service_path, PROMTAIL_SERVICE)?;
-    let node_exporter_service_path = temp_dir.join("node_exporter.service");
+    let node_exporter_service_path = deployer_directory.join("node_exporter.service");
     std::fs::write(&node_exporter_service_path, NODE_EXPORTER_SERVICE)?;
-    let pyroscope_agent_service_path = temp_dir.join("pyroscope-agent.service");
+    let pyroscope_agent_service_path = deployer_directory.join("pyroscope-agent.service");
     std::fs::write(&pyroscope_agent_service_path, PYROSCOPE_AGENT_SERVICE)?;
-    let pyroscope_agent_timer_path = temp_dir.join("pyroscope-agent.timer");
+    let pyroscope_agent_timer_path = deployer_directory.join("pyroscope-agent.timer");
     std::fs::write(&pyroscope_agent_timer_path, PYROSCOPE_AGENT_TIMER)?;
-    let binary_service_path = temp_dir.join("binary.service");
+    let binary_service_path = deployer_directory.join("binary.service");
     std::fs::write(&binary_service_path, BINARY_SERVICE)?;
-    let memleak_agent_service_path = temp_dir.join("memleak-agent.service");
+    let memleak_agent_service_path = deployer_directory.join("memleak-agent.service");
     std::fs::write(&memleak_agent_service_path, MEMLEAK_AGENT_SERVICE)?;
-    let memleak_agent_script_path = temp_dir.join("memleak-agent.sh");
+    let memleak_agent_script_path = deployer_directory.join("memleak-agent.sh");
     std::fs::write(&memleak_agent_script_path, MEMLEAK_AGENT_SCRIPT)?;
 
     // Write logrotate configuration file
-    let logrotate_conf_path = temp_dir.join("logrotate.conf");
+    let logrotate_conf_path = deployer_directory.join("logrotate.conf");
     std::fs::write(&logrotate_conf_path, LOGROTATE_CONF)?;
 
     // Add BBR configuration file
-    let bbr_conf_path = temp_dir.join("99-bbr.conf");
+    let bbr_conf_path = deployer_directory.join("99-bbr.conf");
     std::fs::write(&bbr_conf_path, BBR_CONF)?;
 
     // Configure monitoring instance
@@ -436,17 +436,17 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
         })
         .collect();
     let prom_config = generate_prometheus_config(&instances);
-    let prom_path = temp_dir.join("prometheus.yml");
+    let prom_path = deployer_directory.join("prometheus.yml");
     std::fs::write(&prom_path, prom_config)?;
-    let datasources_path = temp_dir.join("datasources.yml");
+    let datasources_path = deployer_directory.join("datasources.yml");
     std::fs::write(&datasources_path, DATASOURCES_YML)?;
-    let all_yaml_path = temp_dir.join("all.yml");
+    let all_yaml_path = deployer_directory.join("all.yml");
     std::fs::write(&all_yaml_path, ALL_YML)?;
-    let loki_config_path = temp_dir.join("loki.yml");
+    let loki_config_path = deployer_directory.join("loki.yml");
     std::fs::write(&loki_config_path, LOKI_CONFIG)?;
-    let pyroscope_config_path = temp_dir.join("pyroscope.yml");
+    let pyroscope_config_path = deployer_directory.join("pyroscope.yml");
     std::fs::write(&pyroscope_config_path, PYROSCOPE_CONFIG)?;
-    let tempo_yml_path = temp_dir.join("tempo.yml");
+    let tempo_yml_path = deployer_directory.join("tempo.yml");
     std::fs::write(&tempo_yml_path, TEMPO_CONFIG)?;
     rsync_file(
         private_key,
@@ -572,14 +572,14 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
             .collect(),
     };
     let hosts_yaml = serde_yaml::to_string(&hosts)?;
-    let hosts_path = temp_dir.join("hosts.yaml");
+    let hosts_path = deployer_directory.join("hosts.yaml");
     std::fs::write(&hosts_path, hosts_yaml)?;
 
     // Configure binary instances
     info!("configuring binary instances");
     let mut start_futures = Vec::new();
     for deployment in &deployments {
-        let temp_dir = temp_dir.clone();
+        let deployer_directory = deployer_directory.clone();
         let instance = deployment.instance.clone();
         wait_for_instances_ready(&ec2_clients[&instance.region], &[deployment.id.clone()]).await?;
         let ip = deployment.ip.clone();
@@ -610,7 +610,8 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
                 "/home/ubuntu/hosts.yaml",
             )
             .await?;
-            let promtail_config_path = temp_dir.join(format!("promtail_{}.yml", instance.name));
+            let promtail_config_path =
+                deployer_directory.join(format!("promtail_{}.yml", instance.name));
             std::fs::write(
                 &promtail_config_path,
                 promtail_config(
@@ -663,7 +664,7 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
             )
             .await?;
             let pyroscope_agent_script_path =
-                temp_dir.join(format!("pyroscope-agent_{}.sh", instance.name));
+                deployer_directory.join(format!("pyroscope-agent_{}.sh", instance.name));
             std::fs::write(
                 &pyroscope_agent_script_path,
                 generate_pyroscope_script(
@@ -826,7 +827,7 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
     info!("updated monitoring security group");
 
     // Mark deployment as complete
-    File::create(temp_dir.join(CREATED_FILE_NAME))?;
+    File::create(deployer_directory.join(CREATED_FILE_NAME))?;
     info!(
         monitoring = monitoring_ip.as_str(),
         binary = ?all_binary_ips,

--- a/deployer/src/ec2/destroy.rs
+++ b/deployer/src/ec2/destroy.rs
@@ -20,13 +20,13 @@ pub async fn destroy(config: &PathBuf) -> Result<(), Error> {
     info!(tag = tag.as_str(), "loaded configuration");
 
     // Ensure deployment directory exists
-    let temp_dir = deployer_directory(tag);
-    if !temp_dir.exists() {
+    let deployer_directory = deployer_directory(tag);
+    if !deployer_directory.exists() {
         return Err(Error::DeploymentDoesNotExist(tag.clone()));
     }
 
     // Ensure not already destroyed
-    let destroyed_file = deployer_directory(tag).join(DESTROYED_FILE_NAME);
+    let destroyed_file = deployer_directory.join(DESTROYED_FILE_NAME);
     if destroyed_file.exists() {
         warn!("infrastructure already destroyed");
         return Ok(());

--- a/deployer/src/ec2/destroy.rs
+++ b/deployer/src/ec2/destroy.rs
@@ -20,13 +20,13 @@ pub async fn destroy(config: &PathBuf) -> Result<(), Error> {
     info!(tag = tag.as_str(), "loaded configuration");
 
     // Ensure deployment directory exists
-    let deployer_directory = deployer_directory(tag);
-    if !deployer_directory.exists() {
+    let tag_directory = deployer_directory(tag);
+    if !tag_directory.exists() {
         return Err(Error::DeploymentDoesNotExist(tag.clone()));
     }
 
     // Ensure not already destroyed
-    let destroyed_file = deployer_directory.join(DESTROYED_FILE_NAME);
+    let destroyed_file = tag_directory.join(DESTROYED_FILE_NAME);
     if destroyed_file.exists() {
         warn!("infrastructure already destroyed");
         return Ok(());

--- a/deployer/src/ec2/mod.rs
+++ b/deployer/src/ec2/mod.rs
@@ -103,13 +103,13 @@
 //!
 //! ## `ec2 create`
 //!
-//! 1. Validates configuration and generates an SSH key pair, stored in `/tmp/deployer-{tag}/id_rsa_{tag}`.
+//! 1. Validates configuration and generates an SSH key pair, stored in `$HOME/.deployer/{tag}/id_rsa_{tag}`.
 //! 2. Creates VPCs, subnets, internet gateways, route tables, and security groups per region.
 //! 3. Establishes VPC peering between the monitoring region and binary regions.
 //! 4. Launches the monitoring instance, uploads service files, and installs Prometheus, Grafana, Loki, and Pyroscope.
 //! 5. Launches binary instances, uploads binaries, configurations, and hosts.yaml, and installs Promtail and the binary.
 //! 6. Configures BBR on all instances and updates the monitoring security group for Loki traffic.
-//! 7. Marks completion with `/tmp/deployer-{tag}/created`.
+//! 7. Marks completion with `$HOME/.deployer/{tag}/created`.
 //!
 //! ## `ec2 update`
 //!
@@ -126,11 +126,11 @@
 //!
 //! 1. Terminates all instances across regions.
 //! 2. Deletes security groups, subnets, route tables, VPC peering connections, internet gateways, key pairs, and VPCs in dependency order.
-//! 3. Marks destruction with `/tmp/deployer-{tag}/destroyed`, retaining the directory to prevent tag reuse.
+//! 3. Marks destruction with `$HOME/.deployer/{tag}/destroyed`, retaining the directory to prevent tag reuse.
 //!
 //! # Persistence
 //!
-//! * A temporary directory `/tmp/deployer-{tag}` stores the SSH private key, service files, and status files (`created`, `destroyed`).
+//! * A directory `$HOME/.deployer/{tag}` stores the SSH private key, service files, and status files (`created`, `destroyed`).
 //! * The deployment state is tracked via these files, ensuring operations respect prior create/destroy actions.
 //!
 //! # Example Configuration
@@ -229,7 +229,8 @@ cfg_if::cfg_if! {
 
         /// Directory where deployer files are stored
         fn deployer_directory(tag: &str) -> PathBuf {
-            PathBuf::from(format!("/tmp/deployer-{}", tag))
+            let base_dir = std::env::var("HOME").unwrap_or_else(|_| String::from("/tmp"));
+            PathBuf::from(format!("{}/.deployer/{}", base_dir, tag))
         }
 
         /// Errors that can occur when deploying infrastructure on AWS

--- a/deployer/src/ec2/mod.rs
+++ b/deployer/src/ec2/mod.rs
@@ -103,13 +103,13 @@
 //!
 //! ## `ec2 create`
 //!
-//! 1. Validates configuration and generates an SSH key pair, stored in `$HOME/.deployer/{tag}/id_rsa_{tag}`.
+//! 1. Validates configuration and generates an SSH key pair, stored in `$HOME/.commonware_deployer/{tag}/id_rsa_{tag}`.
 //! 2. Creates VPCs, subnets, internet gateways, route tables, and security groups per region.
 //! 3. Establishes VPC peering between the monitoring region and binary regions.
 //! 4. Launches the monitoring instance, uploads service files, and installs Prometheus, Grafana, Loki, and Pyroscope.
 //! 5. Launches binary instances, uploads binaries, configurations, and hosts.yaml, and installs Promtail and the binary.
 //! 6. Configures BBR on all instances and updates the monitoring security group for Loki traffic.
-//! 7. Marks completion with `$HOME/.deployer/{tag}/created`.
+//! 7. Marks completion with `$HOME/.commonware_deployer/{tag}/created`.
 //!
 //! ## `ec2 update`
 //!
@@ -126,11 +126,11 @@
 //!
 //! 1. Terminates all instances across regions.
 //! 2. Deletes security groups, subnets, route tables, VPC peering connections, internet gateways, key pairs, and VPCs in dependency order.
-//! 3. Marks destruction with `$HOME/.deployer/{tag}/destroyed`, retaining the directory to prevent tag reuse.
+//! 3. Marks destruction with `$HOME/.commonware_deployer/{tag}/destroyed`, retaining the directory to prevent tag reuse.
 //!
 //! # Persistence
 //!
-//! * A directory `$HOME/.deployer/{tag}` stores the SSH private key, service files, and status files (`created`, `destroyed`).
+//! * A directory `$HOME/.commonware_deployer/{tag}` stores the SSH private key, service files, and status files (`created`, `destroyed`).
 //! * The deployment state is tracked via these files, ensuring operations respect prior create/destroy actions.
 //!
 //! # Example Configuration
@@ -230,7 +230,7 @@ cfg_if::cfg_if! {
         /// Directory where deployer files are stored
         fn deployer_directory(tag: &str) -> PathBuf {
             let base_dir = std::env::var("HOME").expect("$HOME is not configured");
-            PathBuf::from(format!("{}/.deployer/{}", base_dir, tag))
+            PathBuf::from(format!("{}/.commonware_deployer/{}", base_dir, tag))
         }
 
         /// Errors that can occur when deploying infrastructure on AWS

--- a/deployer/src/ec2/mod.rs
+++ b/deployer/src/ec2/mod.rs
@@ -229,7 +229,7 @@ cfg_if::cfg_if! {
 
         /// Directory where deployer files are stored
         fn deployer_directory(tag: &str) -> PathBuf {
-            let base_dir = std::env::var("HOME").unwrap_or_else(|_| String::from("/tmp"));
+            let base_dir = std::env::var("HOME").expect("$HOME is not configured");
             PathBuf::from(format!("{}/.deployer/{}", base_dir, tag))
         }
 

--- a/deployer/src/ec2/update.rs
+++ b/deployer/src/ec2/update.rs
@@ -22,20 +22,20 @@ pub async fn update(config_path: &PathBuf) -> Result<(), Error> {
     info!(tag = tag.as_str(), "loaded configuration");
 
     // Ensure created file exists
-    let temp_dir = deployer_directory(tag);
-    let created_file = temp_dir.join(CREATED_FILE_NAME);
+    let deployer_directory = deployer_directory(tag);
+    let created_file = deployer_directory.join(CREATED_FILE_NAME);
     if !created_file.exists() {
         return Err(Error::DeploymentNotComplete(tag.clone()));
     }
 
     // Ensure destroyed file does not exist
-    let destroyed_file = temp_dir.join(DESTROYED_FILE_NAME);
+    let destroyed_file = deployer_directory.join(DESTROYED_FILE_NAME);
     if destroyed_file.exists() {
         return Err(Error::DeploymentAlreadyDestroyed(tag.clone()));
     }
 
     // Construct private key path (assumes it exists from create command)
-    let private_key_path = temp_dir.join(format!("id_rsa_{}", tag));
+    let private_key_path = deployer_directory.join(format!("id_rsa_{}", tag));
     if !private_key_path.exists() {
         return Err(Error::PrivateKeyNotFound);
     }

--- a/deployer/src/ec2/update.rs
+++ b/deployer/src/ec2/update.rs
@@ -22,20 +22,20 @@ pub async fn update(config_path: &PathBuf) -> Result<(), Error> {
     info!(tag = tag.as_str(), "loaded configuration");
 
     // Ensure created file exists
-    let deployer_directory = deployer_directory(tag);
-    let created_file = deployer_directory.join(CREATED_FILE_NAME);
+    let tag_directory = deployer_directory(tag);
+    let created_file = tag_directory.join(CREATED_FILE_NAME);
     if !created_file.exists() {
         return Err(Error::DeploymentNotComplete(tag.clone()));
     }
 
     // Ensure destroyed file does not exist
-    let destroyed_file = deployer_directory.join(DESTROYED_FILE_NAME);
+    let destroyed_file = tag_directory.join(DESTROYED_FILE_NAME);
     if destroyed_file.exists() {
         return Err(Error::DeploymentAlreadyDestroyed(tag.clone()));
     }
 
     // Construct private key path (assumes it exists from create command)
-    let private_key_path = deployer_directory.join(format!("id_rsa_{}", tag));
+    let private_key_path = tag_directory.join(format!("id_rsa_{}", tag));
     if !private_key_path.exists() {
         return Err(Error::PrivateKeyNotFound);
     }


### PR DESCRIPTION
During long-running tests, `/tmp` rarely persists long-enough to be useful.