### PR TITLE
[runtime] enable force poll for iouring network tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,7 @@ jobs:
       matrix:
         features:
           - "--features commonware-runtime/iouring-storage"
-          # TODO: Re-enable when #954 is resolved
-          #- "--features commonware-runtime/iouring-network"
+          - "--features commonware-runtime/iouring-network"
           - ""
     steps:
     - name: Checkout repository
@@ -58,8 +57,7 @@ jobs:
       matrix:
         features:
           - "--features commonware-runtime/iouring-storage"
-          # TODO: Re-enable when #954 is resolved
-          #- "--features commonware-runtime/iouring-network"
+          - "--features commonware-runtime/iouring-network"
           - ""
     steps:
     - name: Checkout repository

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -323,8 +323,17 @@ mod tests {
     #[tokio::test]
     async fn test_trait() {
         tests::test_network_trait(|| {
-            Network::start(Config::default(), &mut Registry::default())
-                .expect("Failed to start io_uring")
+            Network::start(
+                Config {
+                    iouring_config: iouring::Config {
+                        force_poll: Some(Duration::from_millis(100)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                &mut Registry::default(),
+            )
+            .expect("Failed to start io_uring")
         })
         .await;
     }

--- a/runtime/src/network/mod.rs
+++ b/runtime/src/network/mod.rs
@@ -97,7 +97,6 @@ mod tests {
             for _ in 0..3 {
                 let (_, mut sink, mut stream) = listener.accept().await.expect("Failed to accept");
 
-                // runtime.spawn(async move {
                 let read = stream
                     .recv(vec![0; CLIENT_SEND_DATA.len()])
                     .await


### PR DESCRIPTION
Should prevent `test_trait` from stalling and resolve #954. Also removes 1 line of dead code.