### PR TITLE
[CI] Fix Lint Error on `main`

### DIFF
--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -234,11 +234,7 @@ impl crate::Blob for Blob {
     // TODO: Make this async. See https://github.com/commonwarexyz/monorepo/issues/831
     async fn truncate(&self, len: u64) -> Result<(), Error> {
         self.file.set_len(len).map_err(|e| {
-            Error::BlobTruncateFailed(
-                self.partition.clone(),
-                hex(&self.name),
-                IoError::new(ErrorKind::Other, e),
-            )
+            Error::BlobTruncateFailed(self.partition.clone(), hex(&self.name), IoError::other(e))
         })
     }
 
@@ -257,7 +253,7 @@ impl crate::Blob for Blob {
                     Error::BlobSyncFailed(
                         self.partition.clone(),
                         hex(&self.name),
-                        IoError::new(ErrorKind::Other, "failed to send work"),
+                        IoError::other("failed to send work"),
                     )
                 })?;
 
@@ -266,7 +262,7 @@ impl crate::Blob for Blob {
                 Error::BlobSyncFailed(
                     self.partition.clone(),
                     hex(&self.name),
-                    IoError::new(ErrorKind::Other, "failed to read result"),
+                    IoError::other("failed to read result"),
                 )
             })?;
             if should_retry(return_value) {
@@ -278,7 +274,7 @@ impl crate::Blob for Blob {
                 return Err(Error::BlobSyncFailed(
                     self.partition.clone(),
                     hex(&self.name),
-                    IoError::new(ErrorKind::Other, format!("error code: {}", return_value)),
+                    IoError::other(format!("error code: {}", return_value)),
                 ));
             }
 


### PR DESCRIPTION
```
error: this can be `std::io::Error::other(_)`
   --> runtime/src/storage/iouring.rs:240:17
    |
240 |                 IoError::new(ErrorKind::Other, e),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
    = note: `-D clippy::io-other-error` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::io_other_error)]`
help: use `std::io::Error::other`
    |
240 -                 IoError::new(ErrorKind::Other, e),
240 +                 IoError::other(e),
    |

error: this can be `std::io::Error::other(_)`
   --> runtime/src/storage/iouring.rs:260:25
    |
260 |                         IoError::new(ErrorKind::Other, "failed to send work"),
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
help: use `std::io::Error::other`
    |
260 -                         IoError::new(ErrorKind::Other, "failed to send work"),
260 +                         IoError::other("failed to send work"),
    |

error: this can be `std::io::Error::other(_)`
   --> runtime/src/storage/iouring.rs:269:21
    |
269 |                     IoError::new(ErrorKind::Other, "failed to read result"),
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
help: use `std::io::Error::other`
    |
269 -                     IoError::new(ErrorKind::Other, "failed to read result"),
269 +                     IoError::other("failed to read result"),
    |

error: this can be `std::io::Error::other(_)`
   --> runtime/src/storage/iouring.rs:281:21
    |
281 |                     IoError::new(ErrorKind::Other, format!("error code: {}", return_value)),
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
help: use `std::io::Error::other`
    |
281 -                     IoError::new(ErrorKind::Other, format!("error code: {}", return_value)),
281 +                     IoError::other(format!("error code: {}", return_value)),
    |

    Checking time-core v0.1.3
error: could not compile `commonware-runtime` (lib) due to 4 previous errors
```