### PR TITLE
[storage] implement destroy for more storage classes

### DIFF
--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -581,23 +581,6 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         Ok(())
     }
 
-    /// Close the db. Operations that have not been committed will be lost.
-    pub async fn close(mut self) -> Result<(), Error> {
-        if self.uncommitted_ops > 0 {
-            warn!(
-                op_count = self.uncommitted_ops,
-                "closing db with uncommitted operations"
-            );
-        }
-
-        try_join!(
-            self.log.close().map_err(Error::JournalError),
-            self.ops.close(&mut self.hasher).map_err(Error::MmrError),
-        )?;
-
-        Ok(())
-    }
-
     // Moves the given operation to the tip of the log if it is active, rendering its old location
     // inactive. If the operation was not active, then this is a no-op. Returns the old location
     // of the operation if it was active.
@@ -678,6 +661,31 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         // Because the log's pruning boundary will be blob-size aligned, we cannot use it as a
         // source of truth for the min provable element.
         self.log.prune(self.inactivity_floor_loc).await?;
+
+        Ok(())
+    }
+
+    /// Close the db. Operations that have not been committed will be lost.
+    pub async fn close(mut self) -> Result<(), Error> {
+        if self.uncommitted_ops > 0 {
+            warn!(
+                op_count = self.uncommitted_ops,
+                "closing db with uncommitted operations"
+            );
+        }
+
+        try_join!(
+            self.log.close().map_err(Error::JournalError),
+            self.ops.close(&mut self.hasher).map_err(Error::MmrError),
+        )?;
+
+        Ok(())
+    }
+
+    /// Destroy the db, removing all data from disk.
+    pub async fn destroy(self) -> Result<(), Error> {
+        self.log.destroy().await?;
+        self.ops.destroy().await?;
 
         Ok(())
     }
@@ -790,6 +798,8 @@ mod test {
                 db.commit().await.unwrap();
                 assert_eq!(db.op_count() - 1, db.inactivity_floor_loc);
             }
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -928,6 +938,8 @@ mod test {
             assert_eq!(db.snapshot.keys(), 2);
             assert_eq!(db.root(&mut hasher), root);
             assert_eq!(db.inactivity_floor_loc, db.oldest_retained_loc().unwrap());
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1039,6 +1051,8 @@ mod test {
                     .unwrap()
                 );
             }
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1087,7 +1101,8 @@ mod test {
             let db = open_db(context.clone()).await;
             assert_eq!(db.op_count(), 2001);
             assert_eq!(db.root(&mut hasher), root);
-            db.close().await.unwrap();
+
+            db.destroy().await.unwrap();
 
             // Recreate the database without any failures and make sure the roots match.
             let mut new_db = Any::<_, Digest, Digest, Sha256, EightCap>::init(
@@ -1116,6 +1131,8 @@ mod test {
             new_db.sync().await.unwrap();
             assert_eq!(new_db.op_count(), 2001);
             assert_eq!(new_db.root(&mut hasher), root);
+
+            new_db.destroy().await.unwrap();
         });
     }
 
@@ -1144,6 +1161,8 @@ mod test {
             let iter = db.snapshot.get(&k);
             assert_eq!(iter.cloned().collect::<Vec<_>>().len(), 1);
             assert_eq!(db.root(&mut hasher), root);
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1180,6 +1199,8 @@ mod test {
             let db = open_db(context.clone()).await;
             assert_eq!(root_digest, db.root(&mut hasher));
             assert!(db.get(&k).await.unwrap().is_none());
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1295,6 +1316,8 @@ mod test {
                     assert!(!bitmap.get_bit(pos));
                 }
             }
+
+            db.destroy().await.unwrap();
         });
     }
 }

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -680,6 +680,11 @@ impl<
         self.any.close().await
     }
 
+    /// Destroy the db, removing all data from disk.
+    pub async fn destroy(self) -> Result<(), Error> {
+        self.any.destroy().await
+    }
+
     #[cfg(test)]
     /// Generate an inclusion proof for any operation regardless of its activity state.
     async fn operation_inclusion_proof(
@@ -833,6 +838,8 @@ pub mod test {
             for i in 0..db.op_count() {
                 assert!(!db.status.get_bit(i));
             }
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -978,6 +985,8 @@ pub mod test {
                 .await
                 .unwrap()
             );
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1057,6 +1066,8 @@ pub mod test {
                     "failed to verify range at start_loc {start_loc}",
                 );
             }
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1139,6 +1150,8 @@ pub mod test {
                     .unwrap()
                 )
             }
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1166,6 +1179,8 @@ pub mod test {
 
             let db = open_db(context, partition).await;
             assert_eq!(db.root(&mut hasher).await.unwrap(), root);
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1222,6 +1237,8 @@ pub mod test {
                 );
                 old_info = info.clone();
             }
+
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1311,6 +1328,8 @@ pub mod test {
                 db.any.oldest_retained_loc().unwrap(),
                 successful_pruning_loc
             );
+
+            db.destroy().await.unwrap();
         });
     }
 }

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -174,6 +174,8 @@ mod tests {
             let buffer = context.encode();
             assert!(buffer.contains("syncs_total 0"));
             assert!(buffer.contains("keys 0"));
+
+            metadata.destroy().await.unwrap();
         });
     }
 
@@ -273,6 +275,8 @@ mod tests {
             assert!(value.is_none());
             let value = metadata.get(&key2).unwrap();
             assert_eq!(value, &foo);
+
+            metadata.destroy().await.unwrap();
         });
     }
 
@@ -319,6 +323,8 @@ mod tests {
             // Get the key (falls back to non-corrupt)
             let value = metadata.get(&key).unwrap();
             assert_eq!(value, &hello);
+
+            metadata.destroy().await.unwrap();
         });
     }
 
@@ -373,6 +379,8 @@ mod tests {
             let buffer = context.encode();
             assert!(buffer.contains("syncs_total 0"));
             assert!(buffer.contains("keys 0"));
+
+            metadata.destroy().await.unwrap();
         });
     }
 
@@ -419,6 +427,8 @@ mod tests {
             // Get the key (falls back to non-corrupt)
             let value = metadata.get(&key).unwrap();
             assert_eq!(value, &hello);
+
+            metadata.destroy().await.unwrap();
         });
     }
 
@@ -465,6 +475,8 @@ mod tests {
             // Get the key (falls back to non-corrupt)
             let value = metadata.get(&key).unwrap();
             assert_eq!(value, &hello);
+
+            metadata.destroy().await.unwrap();
         });
     }
 
@@ -502,6 +514,8 @@ mod tests {
             let buffer = context.encode();
             assert!(buffer.contains("syncs_total 0"));
             assert!(buffer.contains("keys 0"));
+
+            metadata.destroy().await.unwrap();
         });
     }
 
@@ -523,6 +537,8 @@ mod tests {
             // Assert
             let result = metadata.sync().await;
             assert!(matches!(result, Err(Error::ValueTooBig(_))));
+
+            metadata.destroy().await.unwrap();
         });
     }
 }


### PR DESCRIPTION
Adds destroy() capability to Metadata, mmr::Journaled, adb::Any, and adb::Current, and adds them to test cases creating each.
