### PR TITLE
[runtime] Introduce `spawn_setup!` Macro

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -722,17 +722,7 @@ impl crate::Spawner for Context {
 
         // Get metrics
         let label = Label::future(self.name.clone());
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let gauge = spawn_setup!(self, label);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -755,17 +745,7 @@ impl crate::Spawner for Context {
 
         // Get metrics
         let label = Label::future(self.name.clone());
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let gauge = spawn_setup!(self, label);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -792,17 +772,7 @@ impl crate::Spawner for Context {
         } else {
             Label::blocking_shared(self.name.clone())
         };
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let gauge = spawn_setup!(self, label);
 
         // Initialize the blocking task
         let executor = self.executor.clone();
@@ -829,17 +799,7 @@ impl crate::Spawner for Context {
         } else {
             Label::blocking_shared(self.name.clone())
         };
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let gauge = spawn_setup!(self, label);
 
         // Set up the task
         let executor = self.executor.clone();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -27,6 +27,9 @@ use std::{
 };
 use thiserror::Error;
 
+#[macro_use]
+mod spawn_macros;
+
 pub mod deterministic;
 pub mod mocks;
 cfg_if::cfg_if! {

--- a/runtime/src/spawn_macros.rs
+++ b/runtime/src/spawn_macros.rs
@@ -1,0 +1,17 @@
+// Macros shared across runtime implementations.
+
+#[macro_export]
+macro_rules! spawn_setup {
+    ($ctx:ident, $label:expr) => {{
+        $ctx.executor
+            .metrics
+            .tasks_spawned
+            .get_or_create(&$label)
+            .inc();
+        $ctx.executor
+            .metrics
+            .tasks_running
+            .get_or_create(&$label)
+            .clone()
+    }};
+}

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -346,17 +346,7 @@ impl crate::Spawner for Context {
 
         // Get metrics
         let label = Label::future(self.name.clone());
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let gauge = spawn_setup!(self, label);
 
         // Set up the task
         let catch_panics = self.executor.cfg.catch_panics;
@@ -380,17 +370,7 @@ impl crate::Spawner for Context {
 
         // Get metrics
         let label = Label::future(self.name.clone());
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let gauge = spawn_setup!(self, label);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -417,17 +397,7 @@ impl crate::Spawner for Context {
         } else {
             Label::blocking_shared(self.name.clone())
         };
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let gauge = spawn_setup!(self, label);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -457,17 +427,7 @@ impl crate::Spawner for Context {
         } else {
             Label::blocking_shared(self.name.clone())
         };
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let gauge = spawn_setup!(self, label);
 
         // Set up the task
         let executor = self.executor.clone();


### PR DESCRIPTION
Resolves: #958 

## Summary
- factor out metrics setup macro for spawners
- use new macro in deterministic and tokio runtimes
