### PR TITLE
[codec] Add conformity tests

### DIFF
--- a/codec/src/types/bytes.rs
+++ b/codec/src/types/bytes.rs
@@ -66,4 +66,17 @@ mod tests {
             ));
         }
     }
+
+    #[test]
+    fn test_conformity() {
+        assert_eq!(Bytes::new().encode(), &[0x00][..]);
+        assert_eq!(
+            Bytes::from_static(b"hello").encode(),
+            &[0x05, b'h', b'e', b'l', b'l', b'o'][..]
+        );
+        let long_bytes = Bytes::from(vec![0xAA; 150]);
+        let mut expected = vec![0x96, 0x01]; // Varint for 150
+        expected.extend_from_slice(&[0xAA; 150]);
+        assert_eq!(long_bytes.encode(), expected.as_slice());
+    }
 }

--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -300,4 +300,122 @@ mod tests {
         assert_eq!(none.encode_size(), 1);
         assert_eq!(none.encode().len(), 1);
     }
+
+    #[test]
+    fn test_conformity() {
+        // Bool
+        assert_eq!(true.encode(), &[0x01][..]);
+        assert_eq!(false.encode(), &[0x00][..]);
+
+        // 8-bit integers
+        assert_eq!(0u8.encode(), &[0x00][..]);
+        assert_eq!(255u8.encode(), &[0xFF][..]);
+        assert_eq!(0i8.encode(), &[0x00][..]);
+        assert_eq!((-1i8).encode(), &[0xFF][..]);
+        assert_eq!(127i8.encode(), &[0x7F][..]);
+        assert_eq!((-128i8).encode(), &[0x80][..]);
+
+        // 16-bit integers
+        assert_eq!(0u16.encode(), &[0x00, 0x00][..]);
+        assert_eq!(0xABCDu16.encode(), &[0xAB, 0xCD][..]);
+        assert_eq!(u16::MAX.encode(), &[0xFF, 0xFF][..]);
+        assert_eq!(0i16.encode(), &[0x00, 0x00][..]);
+        assert_eq!((-1i16).encode(), &[0xFF, 0xFF][..]);
+        assert_eq!(0x1234i16.encode(), &[0x12, 0x34][..]);
+
+        // 32-bit integers
+        assert_eq!(0u32.encode(), &[0x00, 0x00, 0x00, 0x00][..]);
+        assert_eq!(0xABCDEF01u32.encode(), &[0xAB, 0xCD, 0xEF, 0x01][..]);
+        assert_eq!(u32::MAX.encode(), &[0xFF, 0xFF, 0xFF, 0xFF][..]);
+        assert_eq!(0i32.encode(), &[0x00, 0x00, 0x00, 0x00][..]);
+        assert_eq!((-1i32).encode(), &[0xFF, 0xFF, 0xFF, 0xFF][..]);
+        assert_eq!(0x12345678i32.encode(), &[0x12, 0x34, 0x56, 0x78][..]);
+
+        // 64-bit integers
+        assert_eq!(
+            0u64.encode(),
+            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+        );
+        assert_eq!(
+            0x0123456789ABCDEFu64.encode(),
+            &[0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF][..]
+        );
+        assert_eq!(
+            u64::MAX.encode(),
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF][..]
+        );
+        assert_eq!(
+            0i64.encode(),
+            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+        );
+        assert_eq!(
+            (-1i64).encode(),
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF][..]
+        );
+
+        // 128-bit integers
+        let u128_val = 0x0123456789ABCDEF0123456789ABCDEFu128;
+        let u128_bytes = [
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB,
+            0xCD, 0xEF,
+        ];
+        assert_eq!(u128_val.encode(), &u128_bytes[..]);
+        assert_eq!(u128::MAX.encode(), &[0xFF; 16][..]);
+        assert_eq!((-1i128).encode(), &[0xFF; 16][..]);
+
+        assert_eq!(0.0f32.encode(), 0.0f32.to_be_bytes()[..]);
+        assert_eq!(1.0f32.encode(), 1.0f32.to_be_bytes()[..]);
+        assert_eq!((-1.0f32).encode(), (-1.0f32).to_be_bytes()[..]);
+        assert_eq!(f32::MAX.encode(), f32::MAX.to_be_bytes()[..]);
+        assert_eq!(f32::MIN.encode(), f32::MIN.to_be_bytes()[..]);
+        assert_eq!(f32::NAN.encode(), f32::NAN.to_be_bytes()[..]);
+        assert_eq!(f32::INFINITY.encode(), f32::INFINITY.to_be_bytes()[..]);
+        assert_eq!(
+            f32::NEG_INFINITY.encode(),
+            f32::NEG_INFINITY.to_be_bytes()[..]
+        );
+
+        // 32-bit floats
+        assert_eq!(1.0f32.encode(), &[0x3F, 0x80, 0x00, 0x00][..]);
+        assert_eq!((-1.0f32).encode(), &[0xBF, 0x80, 0x00, 0x00][..]);
+
+        // 64-bit floats
+        assert_eq!(0.0f64.encode(), 0.0f64.to_be_bytes()[..]);
+        assert_eq!(1.0f64.encode(), 1.0f64.to_be_bytes()[..]);
+        assert_eq!((-1.0f64).encode(), (-1.0f64).to_be_bytes()[..]);
+        assert_eq!(f64::MAX.encode(), f64::MAX.to_be_bytes()[..]);
+        assert_eq!(f64::MIN.encode(), f64::MIN.to_be_bytes()[..]);
+        assert_eq!(f64::NAN.encode(), f64::NAN.to_be_bytes()[..]);
+        assert_eq!(f64::INFINITY.encode(), f64::INFINITY.to_be_bytes()[..]);
+        assert_eq!(
+            f64::NEG_INFINITY.encode(),
+            f64::NEG_INFINITY.to_be_bytes()[..]
+        );
+        assert_eq!(
+            1.0f64.encode(),
+            &[0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+        );
+        assert_eq!(
+            (-1.0f64).encode(),
+            &[0xBF, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+        );
+
+        // Fixed-size array
+        assert_eq!([1, 2, 3].encode(), &[0x01, 0x02, 0x03][..]);
+        assert_eq!([].encode(), &[][..]);
+
+        // Option
+        assert_eq!(Some(42u32).encode(), &[0x01, 0x00, 0x00, 0x00, 0x2A][..]);
+        assert_eq!(None::<u32>.encode(), &[0][..]);
+
+        // Usize
+        assert_eq!(0usize.encode(), &[0x00][..]);
+        assert_eq!(1usize.encode(), &[0x01][..]);
+        assert_eq!(127usize.encode(), &[0x7F][..]);
+        assert_eq!(128usize.encode(), &[0x80, 0x01][..]);
+        assert_eq!(
+            (u32::MAX as usize).encode(),
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0x0F][..]
+        );
+    }
 }

--- a/codec/src/types/tuple.rs
+++ b/codec/src/types/tuple.rs
@@ -61,4 +61,27 @@ mod tests {
             assert_eq!(value, decoded);
         }
     }
+
+    #[test]
+    fn test_conformity() {
+        let t1 = (true, 0x42u8);
+        assert_eq!(t1.encode(), &[0x01, 0x42][..]);
+
+        let t2 = (0xABCDu16, false, 0xDEADBEEFu32);
+        assert_eq!(t2.encode(), &[0xAB, 0xCD, 0x00, 0xDE, 0xAD, 0xBE, 0xEF][..]);
+
+        let t3 = ((0x01u8, 0x02u8), 0x03u8); // Nested tuple
+        assert_eq!(t3.encode(), &[0x01, 0x02, 0x03][..]);
+
+        let t_option_some = (Some(0x1234u16), 0xFFu8);
+        // Some -> 0x01
+        // 0x1234u16 -> 0x12, 0x34
+        // 0xFFu8 -> 0xFF
+        assert_eq!(t_option_some.encode(), &[0x01, 0x12, 0x34, 0xFF][..]);
+
+        let t_option_none = (0xFFu8, Option::<u16>::None);
+        // 0xFFu8 -> 0xFF
+        // None -> 0x00
+        assert_eq!(t_option_none.encode(), &[0xFF, 0x00][..]);
+    }
 }

--- a/codec/src/types/vec.rs
+++ b/codec/src/types/vec.rs
@@ -67,4 +67,28 @@ mod tests {
             ));
         }
     }
+
+    #[test]
+    fn test_conformity() {
+        assert_eq!(Vec::<u8>::new().encode(), &[0x00][..]);
+        assert_eq!(
+            vec![0x01u8, 0x02u8, 0x03u8].encode(),
+            &[0x03, 0x01, 0x02, 0x03][..]
+        );
+
+        let v_u16: Vec<u16> = vec![0x1234, 0xABCD];
+        assert_eq!(v_u16.encode(), &[0x02, 0x12, 0x34, 0xAB, 0xCD][..]);
+
+        let v_bool: Vec<bool> = vec![true, false, true];
+        assert_eq!(v_bool.encode(), &[0x03, 0x01, 0x00, 0x01][..]);
+
+        let v_empty_u32: Vec<u32> = Vec::new();
+        assert_eq!(v_empty_u32.encode(), &[0x00][..]);
+
+        // Test with a length that requires a multi-byte varint
+        let v_long_u8: Vec<u8> = vec![0xCC; 200]; // 200 = 0xC8 = 0x80 + 0x48 -> 0xC8 0x01
+        let mut expected_long_u8 = vec![0xC8, 0x01];
+        expected_long_u8.extend_from_slice(&[0xCC; 200]);
+        assert_eq!(v_long_u8.encode(), expected_long_u8.as_slice());
+    }
 }

--- a/codec/src/varint.rs
+++ b/codec/src/varint.rs
@@ -500,4 +500,20 @@ mod tests {
         let out64: i64 = SInt(s64).into();
         assert_eq!(s64, out64);
     }
+
+    #[test]
+    fn test_conformity() {
+        assert_eq!(0usize.encode(), &[0x00][..]);
+        assert_eq!(1usize.encode(), &[0x01][..]);
+        assert_eq!(127usize.encode(), &[0x7F][..]);
+        assert_eq!(128usize.encode(), &[0x80, 0x01][..]);
+        assert_eq!(16383usize.encode(), &[0xFF, 0x7F][..]);
+        assert_eq!(16384usize.encode(), &[0x80, 0x80, 0x01][..]);
+        assert_eq!(2097151usize.encode(), &[0xFF, 0xFF, 0x7F][..]);
+        assert_eq!(2097152usize.encode(), &[0x80, 0x80, 0x80, 0x01][..]);
+        assert_eq!(
+            (u32::MAX as usize).encode(),
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0x0F][..]
+        );
+    }
 }


### PR DESCRIPTION
Fixes #841 

Also fixes a bug due to a misunderstanding about the [`to_bits`](https://doc.rust-lang.org/std/net/struct.Ipv4Addr.html#method.to_bits) method on `Ipv4Addr/Ipv6Addr`. I thought the resulting integer VALUE was dependent on the endianness of the platform, and so was using `u32::to_be` to modify the bits. However, this understanding was incorrect.

This is shown in the example at the link above. Regardless of platform:
```
let addr = Ipv4Addr::new(0x12, 0x34, 0x56, 0x78);
assert_eq!(0x12345678, addr.to_bits());
```

The value is consistent regardless of native endianness, it is just saying that the octets are always stored big-endian in memory, so the memory layout of the resulting `u32` from `to_bits()` may not have the same memory layout. This bug resulted in inconsistent encoding/decoding of `net` types between platforms.