### PR TITLE
[storage/mmr] change API for batching of leaf updates

### DIFF
--- a/storage/src/mmr/benches/update.rs
+++ b/storage/src/mmr/benches/update.rs
@@ -3,7 +3,7 @@ use commonware_runtime::{benchmarks::tokio, tokio::Config};
 use commonware_storage::mmr::{hasher::Standard, mem::Mmr};
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::time::Instant;
+use std::{collections::HashMap, time::Instant};
 
 /// Benchmark the performance of randomly updating leaves in an MMR.
 fn bench_update(c: &mut Criterion) {
@@ -39,21 +39,26 @@ fn bench_update(c: &mut Criterion) {
 
                             // Randomly update leaves -- this is what we are benchmarking.
                             let start = Instant::now();
+
+                            // Simulate leaf-batching being the responsibility of the caller.
+                            let mut leaf_map = HashMap::new();
                             for _ in 0..updates {
                                 let rand_leaf_num = sampler.gen_range(0..leaves);
                                 let rand_leaf_pos = leaf_positions[rand_leaf_num as usize];
                                 let rand_leaf_swap = sampler.gen_range(0..elements.len());
                                 let new_element = &elements[rand_leaf_swap];
-                                if batched {
-                                    mmr.update_leaf_batched(&mut h, rand_leaf_pos, new_element)
-                                        .await
-                                        .unwrap();
-                                } else {
-                                    mmr.update_leaf(&mut h, rand_leaf_pos, new_element)
-                                        .await
-                                        .unwrap();
+                                leaf_map.insert(rand_leaf_pos, *new_element);
+                            }
+                            if batched {
+                                mmr.update_leaf_batched(&mut h, leaf_map.into_iter())
+                                    .await
+                                    .unwrap();
+                            } else {
+                                for (pos, element) in leaf_map {
+                                    mmr.update_leaf(&mut h, pos, &element).await.unwrap();
                                 }
                             }
+
                             mmr.sync(&mut h);
                             start.elapsed()
                         });


### PR DESCRIPTION
Instead of having the caller add leaf modifications one at a time, allow them to be provided in batch to allow for (later) parallelization of leaf digest computations.