### PR TITLE
[cryptography/bls12381] Remove Bisection Recursion

### DIFF
--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -572,6 +572,12 @@ impl Display for G1 {
     }
 }
 
+impl AsRef<G1> for G1 {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl G2 {
     /// Encodes the G2 element into a slice.
     fn as_slice(&self) -> [u8; Self::SIZE] {
@@ -757,6 +763,12 @@ impl Debug for G2 {
 impl Display for G2 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex(&self.as_slice()))
+    }
+}
+
+impl AsRef<G2> for G2 {
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -1830,8 +1830,15 @@ mod tests {
             msg,
             &partials,
         );
-        assert!(result1.is_err());
-        assert!(result2.is_err());
+        for result in [result1, result2] {
+            match result {
+                Err(invalid_sigs) => {
+                    assert_eq!(invalid_sigs.len(), 1);
+                    assert_eq!(invalid_sigs[0].index, 0);
+                }
+                _ => panic!("Expected an error with invalid signatures"),
+            }
+        }
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -353,9 +353,20 @@ where
         })
         .collect::<Vec<_>>();
 
+    // Create references to the pending vector entries
+    let pending_refs = pending
+        .iter()
+        .map(|(pk, partial)| (pk, *partial))
+        .collect::<Vec<_>>();
+
     // Find any invalid partial signatures
     let mut invalid = Vec::new();
-    partial_verify_multiple_public_keys_bisect::<V>(&pending, &mut invalid, namespace, message);
+    partial_verify_multiple_public_keys_bisect::<V>(
+        &pending_refs,
+        &mut invalid,
+        namespace,
+        message,
+    );
 
     // Return invalid partial signatures, if any
     if invalid.is_empty() {
@@ -1869,7 +1880,7 @@ mod tests {
             match result {
                 Err(invalid_sigs) => {
                     assert_eq!(invalid_sigs.len(), 1);
-                    assert_eq!(invalid_sigs[0].index, corrupted_index as u32);
+                    assert_eq!(invalid_sigs[0].index, corrupted_index);
                 }
                 _ => panic!("Expected an error with invalid signatures"),
             }

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -250,8 +250,8 @@ where
     V::verify(&public, &hm_sum, &signature)
 }
 
-/// Attempts to verify [PartialSignature]s provided or performs repeated
-/// bisection to find any invalid signatures.
+/// Verify a list of [PartialSignature]s by performing aggregate verification,
+/// performing repeated bisection to find invalid signatures (if any exist).
 ///
 /// TODO (#903): parallelize this
 fn partial_verify_multiple_public_keys_bisect<'a, V, VP>(

--- a/cryptography/src/bls12381/primitives/variant.rs
+++ b/cryptography/src/bls12381/primitives/variant.rs
@@ -17,7 +17,7 @@ pub trait Variant: Clone + Send + Sync + Hash + Eq + Debug + 'static {
     type Public: Point + FixedSize + Debug + Hash + Copy + AsRef<Self::Public>;
 
     /// The signature type.
-    type Signature: Point + FixedSize + Debug + Hash + Copy;
+    type Signature: Point + FixedSize + Debug + Hash + Copy + AsRef<Self::Signature>;
 
     /// The domain separator tag (DST) for a proof of possession.
     const PROOF_OF_POSSESSION: DST;

--- a/cryptography/src/bls12381/primitives/variant.rs
+++ b/cryptography/src/bls12381/primitives/variant.rs
@@ -14,7 +14,7 @@ use std::hash::Hash;
 /// A specific instance of a signature scheme.
 pub trait Variant: Clone + Send + Sync + Hash + Eq + Debug + 'static {
     /// The public key type.
-    type Public: Point + FixedSize + Debug + Hash + Copy;
+    type Public: Point + FixedSize + Debug + Hash + Copy + AsRef<Self::Public>;
 
     /// The signature type.
     type Signature: Point + FixedSize + Debug + Hash + Copy;


### PR DESCRIPTION
Resolves: #977

## Summary
- replace recursive bisection in partial verification with iterative loops
- expand test coverage for single signature and boundary cases