### PR TITLE
[release] v0.0.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-bridge"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "chrono",
  "clap",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "paste",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "blst",
  "bytes",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "chrono",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bimap",
  "bytes",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "async-lock",
  "axum",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-vrf"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.53", path = "broadcast" }
-commonware-codec = { version = "0.0.53", path = "codec" }
-commonware-consensus = { version = "0.0.53", path = "consensus" }
-commonware-cryptography = { version = "0.0.53", path = "cryptography" }
-commonware-deployer = { version = "0.0.53", path = "deployer", default-features = false }
-commonware-macros = { version = "0.0.53", path = "macros" }
-commonware-p2p = { version = "0.0.53", path = "p2p" }
-commonware-resolver = { version = "0.0.53", path = "resolver" }
-commonware-runtime = { version = "0.0.53", path = "runtime" }
-commonware-storage = { version = "0.0.53", path = "storage" }
-commonware-stream = { version = "0.0.53", path = "stream" }
-commonware-utils = { version = "0.0.53", path = "utils" }
+commonware-broadcast = { version = "0.0.54", path = "broadcast" }
+commonware-codec = { version = "0.0.54", path = "codec" }
+commonware-consensus = { version = "0.0.54", path = "consensus" }
+commonware-cryptography = { version = "0.0.54", path = "cryptography" }
+commonware-deployer = { version = "0.0.54", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.54", path = "macros" }
+commonware-p2p = { version = "0.0.54", path = "p2p" }
+commonware-resolver = { version = "0.0.54", path = "resolver" }
+commonware-runtime = { version = "0.0.54", path = "runtime" }
+commonware-storage = { version = "0.0.54", path = "storage" }
+commonware-stream = { version = "0.0.54", path = "stream" }
+commonware-utils = { version = "0.0.54", path = "utils" }
 thiserror = "2.0.12"
 bytes = "1.7.1"
 sha2 = "0.10.8"

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-broadcast"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Disseminate data over a wide-area network."
 readme = "README.md"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-codec"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Serialize structured data."
 readme = "README.md"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-consensus"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Order opaque messages in a Byzantine environment."
 readme = "README.md"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify signatures."
 readme = "README.md"

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-deployer"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Deploy infrastructure across cloud providers."
 readme = "README.md"

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-bridge"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Send succinct consensus certificates between two networks."
 readme = "README.md"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-flood"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Spam peers deployed to AWS EC2 with random messages."
 readme = "README.md"

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-log"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Commit to a secret log and agree to its hash."
 readme = "README.md"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-vrf"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-macros"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Augment the development of primitives with procedural macros."
 readme = "README.md"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-resolver"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Resolve data identified by a fixed-length key."
 readme = "README.md"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-runtime"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Execute asynchronous tasks with a configurable scheduler."
 readme = "README.md"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-storage"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Persist and retrieve data from an abstract store."
 readme = "README.md"

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-stream"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Exchange messages over arbitrary transport."
 readme = "README.md"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-utils"
 edition = "2021"
 publish = true
-version = "0.0.53"
+version = "0.0.54"
 license = "MIT OR Apache-2.0"
 description = "Leverage common functionality across multiple primitives."
 readme = "README.md"


### PR DESCRIPTION
```
 .github/workflows/coverage.yml                     |   3 -
 .github/workflows/tests.yml                        |  10 +-
 Cargo.lock                                         |  45 +-
 Cargo.toml                                         |  25 +-
 broadcast/Cargo.toml                               |   2 +-
 broadcast/src/buffered/engine.rs                   |  47 +-
 broadcast/src/buffered/ingress.rs                  |  45 +-
 broadcast/src/buffered/mocks.rs                    |   6 +-
 broadcast/src/buffered/mod.rs                      |  13 +-
 codec/Cargo.toml                                   |   2 +-
 codec/src/types/map.rs                             | 683 +++++++++++++++++----
 codec/src/types/mod.rs                             |   1 +
 codec/src/types/set.rs                             | 589 ++++++++++++++++++
 codec/src/varint.rs                                | 149 +++++
 consensus/Cargo.toml                               |   2 +-
 consensus/src/ordered_broadcast/ack_manager.rs     |  41 +-
 consensus/src/ordered_broadcast/config.rs          |   6 +-
 consensus/src/ordered_broadcast/engine.rs          |  45 +-
 consensus/src/ordered_broadcast/mocks/reporter.rs  |  38 +-
 consensus/src/ordered_broadcast/mod.rs             |  71 ++-
 consensus/src/ordered_broadcast/tip_manager.rs     |  42 +-
 consensus/src/ordered_broadcast/types.rs           | 172 +++---
 consensus/src/simplex/actors/resolver/actor.rs     |  28 +-
 consensus/src/simplex/actors/resolver/ingress.rs   |   9 +-
 consensus/src/simplex/actors/resolver/mod.rs       |   4 +-
 consensus/src/simplex/actors/voter/actor.rs        |  55 +-
 consensus/src/simplex/actors/voter/ingress.rs      |  11 +-
 consensus/src/simplex/actors/voter/mod.rs          |  77 ++-
 consensus/src/simplex/config.rs                    |   6 +-
 consensus/src/simplex/engine.rs                    |  13 +-
 consensus/src/simplex/mocks/conflicter.rs          |  10 +-
 consensus/src/simplex/mocks/nuller.rs              |   8 +-
 consensus/src/simplex/mocks/outdated.rs            |   8 +-
 consensus/src/simplex/mocks/supervisor.rs          |  48 +-
 consensus/src/simplex/mod.rs                       |  89 +--
 consensus/src/simplex/types.rs                     | 367 +++++------
 .../src/threshold_simplex/actors/batcher/actor.rs  |  39 +-
 .../src/threshold_simplex/actors/resolver/actor.rs |  28 +-
 .../src/threshold_simplex/actors/resolver/mod.rs   |   4 +-
 .../src/threshold_simplex/actors/voter/actor.rs    |  49 +-
 .../src/threshold_simplex/actors/voter/mod.rs      |  26 +-
 consensus/src/threshold_simplex/config.rs          |   6 +-
 consensus/src/threshold_simplex/engine.rs          |  12 +-
 consensus/src/threshold_simplex/mod.rs             |  31 +-
 cryptography/Cargo.toml                            |   4 +-
 .../benches/batch_verify_multiple_messages.rs      |   6 +-
 .../benches/batch_verify_multiple_public_keys.rs   |   6 +-
 cryptography/src/bls12381/benches/dkg_recovery.rs  |   4 +-
 .../src/bls12381/benches/dkg_reshare_recovery.rs   |   4 +-
 .../src/bls12381/benches/signature_generation.rs   |   8 +-
 .../src/bls12381/benches/signature_verification.rs |  18 +-
 cryptography/src/bls12381/dkg/mod.rs               |  71 +--
 cryptography/src/bls12381/mod.rs                   |   2 +-
 cryptography/src/bls12381/scheme.rs                | 144 ++---
 .../benches/batch_verify_multiple_messages.rs      |   6 +-
 .../benches/batch_verify_multiple_public_keys.rs   |   6 +-
 .../src/ed25519/benches/signature_generation.rs    |   8 +-
 .../src/ed25519/benches/signature_verification.rs  |  18 +-
 cryptography/src/ed25519/mod.rs                    |   8 +-
 cryptography/src/ed25519/scheme.rs                 | 224 +++----
 cryptography/src/lib.rs                            | 295 ++++-----
 .../src/secp256r1/benches/signature_generation.rs  |   6 +-
 .../secp256r1/benches/signature_verification.rs    |  18 +-
 cryptography/src/secp256r1/mod.rs                  |   8 +-
 cryptography/src/secp256r1/scheme.rs               | 200 +++---
 cryptography/src/sha256/mod.rs                     |  10 +
 deployer/Cargo.toml                                |   2 +-
 deployer/src/ec2/aws.rs                            |   7 +-
 deployer/src/ec2/destroy.rs                        | 290 ++++-----
 docs/blogs/buffered-signatures.html                | 127 ++++
 docs/imgs/bisection.png                            | Bin 0 -> 343736 bytes
 docs/imgs/buffering.png                            | Bin 0 -> 231546 bytes
 docs/imgs/gossip-models.png                        | Bin 0 -> 301464 bytes
 docs/imgs/invalid-signature-gossip.png             | Bin 0 -> 353987 bytes
 docs/index.html                                    |   6 +
 examples/bridge/Cargo.toml                         |   2 +-
 examples/bridge/src/bin/dealer.rs                  |   4 +-
 examples/bridge/src/bin/indexer.rs                 |   7 +-
 examples/bridge/src/bin/validator.rs               |  10 +-
 examples/chat/Cargo.toml                           |   2 +-
 examples/chat/src/main.rs                          |   9 +-
 examples/flood/Cargo.toml                          |   2 +-
 examples/flood/src/bin/flood.rs                    |   7 +-
 examples/flood/src/bin/setup.rs                    |   6 +-
 examples/log/Cargo.toml                            |   2 +-
 examples/log/src/application/actor.rs              |   6 +-
 examples/log/src/application/supervisor.rs         |  10 +-
 examples/log/src/main.rs                           |   8 +-
 examples/vrf/Cargo.toml                            |   2 +-
 examples/vrf/src/handlers/arbiter.rs               |  26 +-
 examples/vrf/src/handlers/contributor.rs           |   8 +-
 examples/vrf/src/main.rs                           |  17 +-
 macros/Cargo.toml                                  |   2 +-
 p2p/Cargo.toml                                     |   2 +-
 p2p/src/authenticated/actors/dialer.rs             |  12 +-
 p2p/src/authenticated/actors/listener.rs           |  14 +-
 p2p/src/authenticated/actors/peer/actor.rs         |  20 +-
 p2p/src/authenticated/actors/peer/ingress.rs       |   8 +-
 p2p/src/authenticated/actors/spawner/actor.rs      |  14 +-
 p2p/src/authenticated/actors/tracker/actor.rs      |  94 +--
 p2p/src/authenticated/actors/tracker/directory.rs  |  42 +-
 p2p/src/authenticated/actors/tracker/ingress.rs    |  57 +-
 p2p/src/authenticated/actors/tracker/mod.rs        |   4 +-
 p2p/src/authenticated/actors/tracker/record.rs     | 168 +++--
 p2p/src/authenticated/config.rs                    |   6 +-
 p2p/src/authenticated/metrics.rs                   |  36 +-
 p2p/src/authenticated/mod.rs                       |  18 +-
 p2p/src/authenticated/network.rs                   |  10 +-
 p2p/src/authenticated/types.rs                     |  82 +--
 p2p/src/simulated/mod.rs                           |  46 +-
 p2p/src/simulated/network.rs                       |   8 +-
 p2p/src/utils/requester/requester.rs               |  15 +-
 resolver/Cargo.toml                                |   2 +-
 resolver/src/p2p/mod.rs                            |  18 +-
 runtime/Cargo.toml                                 |   2 +-
 runtime/src/deterministic.rs                       |   2 +-
 runtime/src/iouring/mod.rs                         | 365 ++++++++---
 runtime/src/lib.rs                                 |  46 +-
 runtime/src/mocks.rs                               | 168 +++--
 runtime/src/network/audited.rs                     |  23 +-
 runtime/src/network/deterministic.rs               |  12 +-
 runtime/src/network/iouring.rs                     | 172 +++++-
 runtime/src/network/metered.rs                     |  21 +-
 runtime/src/network/mod.rs                         |  67 +-
 runtime/src/network/tokio.rs                       |  29 +-
 runtime/src/storage/audited.rs                     |  22 +-
 runtime/src/storage/iouring.rs                     | 126 ++--
 runtime/src/storage/memory.rs                      |  16 +-
 runtime/src/storage/metered.rs                     |  13 +-
 runtime/src/storage/mod.rs                         |  38 +-
 runtime/src/storage/tokio.rs                       |  16 +-
 runtime/src/tokio/runtime.rs                       |  82 ++-
 runtime/src/utils/buffer/mod.rs                    | 674 ++++++++++++--------
 runtime/src/utils/buffer/read.rs                   |   9 +-
 runtime/src/utils/buffer/write.rs                  | 176 ++++--
 storage/Cargo.toml                                 |   2 +-
 storage/src/adb/any.rs                             | 136 ++--
 storage/src/adb/current.rs                         |  63 +-
 storage/src/archive/mod.rs                         |  15 +-
 storage/src/journal/fixed.rs                       | 283 +++++++--
 storage/src/journal/variable.rs                    | 636 +++++++++++++++----
 storage/src/metadata/storage.rs                    |  13 +-
 storage/src/mmr/benches/bench.rs                   |   2 +
 storage/src/mmr/benches/update.rs                  |  71 +++
 storage/src/mmr/bitmap.rs                          | 453 +++++++-------
 storage/src/mmr/journaled.rs                       | 141 +++--
 storage/src/mmr/mem.rs                             | 267 +++++++-
 storage/src/mmr/storage.rs                         |   4 +-
 storage/src/mmr/tests/mod.rs                       |  45 ++
 stream/Cargo.toml                                  |   8 +-
 stream/src/lib.rs                                  |  10 +-
 stream/src/public_key/benches/receiver_receive.rs  |  11 +-
 stream/src/public_key/benches/sender_send.rs       |  12 +-
 stream/src/public_key/cipher.rs                    | 316 ++++++++++
 stream/src/public_key/connection.rs                | 392 ++++++++++--
 stream/src/public_key/handshake.rs                 | 152 ++---
 stream/src/public_key/mod.rs                       |  33 +-
 stream/src/public_key/nonce.rs                     |  91 +--
 stream/src/utils/codec.rs                          |  37 +-
 utils/Cargo.toml                                   |   2 +-
 utils/src/lib.rs                                   |   2 -
 utils/src/stable_buf.rs                            | 121 ++--
 utils/src/stable_buf_mut.rs                        |  41 --
 163 files changed, 7230 insertions(+), 3485 deletions(-)
```