### PR TITLE
[runtime] Add iouring config for shutdown timeout

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -200,7 +200,7 @@ pub(crate) async fn run(
 /// until `timeout` fires. If `timeout` is None, wait indefinitely.
 async fn drain(
     ring: &mut IoUring,
-    mut waiters: &mut HashMap<u64, oneshot::Sender<i32>>,
+    waiters: &mut HashMap<u64, oneshot::Sender<i32>>,
     has_op_timeout: bool,
     timeout: Option<Duration>,
 ) {

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -107,7 +107,9 @@ pub(crate) async fn run(
             let (mut work, sender) = if waiters.is_empty() {
                 // Block until there is something to do
                 match receiver.next().await {
+                    // Got work
                     Some(work) => work,
+                    // Channel closed, shut down
                     None => {
                         drain(
                             &mut ring,
@@ -124,8 +126,8 @@ pub(crate) async fn run(
                 match receiver.try_next() {
                     // Got work without blocking
                     Ok(Some(work_item)) => work_item,
+                    // Channel closed, shut down
                     Ok(None) => {
-                        // Channel closed, shut down
                         drain(
                             &mut ring,
                             &mut waiters,

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -101,14 +101,12 @@ fn handle_cqe(waiters: &mut HashMap<u64, oneshot::Sender<i32>>, cqe: CqueueEntry
                 cfg.op_timeout.is_some(),
                 "received TIMEOUT_WORK_ID with op_timeout disabled"
             );
-            return;
         }
         POLL_WORK_ID => {
             assert!(
                 cfg.force_poll.is_some(),
                 "received POLL_WORK_ID without force_poll enabled"
             );
-            return;
         }
         SHUTDOWN_TIMEOUT_WORK_ID => {
             unreachable!("received SHUTDOWN_TIMEOUT_WORK_ID, should be handled in drain");


### PR DESCRIPTION
In `main`, the io_uring event loop `return`s immediately when the incoming work submission channel closes. This PR:
* Adds a `drain` function to process in-flight operations before returning
* Adds a config option to specify how long `drain` should wait for in-flight operations to complete before abandoning them