### PR TITLE
[cryptography/benchmarks] Reduce Test Cardinality

### DIFF
--- a/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
@@ -4,7 +4,7 @@ use rand::{thread_rng, Rng};
 
 fn benchmark_aggregate_verify_multiple_messages(c: &mut Criterion) {
     let namespace = b"namespace";
-    for n in [2, 10, 100, 1000, 10000, 50000].into_iter() {
+    for n in [2, 10, 100, 1000, 10000].into_iter() {
         let mut msgs = Vec::with_capacity(n);
         for _ in 0..n {
             let mut msg = [0u8; 32];
@@ -15,7 +15,7 @@ fn benchmark_aggregate_verify_multiple_messages(c: &mut Criterion) {
             .iter()
             .map(|msg| (Some(&namespace[..]), msg.as_ref()))
             .collect::<Vec<_>>();
-        for concurrency in [1, 2, 4, 8].into_iter() {
+        for concurrency in [1, 8].into_iter() {
             c.bench_function(
                 &format!("{}/conc={} msgs={}", module_path!(), concurrency, n,),
                 |b| {

--- a/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
@@ -15,7 +15,7 @@ fn benchmark_aggregate_verify_multiple_messages(c: &mut Criterion) {
             .iter()
             .map(|msg| (Some(&namespace[..]), msg.as_ref()))
             .collect::<Vec<_>>();
-        for concurrency in [1, 2, 4, 8].into_iter() {
+        for concurrency in [1, 8].into_iter() {
             c.bench_function(
                 &format!("{}/conc={} msgs={}", module_path!(), concurrency, n,),
                 |b| {

--- a/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_multiple_messages.rs
@@ -15,7 +15,7 @@ fn benchmark_aggregate_verify_multiple_messages(c: &mut Criterion) {
             .iter()
             .map(|msg| (Some(&namespace[..]), msg.as_ref()))
             .collect::<Vec<_>>();
-        for concurrency in [1, 8].into_iter() {
+        for concurrency in [1, 2, 4, 8].into_iter() {
             c.bench_function(
                 &format!("{}/conc={} msgs={}", module_path!(), concurrency, n,),
                 |b| {

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -66,7 +66,7 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
             );
         }
 
-        for &concurrency in &[1, 8] {
+        for concurrency in [1, 8] {
             c.bench_function(
                 &format!("{}/conc={} n={} t={}", module_path!(), concurrency, n, t),
                 |b| {

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -66,7 +66,7 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
             );
         }
 
-        for &concurrency in &[1, 2, 4, 8] {
+        for &concurrency in &[1, 8] {
             c.bench_function(
                 &format!("{}/conc={} n={} t={}", module_path!(), concurrency, n, t),
                 |b| {

--- a/cryptography/src/bls12381/benches/evaluate_point.rs
+++ b/cryptography/src/bls12381/benches/evaluate_point.rs
@@ -25,4 +25,8 @@ fn benchmark_evaluate_point(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, benchmark_evaluate_point);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_evaluate_point
+}

--- a/cryptography/src/bls12381/benches/partial_verify_multiple_public_keys.rs
+++ b/cryptography/src/bls12381/benches/partial_verify_multiple_public_keys.rs
@@ -70,4 +70,8 @@ fn benchmark_partial_verify_multiple_public_keys(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, benchmark_partial_verify_multiple_public_keys);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_partial_verify_multiple_public_keys
+}

--- a/cryptography/src/bls12381/benches/partial_verify_multiple_public_keys_precomputed.rs
+++ b/cryptography/src/bls12381/benches/partial_verify_multiple_public_keys_precomputed.rs
@@ -71,7 +71,8 @@ fn benchmark_partial_verify_multiple_public_keys_precomputed(c: &mut Criterion) 
     }
 }
 
-criterion_group!(
-    benches,
-    benchmark_partial_verify_multiple_public_keys_precomputed
-);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_partial_verify_multiple_public_keys_precomputed
+}


### PR DESCRIPTION
Related: #988 

This is a stopgap to restore the benchmark CI (until we add self-hosted runners or refactor how tests are run).