### PR TITLE
[storage/journal] Fix `journal::variable` Handling

### DIFF
--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -647,7 +647,7 @@ impl<
                 debug!(view = past_view, "rebroadcast entry nullification");
             } else {
                 warn!(
-                    view = past_view,
+                    current = self.view,
                     "unable to rebroadcast entry notarization/nullification/finalization"
                 );
             }

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -804,7 +804,7 @@ impl<
                 debug!(view = past_view, "rebroadcast entry nullification");
             } else {
                 warn!(
-                    view = past_view,
+                    current = self.view,
                     "unable to rebroadcast entry notarization/nullification/finalization"
                 );
             }

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -41,13 +41,10 @@ use prometheus_client::metrics::{
     counter::Counter, family::Family, gauge::Gauge, histogram::Histogram,
 };
 use rand::Rng;
+use std::sync::{atomic::AtomicI64, Arc};
 use std::{
     collections::BTreeMap,
     time::{Duration, SystemTime},
-};
-use std::{
-    sync::{atomic::AtomicI64, Arc},
-    time::Instant,
 };
 use tracing::{debug, info, trace, warn};
 
@@ -1674,7 +1671,7 @@ impl<
         .expect("unable to open journal");
 
         // Rebuild from journal
-        let start = Instant::now();
+        let start = self.context.current();
         {
             let stream = journal
                 .replay(self.replay_concurrency, self.replay_buffer)
@@ -1764,8 +1761,14 @@ impl<
         self.journal = Some(journal);
 
         // Update current view and immediately move to timeout (very unlikely we restarted and still within timeout)
+        let end = self.context.current();
+        let elapsed = end.duration_since(start).unwrap_or_default();
         let observed_view = self.view;
-        info!(current_view = observed_view, elapsed = ?start.elapsed(), "consensus initialized");
+        info!(
+            current_view = observed_view,
+            ?elapsed,
+            "consensus initialized"
+        );
         {
             let round = self.views.get_mut(&observed_view).expect("missing round");
             round.leader_deadline = Some(self.context.current());

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -16,36 +16,36 @@ mod tests {
     fn test_read_basic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Create a memory blob with some test data
+            // Test basic buffered reading functionality with sequential reads
             let data = b"Hello, world! This is a test.";
             let (blob, size) = context.open("partition", b"test").await.unwrap();
             assert_eq!(size, 0);
             blob.write_at(data.to_vec(), 0).await.unwrap();
             let size = data.len() as u64;
 
-            // Create a buffer reader with a small buffer size
-            let lookahead = 10;
-            let mut reader = Read::new(blob, size, lookahead);
+            // Create a buffered reader with small buffer to test refilling
+            let buffer_size = 10;
+            let mut reader = Read::new(blob, size, buffer_size);
 
             // Read some data
             let mut buf = [0u8; 5];
             reader.read_exact(&mut buf, 5).await.unwrap();
             assert_eq!(&buf, b"Hello");
 
-            // Read more data that requires a refill
+            // Read more data that requires a buffer refill
             let mut buf = [0u8; 14];
             reader.read_exact(&mut buf, 14).await.unwrap();
             assert_eq!(&buf, b", world! This ");
 
-            // Verify position
+            // Verify position tracking
             assert_eq!(reader.position(), 19);
 
-            // Read the rest
+            // Read the remaining data
             let mut buf = [0u8; 10];
             reader.read_exact(&mut buf, 7).await.unwrap();
             assert_eq!(&buf[..7], b"is a te");
 
-            // Try to read beyond the end
+            // Attempt to read beyond the end should fail
             let mut buf = [0u8; 5];
             let result = reader.read_exact(&mut buf, 5).await;
             assert!(matches!(result, Err(Error::BlobInsufficientLength)));
@@ -57,16 +57,16 @@ mod tests {
     fn test_read_empty() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Create a memory blob with some test data
+            // Test that creating a reader with zero buffer size panics
             let data = b"Hello, world! This is a test.";
             let (blob, size) = context.open("partition", b"test").await.unwrap();
             assert_eq!(size, 0);
             blob.write_at(data.to_vec(), 0).await.unwrap();
             let size = data.len() as u64;
 
-            // Create a buffer reader with a small buffer size
-            let lookahead = 0;
-            Read::new(blob, size, lookahead);
+            // This should panic
+            let buffer_size = 0;
+            Read::new(blob, size, buffer_size);
         });
     }
 
@@ -74,31 +74,31 @@ mod tests {
     fn test_read_cross_boundary() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Create a memory blob with some test data
+            // Test reading data that spans multiple buffer refills
             let data = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
             let (blob, size) = context.open("partition", b"test").await.unwrap();
             assert_eq!(size, 0);
             blob.write_at(data.to_vec(), 0).await.unwrap();
             let size = data.len() as u64;
 
-            // Create a buffer reader with buffer size 10
+            // Use a buffer smaller than the total data size
             let buffer_size = 10;
             let mut reader = Read::new(blob, size, buffer_size);
 
-            // Read data that crosses a buffer boundary
+            // Read data that crosses buffer boundaries
             let mut buf = [0u8; 15];
             reader.read_exact(&mut buf, 15).await.unwrap();
             assert_eq!(&buf, b"ABCDEFGHIJKLMNO");
 
-            // Position should be 15
+            // Verify position tracking
             assert_eq!(reader.position(), 15);
 
-            // Read the rest
+            // Read the remaining data
             let mut buf = [0u8; 11];
             reader.read_exact(&mut buf, 11).await.unwrap();
             assert_eq!(&buf, b"PQRSTUVWXYZ");
 
-            // Position should be 26
+            // Verify we're at the end
             assert_eq!(reader.position(), 26);
             assert_eq!(reader.blob_remaining(), 0);
         });
@@ -108,29 +108,29 @@ mod tests {
     fn test_read_with_known_size() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Create a memory blob with some test data
+            // Test reader behavior with known blob size limits
             let data = b"This is a test with known size limitations.";
             let (blob, size) = context.open("partition", b"test").await.unwrap();
             assert_eq!(size, 0);
             blob.write_at(data.to_vec(), 0).await.unwrap();
             let size = data.len() as u64;
 
-            // Create a buffer reader with a buffer smaller than the data
+            // Create a buffered reader with buffer smaller than total data
             let buffer_size = 10;
             let mut reader = Read::new(blob, size, buffer_size);
 
-            // Check remaining bytes in the blob
+            // Check initial remaining bytes
             assert_eq!(reader.blob_remaining(), size);
 
-            // Read half the buffer size
+            // Read partial data
             let mut buf = [0u8; 5];
             reader.read_exact(&mut buf, 5).await.unwrap();
             assert_eq!(&buf, b"This ");
 
-            // Check remaining after read
+            // Check remaining bytes after partial read
             assert_eq!(reader.blob_remaining(), size - 5);
 
-            // Try to read exactly up to the size limit
+            // Read exactly up to the size limit
             let mut buf = vec![0u8; (size - 5) as usize];
             reader
                 .read_exact(&mut buf, (size - 5) as usize)
@@ -138,10 +138,10 @@ mod tests {
                 .unwrap();
             assert_eq!(&buf, b"is a test with known size limitations.");
 
-            // Now we should be at the end
+            // Verify we're at the end
             assert_eq!(reader.blob_remaining(), 0);
 
-            // Trying to read more should fail
+            // Reading beyond the end should fail
             let mut buf = [0u8; 1];
             let result = reader.read_exact(&mut buf, 1).await;
             assert!(matches!(result, Err(Error::BlobInsufficientLength)));
@@ -152,7 +152,7 @@ mod tests {
     fn test_read_large_data() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Create a larger blob for testing with larger data
+            // Test reading large amounts of data in chunks
             let data_size = 1024 * 256; // 256KB of data
             let data = vec![0x42; data_size];
             let (blob, size) = context.open("partition", b"test").await.unwrap();
@@ -160,11 +160,11 @@ mod tests {
             blob.write_at(data.clone(), 0).await.unwrap();
             let size = data.len() as u64;
 
-            // Create a buffer with size smaller than the data
-            let buffer_size = 64 * 1024; // 64KB
+            // Use a buffer much smaller than the total data
+            let buffer_size = 64 * 1024; // 64KB buffer
             let mut reader = Read::new(blob, size, buffer_size);
 
-            // Read all the data in chunks
+            // Read all data in smaller chunks
             let mut total_read = 0;
             let chunk_size = 8 * 1024; // 8KB chunks
             let mut buf = vec![0u8; chunk_size];
@@ -176,7 +176,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                // Verify the data is correct (all bytes should be 0x42)
+                // Verify data integrity
                 assert!(
                     buf[..to_read].iter().all(|&b| b == 0x42),
                     "Data at position {} is not correct",
@@ -189,7 +189,7 @@ mod tests {
             // Verify we read everything
             assert_eq!(total_read, data_size);
 
-            // Trying to read more should fail
+            // Reading beyond the end should fail
             let mut extra_buf = [0u8; 1];
             let result = reader.read_exact(&mut extra_buf, 1).await;
             assert!(matches!(result, Err(Error::BlobInsufficientLength)));
@@ -402,7 +402,7 @@ mod tests {
     fn test_write_basic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test basic write_at and sync functionality.
+            // Test basic buffered write and sync functionality
             let (blob, size) = context.open("partition", b"write_basic").await.unwrap();
             assert_eq!(size, 0);
 
@@ -412,6 +412,7 @@ mod tests {
             writer.sync().await.unwrap();
             assert_eq!(writer.size().await, 5);
 
+            // Verify data was written correctly
             let (blob, size) = context.open("partition", b"write_basic").await.unwrap();
             assert_eq!(size, 5);
             let mut reader = Read::new(blob, size, 8);
@@ -425,7 +426,7 @@ mod tests {
     fn test_write_multiple_flushes() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test writing data that causes multiple buffer flushes.
+            // Test writes that cause buffer flushes due to capacity limits
             let (blob, size) = context.open("partition", b"write_multi").await.unwrap();
             assert_eq!(size, 0);
 
@@ -435,8 +436,8 @@ mod tests {
             writer.write_at("defg".as_bytes(), 3).await.unwrap();
             assert_eq!(writer.size().await, 7);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 7);
 
+            // Verify the final result
             let (blob, size) = context.open("partition", b"write_multi").await.unwrap();
             assert_eq!(size, 7);
             let mut reader = Read::new(blob, size, 4);
@@ -450,8 +451,8 @@ mod tests {
     fn test_write_large_data() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test writing data significantly larger than the buffer capacity.
-            let (blob, size) = context.open("partition", b"write_multi").await.unwrap();
+            // Test writing data larger than buffer capacity (direct write)
+            let (blob, size) = context.open("partition", b"write_large").await.unwrap();
             assert_eq!(size, 0);
 
             let writer = Write::new(blob.clone(), size, 4);
@@ -465,7 +466,8 @@ mod tests {
             writer.sync().await.unwrap();
             assert_eq!(writer.size().await, 26);
 
-            let (blob, size) = context.open("partition", b"write_multi").await.unwrap();
+            // Verify the complete data
+            let (blob, size) = context.open("partition", b"write_large").await.unwrap();
             assert_eq!(size, 26);
             let mut reader = Read::new(blob, size, 4);
             let mut buf = [0u8; 26];
@@ -479,7 +481,7 @@ mod tests {
     fn test_write_empty() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test creating a writer with zero buffer capacity.
+            // Test that creating a writer with zero buffer capacity panics
             let (blob, size) = context.open("partition", b"write_empty").await.unwrap();
             assert_eq!(size, 0);
             Write::new(blob, size, 0);
@@ -490,19 +492,20 @@ mod tests {
     fn test_write_append_to_buffer() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test appending data that partially fits and then exceeds buffer capacity, causing a flush.
+            // Test sequential appends that exceed buffer capacity
             let (blob, size) = context.open("partition", b"append_buf").await.unwrap();
             let writer = Write::new(blob.clone(), size, 10);
 
-            // Write "hello" (5 bytes) - fits in buffer
+            // Write data that fits in buffer
             writer.write_at("hello".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 5);
-            // Append " world" (6 bytes) - "hello world" is 11 bytes, exceeds buffer
-            // "hello" is flushed, " world" is buffered
+
+            // Append data that causes buffer flush
             writer.write_at(" world".as_bytes(), 5).await.unwrap();
             writer.sync().await.unwrap();
             assert_eq!(writer.size().await, 11);
 
+            // Verify the complete result
             let (blob, size) = context.open("partition", b"append_buf").await.unwrap();
             assert_eq!(size, 11);
             let mut reader = Read::new(blob, size, 10);
@@ -516,35 +519,35 @@ mod tests {
     fn test_write_into_middle_of_buffer() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test writing data into the middle of an existing, partially filled buffer.
+            // Test overwriting data within the buffer and extending it
             let (blob, size) = context.open("partition", b"middle_buf").await.unwrap();
             let writer = Write::new(blob.clone(), size, 20);
 
-            // Write "abcdefghij" (10 bytes)
+            // Initial write
             writer.write_at("abcdefghij".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 10);
-            // Write "01234" into the middle (offset 2, 5 bytes) -> "ab01234hij"
+
+            // Overwrite middle section
             writer.write_at("01234".as_bytes(), 2).await.unwrap();
             assert_eq!(writer.size().await, 10);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 10);
 
+            // Verify overwrite result
             let (blob, size) = context.open("partition", b"middle_buf").await.unwrap();
-            assert_eq!(size, 10); // Original length, as it's an overwrite
+            assert_eq!(size, 10);
             let mut reader = Read::new(blob, size, 10);
             let mut buf = vec![0u8; 10];
             reader.read_exact(&mut buf, 10).await.unwrap();
             assert_eq!(&buf, b"ab01234hij");
 
-            // Write "klmnopqrst" (10 bytes) - buffer becomes "ab01234hijklmnopqrst" (20 bytes)
+            // Extend buffer and do partial overwrite
             writer.write_at("klmnopqrst".as_bytes(), 10).await.unwrap();
             assert_eq!(writer.size().await, 20);
-            // Overwrite "jklm" with "wxyz" -> buffer becomes "ab01234hiwxyzopqrst"
             writer.write_at("wxyz".as_bytes(), 9).await.unwrap();
             assert_eq!(writer.size().await, 20);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 20);
 
+            // Verify final result
             let (blob, size) = context.open("partition", b"middle_buf").await.unwrap();
             assert_eq!(size, 20);
             let mut reader = Read::new(blob, size, 20);
@@ -558,21 +561,20 @@ mod tests {
     fn test_write_before_buffer() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test writing data at an offset that precedes the current buffered data range.
+            // Test writing at offsets before the current buffer position
             let (blob, size) = context.open("partition", b"before_buf").await.unwrap();
             let writer = Write::new(blob.clone(), size, 10);
 
-            // Buffer data at offset 10
+            // Write data at a later offset first
             writer.write_at("0123456789".as_bytes(), 10).await.unwrap();
             assert_eq!(writer.size().await, 20);
 
-            // Write before the buffer - should flush buffer then write directly
+            // Write at an earlier offset (should flush buffer first)
             writer.write_at("abcde".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 20);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 20);
 
-            // Reopen the blob and read the data
+            // Verify data placement with gap
             let (blob, size) = context.open("partition", b"before_buf").await.unwrap();
             assert_eq!(size, 20);
             let mut reader = Read::new(blob, size, 20);
@@ -583,13 +585,13 @@ mod tests {
             expected[10..20].copy_from_slice("0123456789".as_bytes());
             assert_eq!(buf, expected);
 
-            // Write to fill the gap between existing data
+            // Fill the gap between existing data
             writer.write_at("fghij".as_bytes(), 5).await.unwrap();
             assert_eq!(writer.size().await, 20);
             writer.sync().await.unwrap();
             assert_eq!(writer.size().await, 20);
 
-            // Reopen the blob and read the data
+            // Verify gap is filled
             let (blob, size) = context.open("partition", b"before_buf").await.unwrap();
             assert_eq!(size, 20);
             let mut reader = Read::new(blob, size, 20);
@@ -604,11 +606,12 @@ mod tests {
     fn test_write_truncate() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test truncating the blob via the writer and subsequent write behaviors.
+            // Test blob truncation functionality and subsequent writes
             let (blob, size) = context.open("partition", b"truncate_write").await.unwrap();
             let writer = Write::new(blob, size, 10);
 
-            writer.write_at("hello world".as_bytes(), 0).await.unwrap(); // 11 bytes
+            // Write initial data
+            writer.write_at("hello world".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 11);
             writer.sync().await.unwrap();
             assert_eq!(writer.size().await, 11);
@@ -618,12 +621,12 @@ mod tests {
             assert_eq!(size_check, 11);
             drop(blob_check);
 
-            // Truncate to 5 bytes ("hello")
+            // Truncate to smaller size
             writer.truncate(5).await.unwrap();
             assert_eq!(writer.size().await, 5);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 5);
 
+            // Verify truncation
             let (blob, size) = context.open("partition", b"truncate_write").await.unwrap();
             assert_eq!(size, 5);
             let mut reader = Read::new(blob, size, 5);
@@ -631,20 +634,20 @@ mod tests {
             reader.read_exact(&mut buf, 5).await.unwrap();
             assert_eq!(&buf, b"hello");
 
-            // Write data before the buffer
+            // Write to truncated blob
             writer.write_at("X".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 5);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 5);
 
+            // Verify overwrite
             let (blob, size) = context.open("partition", b"truncate_write").await.unwrap();
-            assert_eq!(size, 5); // Blob was "hello", truncated to 5, now overwritten at 0 with "X", size remains 5.
+            assert_eq!(size, 5);
             let mut reader = Read::new(blob, size, 5);
             let mut buf = vec![0u8; 5];
             reader.read_exact(&mut buf, 5).await.unwrap();
             assert_eq!(&buf, b"Xello");
 
-            // Test truncate to 0
+            // Test truncate to zero
             let (blob_zero, size) = context.open("partition", b"truncate_zero").await.unwrap();
             let writer_zero = Write::new(blob_zero.clone(), size, 10);
             writer_zero
@@ -659,6 +662,7 @@ mod tests {
             writer_zero.sync().await.unwrap();
             assert_eq!(writer_zero.size().await, 0);
 
+            // Ensure the blob is empty
             let (_, size_z) = context.open("partition", b"truncate_zero").await.unwrap();
             assert_eq!(size_z, 0);
         });
@@ -668,15 +672,15 @@ mod tests {
     fn test_write_read_at_on_writer() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test reading data through the writer's read_at method, covering buffer and blob reads.
+            // Test reading through writer's read_at method (buffer + blob reads)
             let (blob, size) = context.open("partition", b"read_at_writer").await.unwrap();
-            let writer = Write::new(blob.clone(), size, 10); // Buffer capacity 10
+            let writer = Write::new(blob.clone(), size, 10);
 
-            // Write "buffered" (8 bytes) - stays in buffer
+            // Write data that stays in buffer
             writer.write_at("buffered".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 8);
 
-            // Read from buffer
+            // Read from buffer via writer
             let mut read_buf_vec = vec![0u8; 4];
             read_buf_vec = writer.read_at(read_buf_vec, 0).await.unwrap();
             assert_eq!(&read_buf_vec, b"buff");
@@ -684,11 +688,11 @@ mod tests {
             read_buf_vec = writer.read_at(read_buf_vec, 4).await.unwrap();
             assert_eq!(&read_buf_vec, b"ered");
 
-            // Read past buffer end should fail
+            // Reading past buffer end should fail
             let small_buf_vec = vec![0u8; 1];
             assert!(writer.read_at(small_buf_vec, 8).await.is_err());
 
-            // Write " and flushed" (12 bytes) at offset 8 - this will flush buffer then write directly
+            // Write large data that flushes buffer
             writer.write_at(" and flushed".as_bytes(), 8).await.unwrap();
             assert_eq!(writer.size().await, 20);
             writer.sync().await.unwrap();
@@ -703,21 +707,21 @@ mod tests {
             read_buf_7_vec = writer.read_at(read_buf_7_vec, 13).await.unwrap();
             assert_eq!(&read_buf_7_vec, b"flushed");
 
-            // Buffer new data at the tip
+            // Buffer new data at the end
             writer.write_at(" more data".as_bytes(), 20).await.unwrap();
             assert_eq!(writer.size().await, 30);
 
-            // Read the newly buffered data
+            // Read newly buffered data
             let mut read_buf_vec_3 = vec![0u8; 5];
             read_buf_vec_3 = writer.read_at(read_buf_vec_3, 20).await.unwrap();
             assert_eq!(&read_buf_vec_3, b" more");
 
-            // Read spanning blob and buffer
+            // Read spanning both blob and buffer
             let mut combo_read_buf_vec = vec![0u8; 12];
             combo_read_buf_vec = writer.read_at(combo_read_buf_vec, 16).await.unwrap();
             assert_eq!(&combo_read_buf_vec, b"shed more da");
 
-            // Verify full content by reopening and reading
+            // Verify complete content by reopening
             writer.sync().await.unwrap();
             assert_eq!(writer.size().await, 30);
             let (final_blob, final_size) =
@@ -737,20 +741,21 @@ mod tests {
     fn test_write_straddling_non_mergeable() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test write operations that are non-contiguous with the current buffer, forcing flushes.
+            // Test writes that cannot be merged into buffer (non-contiguous/too large)
             let (blob, size) = context.open("partition", b"write_straddle").await.unwrap();
             let writer = Write::new(blob.clone(), size, 10);
 
-            // Fill buffer with "0123456789"
+            // Fill buffer completely
             writer.write_at("0123456789".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 10);
 
-            // Write at non-contiguous offset 15 - should flush buffer then write directly
+            // Write at non-contiguous offset (should flush then write directly)
             writer.write_at("abc".as_bytes(), 15).await.unwrap();
             assert_eq!(writer.size().await, 18);
             writer.sync().await.unwrap();
             assert_eq!(writer.size().await, 18);
 
+            // Verify data with gap
             let (blob_check, size_check) =
                 context.open("partition", b"write_straddle").await.unwrap();
             assert_eq!(size_check, 18);
@@ -760,17 +765,16 @@ mod tests {
 
             let mut expected = vec![0u8; 18];
             expected[0..10].copy_from_slice(b"0123456789");
-            // Bytes 10-14 are zeros (gap in memory blob)
             expected[15..18].copy_from_slice(b"abc");
             assert_eq!(buf, expected);
 
-            // Test write that overwrites part of buffer but exceeds capacity
+            // Test write that exceeds buffer capacity
             let (blob2, size) = context.open("partition", b"write_straddle2").await.unwrap();
             let writer2 = Write::new(blob2.clone(), size, 10);
             writer2.write_at("0123456789".as_bytes(), 0).await.unwrap();
             assert_eq!(writer2.size().await, 10);
 
-            // Write 12 bytes starting at offset 5 - exceeds capacity so flushes then writes directly
+            // Write large data that exceeds capacity
             writer2
                 .write_at("ABCDEFGHIJKL".as_bytes(), 5)
                 .await
@@ -779,6 +783,7 @@ mod tests {
             writer2.sync().await.unwrap();
             assert_eq!(writer2.size().await, 17);
 
+            // Verify overwrite result
             let (blob_check2, size_check2) =
                 context.open("partition", b"write_straddle2").await.unwrap();
             assert_eq!(size_check2, 17);
@@ -793,16 +798,16 @@ mod tests {
     fn test_write_close() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test that closing the writer flushes any pending data in the buffer.
+            // Test that closing writer flushes and persists buffered data
             let (blob_orig, size) = context.open("partition", b"write_close").await.unwrap();
             let writer = Write::new(blob_orig.clone(), size, 8);
             writer.write_at("pending".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 7);
 
-            // Closing should flush and sync the data
+            // Close should flush and sync data
             writer.close().await.unwrap();
 
-            // Verify data was persisted
+            // Verify data persistence
             let (blob_check, size_check) = context.open("partition", b"write_close").await.unwrap();
             assert_eq!(size_check, 7);
             let mut reader = Read::new(blob_check, size_check, 8);
@@ -816,24 +821,22 @@ mod tests {
     fn test_write_direct_due_to_size() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
+            // Test direct writes when data exceeds buffer capacity
             let (blob, size) = context
                 .open("partition", b"write_direct_size")
                 .await
                 .unwrap();
-            // Buffer capacity 5, initial position 0
             let writer = Write::new(blob.clone(), size, 5);
 
-            // Write 10 bytes, which is > capacity. Should be a direct write.
+            // Write data larger than buffer capacity (should write directly)
             let data_large = b"0123456789";
             writer.write_at(data_large.as_slice(), 0).await.unwrap();
             assert_eq!(writer.size().await, 10);
-            // Inner state: buffer should be empty, position should be 10.
-            // We can't directly check inner state here, so we rely on observable behavior.
 
-            // Sync to ensure data is on disk
+            // Sync to ensure data is persisted
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 10);
 
+            // Verify direct write worked
             let (blob_check, size_check) = context
                 .open("partition", b"write_direct_size")
                 .await
@@ -844,16 +847,18 @@ mod tests {
             reader.read_exact(&mut buf, 10).await.unwrap();
             assert_eq!(&buf, data_large.as_slice());
 
-            // Now, buffer something small
-            writer.write_at(b"abc".as_slice(), 10).await.unwrap(); // This should be buffered
-                                                                   // Attempt to read it back using writer.read_at to see if it's in buffer
+            // Now write small data that should be buffered
+            writer.write_at(b"abc".as_slice(), 10).await.unwrap();
             assert_eq!(writer.size().await, 13);
+
+            // Verify it's in buffer by reading through writer
             let mut read_small_buf_vec = vec![0u8; 3];
             read_small_buf_vec = writer.read_at(read_small_buf_vec, 10).await.unwrap();
             assert_eq!(&read_small_buf_vec, b"abc".as_slice());
 
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 13);
+
+            // Verify final state
             let (blob_check2, size_check2) = context
                 .open("partition", b"write_direct_size")
                 .await
@@ -870,39 +875,29 @@ mod tests {
     fn test_write_overwrite_and_extend_in_buffer() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
+            // Test complex buffer operations: overwrite and extend within capacity
             let (blob, size) = context
                 .open("partition", b"overwrite_extend_buf")
                 .await
                 .unwrap();
-            let writer = Write::new(blob.clone(), size, 15); // buffer capacity 15
+            let writer = Write::new(blob.clone(), size, 15);
 
-            // 1. Buffer initial data: "0123456789" (10 bytes) at offset 0
+            // Write initial data
             writer.write_at("0123456789".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 10);
-            // Inner buffer: "0123456789", position 0
 
-            // 2. Overwrite and extend: write "ABCDEFGHIJ" (10 bytes) at offset 5
-            // This should result in "01234ABCDEFGHIJ" (15 bytes) in the buffer.
-            // write_start = 5, data_len = 10.
-            // buffer_start = 0, buffer_end = 0 + 10 = 10 (current buffer data length)
-            // Scenario 2: can_write_into_buffer
-            //   write_start (5) >= buffer_start (0) -> true
-            //   (write_start - buffer_start) (5) + data_len (10) = 15 <= capacity (15) -> true
-            // Buffer internal offset = 5.
-            // Required buffer len = 5 + 10 = 15.
-            // Current buffer len is 10. Resize to 15.
-            // buffer[5..15] gets "ABCDEFGHIJ"
+            // Overwrite and extend within buffer capacity
             writer.write_at("ABCDEFGHIJ".as_bytes(), 5).await.unwrap();
             assert_eq!(writer.size().await, 15);
 
-            // Check buffer content via read_at on writer
+            // Verify buffer content through writer
             let mut read_buf_vec = vec![0u8; 15];
             read_buf_vec = writer.read_at(read_buf_vec, 0).await.unwrap();
             assert_eq!(&read_buf_vec, b"01234ABCDEFGHIJ".as_slice());
 
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 15);
 
+            // Verify persisted result
             let (blob_check, size_check) = context
                 .open("partition", b"overwrite_extend_buf")
                 .await
@@ -919,22 +914,24 @@ mod tests {
     fn test_write_at_size() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
+            // Test writing at the current logical end of the blob
             let (blob, size) = context.open("partition", b"write_end").await.unwrap();
             let writer = Write::new(blob.clone(), size, 20);
 
+            // Write initial data
             writer.write_at("0123456789".as_bytes(), 0).await.unwrap();
             assert_eq!(writer.size().await, 10);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 10);
 
+            // Append at the current size (logical end)
             writer
                 .write_at("abc".as_bytes(), writer.size().await)
                 .await
                 .unwrap();
             assert_eq!(writer.size().await, 13);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 13);
 
+            // Verify complete result
             let (blob_check, size_check) = context.open("partition", b"write_end").await.unwrap();
             assert_eq!(size_check, 13);
             let mut reader = Read::new(blob_check, size_check, 13);

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -525,9 +525,9 @@ mod tests {
             assert_eq!(writer.size().await, 10);
             // Write "01234" into the middle (offset 2, 5 bytes) -> "ab01234hij"
             writer.write_at("01234".as_bytes(), 2).await.unwrap();
-            assert_eq!(writer.size().await, 15);
+            assert_eq!(writer.size().await, 10);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 15);
+            assert_eq!(writer.size().await, 10);
 
             let (blob, size) = context.open("partition", b"middle_buf").await.unwrap();
             assert_eq!(size, 10); // Original length, as it's an overwrite
@@ -564,15 +564,15 @@ mod tests {
 
             // Buffer some data at offset 10: "0123456789"
             writer.write_at("0123456789".as_bytes(), 10).await.unwrap();
-            assert_eq!(writer.size().await, 10);
+            assert_eq!(writer.size().await, 20);
 
             // Write "abcde" at offset 0. This is before the current buffer.
             // Current buffer should be flushed. "abcde" written directly.
             // New buffer position will be 5.
             writer.write_at("abcde".as_bytes(), 0).await.unwrap();
-            assert_eq!(writer.size().await, 15);
+            assert_eq!(writer.size().await, 20);
             writer.sync().await.unwrap();
-            assert_eq!(writer.size().await, 15);
+            assert_eq!(writer.size().await, 20);
 
             let (blob, size) = context.open("partition", b"before_buf").await.unwrap();
             // Expected: "abcde" at 0 (5 bytes) + "0123456789" at 10 (10 bytes) = 20 total size.
@@ -685,9 +685,9 @@ mod tests {
                 .write_at("some data".as_bytes(), 0)
                 .await
                 .unwrap();
-            assert_eq!(writer_zero.size().await, 10);
+            assert_eq!(writer_zero.size().await, 9);
             writer_zero.sync().await.unwrap();
-            assert_eq!(writer_zero.size().await, 10);
+            assert_eq!(writer_zero.size().await, 9);
             writer_zero.truncate(0).await.unwrap();
             assert_eq!(writer_zero.size().await, 0);
             writer_zero.sync().await.unwrap();
@@ -750,9 +750,9 @@ mod tests {
 
             // 3. Buffer new data without flushing previous
             // Writer inner.position = 20. Buffer is empty.
-            // Write " more data" (9 bytes) at offset 20. This fits in buffer.
+            // Write " more data" (10 bytes) at offset 20. This fits in buffer.
             writer.write_at(" more data".as_bytes(), 20).await.unwrap();
-            assert_eq!(writer.size().await, 29);
+            assert_eq!(writer.size().await, 30);
 
             // Read the newly buffered data: "more"
             let mut read_buf_vec_3 = vec![0u8; 5];

--- a/runtime/src/utils/buffer/read.rs
+++ b/runtime/src/utils/buffer/read.rs
@@ -166,7 +166,7 @@ impl<B: Blob> Read<B> {
         Ok(())
     }
 
-    /// Truncates the blob to the specified len.
+    /// Truncates the blob to the specified len and syncs the blob.
     ///
     /// This may be useful if reading some blob after unclean shutdown.
     pub async fn truncate(self, len: u64) -> Result<(), Error> {

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -144,7 +144,7 @@ impl<B: Blob> Write<B> {
     }
 
     /// Returns the current length of the underlying [Blob] (including all pending bytes in the buffer).
-    /// TODO: fix this
+    #[allow(clippy::len_without_is_empty)]
     pub async fn len(&self) -> u64 {
         let inner = self.inner.read().await;
         inner.position + inner.buffer.len() as u64

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -241,7 +241,6 @@ impl<B: Blob> Blob for Write<B> {
     }
 
     async fn truncate(&self, len: u64) -> Result<(), Error> {
-        // Acquire a write lock on the inner state
         let mut inner = self.inner.write().await;
 
         // Prepare the buffer boundaries

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -143,8 +143,9 @@ impl<B: Blob> Write<B> {
         }
     }
 
-    /// Returns the position of the next byte to be written to the underlying [Blob].
-    pub async fn position(&self) -> u64 {
+    /// Returns the current length of the underlying [Blob] (including all pending bytes in the buffer).
+    /// TODO: fix this
+    pub async fn len(&self) -> u64 {
         let inner = self.inner.read().await;
         inner.position + inner.buffer.len() as u64
     }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -7,59 +7,67 @@ struct Inner<B: Blob> {
     /// The underlying blob to write to.
     blob: B,
     /// The buffer storing data to be written to the blob.
+    ///
+    /// The buffer always represents data at the "tip" of the logical blob,
+    /// starting at `position` and extending for `buffer.len()` bytes.
     buffer: Vec<u8>,
-    /// The offset in the blob where the data in `buffer` starts.
-    /// If `buffer` is empty, this is the position where the next appended byte would conceptually begin in the blob.
+    /// The offset in the blob where the buffered data starts.
+    ///
+    /// This represents the logical position in the blob where `buffer[0]` would be written.
+    /// The buffer is maintained at the "tip" to support efficient size calculation and appends.
     position: u64,
     /// The maximum size of the buffer.
     capacity: usize,
 }
 
 impl<B: Blob> Inner<B> {
-    /// Appends bytes to the internal buffer. If the buffer capacity is exceeded, it will be flushed to the
-    /// underlying [Blob].
+    /// Appends bytes to the internal buffer, maintaining the "buffer at tip" invariant.
     ///
-    /// If the size of the provided bytes is larger than the buffer capacity, the bytes will be written
-    /// directly to the underlying [Blob]. If this occurs regularly, the buffer capacity should be increased (as
-    /// the buffer will not provide any benefit).
+    /// If the buffer capacity would be exceeded, it is flushed first. If the data
+    /// is larger than the buffer capacity, it is written directly to the blob.
     ///
-    /// Returns an error if the write to the underlying [Blob] fails (may be due to a `flush` of data not
-    /// related to the data being written).
+    /// # Returns
+    /// An error if the write to the underlying [Blob] fails.
     async fn write<Buf: StableBuf>(&mut self, buf: Buf) -> Result<(), Error> {
-        // If the buffer capacity will be exceeded, flush the buffer first
         let buf_len = buf.len();
+
+        // Flush buffer if adding this data would exceed capacity
         if self.buffer.len() + buf_len > self.capacity {
             self.flush().await?;
         }
 
-        // Write directly to the blob (if the buffer is too small)
+        // Write directly to blob if data is larger than buffer capacity
         if buf_len > self.capacity {
             self.blob.write_at(buf, self.position).await?;
             self.position += buf_len as u64;
             return Ok(());
         }
 
-        // Append to the buffer
+        // Append to buffer (buffer is now guaranteed to have space)
         self.buffer.extend_from_slice(buf.as_ref());
         Ok(())
     }
 
-    /// Flushes buffered data to the underlying [Blob]. Does nothing if the buffer is empty.
+    /// Flushes buffered data to the underlying [Blob] and advances the position.
     ///
-    /// If the write to the underlying [Blob] fails, the buffer will be reset (and any pending data not yet
-    /// written will be lost).
+    /// After flushing, the buffer is reset and positioned at the new tip.
+    /// Does nothing if the buffer is empty.
+    ///
+    /// # Returns
+    ///
+    /// An error if the write to the underlying [Blob] fails. On failure,
+    /// the buffer is reset and pending data is lost.
     async fn flush(&mut self) -> Result<(), Error> {
-        // If the buffer is empty, do nothing
         if self.buffer.is_empty() {
             return Ok(());
         }
 
-        // Take the buffer and write it to the blob
+        // Take the buffer contents and write to blob
         let buf = std::mem::take(&mut self.buffer);
         let len = buf.len() as u64;
         self.blob.write_at(buf, self.position).await?;
 
-        // If successful, update the position and allocate a new buffer
+        // Advance position and reset buffer at the new tip
         self.position += len;
         self.buffer = Vec::with_capacity(self.capacity);
         Ok(())
@@ -103,14 +111,14 @@ impl<B: Blob> Inner<B> {
 ///     assert_eq!(size, 0);
 ///
 ///     // Create a buffered writer with 16-byte buffer
-///     let mut blob = Write::new(blob, 0, 16);
-///     blob.write_at("hello".as_bytes(), 0).await.expect("write failed");
-///     blob.sync().await.expect("sync failed");
+///     let writer = Write::new(blob, 0, 16);
+///     writer.write_at("hello".as_bytes(), 0).await.expect("write failed");
+///     writer.sync().await.expect("sync failed");
 ///
-///     // Write more data in multiple flushes
-///     blob.write_at(" world".as_bytes(), 5).await.expect("write failed");
-///     blob.write_at("!".as_bytes(), 11).await.expect("write failed");
-///     blob.sync().await.expect("sync failed");
+///     // Write more data
+///     writer.write_at(" world".as_bytes(), 5).await.expect("write failed");
+///     writer.write_at("!".as_bytes(), 11).await.expect("write failed");
+///     writer.sync().await.expect("sync failed");
 ///
 ///     // Read back the data to verify
 ///     let (blob, size) = context.open("my_partition", b"my_data").await.expect("unable to reopen blob");
@@ -143,7 +151,9 @@ impl<B: Blob> Write<B> {
         }
     }
 
-    /// Returns the current size of the underlying [Blob] (including all pending bytes in the buffer).
+    /// Returns the current logical size of the blob including any buffered data.
+    ///
+    /// This represents the total size of data that would be present after flushing.
     #[allow(clippy::len_without_is_empty)]
     pub async fn size(&self) -> u64 {
         let inner = self.inner.read().await;
@@ -164,33 +174,43 @@ impl<B: Blob> Blob for Write<B> {
 
         // If the data required is beyond the buffer end, return an error
         let buffer_start = inner.position;
-        let buffer_end = inner.position + inner.buffer.len() as u64;
+        let buffer_end = buffer_start + inner.buffer.len() as u64;
+
+        // Ensure we don't read beyond the logical end of the blob
         if data_end > buffer_end {
             return Err(Error::BlobInsufficientLength);
         }
 
-        // If the data required is before the buffer start, read directly from the blob
+        // Case 1: Read entirely from the underlying blob (before buffer)
         if data_end <= buffer_start {
             return inner.blob.read_at(buf, offset).await;
         }
 
-        // If the data is entirely within the buffer, read it
+        // Case 2: Read entirely from the buffer
         if offset >= buffer_start {
-            let start = (offset - buffer_start) as usize;
-            if start + data_len > inner.buffer.len() {
+            let buffer_offset = (offset - buffer_start) as usize;
+            let end_offset = buffer_offset + data_len;
+
+            if end_offset > inner.buffer.len() {
                 return Err(Error::BlobInsufficientLength);
             }
-            buf.put_slice(&inner.buffer[start..start + data_len]);
+
+            buf.put_slice(&inner.buffer[buffer_offset..end_offset]);
             return Ok(buf);
         }
 
-        // If the data is a combination of blob and buffer, read from both
+        // Case 3: Read spans both blob and buffer
         let blob_bytes = (buffer_start - offset) as usize;
+        let buffer_bytes = data_len - blob_bytes;
+
+        // Read from blob first
         let blob_part = vec![0u8; blob_bytes];
         let blob_part = inner.blob.read_at(blob_part, offset).await?;
+
+        // Copy blob data and buffer data to result
         buf.deref_mut()[..blob_bytes].copy_from_slice(&blob_part);
-        let buf_bytes = data_len - blob_bytes;
-        buf.deref_mut()[blob_bytes..].copy_from_slice(&inner.buffer[..buf_bytes]);
+        buf.deref_mut()[blob_bytes..].copy_from_slice(&inner.buffer[..buffer_bytes]);
+
         Ok(buf)
     }
 
@@ -206,47 +226,53 @@ impl<B: Blob> Blob for Write<B> {
         let buffer_start = inner.position;
         let buffer_end = buffer_start + inner.buffer.len() as u64;
 
-        // Simple append to the current buffered data
+        // Case 1: Simple append to buffered data (most common case)
         if offset == buffer_end {
             return inner.write(buf).await;
         }
 
-        // Write operation can be merged into the existing buffer if:
-        // a) Write starts at or after the buffer's starting position in the blob.
-        // b) The end of the write, relative to the buffer's start, fits within buffer's capacity.
-        let can_write_into_buffer = offset >= buffer_start
+        // Case 2: Write can be merged into existing buffer
+        let can_merge_into_buffer = offset >= buffer_start
             && (offset - buffer_start) + data_len as u64 <= inner.capacity as u64;
-        if can_write_into_buffer {
-            let buffer_internal_offset = (offset - buffer_start) as usize;
-            let required_buffer_len = buffer_internal_offset + data_len;
-            if required_buffer_len > inner.buffer.len() {
-                inner.buffer.resize(required_buffer_len, 0u8);
+        if can_merge_into_buffer {
+            let buffer_offset = (offset - buffer_start) as usize;
+            let required_len = buffer_offset + data_len;
+
+            // Expand buffer if necessary (fills with zeros)
+            if required_len > inner.buffer.len() {
+                inner.buffer.resize(required_len, 0);
             }
-            inner.buffer[buffer_internal_offset..required_buffer_len].copy_from_slice(data);
+
+            // Copy data into buffer
+            inner.buffer[buffer_offset..required_len].copy_from_slice(data);
             return Ok(());
         }
 
-        // All other cases (e.g., write is before buffer, straddles, or would overflow capacity)
+        // Case 3: All other cases - flush buffer and write directly
+        // This includes: writes before buffer, writes that would exceed capacity,
+        // or non-contiguous writes that can't be merged
         if !inner.buffer.is_empty() {
             inner.flush().await?;
         }
         inner.blob.write_at(buf, offset).await?;
 
-        // Update the position (if larger than the current position)
-        let pending = offset + data_len as u64;
-        if pending > inner.position {
-            inner.position = pending;
+        // Update position to maintain "buffer at tip" invariant
+        // Position should advance to the end of this write if it extends the logical blob
+        let write_end = offset + data_len as u64;
+        if write_end > inner.position {
+            inner.position = write_end;
         }
+
         Ok(())
     }
 
     async fn truncate(&self, len: u64) -> Result<(), Error> {
+        // Acquire a write lock on the inner state
         let mut inner = self.inner.write().await;
 
         // Prepare the buffer boundaries
         let buffer_start = inner.position;
-        let buffer_len = inner.buffer.len() as u64;
-        let buffer_end = buffer_start + buffer_len;
+        let buffer_end = buffer_start + inner.buffer.len() as u64;
 
         // Adjust buffer content based on `len`
         if len <= buffer_start {

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -143,10 +143,10 @@ impl<B: Blob> Write<B> {
         }
     }
 
-    /// Returns the current position of the buffer in the underlying [Blob].
+    /// Returns the position of the next byte to be written to the underlying [Blob].
     pub async fn position(&self) -> u64 {
         let inner = self.inner.read().await;
-        inner.position
+        inner.position + inner.buffer.len() as u64
     }
 }
 

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -231,7 +231,12 @@ impl<B: Blob> Blob for Write<B> {
             inner.flush().await?;
         }
         inner.blob.write_at(buf, offset).await?;
-        inner.position = offset + data_len as u64;
+
+        // Update the position (if larger than the current position)
+        let pending = offset + data_len as u64;
+        if pending > inner.position {
+            inner.position = pending;
+        }
         Ok(())
     }
 

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -142,6 +142,12 @@ impl<B: Blob> Write<B> {
             })),
         }
     }
+
+    /// Returns the current position of the buffer in the underlying [Blob].
+    pub async fn position(&self) -> u64 {
+        let inner = self.inner.read().await;
+        inner.position
+    }
 }
 
 impl<B: Blob> Blob for Write<B> {

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -126,26 +126,26 @@ pub struct Write<B: Blob> {
 }
 
 impl<B: Blob> Write<B> {
-    /// Creates a new `Write` that writes to the given blob starting at `position` with the specified buffer capacity.
+    /// Creates a new `Write` that buffers writes to the end of a [Blob] with the specified buffer capacity.
     ///
     /// # Panics
     ///
     /// Panics if `capacity` is zero.
-    pub fn new(blob: B, position: u64, capacity: usize) -> Self {
+    pub fn new(blob: B, size: u64, capacity: usize) -> Self {
         assert!(capacity > 0, "buffer capacity must be greater than zero");
         Self {
             inner: Arc::new(RwLock::new(Inner {
                 blob,
                 buffer: Vec::with_capacity(capacity),
-                position,
+                position: size,
                 capacity,
             })),
         }
     }
 
-    /// Returns the current length of the underlying [Blob] (including all pending bytes in the buffer).
+    /// Returns the current size of the underlying [Blob] (including all pending bytes in the buffer).
     #[allow(clippy::len_without_is_empty)]
-    pub async fn len(&self) -> u64 {
+    pub async fn size(&self) -> u64 {
         let inner = self.inner.read().await;
         inner.position + inner.buffer.len() as u64
     }

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -423,7 +423,7 @@ mod tests {
             blob.close().await.unwrap();
 
             // Initialize the archive again
-            let result = Archive::<_, _, FixedBytes<64>, i32>::init(
+            let archive= Archive::<_, _, FixedBytes<64>, i32>::init(
                 context,
                 Config {
                     partition: "test_partition".into(),
@@ -437,11 +437,14 @@ mod tests {
                     section_mask: DEFAULT_SECTION_MASK,
                 },
             )
-            .await;
-            assert!(matches!(
-                result,
-                Err(Error::Journal(JournalError::ChecksumMismatch(_, _)))
-            ));
+            .await.expect("Failed to initialize archive");
+
+            // Check that the archive is empty
+            let retrieved: Option<i32> = archive
+                .get(Identifier::Index(index))
+                .await
+                .expect("Failed to get data");
+            assert!(retrieved.is_none());
         });
     }
 

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -1449,7 +1449,7 @@ mod tests {
             blob.close().await.expect("Failed to close blob");
 
             // Re-initialize the journal to simulate a restart
-            let journal = Journal::init(context.clone(), cfg.clone())
+            let mut journal = Journal::init(context.clone(), cfg.clone())
                 .await
                 .expect("Failed to re-initialize journal");
 
@@ -1468,7 +1468,6 @@ mod tests {
                     }
                 }
             }
-            journal.close().await.expect("Failed to close journal");
 
             // Verify that only non-corrupted items were replayed
             assert_eq!(items.len(), 3);
@@ -1479,12 +1478,27 @@ mod tests {
             assert_eq!(items[2].0, data_items[1].0);
             assert_eq!(items[2].1, data_items[1].1);
 
+            // Append a new item to the truncated partition
+            journal.append(2, 5).await.expect("Failed to append data");
+            journal.sync(2).await.expect("Failed to sync blob");
+
+            // Get the new item
+            let item = journal
+                .get(2, 2)
+                .await
+                .expect("Failed to get item")
+                .expect("Failed to get item");
+            assert_eq!(item, 5);
+
+            // Close the journal
+            journal.close().await.expect("Failed to close journal");
+
             // Confirm blob is expected length
             let (_, blob_len) = context
                 .open(&cfg.partition, &2u64.to_be_bytes())
                 .await
                 .expect("Failed to open blob");
-            assert_eq!(blob_len, 32);
+            assert_eq!(blob_len, 48);
 
             // Attempt to replay journal after truncation
             let journal = Journal::init(context, cfg)
@@ -1509,13 +1523,15 @@ mod tests {
             journal.close().await.expect("Failed to close journal");
 
             // Verify that only non-corrupted items were replayed
-            assert_eq!(items.len(), 3);
+            assert_eq!(items.len(), 4);
             assert_eq!(items[0].0, 1);
             assert_eq!(items[0].1, 1);
             assert_eq!(items[1].0, data_items[0].0);
             assert_eq!(items[1].1, data_items[0].1);
             assert_eq!(items[2].0, data_items[1].0);
             assert_eq!(items[2].1, data_items[1].1);
+            assert_eq!(items[3].0, 2);
+            assert_eq!(items[3].1, 5);
         });
     }
 

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -1369,7 +1369,7 @@ mod tests {
             assert_eq!(blob_len, 44);
 
             // Re-initialize the journal to simulate a restart
-            let journal = Journal::init(context, cfg)
+            let journal = Journal::init(context.clone(), cfg.clone())
                 .await
                 .expect("Failed to re-initialize journal");
 
@@ -1399,8 +1399,6 @@ mod tests {
             assert_eq!(items[2].1, data_items[1].1);
             assert_eq!(items[3].0, 2);
             assert_eq!(items[3].1, 5);
-
-            // Confirm blob is expected length
         });
     }
 

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -59,6 +59,13 @@
 //! some in-memory state. `Journal` is heavily optimized for this pattern and provides a `replay`
 //! method that iterates over multiple `sections` concurrently in a single stream.
 //!
+//! ## Recovery
+//!
+//! Like [sqlite](https://github.com/sqlite/sqlite/blob/8658a8df59f00ec8fcfea336a2a6a4b5ef79d2ee/src/wal.c#L1504-L1505)
+//! and [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
+//! any invalid data discovered will be considered the new end of the journal (and the underlying [Blob] will be truncated to the last
+//! valid item).
+//!
 //! # Exact Reads
 //!
 //! To allow for items to be fetched in a single disk operation, `Journal` allows callers to specify

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -59,13 +59,6 @@
 //! some in-memory state. `Journal` is heavily optimized for this pattern and provides a `replay`
 //! method that iterates over multiple `sections` concurrently in a single stream.
 //!
-//! ## Recovery
-//!
-//! Like [sqlite](https://github.com/sqlite/sqlite/blob/8658a8df59f00ec8fcfea336a2a6a4b5ef79d2ee/src/wal.c#L1504-L1505)
-//! and [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
-//! any invalid data discovered will be considered the new end of the journal (and the underlying [Blob] will be truncated to the last
-//! valid item).
-//!
 //! # Exact Reads
 //!
 //! To allow for items to be fetched in a single disk operation, `Journal` allows callers to specify
@@ -390,11 +383,10 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     ///
     /// # Repair
     ///
-    /// If any corrupted data is found, the stream will return an error.
-    ///
-    /// If any trailing data is found (i.e. misaligned entries), the journal will be truncated
-    /// to the last valid item. For this reason, it is recommended to call `replay` before
-    /// calling `append` (as data added to trailing bytes will fail checksum after restart).
+    /// Like [sqlite](https://github.com/sqlite/sqlite/blob/8658a8df59f00ec8fcfea336a2a6a4b5ef79d2ee/src/wal.c#L1504-L1505)
+    /// and [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
+    /// any invalid data discovered will be considered the new end of the journal (and the underlying [Blob] will be truncated to the last
+    /// valid item).
     ///
     /// # Concurrency
     ///

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -397,7 +397,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
         let compressed = self.cfg.compression.is_some();
         let mut blobs = Vec::with_capacity(self.blobs.len());
         for (section, blob) in self.blobs.iter() {
-            let blob_len = blob.position().await;
+            let blob_len = blob.len().await;
             let max_offset = compute_next_offset(blob_len)?;
             blobs.push((
                 *section,
@@ -442,7 +442,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
                             )
                             .await
                             {
-                                Ok((next_offset, next_valid, size, item)) => {
+                                Ok((next_offset, next_valid_len, size, item)) => {
                                     trace!(
                                         blob = section,
                                         cursor = offset,
@@ -455,7 +455,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
                                             section,
                                             reader,
                                             next_offset,
-                                            next_valid,
+                                            next_valid_len,
                                             codec_config,
                                             compressed,
                                         ),
@@ -571,7 +571,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
         assert_eq!(buf.len(), entry_len);
 
         // Append item to blob
-        let cursor = blob.position().await;
+        let cursor = blob.len().await;
         let offset = compute_next_offset(cursor)?;
         let aligned_cursor = offset as u64 * ITEM_ALIGNMENT;
         blob.write_at(buf, aligned_cursor).await?;
@@ -650,7 +650,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
 
             // Remove and close blob
             let blob = self.blobs.remove(&section).unwrap();
-            let len = blob.position().await;
+            let len = blob.len().await;
             blob.close().await?;
 
             // Remove blob from storage
@@ -670,7 +670,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     /// Closes all open sections.
     pub async fn close(self) -> Result<(), Error> {
         for (section, blob) in self.blobs.into_iter() {
-            let len = blob.position().await;
+            let len = blob.len().await;
             blob.close().await?;
             debug!(blob = section, len, "closed blob");
         }
@@ -680,7 +680,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     /// Close and remove any underlying blobs created by the journal.
     pub async fn destroy(self) -> Result<(), Error> {
         for (i, blob) in self.blobs.into_iter() {
-            let len = blob.position().await;
+            let len = blob.len().await;
             blob.close().await?;
             debug!(blob = i, len, "destroyed blob");
             self.context


### PR DESCRIPTION
- [x] Update stored `len` for future appends (or ensure write handles it correctly)
- [x] Update `write::len()` to be correct (rather than just position)
  - [x] Add a failing test for this being wrong (writing to blob at some location over and over again)
  - [x] Keep write buffer at end (having one move around makes no sense in our context)