### PR TITLE
[stream] Harden KDF for ChaCha20Poly1305 cipher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,6 @@ dependencies = [
  "futures",
  "hkdf",
  "rand",
- "sha2 0.10.8",
  "thiserror 2.0.12",
  "x25519-dalek",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,9 @@ dependencies = [
  "commonware-utils",
  "criterion",
  "futures",
+ "hkdf",
  "rand",
+ "sha2 0.10.8",
  "thiserror 2.0.12",
  "x25519-dalek",
 ]
@@ -1994,6 +1996,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,7 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror 2.0.12",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ io-uring = "0.7.4"
 rayon = "1.10.0"
 async-lock = "3.4.0"
 libc = "0.2.172"
+zeroize = "1.5.7"
 
 [profile.bench]
 # Because we enable overflow checks in "release," we should benchmark with them.

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -18,9 +18,9 @@ thiserror = { workspace = true }
 rand = { workspace = true }
 sha2 = { workspace = true }
 rayon = { workspace = true }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 ed25519-consensus = "2.1.0"
 blst = { version = "0.3.13", features = ["no-threads"] }
-zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 
 # Enable "js" feature when WASM is target

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -13,7 +13,7 @@ pub use bls12381::Bls12381;
 pub mod ed25519;
 pub use ed25519::{Ed25519, Ed25519Batch};
 pub mod sha256;
-pub use sha256::{hash, Sha256};
+pub use sha256::{hash, CoreSha256, Sha256};
 pub mod secp256r1;
 pub use secp256r1::Secp256r1;
 

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -30,6 +30,7 @@ use std::{
     fmt::{Debug, Display},
     ops::Deref,
 };
+use zeroize::Zeroize;
 
 /// Re-export `sha2::Sha256` as `CoreSha256` for external use if needed.
 pub type CoreSha256 = ISha256;
@@ -155,6 +156,12 @@ impl crate::Digest for Digest {
         let mut array = [0u8; DIGEST_LENGTH];
         rng.fill_bytes(&mut array);
         Self(array)
+    }
+}
+
+impl Zeroize for Digest {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }
 

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -31,6 +31,9 @@ use std::{
     ops::Deref,
 };
 
+/// Re-export `sha2::Sha256` as `CoreSha256` for external use if needed.
+pub type CoreSha256 = ISha256;
+
 const DIGEST_LENGTH: usize = 32;
 
 /// Generate a SHA-256 digest from a message.

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -20,7 +20,9 @@ thiserror = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
+sha2 = { workspace = true }
 chacha20poly1305 = "0.10"
+hkdf = "0.12"
 x25519-dalek = "2"
 
 [dev-dependencies]

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -21,9 +21,9 @@ bytes = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
 sha2 = { workspace = true }
-chacha20poly1305 = "0.10"
-hkdf = "0.12"
-x25519-dalek = "2"
+chacha20poly1305 = "0.10.1"
+hkdf = "0.12.4"
+x25519-dalek = "2.0.1"
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -21,6 +21,7 @@ bytes = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
 sha2 = { workspace = true }
+zeroize = { workspace = true }
 chacha20poly1305 = "0.10.1"
 hkdf = "0.12.4"
 x25519-dalek = "2.0.1"

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -20,7 +20,6 @@ thiserror = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
-sha2 = { workspace = true }
 zeroize = { workspace = true }
 chacha20poly1305 = "0.10.1"
 hkdf = "0.12.4"

--- a/stream/src/lib.rs
+++ b/stream/src/lib.rs
@@ -37,9 +37,9 @@ pub enum Error {
     #[error("shared secret was not contributory")]
     SharedSecretNotContributory,
     #[error("cipher creation failed")]
-    CipherCreationFailed,
+    CipherCreation,
     #[error("HKDF expansion failed")]
-    HKDFExpansionFailed,
+    HKDFExpansion,
     #[error("nonce overflow")]
     NonceOverflow,
     #[error("encryption failed")]

--- a/stream/src/lib.rs
+++ b/stream/src/lib.rs
@@ -38,6 +38,8 @@ pub enum Error {
     SharedSecretNotContributory,
     #[error("cipher creation failed")]
     CipherCreationFailed,
+    #[error("HKDF expansion failed")]
+    HKDFExpansionFailed,
     #[error("nonce overflow")]
     NonceOverflow,
     #[error("encryption failed")]

--- a/stream/src/public_key/benches/receiver_receive.rs
+++ b/stream/src/public_key/benches/receiver_receive.rs
@@ -14,22 +14,23 @@ fn benchmark_receiver_receive(c: &mut Criterion) {
                 || {
                     // Set up a connection between two parties.
                     // We only send messages in one direction from A to B.
-                    let cipher = ChaCha20Poly1305::new(&[0u8; 32].into());
+                    let cipher1 = ChaCha20Poly1305::new(&[1u8; 32].into());
+                    let cipher2 = ChaCha20Poly1305::new(&[2u8; 32].into());
                     let (sink, stream) = mocks::Channel::init();
                     let (sink_dummy, stream_dummy) = mocks::Channel::init();
                     let conn_a = Connection::from_preestablished(
-                        false,
                         sink,
                         stream_dummy,
-                        cipher.clone(),
                         message_size,
+                        cipher1.clone(),
+                        cipher2.clone(),
                     );
                     let conn_b = Connection::from_preestablished(
-                        true,
                         sink_dummy,
                         stream,
-                        cipher,
                         message_size,
+                        cipher2,
+                        cipher1,
                     );
 
                     let (mut sender, _) = conn_a.split();

--- a/stream/src/public_key/benches/sender_send.rs
+++ b/stream/src/public_key/benches/sender_send.rs
@@ -12,10 +12,16 @@ fn benchmark_sender_send(c: &mut Criterion) {
         c.bench_function(&format!("{}/len={}", module_path!(), message_size), |b| {
             b.iter_batched(
                 || {
-                    let cipher = ChaCha20Poly1305::new(&[0u8; 32].into());
+                    let cipher1 = ChaCha20Poly1305::new(&[1u8; 32].into());
+                    let cipher2 = ChaCha20Poly1305::new(&[2u8; 32].into());
                     let (sink, stream) = mocks::Channel::init();
-                    let connection =
-                        Connection::from_preestablished(true, sink, stream, cipher, message_size);
+                    let connection = Connection::from_preestablished(
+                        sink,
+                        stream,
+                        message_size,
+                        cipher1,
+                        cipher2,
+                    );
                     let (sender, _receiver) = connection.split();
                     let msg = msg.clone();
                     (sender, msg)

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -1,0 +1,322 @@
+use crate::Error;
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit, KeySizeUser};
+use commonware_cryptography::{Hasher, Sha256};
+use hkdf::Hkdf;
+use sha2::{digest::typenum::Unsigned, Sha256 as ISha256};
+use zeroize::Zeroize;
+
+// The size of the key used by the ChaCha20Poly1305 cipher.
+const CHACHA_KEY_SIZE: usize = <ChaCha20Poly1305 as KeySizeUser>::KeySize::USIZE;
+
+// A constant prefix used for the salt hash in the HKDF key derivation.
+const BASE_KDF_PREFIX: &[u8] = b"commonware-stream/KDF/v1/";
+
+// Info values used for deriving directional keys in the KDF.
+const D2L: u8 = 0x01; // Dialer-to-Listener
+const L2D: u8 = 0x02; // Listener-to-Dialer
+
+/// Key Derivation Function (KDF) to derive directional ChaCha20Poly1305 ciphers using HKDF-SHA256.
+///
+/// This function derives two ChaCha20Poly1305 ciphers based on:
+/// - A list of salts, usually containing:
+///   - The unique application namespace
+///   - The dialer handshake message bytes
+///   - The listener handshake message bytes
+/// - The input key material (IKM), usually the shared secret from the Diffie-Hellman key exchange
+///
+/// Returns two ChaCha20Poly1305 ciphers, intended for use as:
+/// - The dialer-to-listener cipher
+/// - The listener-to-dialer cipher
+pub fn derive(ikm: &[u8], salts: &[&[u8]]) -> Result<(ChaCha20Poly1305, ChaCha20Poly1305), Error> {
+    // Create a unique salt for the HKDF expansion.
+    // The salt is generated from a commonware-specific prefix and the list of salts provided.
+    let mut hasher = Sha256::default();
+    hasher.update(BASE_KDF_PREFIX);
+    for salt in salts {
+        hasher.update(salt);
+    }
+    let salt = hasher.finalize();
+
+    // HKDF-Extract: creates a pseudorandom key (PRK)
+    let prk = Hkdf::<ISha256>::new(Some(salt.as_ref()), ikm);
+
+    // Reusable buffer for derived keys
+    let mut buf = [0u8; CHACHA_KEY_SIZE];
+
+    // Dialer-to-Listener cipher
+    prk.expand(&[D2L], &mut buf)
+        .map_err(|_| Error::HKDFExpansion)?;
+    let d2l_cipher = ChaCha20Poly1305::new_from_slice(&buf).map_err(|_| Error::CipherCreation)?;
+
+    // Listener-to-Dialer cipher
+    prk.expand(&[L2D], &mut buf)
+        .map_err(|_| Error::HKDFExpansion)?;
+    let l2d_cipher = ChaCha20Poly1305::new_from_slice(&buf).map_err(|_| Error::CipherCreation)?;
+
+    // Clear the buffer for security
+    buf.zeroize();
+
+    Ok((d2l_cipher, l2d_cipher))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chacha20poly1305::aead::Aead;
+
+    #[test]
+    fn test_derive_success() {
+        let ikm = [1u8; CHACHA_KEY_SIZE];
+        let salt_data1 = b"test_salt_data_success_1";
+        let salt_data2 = b"test_salt_data_success_2";
+        let salts_arr: [&[u8]; 2] = [salt_data1, salt_data2];
+
+        let result = derive(&ikm, &salts_arr);
+        assert!(result.is_ok());
+        let (cipher1, cipher2) = result.unwrap();
+
+        // Basic check: encrypt something and ensure ciphers are different
+        let nonce = Default::default();
+        let plaintext = b"test_encryption";
+        let ciphertext1 = cipher1
+            .encrypt(&nonce, plaintext.as_ref())
+            .expect("Cipher1 encryption failed");
+        let ciphertext2 = cipher2
+            .encrypt(&nonce, plaintext.as_ref())
+            .expect("Cipher2 encryption failed");
+        assert_ne!(
+            ciphertext1, ciphertext2,
+            "Derived ciphers (d2l and l2d) should be different due to KDF info params"
+        );
+    }
+
+    #[test]
+    fn test_derive_consistency() {
+        let ikm = [2u8; CHACHA_KEY_SIZE];
+        let salt_data1 = b"consistency_salt_1";
+        let salt_data2 = b"consistency_salt_2";
+        let salts_arr: [&[u8]; 2] = [salt_data1, salt_data2];
+
+        let (cipher1_a, cipher2_a) = derive(&ikm, &salts_arr).unwrap();
+        let (cipher1_b, cipher2_b) = derive(&ikm, &salts_arr).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"consistency_check";
+
+        assert_eq!(
+            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "D2L ciphers should be consistent for the same inputs"
+        );
+        assert_eq!(
+            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "L2D ciphers should be consistent for the same inputs"
+        );
+    }
+
+    #[test]
+    fn test_derive_sensitivity_to_ikm() {
+        let salt_data = b"common_salt_for_ikm_test";
+        let salts_arr: [&[u8]; 1] = [salt_data];
+
+        let ikm1 = [3u8; CHACHA_KEY_SIZE];
+        let (cipher1_a, cipher2_a) = derive(&ikm1, &salts_arr).unwrap();
+
+        let ikm2 = [4u8; CHACHA_KEY_SIZE]; // Different IKM
+        let (cipher1_b, cipher2_b) = derive(&ikm2, &salts_arr).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"ikm_sensitivity_check";
+
+        assert_ne!(
+            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "D2L cipher should change with IKM"
+        );
+        assert_ne!(
+            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "L2D cipher should change with IKM"
+        );
+    }
+
+    #[test]
+    fn test_derive_sensitivity_to_salt_element_content() {
+        let ikm = [5u8; CHACHA_KEY_SIZE];
+        let common_salt_element = b"common_element";
+
+        let salts1_data: [&[u8]; 2] = [b"salt_A", common_salt_element];
+        let (cipher1_a, cipher2_a) = derive(&ikm, &salts1_data).unwrap();
+
+        let salts2_data: [&[u8]; 2] = [b"salt_B", common_salt_element]; // Different content in first salt element
+        let (cipher1_b, cipher2_b) = derive(&ikm, &salts2_data).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"salt_content_sensitivity";
+
+        assert_ne!(
+            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "D2L cipher should change with salt element content"
+        );
+        assert_ne!(
+            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "L2D cipher should change with salt element content"
+        );
+    }
+
+    #[test]
+    fn test_derive_sensitivity_to_number_of_salt_elements() {
+        let ikm = [6u8; CHACHA_KEY_SIZE];
+        let salt_element_a = b"element_A";
+        let salt_element_b = b"element_B";
+
+        let salts1_data: [&[u8]; 1] = [salt_element_a]; // One salt element
+        let (cipher1_a, cipher2_a) = derive(&ikm, &salts1_data).unwrap();
+
+        let salts2_data: [&[u8]; 2] = [salt_element_a, salt_element_b]; // Two salt elements
+        let (cipher1_b, cipher2_b) = derive(&ikm, &salts2_data).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"num_salts_sensitivity";
+
+        assert_ne!(
+            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "D2L cipher should change with the number of salt elements"
+        );
+        assert_ne!(
+            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "L2D cipher should change with the number of salt elements"
+        );
+    }
+
+    #[test]
+    fn test_derive_sensitivity_to_order_of_salt_elements() {
+        let ikm = [7u8; CHACHA_KEY_SIZE];
+        let salt_element_x = b"element_X";
+        let salt_element_y = b"element_Y";
+
+        let salts1_data: [&[u8]; 2] = [salt_element_x, salt_element_y];
+        let (cipher1_a, cipher2_a) = derive(&ikm, &salts1_data).unwrap();
+
+        let salts2_data: [&[u8]; 2] = [salt_element_y, salt_element_x]; // Different order
+        let (cipher1_b, cipher2_b) = derive(&ikm, &salts2_data).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"order_salts_sensitivity";
+
+        assert_ne!(
+            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "D2L cipher should change with the order of salt elements"
+        );
+        assert_ne!(
+            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "L2D cipher should change with the order of salt elements"
+        );
+    }
+
+    #[test]
+    fn test_derive_with_empty_salts_slice() {
+        let ikm = [8u8; CHACHA_KEY_SIZE];
+        let empty_salts: [&[u8]; 0] = []; // Empty slice of salts
+
+        let result = derive(&ikm, &empty_salts);
+        assert!(
+            result.is_ok(),
+            "Derivation with empty salts slice should succeed"
+        );
+
+        // Further check: ensure it's different from derivation with non-empty salts
+        let salt_data = b"some_salt";
+        let non_empty_salts: [&[u8]; 1] = [salt_data];
+        let (cipher1_empty, cipher2_empty) = result.unwrap();
+        let (cipher1_non_empty, cipher2_non_empty) = derive(&ikm, &non_empty_salts).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"empty_salts_check";
+
+        assert_ne!(
+            cipher1_empty.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher1_non_empty
+                .encrypt(&nonce, plaintext.as_ref())
+                .unwrap(),
+            "D2L cipher with empty salts should differ from non-empty"
+        );
+        assert_ne!(
+            cipher2_empty.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher2_non_empty
+                .encrypt(&nonce, plaintext.as_ref())
+                .unwrap(),
+            "L2D cipher with empty salts should differ from non-empty"
+        );
+    }
+
+    #[test]
+    fn test_derive_with_empty_salt_element_in_slice() {
+        let ikm = [9u8; CHACHA_KEY_SIZE];
+        let empty_salt_element: &[u8] = b"";
+        let salts_with_empty_element: [&[u8]; 1] = [empty_salt_element];
+
+        let result = derive(&ikm, &salts_with_empty_element);
+        assert!(
+            result.is_ok(),
+            "Derivation with an empty salt element should succeed"
+        );
+
+        // Further check: ensure it's different from derivation with non-empty salt or fully empty salts
+        let (cipher1_with_empty_el, cipher2_with_empty_el) = result.unwrap();
+
+        let salt_data = b"non_empty_salt_element";
+        let salts_with_non_empty_el: [&[u8]; 1] = [salt_data];
+        let (cipher1_non_empty_el, cipher2_non_empty_el) =
+            derive(&ikm, &salts_with_non_empty_el).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"empty_salt_element_check";
+
+        assert_ne!(
+            cipher1_with_empty_el
+                .encrypt(&nonce, plaintext.as_ref())
+                .unwrap(),
+            cipher1_non_empty_el
+                .encrypt(&nonce, plaintext.as_ref())
+                .unwrap(),
+            "D2L cipher with empty salt element should differ from one with non-empty salt element"
+        );
+        assert_ne!(
+            cipher2_with_empty_el
+                .encrypt(&nonce, plaintext.as_ref())
+                .unwrap(),
+            cipher2_non_empty_el
+                .encrypt(&nonce, plaintext.as_ref())
+                .unwrap(),
+            "L2D cipher with empty salt element should differ from one with non-empty salt element"
+        );
+    }
+
+    #[test]
+    fn test_d2l_and_l2d_are_different() {
+        let ikm = [10u8; CHACHA_KEY_SIZE];
+        let salt_data = b"test_salt_for_d2l_l2d_diff";
+        let salts_arr: [&[u8]; 1] = [salt_data];
+        let (d2l_cipher, l2d_cipher) = derive(&ikm, &salts_arr).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"d2l_l2d_test_message";
+
+        let ciphertext_d2l = d2l_cipher
+            .encrypt(&nonce, plaintext.as_ref())
+            .expect("D2L encryption failed");
+        let ciphertext_l2d = l2d_cipher
+            .encrypt(&nonce, plaintext.as_ref())
+            .expect("L2D encryption failed");
+
+        assert_ne!(ciphertext_d2l, ciphertext_l2d, "D2L and L2D ciphers should produce different ciphertexts for the same input due to different KDF info parameters.");
+    }
+}

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -13,15 +13,19 @@ const BASE_KDF_PREFIX: &[u8] = b"commonware-stream/KDF/v1/";
 /// Key Derivation Function (KDF) to derive directional ChaCha20Poly1305 ciphers using HKDF-SHA256.
 ///
 /// This function derives two ChaCha20Poly1305 ciphers based on:
-/// - A list of salts, usually containing:
+/// - The input key material (IKM), usually the shared secret from the Diffie-Hellman key exchange
+/// - An ordered list of byte slices (salts), where the order is critical for consistent derivation
+///   between the dialer and the listener. The list usually contains:
 ///   - The unique application namespace
 ///   - The dialer handshake message bytes
 ///   - The listener handshake message bytes
-/// - The input key material (IKM), usually the shared secret from the Diffie-Hellman key exchange
 ///
 /// Returns two ChaCha20Poly1305 ciphers, intended for use as:
 /// - The dialer-to-listener cipher
 /// - The listener-to-dialer cipher
+///
+/// The dialer and listener must use the ciphers in the same order to ensure proper encryption and
+/// decryption.
 pub fn derive(ikm: &[u8], salts: &[&[u8]]) -> Result<(ChaCha20Poly1305, ChaCha20Poly1305), Error> {
     // Create a unique salt for the HKDF expansion.
     // The salt is generated from a commonware-specific prefix and the list of salts provided.

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -1,8 +1,8 @@
 use crate::Error;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit, KeySizeUser};
 use commonware_cryptography::{Hasher, Sha256};
-use hkdf::Hkdf;
-use sha2::{digest::typenum::Unsigned, Sha256 as ISha256};
+use hkdf::{hmac::digest::typenum::Unsigned, Hkdf};
+use sha2::Sha256 as ISha256;
 use zeroize::Zeroize;
 
 // The size of the key used by the ChaCha20Poly1305 cipher.

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -1,8 +1,7 @@
 use crate::Error;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit, KeySizeUser};
-use commonware_cryptography::{Hasher, Sha256};
+use commonware_cryptography::{CoreSha256, Hasher, Sha256};
 use hkdf::{hmac::digest::typenum::Unsigned, Hkdf};
-use sha2::Sha256 as ISha256;
 use zeroize::Zeroize;
 
 // The size of the key used by the ChaCha20Poly1305 cipher.
@@ -38,7 +37,7 @@ pub fn derive(ikm: &[u8], salts: &[&[u8]]) -> Result<(ChaCha20Poly1305, ChaCha20
     let salt = hasher.finalize();
 
     // HKDF-Extract: creates a pseudorandom key (PRK)
-    let prk = Hkdf::<ISha256>::new(Some(salt.as_ref()), ikm);
+    let prk = Hkdf::<CoreSha256>::new(Some(salt.as_ref()), ikm);
 
     // Reusable buffer for derived keys
     let mut buf = [0u8; CHACHA_KEY_SIZE];

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -29,7 +29,13 @@ const BASE_KDF_PREFIX: &[u8] = b"commonware-stream/KDF/v1/";
 const D2L: u8 = 0x01; // Dialer-to-Listener
 const L2D: u8 = 0x02; // Listener-to-Dialer
 
-/// Helper function to derive directional keys using HKDF-SHA256.
+/// Key Derivation Function (KDF) to derive directional ChaCha20Poly1305 ciphers using HKDF-SHA256.
+///
+/// This function derives two ChaCha20Poly1305 ciphers based on:
+/// - A shared secret from the Diffie-Hellman key exchange
+/// - The unique application namespace
+/// - The dialer handshake message bytes
+/// - The listener handshake message bytes
 ///
 /// Returns a tuple of the:
 /// - dialer-to-listener cipher

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -6,13 +6,13 @@ use crate::{
 use bytes::Bytes;
 use chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit, KeySizeUser};
 use commonware_codec::{DecodeExt, Encode};
-use commonware_cryptography::Scheme;
+use commonware_cryptography::{Hasher, Scheme, Sha256};
 use commonware_macros::select;
 use commonware_runtime::{Clock, Sink, Spawner, Stream};
 use commonware_utils::SystemTimeExt as _;
 use hkdf::Hkdf;
 use rand::{CryptoRng, Rng};
-use sha2::{digest::typenum::Unsigned, Digest, Sha256};
+use sha2::{digest::typenum::Unsigned, Sha256 as ISha256};
 use std::time::SystemTime;
 
 // When encrypting data, an encryption tag is appended to the ciphertext.
@@ -62,7 +62,7 @@ fn derive_ciphers(
     // HKDF-Extract: Create a pseudorandom key (PRK) based on:
     // - The salt
     // - The shared secret from the Diffie-Hellman key exchange
-    let prk = Hkdf::<Sha256>::new(Some(salt.as_slice()), shared_secret);
+    let prk = Hkdf::<ISha256>::new(Some(salt.as_ref()), shared_secret);
 
     // Reusable buffer for derived keys
     let mut buf = [0u8; CHACHA_KEY_SIZE];

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -45,22 +45,20 @@
 //! ## Encryption
 //!
 //! During the handshake (described above), a shared x25519 secret is established using a
-//! Diffie-Hellman Key Exchange. This x25519 secret is then used to create a ChaCha20-Poly1305
-//! cipher for encrypting all messages exchanged with the peer.
+//! Diffie-Hellman Key Exchange. This x25519 secret is then used in-conjunction with the handshake
+//! data in a key-derivation-function to create a pair of ChaCha20-Poly1305 ciphers. One cipher per
+//! direction allows for encryption of all messages.
 //!
-//! Each peer maintains a pair of ChaCha20-Poly1305 nonces (12 bytes), one for itself and one for
-//! the other. Each nonce is constructed using a counter that starts at either 1 for the dialer, or
-//! 0 for the listener. For each message sent, the relevant counter is incremented by 2, ensuring that
-//! the two counters have disjoint nonce spaces.
+//! Each direction of communication also uses a 12-byte nonce derived from a counter that is
+//! incremented for each message sent. This provides for a maximum of 2^96 messages per sender,
+//! which is sufficient for all practical use cases. This approach ensures well-behaving peers, as
+//! long as they both stay online, remain connected indefinitely (maximizing the stability of any
+//! p2p construction). In an unlikely case of overflow, a new connection should be established.
 //!
-//! The nonce is the least-significant 12 bytes of the counter, encoded big-endian. This provides 2^95 unique nonces
-//! per sender, sufficient for over 1 trillion years at 1 billion messages/second—far exceeding practical limits. This approach
-//! ensures well-behaving peers, as long as they both stay online, remain connected indefinitely (maximizing the stability
-//! of any p2p construction). In an unlikely case of overflow, the connection would terminate, and a new handshake would be required.
-//!
-//! This simple coordination prevents nonce reuse (which would allow for messages to be decrypted) and saves a small amount of
-//! bandwidth (no need to send the nonce alongside the encrypted message). This "pedantic" construction of the nonce
-//! also avoids accidental reuse of a nonce over long-lived connections (when setting it to be a small hash as in XChaCha20-Poly1305).
+//! This simple coordination prevents nonce reuse (which would allow for messages to be decrypted)
+//! and saves a small amount of bandwidth (no need to send the nonce alongside the encrypted
+//! message). This also avoids accidental reuse of a nonce over long-lived connections (for example
+//! when setting it to be a small hash as in XChaCha20-Poly1305).
 
 use commonware_cryptography::Scheme;
 use std::time::Duration;

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -51,9 +51,11 @@
 //!
 //! Each direction of communication also uses a 12-byte nonce derived from a counter that is
 //! incremented for each message sent. This provides for a maximum of 2^96 messages per sender,
-//! which is sufficient for all practical use cases. This approach ensures well-behaving peers, as
-//! long as they both stay online, remain connected indefinitely (maximizing the stability of any
-//! p2p construction). In an unlikely case of overflow, a new connection should be established.
+//! which would be sufficient for over 2.5 trillion years of continuous communication at a rate of
+//! 1 billion messages per second. In other words, sufficient for all practical use cases. This
+//! approach ensures well-behaving peers, as long as they both stay online, remain connected
+//! indefinitely (maximizing the stability of any p2p construction). In an unlikely case of
+//! overflow, a new connection should be established.
 //!
 //! This simple coordination prevents nonce reuse (which would allow for messages to be decrypted)
 //! and saves a small amount of bandwidth (no need to send the nonce alongside the encrypted

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -63,6 +63,7 @@
 use commonware_cryptography::Scheme;
 use std::time::Duration;
 
+mod cipher;
 mod connection;
 pub use connection::{Connection, IncomingConnection, Receiver, Sender};
 mod handshake;

--- a/stream/src/public_key/nonce.rs
+++ b/stream/src/public_key/nonce.rs
@@ -1,13 +1,9 @@
 use crate::Error;
 use chacha20poly1305::Nonce;
 
-/// A struct that holds the nonce information.
-///
-/// Holds a counter value that is incremented by 2 each time the nonce is used.
-/// The least-significant bit does not change, allowing for two disjoint nonce spaces (one for each
-/// side of a connection).
-///
-/// Is able to be incremented up-to 96 bits (12 bytes) before overflowing.
+/// A struct that holds the nonce information. Holds a counter value that is incremented each time
+/// the nonce is used. Is able to be incremented up-to 96 bits (12 bytes) before overflowing.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Info {
     counter: u128,
 }
@@ -17,28 +13,13 @@ pub struct Info {
 const OVERFLOW_VALUE: u128 = 1 << 96;
 
 impl Info {
-    /// Creates a new `Info` struct.
-    ///
-    /// The `dialer` parameter indicates whether the sender is the dialer or not.
-    /// For example, if the client was the dialer, this is set to true for your own nonces, but
-    /// false for the peer's nonces.
-    pub fn new(dialer: bool) -> Self {
-        Self {
-            counter: if dialer { 1 } else { 0 },
-        }
-    }
-
-    /// Increments the nonce.
-    ///
-    /// The counter is incremented by 2, which prevents nonce reuse while also maintaining the value
-    /// of the least-significant bit. This ensures that the nonce space is disjoint for two nonces
-    /// initialized with different boolean values.
+    /// Increments the nonce by 1.
     ///
     /// An error is returned if-and-only-if the nonce overflows 96 bits.
     pub fn inc(&mut self) -> Result<(), Error> {
-        // This line does not need to check for overflow as the counter should not be initialized
-        // to a value greater than 2^96.
-        let new_counter = self.counter + 2;
+        // This line does not need to check for u128 overflow as the counter should be initialized
+        // to 0.
+        let new_counter = self.counter + 1;
 
         // Check for overflow over 96 bits (12 bytes)
         if new_counter >= OVERFLOW_VALUE {
@@ -71,15 +52,15 @@ mod tests {
     fn test_encode() {
         let mut expected = [0u8; 12];
 
-        // Even
-        let even = Info::new(false);
-        assert_eq!(even.encode()[..], expected[..]);
+        // 0
+        let nonce = Info::default();
+        assert_eq!(nonce.encode()[..], expected[..]);
 
-        // Odd
-        let odd = Info::new(true);
+        // 1
+        let nonce = Info { counter: 1 };
         expected = [0u8; 12];
         expected[11] = 1;
-        assert_eq!(odd.encode()[..], expected[..]);
+        assert_eq!(nonce.encode()[..], expected[..]);
 
         // Two bytes are set
         let two_byte = Info { counter: 0x0102 };
@@ -100,27 +81,24 @@ mod tests {
     }
 
     #[test]
-    fn test_even() {
-        let mut even = Info::new(false);
-        assert_eq!(even.counter, 0);
+    fn test_inc() {
+        let mut nonce = Info::default();
 
-        even.inc().unwrap();
-        assert_eq!(even.counter, 2);
+        // Incrementing should succeed
+        assert!(nonce.inc().is_ok());
+        assert_eq!(nonce.counter, 1);
 
-        even.inc().unwrap();
-        assert_eq!(even.counter, 4);
-    }
+        // Incrementing again should succeed
+        assert!(nonce.inc().is_ok());
+        assert_eq!(nonce.counter, 2);
 
-    #[test]
-    fn test_odd() {
-        let mut odd = Info::new(true);
-        assert_eq!(odd.counter, 1);
+        // Incrementing to the overflow value should succeed
+        nonce.counter = OVERFLOW_VALUE - 1;
+        assert!(nonce.inc().is_ok());
+        assert_eq!(nonce.counter, OVERFLOW_VALUE);
 
-        odd.inc().unwrap();
-        assert_eq!(odd.counter, 3);
-
-        odd.inc().unwrap();
-        assert_eq!(odd.counter, 5);
+        // Incrementing again should overflow
+        assert!(matches!(nonce.inc(), Err(Error::NonceOverflow)));
     }
 
     #[test]
@@ -128,16 +106,15 @@ mod tests {
         let initial = (1 << 96) - 2;
         let mut nonce = Info { counter: initial };
 
-        assert!(matches!(nonce.inc(), Err(Error::NonceOverflow)));
-        assert_eq!(nonce.counter, initial);
-    }
+        // Incrementing should succeed
+        assert!(nonce.inc().is_ok());
 
-    #[test]
-    fn test_inc_overflow_odd() {
-        let initial = (1 << 96) - 1;
-        let mut nonce = Info { counter: initial };
-
+        // Incrementing again should overflow
         assert!(matches!(nonce.inc(), Err(Error::NonceOverflow)));
-        assert_eq!(nonce.counter, initial);
+        assert_eq!(nonce.counter, initial + 1);
+
+        // Incrementing again should not change the counter
+        assert!(matches!(nonce.inc(), Err(Error::NonceOverflow)));
+        assert_eq!(nonce.counter, initial + 1);
     }
 }

--- a/stream/src/public_key/nonce.rs
+++ b/stream/src/public_key/nonce.rs
@@ -91,19 +91,11 @@ mod tests {
         // Incrementing again should succeed
         assert!(nonce.inc().is_ok());
         assert_eq!(nonce.counter, 2);
-
-        // Incrementing to the overflow value should succeed
-        nonce.counter = OVERFLOW_VALUE - 1;
-        assert!(nonce.inc().is_ok());
-        assert_eq!(nonce.counter, OVERFLOW_VALUE);
-
-        // Incrementing again should overflow
-        assert!(matches!(nonce.inc(), Err(Error::NonceOverflow)));
     }
 
     #[test]
-    fn test_inc_overflow_even() {
-        let initial = (1 << 96) - 2;
+    fn test_inc_overflow() {
+        let initial = OVERFLOW_VALUE - 2;
         let mut nonce = Info { counter: initial };
 
         // Incrementing should succeed


### PR DESCRIPTION
Thanks to @dnkolegov-ar for finding these issues

Fixes #1013 
Fixes #1014 
Fixes #1016 

Updates the `ChaCha20Poly1305` cipher derivation for the `commonware-stream::public_key` module:
- Uses `hkdf` and `sha2::Sha256` to derive the cipher from the Diffie-Hellman  shared secret (rather than the shared secret directly)
- Includes a "commonware" constant, the application namespace, and the handshake transcript into the cipher derivation to tie the construction to the exact usecase
- Creates separate ciphers for each direction, allowing for simplification of the cipher nonce code