### PR TITLE
[storage] use `commonware-codec` to serialize/deserialize proofs

### DIFF
--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -98,7 +98,7 @@ impl<H: CHasher> Read for Proof<H> {
             ));
         }
 
-        // 4) Read the digests:
+        // Read the digests
         let mut digests = Vec::with_capacity(count);
         for _ in 0..count {
             digests.push(H::Digest::read(buf)?);

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -895,7 +895,13 @@ mod tests {
                     let end_pos = element_positions[j];
                     let proof = mmr.range_proof(start_pos, end_pos).await.unwrap();
 
+                    let expected_size = proof.encode_size();
                     let serialized_proof = proof.encode().freeze();
+                    assert_eq!(
+                        serialized_proof.len(),
+                        expected_size,
+                        "serialized proof should have expected size"
+                    );
                     let deserialized_proof = Proof::decode_cfg(
                         serialized_proof,
                         &ProofReadCfg {


### PR DESCRIPTION
Replaces custom `serialize`/`deserialize` implementation.

Open questions:
1. Is it OK to assume the number of digests will always be < `u16::MAX`?
2. Do we want to have a `max_len` field in the read config? 