### PR TITLE
[runtime] Reduce Duplicate Metrics Usage (with `spawn_metrics!`)

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -721,18 +721,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let label = Label::future(self.name.clone());
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let (label, gauge) = spawn_setup!(self, future);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -754,18 +743,7 @@ impl crate::Spawner for Context {
         self.spawned = true;
 
         // Get metrics
-        let label = Label::future(self.name.clone());
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let (label, gauge) = spawn_setup!(self, future);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -787,22 +765,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let label = if dedicated {
-            Label::blocking_dedicated(self.name.clone())
-        } else {
-            Label::blocking_shared(self.name.clone())
-        };
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let (label, gauge) = spawn_setup!(self, blocking, dedicated);
 
         // Initialize the blocking task
         let executor = self.executor.clone();
@@ -824,22 +787,7 @@ impl crate::Spawner for Context {
         self.spawned = true;
 
         // Get metrics
-        let label = if dedicated {
-            Label::blocking_dedicated(self.name.clone())
-        } else {
-            Label::blocking_shared(self.name.clone())
-        };
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let (label, gauge) = spawn_setup!(self, blocking, dedicated);
 
         // Set up the task
         let executor = self.executor.clone();

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -721,7 +721,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let (label, gauge) = spawn_setup!(self, future);
+        let (label, gauge) = spawn_metrics!(self, future);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -743,7 +743,7 @@ impl crate::Spawner for Context {
         self.spawned = true;
 
         // Get metrics
-        let (label, gauge) = spawn_setup!(self, future);
+        let (label, gauge) = spawn_metrics!(self, future);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -765,7 +765,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let (label, gauge) = spawn_setup!(self, blocking, dedicated);
+        let (label, gauge) = spawn_metrics!(self, blocking, dedicated);
 
         // Initialize the blocking task
         let executor = self.executor.clone();
@@ -787,7 +787,7 @@ impl crate::Spawner for Context {
         self.spawned = true;
 
         // Get metrics
-        let (label, gauge) = spawn_setup!(self, blocking, dedicated);
+        let (label, gauge) = spawn_metrics!(self, blocking, dedicated);
 
         // Set up the task
         let executor = self.executor.clone();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -28,7 +28,7 @@ use std::{
 use thiserror::Error;
 
 #[macro_use]
-mod spawn_macros;
+mod macros;
 
 pub mod deterministic;
 pub mod mocks;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -27,6 +27,9 @@ use std::{
 };
 use thiserror::Error;
 
+#[macro_use]
+mod spawn_macros;
+
 pub mod deterministic;
 pub mod mocks;
 cfg_if::cfg_if! {

--- a/runtime/src/macros.rs
+++ b/runtime/src/macros.rs
@@ -35,5 +35,4 @@ macro_rules! spawn_metrics {
         let gauge = metrics.tasks_running.get_or_create(&label).clone();
         (label, gauge)
     }};
-
 }

--- a/runtime/src/macros.rs
+++ b/runtime/src/macros.rs
@@ -1,40 +1,39 @@
 //! Macros shared across runtime implementations.
 
 /// Prepare metrics for a spawned task.
+///
+/// This macro returns a tuple `(Label, Gauge)`:
+/// - `Label`: A label representing the task's metrics.
+/// - `Gauge`: A gauge tracking the number of running tasks with the given label.
 #[macro_export]
 macro_rules! spawn_metrics {
-    ($ctx:ident, future) => {{
-        let label = $crate::telemetry::metrics::task::Label::future($ctx.name.clone());
-        $ctx.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = $ctx
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+    // Handle future tasks
+    ($ctx:ident, future) => {
+        $crate::spawn_metrics!(
+            $crate::telemetry::metrics::task::Label::future($ctx.name.clone()),
+            @make $ctx
+        )
+    };
+
+    // Handle blocking tasks
+    ($ctx:ident, blocking, $dedicated:expr) => {
+        $crate::spawn_metrics!(
+            if $dedicated {
+                $crate::telemetry::metrics::task::Label::blocking_dedicated($ctx.name.clone())
+            } else {
+                $crate::telemetry::metrics::task::Label::blocking_shared($ctx.name.clone())
+            },
+            @make $ctx
+        )
+    };
+
+    // Increment the number of spawned tasks and return a gauge for the number of running tasks
+    ($label:expr, @make $ctx:ident) => {{
+        let label = $label;
+        let metrics = &$ctx.executor.metrics;
+        metrics.tasks_spawned.get_or_create(&label).inc();
+        let gauge = metrics.tasks_running.get_or_create(&label).clone();
         (label, gauge)
     }};
-    ($ctx:ident, blocking, $dedicated:expr) => {{
-        let label = if $dedicated {
-            $crate::telemetry::metrics::task::Label::blocking_dedicated($ctx.name.clone())
-        } else {
-            $crate::telemetry::metrics::task::Label::blocking_shared($ctx.name.clone())
-        };
-        $ctx.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = $ctx
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
-        (label, gauge)
-    }};
+
 }

--- a/runtime/src/macros.rs
+++ b/runtime/src/macros.rs
@@ -1,7 +1,8 @@
-// Macros shared across runtime implementations.
+//! Macros shared across runtime implementations.
 
+/// Prepare metrics for a spawned task.
 #[macro_export]
-macro_rules! spawn_setup {
+macro_rules! spawn_metrics {
     ($ctx:ident, future) => {{
         let label = $crate::telemetry::metrics::task::Label::future($ctx.name.clone());
         $ctx.executor
@@ -9,7 +10,8 @@ macro_rules! spawn_setup {
             .tasks_spawned
             .get_or_create(&label)
             .inc();
-        let gauge = $ctx.executor
+        let gauge = $ctx
+            .executor
             .metrics
             .tasks_running
             .get_or_create(&label)
@@ -27,7 +29,8 @@ macro_rules! spawn_setup {
             .tasks_spawned
             .get_or_create(&label)
             .inc();
-        let gauge = $ctx.executor
+        let gauge = $ctx
+            .executor
             .metrics
             .tasks_running
             .get_or_create(&label)

--- a/runtime/src/spawn_macros.rs
+++ b/runtime/src/spawn_macros.rs
@@ -1,0 +1,37 @@
+// Macros shared across runtime implementations.
+
+#[macro_export]
+macro_rules! spawn_setup {
+    ($ctx:ident, future) => {{
+        let label = $crate::telemetry::metrics::task::Label::future($ctx.name.clone());
+        $ctx.executor
+            .metrics
+            .tasks_spawned
+            .get_or_create(&label)
+            .inc();
+        let gauge = $ctx.executor
+            .metrics
+            .tasks_running
+            .get_or_create(&label)
+            .clone();
+        (label, gauge)
+    }};
+    ($ctx:ident, blocking, $dedicated:expr) => {{
+        let label = if $dedicated {
+            $crate::telemetry::metrics::task::Label::blocking_dedicated($ctx.name.clone())
+        } else {
+            $crate::telemetry::metrics::task::Label::blocking_shared($ctx.name.clone())
+        };
+        $ctx.executor
+            .metrics
+            .tasks_spawned
+            .get_or_create(&label)
+            .inc();
+        let gauge = $ctx.executor
+            .metrics
+            .tasks_running
+            .get_or_create(&label)
+            .clone();
+        (label, gauge)
+    }};
+}

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -345,7 +345,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let (_label, gauge) = spawn_setup!(self, future);
+        let (_, gauge) = spawn_metrics!(self, future);
 
         // Set up the task
         let catch_panics = self.executor.cfg.catch_panics;
@@ -368,7 +368,7 @@ impl crate::Spawner for Context {
         self.spawned = true;
 
         // Get metrics
-        let (_label, gauge) = spawn_setup!(self, future);
+        let (_, gauge) = spawn_metrics!(self, future);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -390,7 +390,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let (_label, gauge) = spawn_setup!(self, blocking, dedicated);
+        let (_, gauge) = spawn_metrics!(self, blocking, dedicated);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -415,7 +415,7 @@ impl crate::Spawner for Context {
         self.spawned = true;
 
         // Get metrics
-        let (_label, gauge) = spawn_setup!(self, blocking, dedicated);
+        let (_, gauge) = spawn_metrics!(self, blocking, dedicated);
 
         // Set up the task
         let executor = self.executor.clone();

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -345,18 +345,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let label = Label::future(self.name.clone());
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let (_label, gauge) = spawn_setup!(self, future);
 
         // Set up the task
         let catch_panics = self.executor.cfg.catch_panics;
@@ -379,18 +368,7 @@ impl crate::Spawner for Context {
         self.spawned = true;
 
         // Get metrics
-        let label = Label::future(self.name.clone());
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let (_label, gauge) = spawn_setup!(self, future);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -412,22 +390,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let label = if dedicated {
-            Label::blocking_dedicated(self.name.clone())
-        } else {
-            Label::blocking_shared(self.name.clone())
-        };
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let (_label, gauge) = spawn_setup!(self, blocking, dedicated);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -452,22 +415,7 @@ impl crate::Spawner for Context {
         self.spawned = true;
 
         // Get metrics
-        let label = if dedicated {
-            Label::blocking_dedicated(self.name.clone())
-        } else {
-            Label::blocking_shared(self.name.clone())
-        };
-        self.executor
-            .metrics
-            .tasks_spawned
-            .get_or_create(&label)
-            .inc();
-        let gauge = self
-            .executor
-            .metrics
-            .tasks_running
-            .get_or_create(&label)
-            .clone();
+        let (_label, gauge) = spawn_setup!(self, blocking, dedicated);
 
         // Set up the task
         let executor = self.executor.clone();


### PR DESCRIPTION
Replaces: #960 
Resolves: #958 

## Summary
- factor out metrics setup macro for spawners
- include Label creation inside macro
- use new macro in deterministic and tokio runtimes