### PR TITLE
[storage/mmr/mem] add batch update feature to mem MMR

### DIFF
--- a/storage/src/mmr/benches/update.rs
+++ b/storage/src/mmr/benches/update.rs
@@ -11,41 +11,55 @@ fn bench_update(c: &mut Criterion) {
     let runner = tokio::Runner::new(cfg);
     for updates in [100_000, 1_000_000] {
         for leaves in [10_000u64, 100_000, 1_000_000, 5_000_000, 10_000_000] {
-            c.bench_function(
-                &format!("{}/leaves={} updates={}", module_path!(), leaves, updates),
-                |b| {
-                    b.to_async(&runner).iter_custom(|_iters| async move {
-                        let mut mmr = Mmr::<Sha256>::new();
-                        let mut elements = Vec::with_capacity(leaves as usize);
-                        let mut sampler = StdRng::seed_from_u64(0);
-                        let mut leaf_positions = Vec::with_capacity(leaves as usize);
-                        let mut h = Sha256::new();
-                        let mut h = Standard::new(&mut h);
+            for batched in [true, false] {
+                c.bench_function(
+                    &format!(
+                        "{}/updates={} leaves={}, batched={}",
+                        module_path!(),
+                        updates,
+                        leaves,
+                        batched
+                    ),
+                    |b| {
+                        b.to_async(&runner).iter_custom(|_iters| async move {
+                            let mut mmr = Mmr::<Sha256>::new();
+                            let mut elements = Vec::with_capacity(leaves as usize);
+                            let mut sampler = StdRng::seed_from_u64(0);
+                            let mut leaf_positions = Vec::with_capacity(leaves as usize);
+                            let mut h = Sha256::new();
+                            let mut h = Standard::new(&mut h);
 
-                        // Append random elements to MMR
-                        for _ in 0..leaves {
-                            let digest = sha256::Digest::random(&mut sampler);
-                            elements.push(digest);
-                            let pos = mmr.add(&mut h, &digest).await.unwrap();
-                            leaf_positions.push(pos);
-                        }
+                            // Append random elements to MMR
+                            for _ in 0..leaves {
+                                let digest = sha256::Digest::random(&mut sampler);
+                                elements.push(digest);
+                                let pos = mmr.add(&mut h, &digest).await.unwrap();
+                                leaf_positions.push(pos);
+                            }
 
-                        // Randomly update leaves -- this is what we are benchmarking.
-                        let start = Instant::now();
-                        for _ in 0..updates {
-                            let rand_leaf_num = sampler.gen_range(0..leaves);
-                            let rand_leaf_pos = leaf_positions[rand_leaf_num as usize];
-                            let rand_leaf_swap = sampler.gen_range(0..elements.len());
-                            let new_element = &elements[rand_leaf_swap];
-                            mmr.update_leaf(&mut h, rand_leaf_pos, new_element)
-                                .await
-                                .unwrap();
-                        }
-
-                        start.elapsed()
-                    });
-                },
-            );
+                            // Randomly update leaves -- this is what we are benchmarking.
+                            let start = Instant::now();
+                            for _ in 0..updates {
+                                let rand_leaf_num = sampler.gen_range(0..leaves);
+                                let rand_leaf_pos = leaf_positions[rand_leaf_num as usize];
+                                let rand_leaf_swap = sampler.gen_range(0..elements.len());
+                                let new_element = &elements[rand_leaf_swap];
+                                if batched {
+                                    mmr.update_leaf_batched(&mut h, rand_leaf_pos, new_element)
+                                        .await
+                                        .unwrap();
+                                } else {
+                                    mmr.update_leaf(&mut h, rand_leaf_pos, new_element)
+                                        .await
+                                        .unwrap();
+                                }
+                            }
+                            mmr.sync(&mut h);
+                            start.elapsed()
+                        });
+                    },
+                );
+            }
         }
     }
 }

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -180,7 +180,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             // Recover the orphaned leaf and any missing parents.
             let pos = s.mem_mmr.size();
             warn!(pos, "recovering orphaned leaf");
-            s.mem_mmr.add_leaf_digest(hasher, leaf).await.unwrap();
+            s.mem_mmr.add_leaf_digest(hasher, leaf);
             assert_eq!(pos, journal_size);
             s.sync().await?;
             assert_eq!(s.size(), s.journal.size().await?);


### PR DESCRIPTION
Adds `add_batched` and `update_leaf_batched` methods to the mem-MMR which delays parent node digest updating until `sync` in order to avoid unnecessary digest recomputations (and ultimately parallelization).  Extends the leaf-updating benchmark to compare batching to no batching.