### PR TITLE
[p2p] Release sends message to `tracker` rather than `directory`

### DIFF
--- a/p2p/src/authenticated/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/actors/tracker/actor.rs
@@ -3,7 +3,7 @@ use super::{
     ingress::{Mailbox, Message, Oracle},
     Config, Error,
 };
-use crate::authenticated::{ip, types};
+use crate::authenticated::{actors::tracker::ingress::Releaser, ip, types};
 use commonware_cryptography::Signer;
 use commonware_runtime::{Clock, Handle, Metrics as RuntimeMetrics, Spawner};
 use commonware_utils::{union, SystemTimeExt};
@@ -64,13 +64,25 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
 
         // General initialization
         let directory_cfg = directory::Config {
-            mailbox_size: cfg.mailbox_size,
             max_sets: cfg.tracked_peer_sets,
             dial_fail_limit: cfg.dial_fail_limit,
             rate_limit: cfg.allowed_connection_rate_per_peer,
         };
-        let directory = Directory::init(context.clone(), cfg.bootstrappers, myself, directory_cfg);
+
+        // Create the mailboxes
         let (sender, receiver) = mpsc::channel(cfg.mailbox_size);
+        let mailbox = Mailbox::new(sender.clone());
+        let releaser = Releaser::new(sender.clone());
+        let oracle = Oracle::new(sender);
+
+        // Create the directory
+        let directory = Directory::init(
+            context.clone(),
+            cfg.bootstrappers,
+            myself,
+            directory_cfg,
+            releaser,
+        );
 
         (
             Self {
@@ -84,8 +96,8 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
                 receiver,
                 directory,
             },
-            Mailbox::new(sender.clone()),
-            Oracle::new(sender),
+            mailbox,
+            oracle,
         )
     }
 
@@ -136,7 +148,6 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
 
     async fn run(mut self) {
         while let Some(msg) = self.receiver.next().await {
-            self.directory.process_releases();
             match msg {
                 Message::Register { index, peers } => {
                     // Ensure that peer set is not too large.
@@ -228,6 +239,10 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
 
                     // We don't have to kill the peer now. It will be sent a `Kill` message the next
                     // time it sends the `Connect` or `Construct` message to the tracker.
+                }
+                Message::Release { metadata } => {
+                    // Release the peer
+                    self.directory.release(metadata);
                 }
             }
         }

--- a/p2p/src/authenticated/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/actors/tracker/ingress.rs
@@ -1,5 +1,8 @@
 use super::Reservation;
-use crate::authenticated::{actors::peer, types};
+use crate::authenticated::{
+    actors::{peer, tracker::Metadata},
+    types,
+};
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Metrics, Spawner};
 use futures::{
@@ -100,6 +103,13 @@ pub enum Message<E: Spawner + Metrics, C: PublicKey> {
         /// The sender to respond with the reservation.
         reservation: oneshot::Sender<Option<Reservation<E, C>>>,
     },
+
+    // ---------- Used by reservation ----------
+    /// Release a reservation.
+    Release {
+        /// The metadata of the reservation to release.
+        metadata: Metadata<C>,
+    },
 }
 
 /// Mailbox for sending messages to the tracker actor.
@@ -184,6 +194,44 @@ impl<E: Spawner + Metrics, C: PublicKey> Mailbox<E, C> {
             .await
             .unwrap();
         rx.await.unwrap()
+    }
+}
+
+/// Allows releasing reservations
+#[derive(Clone)]
+pub struct Releaser<E: Spawner + Metrics, C: PublicKey> {
+    sender: mpsc::Sender<Message<E, C>>,
+}
+
+impl<E: Spawner + Metrics, C: PublicKey> Releaser<E, C> {
+    /// Create a new releaser.
+    pub(super) fn new(sender: mpsc::Sender<Message<E, C>>) -> Self {
+        Self { sender }
+    }
+
+    /// Try to release a reservation.
+    ///
+    /// Returns `true` if the reservation was released, `false` if the mailbox is full.
+    pub fn try_release(&mut self, metadata: Metadata<C>) -> bool {
+        let Err(e) = self.sender.try_send(Message::Release { metadata }) else {
+            return true;
+        };
+        assert!(
+            e.is_full(),
+            "Unexpected error trying to release reservation {:?}",
+            e
+        );
+        false
+    }
+
+    /// Release a reservation.
+    ///
+    /// This method will panic if the mailbox is full.
+    pub async fn release(&mut self, metadata: Metadata<C>) {
+        self.sender
+            .send(Message::Release { metadata })
+            .await
+            .unwrap();
     }
 }
 

--- a/p2p/src/authenticated/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/actors/tracker/ingress.rs
@@ -226,7 +226,7 @@ impl<E: Spawner + Metrics, C: PublicKey> Releaser<E, C> {
 
     /// Release a reservation.
     ///
-    /// This method will panic if the mailbox is full.
+    /// This method will block if the mailbox is full.
     pub async fn release(&mut self, metadata: Metadata<C>) {
         self.sender
             .send(Message::Release { metadata })

--- a/p2p/src/authenticated/actors/tracker/reservation.rs
+++ b/p2p/src/authenticated/actors/tracker/reservation.rs
@@ -1,7 +1,7 @@
 use super::Metadata;
+use crate::authenticated::actors::tracker::ingress::Releaser;
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Metrics, Spawner};
-use futures::{channel::mpsc, SinkExt};
 
 /// Reservation for a peer in the network. This is used to ensure that the peer is reserved only
 /// once, and that the reservation is released when the peer connection fails or is closed.
@@ -12,20 +12,19 @@ pub struct Reservation<E: Spawner + Metrics, P: PublicKey> {
     /// Metadata about the reservation.
     metadata: Metadata<P>,
 
-    /// Sender used to automatically notify the completion of the reservation when it is dropped.
+    /// Used to automatically notify the completion of the reservation when it is dropped.
     ///
-    /// Stored as an `Option` to avoid unnecessary cloning by `take`ing the value when
-    /// dropping the reservation.
-    closer: Option<mpsc::Sender<Metadata<P>>>,
+    /// Stored as an `Option` to avoid unnecessary cloning by `take`ing the value.
+    releaser: Option<Releaser<E, P>>,
 }
 
 impl<E: Spawner + Metrics, P: PublicKey> Reservation<E, P> {
     /// Create a new reservation for a peer.
-    pub fn new(context: E, metadata: Metadata<P>, closer: mpsc::Sender<Metadata<P>>) -> Self {
+    pub fn new(context: E, metadata: Metadata<P>, releaser: Releaser<E, P>) -> Self {
         Self {
             context,
             metadata,
-            closer: Some(closer),
+            releaser: Some(releaser),
         }
     }
 }
@@ -39,26 +38,22 @@ impl<E: Spawner + Metrics, P: PublicKey> Reservation<E, P> {
 
 impl<E: Spawner + Metrics, P: PublicKey> Drop for Reservation<E, P> {
     fn drop(&mut self) {
-        let mut closer = self.closer.take().expect("Reservation::drop called twice");
+        let mut releaser = self
+            .releaser
+            .take()
+            .expect("Reservation::drop called twice");
 
         // If the mailbox is not full, we can release the reservation immediately without spawning a task.
-        let Err(e) = closer.try_send(self.metadata.clone()) else {
+        if releaser.try_release(self.metadata.clone()) {
             // Sent successfully, nothing to do.
             return;
         };
-        if e.is_full() {
-            // If the mailbox is full, we need to spawn a task to handle the release. If we used `block_on` here,
-            // it could cause a deadlock.
-            let metadata = self.metadata.clone();
-            self.context.spawn_ref()(async move {
-                closer.send(metadata).await.unwrap();
-            });
-        } else {
-            // If any other error occurs, we should panic!
-            panic!(
-                "unexpected error while trying to release reservation: {:?}",
-                e
-            );
-        }
+
+        // If the mailbox is full, we need to spawn a task to handle the release. If we used `block_on` here,
+        // it could cause a deadlock.
+        let metadata = self.metadata.clone();
+        self.context.spawn_ref()(async move {
+            releaser.release(metadata).await;
+        });
     }
 }


### PR DESCRIPTION
Fixes #1106 

Unfortunately I found it hard to create a test for this issue (to prevent regression) due to how the runtime deals with async stuff and how you have to release the reservation AFTER connecting, but also immediately, but then also during that time never loop a single time within the tracker actor