### PR TITLE
[storage/journal + storage/adb/any] Make replay ordered

### DIFF
--- a/consensus/src/ordered_broadcast/config.rs
+++ b/consensus/src/ordered_broadcast/config.rs
@@ -74,9 +74,6 @@ pub struct Config<
     /// The number of entries to keep per journal section.
     pub journal_heights_per_section: u64,
 
-    /// Upon replaying a journal, the number of entries to replay concurrently.
-    pub journal_replay_concurrency: usize,
-
     /// The number of bytes to buffer when replaying a journal.
     pub journal_replay_buffer: usize,
 

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -139,9 +139,6 @@ pub struct Engine<
     // The number of heights per each journal section.
     journal_heights_per_section: u64,
 
-    // The number of concurrent operations when replaying journals.
-    journal_replay_concurrency: usize,
-
     // The number of bytes to buffer when replaying a journal.
     journal_replay_buffer: usize,
 
@@ -241,7 +238,6 @@ impl<
             height_bound: cfg.height_bound,
             pending_verifies: FuturesPool::default(),
             journal_heights_per_section: cfg.journal_heights_per_section,
-            journal_replay_concurrency: cfg.journal_replay_concurrency,
             journal_replay_buffer: cfg.journal_replay_buffer,
             journal_write_buffer: cfg.journal_write_buffer,
             journal_name_prefix: cfg.journal_name_prefix,
@@ -979,7 +975,7 @@ impl<
 
             // Prepare the stream
             let stream = journal
-                .replay(self.journal_replay_concurrency, self.journal_replay_buffer)
+                .replay(self.journal_replay_buffer)
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -232,7 +232,6 @@ mod tests {
                     priority_acks: false,
                     priority_proposals: false,
                     journal_heights_per_section: 10,
-                    journal_replay_concurrency: 1,
                     journal_replay_buffer: 4096,
                     journal_write_buffer: 4096,
                     journal_name_prefix: format!("ordered-broadcast-seq/{}/", validator),
@@ -863,7 +862,6 @@ mod tests {
                         priority_acks: false,
                         priority_proposals: false,
                         journal_heights_per_section: 10,
-                        journal_replay_concurrency: 1,
                         journal_replay_buffer: 4096,
                         journal_write_buffer: 4096,
                         journal_name_prefix: format!("ordered-broadcast-seq/{}/", validator),
@@ -914,7 +912,6 @@ mod tests {
                         priority_acks: false,
                         priority_proposals: false,
                         journal_heights_per_section: 10,
-                        journal_replay_concurrency: 1,
                         journal_replay_buffer: 4096,
                         journal_write_buffer: 4096,
                         journal_name_prefix: format!(

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -326,7 +326,6 @@ pub struct Actor<
 
     partition: String,
     compression: Option<u8>,
-    replay_concurrency: usize,
     replay_buffer: usize,
     write_buffer: usize,
     journal: Option<Journal<E, Voter<C::Signature, D>>>,
@@ -419,7 +418,6 @@ impl<
 
                 partition: cfg.partition,
                 compression: cfg.compression,
-                replay_concurrency: cfg.replay_concurrency,
                 replay_buffer: cfg.replay_buffer,
                 write_buffer: cfg.write_buffer,
                 journal: None,
@@ -1714,7 +1712,7 @@ impl<
         let start = self.context.current();
         {
             let stream = journal
-                .replay(self.replay_concurrency, self.replay_buffer)
+                .replay(self.replay_buffer)
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -34,7 +34,6 @@ pub struct Config<
     pub max_participants: usize,
     pub activity_timeout: View,
     pub skip_timeout: View,
-    pub replay_concurrency: usize,
     pub replay_buffer: usize,
     pub write_buffer: usize,
 }
@@ -132,7 +131,6 @@ mod tests {
                 max_participants: n as usize,
                 activity_timeout: 10,
                 skip_timeout: 10,
-                replay_concurrency: 1,
                 replay_buffer: 1024 * 1024,
                 write_buffer: 1024 * 1024,
             };
@@ -329,7 +327,6 @@ mod tests {
                 max_participants: n as usize,
                 activity_timeout,
                 skip_timeout: 10,
-                replay_concurrency: 1,
                 replay_buffer: 1024 * 1024,
                 write_buffer: 1024 * 1024,
             };

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -41,9 +41,6 @@ pub struct Config<
     /// Prefix for all signed messages to prevent replay attacks.
     pub namespace: Vec<u8>,
 
-    /// Number of views to replay concurrently during startup.
-    pub replay_concurrency: usize,
-
     /// Number of bytes to buffer when replaying during startup.
     pub replay_buffer: usize,
 
@@ -145,10 +142,6 @@ impl<
         assert!(
             self.fetch_concurrent > 0,
             "it must be possible to fetch from at least one peer at a time"
-        );
-        assert!(
-            self.replay_concurrency > 0,
-            "it must be possible to replay at least one view at a time"
         );
     }
 }

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -65,7 +65,6 @@ impl<
                 nullify_retry: cfg.nullify_retry,
                 activity_timeout: cfg.activity_timeout,
                 skip_timeout: cfg.skip_timeout,
-                replay_concurrency: cfg.replay_concurrency,
                 replay_buffer: cfg.replay_buffer,
                 write_buffer: cfg.write_buffer,
             },

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -326,7 +326,6 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -571,7 +570,6 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -741,7 +739,6 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -860,7 +857,6 @@ mod tests {
                 max_participants: n as usize,
                 fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                 fetch_concurrent: 1,
-                replay_concurrency: 1,
                 replay_buffer: 1024 * 1024,
                 write_buffer: 1024 * 1024,
             };
@@ -983,7 +979,6 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -1210,7 +1205,6 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -1369,7 +1363,6 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -1553,7 +1546,6 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -1733,7 +1725,6 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -1901,7 +1892,6 @@ mod tests {
                         max_participants: n as usize,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -2070,7 +2060,6 @@ mod tests {
                         max_participants: n as usize,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -2235,7 +2224,6 @@ mod tests {
                         max_participants: n as usize,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -2372,7 +2360,6 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -449,7 +449,6 @@ pub struct Actor<
 
     partition: String,
     compression: Option<u8>,
-    replay_concurrency: usize,
     replay_buffer: usize,
     write_buffer: usize,
     journal: Option<Journal<E, Voter<V, D>>>,
@@ -557,7 +556,6 @@ impl<
 
                 partition: cfg.partition,
                 compression: cfg.compression,
-                replay_concurrency: cfg.replay_concurrency,
                 replay_buffer: cfg.replay_buffer,
                 write_buffer: cfg.write_buffer,
                 journal: None,
@@ -1684,7 +1682,7 @@ impl<
         let start = self.context.current();
         {
             let stream = journal
-                .replay(self.replay_concurrency, self.replay_buffer)
+                .replay(self.replay_buffer)
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -39,7 +39,6 @@ pub struct Config<
     pub notarization_timeout: Duration,
     pub nullify_retry: Duration,
     pub activity_timeout: View,
-    pub replay_concurrency: usize,
     pub replay_buffer: usize,
     pub write_buffer: usize,
 }
@@ -149,7 +148,6 @@ mod tests {
                 notarization_timeout: Duration::from_secs(5),
                 nullify_retry: Duration::from_secs(5),
                 activity_timeout: 10,
-                replay_concurrency: 1,
                 replay_buffer: 1024 * 1024,
                 write_buffer: 1024 * 1024,
             };
@@ -458,7 +456,6 @@ mod tests {
                 notarization_timeout: Duration::from_millis(1000),
                 nullify_retry: Duration::from_millis(1000),
                 activity_timeout,
-                replay_concurrency: 1,
                 replay_buffer: 10240,
                 write_buffer: 10240,
             };

--- a/consensus/src/threshold_simplex/config.rs
+++ b/consensus/src/threshold_simplex/config.rs
@@ -58,9 +58,6 @@ pub struct Config<
     /// Prefix for all signed messages to prevent replay attacks.
     pub namespace: Vec<u8>,
 
-    /// Number of views to replay concurrently during startup.
-    pub replay_concurrency: usize,
-
     /// Number of bytes to buffer when replaying during startup.
     pub replay_buffer: usize,
 
@@ -163,10 +160,6 @@ impl<
         assert!(
             self.fetch_concurrent > 0,
             "it must be possible to fetch from at least one peer at a time"
-        );
-        assert!(
-            self.replay_concurrency > 0,
-            "it must be possible to replay at least one view at a time"
         );
     }
 }

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -102,7 +102,6 @@ impl<
                 notarization_timeout: cfg.notarization_timeout,
                 nullify_retry: cfg.nullify_retry,
                 activity_timeout: cfg.activity_timeout,
-                replay_concurrency: cfg.replay_concurrency,
                 replay_buffer: cfg.replay_buffer,
                 write_buffer: cfg.write_buffer,
             },

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -420,7 +420,6 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -687,7 +686,6 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -882,7 +880,6 @@ mod tests {
                     max_fetch_count: 1, // force many fetches
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -1006,7 +1003,6 @@ mod tests {
                 max_fetch_count: 1,
                 fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                 fetch_concurrent: 1,
-                replay_concurrency: 1,
                 replay_buffer: 1024 * 1024,
                 write_buffer: 1024 * 1024,
             };
@@ -1152,7 +1148,6 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -1418,7 +1413,6 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -1593,7 +1587,6 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -1804,7 +1797,6 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -2011,7 +2003,6 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };
@@ -2206,7 +2197,6 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -2397,7 +2387,6 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -2579,7 +2568,6 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -2753,7 +2741,6 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -2941,7 +2928,6 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_concurrency: 1,
                         replay_buffer: 1024 * 1024,
                         write_buffer: 1024 * 1024,
                     };
@@ -3093,7 +3079,6 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_concurrency: 1,
                     replay_buffer: 1024 * 1024,
                     write_buffer: 1024 * 1024,
                 };

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -239,7 +239,6 @@ fn main() {
                 compression: Some(3),
                 namespace: consensus_namespace,
                 mailbox_size: 1024,
-                replay_concurrency: 1,
                 replay_buffer: 1024 * 1024,
                 write_buffer: 1024 * 1024,
                 leader_timeout: Duration::from_secs(1),

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -203,7 +203,6 @@ fn main() {
             partition: String::from("log"),
             compression: Some(3),
             mailbox_size: 1024,
-            replay_concurrency: 1,
             replay_buffer: 1024 * 1024,
             write_buffer: 1024 * 1024,
             leader_timeout: Duration::from_secs(1),

--- a/runtime/src/utils/buffer/read.rs
+++ b/runtime/src/utils/buffer/read.rs
@@ -77,6 +77,11 @@ impl<B: Blob> Read<B> {
             .saturating_sub(self.blob_position + self.buffer_position as u64)
     }
 
+    /// Returns the number of bytes in the blob, as provided at construction.
+    pub fn blob_size(&self) -> u64 {
+        self.blob_size
+    }
+
     /// Refills the buffer from the blob starting at the current blob position.
     /// Returns the number of bytes read or an error if the read failed.
     async fn refill(&mut self) -> Result<usize, Error> {

--- a/storage/src/archive/benches/restart.rs
+++ b/storage/src/archive/benches/restart.rs
@@ -11,7 +11,7 @@ fn bench_restart(c: &mut Criterion) {
     // Create a config we can use across all benchmarks (with a fixed `storage_directory`).
     let cfg = Config::default();
     for compression in [None, Some(3)] {
-        for items in [10_000, 50_000, 100_000] {
+        for items in [10_000, 50_000, 100_000, 500_000] {
             let builder = commonware_runtime::tokio::Runner::new(cfg.clone());
             builder.start(|ctx| async move {
                 let mut a = get_archive(ctx, compression).await;

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -20,9 +20,6 @@ const WRITE_BUFFER: usize = 1024;
 /// Section-mask that yields reasonably small blobs for local testing.
 const SECTION_MASK: u64 = 0xffff_ffff_ffff_ff00u64;
 
-/// Number of blobs to read concurrently during replay.
-const REPLAY_CONCURRENCY: usize = 1;
-
 /// Number of bytes to buffer when replaying.
 const REPLAY_BUFFER: usize = 1024 * 1024; // 1MB
 
@@ -45,7 +42,6 @@ pub async fn get_archive(ctx: Context, compression: Option<u8>) -> ArchiveType {
         section_mask: SECTION_MASK,
         pending_writes: PENDING_WRITES,
         write_buffer: WRITE_BUFFER,
-        replay_concurrency: REPLAY_CONCURRENCY,
         replay_buffer: REPLAY_BUFFER,
     };
     Archive::init(ctx, cfg).await.unwrap()

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -129,7 +129,6 @@
 //!         section_mask: 0xffff_ffff_ffff_0000u64,
 //!         pending_writes: 10,
 //!         write_buffer: 1024 * 1024,
-//!         replay_concurrency: 4,
 //!         replay_buffer: 4096,
 //!     };
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
@@ -191,9 +190,6 @@ pub struct Config<T: Translator, C> {
     /// The amount of bytes that can be buffered in a section before being written to disk.
     pub write_buffer: usize,
 
-    /// The number of blobs to replay concurrently on initialization.
-    pub replay_concurrency: usize,
-
     /// The buffer size to use when replaying a blob.
     pub replay_buffer: usize,
 }
@@ -215,7 +211,6 @@ mod tests {
     const DEFAULT_SECTION_MASK: u64 = 0xffff_ffff_ffff_0000u64;
     const DEFAULT_PENDING_WRITES: usize = 10;
     const DEFAULT_WRITE_BUFFER: usize = 1024;
-    const DEFAULT_REPLAY_CONCURRENCY: usize = 4;
     const DEFAULT_REPLAY_BUFFER: usize = 4096;
 
     fn test_key(key: &str) -> FixedBytes<64> {
@@ -238,7 +233,6 @@ mod tests {
                 codec_config: (),
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask: DEFAULT_SECTION_MASK,
             };
@@ -338,7 +332,6 @@ mod tests {
                 compression: Some(3),
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask: DEFAULT_SECTION_MASK,
             };
@@ -366,7 +359,6 @@ mod tests {
                 compression: None,
                 pending_writes: 10,
                 write_buffer: 1024,
-                replay_concurrency: 4,
                 replay_buffer: 4096,
                 section_mask: DEFAULT_SECTION_MASK,
             };
@@ -391,7 +383,6 @@ mod tests {
                 compression: None,
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask: DEFAULT_SECTION_MASK,
             };
@@ -432,7 +423,6 @@ mod tests {
                     compression: None,
                     pending_writes: DEFAULT_PENDING_WRITES,
                     write_buffer: DEFAULT_WRITE_BUFFER,
-                    replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                     replay_buffer: DEFAULT_REPLAY_BUFFER,
                     section_mask: DEFAULT_SECTION_MASK,
                 },
@@ -461,7 +451,6 @@ mod tests {
                 compression: None,
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask: DEFAULT_SECTION_MASK,
             };
@@ -521,7 +510,6 @@ mod tests {
                 compression: None,
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask: DEFAULT_SECTION_MASK,
             };
@@ -566,7 +554,6 @@ mod tests {
                 compression: None,
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask: DEFAULT_SECTION_MASK,
             };
@@ -630,7 +617,6 @@ mod tests {
                 compression: None,
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask: DEFAULT_SECTION_MASK,
             };
@@ -688,7 +674,6 @@ mod tests {
                 compression: None,
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask: 0xffff_ffff_ffff_ffffu64, // no mask
             };
@@ -775,7 +760,6 @@ mod tests {
                 compression: None,
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask,
             };
@@ -834,7 +818,6 @@ mod tests {
                 compression: None,
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask,
             };
@@ -933,7 +916,6 @@ mod tests {
                 compression: None,
                 pending_writes: DEFAULT_PENDING_WRITES,
                 write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_concurrency: DEFAULT_REPLAY_CONCURRENCY,
                 replay_buffer: DEFAULT_REPLAY_BUFFER,
                 section_mask: DEFAULT_SECTION_MASK,
             };

--- a/storage/src/archive/storage.rs
+++ b/storage/src/archive/storage.rs
@@ -116,9 +116,7 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
         let mut intervals = RMap::new();
         {
             debug!("initializing archive");
-            let stream = journal
-                .replay(cfg.replay_concurrency, cfg.replay_buffer)
-                .await?;
+            let stream = journal.replay(cfg.replay_buffer).await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 // Extract key from record

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -25,9 +25,9 @@ async fn bench_run(
     buffer: usize,
     items_to_read: u64,
 ) {
-    let concurrency = std::cmp::max(1, (items_to_read / ITEMS_PER_BLOB) as usize);
+    let concurrency = 1; /*std::cmp::max(1, (items_to_read / ITEMS_PER_BLOB) as usize);*/
     let stream = journal
-        .replay(concurrency, buffer, 0)
+        .replay(/*concurrency, */ buffer, 0)
         .await
         .expect("failed to replay journal");
     pin_mut!(stream);
@@ -60,7 +60,7 @@ fn bench_fixed_replay(c: &mut Criterion) {
 
         // Run the benchmarks
         let runner = tokio::Runner::new(cfg.clone());
-        for buffer in [128, 16_384, 65_536, 1_048_576] {
+        for buffer in [/*128, 16_384, 65_536, */ 1_048_576] {
             c.bench_function(
                 &format!(
                     "{}/items={} buffer={} size={}",

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -20,14 +20,9 @@ const ITEMS_PER_BLOB: u64 = 100_000;
 const ITEM_SIZE: usize = 32;
 
 /// Replay all items in the given `journal`.
-async fn bench_run(
-    journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
-    buffer: usize,
-    items_to_read: u64,
-) {
-    let concurrency = 1; /*std::cmp::max(1, (items_to_read / ITEMS_PER_BLOB) as usize);*/
+async fn bench_run(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: usize) {
     let stream = journal
-        .replay(/*concurrency, */ buffer, 0)
+        .replay(buffer, 0)
         .await
         .expect("failed to replay journal");
     pin_mut!(stream);
@@ -60,7 +55,7 @@ fn bench_fixed_replay(c: &mut Criterion) {
 
         // Run the benchmarks
         let runner = tokio::Runner::new(cfg.clone());
-        for buffer in [/*128, 16_384, 65_536, */ 1_048_576] {
+        for buffer in [128, 16_384, 65_536, 1_048_576] {
             c.bench_function(
                 &format!(
                     "{}/items={} buffer={} size={}",
@@ -76,7 +71,7 @@ fn bench_fixed_replay(c: &mut Criterion) {
                         let mut duration = Duration::ZERO;
                         for _ in 0..iters {
                             let start = Instant::now();
-                            bench_run(&j, buffer, items).await;
+                            bench_run(&j, buffer).await;
                             duration += start.elapsed();
                         }
 

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -435,15 +435,8 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
                 match reader.read_exact(&mut buf, Self::CHUNK_SIZE).await {
                     Ok(()) => {
                         let next_offset = offset + Self::CHUNK_SIZE_U64;
-                        match Self::verify_integrity(&buf) {
-                            Ok(item) => Some((
-                                Ok((item_pos, item)),
-                                (buf, blobs, blob_num, reader, next_offset),
-                            )),
-                            Err(err) => {
-                                Some((Err(err), (buf, blobs, blob_num, reader, next_offset)))
-                            }
-                        }
+                        let result = Self::verify_integrity(&buf).map(|item| (item_pos, item));
+                        Some((result, (buf, blobs, blob_num, reader, next_offset)))
                     }
                     Err(err) => {
                         let sz = reader.blob_size();


### PR DESCRIPTION
- Changes fixed journal's replay functionality to guarantee in-order element production & optimizes it a bit.
- Changes adb::any's snapshot building to use replay now that it is ordered.
- Removes concurrency from variable journal's replay() so it produces elements in-order, though without any significant simplification or optimization.
- Removes replay_concurrency config parameters throughout.

Performance on the fixed_replay benchmark is about 25-30% faster.

Archive restart benchmark unaffected.

Addresses https://github.com/commonwarexyz/monorepo/issues/1109.
