### PR TITLE
[storage/mmr] Parallelize merkleization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "futures-util",
  "prometheus-client",
  "rand",
+ "rayon",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -24,6 +24,7 @@ prometheus-client = { workspace = true }
 futures-util = { workspace = true }
 tracing = { workspace = true }
 zstd = { workspace = true }
+rayon = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -216,11 +216,13 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         Ok((mmr, log))
     }
 
-    /// Builds the database's snapshot by replaying the log starting at `start_leaf_num`. If a bitmap is
-    /// provided, then a bit is appended for each operation in the operation log, with its value
-    /// reflecting its activity status. The bitmap is expected to already have a number of bits
-    /// corresponding to the portion of the database below the inactivity floor, and this method
-    /// will panic otherwise.
+    /// Builds the database's snapshot by replaying the log starting at `start_leaf_num`.
+    ///
+    /// If a bitmap is provided, then a bit is appended for each operation in the operation log,
+    /// with its value reflecting its activity status. The bitmap is expected to already have a
+    /// number of bits corresponding to the portion of the database below the inactivity floor, and
+    /// this method will panic otherwise. The caller is responsible for syncing any changes made to
+    /// the bitmap.
     pub(super) async fn build_snapshot_from_log<const N: usize>(
         start_leaf_num: u64,
         log: &Journal<E, Operation<K, V>>,

--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -117,7 +117,6 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         let mut hasher = Standard::<H>::new();
         let (mmr, log) = Self::init_mmr_and_log(
             context,
-            &mut hasher,
             Config {
                 mmr_journal_partition: cfg.mmr_journal_partition,
                 mmr_metadata_partition: cfg.mmr_metadata_partition,
@@ -129,6 +128,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
                 translator: cfg.translator,
                 pool: cfg.pool,
             },
+            &mut hasher,
         )
         .await?;
 
@@ -158,8 +158,8 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
     /// db will be as of the last committed operation.
     pub(super) async fn init_mmr_and_log(
         context: E,
-        hasher: &mut Standard<H>,
         cfg: Config<T>,
+        hasher: &mut Standard<H>,
     ) -> Result<(Mmr<E, H>, Journal<E, Operation<K, V>>), Error> {
         let mut mmr = Mmr::init(
             context.with_label("mmr"),
@@ -1239,8 +1239,8 @@ mod test {
             let cfg = any_db_config("partition", TwoCap);
             let (mmr, log) = Any::<_, Digest, Digest, _, TwoCap>::init_mmr_and_log(
                 context.clone(),
-                &mut hasher,
                 cfg,
+                &mut hasher,
             )
             .await
             .unwrap();

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -153,7 +153,7 @@ impl<
         // Initialize the db's mmr/log.
         let mut hasher = Standard::<H>::new();
         let (mut mmr, log) =
-            Any::<_, _, _, _, T>::init_mmr_and_log(context.clone(), &mut hasher, cfg).await?;
+            Any::<_, _, _, _, T>::init_mmr_and_log(context.clone(), cfg, &mut hasher).await?;
 
         // Ensure consistency between the bitmap and the db's MMR.
         let mmr_pruned_pos = mmr.pruned_to_pos();

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -212,7 +212,7 @@ impl<
             snapshot,
             inactivity_floor_loc,
             uncommitted_ops: 0,
-            hasher,
+            hasher: Standard::<H>::new(),
         };
 
         Ok(Self {

--- a/storage/src/mmr/benches/update.rs
+++ b/storage/src/mmr/benches/update.rs
@@ -1,24 +1,47 @@
 use commonware_cryptography::{sha256, Digest as _, Sha256};
-use commonware_runtime::{benchmarks::tokio, tokio::Config};
+use commonware_runtime::{
+    benchmarks::{context, tokio},
+    tokio::Config,
+};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{collections::HashMap, time::Instant};
 
+#[derive(PartialEq, Debug, Clone, Copy)]
+enum SyncType {
+    NoBatching,
+    BatchedSerial,
+    BatchedParallel,
+}
+
+/// Minimum number of computations required to trigger parallelization. This value doesn't appear to
+/// impact performance all that much so we use just this fixed value for all benchmarks.
+const MIN_TO_PARALLELIZE: usize = 100;
+
+/// Threads (cores) to use for parallelization. We pick 8 since our benchmarking pipeline is
+/// configured to provide 8 cores. More threads may be faster on machines with more cores, but
+/// returns start diminishing.
+const THREADS: usize = 8;
+
 /// Benchmark the performance of randomly updating leaves in an MMR.
 fn bench_update(c: &mut Criterion) {
     let cfg = Config::default();
     let runner = tokio::Runner::new(cfg);
-    for updates in [100_000, 1_000_000] {
-        for leaves in [10_000u64, 100_000, 1_000_000, 5_000_000, 10_000_000] {
-            for batched in [true, false] {
+    for updates in [1_000_000, 100_000] {
+        for leaves in [100_000, 1_000_000, 5_000_000, 10_000_000] {
+            for sync_type in [
+                SyncType::NoBatching,
+                SyncType::BatchedSerial,
+                SyncType::BatchedParallel,
+            ] {
                 c.bench_function(
                     &format!(
-                        "{}/updates={} leaves={} batched={}",
+                        "{}/updates={} leaves={} sync_type={:?}",
                         module_path!(),
                         updates,
                         leaves,
-                        batched
+                        sync_type,
                     ),
                     |b| {
                         b.to_async(&runner).iter_custom(|_iters| async move {
@@ -35,6 +58,9 @@ fn bench_update(c: &mut Criterion) {
                                 let pos = mmr.add(&mut h, &digest);
                                 leaf_positions.push(pos);
                             }
+                            let ctx = context::get::<commonware_runtime::tokio::Context>();
+                            let mut pool =
+                                commonware_runtime::create_pool(ctx.clone(), THREADS).unwrap();
 
                             // Randomly update leaves -- this is what we are benchmarking.
                             let start = Instant::now();
@@ -48,15 +74,35 @@ fn bench_update(c: &mut Criterion) {
                                 let new_element = &elements[rand_leaf_swap];
                                 leaf_map.insert(rand_leaf_pos, *new_element);
                             }
-                            if batched {
-                                mmr.update_leaf_batched(&mut h, leaf_map.into_iter());
-                            } else {
-                                for (pos, element) in leaf_map {
-                                    mmr.update_leaf(&mut h, pos, &element);
+
+                            match sync_type {
+                                SyncType::NoBatching => {
+                                    for (pos, element) in leaf_map {
+                                        mmr.update_leaf(&mut h, pos, &element);
+                                    }
+                                }
+                                SyncType::BatchedSerial => {
+                                    mmr.update_leaf_batched(&mut h, leaf_map.into_iter());
+                                }
+                                SyncType::BatchedParallel => {
+                                    let update_vec = leaf_map
+                                        .into_iter()
+                                        .collect::<Vec<(u64, sha256::Digest)>>();
+                                    mmr.update_leaf_parallel(
+                                        &mut h,
+                                        &mut pool,
+                                        MIN_TO_PARALLELIZE,
+                                        update_vec,
+                                    );
                                 }
                             }
 
-                            mmr.sync(&mut h);
+                            if sync_type == SyncType::BatchedParallel {
+                                mmr.sync_parallel(&mut h, &mut pool, MIN_TO_PARALLELIZE);
+                            } else {
+                                mmr.sync(&mut h);
+                            }
+
                             start.elapsed()
                         });
                     },

--- a/storage/src/mmr/benches/update.rs
+++ b/storage/src/mmr/benches/update.rs
@@ -15,10 +15,6 @@ enum SyncType {
     BatchedParallel,
 }
 
-/// Minimum number of computations required to trigger parallelization. This value doesn't appear to
-/// impact performance all that much so we use just this fixed value for all benchmarks.
-const MIN_TO_PARALLELIZE: usize = 100;
-
 /// Threads (cores) to use for parallelization. We pick 8 since our benchmarking pipeline is
 /// configured to provide 8 cores. More threads may be faster on machines with more cores, but
 /// returns start diminishing.
@@ -45,7 +41,16 @@ fn bench_update(c: &mut Criterion) {
                     ),
                     |b| {
                         b.to_async(&runner).iter_custom(|_iters| async move {
-                            let mut mmr = Mmr::<Sha256>::new();
+                            let mut mmr = match sync_type {
+                                SyncType::BatchedParallel => {
+                                    let ctx = context::get::<commonware_runtime::tokio::Context>();
+                                    let pool =
+                                        commonware_runtime::create_pool(ctx.clone(), THREADS)
+                                            .unwrap();
+                                    Mmr::<Sha256>::init(vec![], 0, vec![], Some(pool))
+                                }
+                                _ => Mmr::<Sha256>::new(),
+                            };
                             let mut elements = Vec::with_capacity(leaves as usize);
                             let mut sampler = StdRng::seed_from_u64(0);
                             let mut leaf_positions = Vec::with_capacity(leaves as usize);
@@ -58,9 +63,6 @@ fn bench_update(c: &mut Criterion) {
                                 let pos = mmr.add(&mut h, &digest);
                                 leaf_positions.push(pos);
                             }
-                            let ctx = context::get::<commonware_runtime::tokio::Context>();
-                            let mut pool =
-                                commonware_runtime::create_pool(ctx.clone(), THREADS).unwrap();
 
                             // Randomly update leaves -- this is what we are benchmarking.
                             let start = Instant::now();
@@ -81,27 +83,16 @@ fn bench_update(c: &mut Criterion) {
                                         mmr.update_leaf(&mut h, pos, &element);
                                     }
                                 }
-                                SyncType::BatchedSerial => {
-                                    mmr.update_leaf_batched(&mut h, leaf_map.into_iter());
-                                }
-                                SyncType::BatchedParallel => {
-                                    let update_vec = leaf_map
-                                        .into_iter()
-                                        .collect::<Vec<(u64, sha256::Digest)>>();
-                                    mmr.update_leaf_parallel(
-                                        &mut h,
-                                        &mut pool,
-                                        MIN_TO_PARALLELIZE,
-                                        update_vec,
-                                    );
+                                _ => {
+                                    // Collect the map into a Vec of (position, element) pairs for batched updates
+                                    let updates: Vec<(
+                                        u64,
+                                        commonware_cryptography::sha256::Digest,
+                                    )> = leaf_map.into_iter().collect();
+                                    mmr.update_leaf_batched(&mut h, &updates);
                                 }
                             }
-
-                            if sync_type == SyncType::BatchedParallel {
-                                mmr.sync_parallel(&mut h, &mut pool, MIN_TO_PARALLELIZE);
-                            } else {
-                                mmr.sync(&mut h);
-                            }
+                            mmr.sync(&mut h);
 
                             start.elapsed()
                         });

--- a/storage/src/mmr/benches/update.rs
+++ b/storage/src/mmr/benches/update.rs
@@ -3,7 +3,10 @@ use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::Config,
 };
-use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
+use commonware_storage::mmr::{
+    hasher::Standard,
+    mem::{Config as MemConfig, Mmr},
+};
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{collections::HashMap, time::Instant};
@@ -47,7 +50,12 @@ fn bench_update(c: &mut Criterion) {
                                     let pool =
                                         commonware_runtime::create_pool(ctx.clone(), THREADS)
                                             .unwrap();
-                                    Mmr::<Sha256>::init(vec![], 0, vec![], Some(pool))
+                                    Mmr::<Sha256>::init(MemConfig {
+                                        nodes: vec![],
+                                        pruned_to_pos: 0,
+                                        pinned_nodes: vec![],
+                                        pool: Some(pool),
+                                    })
                                 }
                                 _ => Mmr::<Sha256>::new(),
                             };

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use commonware_codec::DecodeExt;
 use commonware_cryptography::Hasher as CHasher;
-use commonware_runtime::{Clock, Metrics, Storage as RStorage};
+use commonware_runtime::{Clock, Metrics, Storage as RStorage, ThreadPool};
 use commonware_utils::array::prefixed_u64::U64;
 use std::collections::{HashSet, VecDeque};
 use tracing::{debug, error, warn};
@@ -118,6 +118,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
     pub async fn restore_pruned<C: RStorage + Metrics + Clock>(
         context: C,
         partition: &str,
+        pool: Option<ThreadPool>,
     ) -> Result<Self, Error> {
         let metadata_cfg = MConfig {
             partition: partition.to_string(),
@@ -161,7 +162,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
 
         metadata.close().await?;
 
-        let mmr = Mmr::init(Vec::new(), mmr_size, pinned_nodes);
+        let mmr = Mmr::init(Vec::new(), mmr_size, pinned_nodes, pool);
 
         Ok(Self {
             bitmap: VecDeque::from([[0u8; N]]),
@@ -447,11 +448,15 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
         self.authenticated_len = end;
 
         // Inform the MMR of modified chunks.
-        let updates = self.dirty_chunks.iter().map(|chunk_index| {
-            let pos = leaf_num_to_pos((*chunk_index + self.pruned_chunks) as u64);
-            (pos, &self.bitmap[*chunk_index])
-        });
-        self.mmr.update_leaf_batched(hasher, updates);
+        let updates = self
+            .dirty_chunks
+            .iter()
+            .map(|chunk_index| {
+                let pos = leaf_num_to_pos((*chunk_index + self.pruned_chunks) as u64);
+                (pos, &self.bitmap[*chunk_index])
+            })
+            .collect::<Vec<_>>();
+        self.mmr.update_leaf_batched(hasher, &updates);
         self.dirty_chunks.clear();
         self.mmr.sync(hasher);
 
@@ -1029,7 +1034,7 @@ mod tests {
         executor.start(|context| async move {
             // Initializing from an empty partition should result in an empty bitmap.
             let mut bitmap =
-                Bitmap::<Sha256, SHA256_SIZE>::restore_pruned(context.clone(), PARTITION)
+                Bitmap::<Sha256, SHA256_SIZE>::restore_pruned(context.clone(), PARTITION, None)
                     .await
                     .unwrap();
             assert_eq!(bitmap.bit_count(), 0);
@@ -1057,7 +1062,7 @@ mod tests {
                     .write_pruned(context.clone(), PARTITION)
                     .await
                     .unwrap();
-                bitmap = Bitmap::<_, SHA256_SIZE>::restore_pruned(context.clone(), PARTITION)
+                bitmap = Bitmap::<_, SHA256_SIZE>::restore_pruned(context.clone(), PARTITION, None)
                     .await
                     .unwrap();
                 let _ = bitmap.root(&mut hasher).await.unwrap();

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -12,7 +12,14 @@
 
 use crate::{
     metadata::{Config as MConfig, Metadata},
-    mmr::{iterator::leaf_num_to_pos, mem::Mmr, verification::Proof, Error, Error::*, Hasher},
+    mmr::{
+        iterator::leaf_num_to_pos,
+        mem::{Config as MemConfig, Mmr},
+        verification::Proof,
+        Error,
+        Error::*,
+        Hasher,
+    },
 };
 use commonware_codec::DecodeExt;
 use commonware_cryptography::Hasher as CHasher;
@@ -162,7 +169,12 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
 
         metadata.close().await?;
 
-        let mmr = Mmr::init(Vec::new(), mmr_size, pinned_nodes, pool);
+        let mmr = Mmr::init(MemConfig {
+            nodes: Vec::new(),
+            pruned_to_pos: mmr_size,
+            pinned_nodes,
+            pool,
+        });
 
         Ok(Self {
             bitmap: VecDeque::from([[0u8; N]]),

--- a/storage/src/mmr/hasher.rs
+++ b/storage/src/mmr/hasher.rs
@@ -20,10 +20,10 @@ pub trait Hasher<H: CHasher>: Send + Sync {
 
     /// Computes the root for an MMR given its size and an iterator over the digests of its peaks in
     /// decreasing order of height.
-    fn root_digest<'b>(
+    fn root_digest<'a>(
         &mut self,
         size: u64,
-        peak_digests: impl Iterator<Item = &'b H::Digest>,
+        peak_digests: impl Iterator<Item = &'a H::Digest>,
     ) -> H::Digest;
 
     /// Compute the digest of a byte slice.
@@ -31,6 +31,8 @@ pub trait Hasher<H: CHasher>: Send + Sync {
 
     /// Access the inner [CHasher] hasher.
     fn inner(&mut self) -> &mut H;
+
+    fn clone(&self) -> impl Hasher<H>;
 }
 
 /// The standard hasher to use with an MMR for computing leaf, node and root digests. Leverages no
@@ -71,6 +73,10 @@ impl<H: CHasher> Default for Standard<H> {
 impl<H: CHasher> Hasher<H> for Standard<H> {
     fn inner(&mut self) -> &mut H {
         &mut self.hasher
+    }
+
+    fn clone(&self) -> impl Hasher<H> {
+        Standard { hasher: H::new() }
     }
 
     fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest {
@@ -187,7 +193,8 @@ impl<'a, H: CHasher> Grafting<'a, H> {
     }
 
     /// Loads the grafted digests for the specified leaves into the internal map. Does not clear out
-    /// any previously loaded digests.
+    /// any previously loaded digests. This method must be used to provide grafted digests for any
+    /// leaf whose `leaf_digest` needs to be computed.
     ///
     /// # Warning
     ///
@@ -220,6 +227,13 @@ impl<'a, H: CHasher> Grafting<'a, H> {
     fn destination_pos(&self, pos: u64) -> u64 {
         destination_pos(pos, self.height)
     }
+}
+
+/// A lightweight, short-lived "clone" of a Grafting hasher that can be used in parallel computations.
+pub struct GraftingClone<'a, H: CHasher> {
+    hasher: Standard<H>,
+    height: u32,
+    grafted_digests: &'a HashMap<u64, H::Digest>,
 }
 
 /// Compute the position of the node in the base tree onto which we should graft the node at
@@ -292,8 +306,14 @@ pub(super) fn source_pos(base_node_pos: u64, height: u32) -> Option<u64> {
 }
 
 impl<H: CHasher> Hasher<H> for Grafting<'_, H> {
+    /// Computes the digest of a leaf in the peak_tree of a grafted MMR.
+    ///
+    /// # Warning
+    ///
+    /// Panics if the grafted_digest was not previously loaded for the leaf.
     fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest {
-        let Some(grafted_digest) = self.grafted_digests.get(&pos) else {
+        let grafted_digest = self.grafted_digests.get(&pos);
+        let Some(grafted_digest) = grafted_digest else {
             panic!("missing grafted digest for leaf_pos {}", pos);
         };
 
@@ -303,6 +323,14 @@ impl<H: CHasher> Hasher<H> for Grafting<'_, H> {
         self.hasher.update_with_digest(grafted_digest);
 
         self.hasher.finalize()
+    }
+
+    fn clone(&self) -> impl Hasher<H> {
+        GraftingClone {
+            hasher: Standard::new(),
+            height: self.height,
+            grafted_digests: &self.grafted_digests,
+        }
     }
 
     fn node_digest(
@@ -322,6 +350,57 @@ impl<H: CHasher> Hasher<H> for Grafting<'_, H> {
     ) -> H::Digest {
         self.hasher
             .root_digest(self.destination_pos(size), peak_digests)
+    }
+
+    fn digest(&mut self, data: &[u8]) -> H::Digest {
+        self.hasher.digest(data)
+    }
+
+    fn inner(&mut self) -> &mut H {
+        self.hasher.inner()
+    }
+}
+
+impl<H: CHasher> Hasher<H> for GraftingClone<'_, H> {
+    fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest {
+        let grafted_digest = self.grafted_digests.get(&pos);
+        let Some(grafted_digest) = grafted_digest else {
+            panic!("missing grafted digest for leaf_pos {}", pos);
+        };
+
+        // We do not include position in the digest material here since the position information is
+        // already captured in the base_node_digest.
+        self.hasher.update_with_element(element);
+        self.hasher.update_with_digest(grafted_digest);
+
+        self.hasher.finalize()
+    }
+
+    fn clone(&self) -> impl Hasher<H> {
+        GraftingClone {
+            hasher: Standard::new(),
+            height: self.height,
+            grafted_digests: self.grafted_digests,
+        }
+    }
+
+    fn node_digest(
+        &mut self,
+        pos: u64,
+        left_digest: &H::Digest,
+        right_digest: &H::Digest,
+    ) -> H::Digest {
+        self.hasher
+            .node_digest(destination_pos(pos, self.height), left_digest, right_digest)
+    }
+
+    fn root_digest<'a>(
+        &mut self,
+        size: u64,
+        peak_digests: impl Iterator<Item = &'a H::Digest>,
+    ) -> H::Digest {
+        self.hasher
+            .root_digest(destination_pos(size, self.height), peak_digests)
     }
 
     fn digest(&mut self, data: &[u8]) -> H::Digest {
@@ -363,6 +442,15 @@ impl<'a, H: CHasher> GraftingVerifier<'a, H> {
 impl<H: CHasher> Hasher<H> for GraftingVerifier<'_, H> {
     fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest {
         self.hasher.leaf_digest(pos, element)
+    }
+
+    fn clone(&self) -> impl Hasher<H> {
+        GraftingVerifier {
+            hasher: Standard::new(),
+            height: self.height,
+            elements: self.elements.clone(),
+            num: self.num,
+        }
     }
 
     fn node_digest(

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use commonware_codec::DecodeExt;
 use commonware_cryptography::Hasher as CHasher;
-use commonware_runtime::{Clock, Metrics, Storage as RStorage};
+use commonware_runtime::{Clock, Metrics, Storage as RStorage, ThreadPool};
 use commonware_utils::array::prefixed_u64::U64;
 use std::collections::HashMap;
 use tracing::{debug, error, warn};
@@ -57,8 +57,8 @@ pub struct Mmr<E: RStorage + Clock + Metrics, H: CHasher> {
     /// until pruning is invoked, and its contents change only when the pruning boundary moves.
     metadata: Metadata<E, U64>,
 
-    // The highest position for which this MMR has been pruned, or 0 if this MMR has never been
-    // pruned.
+    /// The highest position for which this MMR has been pruned, or 0 if this MMR has never been
+    /// pruned.
     pruned_to_pos: u64,
 }
 
@@ -80,7 +80,12 @@ const PRUNE_TO_POS_PREFIX: u8 = 1;
 
 impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
     /// Initialize a new `Mmr` instance.
-    pub async fn init(context: E, hasher: &mut impl Hasher<H>, cfg: Config) -> Result<Self, Error> {
+    pub async fn init(
+        context: E,
+        hasher: &mut impl Hasher<H>,
+        cfg: Config,
+        pool: Option<ThreadPool>,
+    ) -> Result<Self, Error> {
         let journal_cfg = JConfig {
             partition: cfg.journal_partition,
             items_per_blob: cfg.items_per_blob,
@@ -97,7 +102,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
 
         if journal_size == 0 {
             return Ok(Self {
-                mem_mmr: MemMmr::new(),
+                mem_mmr: MemMmr::init(vec![], 0, vec![], pool),
                 journal,
                 journal_size,
                 metadata,
@@ -158,7 +163,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
                 Mmr::<E, H>::get_from_metadata_or_journal(&metadata, &journal, pos).await?;
             pinned_nodes.push(digest);
         }
-        let mut mem_mmr = MemMmr::init(vec![], journal_size, pinned_nodes);
+        let mut mem_mmr = MemMmr::init(vec![], journal_size, pinned_nodes, pool);
 
         // Compute the additional pinned nodes needed to prove all journal elements at the current
         // pruning boundary.
@@ -320,7 +325,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
                     .await?;
             pinned_nodes.push(digest);
         }
-        self.mem_mmr = MemMmr::init(vec![], new_size, pinned_nodes);
+        self.mem_mmr = MemMmr::init(vec![], new_size, pinned_nodes, self.mem_mmr.pool.take());
 
         Ok(())
     }
@@ -334,7 +339,8 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         self.mem_mmr.root(h)
     }
 
-    /// Process all batched updates and sync the MMR to disk.
+    /// Process all batched updates and sync the MMR to disk. If `pool` is non-null, then it will be
+    /// used to parallelize the sync.
     pub async fn sync(&mut self, h: &mut impl Hasher<H>) -> Result<(), Error> {
         if self.size() == 0 {
             return Ok(());
@@ -342,6 +348,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
 
         // Write the nodes cached in the memory-resident MMR to the journal.
         self.mem_mmr.sync(h);
+
         for i in self.journal_size..self.size() {
             let node = *self.mem_mmr.get_node_unchecked(i);
             self.journal.append(node).await?;
@@ -432,7 +439,8 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
 
     /// Prune all nodes up to but not including the given position and update the pinned nodes.
     ///
-    /// This implementation ensures that no failure can leave the MMR in an unrecoverable state.
+    /// This implementation ensures that no failure can leave the MMR in an unrecoverable state,
+    /// requiring it sync the MMR to write any potential unprocessed updates.
     pub async fn prune_to_pos(&mut self, h: &mut impl Hasher<H>, pos: u64) -> Result<(), Error> {
         assert!(pos <= self.size());
         if self.size() == 0 {
@@ -536,18 +544,21 @@ mod tests {
         hash(&v.to_be_bytes())
     }
 
+    fn test_config() -> Config {
+        Config {
+            journal_partition: "journal_partition".into(),
+            metadata_partition: "metadata_partition".into(),
+            items_per_blob: 7,
+            write_buffer: 1024,
+        }
+    }
+
     /// Test that the MMR root computation remains stable.
     #[test]
     fn test_journaled_mmr_root_stability() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let cfg = Config {
-                journal_partition: "journal_partition".into(),
-                metadata_partition: "metadata_partition".into(),
-                items_per_blob: 7,
-                write_buffer: 1024,
-            };
-            let mut mmr = Mmr::init(context.clone(), &mut Standard::new(), cfg.clone())
+            let mut mmr = Mmr::init(context.clone(), &mut Standard::new(), test_config(), None)
                 .await
                 .unwrap();
             build_and_check_test_roots_mmr(&mut mmr).await;
@@ -560,14 +571,8 @@ mod tests {
     fn test_journaled_mmr_root_stability_batched() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let cfg = Config {
-                journal_partition: "journal_partition".into(),
-                metadata_partition: "metadata_partition".into(),
-                items_per_blob: 7,
-                write_buffer: 1024,
-            };
             let mut std_hasher = Standard::new();
-            let mut mmr = Mmr::init(context.clone(), &mut std_hasher, cfg.clone())
+            let mut mmr = Mmr::init(context.clone(), &mut std_hasher, test_config(), None)
                 .await
                 .unwrap();
             build_batched_and_check_test_roots_journaled(&mut mmr).await;
@@ -578,14 +583,8 @@ mod tests {
     fn test_journaled_mmr_empty() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let cfg = Config {
-                journal_partition: "journal_partition".into(),
-                metadata_partition: "metadata_partition".into(),
-                items_per_blob: 7,
-                write_buffer: 1024,
-            };
             let mut hasher: Standard<Sha256> = Standard::new();
-            let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mut mmr = Mmr::init(context.clone(), &mut hasher, test_config(), None)
                 .await
                 .unwrap();
             assert_eq!(mmr.size(), 0);
@@ -603,15 +602,8 @@ mod tests {
     fn test_journaled_mmr_pop() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let cfg = Config {
-                journal_partition: "journal_partition".into(),
-                metadata_partition: "metadata_partition".into(),
-                items_per_blob: 7,
-                write_buffer: 1024,
-            };
-
             let mut hasher: Standard<Sha256> = Standard::new();
-            let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mut mmr = Mmr::init(context.clone(), &mut hasher, test_config(), None)
                 .await
                 .unwrap();
 
@@ -673,14 +665,8 @@ mod tests {
     fn test_journaled_mmr_basic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let cfg = Config {
-                journal_partition: "journal_partition".into(),
-                metadata_partition: "metadata_partition".into(),
-                items_per_blob: 7,
-                write_buffer: 1024,
-            };
             let mut hasher: Standard<Sha256> = Standard::new();
-            let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mut mmr = Mmr::init(context.clone(), &mut hasher, test_config(), None)
                 .await
                 .unwrap();
             // Build a test MMR with 255 leaves
@@ -748,14 +734,8 @@ mod tests {
     fn test_journaled_mmr_recovery() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let cfg = Config {
-                journal_partition: "journal_partition".into(),
-                metadata_partition: "metadata_partition".into(),
-                items_per_blob: 7,
-                write_buffer: 1024,
-            };
             let mut hasher: Standard<Sha256> = Standard::new();
-            let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mut mmr = Mmr::init(context.clone(), &mut hasher, test_config(), None)
                 .await
                 .unwrap();
             assert_eq!(mmr.size(), 0);
@@ -790,7 +770,7 @@ mod tests {
                 .expect("Failed to corrupt blob");
             blob.close().await.expect("Failed to close blob");
 
-            let mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mmr = Mmr::init(context.clone(), &mut hasher, test_config(), None)
                 .await
                 .unwrap();
             // Since we didn't corrupt the leaf, the MMR is able to replay the leaf and recover to
@@ -800,7 +780,7 @@ mod tests {
 
             // Make sure closing it and re-opening it persists the recovered state.
             mmr.close(&mut hasher).await.unwrap();
-            let mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mmr = Mmr::init(context.clone(), &mut hasher, test_config(), None)
                 .await
                 .unwrap();
             assert_eq!(mmr.size(), 498);
@@ -825,7 +805,7 @@ mod tests {
                 .expect("Failed to corrupt blob");
             blob.close().await.expect("Failed to close blob");
 
-            let mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mmr = Mmr::init(context.clone(), &mut hasher, test_config(), None)
                 .await
                 .unwrap();
             // Since the leaf was corrupted, it should not have been recovered, and the journal's
@@ -838,17 +818,11 @@ mod tests {
     fn test_journaled_mmr_pruning() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let cfg = Config {
-                journal_partition: "journal_partition".into(),
-                metadata_partition: "metadata_partition".into(),
-                items_per_blob: 7,
-                write_buffer: 1024,
-            };
-
             let mut hasher: Standard<Sha256> = Standard::new();
             // make sure pruning doesn't break root computation, adding of new nodes, etc.
             const LEAF_COUNT: usize = 2000;
-            let mut pruned_mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let cfg_pruned = test_config();
+            let mut pruned_mmr = Mmr::init(context.clone(), &mut hasher, cfg_pruned.clone(), None)
                 .await
                 .unwrap();
             let cfg_unpruned = Config {
@@ -857,7 +831,7 @@ mod tests {
                 items_per_blob: 7,
                 write_buffer: 1024,
             };
-            let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg_unpruned)
+            let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg_unpruned, None)
                 .await
                 .unwrap();
             let mut leaves = Vec::with_capacity(LEAF_COUNT);
@@ -898,7 +872,7 @@ mod tests {
 
             // Close the MMR & reopen.
             pruned_mmr.close(&mut hasher).await.unwrap();
-            let mut pruned_mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mut pruned_mmr = Mmr::init(context.clone(), &mut hasher, cfg_pruned.clone(), None)
                 .await
                 .unwrap();
             assert_eq!(pruned_mmr.root(&mut hasher), mmr.root(&mut hasher));
@@ -919,9 +893,9 @@ mod tests {
                 .add(&mut hasher, &test_digest(LEAF_COUNT))
                 .await
                 .unwrap();
-            assert!(pruned_mmr.size() % cfg.items_per_blob != 0);
+            assert!(pruned_mmr.size() % cfg_pruned.items_per_blob != 0);
             pruned_mmr.close(&mut hasher).await.unwrap();
-            let mut pruned_mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mut pruned_mmr = Mmr::init(context.clone(), &mut hasher, cfg_pruned.clone(), None)
                 .await
                 .unwrap();
             assert_eq!(pruned_mmr.root(&mut hasher), mmr.root(&mut hasher));
@@ -930,7 +904,7 @@ mod tests {
 
             // Add nodes until we are on a blob boundary, and confirm prune_all still removes all
             // retained nodes.
-            while pruned_mmr.size() % cfg.items_per_blob != 0 {
+            while pruned_mmr.size() % cfg_pruned.items_per_blob != 0 {
                 pruned_mmr
                     .add(&mut hasher, &test_digest(LEAF_COUNT))
                     .await
@@ -946,16 +920,10 @@ mod tests {
     fn test_journaled_mmr_recovery_with_pruning() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let cfg = Config {
-                journal_partition: "journal_partition".into(),
-                metadata_partition: "metadata_partition".into(),
-                items_per_blob: 7,
-                write_buffer: 1024,
-            };
             // Build MMR with 2000 leaves.
             let mut hasher: Standard<Sha256> = Standard::new();
             const LEAF_COUNT: usize = 2000;
-            let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+            let mut mmr = Mmr::init(context.clone(), &mut hasher, test_config(), None)
                 .await
                 .unwrap();
             let mut leaves = Vec::with_capacity(LEAF_COUNT);
@@ -972,7 +940,7 @@ mod tests {
 
             // Prune the MMR in increments of 50, simulating a partial write after each prune.
             for i in 0usize..200 {
-                let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
+                let mut mmr = Mmr::init(context.clone(), &mut hasher, test_config(), None)
                     .await
                     .unwrap();
                 let start_size = mmr.size();

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -391,7 +391,7 @@ impl<H: CHasher> Mmr<H> {
             let digests: Vec<(u64, H::Digest)> = updates
                 .par_iter()
                 .map_init(
-                    || hasher.clone(),
+                    || hasher.duplicate(),
                     |hasher, (pos, elem)| {
                         let digest = hasher.leaf_digest(*pos, elem.as_ref());
                         (*pos, digest)
@@ -506,7 +506,7 @@ impl<H: CHasher> Mmr<H> {
             let computed_digests: Vec<(usize, H::Digest)> = same_height
                 .par_iter()
                 .map_init(
-                    || hasher.clone(),
+                    || hasher.duplicate(),
                     |hasher, &pos| {
                         let left = pos - two_h;
                         let right = pos - 1;

--- a/storage/src/mmr/tests/mod.rs
+++ b/storage/src/mmr/tests/mod.rs
@@ -7,7 +7,6 @@ use crate::mmr::{
 use commonware_cryptography::{Hasher as CHasher, Sha256};
 use commonware_runtime::{Clock, Metrics, Storage as RStorage};
 use commonware_utils::hex;
-use rayon::ThreadPool;
 
 /// Build the MMR corresponding to the stability test `ROOTS` and confirm the
 /// roots match that from the builder's root computation
@@ -45,25 +44,6 @@ pub async fn build_batched_and_check_test_roots(mem_mmr: &mut MemMmr<Sha256>) {
         mem_mmr.add_batched(&mut hasher, &element);
     }
     mem_mmr.sync(&mut hasher);
-    assert_eq!(
-        hex(&mem_mmr.root(&mut hasher)),
-        ROOTS[199],
-        "Root after 200 elements"
-    );
-}
-
-pub async fn build_parallel_and_check_test_roots(
-    pool: &mut ThreadPool,
-    mem_mmr: &mut MemMmr<Sha256>,
-) {
-    let mut hasher = Standard::<Sha256>::new();
-    for i in 0u64..199 {
-        hasher.inner().update(&i.to_be_bytes());
-        let element = hasher.inner().finalize();
-        mem_mmr.add_batched(&mut hasher, &element);
-    }
-    mem_mmr.sync_parallel(&mut hasher, pool, 20);
-
     assert_eq!(
         hex(&mem_mmr.root(&mut hasher)),
         ROOTS[199],


### PR DESCRIPTION
- Adds parallel version of mmr::mem::sync()
- Adds parallel version of mmr::mem::update_leaf_batched()
- Extends update benchmark to contrast performance of no-batching/serial batching/parallel batching
- Extends structures based on MMRs to accept an optional thread pool during initialization, which configures them for parallelizing batch operations.