### PR TITLE
[storage/hasher] remove unnecessary generic hasher parameter from root testers

### DIFF
--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -574,7 +574,7 @@ mod tests {
             let mut mmr = Mmr::init(context.clone(), &mut std_hasher, cfg.clone())
                 .await
                 .unwrap();
-            build_batched_and_check_test_roots_journaled(&mut std_hasher, &mut mmr).await;
+            build_batched_and_check_test_roots_journaled(&mut mmr).await;
         });
     }
 

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -738,9 +738,7 @@ mod tests {
             let mut mmr = Mmr::new();
             build_and_check_test_roots_mmr(&mut mmr).await;
             let mut mmr = Mmr::new();
-            let mut hasher = Sha256::default();
-            let mut hasher = Standard::new(&mut hasher);
-            build_batched_and_check_test_roots(&mut hasher, &mut mmr).await;
+            build_batched_and_check_test_roots(&mut mmr).await;
         });
     }
 


### PR DESCRIPTION
The root stability tests require Sha256, so no point in allowing the hasher to be parameterized.