### PR TITLE
[runtime/iouring] Fix `iouring` Buffer Aliasing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,7 @@ jobs:
       matrix:
         features:
           - "--features commonware-runtime/iouring-storage"
-          # TODO: Re-enable when issue causing flaky authenticated::tests::test_tokio_connectivity is resolved
-          # See https://github.com/commonwarexyz/monorepo/issues/954
-          #- "--features commonware-runtime/iouring-network"
+          - "--features commonware-runtime/iouring-network"
           - ""
     steps:
     - name: Checkout repository
@@ -56,9 +54,7 @@ jobs:
       matrix:
         features:
           - "--features commonware-runtime/iouring-storage"
-          # TODO: Re-enable when issue causing flaky authenticated::tests::test_tokio_connectivity is resolved
-          # See https://github.com/commonwarexyz/monorepo/issues/954
-          #- "--features commonware-runtime/iouring-network"
+          - "--features commonware-runtime/iouring-network"
           - ""
     steps:
     - name: Checkout repository

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -208,15 +208,15 @@ impl crate::Stream for Stream {
     async fn recv<B: StableBufMut>(&mut self, mut buf: B) -> Result<B, crate::Error> {
         let mut bytes_received = 0;
         let buf_len = buf.len();
-        let buf_ref = buf.deref_mut();
         while bytes_received < buf_len {
-            let remaining = &mut buf_ref[bytes_received..];
+            let remaining_len = buf_len - bytes_received;
+            let buf_ptr = unsafe { buf.stable_mut_ptr().add(bytes_received) };
 
             // Create the io_uring recv operation
             let op = io_uring::opcode::Recv::new(
                 self.as_raw_fd(),
-                remaining.as_mut_ptr(),
-                remaining.len() as u32,
+                buf_ptr,
+                remaining_len as u32,
             )
             .build();
 

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -243,8 +243,6 @@ impl crate::Stream for Stream {
 mod tests {
     use super::*;
     use crate::network::tests;
-    use crate::{Listener as _, Network as _, Sink as _, Stream as _};
-    use std::net::SocketAddr;
 
     #[tokio::test]
     async fn test_trait() {

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -213,12 +213,8 @@ impl crate::Stream for Stream {
             let buf_ptr = unsafe { buf.stable_mut_ptr().add(bytes_received) };
 
             // Create the io_uring recv operation
-            let op = io_uring::opcode::Recv::new(
-                self.as_raw_fd(),
-                buf_ptr,
-                remaining_len as u32,
-            )
-            .build();
+            let op = io_uring::opcode::Recv::new(self.as_raw_fd(), buf_ptr, remaining_len as u32)
+                .build();
 
             // Submit the operation to the io_uring event loop
             let (tx, rx) = oneshot::channel();
@@ -240,5 +236,24 @@ impl crate::Stream for Stream {
             bytes_received += result as usize;
         }
         Ok(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::tests;
+    use crate::{Listener as _, Network as _, Sink as _, Stream as _};
+    use std::net::SocketAddr;
+
+    #[tokio::test]
+    async fn test_trait() {
+        tests::test_network_trait(|| Network::start(iouring::Config::default()).unwrap()).await;
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn stress_trait() {
+        tests::stress_network_trait(|| Network::start(iouring::Config::default()).unwrap()).await;
     }
 }

--- a/runtime/src/network/mod.rs
+++ b/runtime/src/network/mod.rs
@@ -222,8 +222,8 @@ mod tests {
     }
 
     async fn stress_concurrent_streams<N: crate::Network>(network: N) {
-        const NUM_CLIENTS: usize = 16;
-        const NUM_MESSAGES: usize = 64;
+        const NUM_CLIENTS: usize = 96;
+        const NUM_MESSAGES: usize = 32_768;
         const MESSAGE_SIZE: usize = 4096;
 
         let mut listener = network

--- a/runtime/src/network/mod.rs
+++ b/runtime/src/network/mod.rs
@@ -212,4 +212,57 @@ mod tests {
         let result = network.bind(listener_addr).await;
         assert!(matches!(result, Err(crate::Error::BindFailed)));
     }
+
+    pub(super) async fn stress_network_trait<N, F>(new_network: F)
+    where
+        F: Fn() -> N,
+        N: crate::Network,
+    {
+        stress_concurrent_streams(new_network()).await;
+    }
+
+    async fn stress_concurrent_streams<N: crate::Network>(network: N) {
+        const NUM_CLIENTS: usize = 16;
+        const NUM_MESSAGES: usize = 64;
+        const MESSAGE_SIZE: usize = 4096;
+
+        let mut listener = network
+            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .expect("failed to bind");
+        let addr = listener.local_addr().unwrap();
+
+        // Spawn a server task that echoes messages from many clients.
+        let server = tokio::spawn(async move {
+            for _ in 0..NUM_CLIENTS {
+                let (_, mut sink, mut stream) = listener.accept().await.expect("failed to accept");
+                tokio::spawn(async move {
+                    for _ in 0..NUM_MESSAGES {
+                        let data = stream.recv(vec![0; MESSAGE_SIZE]).await.expect("recv");
+                        sink.send(data).await.expect("send");
+                    }
+                });
+            }
+        });
+
+        // Spawn all clients.
+        let mut clients = Vec::new();
+        for _ in 0..NUM_CLIENTS {
+            let network = network.clone();
+            clients.push(tokio::spawn(async move {
+                let (mut sink, mut stream) = network.dial(addr).await.unwrap();
+                let payload = vec![42u8; MESSAGE_SIZE];
+                for _ in 0..NUM_MESSAGES {
+                    sink.send(payload.clone()).await.unwrap();
+                    let echo = stream.recv(vec![0; MESSAGE_SIZE]).await.unwrap();
+                    assert_eq!(echo, payload);
+                }
+            }));
+        }
+
+        for client in clients {
+            client.await.unwrap();
+        }
+        server.await.unwrap();
+    }
 }

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -233,4 +233,17 @@ mod tests {
         })
         .await;
     }
+
+    #[tokio::test]
+    #[ignore]
+    async fn stress_trait() {
+        tests::stress_network_trait(|| {
+            TokioNetwork::Network::from(
+                TokioNetwork::Config::default()
+                    .with_read_timeout(Duration::from_secs(15))
+                    .with_write_timeout(Duration::from_secs(15)),
+            )
+        })
+        .await;
+    }
 }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -156,16 +156,16 @@ impl crate::Blob for Blob {
         let fd = types::Fd(self.file.as_raw_fd());
         let mut total_read = 0;
         let len = buf.len();
-        let buf_ref = buf.deref_mut();
 
         let mut io_sender = self.io_sender.clone();
         while total_read < len {
             // Figure out how much is left to read and where to read into
-            let remaining = &mut buf_ref[total_read..];
+            let remaining_len = len - total_read;
             let offset = offset + total_read as u64;
+            let buf_ptr = unsafe { buf.stable_mut_ptr().add(total_read) };
 
             // Create an operation to do the read
-            let op = opcode::Read::new(fd, remaining.as_mut_ptr(), remaining.len() as _)
+            let op = opcode::Read::new(fd, buf_ptr, remaining_len as _)
                 .offset(offset as _)
                 .build();
 


### PR DESCRIPTION
Related: #954 

## Summary
- fix unsound &mut buffer aliasing in io_uring network recv
- fix unsound &mut buffer aliasing in io_uring storage read

## Rationale

_This was generated by Codex. Review with caution!_

This change modifies how buffers are passed to io_uring reads. The recv implementation for the network and the read_at implementation for storage now compute a raw pointer to the buffer on each iteration instead of holding a mutable slice across awaits.

In the previous implementation, recv and read_at first called buf.deref_mut() to obtain a long‑lived &mut [u8]:

```rust
let buf_ref = buf.deref_mut();
while bytes_received < buf_len {
    let remaining = &mut buf_ref[bytes_received..];
    // submit io_uring read using remaining.as_mut_ptr()
}
```

That mutable slice remained in scope across every await. While a read was in progress, subsequent iterations produced new mutable slices from the same buf_ref. This violated Rust's aliasing rules—multiple &mut references to overlapping memory were alive concurrently—and could result in memory corruption or the allocator errors you observed.

The fix removes the long‑lived mutable reference. On each iteration, the code computes a raw pointer at the current offset and passes that pointer to io_uring:

```rust
while bytes_received < buf_len {
    let remaining_len = buf_len - bytes_received;
    let buf_ptr = unsafe { buf.stable_mut_ptr().add(bytes_received) };
    // submit io_uring read using buf_ptr
}
```

Because raw pointers do not enforce borrowing, the buffer is no longer mutably borrowed across await points. Each operation owns only a pointer to the relevant region, preventing aliasing between iterations. This resolves the allocator errors triggered by unsound buffer mutation.

## TODO
- [ ] Is there a similar issue with storage?
- [ ] Re-enable CI