### PR TITLE
[crypto] move `random` method to Digest trait

### DIFF
--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -5,6 +5,7 @@ use crate::{
     Supervisor,
 };
 use commonware_codec::{Decode, Encode};
+use commonware_cryptography::Digest;
 use commonware_cryptography::{Hasher, Scheme};
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{Clock, Handle, Spawner};
@@ -77,7 +78,7 @@ impl<
                         .unwrap();
 
                     // Notarize random digest
-                    let payload = H::random(&mut self.context);
+                    let payload = H::Digest::random(&mut self.context);
                     let proposal = Proposal::new(view, notarize.proposal.parent, payload);
                     let msg = Notarize::sign(
                         &self.namespace,
@@ -106,7 +107,7 @@ impl<
                         .unwrap();
 
                     // Finalize random digest
-                    let payload = H::random(&mut self.context);
+                    let payload = H::Digest::random(&mut self.context);
                     let proposal = Proposal::new(view, finalize.proposal.parent, payload);
                     let msg = Finalize::sign(
                         &self.namespace,

--- a/consensus/src/threshold_simplex/mocks/conflicter.rs
+++ b/consensus/src/threshold_simplex/mocks/conflicter.rs
@@ -5,6 +5,7 @@ use crate::{
     ThresholdSupervisor,
 };
 use commonware_codec::{DecodeExt, Encode};
+use commonware_cryptography::Digest;
 use commonware_cryptography::{
     bls12381::primitives::{group, variant::Variant},
     Hasher,
@@ -76,7 +77,7 @@ impl<
                     // Notarize random digest
                     let view = notarize.view();
                     let share = self.supervisor.share(view).unwrap();
-                    let payload = H::random(&mut self.context);
+                    let payload = H::Digest::random(&mut self.context);
                     let proposal = Proposal::new(view, notarize.proposal.parent, payload);
                     let n = Notarize::<V, _>::sign(&self.namespace, share, proposal);
                     let msg = Voter::Notarize(n).encode().into();
@@ -91,7 +92,7 @@ impl<
                     // Finalize random digest
                     let view = finalize.view();
                     let share = self.supervisor.share(view).unwrap();
-                    let payload = H::random(&mut self.context);
+                    let payload = H::Digest::random(&mut self.context);
                     let proposal = Proposal::new(view, finalize.proposal.parent, payload);
                     let f = Finalize::<V, _>::sign(&self.namespace, share, proposal);
                     let msg = Voter::Finalize(f).encode().into();

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -129,7 +129,15 @@ pub trait BatchScheme: Specification {
 
 /// Specializes the [commonware_utils::Array] trait with the Copy trait for cryptographic digests
 /// (which should be cheap to clone).
-pub trait Digest: Array + Copy {}
+pub trait Digest: Array + Copy {
+    /// Generate a random digest.
+    ///
+    /// # Warning
+    ///
+    /// This function is typically used for testing and is not recommended
+    /// for production use.
+    fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self;
+}
 
 /// An object that can be uniquely represented as a [Digest].
 pub trait Digestible<D: Digest>: Clone + Sized + Send + Sync + 'static {
@@ -187,14 +195,6 @@ pub trait Hasher: Clone + Send + Sync + 'static {
     ///
     /// This function does not need to be called after `finalize`.
     fn reset(&mut self);
-
-    /// Generate a random digest.
-    ///
-    /// # Warning
-    ///
-    /// This function is typically used for testing and is not recommended
-    /// for production use.
-    fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self::Digest;
 }
 
 #[cfg(test)]

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -88,12 +88,6 @@ impl Hasher for Sha256 {
     fn reset(&mut self) {
         self.hasher = ISha256::new();
     }
-
-    fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self::Digest {
-        let mut digest = [0u8; DIGEST_LENGTH];
-        rng.fill_bytes(&mut digest);
-        Self::Digest::from(digest)
-    }
 }
 
 /// Digest of a SHA-256 hashing operation.
@@ -153,7 +147,13 @@ impl Display for Digest {
     }
 }
 
-impl crate::Digest for Digest {}
+impl crate::Digest for Digest {
+    fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+        let mut array = [0u8; DIGEST_LENGTH];
+        rng.fill_bytes(&mut array);
+        Self(array)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/storage/src/bmt/benches/build.rs
+++ b/storage/src/bmt/benches/build.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Sha256};
 use commonware_storage::bmt::Builder;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
@@ -9,7 +9,7 @@ fn bench_new(c: &mut Criterion) {
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
         for _ in 0..n {
-            let element = Sha256::random(&mut sampler);
+            let element = sha256::Digest::random(&mut sampler);
             elements.push(element);
         }
 

--- a/storage/src/bmt/benches/prove_single_element.rs
+++ b/storage/src/bmt/benches/prove_single_element.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
 use commonware_storage::bmt::Builder;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -12,7 +12,7 @@ fn bench_prove_single_element(c: &mut Criterion) {
         let mut queries = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
         for pos in 0..n {
-            let element = Sha256::random(&mut sampler);
+            let element = sha256::Digest::random(&mut sampler);
             builder.add(&element);
             queries.push((pos as u32, element));
         }

--- a/storage/src/mmr/benches/append.rs
+++ b/storage/src/mmr/benches/append.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
@@ -10,7 +10,7 @@ fn bench_append(c: &mut Criterion) {
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
         for _ in 0..n {
-            let element = Sha256::random(&mut sampler);
+            let element = sha256::Digest::random(&mut sampler);
             elements.push(element);
         }
 

--- a/storage/src/mmr/benches/append_additional.rs
+++ b/storage/src/mmr/benches/append_additional.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
@@ -10,7 +10,7 @@ fn bench_append_additional(c: &mut Criterion) {
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
         for _ in 0..n {
-            let element = Sha256::random(&mut sampler);
+            let element = sha256::Digest::random(&mut sampler);
             elements.push(element);
         }
 
@@ -18,7 +18,7 @@ fn bench_append_additional(c: &mut Criterion) {
         for a in [100, 1_000, 10_000, 50_000] {
             let mut additional = Vec::with_capacity(a);
             for _ in 0..a {
-                let element = Sha256::random(&mut sampler);
+                let element = sha256::Digest::random(&mut sampler);
                 additional.push(element);
             }
             c.bench_function(&format!("{}/start={} add={}", module_path!(), n, a), |b| {

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
@@ -18,7 +18,7 @@ fn bench_prove_many_elements(c: &mut Criterion) {
 
         block_on(async {
             for i in 0..n {
-                let element = Sha256::random(&mut sampler);
+                let element = sha256::Digest::random(&mut sampler);
                 let pos = mmr.add(&mut hasher, &element).await.unwrap();
                 positions.push((i, pos));
                 elements.push(element);

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
@@ -16,7 +16,7 @@ fn bench_prove_single_element(c: &mut Criterion) {
         let mut hasher = Standard::new(&mut hasher);
         block_on(async {
             for _ in 0..n {
-                let element = Sha256::random(&mut sampler);
+                let element = sha256::Digest::random(&mut sampler);
                 let pos = mmr.add(&mut hasher, &element).await.unwrap();
                 elements.push((pos, element));
             }


### PR DESCRIPTION
Moves `fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self;` to `Digest` trait. It felt odd that the Hasher was responsible for making a random hash rather than the hash.