### PR TITLE
[runtime] Add Support for `spawn_blocking(dedicated)` + Pass `Context` to `spawn_blocking`

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -518,7 +518,7 @@ impl Tasks {
         let mut queue = arc_self.queue.lock().unwrap();
         queue.push(Arc::new(Task {
             id,
-            label: Label::root(String::new()),
+            label: Label::root(),
             tasks: arc_self.clone(),
             operation: Operation::Root,
         }));

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -72,6 +72,8 @@ struct Metrics {
     tasks_running: Family<Work, Gauge>,
     blocking_tasks_spawned: Family<Work, Counter>,
     blocking_tasks_running: Family<Work, Gauge>,
+    dedicated_tasks_spawned: Family<Work, Counter>,
+    dedicated_tasks_running: Family<Work, Gauge>,
     task_polls: Family<Work, Counter>,
 
     network_bandwidth: Counter,
@@ -85,6 +87,8 @@ impl Metrics {
             tasks_running: Family::default(),
             blocking_tasks_spawned: Family::default(),
             blocking_tasks_running: Family::default(),
+            dedicated_tasks_spawned: Family::default(),
+            dedicated_tasks_running: Family::default(),
             network_bandwidth: Counter::default(),
         };
         registry.register(
@@ -106,6 +110,16 @@ impl Metrics {
             "blocking_tasks_running",
             "Number of blocking tasks currently running",
             metrics.blocking_tasks_running.clone(),
+        );
+        registry.register(
+            "dedicated_tasks_spawned",
+            "Total number of dedicated tasks spawned",
+            metrics.dedicated_tasks_spawned.clone(),
+        );
+        registry.register(
+            "dedicated_tasks_running",
+            "Number of dedicated tasks currently running",
+            metrics.dedicated_tasks_running.clone(),
         );
         registry.register(
             "task_polls",
@@ -833,6 +847,39 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the blocking task
+        let (f, handle) = Handle::init_blocking(f, gauge, false);
+
+        // Spawn the task
+        let f = async move { f() };
+        Tasks::register_work(&self.executor.tasks, &self.label, Box::pin(f));
+        handle
+    }
+
+    fn spawn_dedicated<F, T>(self, f: F) -> Handle<T>
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        // Ensure a context only spawns one task
+        assert!(!self.spawned, "already spawned");
+
+        // Get metrics
+        let work = Work {
+            label: self.label.clone(),
+        };
+        self.executor
+            .metrics
+            .dedicated_tasks_spawned
+            .get_or_create(&work)
+            .inc();
+        let gauge = self
+            .executor
+            .metrics
+            .dedicated_tasks_running
+            .get_or_create(&work)
+            .clone();
+
+        // Initialize the dedicated task
         let (f, handle) = Handle::init_blocking(f, gauge, false);
 
         // Spawn the task

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -847,7 +847,7 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the blocking task
-        let (f, handle) = Handle::init(f, gauge, false);
+        let (f, handle) = Handle::init_blocking(f, gauge, false);
 
         // Spawn the task
         let f = async move { f() };
@@ -880,7 +880,7 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the dedicated task
-        let (f, handle) = Handle::init(f, gauge, false);
+        let (f, handle) = Handle::init_blocking(f, gauge, false);
 
         // Spawn the task
         let f = async move { f() };

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -778,7 +778,7 @@ impl crate::Spawner for Context {
         // Set up the task
         let executor = self.executor.clone();
         let future = f(self);
-        let (f, handle) = Handle::init(future, gauge, false);
+        let (f, handle) = Handle::init_future(future, gauge, false);
 
         // Spawn the task
         Tasks::register_work(&executor.tasks, &label, Box::pin(f));
@@ -814,7 +814,7 @@ impl crate::Spawner for Context {
         let label = self.label.clone();
         let executor = self.executor.clone();
         move |f: F| {
-            let (f, handle) = Handle::init(f, gauge, false);
+            let (f, handle) = Handle::init_future(f, gauge, false);
 
             // Spawn the task
             Tasks::register_work(&executor.tasks, &label, Box::pin(f));
@@ -847,7 +847,7 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the blocking task
-        let (f, handle) = Handle::init_blocking(f, gauge, false);
+        let (f, handle) = Handle::init(f, gauge, false);
 
         // Spawn the task
         let f = async move { f() };
@@ -880,7 +880,7 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the dedicated task
-        let (f, handle) = Handle::init_blocking(f, gauge, false);
+        let (f, handle) = Handle::init(f, gauge, false);
 
         // Spawn the task
         let f = async move { f() };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -934,7 +934,7 @@ mod tests {
         R::Context: Spawner,
     {
         runner.start(|context| async move {
-            let handle = context.spawn_blocking(|| 42);
+            let handle = context.spawn_blocking(|_| 42);
             let result = handle.await;
             assert!(matches!(result, Ok(42)));
         });
@@ -947,7 +947,7 @@ mod tests {
         runner.start(|context| async move {
             // Create task
             let (sender, mut receiver) = oneshot::channel();
-            let handle = context.spawn_blocking(move || {
+            let handle = context.spawn_blocking(move |_| {
                 // Wait for abort to be called
                 loop {
                     if receiver.try_recv().is_ok() {
@@ -984,7 +984,7 @@ mod tests {
         R::Context: Spawner,
     {
         runner.start(|context| async move {
-            let handle = context.spawn_dedicated(|| 42);
+            let handle = context.spawn_dedicated(|_| 42);
             let result = handle.await;
             assert!(matches!(result, Ok(42)));
         });
@@ -995,7 +995,7 @@ mod tests {
         R::Context: Spawner,
     {
         runner.start(|context| async move {
-            let handle = context.spawn_dedicated(|| 42);
+            let handle = context.spawn_dedicated(|_| 42);
             handle.abort();
         });
     }
@@ -1166,7 +1166,7 @@ mod tests {
     fn test_deterministic_spawn_blocking_panic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let handle = context.spawn_blocking(|| {
+            let handle = context.spawn_blocking(|_| {
                 panic!("blocking task panicked");
             });
             handle.await.unwrap();
@@ -1190,7 +1190,7 @@ mod tests {
     fn test_deterministic_spawn_dedicated_panic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let handle = context.spawn_dedicated(|| {
+            let handle = context.spawn_dedicated(|_| {
                 panic!("dedicated task panicked");
             });
             handle.await.unwrap();
@@ -1337,7 +1337,7 @@ mod tests {
     fn test_tokio_spawn_blocking_panic() {
         let executor = tokio::Runner::default();
         executor.start(|context| async move {
-            let handle = context.spawn_blocking(|| {
+            let handle = context.spawn_blocking(|_| {
                 panic!("blocking task panicked");
             });
             let result = handle.await;
@@ -1361,7 +1361,7 @@ mod tests {
     fn test_tokio_spawn_dedicated_panic() {
         let executor = tokio::Runner::default();
         executor.start(|context| async move {
-            let handle = context.spawn_dedicated(|| {
+            let handle = context.spawn_dedicated(|_| {
                 panic!("dedicated task panicked");
             });
             assert!(matches!(handle.await, Err(Error::Exited)));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1358,14 +1358,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "dedicated task panicked")]
     fn test_tokio_spawn_dedicated_panic() {
         let executor = tokio::Runner::default();
         executor.start(|context| async move {
             let handle = context.spawn_dedicated(|| {
                 panic!("dedicated task panicked");
             });
-            handle.await.unwrap();
+
+            // Because the task panics in a dedicated thread, the `should_panic` attribute will not
+            // catch the panic.
+            assert!(matches!(handle.await, Err(Error::Exited)));
         });
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1364,9 +1364,6 @@ mod tests {
             let handle = context.spawn_dedicated(|| {
                 panic!("dedicated task panicked");
             });
-
-            // Because the task panics in a dedicated thread, the `should_panic` attribute will not
-            // catch the panic.
             assert!(matches!(handle.await, Err(Error::Exited)));
         });
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -136,14 +136,20 @@ pub trait Spawner: Clone + Send + Sync + 'static {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static;
 
-    /// TODO: fix
-    /// Enqueue a blocking task shared thread.
+    /// Enqueue a blocking task to be executed.
     ///
-    /// This method runs synchronous operations in a shared thread pool. Tasks spawned using this method
-    /// should eventually finish on their own (to avoid blocking the thread pool).
+    /// This method is designed for synchronous, potentially long-running operations. Tasks can either
+    /// be executed in a shared thread (tasks that are expected to finish on their own) or a dedicated
+    /// thread (tasks that are expected to run indefinitely).
     ///
     /// The task starts executing immediately, and the returned handle can be awaited to retrieve the
     /// result.
+    ///
+    /// # Motivation
+    ///
+    /// Most runtimes allocate a limited number of threads for executing async tasks, running whatever
+    /// isn't waiting. If blocking tasks are spawned this way, they can dramatically reduce the efficiency
+    /// of said runtimes.
     ///
     /// # Warning
     ///

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -136,11 +136,13 @@ pub trait Spawner: Clone + Send + Sync + 'static {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static;
 
-    /// Enqueue a blocking task to be executed.
+    /// Enqueue a blocking task on a shared thread.
     ///
-    /// This method is designed for synchronous, potentially long-running operations that should
-    /// not block the asynchronous event loop. The task starts executing immediately, and the
-    /// returned handle can be awaited to retrieve the result.
+    /// This method runs synchronous operations in a shared thread pool. Tasks spawned using this method
+    /// should eventually finish on their own (to avoid blocking the thread pool).
+    ///
+    /// The task starts executing immediately, and the returned handle can be awaited to retrieve the
+    /// result.
     ///
     /// # Warning
     ///
@@ -150,7 +152,17 @@ pub trait Spawner: Clone + Send + Sync + 'static {
         F: FnOnce() -> T + Send + 'static,
         T: Send + 'static;
 
-    /// Create a long-running task that is not expected to finish.
+    /// Enqueue a blocking task on a dedicated thread.
+    ///
+    /// This method runs synchronous operations in a dedicated thread. Tasks spawned using this method
+    /// are only expected to finish when there is an error or when `stop` is called.
+    ///
+    /// The task starts executing immediately, and the returned handle can be awaited to retrieve the
+    /// result.
+    ///
+    /// # Warning
+    ///
+    /// Dedicated tasks cannot be aborted.
     fn spawn_dedicated<F, T>(self, f: F) -> Handle<T>
     where
         F: FnOnce() -> T + Send + 'static,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -150,6 +150,12 @@ pub trait Spawner: Clone + Send + Sync + 'static {
         F: FnOnce() -> T + Send + 'static,
         T: Send + 'static;
 
+    /// Create a long-running task that is not expected to finish.
+    fn spawn_dedicated<F, T>(self, f: F) -> Handle<T>
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static;
+
     /// Signals the runtime to stop execution and that all outstanding tasks
     /// should perform any required cleanup and exit. This method is idempotent and
     /// can be called multiple times.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -149,7 +149,7 @@ pub trait Spawner: Clone + Send + Sync + 'static {
     /// Blocking tasks cannot be aborted.
     fn spawn_blocking<F, T>(self, f: F) -> Handle<T>
     where
-        F: FnOnce() -> T + Send + 'static,
+        F: FnOnce(Self) -> T + Send + 'static,
         T: Send + 'static;
 
     /// Enqueue a blocking task on a dedicated thread.
@@ -165,7 +165,7 @@ pub trait Spawner: Clone + Send + Sync + 'static {
     /// Dedicated tasks cannot be aborted.
     fn spawn_dedicated<F, T>(self, f: F) -> Handle<T>
     where
-        F: FnOnce() -> T + Send + 'static,
+        F: FnOnce(Self) -> T + Send + 'static,
         T: Send + 'static;
 
     /// Signals the runtime to stop execution and that all outstanding tasks

--- a/runtime/src/telemetry/metrics/mod.rs
+++ b/runtime/src/telemetry/metrics/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod histogram;
 pub mod status;
+pub(crate) mod task;

--- a/runtime/src/telemetry/metrics/status.rs
+++ b/runtime/src/telemetry/metrics/status.rs
@@ -22,6 +22,15 @@ impl From<bool> for Bool {
     }
 }
 
+/// Type of task that can be spawned.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+pub enum Task {
+    Root,
+    Async,
+    BlockingShared,
+    BlockingDedicated,
+}
+
 /// Metric label that indicates status.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct Label {

--- a/runtime/src/telemetry/metrics/status.rs
+++ b/runtime/src/telemetry/metrics/status.rs
@@ -8,9 +8,13 @@ use prometheus_client::{
 /// Metric label that indicates the type of task spawned.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
 pub enum Task {
+    /// The root task.
     Root,
+    /// An async task.
     Async,
+    /// A blocking task spawned in a shared thread pool.
     BlockingShared,
+    /// A blocking task spawned on a dedicated thread.
     BlockingDedicated,
 }
 

--- a/runtime/src/telemetry/metrics/status.rs
+++ b/runtime/src/telemetry/metrics/status.rs
@@ -5,19 +5,6 @@ use prometheus_client::{
     metrics::{counter::Counter as DefaultCounter, family::Family},
 };
 
-/// Metric label that indicates the type of task spawned.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
-pub enum Task {
-    /// The root task.
-    Root,
-    /// An async task.
-    Async,
-    /// A blocking task spawned in a shared thread pool.
-    BlockingShared,
-    /// A blocking task spawned on a dedicated thread.
-    BlockingDedicated,
-}
-
 /// Metric label that indicates status.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct Label {

--- a/runtime/src/telemetry/metrics/status.rs
+++ b/runtime/src/telemetry/metrics/status.rs
@@ -22,7 +22,7 @@ impl From<bool> for Bool {
     }
 }
 
-/// Type of task that can be spawned.
+/// Metric label that indicates the type of task spawned.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
 pub enum Task {
     Root,

--- a/runtime/src/telemetry/metrics/status.rs
+++ b/runtime/src/telemetry/metrics/status.rs
@@ -5,23 +5,6 @@ use prometheus_client::{
     metrics::{counter::Counter as DefaultCounter, family::Family},
 };
 
-/// Metric label that indicates whether something is true or false.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
-pub enum Bool {
-    False,
-    True,
-}
-
-impl From<bool> for Bool {
-    fn from(value: bool) -> Self {
-        if value {
-            Bool::True
-        } else {
-            Bool::False
-        }
-    }
-}
-
 /// Metric label that indicates the type of task spawned.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
 pub enum Task {

--- a/runtime/src/telemetry/metrics/status.rs
+++ b/runtime/src/telemetry/metrics/status.rs
@@ -5,6 +5,23 @@ use prometheus_client::{
     metrics::{counter::Counter as DefaultCounter, family::Family},
 };
 
+/// Metric label that indicates whether something is true or false.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+pub enum Bool {
+    False,
+    True,
+}
+
+impl From<bool> for Bool {
+    fn from(value: bool) -> Self {
+        if value {
+            Bool::True
+        } else {
+            Bool::False
+        }
+    }
+}
+
 /// Metric label that indicates status.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct Label {

--- a/runtime/src/telemetry/metrics/task.rs
+++ b/runtime/src/telemetry/metrics/task.rs
@@ -12,9 +12,9 @@ pub struct Label {
 }
 
 impl Label {
-    pub fn root(name: String) -> Self {
+    pub fn root() -> Self {
         Self {
-            name,
+            name: String::new(),
             task: Task::Root,
         }
     }

--- a/runtime/src/telemetry/metrics/task.rs
+++ b/runtime/src/telemetry/metrics/task.rs
@@ -12,6 +12,7 @@ pub struct Label {
 }
 
 impl Label {
+    /// Create a new label for the root task.
     pub fn root() -> Self {
         Self {
             name: String::new(),
@@ -19,6 +20,7 @@ impl Label {
         }
     }
 
+    /// Create a new label for a future task.
     pub fn future(name: String) -> Self {
         Self {
             name,
@@ -26,6 +28,7 @@ impl Label {
         }
     }
 
+    /// Create a new label for a blocking task spawned in a shared thread pool.
     pub fn blocking_shared(name: String) -> Self {
         Self {
             name,
@@ -33,6 +36,7 @@ impl Label {
         }
     }
 
+    /// Create a new label for a blocking task spawned on a dedicated thread.
     pub fn blocking_dedicated(name: String) -> Self {
         Self {
             name,
@@ -40,6 +44,7 @@ impl Label {
         }
     }
 
+    /// Get the name of the task.
     pub fn name(&self) -> String {
         self.name.clone()
     }

--- a/runtime/src/telemetry/metrics/task.rs
+++ b/runtime/src/telemetry/metrics/task.rs
@@ -1,0 +1,59 @@
+//! Recording metrics related to tasks.
+
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
+
+/// Metric label that indicates the type of task spawned.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct Label {
+    /// The name of the task.
+    name: String,
+    /// The type of task.
+    task: Task,
+}
+
+impl Label {
+    pub fn root(name: String) -> Self {
+        Self {
+            name,
+            task: Task::Root,
+        }
+    }
+
+    pub fn future(name: String) -> Self {
+        Self {
+            name,
+            task: Task::Future,
+        }
+    }
+
+    pub fn blocking_shared(name: String) -> Self {
+        Self {
+            name,
+            task: Task::BlockingShared,
+        }
+    }
+
+    pub fn blocking_dedicated(name: String) -> Self {
+        Self {
+            name,
+            task: Task::BlockingDedicated,
+        }
+    }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+}
+
+/// Metric label that indicates the type of task spawned.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+pub enum Task {
+    /// The root task.
+    Root,
+    /// An async task.
+    Future,
+    /// A blocking task spawned in a shared thread pool.
+    BlockingShared,
+    /// A blocking task spawned on a dedicated thread.
+    BlockingDedicated,
+}

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -348,7 +348,7 @@ impl crate::Spawner for Context {
         let catch_panics = self.executor.cfg.catch_panics;
         let executor = self.executor.clone();
         let future = f(self);
-        let (f, handle) = Handle::init(future, gauge, catch_panics);
+        let (f, handle) = Handle::init_future(future, gauge, catch_panics);
 
         // Spawn the task
         executor.runtime.spawn(f);
@@ -383,7 +383,7 @@ impl crate::Spawner for Context {
         // Set up the task
         let executor = self.executor.clone();
         move |f: F| {
-            let (f, handle) = Handle::init(f, gauge, executor.cfg.catch_panics);
+            let (f, handle) = Handle::init_future(f, gauge, executor.cfg.catch_panics);
 
             // Spawn the task
             executor.runtime.spawn(f);
@@ -416,7 +416,7 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the blocking task using the new function
-        let (f, handle) = Handle::init_blocking(f, gauge, self.executor.cfg.catch_panics);
+        let (f, handle) = Handle::init(f, gauge, self.executor.cfg.catch_panics);
 
         // Spawn the blocking task
         self.executor.runtime.spawn_blocking(f);
@@ -448,9 +448,9 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the blocking task using the new function
-        let (f, handle) = Handle::init_blocking(f, gauge, self.executor.cfg.catch_panics);
+        let (f, handle) = Handle::init(f, gauge, self.executor.cfg.catch_panics);
 
-        // Spawn the dedicated task
+        // Spawn the dedicated task as a thread (rather than consuming a shared thread from the runtime)
         std::thread::spawn(f);
         handle
     }

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -416,7 +416,7 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the blocking task using the new function
-        let (f, handle) = Handle::init(f, gauge, self.executor.cfg.catch_panics);
+        let (f, handle) = Handle::init_blocking(f, gauge, self.executor.cfg.catch_panics);
 
         // Spawn the blocking task
         self.executor.runtime.spawn_blocking(f);
@@ -448,7 +448,7 @@ impl crate::Spawner for Context {
             .clone();
 
         // Initialize the dedicated task using the new function
-        let (f, handle) = Handle::init(f, gauge, self.executor.cfg.catch_panics);
+        let (f, handle) = Handle::init_blocking(f, gauge, self.executor.cfg.catch_panics);
 
         // Spawn the dedicated task as a thread (rather than consuming a shared thread from the runtime)
         std::thread::spawn(f);

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -447,7 +447,7 @@ impl crate::Spawner for Context {
             .get_or_create(&work)
             .clone();
 
-        // Initialize the blocking task using the new function
+        // Initialize the dedicated task using the new function
         let (f, handle) = Handle::init(f, gauge, self.executor.cfg.catch_panics);
 
         // Spawn the dedicated task as a thread (rather than consuming a shared thread from the runtime)

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -269,7 +269,7 @@ impl crate::Runner for Runner {
         });
 
         // Get metrics
-        let label = Label::root(String::new());
+        let label = Label::root();
         executor.metrics.tasks_spawned.get_or_create(&label).inc();
         let gauge = executor.metrics.tasks_running.get_or_create(&label).clone();
 

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -30,59 +30,6 @@ impl<T> Handle<T>
 where
     T: Send + 'static,
 {
-    pub(crate) fn init<F>(f: F, running: Gauge, catch_panic: bool) -> (impl FnOnce(), Self)
-    where
-        F: FnOnce() -> T + Send + 'static,
-    {
-        // Increment the running tasks gauge
-        running.inc();
-
-        // Initialize channel to handle result
-        let once = Arc::new(Once::new());
-        let (sender, receiver) = oneshot::channel();
-
-        // Wrap the closure with panic handling
-        let f = {
-            let once = once.clone();
-            let running = running.clone();
-            move || {
-                // Run blocking task
-                let result = catch_unwind(AssertUnwindSafe(f));
-
-                // Decrement running counter
-                once.call_once(|| {
-                    running.dec();
-                });
-
-                // Handle result
-                let result = match result {
-                    Ok(value) => Ok(value),
-                    Err(err) => {
-                        if !catch_panic {
-                            resume_unwind(err);
-                        }
-                        let err = extract_panic_message(&*err);
-                        error!(?err, "blocking task panicked");
-                        Err(Error::Exited)
-                    }
-                };
-                let _ = sender.send(result);
-            }
-        };
-
-        // Return the task and handle
-        (
-            f,
-            Self {
-                aborter: None,
-                receiver,
-
-                running,
-                once,
-            },
-        )
-    }
-
     pub(crate) fn init_future<F>(
         f: F,
         running: Gauge,
@@ -134,6 +81,59 @@ where
             abortable.map(|_| ()),
             Self {
                 aborter: Some(aborter),
+                receiver,
+
+                running,
+                once,
+            },
+        )
+    }
+
+    pub(crate) fn init_blocking<F>(f: F, running: Gauge, catch_panic: bool) -> (impl FnOnce(), Self)
+    where
+        F: FnOnce() -> T + Send + 'static,
+    {
+        // Increment the running tasks gauge
+        running.inc();
+
+        // Initialize channel to handle result
+        let once = Arc::new(Once::new());
+        let (sender, receiver) = oneshot::channel();
+
+        // Wrap the closure with panic handling
+        let f = {
+            let once = once.clone();
+            let running = running.clone();
+            move || {
+                // Run blocking task
+                let result = catch_unwind(AssertUnwindSafe(f));
+
+                // Decrement running counter
+                once.call_once(|| {
+                    running.dec();
+                });
+
+                // Handle result
+                let result = match result {
+                    Ok(value) => Ok(value),
+                    Err(err) => {
+                        if !catch_panic {
+                            resume_unwind(err);
+                        }
+                        let err = extract_panic_message(&*err);
+                        error!(?err, "task panicked");
+                        Err(Error::Exited)
+                    }
+                };
+                let _ = sender.send(result);
+            }
+        };
+
+        // Return the task and handle
+        (
+            f,
+            Self {
+                aborter: None,
                 receiver,
 
                 running,

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -160,9 +160,11 @@ pub fn create_pool<S: Spawner + Metrics>(
     ThreadPoolBuilder::new()
         .num_threads(concurrency)
         .spawn_handler(move |thread| {
+            // Tasks spawned in a thread pool are expected to run longer than any single
+            // task and thus should be provisioned as a dedicated thread.
             context
                 .with_label("rayon-thread")
-                .spawn_blocking(false, move |_| thread.run());
+                .spawn_blocking(true, move |_| thread.run());
             Ok(())
         })
         .build()

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -162,7 +162,7 @@ pub fn create_pool<S: Spawner + Metrics>(
         .spawn_handler(move |thread| {
             context
                 .with_label("rayon-thread")
-                .spawn_blocking(move || thread.run());
+                .spawn_blocking(move |_| thread.run());
             Ok(())
         })
         .build()

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -162,7 +162,7 @@ pub fn create_pool<S: Spawner + Metrics>(
         .spawn_handler(move |thread| {
             context
                 .with_label("rayon-thread")
-                .spawn_blocking(move |_| thread.run());
+                .spawn_blocking(false, move |_| thread.run());
             Ok(())
         })
         .build()


### PR DESCRIPTION
`spawn_blocking` is meant for blocking tasks that finish on their own (using a shared thread pool). This PR adds support for spawning long-lived, blocking tasks that don't consume threads from the shared thread pool (recommended against doing in the `tokio` docs: https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html).