### PR TITLE
[WiP] [storage/mmr + storage/adb] Support batch updates

### DIFF
--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -175,8 +175,9 @@ impl<
             // Prepend the missing (inactive) bits needed to align the bitmap, which can only be
             // pruned to a chunk boundary, with the MMR's pruning boundary.
             for _ in pruned_bits..mmr_pruned_leaves {
-                status.append(&mut grafter, false).await?;
+                status.append(false);
             }
+            status.process_updates(&mut grafter).await.unwrap();
         }
 
         // Replay the log to generate the snapshot & populate the retained portion of the bitmap.
@@ -200,7 +201,8 @@ impl<
                 inactivity_floor_loc,
                 "pruning any db to the current inactivity floor"
             );
-            mmr.prune_to_pos(leaf_num_to_pos(inactivity_floor_loc))
+            let mut hasher = Standard::new(&mut hasher);
+            mmr.prune_to_pos(&mut hasher, leaf_num_to_pos(inactivity_floor_loc))
                 .await?;
         }
 
@@ -250,16 +252,14 @@ impl<
     /// next successful `commit`.
     pub async fn update(&mut self, key: K, value: V) -> Result<UpdateResult, Error> {
         let update_result = self.any.update(key, value).await?;
-        let mut grafter =
-            Grafter::new(&mut self.any.hasher, Self::grafting_height(), &self.any.ops);
         match update_result {
             UpdateResult::NoOp => return Ok(update_result),
             UpdateResult::Inserted(_) => (),
             UpdateResult::Updated(old_loc, _) => {
-                self.status.set_bit(&mut grafter, old_loc, false).await?;
+                self.status.set_bit(old_loc, false);
             }
         }
-        self.status.append(&mut grafter, true).await?;
+        self.status.append(true);
 
         Ok(update_result)
     }
@@ -272,10 +272,8 @@ impl<
             return Ok(());
         };
 
-        let mut grafter =
-            Grafter::new(&mut self.any.hasher, Self::grafting_height(), &self.any.ops);
-        self.status.append(&mut grafter, false).await?;
-        self.status.set_bit(&mut grafter, old_loc, false).await?;
+        self.status.append(false);
+        self.status.set_bit(old_loc, false);
 
         Ok(())
     }
@@ -308,10 +306,8 @@ impl<
                 .move_op_if_active(op, self.any.inactivity_floor_loc)
                 .await?;
             if let Some(old_loc) = old_loc {
-                let mut grafter =
-                    Grafter::new(&mut self.any.hasher, Self::grafting_height(), &self.any.ops);
-                self.status.set_bit(&mut grafter, old_loc, false).await?;
-                self.status.append(&mut grafter, true).await?;
+                self.status.set_bit(old_loc, false);
+                self.status.append(true);
             }
             self.any.inactivity_floor_loc += 1;
         }
@@ -319,9 +315,7 @@ impl<
         self.any
             .apply_op(Operation::Commit(self.any.inactivity_floor_loc))
             .await?;
-        let mut grafter =
-            Grafter::new(&mut self.any.hasher, Self::grafting_height(), &self.any.ops);
-        self.status.append(&mut grafter, false).await?;
+        self.status.append(false);
 
         Ok(())
     }
@@ -336,6 +330,9 @@ impl<
         //  (3) prune the any db of inactive operations.
         self.commit_ops().await?; // (1)
 
+        let mut grafter =
+            Grafter::new(&mut self.any.hasher, Self::grafting_height(), &self.any.ops);
+        self.status.process_updates(&mut grafter).await?;
         self.status.prune_to_bit(self.any.inactivity_floor_loc);
         self.status
             .write_pruned(
@@ -351,7 +348,7 @@ impl<
         Ok(())
     }
 
-    /// Return the root of the db.
+    /// Return the root of the db. Will panic if there are uncommitted operations.
     pub async fn root(&self, hasher: &mut H) -> Result<H::Digest, Error> {
         let ops = &self.any.ops;
         let height = Self::grafting_height();
@@ -692,6 +689,9 @@ impl<
         // Only successfully complete operations (1) and (2) of the commit process.
         self.commit_ops().await?; // (1)
 
+        let mut grafter =
+            Grafter::new(&mut self.any.hasher, Self::grafting_height(), &self.any.ops);
+        self.status.process_updates(&mut grafter).await.unwrap();
         self.status.prune_to_bit(self.any.inactivity_floor_loc);
         self.status
             .write_pruned(
@@ -1163,7 +1163,8 @@ pub mod test {
                     )
                     .await
                     .unwrap(),
-                    "proof of update {i} failed to verify"
+                    "proof of update {} failed to verify",
+                    db.status.bit_count()
                 );
                 // Ensure the proof does NOT verify if we use the previous value.
                 assert!(
@@ -1205,8 +1206,6 @@ pub mod test {
             apply_random_ops(ELEMENTS, false, rng_seed + 1, &mut db)
                 .await
                 .unwrap();
-            let uncommitted_root = db.root(&mut hasher).await.unwrap();
-            assert!(uncommitted_root != committed_root);
 
             // SCENARIO #1: Simulate a crash that happens before any writes. Upon reopening, the
             // state of the DB should be as of the last commit.
@@ -1219,7 +1218,6 @@ pub mod test {
             apply_random_ops(ELEMENTS, false, rng_seed + 1, &mut db)
                 .await
                 .unwrap();
-            assert_eq!(db.root(&mut hasher).await.unwrap(), uncommitted_root);
 
             // SCENARIO #2: Simulate a crash that happens after the any db has been committed, but
             // before the state of the pruned bitmap can be written to disk.
@@ -1231,7 +1229,6 @@ pub mod test {
             // the op count should be greater than before.
             let db = open_db(context.clone(), partition).await;
             let scenario_2_root = db.root(&mut hasher).await.unwrap();
-            assert!(scenario_2_root != uncommitted_root);
             let scenario_2_pruning_loc = db.any.oldest_retained_loc().unwrap();
 
             // To confirm the second committed hash is correct we'll re-build the DB in a new

--- a/storage/src/mmr/benches/update.rs
+++ b/storage/src/mmr/benches/update.rs
@@ -11,41 +11,57 @@ fn bench_update(c: &mut Criterion) {
     let runner = tokio::Runner::new(cfg);
     for updates in [100_000, 1_000_000] {
         for leaves in [10_000u64, 100_000, 1_000_000, 5_000_000, 10_000_000] {
-            c.bench_function(
-                &format!("{}/leaves={} updates={}", module_path!(), leaves, updates),
-                |b| {
-                    b.to_async(&runner).iter_custom(|_iters| async move {
-                        let mut mmr = Mmr::<Sha256>::new();
-                        let mut elements = Vec::with_capacity(leaves as usize);
-                        let mut sampler = StdRng::seed_from_u64(0);
-                        let mut leaf_positions = Vec::with_capacity(leaves as usize);
-                        let mut h = Sha256::new();
-                        let mut h = Standard::new(&mut h);
+            for batched in [true, false] {
+                c.bench_function(
+                    &format!(
+                        "{}/updates={} leaves={}, batched={}",
+                        module_path!(),
+                        updates,
+                        leaves,
+                        batched
+                    ),
+                    |b| {
+                        b.to_async(&runner).iter_custom(|_iters| async move {
+                            let mut mmr = Mmr::<Sha256>::new();
+                            let mut elements = Vec::with_capacity(leaves as usize);
+                            let mut sampler = StdRng::seed_from_u64(0);
+                            let mut leaf_positions = Vec::with_capacity(leaves as usize);
+                            let mut h = Sha256::new();
+                            let mut h = Standard::new(&mut h);
 
-                        // Append random elements to MMR
-                        for _ in 0..leaves {
-                            let digest = sha256::Digest::random(&mut sampler);
-                            elements.push(digest);
-                            let pos = mmr.add(&mut h, &digest).await.unwrap();
-                            leaf_positions.push(pos);
-                        }
+                            // Append random elements to MMR
+                            for _ in 0..leaves {
+                                let digest = sha256::Digest::random(&mut sampler);
+                                elements.push(digest);
+                                let pos = mmr.add(&mut h, &digest).await.unwrap();
+                                leaf_positions.push(pos);
+                            }
 
-                        // Randomly update leaves -- this is what we are benchmarking.
-                        let start = Instant::now();
-                        for _ in 0..updates {
-                            let rand_leaf_num = sampler.gen_range(0..leaves);
-                            let rand_leaf_pos = leaf_positions[rand_leaf_num as usize];
-                            let rand_leaf_swap = sampler.gen_range(0..elements.len());
-                            let new_element = &elements[rand_leaf_swap];
-                            mmr.update_leaf(&mut h, rand_leaf_pos, new_element)
-                                .await
-                                .unwrap();
-                        }
-
-                        start.elapsed()
-                    });
-                },
-            );
+                            // Randomly update leaves -- this is what we are benchmarking.
+                            let start = Instant::now();
+                            for _ in 0..updates {
+                                let rand_leaf_num = sampler.gen_range(0..leaves);
+                                let rand_leaf_pos = leaf_positions[rand_leaf_num as usize];
+                                let rand_leaf_swap = sampler.gen_range(0..elements.len());
+                                let new_element = &elements[rand_leaf_swap];
+                                if batched {
+                                    mmr.update_leaf_batched(&mut h, rand_leaf_pos, new_element)
+                                        .await
+                                        .unwrap();
+                                    continue;
+                                }
+                                mmr.update_leaf(&mut h, rand_leaf_pos, new_element)
+                                    .await
+                                    .unwrap();
+                            }
+                            if batched {
+                                mmr.process_updates(&mut h);
+                            }
+                            start.elapsed()
+                        });
+                    },
+                );
+            }
         }
     }
 }

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -180,9 +180,9 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             // Recover the orphaned leaf and any missing parents.
             let pos = s.mem_mmr.size();
             warn!(pos, "recovering orphaned leaf");
-            s.mem_mmr.add_leaf_digest(hasher, leaf).await.unwrap();
+            s.mem_mmr.add_leaf_digest(hasher, leaf, false);
             assert_eq!(pos, journal_size);
-            s.sync().await?;
+            s.sync(hasher).await?;
             assert_eq!(s.size(), s.journal.size().await?);
         }
 
@@ -254,6 +254,15 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         self.mem_mmr.add(h, element).await
     }
 
+    /// Add an element to the MMR, delaying the computation of parent node digests until the next `sync`
+    pub async fn add_batched(
+        &mut self,
+        h: &mut impl Hasher<H>,
+        element: &[u8],
+    ) -> Result<u64, Error> {
+        self.mem_mmr.add_batched(h, element).await
+    }
+
     /// Pop the given number of elements from the tip of the MMR assuming they exist, and otherwise
     /// return Empty or ElementPruned errors.
     pub async fn pop(&mut self, mut leaves_to_pop: usize) -> Result<(), Error> {
@@ -305,18 +314,24 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         Ok(())
     }
 
-    /// Return the root of the MMR.
+    /// Return the root of the MMR. Panics if there are unprocessed updates.
     pub fn root(&self, h: &mut impl Hasher<H>) -> H::Digest {
         self.mem_mmr.root(h)
     }
 
+    pub fn process_updates(&mut self, h: &mut impl Hasher<H>) {
+        // Process any updates in the memory-resident MMR.
+        self.mem_mmr.process_updates(h);
+    }
+
     /// Sync any new elements to disk.
-    pub async fn sync(&mut self) -> Result<(), Error> {
+    pub async fn sync(&mut self, h: &mut impl Hasher<H>) -> Result<(), Error> {
         if self.size() == 0 {
             return Ok(());
         }
 
         // Write the nodes cached in the memory-resident MMR to the journal.
+        self.mem_mmr.process_updates(h);
         for i in self.journal_size..self.size() {
             let node = *self.mem_mmr.get_node_unchecked(i);
             self.journal.append(node).await?;
@@ -364,8 +379,8 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
     }
 
     /// Close the MMR, syncing any cached elements to disk and closing the journal.
-    pub async fn close(mut self) -> Result<(), Error> {
-        self.sync().await?;
+    pub async fn close(mut self, h: &mut impl Hasher<H>) -> Result<(), Error> {
+        self.sync(h).await?;
         self.journal.close().await?;
         self.metadata.close().await.map_err(Error::MetadataError)
     }
@@ -390,9 +405,9 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
 
     /// Prune as many nodes as possible, leaving behind at most items_per_blob nodes in the current
     /// blob.
-    pub async fn prune_all(&mut self) -> Result<(), Error> {
+    pub async fn prune_all(&mut self, h: &mut impl Hasher<H>) -> Result<(), Error> {
         if self.size() != 0 {
-            self.prune_to_pos(self.size()).await?;
+            self.prune_to_pos(h, self.size()).await?;
             return Ok(());
         }
         Ok(())
@@ -401,14 +416,14 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
     /// Prune all nodes up to but not including the given position and update the pinned nodes.
     ///
     /// This implementation ensures that no failure can leave the MMR in an unrecoverable state.
-    pub async fn prune_to_pos(&mut self, pos: u64) -> Result<(), Error> {
+    pub async fn prune_to_pos(&mut self, h: &mut impl Hasher<H>, pos: u64) -> Result<(), Error> {
         assert!(pos <= self.size());
         if self.size() == 0 {
             return Ok(());
         }
 
         // Flush items cached in the mem_mmr to disk to ensure the current state is recoverable.
-        self.sync().await?;
+        self.sync(h).await?;
 
         // Update metadata to reflect the desired pruning boundary, allowing for recovery in the
         // event of a pruning failure.
@@ -461,11 +476,15 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
     }
 
     #[cfg(test)]
-    pub async fn simulate_pruning_failure(mut self, prune_to_pos: u64) -> Result<(), Error> {
+    pub async fn simulate_pruning_failure(
+        mut self,
+        h: &mut impl Hasher<H>,
+        prune_to_pos: u64,
+    ) -> Result<(), Error> {
         assert!(prune_to_pos <= self.size());
 
         // Flush items cached in the mem_mmr to disk to ensure the current state is recoverable.
-        self.sync().await?;
+        self.sync(h).await?;
 
         // Update metadata to reflect the desired pruning boundary, allowing for recovery in the
         // event of a pruning failure.
@@ -534,10 +553,10 @@ mod tests {
             assert_eq!(mmr.size(), 0);
             assert!(mmr.get_node(0).await.is_err());
             assert_eq!(mmr.oldest_retained_pos(), None);
-            assert!(mmr.prune_all().await.is_ok());
+            assert!(mmr.prune_all(&mut hasher).await.is_ok());
             assert_eq!(mmr.pruned_to_pos(), 0);
-            assert!(mmr.prune_to_pos(0).await.is_ok());
-            assert!(mmr.sync().await.is_ok());
+            assert!(mmr.prune_to_pos(&mut hasher, 0).await.is_ok());
+            assert!(mmr.sync(&mut hasher).await.is_ok());
             assert!(matches!(mmr.pop(1).await, Err(Error::Empty)));
         });
     }
@@ -563,8 +582,9 @@ mod tests {
             for i in 0u64..199 {
                 c_hasher.update(&i.to_be_bytes());
                 let element = c_hasher.finalize();
-                mmr.add(&mut hasher, &element).await.unwrap();
+                mmr.add_batched(&mut hasher, &element).await.unwrap();
             }
+            mmr.process_updates(&mut hasher);
             assert_eq!(ROOTS[199], hex(&mmr.root(&mut hasher)));
 
             // Pop off one node at a time without syncing until empty, confirming the root is still
@@ -583,12 +603,13 @@ mod tests {
             for i in 0u64..199 {
                 c_hasher.update(&i.to_be_bytes());
                 let element = c_hasher.finalize();
-                mmr.add(&mut hasher, &element).await.unwrap();
+                mmr.add_batched(&mut hasher, &element).await.unwrap();
                 if i == 101 {
-                    mmr.sync().await.unwrap();
+                    mmr.sync(&mut hasher).await.unwrap();
                 }
             }
             for i in (0..198u64).rev().step_by(2) {
+                mmr.process_updates(&mut hasher);
                 assert!(mmr.pop(2).await.is_ok());
                 let root = mmr.root(&mut hasher);
                 let expected_root = ROOTS[i as usize];
@@ -605,7 +626,7 @@ mod tests {
                 mmr.add(&mut hasher, &element).await.unwrap();
             }
             let leaf_pos = leaf_num_to_pos(50);
-            mmr.prune_to_pos(leaf_pos).await.unwrap();
+            mmr.prune_to_pos(&mut hasher, leaf_pos).await.unwrap();
             while mmr.size() > leaf_pos {
                 assert!(mmr.pop(1).await.is_ok());
             }
@@ -658,7 +679,7 @@ mod tests {
                 .unwrap());
 
             // Sync the MMR, make sure it flushes the in-mem MMR as expected.
-            mmr.sync().await.unwrap();
+            mmr.sync(&mut hasher).await.unwrap();
             assert_eq!(mmr.journal_size, 502);
             assert_eq!(mmr.mem_mmr.oldest_retained_pos(), None);
 
@@ -713,12 +734,16 @@ mod tests {
             for i in 0..LEAF_COUNT {
                 let digest = test_digest(i);
                 leaves.push(digest);
-                let pos = mmr.add(&mut hasher, leaves.last().unwrap()).await.unwrap();
+                let pos = mmr
+                    .add_batched(&mut hasher, leaves.last().unwrap())
+                    .await
+                    .unwrap();
                 positions.push(pos);
             }
             assert_eq!(mmr.size(), 498);
+            mmr.process_updates(&mut hasher);
             let root = mmr.root(&mut hasher);
-            mmr.close().await.unwrap();
+            mmr.close(&mut hasher).await.unwrap();
 
             // The very last element we added (pos=495) resulted in new parents at positions 496 &
             // 497. Simulate a partial write by corrupting the last parent's checksum by truncating
@@ -745,12 +770,12 @@ mod tests {
             assert_eq!(mmr.root(&mut hasher), root);
 
             // Make sure closing it and re-opening it persists the recovered state.
-            mmr.close().await.unwrap();
+            mmr.close(&mut hasher).await.unwrap();
             let mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(mmr.size(), 498);
-            mmr.close().await.unwrap();
+            mmr.close(&mut hasher).await.unwrap();
 
             // Repeat partial write test though this time truncate the leaf itself not just some
             // parent. The leaf is in the *previous* blob so we'll have to delete the most recent
@@ -813,10 +838,11 @@ mod tests {
                 let digest = test_digest(i);
                 leaves.push(digest);
                 let last_leaf = leaves.last().unwrap();
-                let pos = mmr.add(&mut hasher, last_leaf).await.unwrap();
+                let pos = mmr.add_batched(&mut hasher, last_leaf).await.unwrap();
                 positions.push(pos);
                 pruned_mmr.add(&mut hasher, last_leaf).await.unwrap();
             }
+            mmr.process_updates(&mut hasher);
             assert_eq!(mmr.size(), 3994);
             assert_eq!(pruned_mmr.size(), 3994);
 
@@ -824,7 +850,10 @@ mod tests {
             // roots and accept new elements.
             for i in 0usize..300 {
                 let prune_pos = i as u64 * 10;
-                pruned_mmr.prune_to_pos(prune_pos).await.unwrap();
+                pruned_mmr
+                    .prune_to_pos(&mut hasher, prune_pos)
+                    .await
+                    .unwrap();
                 assert_eq!(prune_pos, pruned_mmr.pruned_to_pos());
 
                 let digest = test_digest(LEAF_COUNT + i);
@@ -837,11 +866,11 @@ mod tests {
             }
 
             // Sync the MMRs.
-            pruned_mmr.sync().await.unwrap();
+            pruned_mmr.sync(&mut hasher).await.unwrap();
             assert_eq!(pruned_mmr.root(&mut hasher), mmr.root(&mut hasher));
 
             // Close the MMR & reopen.
-            pruned_mmr.close().await.unwrap();
+            pruned_mmr.close(&mut hasher).await.unwrap();
             let mut pruned_mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
                 .await
                 .unwrap();
@@ -849,7 +878,7 @@ mod tests {
 
             // Prune everything.
             let size = pruned_mmr.size();
-            pruned_mmr.prune_all().await.unwrap();
+            pruned_mmr.prune_all(&mut hasher).await.unwrap();
             assert_eq!(pruned_mmr.root(&mut hasher), mmr.root(&mut hasher));
             assert_eq!(pruned_mmr.oldest_retained_pos(), None);
             assert_eq!(pruned_mmr.pruned_to_pos(), size);
@@ -864,7 +893,7 @@ mod tests {
                 .await
                 .unwrap();
             assert!(pruned_mmr.size() % cfg.items_per_blob != 0);
-            pruned_mmr.close().await.unwrap();
+            pruned_mmr.close(&mut hasher).await.unwrap();
             let mut pruned_mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
                 .await
                 .unwrap();
@@ -880,7 +909,7 @@ mod tests {
                     .await
                     .unwrap();
             }
-            pruned_mmr.prune_all().await.unwrap();
+            pruned_mmr.prune_all(&mut hasher).await.unwrap();
             assert_eq!(pruned_mmr.oldest_retained_pos(), None);
         });
     }
@@ -914,7 +943,7 @@ mod tests {
                 positions.push(pos);
             }
             assert_eq!(mmr.size(), 3994);
-            mmr.close().await.unwrap();
+            mmr.close(&mut hasher).await.unwrap();
 
             // Prune the MMR in increments of 50, simulating a partial write after each prune.
             for i in 0usize..200 {
@@ -924,10 +953,12 @@ mod tests {
                 let start_size = mmr.size();
                 let prune_pos = std::cmp::min(i as u64 * 50, start_size);
                 if i % 5 == 0 {
-                    mmr.simulate_pruning_failure(prune_pos).await.unwrap();
+                    mmr.simulate_pruning_failure(&mut hasher, prune_pos)
+                        .await
+                        .unwrap();
                     continue;
                 }
-                mmr.prune_to_pos(prune_pos).await.unwrap();
+                mmr.prune_to_pos(&mut hasher, prune_pos).await.unwrap();
 
                 // add 25 new elements, simulating a partial write after each.
                 for j in 0..10 {

--- a/storage/src/mmr/storage.rs
+++ b/storage/src/mmr/storage.rs
@@ -52,7 +52,7 @@ impl<H: CHasher, const N: usize> Storage<H::Digest> for Bitmap<H, N> {
     }
 
     async fn get_node(&self, position: u64) -> Result<Option<H::Digest>, Error> {
-        Bitmap::get_node(self, position).await
+        Ok(Bitmap::get_node(self, position))
     }
 }
 

--- a/storage/src/mmr/tests/mod.rs
+++ b/storage/src/mmr/tests/mod.rs
@@ -18,6 +18,11 @@ pub async fn build_and_check_test_roots_mmr(mmr: &mut impl Builder<Sha256>) {
         assert_eq!(hex(&root), expected_root, "at: {}", i);
         mmr.add(&mut hasher, &element).await.unwrap();
     }
+    assert_eq!(
+        hex(&mmr.root(&mut hasher)),
+        ROOTS[199],
+        "Root after 200 elements"
+    );
 }
 
 /// Build an MMR for testing with 199 elements.
@@ -27,6 +32,23 @@ pub async fn build_test_mmr<H: CHasher>(hasher: &mut impl Hasher<H>, mmr: &mut i
         let element = hasher.inner().finalize();
         mmr.add(hasher, &element).await.unwrap();
     }
+}
+
+pub async fn build_batched_and_check_test_roots<H: CHasher>(
+    hasher: &mut impl Hasher<H>,
+    mem_mmr: &mut super::mem::Mmr<H>,
+) {
+    for i in 0u64..199 {
+        hasher.inner().update(&i.to_be_bytes());
+        let element = hasher.inner().finalize();
+        mem_mmr.add_batched(hasher, &element).await.unwrap();
+    }
+    mem_mmr.process_updates(hasher);
+    assert_eq!(
+        hex(&mem_mmr.root(hasher)),
+        ROOTS[199],
+        "Root after 200 elements"
+    );
 }
 
 /// Roots for all MMRs with 0..200 elements for testing stability in


### PR DESCRIPTION
- Extends mem::Mmr with batch-update methods for mutating and adding nodes, postponing parent node updates until a new method `process_updates` is called.  Current implementation does not implement parallelization of the updates, so it shouldn't provide latency improvements unless mutations are involved.
- Updated the mem MMR update benchmark to compare batching to non-batching, and we indeed see significant speedups there.
- Authenticated bitmap changed to allow for batch updating only.
- Current & Any authenticated DBs modified to use batching.

