### PR TITLE
[storage/mmr/bitmap] Change how we handle partial chunks in proving

### DIFF
--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -12,37 +12,14 @@
 
 use crate::{
     metadata::{Config as MConfig, Metadata},
-    mmr::{iterator::leaf_num_to_pos, mem::Mmr, verification::Proof, Error, Hasher, Storage},
+    mmr::{iterator::leaf_num_to_pos, mem::Mmr, verification::Proof, Error, Error::*, Hasher},
 };
 use commonware_codec::DecodeExt;
 use commonware_cryptography::Hasher as CHasher;
 use commonware_runtime::{Clock, Metrics, Storage as RStorage};
 use commonware_utils::array::prefixed_u64::U64;
 use std::collections::VecDeque;
-use tracing::{error, warn};
-
-/// Implements the [Storage] trait for generating inclusion proofs over the bitmap.
-struct BitmapStorage<'a, H: CHasher> {
-    /// The Merkle tree over all bitmap bits other than the last chunk.
-    mmr: &'a Mmr<H>,
-
-    /// A pruned Merkle tree over all bits of the bitmap including the last chunk.
-    last_chunk_mmr: &'a Mmr<H>,
-}
-
-impl<H: CHasher + Send + Sync> Storage<H::Digest> for BitmapStorage<'_, H> {
-    async fn get_node(&self, pos: u64) -> Result<Option<H::Digest>, Error> {
-        if pos < self.mmr.size() {
-            Ok(self.mmr.get_node(pos))
-        } else {
-            Ok(self.last_chunk_mmr.get_node(pos))
-        }
-    }
-
-    fn size(&self) -> u64 {
-        self.last_chunk_mmr.size()
-    }
-}
+use tracing::{debug, error, warn};
 
 /// A bitmap supporting inclusion proofs through Merkelization.
 ///
@@ -144,7 +121,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
         for (index, pos) in Proof::<H>::nodes_to_pin(mmr_size).enumerate() {
             let Some(bytes) = metadata.get(&U64::new(NODE_PREFIX, index as u64)) else {
                 error!(size = mmr_size, pos, "missing pinned node");
-                return Err(Error::MissingNode(pos));
+                return Err(MissingNode(pos));
             };
             let digest = H::Digest::decode(bytes.as_ref());
             let Ok(digest) = digest else {
@@ -152,7 +129,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
                     size = mmr_size,
                     pos, "could not convert node bytes to digest"
                 );
-                return Err(Error::MissingNode(pos));
+                return Err(MissingNode(pos));
             };
             pinned_nodes.push(digest);
         }
@@ -195,7 +172,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
             metadata.put(key, digest.to_vec());
         }
 
-        metadata.close().await.map_err(Error::MetadataError)
+        metadata.close().await.map_err(MetadataError)
     }
 
     /// Return the number of bits currently stored in the bitmap, irrespective of any pruning.
@@ -395,25 +372,35 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
         self.mmr.update_leaf(hasher, leaf_pos, chunk).await
     }
 
-    /// Return the root of the Merkle tree over the bitmap.
-    ///
-    /// # Warning
-    ///
-    /// The root will not change when adding "0" bits unless a chunk boundary is crossed. If you
-    /// require a root digest that changes with every bit added, you can hash the value of
-    /// `bit_count()` into the result.
+    /// Return the root digest against which inclusion proofs can be verified.
     pub async fn root(&self, hasher: &mut impl Hasher<H>) -> Result<H::Digest, Error> {
+        let mmr_root = self.mmr.root(hasher);
         if self.next_bit == 0 {
-            return Ok(self.mmr.root(hasher));
+            return Ok(mmr_root);
         }
 
-        // We must add the partial chunk to the Merkle tree for its bits to be provable. We do so on
-        // a temporary lightweight (fully pruned) copy of the tree so that we don't require
-        // mutability of the original.
-        let mut mmr = self.mmr.clone_pruned();
-        mmr.add(hasher, self.last_chunk()).await?;
+        // We must add the partial chunk to the digest for its bits to be provable.
+        let last_chunk_digest = hasher.digest(self.last_chunk());
+        Ok(Self::partial_chunk_root(
+            hasher.inner(),
+            self.next_bit,
+            &mmr_root,
+            &last_chunk_digest,
+        ))
+    }
 
-        Ok(mmr.root(hasher))
+    fn partial_chunk_root(
+        hasher: &mut H,
+        next_bit: u64,
+        mmr_root: &H::Digest,
+        last_chunk_digest: &H::Digest,
+    ) -> H::Digest {
+        assert!(next_bit > 0);
+        assert!(next_bit < Self::CHUNK_SIZE_BITS);
+        hasher.update(&next_bit.to_be_bytes());
+        hasher.update(mmr_root);
+        hasher.update(last_chunk_digest);
+        hasher.finalize()
     }
 
     /// Return an inclusion proof for the specified bit, along with the chunk of the bitmap
@@ -428,20 +415,30 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
         let leaf_pos = Self::leaf_pos(bit_offset);
         let chunk = self.get_chunk(bit_offset);
 
+        if leaf_pos == self.mmr.size() {
+            assert!(self.next_bit > 0);
+            // Proof is over a bit in the partial chunk. In this case only a single digest is
+            // required in the proof: the mmr's root.
+            return Ok((
+                Proof {
+                    size: self.bit_count(),
+                    hashes: vec![self.mmr.root(hasher)],
+                },
+                *chunk,
+            ));
+        }
+
+        let mut proof = Proof::<H>::range_proof(&self.mmr, leaf_pos, leaf_pos).await?;
+        proof.size = self.bit_count();
         if self.next_bit == 0 {
-            let proof = Proof::<H>::range_proof(&self.mmr, leaf_pos, leaf_pos).await?;
+            // Bitmap is chunk aligned.
             return Ok((proof, *chunk));
         }
 
-        // We must account for the bits in the last chunk.
-        let mut mmr = self.mmr.clone_pruned();
-        mmr.add(hasher, self.last_chunk()).await?;
-
-        let storage = BitmapStorage {
-            mmr: &self.mmr,
-            last_chunk_mmr: &mmr,
-        };
-        let proof = Proof::<H>::range_proof(&storage, leaf_pos, leaf_pos).await?;
+        let last_chunk_digest = hasher.digest(self.last_chunk());
+        // Since the bitmap wasn't chunk aligned, we'll need to include the digest of the last chunk
+        // in the proof to be able to re-derive the root.
+        proof.hashes.push(last_chunk_digest);
 
         Ok((proof, *chunk))
     }
@@ -455,10 +452,67 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
         bit_offset: u64,
         root_digest: &H::Digest,
     ) -> Result<bool, Error> {
+        let bit_count = proof.size;
+        if bit_offset >= bit_count {
+            debug!(bit_count, bit_offset, "tried to verify non-existent bit");
+            return Ok(false);
+        }
         let leaf_pos = Self::leaf_pos(bit_offset);
-        proof
-            .verify_element_inclusion(hasher, chunk, leaf_pos, root_digest)
+
+        let mut mmr_proof = Proof::<H> {
+            size: leaf_num_to_pos(bit_count / Self::CHUNK_SIZE_BITS),
+            hashes: proof.hashes.clone(),
+        };
+
+        if bit_count % Self::CHUNK_SIZE_BITS == 0 {
+            return mmr_proof
+                .verify_element_inclusion(hasher, chunk, leaf_pos, root_digest)
+                .await;
+        }
+
+        // The proof must contain the partial chunk digest as its last hash.
+        if proof.hashes.is_empty() {
+            debug!("proof has no digests");
+            return Ok(false);
+        }
+        if mmr_proof.size == leaf_pos {
+            // The proof is over a bit in the partial chunk. In this case the proof's hashes should
+            // contain only a single digest: the mmr root.
+            if mmr_proof.hashes.len() != 1 {
+                debug!("proof has more than one digest");
+                return Ok(false);
+            }
+            let mmr_root = mmr_proof.hashes.pop().unwrap();
+            let last_chunk_digest = hasher.digest(chunk);
+            let next_bit = bit_count % Self::CHUNK_SIZE_BITS;
+            let reconstructed_root =
+                Self::partial_chunk_root(hasher.inner(), next_bit, &mmr_root, &last_chunk_digest);
+            return Ok(reconstructed_root == *root_digest);
+        };
+        let last_chunk_digest = mmr_proof.hashes.pop().unwrap();
+
+        // Reconstruct the MMR root.
+        let mmr_root = match mmr_proof
+            .reconstruct_root(hasher, &[chunk], leaf_pos, leaf_pos)
             .await
+        {
+            Ok(root) => root,
+            Err(MissingHashes) => {
+                debug!("Not enough hashes in proof to reconstruct root");
+                return Ok(false);
+            }
+            Err(ExtraHashes) => {
+                debug!("Not all hashes in proof were used to reconstruct root");
+                return Ok(false);
+            }
+            Err(e) => return Err(e),
+        };
+
+        let next_bit = bit_count % Self::CHUNK_SIZE_BITS;
+        let reconstructed_root =
+            Self::partial_chunk_root(hasher.inner(), next_bit, &mmr_root, &last_chunk_digest);
+
+        Ok(reconstructed_root == *root_digest)
     }
 }
 
@@ -483,7 +537,7 @@ mod tests {
         vec.try_into().unwrap()
     }
 
-    #[test]
+    #[test_traced]
     fn test_bitmap_empty_then_one() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
@@ -540,7 +594,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     fn test_bitmap_building() {
         // Build the same bitmap with 2 chunks worth of bits in multiple ways and make sure they are
         // equivalent based on their roots.
@@ -601,7 +655,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     #[should_panic(expected = "cannot add chunk")]
     fn test_bitmap_build_chunked_panic() {
         let executor = deterministic::Runner::default();
@@ -621,7 +675,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     #[should_panic(expected = "cannot add byte")]
     fn test_bitmap_build_byte_panic() {
         let executor = deterministic::Runner::default();
@@ -641,7 +695,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     #[should_panic(expected = "out of bounds")]
     fn test_bitmap_get_out_of_bounds_bit_panic() {
         let executor = deterministic::Runner::default();
@@ -656,7 +710,7 @@ mod tests {
             bitmap.get_bit(256);
         });
     }
-    #[test]
+    #[test_traced]
     #[should_panic(expected = "pruned")]
     fn test_bitmap_get_pruned_bit_panic() {
         let executor = deterministic::Runner::default();
@@ -677,7 +731,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     fn test_bitmap_root_boundaries() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
@@ -706,8 +760,8 @@ mod tests {
             for _ in 0..(Bitmap::<Sha256, SHA256_SIZE>::CHUNK_SIZE * 8 - 1) {
                 bitmap.append(&mut hasher, false).await.unwrap();
                 let newer_root = bitmap.root(&mut hasher).await.unwrap();
-                // root won't change when adding 0s within the same chunk
-                assert_eq!(new_root, newer_root);
+                // root will change when adding 0s within the same chunk
+                assert!(new_root != newer_root);
             }
             assert_eq!(bitmap.mmr.size(), 4); // chunk we filled should have been added to mmr
 
@@ -725,7 +779,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     fn test_bitmap_get_set_bits() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
@@ -775,7 +829,7 @@ mod tests {
         tmp.try_into().unwrap()
     }
 
-    #[test]
+    #[test_traced]
     fn test_bitmap_mmr_proof_verification() {
         test_bitmap_mmr_proof_verification_n::<32>();
         test_bitmap_mmr_proof_verification_n::<64>();

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -117,10 +117,10 @@ pub enum Error {
     MissingNode(u64),
     #[error("MMR is empty")]
     Empty,
-    #[error("missing hashes in proof")]
-    MissingHashes,
-    #[error("extra hashes in proof")]
-    ExtraHashes,
+    #[error("missing digests in proof")]
+    MissingDigests,
+    #[error("extra digests in proof")]
+    ExtraDigests,
     #[error("invalid update")]
     InvalidUpdate,
 }

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -13,34 +13,34 @@ use commonware_cryptography::Hasher as CHasher;
 use futures::future::try_join_all;
 use tracing::debug;
 
-/// Contains the information necessary for proving the inclusion of an element, or some range of elements, in the MMR
-/// from its root hash.
+/// Contains the information necessary for proving the inclusion of an element, or some range of
+/// elements, in the MMR from its root hash.
 ///
-/// The `hashes` vector contains:
+/// The `digests` vector contains:
 ///
-/// 1: the hashes of each peak corresponding to a mountain containing no elements from the element range being proven
-/// in decreasing order of height, followed by:
+/// 1: the digests of each peak corresponding to a mountain containing no elements from the element
+/// range being proven in decreasing order of height, followed by:
 ///
-/// 2: the nodes in the remaining mountains necessary for reconstructing their peak hashes from the elements within
-/// the range, ordered by the position of their parent.
+/// 2: the nodes in the remaining mountains necessary for reconstructing their peak digests from the
+/// elements within the range, ordered by the position of their parent.
 #[derive(Clone, Debug, Eq)]
 pub struct Proof<H: CHasher> {
     /// The total number of nodes in the MMR.
     pub size: u64,
-    /// The hashes necessary for proving the inclusion of an element, or range of elements, in the
+    /// The digests necessary for proving the inclusion of an element, or range of elements, in the
     /// MMR.
-    pub hashes: Vec<H::Digest>,
+    pub digests: Vec<H::Digest>,
 }
 
 impl<H: CHasher> PartialEq for Proof<H> {
     fn eq(&self, other: &Self) -> bool {
-        self.size == other.size && self.hashes == other.hashes
+        self.size == other.size && self.digests == other.digests
     }
 }
 
 impl<H: CHasher> Proof<H> {
-    /// Return true if `proof` proves that `element` appears at position `element_pos` within the MMR
-    /// with root `root_digest`.
+    /// Return true if `proof` proves that `element` appears at position `element_pos` within the
+    /// MMR with root `root_digest`.
     pub async fn verify_element_inclusion<M: Hasher<H>>(
         &self,
         hasher: &mut M,
@@ -71,12 +71,12 @@ impl<H: CHasher> Proof<H> {
             .await
         {
             Ok(reconstructed_root) => Ok(*root_digest == reconstructed_root),
-            Err(MissingHashes) => {
-                debug!("Not enough hashes in proof to reconstruct peak hashes");
+            Err(MissingDigests) => {
+                debug!("Not enough digests in proof to reconstruct peak digests");
                 Ok(false)
             }
-            Err(ExtraHashes) => {
-                debug!("Not all hashes in proof were used to reconstruct peak hashes");
+            Err(ExtraDigests) => {
+                debug!("Not all digests in proof were used to reconstruct peak digests");
                 Ok(false)
             }
             Err(e) => Err(e),
@@ -100,9 +100,9 @@ impl<H: CHasher> Proof<H> {
         Ok(hasher.root_digest(self.size, peak_digests.iter()))
     }
 
-    /// Reconstruct the peak hashes of the MMR that produced this proof, returning `MissingHashes`
-    /// error if there are not enough proof hashes, or `ExtraHashes` error if not all proof hashes
-    /// were used in the reconstruction.
+    /// Reconstruct the peak digests of the MMR that produced this proof, returning `MissingDigests`
+    /// error if there are not enough proof digests, or `ExtraDigests` error if not all proof
+    /// digests were used in the reconstruction.
     async fn reconstruct_peak_digests<T>(
         &self,
         hasher: &mut impl Hasher<H>,
@@ -113,11 +113,11 @@ impl<H: CHasher> Proof<H> {
     where
         T: IntoIterator<Item: AsRef<[u8]>>,
     {
-        let mut proof_digests_iter = self.hashes.iter();
-        let mut siblings_iter = self.hashes.iter().rev();
+        let mut proof_digests_iter = self.digests.iter();
+        let mut siblings_iter = self.digests.iter().rev();
         let mut elements_iter = elements.into_iter();
 
-        // Include peak hashes only for trees that have no elements from the range, and keep track
+        // Include peak digests only for trees that have no elements from the range, and keep track
         // of the starting and ending trees of those that do contain some.
         let mut peak_digests: Vec<H::Digest> = Vec::new();
         let mut proof_digests_used = 0;
@@ -139,19 +139,19 @@ impl<H: CHasher> Proof<H> {
                 proof_digests_used += 1;
                 peak_digests.push(*hash);
             } else {
-                return Err(MissingHashes);
+                return Err(MissingDigests);
             }
         }
 
         if elements_iter.next().is_some() {
-            return Err(ExtraHashes);
+            return Err(ExtraDigests);
         }
         let next_sibling = siblings_iter.next();
         if (proof_digests_used == 0 && next_sibling.is_some())
             || (next_sibling.is_some()
-                && *next_sibling.unwrap() != self.hashes[proof_digests_used - 1])
+                && *next_sibling.unwrap() != self.digests[proof_digests_used - 1])
         {
-            return Err(ExtraHashes);
+            return Err(ExtraDigests);
         }
 
         Ok(peak_digests)
@@ -168,19 +168,19 @@ impl<H: CHasher> Proof<H> {
     ///    [8-...): raw bytes of each hash, each of length `H::len()`
     /// ```
     pub fn serialize(&self) -> Vec<u8> {
-        // A proof should never contain more hashes than the depth of the MMR, thus a single byte
-        // for encoding the length of the hashes array still allows serializing MMRs up to 2^255
+        // A proof should never contain more digests than the depth of the MMR, thus a single byte
+        // for encoding the length of the digests array still allows serializing MMRs up to 2^255
         // elements.
         assert!(
-            self.hashes.len() <= u8::MAX as usize,
-            "too many hashes in proof"
+            self.digests.len() <= u8::MAX as usize,
+            "too many digests in proof"
         );
 
         // Serialize the proof as a byte vector.
-        let bytes_len = u64::SIZE + (self.hashes.len() * H::Digest::SIZE);
+        let bytes_len = u64::SIZE + (self.digests.len() * H::Digest::SIZE);
         let mut bytes = Vec::with_capacity(bytes_len);
         bytes.put_u64(self.size);
-        for hash in self.hashes.iter() {
+        for hash in self.digests.iter() {
             bytes.extend_from_slice(hash.as_ref());
         }
         assert_eq!(bytes.len(), bytes_len, "serialization length mismatch");
@@ -195,18 +195,18 @@ impl<H: CHasher> Proof<H> {
         }
         let size = buf.get_u64();
 
-        // A proof should divide neatly into the hash length and not contain more than 255 hashes.
+        // A proof should divide neatly into the hash length and not contain more than 255 digests.
         let buf_remaining = buf.remaining();
-        let hashes_len = buf_remaining / H::Digest::SIZE;
-        if buf_remaining % H::Digest::SIZE != 0 || hashes_len > u8::MAX as usize {
+        let digests_len = buf_remaining / H::Digest::SIZE;
+        if buf_remaining % H::Digest::SIZE != 0 || digests_len > u8::MAX as usize {
             return None;
         }
-        let mut hashes = Vec::with_capacity(hashes_len);
-        for _ in 0..hashes_len {
+        let mut digests = Vec::with_capacity(digests_len);
+        for _ in 0..digests_len {
             let digest = H::Digest::read(&mut buf).ok()?;
-            hashes.push(digest);
+            digests.push(digest);
         }
-        Some(Self { size, hashes })
+        Some(Self { size, digests })
     }
 
     /// Return the list of pruned (pos < `start_pos`) node positions that are still required for
@@ -288,7 +288,7 @@ impl<H: CHasher> Proof<H> {
             // filter the left path for left siblings only
             siblings.extend(left_path_iter.filter(|(parent_pos, pos)| *parent_pos != *pos + 1));
 
-            // If the range spans more than one tree, then the hashes must already be in the correct
+            // If the range spans more than one tree, then the digests must already be in the correct
             // order. Otherwise, we enforce the desired order through sorting.
             if start_tree_with_element.0 == end_tree_with_element.0 {
                 siblings.sort_by(|a, b| b.0.cmp(&a.0));
@@ -306,7 +306,7 @@ impl<H: CHasher> Proof<H> {
         start_element_pos: u64,
         end_element_pos: u64,
     ) -> Result<Proof<H>, Error> {
-        let mut hashes: Vec<H::Digest> = Vec::new();
+        let mut digests: Vec<H::Digest> = Vec::new();
         let positions =
             Self::nodes_required_for_range_proof(mmr.size(), start_element_pos, end_element_pos);
 
@@ -315,14 +315,14 @@ impl<H: CHasher> Proof<H> {
 
         for (i, hash_result) in hash_results.into_iter().enumerate() {
             match hash_result {
-                Some(hash) => hashes.push(hash),
+                Some(hash) => digests.push(hash),
                 None => return Err(Error::ElementPruned(positions[i])),
             };
         }
 
         Ok(Proof {
             size: mmr.size(),
-            hashes,
+            digests,
         })
     }
 }
@@ -346,7 +346,7 @@ where
         // we are at a leaf
         match elements.next() {
             Some(element) => return hasher.leaf_digest(pos, element.as_ref()).await,
-            None => return Err(MissingHashes),
+            None => return Err(MissingDigests),
         }
     }
 
@@ -385,13 +385,13 @@ where
     if left_digest.is_none() {
         match sibling_digests.next() {
             Some(hash) => left_digest = Some(*hash),
-            None => return Err(MissingHashes),
+            None => return Err(MissingDigests),
         }
     }
     if right_digest.is_none() {
         match sibling_digests.next() {
             Some(hash) => right_digest = Some(*hash),
-            None => return Err(MissingHashes),
+            None => return Err(MissingDigests),
         }
     }
 
@@ -477,7 +477,7 @@ mod tests {
                 "proof verification should fail with mangled root_digest"
             );
             let mut proof2 = proof.clone();
-            proof2.hashes[0] = test_digest(0);
+            proof2.digests[0] = test_digest(0);
             assert!(
                 !proof2
                     .verify_element_inclusion(&mut hasher, &element, POS, &root_digest)
@@ -495,7 +495,7 @@ mod tests {
                 "proof verification should fail with incorrect size"
             );
             proof2 = proof.clone();
-            proof2.hashes.push(test_digest(0));
+            proof2.digests.push(test_digest(0));
             assert!(
                 !proof2
                     .verify_element_inclusion(&mut hasher, &element, POS, &root_digest)
@@ -504,27 +504,28 @@ mod tests {
                 "proof verification should fail with extra hash"
             );
             proof2 = proof.clone();
-            while !proof2.hashes.is_empty() {
-                proof2.hashes.pop();
+            while !proof2.digests.is_empty() {
+                proof2.digests.pop();
                 assert!(
                     !proof2
                         .verify_element_inclusion(&mut hasher, &element, 7, &root_digest)
                         .await
                         .unwrap(),
-                    "proof verification should fail with missing hashes"
+                    "proof verification should fail with missing digests"
                 );
             }
             proof2 = proof.clone();
-            proof2.hashes.clear();
+            proof2.digests.clear();
             const PEAK_COUNT: usize = 3;
             proof2
-                .hashes
-                .extend(proof.hashes[0..PEAK_COUNT - 1].iter().cloned());
-            // sneak in an extra hash that won't be used in the computation and make sure it's detected
-            proof2.hashes.push(test_digest(0));
+                .digests
+                .extend(proof.digests[0..PEAK_COUNT - 1].iter().cloned());
+            // sneak in an extra hash that won't be used in the computation and make sure it's
+            // detected
+            proof2.digests.push(test_digest(0));
             proof2
-                .hashes
-                .extend(proof.hashes[PEAK_COUNT - 1..].iter().cloned());
+                .digests
+                .extend(proof.digests[PEAK_COUNT - 1..].iter().cloned());
             assert!(
             !proof2.verify_element_inclusion(&mut hasher, &element, POS, &root_digest).await.unwrap(),
             "proof verification should fail with extra hash even if it's unused by the computation"
@@ -598,8 +599,8 @@ mod tests {
                 "valid range proof should verify successfully"
             );
             let mut invalid_proof = range_proof.clone();
-            for _i in 0..range_proof.hashes.len() {
-                invalid_proof.hashes.remove(0);
+            for _i in 0..range_proof.digests.len() {
+                invalid_proof.digests.remove(0);
                 assert!(
                     !range_proof
                         .verify_range_inclusion(
@@ -614,7 +615,7 @@ mod tests {
                     "range proof with removed elements should fail"
                 );
             }
-            // confirm proof fails with invalid element hashes
+            // confirm proof fails with invalid element digests
             for i in 0..elements.len() {
                 for j in i..elements.len() {
                     if i == start_index && j == end_index {
@@ -655,7 +656,7 @@ mod tests {
             );
             // mangle the proof and confirm it fails
             let mut invalid_proof = range_proof.clone();
-            invalid_proof.hashes[1] = test_digest(0);
+            invalid_proof.digests[1] = test_digest(0);
             assert!(
                 !invalid_proof
                     .verify_range_inclusion(
@@ -670,9 +671,9 @@ mod tests {
                 "mangled range proof should fail verification"
             );
             // inserting elements into the proof should also cause it to fail (malleability check)
-            for i in 0..range_proof.hashes.len() {
+            for i in 0..range_proof.digests.len() {
                 let mut invalid_proof = range_proof.clone();
-                invalid_proof.hashes.insert(i, test_digest(0));
+                invalid_proof.digests.insert(i, test_digest(0));
                 assert!(
                     !invalid_proof
                         .verify_range_inclusion(
@@ -690,8 +691,8 @@ mod tests {
             }
             // removing proof elements should cause verification to fail
             let mut invalid_proof = range_proof.clone();
-            for _ in 0..range_proof.hashes.len() {
-                invalid_proof.hashes.remove(0);
+            for _ in 0..range_proof.digests.len() {
+                invalid_proof.digests.remove(0);
                 assert!(
                     !invalid_proof
                         .verify_range_inclusion(


### PR DESCRIPTION
Special cases partial chunk handling in a different way, avoiding relying on a temporary Storage interface, and making it so that any proof over bits in the partial chunk always require only one digest of proof material.

Also renames the "hashes" field of Proof to "digests" which is more consistent with other usage of the term.