### PR TITLE
Fix typo in test function name in mod.rs

### DIFF
--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -765,7 +765,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_write_straddling_non_mergable() {
+    fn test_write_straddling_non_mergeable() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Test write operations that are non-contiguous with the current buffer, forcing flushes.


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the test function name from `test_write_straddling_non_mergable` to `test_write_straddling_non_mergeable` in the `runtime/src/utils/buffer/mod.rs` file. No other logic or functionality was changed. This update improves code clarity and consistency in naming conventions.
