### PR TITLE
[p2p] Prevent dial handshake re-use

### DIFF
--- a/p2p/src/authenticated/actors/listener.rs
+++ b/p2p/src/authenticated/actors/listener.rs
@@ -97,7 +97,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
         // Reserve also checks if the peer is authorized.
         let peer = incoming.peer();
         let Some(reservation) = tracker
-            .listen(peer.clone())
+            .listen(peer.clone(), incoming.timestamp())
             .instrument(debug_span!("reserve"))
             .await
         else {

--- a/p2p/src/authenticated/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/actors/tracker/directory.rs
@@ -347,10 +347,14 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Verifier> Directory<
             return None;
         }
 
-        // Timestamp too old
+        // Check timestamp
         if let Metadata::Listener(_, timestamp) = &metadata {
             if *timestamp <= record.timestamp() {
+                // Reject timestamps that are too old
                 return None;
+            } else {
+                // Record new timestamps even if we ultimately reject the reservation
+                record.set_timestamp(*timestamp);
             }
         }
 
@@ -370,9 +374,6 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Verifier> Directory<
 
         // Success
         self.metrics.reserved.inc();
-        if let Metadata::Listener(_, timestamp) = &metadata {
-            record.set_timestamp(*timestamp);
-        }
         Some(Reservation::new(
             self.context.clone(),
             metadata,

--- a/p2p/src/authenticated/actors/tracker/metadata.rs
+++ b/p2p/src/authenticated/actors/tracker/metadata.rs
@@ -15,7 +15,8 @@ pub enum Metadata<P: Array> {
     ///
     /// Contains:
     /// - The public key of the peer.
-    Listener(P),
+    /// - The timestamp of the handshake of the peer.
+    Listener(P, u64),
 }
 
 impl<P: Array> Metadata<P> {
@@ -23,7 +24,7 @@ impl<P: Array> Metadata<P> {
     pub fn public_key(&self) -> &P {
         match self {
             Metadata::Dialer(public_key, _) => public_key,
-            Metadata::Listener(public_key) => public_key,
+            Metadata::Listener(public_key, _) => public_key,
         }
     }
 }

--- a/p2p/src/authenticated/actors/tracker/record.rs
+++ b/p2p/src/authenticated/actors/tracker/record.rs
@@ -55,6 +55,10 @@ pub struct Record<C: Verifier> {
     /// Number of peer sets this peer is part of.
     sets: usize,
 
+    /// The highest timestamp (in epoch milliseconds) of the peer's dial handshake. Must be
+    /// monotonically increasing. Used to prevent replay attacks. Defaults to `0`.
+    timestamp: u64,
+
     /// If `true`, the record should persist even if the peer is not part of any peer sets.
     persistent: bool,
 }
@@ -68,6 +72,7 @@ impl<C: Verifier> Record<C> {
             address: Address::Unknown,
             status: Status::Inert,
             sets: 0,
+            timestamp: 0,
             persistent: false,
         }
     }
@@ -78,6 +83,7 @@ impl<C: Verifier> Record<C> {
             address: Address::Myself(info),
             status: Status::Inert,
             sets: 0,
+            timestamp: 0,
             persistent: true,
         }
     }
@@ -88,6 +94,7 @@ impl<C: Verifier> Record<C> {
             address: Address::Bootstrapper(socket),
             status: Status::Inert,
             sets: 0,
+            timestamp: 0,
             persistent: true,
         }
     }
@@ -201,7 +208,22 @@ impl<C: Verifier> Record<C> {
         }
     }
 
+    /// Set the timestamp of the record.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided timestamp is not strictly greater than the current timestamp.
+    pub fn set_timestamp(&mut self, timestamp: u64) {
+        assert!(timestamp > self.timestamp);
+        self.timestamp = timestamp;
+    }
+
     // ---------- Getters ----------
+
+    /// Returns the highest `timestamp` that this peer has dialed us with.
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
 
     /// Returns `true` if the record is blocked.
     pub fn blocked(&self) -> bool {

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -25,6 +25,7 @@ pub struct IncomingConnection<C: Scheme, Si: Sink, St: Stream> {
     deadline: SystemTime,
     ephemeral_public_key: x25519::PublicKey,
     peer_public_key: C::PublicKey,
+    handshake_timestamp: u64,
 
     /// Stores the raw bytes of the dialer handshake message.
     /// Necessary for the cipher derivation.
@@ -64,6 +65,7 @@ impl<C: Scheme, Si: Sink, St: Stream> IncomingConnection<C, Si, St> {
             deadline,
             ephemeral_public_key: signed_handshake.ephemeral(),
             peer_public_key: signed_handshake.signer(),
+            handshake_timestamp: signed_handshake.timestamp(),
             dialer_handshake_bytes: msg,
         })
     }
@@ -76,6 +78,11 @@ impl<C: Scheme, Si: Sink, St: Stream> IncomingConnection<C, Si, St> {
     /// The ephemeral public key of the peer attempting to connect.
     pub fn ephemeral(&self) -> x25519::PublicKey {
         self.ephemeral_public_key
+    }
+
+    /// The timestamp of the dialer's handshake message.
+    pub fn timestamp(&self) -> u64 {
+        self.handshake_timestamp
     }
 }
 

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -107,6 +107,10 @@ impl<C: Scheme> Signed<C> {
         self.info.ephemeral_public_key
     }
 
+    pub fn timestamp(&self) -> u64 {
+        self.info.timestamp
+    }
+
     pub fn verify<E: Clock>(
         &self,
         context: &E,


### PR DESCRIPTION
Proof-of-concept for #1018 

If receiving a valid dial from a peer (i.e. we are the listener), record the timestamp of the highest dial handshake timestamp (on a per-peer basis). Don't allow connection based on dials that have timestamps LTE (`<=`) dial timestamps seen before.

In the other case (i.e. where we are the dialer) the listener's handshake timestamp is ignored. (Should we record this one too?)