### PR TITLE
[p2p] log actual error instead of ChannelClosed

### DIFF
--- a/p2p/src/authenticated/actors/peer/actor.rs
+++ b/p2p/src/authenticated/actors/peer/actor.rs
@@ -270,7 +270,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                             // close the peer (as other channels may still be open).
                             let sender = senders.get_mut(&data.channel).unwrap();
                             let _ = sender.send((peer.clone(), data.message)).await.inspect_err(
-                                |e| debug!(err=?e, "failed to send message to client"),
+                                |e| debug!(err=?e, channel=data.channel, "failed to send message to client"),
                             );
                         }
                     }

--- a/p2p/src/authenticated/actors/peer/actor.rs
+++ b/p2p/src/authenticated/actors/peer/actor.rs
@@ -269,13 +269,9 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                             // If the channel handler is closed, we log an error but don't
                             // close the peer (as other channels may still be open).
                             let sender = senders.get_mut(&data.channel).unwrap();
-                            if let Err(e) = sender
-                                .send((peer.clone(), data.message))
-                                .await
-                                .map_err(|_| Error::ChannelClosed(data.channel))
-                            {
-                                debug!(err=?e, "failed to send message to client");
-                            }
+                            let _ = sender.send((peer.clone(), data.message)).await.inspect_err(
+                                |e| debug!(err=?e, "failed to send message to client"),
+                            );
                         }
                     }
                 }

--- a/p2p/src/authenticated/actors/peer/mod.rs
+++ b/p2p/src/authenticated/actors/peer/mod.rs
@@ -44,6 +44,4 @@ pub enum Error {
     MessageDropped,
     #[error("invalid channel")]
     InvalidChannel,
-    #[error("channel closed: {0}")]
-    ChannelClosed(u32),
 }


### PR DESCRIPTION
Logs the actual error instead of just `ChannelClosed`.