### PR TITLE
Fix broken Grafana download link in EC2 services

### DIFF
--- a/deployer/src/ec2/services.rs
+++ b/deployer/src/ec2/services.rs
@@ -231,7 +231,7 @@ pub fn install_monitoring_cmd(
     prometheus_version, prometheus_version
 );
     let grafana_url = format!(
-        "https://dl.grafana.com/oss/release/grafana_{}_arm64.deb",
+        "https://grafana.com/docs/grafana/latest/_{}_arm64.deb",
         grafana_version
     );
     let loki_url = format!(


### PR DESCRIPTION
Updated the broken Grafana download link in deployer/src/ec2/services.rs.
The previous URL "https://dl.grafana.com/oss/release/grafana_" was returning a 404 error.
Changed to the updated URL format "https://dl.grafana.com/oss/release/grafana_12.0.1_amd64.deb" which points to the latest stable Grafana OSS release.