### PR TITLE
[cryptography] Take `rayon` Argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "prometheus-client",
  "rand",
  "rand_distr",
+ "rayon",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -16,6 +16,7 @@ commonware-cryptography = { workspace = true }
 commonware-utils = { workspace = true }
 bytes = { workspace = true }
 cfg-if = { workspace = true }
+rayon = { workspace = true }
 thiserror = { workspace = true }
 futures = { workspace = true }
 

--- a/consensus/src/threshold_simplex/types.rs
+++ b/consensus/src/threshold_simplex/types.rs
@@ -17,6 +17,7 @@ use commonware_cryptography::{
     Digest,
 };
 use commonware_utils::union;
+use rayon::ThreadPoolBuilder;
 
 /// View is a monotonically increasing counter that represents the current focus of consensus.
 /// Each View corresponds to a round in the consensus protocol where validators attempt to agree
@@ -424,11 +425,12 @@ impl<V: Variant, D: Digest> Notarization<V, D> {
         let seed_message = (Some(seed_namespace.as_ref()), seed_message.as_ref());
         let signature =
             aggregate_signatures::<V, _>(&[self.proposal_signature, self.seed_signature]);
+        let pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         aggregate_verify_multiple_messages::<V, _>(
+            &pool,
             public_key,
             &[notarize_message, seed_message],
             &signature,
-            1,
         )
         .is_ok()
     }
@@ -622,11 +624,12 @@ impl<V: Variant> Nullification<V> {
         let seed_namespace = seed_namespace(namespace);
         let seed_message = (Some(seed_namespace.as_ref()), view_message.as_ref());
         let signature = aggregate_signatures::<V, _>(&[self.view_signature, self.seed_signature]);
+        let pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         aggregate_verify_multiple_messages::<V, _>(
+            &pool,
             public_key,
             &[nullify_message, seed_message],
             &signature,
-            1,
         )
         .is_ok()
     }
@@ -799,11 +802,12 @@ impl<V: Variant, D: Digest> Finalization<V, D> {
         let seed_message = (Some(seed_namespace.as_ref()), seed_message.as_ref());
         let signature =
             aggregate_signatures::<V, _>(&[self.proposal_signature, self.seed_signature]);
+        let pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         aggregate_verify_multiple_messages::<V, _>(
+            &pool,
             public_key,
             &[finalize_message, seed_message],
             &signature,
-            1,
         )
         .is_ok()
     }

--- a/cryptography/src/bls12381/dkg/player.rs
+++ b/cryptography/src/bls12381/dkg/player.rs
@@ -13,6 +13,7 @@ use crate::{
     Array,
 };
 use commonware_utils::quorum;
+use rayon::ThreadPoolBuilder;
 use std::collections::{BTreeMap, HashMap};
 
 /// Output of a DKG/Resharing procedure.
@@ -204,12 +205,16 @@ impl<P: Array, V: Variant> Player<P, V> {
                     .iter()
                     .map(|(dealer, (commitment, _))| (*dealer, commitment.clone()))
                     .collect();
+                let pool = ThreadPoolBuilder::new()
+                    .num_threads(self.concurrency)
+                    .build()
+                    .expect("unable to build thread pool");
                 public = ops::recover_public_with_weights::<V>(
+                    &pool,
                     &previous,
                     commitments,
                     &weights,
                     self.player_threshold,
-                    self.concurrency,
                 )?;
 
                 // Recover share via interpolation


### PR DESCRIPTION
Related: #903  

## Summary
- migrate BLS12‑381 concurrent ops to accept `&ThreadPool` instead of a concurrency integer
- build thread pools at call sites for `recover_public*` and `aggregate_verify_multiple_messages`
- wire consensus tests to build pools
- add missing `rayon` dep for consensus