### PR TITLE
[lint/fmt] Format imports

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Install nightly Rust toolchain
-      run: rustup toolchain install nightly
+      run: rustup toolchain install nightly && rustup component add --toolchain nightly rustfmt
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Lint

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -25,12 +25,14 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    - name: Install nightly Rust toolchain
+      run: rustup toolchain install nightly
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Lint
       run: cargo clippy --all-targets ${{ matrix.flags }} -- -D warnings
     - name: Fmt
-      run: cargo fmt --all -- --check
+      run: cargo +nightly fmt --all -- --check
     - name: Check docs
       run: cargo doc ${{ matrix.flags }} --no-deps --document-private-items
       env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,13 @@ This repository uses the default cargo and clippy formatting rules for `.rs` fil
 
 ```bash
 $ cargo clippy --all-targets --all-features -- -D warnings
-$ cargo fmt --all -- --check
+$ cargo +nightly fmt --all -- --check
 ```
 
 To fix linting automatically, run:
 
 ```bash
-$ cargo fmt --all
+$ cargo +nightly fmt --all
 ```
 
 # Releases

--- a/codec/src/types/set.rs
+++ b/codec/src/types/set.rs
@@ -147,8 +147,10 @@ mod tests {
         FixedSize,
     };
     use bytes::{Bytes, BytesMut};
-    use std::collections::{BTreeSet, HashSet};
-    use std::fmt::Debug;
+    use std::{
+        collections::{BTreeSet, HashSet},
+        fmt::Debug,
+    };
 
     // Generic round trip test function for BTreeSet
     fn round_trip_btree<K>(set: &BTreeSet<K>, range_cfg: RangeCfg, item_cfg: K::Cfg)

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -72,19 +72,14 @@ mod tests {
     use commonware_p2p::simulated::{Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{
         deterministic::{self, Context},
-        Metrics,
+        Clock, Metrics, Runner, Spawner,
     };
-    use commonware_runtime::{Clock, Runner, Spawner};
     use commonware_utils::quorum;
-    use futures::channel::oneshot;
-    use futures::future::join_all;
+    use futures::{channel::oneshot, future::join_all};
     use rand::{rngs::StdRng, SeedableRng as _};
     use std::{
-        collections::HashMap,
+        collections::{BTreeMap, HashMap, HashSet},
         sync::{Arc, Mutex},
-    };
-    use std::{
-        collections::{BTreeMap, HashSet},
         time::Duration,
     };
     use tracing::debug;

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -31,10 +31,10 @@ use prometheus_client::metrics::{
 use rand::Rng;
 use std::{
     cmp::max,
-    collections::{btree_map::Entry, BTreeMap, HashMap},
+    collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap},
+    sync::atomic::AtomicI64,
     time::{Duration, SystemTime},
 };
-use std::{collections::BTreeSet, sync::atomic::AtomicI64};
 use tracing::{debug, trace, warn};
 
 type Notarizable<'a, V, D> = Option<(

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -1,9 +1,10 @@
 mod actor;
 mod ingress;
 
-use crate::simplex::types::{Activity, Context, View};
-use crate::{Automaton, Supervisor};
-use crate::{Relay, Reporter};
+use crate::{
+    simplex::types::{Activity, Context, View},
+    Automaton, Relay, Reporter, Supervisor,
+};
 pub use actor::Actor;
 use commonware_cryptography::{Digest, Signer};
 pub use ingress::{Mailbox, Message};
@@ -56,8 +57,7 @@ mod tests {
     use commonware_runtime::{deterministic, Metrics, Runner, Spawner};
     use commonware_utils::quorum;
     use futures::{channel::mpsc, StreamExt};
-    use std::time::Duration;
-    use std::{collections::BTreeMap, sync::Arc};
+    use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
     /// Trigger processing of an uninteresting view from the resolver after
     /// jumping ahead to a new finalize view:

--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -5,8 +5,7 @@ use crate::{
     Supervisor,
 };
 use commonware_codec::{Decode, Encode};
-use commonware_cryptography::Hasher;
-use commonware_cryptography::{Digest, Signer};
+use commonware_cryptography::{Digest, Hasher, Signer};
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{Clock, Handle, Spawner};
 use rand::{CryptoRng, Rng};

--- a/consensus/src/threshold_simplex/actors/batcher/mod.rs
+++ b/consensus/src/threshold_simplex/actors/batcher/mod.rs
@@ -1,11 +1,10 @@
 mod actor;
 mod ingress;
 
-pub use actor::Actor;
-pub use ingress::{Mailbox, Message};
-
 use crate::{threshold_simplex::types::View, Reporter, ThresholdSupervisor};
+pub use actor::Actor;
 use commonware_p2p::Blocker;
+pub use ingress::{Mailbox, Message};
 
 pub struct Config<B: Blocker, R: Reporter, S: ThresholdSupervisor> {
     pub blocker: B,

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -41,9 +41,9 @@ use prometheus_client::metrics::{
     counter::Counter, family::Family, gauge::Gauge, histogram::Histogram,
 };
 use rand::Rng;
-use std::sync::{atomic::AtomicI64, Arc};
 use std::{
     collections::BTreeMap,
+    sync::{atomic::AtomicI64, Arc},
     time::{Duration, SystemTime},
 };
 use tracing::{debug, info, trace, warn};

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -1,17 +1,18 @@
 mod actor;
 mod ingress;
 
-use std::time::Duration;
-
 use crate::{
     threshold_simplex::types::{Activity, Context, View},
     Automaton, Relay, Reporter, ThresholdSupervisor,
 };
 pub use actor::Actor;
-use commonware_cryptography::{bls12381::primitives::group, Digest};
-use commonware_cryptography::{bls12381::primitives::variant::Variant, Signer};
+use commonware_cryptography::{
+    bls12381::primitives::{group, variant::Variant},
+    Digest, Signer,
+};
 use commonware_p2p::Blocker;
 pub use ingress::{Mailbox, Message};
+use std::time::Duration;
 
 pub struct Config<
     C: Signer,
@@ -67,8 +68,7 @@ mod tests {
     use commonware_runtime::{deterministic, Metrics, Runner, Spawner};
     use commonware_utils::quorum;
     use futures::{channel::mpsc, StreamExt};
-    use std::time::Duration;
-    use std::{collections::BTreeMap, sync::Arc};
+    use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
     /// Trigger processing of an uninteresting view from the resolver after
     /// jumping ahead to a new finalize view:

--- a/consensus/src/threshold_simplex/mocks/conflicter.rs
+++ b/consensus/src/threshold_simplex/mocks/conflicter.rs
@@ -5,10 +5,9 @@ use crate::{
     ThresholdSupervisor,
 };
 use commonware_codec::{DecodeExt, Encode};
-use commonware_cryptography::Digest;
 use commonware_cryptography::{
     bls12381::primitives::{group, variant::Variant},
-    Hasher,
+    Digest, Hasher,
 };
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{Clock, Handle, Spawner};

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -1,12 +1,14 @@
-use commonware_cryptography::bls12381::dkg::{Dealer, Player};
-use commonware_cryptography::bls12381::primitives::variant::MinSig;
-use commonware_cryptography::{ed25519, PrivateKeyExt as _, Signer as _};
+use commonware_cryptography::{
+    bls12381::{
+        dkg::{Dealer, Player},
+        primitives::variant::MinSig,
+    },
+    ed25519, PrivateKeyExt as _, Signer as _,
+};
 use commonware_utils::quorum;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::rngs::StdRng;
-use rand::SeedableRng;
-use std::collections::HashMap;
-use std::hint::black_box;
+use rand::{rngs::StdRng, SeedableRng};
+use std::{collections::HashMap, hint::black_box};
 
 /// Concurrency isn't used in DKG recovery, so we set it to 1.
 const CONCURRENCY: usize = 1;

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -8,8 +8,7 @@ use commonware_cryptography::{
 use commonware_utils::quorum;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
-use std::collections::HashMap;
-use std::hint::black_box;
+use std::{collections::HashMap, hint::black_box};
 
 fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0);

--- a/cryptography/src/bls12381/benches/partial_verify_multiple_public_keys.rs
+++ b/cryptography/src/bls12381/benches/partial_verify_multiple_public_keys.rs
@@ -1,5 +1,3 @@
-use std::hint::black_box;
-
 use commonware_cryptography::bls12381::{
     dkg,
     primitives::{self, variant::MinSig},
@@ -7,6 +5,7 @@ use commonware_cryptography::bls12381::{
 use commonware_utils::quorum;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use std::hint::black_box;
 
 fn benchmark_partial_verify_multiple_public_keys(c: &mut Criterion) {
     let namespace = b"benchmark";

--- a/cryptography/src/bls12381/dkg/mod.rs
+++ b/cryptography/src/bls12381/dkg/mod.rs
@@ -131,7 +131,6 @@ pub use dealer::Dealer;
 pub mod ops;
 pub mod player;
 pub use player::Player;
-
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -187,17 +186,21 @@ pub enum Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bls12381::primitives::ops::{
-        partial_sign_proof_of_possession, threshold_signature_recover, verify_proof_of_possession,
+    use crate::{
+        bls12381::primitives::{
+            ops::{
+                partial_sign_proof_of_possession, threshold_signature_recover,
+                verify_proof_of_possession,
+            },
+            poly::public,
+            variant::{MinPk, MinSig, Variant},
+        },
+        ed25519::PrivateKey,
+        PrivateKeyExt as _, Signer as _,
     };
-    use crate::bls12381::primitives::poly::public;
-    use crate::bls12381::primitives::variant::{MinPk, MinSig, Variant};
-    use crate::Signer as _;
-    use crate::{ed25519::PrivateKey, PrivateKeyExt as _};
     use arbiter::Output;
     use commonware_utils::quorum;
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
+    use rand::{rngs::StdRng, SeedableRng};
     use std::collections::HashMap;
 
     fn run_dkg_and_reshare<V: Variant>(

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -9,4 +9,4 @@
 pub mod dkg;
 pub mod primitives;
 mod scheme;
-pub use {scheme::Batch, scheme::PrivateKey, scheme::PublicKey, scheme::Signature};
+pub use scheme::{Batch, PrivateKey, PublicKey, Signature};

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -381,11 +381,10 @@ pub fn public<V: Variant>(public: &Public<V>) -> &V::Public {
 
 #[cfg(test)]
 pub mod tests {
-    use commonware_codec::{Decode, Encode};
-
     // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/b0ef82ff79769d085a5a7d3f4fe690b1c8fe6dc9/crates/threshold-bls/src/poly.rs#L355-L604
     use super::*;
     use crate::bls12381::primitives::group::{Scalar, G2};
+    use commonware_codec::{Decode, Encode};
 
     #[test]
     fn poly_degree() {

--- a/cryptography/src/bls12381/primitives/variant.rs
+++ b/cryptography/src/bls12381/primitives/variant.rs
@@ -1,15 +1,16 @@
 //! Different variants of the BLS signature scheme.
 
-use super::group::{
-    Point, DST, G1, G1_MESSAGE, G1_PROOF_OF_POSSESSION, G2, G2_MESSAGE, G2_PROOF_OF_POSSESSION,
+use super::{
+    group::{
+        Point, DST, G1, G1_MESSAGE, G1_PROOF_OF_POSSESSION, G2, G2_MESSAGE, G2_PROOF_OF_POSSESSION,
+    },
+    Error,
 };
-use super::Error;
 use crate::bls12381::primitives::group::{Element, Scalar};
 use blst::{Pairing as blst_pairing, BLS12_381_NEG_G1, BLS12_381_NEG_G2};
 use commonware_codec::FixedSize;
 use rand::{CryptoRng, RngCore};
-use std::fmt::Debug;
-use std::hash::Hash;
+use std::{fmt::Debug, hash::Hash};
 
 /// A specific instance of a signature scheme.
 pub trait Variant: Clone + Send + Sync + Hash + Eq + Debug + 'static {

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -383,7 +383,7 @@ impl BatchVerifier<PublicKey> for Batch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{bls12381, BatchVerifier as _, Signer as _, Verifier as _};
+    use crate::{bls12381, Verifier as _};
     use commonware_codec::{DecodeExt, Encode};
 
     #[test]

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -382,9 +382,8 @@ impl BatchVerifier<PublicKey> for Batch {
 /// Test vectors sourced from https://github.com/ethereum/bls12-381-tests/releases/tag/v0.1.2.
 #[cfg(test)]
 mod tests {
-    use crate::{bls12381, BatchVerifier as _, Signer as _, Verifier as _};
-
     use super::*;
+    use crate::{bls12381, BatchVerifier as _, Signer as _, Verifier as _};
     use commonware_codec::{DecodeExt, Encode};
 
     #[test]

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -4,10 +4,12 @@ use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use commonware_utils::{hex, union_unique};
 use ed25519_consensus::{self, VerificationKey};
 use rand::{CryptoRng, Rng, RngCore};
-use std::borrow::Cow;
-use std::fmt::{Debug, Display};
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
+use std::{
+    borrow::Cow,
+    fmt::{Debug, Display},
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const CURVE_NAME: &str = "ed25519";

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -327,9 +327,8 @@ impl Display for Signature {
 /// https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/digital-signatures.
 #[cfg(test)]
 mod tests {
-    use crate::{Signer as _, Verifier as _};
-
     use super::*;
+    use crate::{Signer as _, Verifier as _};
     use bytes::Bytes;
     use commonware_codec::{DecodeExt, Encode};
 

--- a/deployer/src/ec2/authorize.rs
+++ b/deployer/src/ec2/authorize.rs
@@ -1,15 +1,12 @@
 //! `authorize` subcommand for `ec2`
 
-use crate::ec2::utils::{
-    exact_cidr, get_public_ip, DEPLOYER_MAX_PORT, DEPLOYER_MIN_PORT, DEPLOYER_PROTOCOL,
-};
 use crate::ec2::{
-    aws::*, deployer_directory, Config, Error, CREATED_FILE_NAME, DESTROYED_FILE_NAME,
-    MONITORING_REGION,
+    aws::*,
+    deployer_directory,
+    utils::{exact_cidr, get_public_ip, DEPLOYER_MAX_PORT, DEPLOYER_MIN_PORT, DEPLOYER_PROTOCOL},
+    Config, Error, CREATED_FILE_NAME, DESTROYED_FILE_NAME, MONITORING_REGION,
 };
-use std::collections::HashSet;
-use std::fs::File;
-use std::path::PathBuf;
+use std::{collections::HashSet, fs::File, path::PathBuf};
 use tracing::info;
 
 /// Adds the deployer's IP (or the one provided) to all security groups.

--- a/deployer/src/ec2/aws.rs
+++ b/deployer/src/ec2/aws.rs
@@ -7,16 +7,20 @@ use crate::ec2::{
 };
 use aws_config::BehaviorVersion;
 pub use aws_config::Region;
-use aws_sdk_ec2::error::BuildError;
-use aws_sdk_ec2::primitives::Blob;
-use aws_sdk_ec2::types::{
-    BlockDeviceMapping, EbsBlockDevice, Filter, InstanceStateName, ResourceType, SecurityGroup,
-    SummaryStatus, Tag, TagSpecification, VpcPeeringConnectionStateReasonCode,
-};
 pub use aws_sdk_ec2::types::{InstanceType, IpPermission, IpRange, UserIdGroupPair, VolumeType};
-use aws_sdk_ec2::{Client as Ec2Client, Error as Ec2Error};
-use std::collections::{HashMap, HashSet};
-use std::time::Duration;
+use aws_sdk_ec2::{
+    error::BuildError,
+    primitives::Blob,
+    types::{
+        BlockDeviceMapping, EbsBlockDevice, Filter, InstanceStateName, ResourceType, SecurityGroup,
+        SummaryStatus, Tag, TagSpecification, VpcPeeringConnectionStateReasonCode,
+    },
+    Client as Ec2Client, Error as Ec2Error,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 use tokio::time::sleep;
 
 /// Creates an EC2 client for the specified AWS region

--- a/deployer/src/ec2/create.rs
+++ b/deployer/src/ec2/create.rs
@@ -5,10 +5,12 @@ use crate::ec2::{
     CREATED_FILE_NAME, LOGS_PORT, MONITORING_NAME, MONITORING_REGION, PROFILES_PORT, TRACES_PORT,
 };
 use futures::future::try_join_all;
-use std::collections::{BTreeSet, HashMap, HashSet};
-use std::fs::File;
-use std::net::IpAddr;
-use std::path::PathBuf;
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    fs::File,
+    net::IpAddr,
+    path::PathBuf,
+};
 use tokio::process::Command;
 use tracing::info;
 

--- a/deployer/src/ec2/destroy.rs
+++ b/deployer/src/ec2/destroy.rs
@@ -5,9 +5,7 @@ use crate::ec2::{
     PROFILES_PORT, TRACES_PORT,
 };
 use futures::future::try_join_all;
-use std::collections::HashSet;
-use std::fs::File;
-use std::path::PathBuf;
+use std::{collections::HashSet, fs::File, path::PathBuf};
 use tracing::{info, warn};
 
 /// Tears down all resources associated with the deployment tag

--- a/deployer/src/ec2/update.rs
+++ b/deployer/src/ec2/update.rs
@@ -6,9 +6,7 @@ use crate::ec2::{
 };
 use aws_sdk_ec2::types::Filter;
 use futures::future::try_join_all;
-use std::collections::HashMap;
-use std::fs::File;
-use std::path::PathBuf;
+use std::{collections::HashMap, fs::File, path::PathBuf};
 use tracing::{error, info};
 
 /// Updates the binary and configuration on all binary nodes

--- a/deployer/src/ec2/utils.rs
+++ b/deployer/src/ec2/utils.rs
@@ -1,8 +1,10 @@
 //! Utility functions for interacting with EC2 instances
 
 use crate::ec2::Error;
-use tokio::process::Command;
-use tokio::time::{sleep, Duration};
+use tokio::{
+    process::Command,
+    time::{sleep, Duration},
+};
 use tracing::warn;
 
 /// Maximum number of SSH connection attempts before failing

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -17,8 +17,11 @@ use commonware_runtime::{tokio, Metrics, Network, Runner};
 use commonware_stream::public_key::{self, Connection};
 use commonware_utils::{from_hex, quorum, union, NZU32};
 use governor::Quota;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::{str::FromStr, time::Duration};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    time::Duration,
+};
 
 fn main() {
     // Parse arguments

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -56,17 +56,16 @@ mod handler;
 mod logger;
 
 use clap::{value_parser, Arg, Command};
-use commonware_cryptography::PrivateKeyExt as _;
-use commonware_cryptography::{ed25519, Signer as _};
+use commonware_cryptography::{ed25519, PrivateKeyExt as _, Signer as _};
 use commonware_p2p::authenticated::{self, Network};
-use commonware_runtime::tokio;
-use commonware_runtime::Metrics;
-use commonware_runtime::Runner as _;
+use commonware_runtime::{tokio, Metrics, Runner as _};
 use commonware_utils::NZU32;
 use governor::Quota;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 use tracing::info;
 
 /// Unique namespace to avoid message replay attacks.

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -54,8 +54,11 @@ use commonware_p2p::authenticated::{self, Network};
 use commonware_runtime::{tokio, Metrics, Runner};
 use commonware_utils::{union, NZU32};
 use governor::Quota;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::{str::FromStr, time::Duration};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    time::Duration,
+};
 
 /// Unique namespace to avoid message replay attacks.
 const APPLICATION_NAMESPACE: &[u8] = b"_COMMONWARE_LOG";

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -14,8 +14,10 @@ use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{Clock, Handle, Spawner};
 use futures::{channel::mpsc, StreamExt};
-use std::collections::{HashMap, HashSet};
-use std::time::Duration;
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 use tracing::{debug, info, warn};
 
 const VRF_NAMESPACE: &[u8] = b"_COMMONWARE_EXAMPLES_VRF_";

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -87,8 +87,11 @@ use commonware_p2p::authenticated::{self, Network};
 use commonware_runtime::{tokio, Metrics, Runner};
 use commonware_utils::{quorum, NZU32};
 use governor::Quota;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::{str::FromStr, time::Duration};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    time::Duration,
+};
 use tracing::info;
 
 // Unique namespace to avoid message replay attacks.

--- a/p2p/src/authenticated/actors/dialer.rs
+++ b/p2p/src/authenticated/actors/dialer.rs
@@ -15,8 +15,7 @@ use commonware_runtime::{
 use commonware_stream::public_key::{Config as StreamConfig, Connection};
 use commonware_utils::SystemTimeExt;
 use governor::clock::Clock as GClock;
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::{counter::Counter, family::Family};
 use rand::{seq::SliceRandom, CryptoRng, Rng};
 use std::time::Duration;
 use tracing::{debug, debug_span, Instrument};

--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -248,10 +248,9 @@ mod tests {
         // Blocker is implicitly available via oracle.block() due to Oracle implementing crate::Blocker
     };
     use commonware_codec::{DecodeExt, Encode};
-    use commonware_cryptography::PrivateKeyExt as _;
     use commonware_cryptography::{
         ed25519::{PrivateKey, PublicKey, Signature},
-        Signer,
+        PrivateKeyExt as _, Signer,
     };
     use commonware_runtime::{
         deterministic::{self, Context},
@@ -260,10 +259,10 @@ mod tests {
     use commonware_utils::{BitVec as UtilsBitVec, NZU32};
     use futures::future::Either;
     use governor::Quota;
-    use std::time::Duration;
     use std::{
         collections::HashSet,
         net::{IpAddr, Ipv4Addr, SocketAddr},
+        time::Duration,
     };
     use types::PeerInfo;
 

--- a/p2p/src/authenticated/actors/tracker/mod.rs
+++ b/p2p/src/authenticated/actors/tracker/mod.rs
@@ -3,9 +3,10 @@
 use crate::authenticated::config::Bootstrapper;
 use commonware_cryptography::Signer;
 use governor::Quota;
-use std::net::IpAddr;
-use std::net::SocketAddr;
-use std::time::Duration;
+use std::{
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 use thiserror::Error;
 
 mod actor;

--- a/p2p/src/authenticated/ip.rs
+++ b/p2p/src/authenticated/ip.rs
@@ -98,8 +98,10 @@ const fn is_global_v6(ip: Ipv6Addr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-    use std::str::FromStr;
+    use std::{
+        net::{IpAddr, Ipv4Addr, Ipv6Addr},
+        str::FromStr,
+    };
 
     #[test]
     fn test_is_global_v4() {

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -218,8 +218,8 @@ mod tests {
     use commonware_utils::NZU32;
     use governor::{clock::ReasonablyRealtime, Quota};
     use rand::{CryptoRng, Rng};
-    use std::collections::HashSet;
     use std::{
+        collections::HashSet,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         time::Duration,
     };

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -7,9 +7,7 @@
 
 use bytes::Bytes;
 use commonware_cryptography::PublicKey;
-use std::error::Error as StdError;
-use std::fmt::Debug;
-use std::future::Future;
+use std::{error::Error as StdError, fmt::Debug, future::Future};
 
 pub mod authenticated;
 pub mod simulated;

--- a/p2p/src/utils/requester/requester.rs
+++ b/p2p/src/utils/requester/requester.rs
@@ -257,10 +257,8 @@ impl<E: Clock + GClock + Rng + Metrics, P: PublicKey> Requester<E, P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use commonware_cryptography::ed25519::PrivateKey;
-    use commonware_cryptography::{PrivateKeyExt as _, Signer as _};
-    use commonware_runtime::deterministic;
-    use commonware_runtime::Runner;
+    use commonware_cryptography::{ed25519::PrivateKey, PrivateKeyExt as _, Signer as _};
+    use commonware_runtime::{deterministic, Runner};
     use commonware_utils::NZU32;
     use governor::Quota;
     use std::time::Duration;

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -2,9 +2,8 @@ use super::{
     config::Config,
     fetcher::Fetcher,
     ingress::{Mailbox, Message},
-    metrics,
+    metrics, wire, Coordinator, Producer,
 };
-use super::{wire, Coordinator, Producer};
 use crate::Consumer;
 use bytes::Bytes;
 use commonware_cryptography::PublicKey;

--- a/resolver/src/p2p/mocks/consumer.rs
+++ b/resolver/src/p2p/mocks/consumer.rs
@@ -1,6 +1,5 @@
 use crate::Array;
-use futures::channel::mpsc;
-use futures::SinkExt;
+use futures::{channel::mpsc, SinkExt};
 use std::collections::HashMap;
 
 /// An event that indicates the messages that were sent to the consumer

--- a/resolver/src/p2p/mocks/coordinator.rs
+++ b/resolver/src/p2p/mocks/coordinator.rs
@@ -1,7 +1,6 @@
 use commonware_cryptography::PublicKey;
 use commonware_runtime::Spawner;
-use futures::channel::mpsc;
-use futures::StreamExt;
+use futures::{channel::mpsc, StreamExt};
 use std::sync::{Arc, Mutex};
 
 /// Message type for coordinator updates

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -358,10 +358,10 @@ mod tests {
         types::{Fd, Timespec},
     };
     use prometheus_client::registry::Registry;
-    use std::time::Duration;
     use std::{
         os::{fd::AsRawFd, unix::net::UnixStream},
         sync::Arc,
+        time::Duration,
     };
 
     async fn recv_then_send(cfg: Config, should_succeed: bool) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -19,9 +19,9 @@
 
 use commonware_utils::StableBuf;
 use prometheus_client::registry::Metric;
-use std::io::Error as IoError;
 use std::{
     future::Future,
+    io::Error as IoError,
     net::SocketAddr,
     time::{Duration, SystemTime},
 };
@@ -395,13 +395,18 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use commonware_macros::select;
-    use futures::channel::oneshot;
-    use futures::{channel::mpsc, future::ready, join, SinkExt, StreamExt};
+    use futures::{
+        channel::{mpsc, oneshot},
+        future::ready,
+        join, SinkExt, StreamExt,
+    };
     use prometheus_client::metrics::counter::Counter;
-    use std::collections::HashMap;
-    use std::panic::{catch_unwind, AssertUnwindSafe};
-    use std::str::FromStr;
-    use std::sync::Mutex;
+    use std::{
+        collections::HashMap,
+        panic::{catch_unwind, AssertUnwindSafe},
+        str::FromStr,
+        sync::Mutex,
+    };
     use tracing::{error, Level};
     use utils::reschedule;
 

--- a/runtime/src/network/audited.rs
+++ b/runtime/src/network/audited.rs
@@ -182,13 +182,15 @@ impl<N: crate::Network> crate::Network for Network<N> {
 
 #[cfg(test)]
 mod tests {
-    use crate::deterministic::Auditor;
-    use crate::network::audited::Network as AuditedNetwork;
-    use crate::network::deterministic::Network as DeterministicNetwork;
-    use crate::network::tests;
-    use crate::{Listener as _, Network as _, Sink as _, Stream as _};
-    use std::net::SocketAddr;
-    use std::sync::Arc;
+    use crate::{
+        deterministic::Auditor,
+        network::{
+            audited::Network as AuditedNetwork, deterministic::Network as DeterministicNetwork,
+            tests,
+        },
+        Listener as _, Network as _, Sink as _, Stream as _,
+    };
+    use std::{net::SocketAddr, sync::Arc};
 
     #[tokio::test]
     async fn test_trait() {

--- a/runtime/src/network/deterministic.rs
+++ b/runtime/src/network/deterministic.rs
@@ -144,8 +144,7 @@ impl crate::Network for Network {
 
 #[cfg(test)]
 mod tests {
-    use crate::network::deterministic as DeterministicNetwork;
-    use crate::network::tests;
+    use crate::network::{deterministic as DeterministicNetwork, tests};
 
     #[tokio::test]
     async fn test_trait() {

--- a/runtime/src/network/metered.rs
+++ b/runtime/src/network/metered.rs
@@ -166,10 +166,13 @@ impl<N: crate::Network> crate::Network for Network<N> {
 
 #[cfg(test)]
 mod tests {
-    use crate::network::deterministic::Network as DeterministicNetwork;
-    use crate::network::metered::Network as MeteredNetwork;
-    use crate::network::tests;
-    use crate::{Listener as _, Network as _, Sink as _, Stream as _};
+    use crate::{
+        network::{
+            deterministic::Network as DeterministicNetwork, metered::Network as MeteredNetwork,
+            tests,
+        },
+        Listener as _, Network as _, Sink as _, Stream as _,
+    };
     use prometheus_client::registry::Registry;
     use std::net::SocketAddr;
 

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -220,8 +220,7 @@ impl crate::Network for Network {
 
 #[cfg(test)]
 mod tests {
-    use crate::network::tests;
-    use crate::network::tokio as TokioNetwork;
+    use crate::network::{tests, tokio as TokioNetwork};
     use std::time::Duration;
 
     #[tokio::test]

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -10,11 +10,13 @@ use futures::{
 };
 use io_uring::{opcode, types};
 use prometheus_client::registry::Registry;
-use std::fs::{self, File};
-use std::io::Error as IoError;
-use std::os::fd::AsRawFd;
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::{
+    fs::{self, File},
+    io::Error as IoError,
+    os::fd::AsRawFd,
+    path::PathBuf,
+    sync::Arc,
+};
 
 #[derive(Clone, Debug)]
 /// Configuration for a [Storage].

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,6 +1,8 @@
 use commonware_utils::{hex, StableBuf};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, RwLock},
+};
 
 /// In-memory storage implementation for the commonware runtime.
 #[derive(Clone)]

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -1,7 +1,9 @@
 use crate::Error;
 use commonware_utils::StableBuf;
-use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
-use prometheus_client::registry::Registry;
+use prometheus_client::{
+    metrics::{counter::Counter, gauge::Gauge},
+    registry::Registry,
+};
 use std::sync::Arc;
 
 pub struct Metrics {
@@ -142,9 +144,10 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::memory::Storage as MemoryStorage;
-    use crate::storage::tests::run_storage_tests;
-    use crate::{Blob, Storage as _};
+    use crate::{
+        storage::{memory::Storage as MemoryStorage, tests::run_storage_tests},
+        Blob, Storage as _,
+    };
     use prometheus_client::registry::Registry;
 
     #[tokio::test]

--- a/runtime/src/storage/tokio.rs
+++ b/runtime/src/storage/tokio.rs
@@ -1,7 +1,6 @@
 use crate::Error;
 use commonware_utils::{from_hex, hex, StableBuf};
-use std::sync::Arc;
-use std::{io::SeekFrom, path::PathBuf};
+use std::{io::SeekFrom, path::PathBuf, sync::Arc};
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -1,23 +1,19 @@
+#[cfg(not(feature = "iouring-network"))]
+use crate::network::tokio::{Config as TokioNetworkConfig, Network as TokioNetwork};
 #[cfg(feature = "iouring-storage")]
 use crate::storage::iouring::{Config as IoUringConfig, Storage as IoUringStorage};
-
+#[cfg(not(feature = "iouring-storage"))]
+use crate::storage::tokio::{Config as TokioStorageConfig, Storage as TokioStorage};
 #[cfg(feature = "iouring-network")]
 use crate::{
     iouring,
     network::iouring::{Config as IoUringNetworkConfig, Network as IoUringNetwork},
 };
-
-#[cfg(not(feature = "iouring-network"))]
-use crate::network::tokio::{Config as TokioNetworkConfig, Network as TokioNetwork};
-
-#[cfg(not(feature = "iouring-storage"))]
-use crate::storage::tokio::{Config as TokioStorageConfig, Storage as TokioStorage};
-
-use crate::network::metered::Network as MeteredNetwork;
-use crate::storage::metered::Storage as MeteredStorage;
-use crate::telemetry::metrics::task::Label;
-use crate::{utils::Signaler, Clock, Error, Handle, Signal, METRICS_PREFIX};
-use crate::{SinkOf, StreamOf};
+use crate::{
+    network::metered::Network as MeteredNetwork, storage::metered::Storage as MeteredStorage,
+    telemetry::metrics::task::Label, utils::Signaler, Clock, Error, Handle, Signal, SinkOf,
+    StreamOf, METRICS_PREFIX,
+};
 use governor::clock::{Clock as GClock, ReasonablyRealtime};
 use prometheus_client::{
     encoding::text::encode,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+# Imports
+imports_granularity = "Crate"
+group_imports = "One"

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -143,9 +143,8 @@
 //! ```
 
 mod storage;
-pub use storage::{Archive, Identifier};
-
 pub use crate::index::Translator;
+pub use storage::{Archive, Identifier};
 use thiserror::Error;
 
 /// Errors that can occur when interacting with the archive.
@@ -202,10 +201,11 @@ pub struct Config<T: Translator, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::index::translator::{FourCap, TwoCap};
-    use crate::journal::Error as JournalError;
-    use commonware_codec::varint::UInt;
-    use commonware_codec::{DecodeExt, EncodeSize, Error as CodecError};
+    use crate::{
+        index::translator::{FourCap, TwoCap},
+        journal::Error as JournalError,
+    };
+    use commonware_codec::{varint::UInt, DecodeExt, EncodeSize, Error as CodecError};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
     use commonware_utils::array::FixedBytes;

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -58,8 +58,7 @@ use commonware_runtime::{
 use commonware_utils::hex;
 use futures::stream::{self, Stream, StreamExt};
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
-use std::collections::BTreeMap;
-use std::marker::PhantomData;
+use std::{collections::BTreeMap, marker::PhantomData};
 use tracing::{debug, trace, warn};
 
 /// Configuration for `Journal` storage.

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -66,9 +66,8 @@
 //! ```
 
 mod storage;
-pub use storage::Metadata;
-
 use commonware_utils::Array;
+pub use storage::Metadata;
 use thiserror::Error;
 
 /// Errors that can occur when interacting with `Metadata`.

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -4,13 +4,15 @@
 //! used to preserve digests required for root and proof generation that would have otherwise been
 //! pruned.
 
-use crate::journal::{
-    fixed::{Config as JConfig, Journal},
-    Error as JError,
-};
-use crate::metadata::{Config as MConfig, Metadata};
-use crate::mmr::{
-    iterator::PeakIterator, mem::Mmr as MemMmr, verification::Proof, Builder, Error, Hasher,
+use crate::{
+    journal::{
+        fixed::{Config as JConfig, Journal},
+        Error as JError,
+    },
+    metadata::{Config as MConfig, Metadata},
+    mmr::{
+        iterator::PeakIterator, mem::Mmr as MemMmr, verification::Proof, Builder, Error, Hasher,
+    },
 };
 use commonware_codec::DecodeExt;
 use commonware_cryptography::Hasher as CHasher;

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -520,7 +520,6 @@ mod tests {
         iterator::leaf_num_to_pos,
         tests::{build_and_check_test_roots_mmr, build_batched_and_check_test_roots, ROOTS},
     };
-
     use commonware_cryptography::Sha256;
     use commonware_runtime::{deterministic, Runner};
     use commonware_utils::hex;

--- a/utils/src/stable_buf.rs
+++ b/utils/src/stable_buf.rs
@@ -2,9 +2,8 @@
 //!
 //! This code is inspired by [tokio-uring](https://github.com/tokio-rs/tokio-uring>) at commit 7761222.
 
-use std::ops::Index;
-
 use bytes::Bytes;
+use std::ops::Index;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// A buffer whose memory is stable as long as its not reallocated.


### PR DESCRIPTION
Enforce formatting of imports consistently in the repository. While we have historically used default linting, this has started to result in inconsistencies in imports between files. Since the linter can both detect and fix these issues, I think it might be better to start enforcing a minimal set of rules around imports. We should continue to avoid using non-defaults for linting of code as this can start to get contentious.

We may also choose to use `group_imports = "StdExternalCrate"` which seems to be more standard. Though `"One"` is certainly how most files are maintained today. I would suggest using `"One"` for now and switching over if `"StdExternalCrate"` ever becomes the default.