### PR TITLE
[release] v0.0.51

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-bridge"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "chrono",
  "clap",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "paste",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "blst",
  "bytes",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "chrono",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bimap",
  "bytes",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "async-lock",
  "axum",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-vrf"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.50", path = "broadcast" }
-commonware-codec = { version = "0.0.50", path = "codec" }
-commonware-consensus = { version = "0.0.50", path = "consensus" }
-commonware-cryptography = { version = "0.0.50", path = "cryptography" }
-commonware-deployer = { version = "0.0.50", path = "deployer", default-features = false }
-commonware-macros = { version = "0.0.50", path = "macros" }
-commonware-p2p = { version = "0.0.50", path = "p2p" }
-commonware-resolver = { version = "0.0.50", path = "resolver" }
-commonware-runtime = { version = "0.0.50", path = "runtime" }
-commonware-storage = { version = "0.0.50", path = "storage" }
-commonware-stream = { version = "0.0.50", path = "stream" }
-commonware-utils = { version = "0.0.50", path = "utils" }
+commonware-broadcast = { version = "0.0.51", path = "broadcast" }
+commonware-codec = { version = "0.0.51", path = "codec" }
+commonware-consensus = { version = "0.0.51", path = "consensus" }
+commonware-cryptography = { version = "0.0.51", path = "cryptography" }
+commonware-deployer = { version = "0.0.51", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.51", path = "macros" }
+commonware-p2p = { version = "0.0.51", path = "p2p" }
+commonware-resolver = { version = "0.0.51", path = "resolver" }
+commonware-runtime = { version = "0.0.51", path = "runtime" }
+commonware-storage = { version = "0.0.51", path = "storage" }
+commonware-stream = { version = "0.0.51", path = "stream" }
+commonware-utils = { version = "0.0.51", path = "utils" }
 thiserror = "2.0.12"
 bytes = "1.7.1"
 sha2 = "0.10.8"

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-broadcast"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Disseminate data over a wide-area network."
 readme = "README.md"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-codec"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Serialize structured data."
 readme = "README.md"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-consensus"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Order opaque messages in a Byzantine environment."
 readme = "README.md"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify signatures."
 readme = "README.md"

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-deployer"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Deploy infrastructure across cloud providers."
 readme = "README.md"

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-bridge"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Send succinct consensus certificates between two networks."
 readme = "README.md"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-flood"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Spam peers deployed to AWS EC2 with random messages."
 readme = "README.md"

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-log"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Commit to a secret log and agree to its hash."
 readme = "README.md"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-vrf"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-macros"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Augment the development of primitives with procedural macros."
 readme = "README.md"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-resolver"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Resolve data identified by a fixed-length key."
 readme = "README.md"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-runtime"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Execute asynchronous tasks with a configurable scheduler."
 readme = "README.md"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-storage"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Persist and retrieve data from an abstract store."
 readme = "README.md"

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-stream"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Exchange messages over arbitrary transport."
 readme = "README.md"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-utils"
 edition = "2021"
 publish = true
-version = "0.0.50"
+version = "0.0.51"
 license = "MIT OR Apache-2.0"
 description = "Leverage common functionality across multiple primitives."
 readme = "README.md"


### PR DESCRIPTION
# Stats

```
 .github/workflows/benchmark.yml                    |   28 +-
 .github/workflows/coverage.yml                     |    6 +-
 .github/workflows/tests.yml                        |   35 +-
 Cargo.lock                                         |   52 +-
 Cargo.toml                                         |   26 +-
 broadcast/Cargo.toml                               |    2 +-
 codec/Cargo.toml                                   |    2 +-
 codec/src/types/bytes.rs                           |   13 +
 codec/src/types/map.rs                             |   46 +
 codec/src/types/net.rs                             |   64 +-
 codec/src/types/primitives.rs                      |  118 +
 codec/src/types/tuple.rs                           |   23 +
 codec/src/types/vec.rs                             |   24 +
 codec/src/varint.rs                                |   16 +
 consensus/Cargo.toml                               |    2 +-
 consensus/src/lib.rs                               |   30 +-
 consensus/src/ordered_broadcast/ack_manager.rs     |  274 ++-
 consensus/src/ordered_broadcast/config.rs          |   13 +-
 consensus/src/ordered_broadcast/engine.rs          |   94 +-
 consensus/src/ordered_broadcast/mocks/reporter.rs  |   30 +-
 .../src/ordered_broadcast/mocks/validators.rs      |   38 +-
 consensus/src/ordered_broadcast/mod.rs             |  199 +-
 consensus/src/ordered_broadcast/tip_manager.rs     |   84 +-
 consensus/src/ordered_broadcast/types.rs           |  529 +++--
 consensus/src/simplex/actors/voter/actor.rs        |    9 +-
 consensus/src/simplex/actors/voter/mod.rs          |    4 +
 consensus/src/simplex/config.rs                    |    6 +
 consensus/src/simplex/engine.rs                    |    2 +
 consensus/src/simplex/mocks/conflicter.rs          |    5 +-
 consensus/src/simplex/mod.rs                       |  130 +-
 .../src/threshold_simplex/actors/batcher/actor.rs  |  577 +++++
 .../threshold_simplex/actors/batcher/ingress.rs    |   50 +
 .../src/threshold_simplex/actors/batcher/mod.rs    |   19 +
 consensus/src/threshold_simplex/actors/mod.rs      |    1 +
 .../src/threshold_simplex/actors/resolver/actor.rs |  106 +-
 .../threshold_simplex/actors/resolver/ingress.rs   |   20 +-
 .../src/threshold_simplex/actors/resolver/mod.rs   |    4 +-
 .../src/threshold_simplex/actors/voter/actor.rs    | 1203 +++++-----
 .../src/threshold_simplex/actors/voter/ingress.rs  |   43 +-
 .../src/threshold_simplex/actors/voter/mod.rs      |  204 +-
 consensus/src/threshold_simplex/config.rs          |   45 +-
 consensus/src/threshold_simplex/engine.rs          |  112 +-
 consensus/src/threshold_simplex/metrics.rs         |   88 -
 .../src/threshold_simplex/mocks/conflicter.rs      |   42 +-
 .../src/threshold_simplex/mocks/impersonator.rs    |  113 +
 consensus/src/threshold_simplex/mocks/invalid.rs   |  106 +
 consensus/src/threshold_simplex/mocks/mod.rs       |    2 +
 consensus/src/threshold_simplex/mocks/nuller.rs    |   33 +-
 consensus/src/threshold_simplex/mocks/outdated.rs  |   39 +-
 .../src/threshold_simplex/mocks/supervisor.rs      |  223 +-
 consensus/src/threshold_simplex/mod.rs             | 1009 +++++++--
 consensus/src/threshold_simplex/types.rs           | 2288 ++++++++++++++++----
 cryptography/Cargo.toml                            |    2 +-
 .../src/bls12381/benches/aggregate_public_keys.rs  |    6 +-
 .../src/bls12381/benches/aggregate_signatures.rs   |    8 +-
 .../benches/aggregate_verify_multiple_messages.rs  |   11 +-
 .../aggregate_verify_multiple_public_keys.rs       |   14 +-
 .../benches/batch_verify_multiple_messages.rs      |   39 +
 .../benches/batch_verify_multiple_public_keys.rs   |   35 +
 cryptography/src/bls12381/benches/bench.rs         |   10 +
 cryptography/src/bls12381/benches/dkg_recovery.rs  |    5 +-
 .../src/bls12381/benches/dkg_reshare_recovery.rs   |   14 +-
 .../src/bls12381/benches/evaluate_point.rs         |   28 +
 .../benches/partial_verify_multiple_public_keys.rs |   73 +
 ...tial_verify_multiple_public_keys_precomputed.rs |   77 +
 .../benches/threshold_signature_recover.rs         |   16 +-
 cryptography/src/bls12381/dkg/arbiter.rs           |   31 +-
 cryptography/src/bls12381/dkg/dealer.rs            |   19 +-
 cryptography/src/bls12381/dkg/mod.rs               |  229 +-
 cryptography/src/bls12381/dkg/ops.rs               |   93 +-
 cryptography/src/bls12381/dkg/player.rs            |   44 +-
 cryptography/src/bls12381/mod.rs                   |  149 +-
 cryptography/src/bls12381/primitives/group.rs      |  438 +++-
 cryptography/src/bls12381/primitives/mod.rs        |   17 +-
 cryptography/src/bls12381/primitives/ops.rs        | 2082 +++++++++++++++---
 cryptography/src/bls12381/primitives/poly.rs       |  215 +-
 cryptography/src/bls12381/primitives/variant.rs    |  306 +++
 cryptography/src/bls12381/scheme.rs                |  107 +-
 cryptography/src/ed25519/scheme.rs                 |   37 +
 cryptography/src/lib.rs                            |   18 +-
 cryptography/src/secp256r1/scheme.rs               |   32 +
 cryptography/src/sha256/mod.rs                     |   24 +-
 deployer/Cargo.toml                                |    2 +-
 deployer/src/ec2/authorize.rs                      |    8 +-
 deployer/src/ec2/create.rs                         |   61 +-
 deployer/src/ec2/destroy.rs                        |    6 +-
 deployer/src/ec2/mod.rs                            |   11 +-
 deployer/src/ec2/update.rs                         |    8 +-
 docs/blogs/threshold-simplex.html                  |    6 +-
 examples/bridge/Cargo.toml                         |    2 +-
 examples/bridge/src/application/actor.rs           |   11 +-
 examples/bridge/src/application/ingress.rs         |    6 +-
 examples/bridge/src/application/mod.rs             |   10 +-
 examples/bridge/src/application/supervisor.rs      |   35 +-
 examples/bridge/src/bin/dealer.rs                  |    9 +-
 examples/bridge/src/bin/indexer.rs                 |   17 +-
 examples/bridge/src/bin/validator.rs               |   41 +-
 examples/bridge/src/types/block.rs                 |   15 +-
 examples/bridge/src/types/inbound.rs               |   44 +-
 examples/bridge/src/types/outbound.rs              |   15 +-
 examples/chat/Cargo.toml                           |    2 +-
 examples/chat/src/main.rs                          |    4 +-
 examples/flood/Cargo.toml                          |    2 +-
 examples/flood/README.md                           |    2 +-
 examples/flood/dashboard.json                      |   19 +-
 examples/flood/src/bin/flood.rs                    |   32 +-
 examples/flood/src/bin/setup.rs                    |   10 +-
 examples/flood/src/lib.rs                          |    1 +
 examples/log/Cargo.toml                            |    2 +-
 examples/log/src/main.rs                           |   15 +-
 examples/vrf/Cargo.toml                            |    2 +-
 examples/vrf/src/handlers/arbiter.rs               |   11 +-
 examples/vrf/src/handlers/contributor.rs           |   12 +-
 examples/vrf/src/handlers/utils.rs                 |    4 +-
 examples/vrf/src/handlers/vrf.rs                   |   20 +-
 examples/vrf/src/handlers/wire.rs                  |   38 +-
 examples/vrf/src/main.rs                           |   13 +-
 macros/Cargo.toml                                  |    2 +-
 p2p/Cargo.toml                                     |    2 +-
 p2p/src/authenticated/actors/dialer.rs             |  207 +-
 p2p/src/authenticated/actors/listener.rs           |   21 +-
 p2p/src/authenticated/actors/peer/actor.rs         |   27 +-
 p2p/src/authenticated/actors/peer/ingress.rs       |    7 +
 p2p/src/authenticated/actors/spawner/actor.rs      |    4 +-
 p2p/src/authenticated/actors/spawner/ingress.rs    |   31 +-
 p2p/src/authenticated/actors/tracker/actor.rs      | 1670 +++++++++-----
 p2p/src/authenticated/actors/tracker/directory.rs  |  384 ++++
 p2p/src/authenticated/actors/tracker/ingress.rs    |  183 +-
 p2p/src/authenticated/actors/tracker/metadata.rs   |   29 +
 p2p/src/authenticated/actors/tracker/metrics.rs    |   57 +
 p2p/src/authenticated/actors/tracker/mod.rs        |   16 +-
 p2p/src/authenticated/actors/tracker/record.rs     |  994 +++++++--
 .../authenticated/actors/tracker/reservation.rs    |   64 +
 p2p/src/authenticated/actors/tracker/set.rs        |  319 ++-
 p2p/src/authenticated/config.rs                    |   56 +-
 p2p/src/authenticated/mod.rs                       |   47 +-
 p2p/src/authenticated/network.rs                   |    3 +-
 p2p/src/authenticated/types.rs                     |   39 +-
 p2p/src/lib.rs                                     |    9 +
 p2p/src/simulated/ingress.rs                       |   52 +
 p2p/src/simulated/network.rs                       |   28 +-
 p2p/src/utils/requester/requester.rs               |    6 +-
 resolver/Cargo.toml                                |    2 +-
 resolver/src/p2p/mod.rs                            |    5 +-
 runtime/Cargo.toml                                 |    9 +-
 runtime/src/deterministic.rs                       |  165 +-
 runtime/src/iouring/mod.rs                         |  207 ++
 runtime/src/lib.rs                                 |  277 ++-
 runtime/src/macros.rs                              |   38 +
 runtime/src/mocks.rs                               |   71 +-
 runtime/src/network/audited.rs                     |  126 +-
 runtime/src/network/deterministic.rs               |   17 +-
 runtime/src/network/iouring.rs                     |  244 +++
 runtime/src/network/metered.rs                     |   86 +-
 runtime/src/network/mod.rs                         |  210 ++
 runtime/src/network/tokio.rs                       |   38 +-
 runtime/src/storage/audited.rs                     |   23 +-
 runtime/src/storage/iouring.rs                     |  321 +++
 runtime/src/storage/memory.rs                      |   12 +-
 runtime/src/storage/metered.rs                     |   20 +-
 runtime/src/storage/mod.rs                         |  117 +-
 runtime/src/storage/tokio.rs                       |   16 +-
 runtime/src/telemetry/metrics/histogram.rs         |   10 +
 runtime/src/telemetry/metrics/mod.rs               |    1 +
 runtime/src/telemetry/metrics/task.rs              |   64 +
 runtime/src/tokio/runtime.rs                       |  232 +-
 runtime/src/utils/buffer/mod.rs                    |  953 ++++++++
 runtime/src/utils/buffer/read.rs                   |  167 ++
 runtime/src/utils/buffer/write.rs                  |  270 +++
 runtime/src/utils/handle.rs                        |  189 ++
 runtime/src/{utils.rs => utils/mod.rs}             |  196 +-
 storage/Cargo.toml                                 |    2 +-
 storage/src/adb/any.rs                             |  391 ++--
 storage/src/adb/current.rs                         |  635 ++++++
 storage/src/adb/mod.rs                             |    1 +
 storage/src/adb/operation.rs                       |   15 +-
 storage/src/archive/benches/utils.rs               |   13 +-
 storage/src/archive/mod.rs                         |   88 +-
 storage/src/archive/storage.rs                     |    7 +-
 storage/src/bmt/benches/build.rs                   |    4 +-
 storage/src/bmt/benches/prove_single_element.rs    |    4 +-
 storage/src/journal/benches/bench.rs               |    3 +
 storage/src/journal/benches/fixed_replay.rs        |   79 +-
 storage/src/journal/fixed.rs                       |  132 +-
 storage/src/journal/variable.rs                    |  264 ++-
 storage/src/metadata/mod.rs                        |    6 +-
 storage/src/metadata/storage.rs                    |    5 +-
 storage/src/mmr/benches/append.rs                  |   22 +-
 storage/src/mmr/benches/append_additional.rs       |   27 +-
 storage/src/mmr/benches/prove_many_elements.rs     |   58 +-
 storage/src/mmr/benches/prove_single_element.rs    |   35 +-
 storage/src/mmr/bitmap.rs                          |  744 ++++---
 storage/src/mmr/hasher.rs                          |  433 +++-
 storage/src/mmr/iterator.rs                        |   43 +-
 storage/src/mmr/journaled.rs                       |  217 +-
 storage/src/mmr/mem.rs                             |  651 +++---
 storage/src/mmr/mod.rs                             |   41 +-
 storage/src/mmr/tests/mod.rs                       |  235 ++
 storage/src/mmr/verification.rs                    |  599 ++---
 stream/Cargo.toml                                  |    2 +-
 stream/src/utils/codec.rs                          |   67 +-
 utils/Cargo.toml                                   |    9 +-
 utils/src/lib.rs                                   |   51 +-
 utils/src/stable_buf.rs                            |   71 +
 utils/src/stable_buf_mut.rs                        |   41 +
 utils/src/time.rs                                  |   32 +
 206 files changed, 19719 insertions(+), 6557 deletions(-)
```