### PR TITLE
Add spawn_blocking_ref to Spawner trait

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -161,6 +161,24 @@ pub trait Spawner: Clone + Send + Sync + 'static {
         F: FnOnce(Self) -> T + Send + 'static,
         T: Send + 'static;
 
+    /// Enqueue a blocking task to be executed (without consuming the context).
+    ///
+    /// The semantics are identical to [`spawn_blocking`], but the provided
+    /// closure does not receive the context as a parameter. This is useful when
+    /// the task already owns a clone of the context or does not need one.
+    ///
+    /// # Warning
+    ///
+    /// If this function is used to spawn multiple tasks from the same context,
+    /// the runtime will panic to prevent accidental misuse.
+    fn spawn_blocking_ref<F, T>(
+        &mut self,
+        dedicated: bool,
+    ) -> impl FnOnce(F) -> Handle<T> + 'static
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static;
+
     /// Signals the runtime to stop execution and that all outstanding tasks
     /// should perform any required cleanup and exit. This method is idempotent and
     /// can be called multiple times.
@@ -933,6 +951,32 @@ mod tests {
         });
     }
 
+    fn test_spawn_blocking_ref<R: Runner>(runner: R, dedicated: bool)
+    where
+        R::Context: Spawner,
+    {
+        runner.start(|mut context| async move {
+            let spawn = context.spawn_blocking_ref(dedicated);
+            let handle = spawn(|| 42);
+            let result = handle.await;
+            assert!(matches!(result, Ok(42)));
+        });
+    }
+
+    fn test_spawn_blocking_ref_duplicate<R: Runner>(runner: R, dedicated: bool)
+    where
+        R::Context: Spawner,
+    {
+        runner.start(|mut context| async move {
+            let spawn = context.spawn_blocking_ref(dedicated);
+            let result = spawn(|| 42).await;
+            assert!(matches!(result, Ok(42)));
+
+            // Ensure context is consumed
+            context.spawn_blocking(dedicated, |_| 42);
+        });
+    }
+
     fn test_spawn_blocking_abort<R: Runner>(runner: R, dedicated: bool)
     where
         R::Context: Spawner,
@@ -1158,6 +1202,23 @@ mod tests {
     }
 
     #[test]
+    fn test_deterministic_spawn_blocking_ref() {
+        for dedicated in [false, true] {
+            let executor = deterministic::Runner::default();
+            test_spawn_blocking_ref(executor, dedicated);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_deterministic_spawn_blocking_ref_duplicate() {
+        for dedicated in [false, true] {
+            let executor = deterministic::Runner::default();
+            test_spawn_blocking_ref_duplicate(executor, dedicated);
+        }
+    }
+
+    #[test]
     fn test_deterministic_metrics() {
         let executor = deterministic::Runner::default();
         test_metrics(executor);
@@ -1308,6 +1369,23 @@ mod tests {
         for dedicated in [false, true] {
             let executor = tokio::Runner::default();
             test_spawn_blocking_abort(executor, dedicated);
+        }
+    }
+
+    #[test]
+    fn test_tokio_spawn_blocking_ref() {
+        for dedicated in [false, true] {
+            let executor = tokio::Runner::default();
+            test_spawn_blocking_ref(executor, dedicated);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_tokio_spawn_blocking_ref_duplicate() {
+        for dedicated in [false, true] {
+            let executor = tokio::Runner::default();
+            test_spawn_blocking_ref_duplicate(executor, dedicated);
         }
     }
 

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -442,6 +442,47 @@ impl crate::Spawner for Context {
         handle
     }
 
+    fn spawn_blocking_ref<F, T>(&mut self, dedicated: bool) -> impl FnOnce(F) -> Handle<T> + 'static
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        // Ensure a context only spawns one task
+        assert!(!self.spawned, "already spawned");
+        self.spawned = true;
+
+        // Get metrics
+        let label = if dedicated {
+            Label::blocking_dedicated(self.name.clone())
+        } else {
+            Label::blocking_shared(self.name.clone())
+        };
+        self.executor
+            .metrics
+            .tasks_spawned
+            .get_or_create(&label)
+            .inc();
+        let gauge = self
+            .executor
+            .metrics
+            .tasks_running
+            .get_or_create(&label)
+            .clone();
+
+        // Set up the task
+        let executor = self.executor.clone();
+        move |f: F| {
+            let (f, handle) = Handle::init_blocking(f, gauge, executor.cfg.catch_panics);
+
+            if dedicated {
+                std::thread::spawn(f);
+            } else {
+                executor.runtime.spawn_blocking(f);
+            }
+            handle
+        }
+    }
+
     fn stop(&self, value: i32) {
         self.executor.signaler.lock().unwrap().signal(value);
     }


### PR DESCRIPTION
## Summary
- extend `runtime::Spawner` with `spawn_blocking_ref`
- implement new method for deterministic and tokio runtimes
- add tests for `spawn_blocking_ref` and its duplicate panic behavior

## Testing
- `cargo check -p commonware-runtime`
- `cargo test -p commonware-runtime`
