### PR TITLE
[p2p] Remove authenticated `Mailbox` implementations for message types

### DIFF
--- a/p2p/src/authenticated/actors/dialer.rs
+++ b/p2p/src/authenticated/actors/dialer.rs
@@ -128,7 +128,14 @@ impl<E: Spawner + Clock + GClock + Network + Rng + CryptoRng + Metrics, C: Signe
                 drop(guard);
 
                 // Start peer to handle messages
-                supervisor.spawn(instance, reservation).await;
+                supervisor
+                    .send(spawner::Message::Spawn {
+                        peer: peer.clone(),
+                        connection: instance,
+                        reservation,
+                    })
+                    .await
+                    .unwrap();
             }
         });
     }

--- a/p2p/src/authenticated/actors/listener.rs
+++ b/p2p/src/authenticated/actors/listener.rs
@@ -126,7 +126,14 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
         drop(guard);
 
         // Start peer to handle messages
-        supervisor.spawn(stream, reservation).await;
+        supervisor
+            .send(spawner::Message::Spawn {
+                peer: peer.clone(),
+                connection: stream,
+                reservation,
+            })
+            .await
+            .unwrap();
     }
 
     pub fn start(

--- a/p2p/src/authenticated/actors/listener.rs
+++ b/p2p/src/authenticated/actors/listener.rs
@@ -72,7 +72,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
         stream_cfg: StreamConfig<C>,
         sink: SinkOf<E>,
         stream: StreamOf<E>,
-        mut tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
+        mut tracker_mailbox: Mailbox<tracker::Message<E, C::PublicKey>>,
         mut supervisor: Mailbox<spawner::Message<E, C::PublicKey>>,
     ) {
         // Create span
@@ -99,8 +99,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
         //
         // Reserve also checks if the peer is authorized.
         let peer = incoming.peer();
-        let Some(reservation) = tracker
-            .listen(peer.clone())
+        let Some(reservation) = tracker::listen(&mut tracker_mailbox, peer.clone())
             .instrument(debug_span!("reserve"))
             .await
         else {

--- a/p2p/src/authenticated/actors/peer/actor.rs
+++ b/p2p/src/authenticated/actors/peer/actor.rs
@@ -127,7 +127,11 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
             let dialer = matches!(self.reservation.metadata(), Metadata::Dialer(..));
             move |context| async move {
                 // Allow tracker to initialize the peer
-                tracker.connect(peer.clone(), dialer, mailbox.clone()).await;
+                tracker.send(tracker::Message::Connect {
+                    public_key: peer.clone(),
+                    dialer,
+                    peer: mailbox.clone(),
+                }).await.unwrap();
 
                 // Set the initial deadline to now to start gossiping immediately
                 let mut deadline = context.current();

--- a/p2p/src/authenticated/actors/peer/ingress.rs
+++ b/p2p/src/authenticated/actors/peer/ingress.rs
@@ -1,8 +1,5 @@
 use super::Error;
-use crate::{
-    authenticated::{types, Mailbox},
-    Channel,
-};
+use crate::{authenticated::types, Channel};
 use bytes::Bytes;
 use commonware_cryptography::PublicKey;
 use futures::{channel::mpsc, SinkExt};
@@ -18,20 +15,6 @@ pub enum Message<C: PublicKey> {
 
     /// Kill the peer actor.
     Kill,
-}
-
-impl<C: PublicKey> Mailbox<Message<C>> {
-    pub async fn bit_vec(&mut self, bit_vec: types::BitVec) {
-        let _ = self.send(Message::BitVec(bit_vec)).await;
-    }
-
-    pub async fn peers(&mut self, peers: Vec<types::PeerInfo<C>>) {
-        let _ = self.send(Message::Peers(peers)).await;
-    }
-
-    pub async fn kill(&mut self) {
-        let _ = self.send(Message::Kill).await;
-    }
 }
 
 #[derive(Clone)]

--- a/p2p/src/authenticated/actors/router/ingress.rs
+++ b/p2p/src/authenticated/actors/router/ingress.rs
@@ -1,5 +1,5 @@
 use crate::{
-    authenticated::{actors::peer, channels::Channels, Mailbox},
+    authenticated::{actors::peer, channels::Channels},
     Channel, Recipients,
 };
 use bytes::Bytes;
@@ -27,26 +27,6 @@ pub enum Message<P: PublicKey> {
         priority: bool,
         success: oneshot::Sender<Vec<P>>,
     },
-}
-
-impl<P: PublicKey> Mailbox<Message<P>> {
-    /// Notify the router that a peer is ready to communicate.
-    pub async fn ready(&mut self, peer: P, relay: peer::Relay) -> Channels<P> {
-        let (response, receiver) = oneshot::channel();
-        self.send(Message::Ready {
-            peer,
-            relay,
-            channels: response,
-        })
-        .await
-        .unwrap();
-        receiver.await.unwrap()
-    }
-
-    /// Notify the router that a peer is no longer available.
-    pub async fn release(&mut self, peer: P) {
-        self.send(Message::Release { peer }).await.unwrap();
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/p2p/src/authenticated/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/actors/spawner/actor.rs
@@ -156,7 +156,10 @@ impl<
 
                             // Let the router know the peer has exited
                             debug!(error = ?e, ?peer, "peer shutdown");
-                            let _ = router.send(router::Message::Release { peer }).await;
+                            router
+                                .send(router::Message::Release { peer })
+                                .await
+                                .unwrap();
                         });
                 }
             }

--- a/p2p/src/authenticated/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/actors/spawner/ingress.rs
@@ -1,4 +1,4 @@
-use crate::authenticated::{actors::tracker::Reservation, Mailbox};
+use crate::authenticated::actors::tracker::Reservation;
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Clock, Metrics, Network, SinkOf, Spawner, StreamOf};
 use commonware_stream::public_key::Connection;
@@ -14,21 +14,4 @@ pub enum Message<E: Spawner + Clock + Metrics + Network, P: PublicKey> {
         /// The reservation for the peer.
         reservation: Reservation<E, P>,
     },
-}
-
-impl<E: Spawner + Clock + Metrics + Network, P: PublicKey> Mailbox<Message<E, P>> {
-    /// Send a message to the actor to spawn a new task for the given peer.
-    pub async fn spawn(
-        &mut self,
-        connection: Connection<SinkOf<E>, StreamOf<E>>,
-        reservation: Reservation<E, P>,
-    ) {
-        self.send(Message::Spawn {
-            peer: reservation.metadata().public_key().clone(),
-            connection,
-            reservation,
-        })
-        .await
-        .unwrap();
-    }
 }

--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -438,7 +438,7 @@ mod tests {
             // Connect as dialer
             mailbox
                 .send(tracker::Message::Connect {
-                    public_key: unauth_pk.clone(),
+                    public_key: unauth_pk,
                     dialer: true,
                     peer: peer_mailbox,
                 })

--- a/p2p/src/authenticated/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/actors/tracker/ingress.rs
@@ -103,17 +103,6 @@ pub enum Message<E: Spawner + Metrics, C: PublicKey> {
 }
 
 impl<E: Spawner + Metrics, C: PublicKey> Mailbox<Message<E, C>> {
-    /// Send a `Connect` message to the tracker.
-    pub async fn connect(&mut self, public_key: C, dialer: bool, peer: Mailbox<peer::Message<C>>) {
-        self.send(Message::Connect {
-            public_key,
-            dialer,
-            peer,
-        })
-        .await
-        .unwrap();
-    }
-
     /// Send a `Construct` message to the tracker.
     pub async fn construct(&mut self, public_key: C, peer: Mailbox<peer::Message<C>>) {
         self.send(Message::Construct { public_key, peer })

--- a/p2p/src/authenticated/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/actors/tracker/ingress.rs
@@ -103,23 +103,6 @@ pub enum Message<E: Spawner + Metrics, C: PublicKey> {
 }
 
 impl<E: Spawner + Metrics, C: PublicKey> Mailbox<Message<E, C>> {
-    /// Send a `Construct` message to the tracker.
-    pub async fn construct(&mut self, public_key: C, peer: Mailbox<peer::Message<C>>) {
-        self.send(Message::Construct { public_key, peer })
-            .await
-            .unwrap();
-    }
-
-    /// Send a `BitVec` message to the tracker.
-    pub async fn bit_vec(&mut self, bit_vec: types::BitVec, peer: Mailbox<peer::Message<C>>) {
-        self.send(Message::BitVec { bit_vec, peer }).await.unwrap();
-    }
-
-    /// Send a `Peers` message to the tracker.
-    pub async fn peers(&mut self, peers: Vec<types::PeerInfo<C>>, peer: Mailbox<peer::Message<C>>) {
-        self.send(Message::Peers { peers, peer }).await.unwrap();
-    }
-
     /// Send a `Block` message to the tracker.
     pub async fn dialable(&mut self) -> Vec<C> {
         let (sender, receiver) = oneshot::channel();

--- a/p2p/src/authenticated/actors/tracker/mod.rs
+++ b/p2p/src/authenticated/actors/tracker/mod.rs
@@ -18,7 +18,7 @@ mod reservation;
 mod set;
 
 pub use actor::Actor;
-pub use ingress::{Message, Oracle};
+pub use ingress::{dial, dialable, listen, Message, Oracle};
 pub use metadata::Metadata;
 pub use reservation::Reservation;
 


### PR DESCRIPTION
Staging this this as part of a series of PRs to clean up message passing in the `authenticated` code.