### PR TITLE
[storage/mmr] mmr::Hasher refactoring for parallel merklezation

### DIFF
--- a/storage/src/mmr/benches/append.rs
+++ b/storage/src/mmr/benches/append.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Sha256};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
@@ -18,11 +18,10 @@ fn bench_append(c: &mut Criterion) {
         c.bench_function(&format!("{}/n={}", module_path!(), n), |b| {
             b.iter(|| {
                 block_on(async {
-                    let mut h = Sha256::new();
-                    let mut h = Standard::new(&mut h);
+                    let mut h = Standard::new();
                     let mut mmr = Mmr::<Sha256>::new();
                     for digest in &elements {
-                        mmr.add(&mut h, digest).await.unwrap();
+                        mmr.add(&mut h, digest);
                     }
                 })
             });

--- a/storage/src/mmr/benches/append_additional.rs
+++ b/storage/src/mmr/benches/append_additional.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Sha256};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
@@ -24,22 +24,20 @@ fn bench_append_additional(c: &mut Criterion) {
             c.bench_function(&format!("{}/start={} add={}", module_path!(), n, a), |b| {
                 b.iter_batched(
                     || {
-                        let mut h = Sha256::new();
-                        let mut h = Standard::new(&mut h);
+                        let mut h = Standard::new();
                         let mut mmr = Mmr::<Sha256>::new();
                         block_on(async {
                             for digest in &elements {
-                                mmr.add(&mut h, digest).await.unwrap();
+                                mmr.add(&mut h, digest);
                             }
                         });
                         mmr
                     },
                     |mut mmr| {
-                        let mut h = Sha256::new();
-                        let mut h = Standard::new(&mut h);
+                        let mut h = Standard::new();
                         block_on(async {
                             for digest in &additional {
-                                mmr.add(&mut h, digest).await.unwrap();
+                                mmr.add(&mut h, digest);
                             }
                         });
                     },

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Sha256};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
@@ -13,13 +13,12 @@ fn bench_prove_many_elements(c: &mut Criterion) {
         let mut positions = Vec::with_capacity(n);
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
-        let mut hasher = Sha256::new();
-        let mut hasher = Standard::new(&mut hasher);
+        let mut hasher = Standard::new();
 
         block_on(async {
             for i in 0..n {
                 let element = sha256::Digest::random(&mut sampler);
-                let pos = mmr.add(&mut hasher, &element).await.unwrap();
+                let pos = mmr.add(&mut hasher, &element);
                 positions.push((i, pos));
                 elements.push(element);
             }
@@ -55,8 +54,7 @@ fn bench_prove_many_elements(c: &mut Criterion) {
                             })
                         },
                         |samples| {
-                            let mut hasher = Sha256::new();
-                            let mut hasher = Standard::new(&mut hasher);
+                            let mut hasher = Standard::new();
                             block_on(async {
                                 for ((start_index, end_index), (start_pos, end_pos)) in samples {
                                     let proof = mmr.range_proof(start_pos, end_pos).await.unwrap();

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Sha256};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
@@ -12,12 +12,11 @@ fn bench_prove_single_element(c: &mut Criterion) {
         let mut mmr = Mmr::<Sha256>::new();
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
-        let mut hasher = Sha256::new();
-        let mut hasher = Standard::new(&mut hasher);
+        let mut hasher = Standard::new();
         block_on(async {
             for _ in 0..n {
                 let element = sha256::Digest::random(&mut sampler);
-                let pos = mmr.add(&mut hasher, &element).await.unwrap();
+                let pos = mmr.add(&mut hasher, &element);
                 elements.push((pos, element));
             }
         });
@@ -37,8 +36,7 @@ fn bench_prove_single_element(c: &mut Criterion) {
                     },
                     |samples| {
                         block_on(async {
-                            let mut hasher = Sha256::new();
-                            let mut hasher = Standard::new(&mut hasher);
+                            let mut hasher = Standard::new();
                             for (pos, element) in samples {
                                 let proof = mmr.proof(pos).await.unwrap();
                                 assert!(proof

--- a/storage/src/mmr/benches/update.rs
+++ b/storage/src/mmr/benches/update.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
+use commonware_cryptography::{sha256, Digest as _, Sha256};
 use commonware_runtime::{benchmarks::tokio, tokio::Config};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
@@ -26,14 +26,13 @@ fn bench_update(c: &mut Criterion) {
                             let mut elements = Vec::with_capacity(leaves as usize);
                             let mut sampler = StdRng::seed_from_u64(0);
                             let mut leaf_positions = Vec::with_capacity(leaves as usize);
-                            let mut h = Sha256::new();
-                            let mut h = Standard::new(&mut h);
+                            let mut h = Standard::new();
 
                             // Append random elements to MMR
                             for _ in 0..leaves {
                                 let digest = sha256::Digest::random(&mut sampler);
                                 elements.push(digest);
-                                let pos = mmr.add(&mut h, &digest).await.unwrap();
+                                let pos = mmr.add(&mut h, &digest);
                                 leaf_positions.push(pos);
                             }
 
@@ -50,12 +49,10 @@ fn bench_update(c: &mut Criterion) {
                                 leaf_map.insert(rand_leaf_pos, *new_element);
                             }
                             if batched {
-                                mmr.update_leaf_batched(&mut h, leaf_map.into_iter())
-                                    .await
-                                    .unwrap();
+                                mmr.update_leaf_batched(&mut h, leaf_map.into_iter());
                             } else {
                                 for (pos, element) in leaf_map {
-                                    mmr.update_leaf(&mut h, pos, &element).await.unwrap();
+                                    mmr.update_leaf(&mut h, pos, &element);
                                 }
                             }
 

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -223,18 +223,18 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
     ///
     /// - Panics if there are unprocessed updates.
     pub fn prune_to_bit(&mut self, bit_offset: u64) {
-        let chunk_pos = Self::chunk_pos(bit_offset);
-        if chunk_pos < self.pruned_chunks {
+        let chunk_num = Self::chunk_num(bit_offset);
+        if chunk_num < self.pruned_chunks {
             return;
         }
         assert!(!self.is_dirty(), "cannot prune with unprocessed updates");
 
-        let chunk_index = chunk_pos - self.pruned_chunks;
+        let chunk_index = chunk_num - self.pruned_chunks;
         self.bitmap.drain(0..chunk_index);
-        self.pruned_chunks = chunk_pos;
+        self.pruned_chunks = chunk_num;
         self.authenticated_len = self.bitmap.len() - 1;
 
-        let mmr_pos = leaf_num_to_pos(chunk_pos as u64);
+        let mmr_pos = leaf_num_to_pos(chunk_num as u64);
         self.mmr.prune_to_pos(mmr_pos);
     }
 
@@ -341,7 +341,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
     /// Convert a bit offset into the position of the Merkle tree leaf it belongs to.
     #[inline]
     pub(crate) fn leaf_pos(bit_offset: u64) -> u64 {
-        leaf_num_to_pos(Self::chunk_pos(bit_offset) as u64)
+        leaf_num_to_pos(Self::chunk_num(bit_offset) as u64)
     }
 
     #[inline]
@@ -356,19 +356,19 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
             "out of bounds: {}",
             bit_offset
         );
-        let chunk_pos = Self::chunk_pos(bit_offset);
+        let chunk_num = Self::chunk_num(bit_offset);
         assert!(
-            chunk_pos >= self.pruned_chunks,
+            chunk_num >= self.pruned_chunks,
             "bit pruned: {}",
             bit_offset
         );
 
-        chunk_pos - self.pruned_chunks
+        chunk_num - self.pruned_chunks
     }
 
-    // Convert a bit offset into the position of the chunk it belongs to.
+    // Convert a bit offset into the number of the chunk it belongs to.
     #[inline]
-    fn chunk_pos(bit_offset: u64) -> usize {
+    fn chunk_num(bit_offset: u64) -> usize {
         (bit_offset / Self::CHUNK_SIZE_BITS) as usize
     }
 
@@ -421,6 +421,20 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
         !self.dirty_chunks.is_empty() || self.authenticated_len < self.bitmap.len() - 1
     }
 
+    /// The chunks (identified by their number) that have been modified or added since the last `sync`.
+    pub fn dirty_chunks(&self) -> Vec<u64> {
+        let mut chunks: Vec<u64> = self
+            .dirty_chunks
+            .iter()
+            .map(|&chunk_index| (chunk_index + self.pruned_chunks) as u64)
+            .collect();
+        for i in self.authenticated_len..self.bitmap.len() - 1 {
+            chunks.push((i + self.pruned_chunks) as u64);
+        }
+
+        chunks
+    }
+
     /// Process all updates not yet reflected in the bitmap's root.
     pub async fn sync(&mut self, hasher: &mut impl Hasher<H>) -> Result<(), Error> {
         // Add newly appended chunks to the MMR (other than the very last).
@@ -428,7 +442,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
         assert!(!self.bitmap.is_empty());
         let end = self.bitmap.len() - 1;
         for i in start..end {
-            self.mmr.add_batched(hasher, &self.bitmap[i]).await?;
+            self.mmr.add_batched(hasher, &self.bitmap[i]);
         }
         self.authenticated_len = end;
 
@@ -437,7 +451,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
             let pos = leaf_num_to_pos((*chunk_index + self.pruned_chunks) as u64);
             (pos, &self.bitmap[*chunk_index])
         });
-        self.mmr.update_leaf_batched(hasher, updates).await?;
+        self.mmr.update_leaf_batched(hasher, updates);
         self.dirty_chunks.clear();
         self.mmr.sync(hasher);
 
@@ -647,8 +661,7 @@ mod tests {
     fn test_bitmap_verify_empty_proof() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher = Standard::new();
             let proof = Proof {
                 size: 100,
                 digests: Vec::new(),
@@ -672,7 +685,7 @@ mod tests {
     fn test_bitmap_empty_then_one() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let mut bitmap = Bitmap::new();
+            let mut bitmap: Bitmap<Sha256, SHA256_SIZE> = Bitmap::new();
             assert_eq!(bitmap.bit_count(), 0);
             assert_eq!(bitmap.pruned_chunks, 0);
             bitmap.prune_to_bit(0);
@@ -681,8 +694,7 @@ mod tests {
             assert_eq!(bitmap.last_chunk().1, 0);
 
             // Add a single bit
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher = Standard::new();
             let root = bitmap.root(&mut hasher).await.unwrap();
             bitmap.append(true);
             bitmap.sync(&mut hasher).await.unwrap();
@@ -745,8 +757,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             let test_chunk = test_chunk(b"test");
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
 
             // Add each bit one at a time after the first chunk.
             let mut bitmap = Bitmap::<_, SHA256_SIZE>::new();
@@ -829,11 +840,10 @@ mod tests {
     fn test_bitmap_get_pruned_bit_panic() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let mut bitmap = Bitmap::<_, SHA256_SIZE>::new();
+            let mut bitmap = Bitmap::<Sha256, SHA256_SIZE>::new();
             bitmap.append_chunk_unchecked(&test_chunk(b"test"));
             bitmap.append_chunk_unchecked(&test_chunk(b"test2"));
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher = Standard::new();
             bitmap.sync(&mut hasher).await.unwrap();
 
             bitmap.prune_to_bit(256);
@@ -846,9 +856,8 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             // Build a starting test MMR with two chunks worth of bits.
-            let mut bitmap = Bitmap::<_, SHA256_SIZE>::default();
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut bitmap = Bitmap::<Sha256, SHA256_SIZE>::default();
+            let mut hasher = Standard::new();
             bitmap.append_chunk_unchecked(&test_chunk(b"test"));
             bitmap.append_chunk_unchecked(&test_chunk(b"test2"));
             bitmap.sync(&mut hasher).await.unwrap();
@@ -892,9 +901,8 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             // Build a test MMR with a few chunks worth of bits.
-            let mut bitmap = Bitmap::<_, SHA256_SIZE>::default();
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut bitmap = Bitmap::<Sha256, SHA256_SIZE>::default();
+            let mut hasher = Standard::new();
             bitmap.append_chunk_unchecked(&test_chunk(b"test"));
             bitmap.append_chunk_unchecked(&test_chunk(b"test2"));
             bitmap.append_chunk_unchecked(&test_chunk(b"test3"));
@@ -959,9 +967,8 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             // Build a bitmap with 10 chunks worth of bits.
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
-            let mut bitmap = Bitmap::<_, N>::new();
+            let mut hasher = Standard::new();
+            let mut bitmap = Bitmap::<Sha256, N>::new();
             for i in 0u32..10 {
                 bitmap.append_chunk_unchecked(&test_chunk(format!("test{}", i).as_bytes()));
             }
@@ -1021,14 +1028,14 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Initializing from an empty partition should result in an empty bitmap.
-            let mut bitmap = Bitmap::<_, SHA256_SIZE>::restore_pruned(context.clone(), PARTITION)
-                .await
-                .unwrap();
+            let mut bitmap =
+                Bitmap::<Sha256, SHA256_SIZE>::restore_pruned(context.clone(), PARTITION)
+                    .await
+                    .unwrap();
             assert_eq!(bitmap.bit_count(), 0);
 
             // Add a non-trivial amount of data.
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher = Standard::new();
             for i in 0..FULL_CHUNK_COUNT {
                 bitmap.append_chunk_unchecked(&test_chunk(format!("test{}", i).as_bytes()));
             }

--- a/storage/src/mmr/hasher.rs
+++ b/storage/src/mmr/hasher.rs
@@ -1,22 +1,19 @@
 //! Decorator for a cryptographic hasher that implements the MMR-specific hashing logic.
 
 use crate::mmr::{
-    iterator::{leaf_pos_to_num, pos_to_height},
+    iterator::{leaf_num_to_pos, leaf_pos_to_num, pos_to_height},
     storage::Storage,
     Error,
 };
 use commonware_cryptography::Hasher as CHasher;
-use std::future::Future;
+use futures::future::try_join_all;
+use std::collections::HashMap;
 use tracing::debug;
 
 /// A trait for computing the various digests of an MMR.
 pub trait Hasher<H: CHasher>: Send + Sync {
     /// Computes the digest for a leaf given its position and the element it represents.
-    fn leaf_digest(
-        &mut self,
-        pos: u64,
-        element: &[u8],
-    ) -> impl Future<Output = Result<H::Digest, Error>> + Send;
+    fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest;
 
     /// Computes the digest for a node given its position and the digests of its children.
     fn node_digest(&mut self, pos: u64, left: &H::Digest, right: &H::Digest) -> H::Digest;
@@ -38,14 +35,14 @@ pub trait Hasher<H: CHasher>: Send + Sync {
 
 /// The standard hasher to use with an MMR for computing leaf, node and root digests. Leverages no
 /// external data.
-pub struct Standard<'a, H: CHasher> {
-    hasher: &'a mut H,
+pub struct Standard<H: CHasher> {
+    hasher: H,
 }
 
-impl<'a, H: CHasher> Standard<'a, H> {
+impl<H: CHasher> Standard<H> {
     /// Creates a new [Standard] hasher.
-    pub fn new(hasher: &'a mut H) -> Self {
-        Self { hasher }
+    pub fn new() -> Self {
+        Self { hasher: H::new() }
     }
 
     pub(crate) fn update_with_pos(&mut self, pos: u64) {
@@ -65,15 +62,21 @@ impl<'a, H: CHasher> Standard<'a, H> {
     }
 }
 
-impl<H: CHasher> Hasher<H> for Standard<'_, H> {
+impl<H: CHasher> Default for Standard<H> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<H: CHasher> Hasher<H> for Standard<H> {
     fn inner(&mut self) -> &mut H {
-        self.hasher
+        &mut self.hasher
     }
 
-    async fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> Result<H::Digest, Error> {
+    fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest {
         self.update_with_pos(pos);
         self.update_with_element(element);
-        Ok(self.finalize())
+        self.finalize()
     }
 
     fn node_digest(&mut self, pos: u64, left: &H::Digest, right: &H::Digest) -> H::Digest {
@@ -83,10 +86,10 @@ impl<H: CHasher> Hasher<H> for Standard<'_, H> {
         self.finalize()
     }
 
-    fn root_digest<'b>(
+    fn root_digest<'a>(
         &mut self,
         size: u64,
-        peak_digests: impl Iterator<Item = &'b H::Digest>,
+        peak_digests: impl Iterator<Item = &'a H::Digest>,
     ) -> H::Digest {
         self.update_with_pos(size);
         for digest in peak_digests {
@@ -161,24 +164,55 @@ impl<H: CHasher> Hasher<H> for Standard<'_, H> {
 /// Walking up two levels from any of these base MMR leaves produces node 6 of the base MMR, which
 /// is thus its grafting point. Leaf 1 in the peak tree corresponds to leaves \[7,8,10,11\] in the
 /// base MMR, yielding node 13 as its grafting point.
-pub struct Grafting<'a, H: CHasher, S: Storage<H::Digest>> {
-    hasher: Standard<'a, H>,
+pub struct Grafting<'a, H: CHasher> {
+    hasher: &'a mut Standard<H>,
     height: u32,
-    base_mmr: &'a S,
+
+    /// Maps a leaf's position to the digest of the node on which the leaf is grafted.
+    grafted_digests: HashMap<u64, H::Digest>,
 }
 
-impl<'a, H: CHasher, S: Storage<H::Digest>> Grafting<'a, H, S> {
-    pub fn new(hasher: &'a mut H, height: u32, base_mmr: &'a S) -> Self {
+impl<'a, H: CHasher> Grafting<'a, H> {
+    pub fn new(hasher: &'a mut Standard<H>, height: u32) -> Self {
         Self {
-            hasher: Standard::new(hasher),
+            hasher,
             height,
-            base_mmr,
+            grafted_digests: HashMap::new(),
         }
     }
 
     /// Access the underlying [Standard] (non-grafting) hasher.
-    pub fn standard(&mut self) -> &mut Standard<'a, H> {
-        &mut self.hasher
+    pub fn standard(&mut self) -> &mut Standard<H> {
+        self.hasher
+    }
+
+    /// Loads the grafted digests for the specified leaves into the internal map. Does not clear out
+    /// any previously loaded digests.
+    ///
+    /// # Warning
+    ///
+    /// Panics if any of the grafted digests are missing from the MMR.
+    pub async fn load_grafted_digests(
+        &mut self,
+        leaves: &[u64],
+        mmr: &impl Storage<H::Digest>,
+    ) -> Result<(), Error> {
+        let mut futures = Vec::with_capacity(leaves.len());
+        for leaf_num in leaves {
+            let dest_pos = self.destination_pos(leaf_num_to_pos(*leaf_num));
+            let future = mmr.get_node(dest_pos);
+            futures.push(future);
+        }
+        let join = try_join_all(futures).await?;
+        for (i, digest) in join.into_iter().enumerate() {
+            let Some(digest) = digest else {
+                panic!("missing grafted digest for leaf {}", leaves[i]);
+            };
+            let leaf_pos = leaf_num_to_pos(leaves[i]);
+            self.grafted_digests.insert(leaf_pos, digest);
+        }
+
+        Ok(())
     }
 
     /// Compute the position of the leaf in the base tree onto which we should graft the leaf at
@@ -257,21 +291,18 @@ pub(super) fn source_pos(base_node_pos: u64, height: u32) -> Option<u64> {
     Some(peak_pos)
 }
 
-impl<H: CHasher, S: Storage<H::Digest>> Hasher<H> for Grafting<'_, H, S> {
-    async fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> Result<H::Digest, Error> {
-        let base_node_pos = self.destination_pos(pos);
-        assert!(
-            base_node_pos < self.base_mmr.size(),
-            "grafting destination out of bounds"
-        );
-        let base_node_digest = self.base_mmr.get_node(base_node_pos).await?.unwrap();
+impl<H: CHasher> Hasher<H> for Grafting<'_, H> {
+    fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest {
+        let Some(grafted_digest) = self.grafted_digests.get(&pos) else {
+            panic!("missing grafted digest for leaf_pos {}", pos);
+        };
 
         // We do not include position in the digest material here since the position information is
-        // already captured in the base_node_digest.
+        // already captured in the grafted_digest.
         self.hasher.update_with_element(element);
-        self.hasher.update_with_digest(&base_node_digest);
+        self.hasher.update_with_digest(grafted_digest);
 
-        Ok(self.hasher.finalize())
+        self.hasher.finalize()
     }
 
     fn node_digest(
@@ -304,7 +335,7 @@ impl<H: CHasher, S: Storage<H::Digest>> Hasher<H> for Grafting<'_, H, S> {
 
 /// A [Hasher] implementation to use when verifying proofs over GraftedStorage.
 pub struct GraftingVerifier<'a, H: CHasher> {
-    hasher: Standard<'a, H>,
+    hasher: Standard<H>,
     height: u32,
 
     /// The required leaf elements from the peak tree that we are verifying.
@@ -315,23 +346,23 @@ pub struct GraftingVerifier<'a, H: CHasher> {
 }
 
 impl<'a, H: CHasher> GraftingVerifier<'a, H> {
-    pub fn new(hasher: &'a mut H, height: u32, num: u64, elements: Vec<&'a [u8]>) -> Self {
+    pub fn new(height: u32, num: u64, elements: Vec<&'a [u8]>) -> Self {
         Self {
-            hasher: Standard::new(hasher),
+            hasher: Standard::new(),
             height,
             elements,
             num,
         }
     }
 
-    pub fn standard(&mut self) -> &mut Standard<'a, H> {
+    pub fn standard(&mut self) -> &mut Standard<H> {
         &mut self.hasher
     }
 }
 
 impl<H: CHasher> Hasher<H> for GraftingVerifier<'_, H> {
-    async fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> Result<H::Digest, Error> {
-        self.hasher.leaf_digest(pos, element).await
+    fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest {
+        self.hasher.leaf_digest(pos, element)
     }
 
     fn node_digest(
@@ -405,7 +436,7 @@ mod tests {
     use crate::mmr::{
         iterator::leaf_num_to_pos,
         mem::Mmr,
-        storage::Grafting as GStorage,
+        storage::{Grafting as GStorage, Storage},
         tests::{build_test_mmr, ROOTS},
         verification::Proof,
     };
@@ -438,29 +469,27 @@ mod tests {
     fn test_leaf_digest<H: CHasher>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let mut hasher = H::new();
-            let mut mmr_hasher = Standard::new(&mut hasher);
+            let mut mmr_hasher: Standard<H> = Standard::new();
             // input hashes to use
             let digest1 = test_digest::<H>(1);
             let digest2 = test_digest::<H>(2);
 
-            let out = mmr_hasher.leaf_digest(0, &digest1).await.unwrap();
+            let out = mmr_hasher.leaf_digest(0, &digest1);
             assert_ne!(out, test_digest::<H>(0), "hash should be non-zero");
 
-            let mut out2 = mmr_hasher.leaf_digest(0, &digest1).await.unwrap();
+            let mut out2 = mmr_hasher.leaf_digest(0, &digest1);
             assert_eq!(out, out2, "hash should be re-computed consistently");
 
-            out2 = mmr_hasher.leaf_digest(1, &digest1).await.unwrap();
+            out2 = mmr_hasher.leaf_digest(1, &digest1);
             assert_ne!(out, out2, "hash should change with different pos");
 
-            out2 = mmr_hasher.leaf_digest(0, &digest2).await.unwrap();
+            out2 = mmr_hasher.leaf_digest(0, &digest2);
             assert_ne!(out, out2, "hash should change with different input digest");
         });
     }
 
     fn test_node_digest<H: CHasher>() {
-        let mut hasher = H::new();
-        let mut mmr_hasher = Standard::new(&mut hasher);
+        let mut mmr_hasher: Standard<H> = Standard::new();
         // input hashes to use
 
         let d1 = test_digest::<H>(1);
@@ -496,8 +525,7 @@ mod tests {
     }
 
     fn test_root_digest<H: CHasher>() {
-        let mut hasher = H::new();
-        let mut mmr_hasher = Standard::new(&mut hasher);
+        let mut mmr_hasher: Standard<H> = Standard::new();
         // input digests to use
         let d1 = test_digest::<H>(1);
         let d2 = test_digest::<H>(2);
@@ -569,19 +597,22 @@ mod tests {
     fn test_hasher_grafting() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut standard: Standard<Sha256> = Standard::new();
             let mut base_mmr = Mmr::new();
-            build_test_mmr(&mut hasher, &mut base_mmr).await;
-            let root = base_mmr.root(&mut hasher);
+            build_test_mmr(&mut standard, &mut base_mmr).await;
+            let root = base_mmr.root(&mut standard);
             let expected_root = ROOTS[199];
             assert_eq!(&hex(&root), expected_root);
+
+            let mut hasher: Grafting<Sha256> = Grafting::new(&mut standard, 0);
+            hasher
+                .load_grafted_digests(&(0..199).collect::<Vec<_>>(), &base_mmr)
+                .await
+                .unwrap();
 
             {
                 // Build another MMR with the same elements only using a grafting hasher, using the
                 // previous mmr as the base.
-                let mut hasher = Sha256::new();
-                let mut hasher = Grafting::new(&mut hasher, 0, &base_mmr);
 
                 // Since we're grafting 1-1, the destination position computation should be the identity function.
                 assert_eq!(hasher.destination_pos(0), 0);
@@ -597,12 +628,13 @@ mod tests {
 
             // Try grafting at a height of 1 instead of 0, which requires we double the # of leaves in the base
             // tree to maintain the corresponding # of segments.
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
-            build_test_mmr(&mut hasher, &mut base_mmr).await;
+            build_test_mmr(&mut standard, &mut base_mmr).await;
             {
-                let mut hasher = Sha256::new();
-                let mut hasher = Grafting::new(&mut hasher, 1, &base_mmr);
+                let mut hasher: Grafting<Sha256> = Grafting::new(&mut standard, 1);
+                hasher
+                    .load_grafted_digests(&(0..199).collect::<Vec<_>>(), &base_mmr)
+                    .await
+                    .unwrap();
 
                 // Confirm we're now grafting leaves to the positions of their immediate parent in
                 // an MMR.
@@ -620,14 +652,12 @@ mod tests {
             }
 
             // Height 2 grafting destination computation check.
-            let mut hasher = Sha256::new();
-            let hasher = Grafting::new(&mut hasher, 2, &base_mmr);
+            let hasher: Grafting<Sha256> = Grafting::new(&mut standard, 2);
             assert_eq!(hasher.destination_pos(leaf_num_to_pos(0)), 6);
             assert_eq!(hasher.destination_pos(leaf_num_to_pos(1)), 13);
 
             // Height 3 grafting destination computation check.
-            let mut hasher = Sha256::new();
-            let hasher = Grafting::new(&mut hasher, 3, &base_mmr);
+            let hasher: Grafting<Sha256> = Grafting::new(&mut standard, 3);
             assert_eq!(hasher.destination_pos(leaf_num_to_pos(0)), 14);
         });
     }
@@ -638,45 +668,43 @@ mod tests {
         let executor = deterministic::Runner::default();
         const GRAFTING_HEIGHT: u32 = 1;
         executor.start(|_| async move {
-            let mut hasher = Sha256::new();
-
             let b1 = Sha256::fill(0x01);
             let b2 = Sha256::fill(0x02);
             let b3 = Sha256::fill(0x03);
             let b4 = Sha256::fill(0x04);
+            let mut standard: Standard<Sha256> = Standard::new();
 
             // Make a base MMR with 4 leaves.
             let mut base_mmr = Mmr::new();
-            {
-                let mut standard = Standard::new(&mut hasher);
-
-                base_mmr.add(&mut standard, &b1).await.unwrap();
-                base_mmr.add(&mut standard, &b2).await.unwrap();
-                base_mmr.add(&mut standard, &b3).await.unwrap();
-                base_mmr.add(&mut standard, &b4).await.unwrap();
-            }
+            base_mmr.add(&mut standard, &b1);
+            base_mmr.add(&mut standard, &b2);
+            base_mmr.add(&mut standard, &b3);
+            base_mmr.add(&mut standard, &b4);
 
             let p1 = Sha256::fill(0xF1);
             let p2 = Sha256::fill(0xF2);
 
             // Since we are using grafting height of 1, peak tree must have half the leaves of the base (2).
-            let mut peak_tree = Mmr::new();
+            let mut peak_tree: Mmr<Sha256> = Mmr::new();
             {
-                let mut grafter = Grafting::new(&mut hasher, GRAFTING_HEIGHT, &base_mmr);
-                peak_tree.add(&mut grafter, &p1).await.unwrap();
-                peak_tree.add(&mut grafter, &p2).await.unwrap();
+                let mut grafter = Grafting::new(&mut standard, GRAFTING_HEIGHT);
+                grafter
+                    .load_grafted_digests(&[0, 1], &base_mmr)
+                    .await
+                    .unwrap();
+                peak_tree.add(&mut grafter, &p1);
+                peak_tree.add(&mut grafter, &p2);
             }
 
-            let peak_root =
-                peak_tree.root(&mut Grafting::new(&mut hasher, GRAFTING_HEIGHT, &base_mmr));
-            let base_root = base_mmr.root(&mut Standard::new(&mut hasher));
+            let peak_root = peak_tree.root(&mut standard);
+            let base_root = base_mmr.root(&mut standard);
             assert_ne!(peak_root, base_root);
 
             {
                 let grafted_mmr = GStorage::new(&peak_tree, &base_mmr, GRAFTING_HEIGHT);
                 assert_eq!(grafted_mmr.size(), base_mmr.size());
 
-                let grafted_storage_root = grafted_mmr.root(&mut hasher).await.unwrap();
+                let grafted_storage_root = grafted_mmr.root(&mut standard).await.unwrap();
                 assert_ne!(grafted_storage_root, base_root);
 
                 // Grafted storage root uses the size of the base MMR in its digest, so it will differ
@@ -691,8 +719,7 @@ mod tests {
                         .await
                         .unwrap();
 
-                    let mut verifier =
-                        GraftingVerifier::new(&mut hasher, GRAFTING_HEIGHT, 0, vec![&p1]);
+                    let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![&p1]);
                     assert!(proof
                         .verify_element_inclusion(&mut verifier, &b1, pos, &grafted_storage_root)
                         .await
@@ -711,8 +738,7 @@ mod tests {
                     let proof = Proof::<Sha256>::range_proof(&grafted_mmr, pos, pos)
                         .await
                         .unwrap();
-                    let mut verifier =
-                        GraftingVerifier::new(&mut hasher, GRAFTING_HEIGHT, 1, vec![&p2]);
+                    let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 1, vec![&p2]);
                     assert!(proof
                         .verify_element_inclusion(&mut verifier, &b3, pos, &grafted_storage_root)
                         .await
@@ -735,8 +761,7 @@ mod tests {
                     let proof = Proof::<Sha256>::range_proof(&grafted_mmr, pos, pos)
                         .await
                         .unwrap();
-                    let mut verifier =
-                        GraftingVerifier::new(&mut hasher, GRAFTING_HEIGHT, 1, vec![&p2]);
+                    let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 1, vec![&p2]);
                     assert!(proof
                         .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
                         .await
@@ -761,16 +786,14 @@ mod tests {
                         .unwrap());
 
                     // Proof should fail if we inject the wrong peak element into the verifier.
-                    let mut verifier =
-                        GraftingVerifier::new(&mut hasher, GRAFTING_HEIGHT, 1, vec![&p1]);
+                    let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 1, vec![&p1]);
                     assert!(!proof
                         .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
                         .await
                         .unwrap());
 
                     // Proof should fail if we give the verifier the wrong peak tree leaf number.
-                    let mut verifier =
-                        GraftingVerifier::new(&mut hasher, GRAFTING_HEIGHT, 2, vec![&p1]);
+                    let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 2, vec![&p1]);
                     assert!(!proof
                         .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
                         .await
@@ -784,16 +807,14 @@ mod tests {
                         .await
                         .unwrap();
                     let range = vec![&b1, &b2, &b3, &b4];
-                    let mut verifier =
-                        GraftingVerifier::new(&mut hasher, GRAFTING_HEIGHT, 0, vec![&p1, &p2]);
+                    let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![&p1, &p2]);
                     assert!(proof
                         .verify_range_inclusion(&mut verifier, &range, 0, 4, &grafted_storage_root)
                         .await
                         .unwrap());
 
                     // Confirm same proof fails with shortened verifier range.
-                    let mut verifier =
-                        GraftingVerifier::new(&mut hasher, GRAFTING_HEIGHT, 0, vec![&p1]);
+                    let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![&p1]);
                     assert!(!proof
                         .verify_range_inclusion(&mut verifier, &range, 0, 4, &grafted_storage_root)
                         .await
@@ -804,27 +825,25 @@ mod tests {
             // Add one more leaf to our base MMR, which will not have any corresponding peak tree
             // leaf since it will have no ancestors at or above the grafting height.
             let b5 = Sha256::fill(0x05);
-            {
-                let mut standard = Standard::new(&mut hasher);
-                base_mmr.add(&mut standard, &b5).await.unwrap();
-            }
+            base_mmr.add(&mut standard, &b5);
+
             let grafted_mmr = GStorage::new(&peak_tree, &base_mmr, GRAFTING_HEIGHT);
             assert_eq!(grafted_mmr.size(), base_mmr.size());
 
             // Confirm we can generate and verify inclusion proofs for the "orphaned" leaf as well as an existing one.
-            let grafted_storage_root = grafted_mmr.root(&mut hasher).await.unwrap();
+            let grafted_storage_root = grafted_mmr.root(&mut standard).await.unwrap();
             let pos = 0;
             let proof = Proof::<Sha256>::range_proof(&grafted_mmr, pos, pos)
                 .await
                 .unwrap();
 
-            let mut verifier = GraftingVerifier::new(&mut hasher, GRAFTING_HEIGHT, 0, vec![&p1]);
+            let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![&p1]);
             assert!(proof
                 .verify_element_inclusion(&mut verifier, &b1, pos, &grafted_storage_root)
                 .await
                 .unwrap());
 
-            let mut verifier = GraftingVerifier::new(&mut hasher, GRAFTING_HEIGHT, 0, vec![]);
+            let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![]);
             let pos = 7;
             let proof = Proof::<Sha256>::range_proof(&grafted_mmr, pos, pos)
                 .await

--- a/storage/src/mmr/iterator.rs
+++ b/storage/src/mmr/iterator.rs
@@ -293,12 +293,11 @@ mod tests {
         executor.start(|_| async move {
             // Build MMR with 1000 leaves and make sure we can correctly convert each leaf position to
             // its number and back again.
-            let mut mmr = Mmr::new();
-            let mut hasher = Sha256::default();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut mmr: Mmr<Sha256> = Mmr::new();
+            let mut hasher = Standard::new();
             let mut num_to_pos = Vec::new();
             for _ in 0u64..1000 {
-                num_to_pos.push(mmr.add(&mut hasher, &digest).await.unwrap());
+                num_to_pos.push(mmr.add(&mut hasher, &digest));
             }
 
             let mut last_leaf_pos = 0;

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -255,7 +255,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
     ///
     /// Panics if there are unprocessed updates.
     pub async fn add(&mut self, h: &mut impl Hasher<H>, element: &[u8]) -> Result<u64, Error> {
-        self.mem_mmr.add(h, element).await
+        Ok(self.mem_mmr.add(h, element))
     }
 
     /// Add an element to the MMR, delaying the computation of ancestor digests
@@ -265,7 +265,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         h: &mut impl Hasher<H>,
         element: &[u8],
     ) -> Result<u64, Error> {
-        self.mem_mmr.add_batched(h, element).await
+        Ok(self.mem_mmr.add_batched(h, element))
     }
 
     /// Pop the given number of elements from the tip of the MMR assuming they exist, and otherwise
@@ -545,14 +545,9 @@ mod tests {
                 items_per_blob: 7,
                 write_buffer: 1024,
             };
-            let mut hasher = Sha256::new();
-            let mut mmr = Mmr::init(
-                context.clone(),
-                &mut Standard::new(&mut hasher),
-                cfg.clone(),
-            )
-            .await
-            .unwrap();
+            let mut mmr = Mmr::init(context.clone(), &mut Standard::new(), cfg.clone())
+                .await
+                .unwrap();
             build_and_check_test_roots_mmr(&mut mmr).await;
         });
     }
@@ -569,8 +564,7 @@ mod tests {
                 items_per_blob: 7,
                 write_buffer: 1024,
             };
-            let mut hasher = Sha256::new();
-            let mut std_hasher = Standard::new(&mut hasher);
+            let mut std_hasher = Standard::new();
             let mut mmr = Mmr::init(context.clone(), &mut std_hasher, cfg.clone())
                 .await
                 .unwrap();
@@ -588,8 +582,7 @@ mod tests {
                 items_per_blob: 7,
                 write_buffer: 1024,
             };
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
                 .await
                 .unwrap();
@@ -615,8 +608,7 @@ mod tests {
                 write_buffer: 1024,
             };
 
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
                 .await
                 .unwrap();
@@ -685,8 +677,7 @@ mod tests {
                 items_per_blob: 7,
                 write_buffer: 1024,
             };
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
                 .await
                 .unwrap();
@@ -761,8 +752,7 @@ mod tests {
                 items_per_blob: 7,
                 write_buffer: 1024,
             };
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
                 .await
                 .unwrap();
@@ -853,8 +843,7 @@ mod tests {
                 write_buffer: 1024,
             };
 
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             // make sure pruning doesn't break root computation, adding of new nodes, etc.
             const LEAF_COUNT: usize = 2000;
             let mut pruned_mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
@@ -961,10 +950,8 @@ mod tests {
                 items_per_blob: 7,
                 write_buffer: 1024,
             };
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
-
             // Build MMR with 2000 leaves.
+            let mut hasher: Standard<Sha256> = Standard::new();
             const LEAF_COUNT: usize = 2000;
             let mut mmr = Mmr::init(context.clone(), &mut hasher, cfg.clone())
                 .await

--- a/storage/src/mmr/storage.rs
+++ b/storage/src/mmr/storage.rs
@@ -77,13 +77,12 @@ impl<'a, H: CHasher, S1: Storage<H::Digest>, S2: Storage<H::Digest>> Grafting<'a
         }
     }
 
-    pub async fn root(&self, hasher: &mut H) -> Result<H::Digest, Error> {
+    pub async fn root(&self, hasher: &mut Standard<H>) -> Result<H::Digest, Error> {
         let size = self.size();
         let peak_futures = PeakIterator::new(size).map(|(peak_pos, _)| self.get_node(peak_pos));
         let peaks = try_join_all(peak_futures).await?;
         let unwrapped_peaks = peaks.iter().map(|p| p.as_ref().unwrap());
-        let mut standard = Standard::new(hasher);
-        let digest = standard.root_digest(self.base_mmr.size(), unwrapped_peaks);
+        let digest = hasher.root_digest(self.base_mmr.size(), unwrapped_peaks);
 
         Ok(digest)
     }

--- a/storage/src/mmr/tests/mod.rs
+++ b/storage/src/mmr/tests/mod.rs
@@ -11,8 +11,7 @@ use commonware_utils::hex;
 /// Build the MMR corresponding to the stability test `ROOTS` and confirm the
 /// roots match that from the builder's root computation
 pub async fn build_and_check_test_roots_mmr(mmr: &mut impl Builder<Sha256>) {
-    let mut hasher = Sha256::new();
-    let mut hasher = Standard::new(&mut hasher);
+    let mut hasher: Standard<Sha256> = Standard::new();
     for i in 0u64..199 {
         hasher.inner().update(&i.to_be_bytes());
         let element = hasher.inner().finalize();
@@ -38,12 +37,11 @@ pub async fn build_test_mmr<H: CHasher>(hasher: &mut impl Hasher<H>, mmr: &mut i
 }
 
 pub async fn build_batched_and_check_test_roots(mem_mmr: &mut MemMmr<Sha256>) {
-    let mut hasher = Sha256::new();
-    let mut hasher = Standard::new(&mut hasher);
+    let mut hasher: Standard<Sha256> = Standard::new();
     for i in 0u64..199 {
         hasher.inner().update(&i.to_be_bytes());
         let element = hasher.inner().finalize();
-        mem_mmr.add_batched(&mut hasher, &element).await.unwrap();
+        mem_mmr.add_batched(&mut hasher, &element);
     }
     mem_mmr.sync(&mut hasher);
     assert_eq!(
@@ -56,8 +54,7 @@ pub async fn build_batched_and_check_test_roots(mem_mmr: &mut MemMmr<Sha256>) {
 pub async fn build_batched_and_check_test_roots_journaled<E: RStorage + Clock + Metrics>(
     journaled_mmr: &mut JournaledMmr<E, Sha256>,
 ) {
-    let mut hasher = Sha256::new();
-    let mut hasher = Standard::new(&mut hasher);
+    let mut hasher: Standard<Sha256> = Standard::new();
     for i in 0u64..199 {
         hasher.inner().update(&i.to_be_bytes());
         let element = hasher.inner().finalize();

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -355,7 +355,7 @@ where
     if two_h == 1 {
         // we are at a leaf
         match elements.next() {
-            Some(element) => return hasher.leaf_digest(pos, element.as_ref()).await,
+            Some(element) => return Ok(hasher.leaf_digest(pos, element.as_ref())),
             None => return Err(MissingDigests),
         }
     }
@@ -410,9 +410,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::Proof;
+    use super::*;
     use crate::mmr::{hasher::Standard, mem::Mmr};
-    use commonware_cryptography::{hash, sha256::Digest, Hasher, Sha256};
+    use commonware_cryptography::{hash, sha256::Digest, Sha256};
     use commonware_runtime::{deterministic, Runner};
 
     fn test_digest(v: u8) -> Digest {
@@ -427,10 +427,9 @@ mod tests {
             let mut mmr = Mmr::new();
             let element = Digest::from(*b"01234567012345670123456701234567");
             let mut leaves: Vec<u64> = Vec::new();
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             for _ in 0..11 {
-                leaves.push(mmr.add(&mut hasher, &element).await.unwrap());
+                leaves.push(mmr.add(&mut hasher, &element));
             }
 
             let root_digest = mmr.root(&mut hasher);
@@ -552,15 +551,10 @@ mod tests {
             let mut mmr = Mmr::default();
             let mut elements = Vec::new();
             let mut element_positions = Vec::new();
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             for i in 0..49 {
                 elements.push(test_digest(i));
-                element_positions.push(
-                    mmr.add(&mut hasher, elements.last().unwrap())
-                        .await
-                        .unwrap(),
-                );
+                element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
             }
             // test range proofs over all possible ranges of at least 2 elements
             let root_digest = mmr.root(&mut hasher);
@@ -753,15 +747,10 @@ mod tests {
             let mut mmr = Mmr::default();
             let mut elements = Vec::new();
             let mut element_positions = Vec::new();
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             for i in 0..49 {
                 elements.push(test_digest(i));
-                element_positions.push(
-                    mmr.add(&mut hasher, elements.last().unwrap())
-                        .await
-                        .unwrap(),
-                );
+                element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
             }
 
             // Confirm we can successfully prove all retained elements in the MMR after pruning.
@@ -795,11 +784,10 @@ mod tests {
             let mut mmr = Mmr::default();
             let mut elements = Vec::new();
             let mut element_positions = Vec::new();
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             for i in 0..49 {
                 elements.push(test_digest(i));
-                element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()).await.unwrap());
+                element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
             }
 
             // prune up to the first peak
@@ -815,8 +803,7 @@ mod tests {
 
             // test range proofs over all possible ranges of at least 2 elements
             let root_digest = mmr.root(&mut hasher);
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+                        let mut hasher: Standard<Sha256> = Standard::new();
             for i in 0..elements.len() {
                 for j in i + 1..elements.len() {
                     let start_pos = element_positions[i];
@@ -838,7 +825,7 @@ mod tests {
             // add a few more nodes, prune again, and test again to make sure repeated pruning works
             for i in 0..37 {
                 elements.push(test_digest(i));
-                element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()).await.unwrap());
+                element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
             }
             mmr.prune_to_pos(130); // a bit after the new highest peak
             assert_eq!(mmr.oldest_retained_pos().unwrap(), 130);
@@ -880,15 +867,10 @@ mod tests {
             let mut mmr = Mmr::default();
             let mut elements = Vec::new();
             let mut element_positions = Vec::new();
-            let mut hasher = Sha256::new();
-            let mut hasher = Standard::new(&mut hasher);
+            let mut hasher: Standard<Sha256> = Standard::new();
             for i in 0..25 {
                 elements.push(test_digest(i));
-                element_positions.push(
-                    mmr.add(&mut hasher, elements.last().unwrap())
-                        .await
-                        .unwrap(),
-                );
+                element_positions.push(mmr.add(&mut hasher, elements.last().unwrap()));
             }
 
             // Generate proofs over all possible ranges of elements and confirm each


### PR DESCRIPTION
- Make Standard<H> hasher own the internal cryptographic hasher. This will allow it to be easily cloned & used across multiple threads.
- Change Grafting<H> hasher to no longer require a reference to the base mmr as the source of grafted digests. Instead it's now the responsibility of the user to load the necessary grafted digests before using it.  This allows for concurrent retrieval of the grafted digests, and will allow for parallel computation of leaf digests without blocking on async calls.
- Remove async from leaf_digest(), clarifying it should never perform IO-bound computation to allow for CPU parallelization.
- Renames "chunk_pos" in Bitmap to the more terminologically accurate "chunk_num"