### PR TITLE
[codec] Add derive macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,8 +996,18 @@ name = "commonware-codec"
 version = "0.0.54"
 dependencies = [
  "bytes",
+ "commonware-codec-derive",
  "paste",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "commonware-codec-derive"
+version = "0.0.54"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,8 @@ dependencies = [
 name = "commonware-codec-derive"
 version = "0.0.54"
 dependencies = [
+ "bytes",
+ "commonware-codec",
  "proc-macro2",
  "quote",
  "syn 2.0.98",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ resolver = "2"
 [workspace.dependencies]
 commonware-broadcast = { version = "0.0.54", path = "broadcast" }
 commonware-codec = { version = "0.0.54", path = "codec" }
+commonware-codec-derive = { version = "0.0.54", path = "codec-derive" }
 commonware-consensus = { version = "0.0.54", path = "consensus" }
 commonware-cryptography = { version = "0.0.54", path = "cryptography" }
 commonware-deployer = { version = "0.0.54", path = "deployer", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "broadcast",
     "codec",
+    "codec-derive",
     "consensus",
     "cryptography",
     "deployer",

--- a/codec-derive/Cargo.toml
+++ b/codec-derive/Cargo.toml
@@ -21,3 +21,6 @@ syn = { version = "2.0", features = ["full"] }
 [dev-dependencies]
 commonware-codec = { workspace = true }
 bytes = { workspace = true }
+
+[package.metadata.cargo-udeps.ignore]
+development = ["commonware-codec", "bytes"]

--- a/codec-derive/Cargo.toml
+++ b/codec-derive/Cargo.toml
@@ -17,3 +17,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+
+[dev-dependencies]
+commonware-codec = { workspace = true }
+bytes = { workspace = true }

--- a/codec-derive/Cargo.toml
+++ b/codec-derive/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "commonware-codec-derive"
+edition = "2021"
+publish = true
+version = "0.0.54"
+license = "MIT OR Apache-2.0"
+description = "Derive macros for commonware-codec traits."
+readme = "README.md"
+homepage = "https://commonware.xyz"
+repository = "https://github.com/commonwarexyz/monorepo/tree/main/codec-derive"
+documentation = "https://docs.rs/commonware-codec-derive"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }

--- a/codec-derive/README.md
+++ b/codec-derive/README.md
@@ -1,0 +1,45 @@
+# commonware-codec-derive
+
+Derive macros for `commonware-codec` traits.
+
+This crate provides procedural derive macros for automatically implementing the `Read`, `Write`, and `EncodeSize` traits from `commonware-codec`.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+commonware-codec = "0.0.54"
+commonware-codec-derive = "0.0.54"
+```
+
+Then derive the traits on your structs:
+
+```rust
+use commonware_codec::{Read, Write, EncodeSize};
+use commonware_codec_derive::{Read, Write, EncodeSize};
+
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+// The traits are now automatically implemented!
+```
+
+## Supported Types
+
+The derive macros work with:
+- Structs with named fields
+- Tuple structs  
+- Unit structs
+
+All fields must implement the corresponding traits.
+
+## Limitations
+
+- The generated `Read` implementation uses `()` as the `Cfg` type
+- Enums are not supported
+- Unions are not supported

--- a/codec-derive/src/lib.rs
+++ b/codec-derive/src/lib.rs
@@ -1,0 +1,289 @@
+//! Derive macros for commonware-codec traits.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, Data, DeriveInput, Fields, FieldsNamed, FieldsUnnamed, Index};
+
+/// Derive macro for the `Read` trait.
+///
+/// Automatically implements `Read` for structs where all fields implement `Read`.
+/// The generated implementation will use `()` as the `Cfg` type for simplicity.
+/// If any field requires a different `Cfg`, you'll need to implement `Read` manually.
+///
+/// # Example
+///
+/// ```
+/// use commonware_codec::{Read, extensions::ReadExt};
+/// use commonware_codec_derive::Read;
+///
+/// #[derive(Read)]
+/// struct Point {
+///     x: u32,
+///     y: u32,
+/// }
+///
+/// // Read is now implemented for Point
+/// ```
+#[proc_macro_derive(Read)]
+pub fn derive_read(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_read(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// Derive macro for the `Write` trait.
+///
+/// Automatically implements `Write` for structs where all fields implement `Write`.
+///
+/// # Example
+///
+/// ```
+/// use commonware_codec::Write;
+/// use commonware_codec_derive::Write;
+///
+/// #[derive(Write)]
+/// struct Point {
+///     x: u32,
+///     y: u32,
+/// }
+///
+/// // Write is now implemented for Point
+/// ```
+#[proc_macro_derive(Write)]
+pub fn derive_write(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_write(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// Derive macro for the `EncodeSize` trait.
+///
+/// Automatically implements `EncodeSize` for structs where all fields implement `EncodeSize`.
+///
+/// # Example
+///
+/// ```
+/// use commonware_codec::EncodeSize;
+/// use commonware_codec_derive::EncodeSize;
+///
+/// #[derive(EncodeSize)]
+/// struct Point {
+///     x: u32,
+///     y: u32,
+/// }
+///
+/// // EncodeSize is now implemented for Point
+/// ```
+#[proc_macro_derive(EncodeSize)]
+pub fn derive_encode_size(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_encode_size(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+fn expand_read(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+    let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+
+    let read_fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(fields) => expand_read_named_fields(fields)?,
+            Fields::Unnamed(fields) => expand_read_unnamed_fields(fields)?,
+            Fields::Unit => quote! { Ok(#name) },
+        },
+        Data::Enum(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "Read derive macro does not support enums",
+            ));
+        }
+        Data::Union(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "Read derive macro does not support unions",
+            ));
+        }
+    };
+
+    Ok(quote! {
+        impl #impl_generics ::commonware_codec::Read for #name #type_generics #where_clause {
+            type Cfg = ();
+
+            fn read_cfg(buf: &mut impl ::bytes::Buf, _cfg: &Self::Cfg) -> Result<Self, ::commonware_codec::Error> {
+                #read_fields
+            }
+        }
+    })
+}
+
+fn expand_write(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+    let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+
+    let write_fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(fields) => expand_write_named_fields(fields)?,
+            Fields::Unnamed(fields) => expand_write_unnamed_fields(fields)?,
+            Fields::Unit => quote! {},
+        },
+        Data::Enum(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "Write derive macro does not support enums",
+            ));
+        }
+        Data::Union(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "Write derive macro does not support unions",
+            ));
+        }
+    };
+
+    Ok(quote! {
+        impl #impl_generics ::commonware_codec::Write for #name #type_generics #where_clause {
+            fn write(&self, buf: &mut impl ::bytes::BufMut) {
+                #write_fields
+            }
+        }
+    })
+}
+
+fn expand_encode_size(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+    let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+
+    let size_calculation = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(fields) => expand_encode_size_named_fields(fields)?,
+            Fields::Unnamed(fields) => expand_encode_size_unnamed_fields(fields)?,
+            Fields::Unit => quote! { 0 },
+        },
+        Data::Enum(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "EncodeSize derive macro does not support enums",
+            ));
+        }
+        Data::Union(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "EncodeSize derive macro does not support unions",
+            ));
+        }
+    };
+
+    Ok(quote! {
+        impl #impl_generics ::commonware_codec::EncodeSize for #name #type_generics #where_clause {
+            fn encode_size(&self) -> usize {
+                #size_calculation
+            }
+        }
+    })
+}
+
+fn expand_read_named_fields(fields: &FieldsNamed) -> syn::Result<TokenStream2> {
+    if fields.named.is_empty() {
+        return Ok(quote! { Ok(Self) });
+    }
+
+    let field_reads = fields.named.iter().map(|field| {
+        let field_name = &field.ident;
+        quote! {
+            let #field_name = ::commonware_codec::Read::read_cfg(buf, &())?;
+        }
+    });
+
+    let field_names = fields.named.iter().map(|field| &field.ident);
+
+    Ok(quote! {
+        #(#field_reads)*
+        Ok(Self {
+            #(#field_names,)*
+        })
+    })
+}
+
+fn expand_read_unnamed_fields(fields: &FieldsUnnamed) -> syn::Result<TokenStream2> {
+    if fields.unnamed.is_empty() {
+        return Ok(quote! { Ok(Self) });
+    }
+
+    let field_reads = fields.unnamed.iter().enumerate().map(|(i, _)| {
+        let field_name = format_ident!("field_{}", i);
+        quote! {
+            let #field_name = ::commonware_codec::Read::read_cfg(buf, &())?;
+        }
+    });
+
+    let field_names = (0..fields.unnamed.len()).map(|i| format_ident!("field_{}", i));
+
+    Ok(quote! {
+        #(#field_reads)*
+        Ok(Self(#(#field_names,)*))
+    })
+}
+
+fn expand_write_named_fields(fields: &FieldsNamed) -> syn::Result<TokenStream2> {
+    let field_writes = fields.named.iter().map(|field| {
+        let field_name = &field.ident;
+        quote! {
+            ::commonware_codec::Write::write(&self.#field_name, buf);
+        }
+    });
+
+    Ok(quote! {
+        #(#field_writes)*
+    })
+}
+
+fn expand_write_unnamed_fields(fields: &FieldsUnnamed) -> syn::Result<TokenStream2> {
+    let field_writes = fields.unnamed.iter().enumerate().map(|(i, _)| {
+        let index = Index::from(i);
+        quote! {
+            ::commonware_codec::Write::write(&self.#index, buf);
+        }
+    });
+
+    Ok(quote! {
+        #(#field_writes)*
+    })
+}
+
+fn expand_encode_size_named_fields(fields: &FieldsNamed) -> syn::Result<TokenStream2> {
+    if fields.named.is_empty() {
+        return Ok(quote! { 0 });
+    }
+
+    let field_sizes = fields.named.iter().map(|field| {
+        let field_name = &field.ident;
+        quote! {
+            ::commonware_codec::EncodeSize::encode_size(&self.#field_name)
+        }
+    });
+
+    Ok(quote! {
+        0 #(+ #field_sizes)*
+    })
+}
+
+fn expand_encode_size_unnamed_fields(fields: &FieldsUnnamed) -> syn::Result<TokenStream2> {
+    if fields.unnamed.is_empty() {
+        return Ok(quote! { 0 });
+    }
+
+    let field_sizes = fields.unnamed.iter().enumerate().map(|(i, _)| {
+        let index = Index::from(i);
+        quote! {
+            ::commonware_codec::EncodeSize::encode_size(&self.#index)
+        }
+    });
+
+    Ok(quote! {
+        0 #(+ #field_sizes)*
+    })
+}

--- a/codec-derive/src/lib.rs
+++ b/codec-derive/src/lib.rs
@@ -10,20 +10,27 @@ use syn::{
 /// Derive macro for the `Read` trait.
 ///
 /// Automatically implements `Read` for structs where all fields implement `Read`.
-/// The generated implementation will use `()` as the `Cfg` type for simplicity.
-/// If any field requires a different `Cfg`, you'll need to implement `Read` manually.
+/// The `Cfg` type is automatically inferred from field attributes and types.
 ///
-/// # Codec Helper Attributes
+/// # Helper Attributes
 ///
+/// ## Codec Attributes
 /// You can use the `#[codec(varint)]` helper attribute to enable variable-length encoding for integer fields.
 /// The wrapper type (UInt for unsigned, SInt for signed) is automatically inferred from the field type.
 ///
 /// Supported types: u16, u32, u64, u128, i16, i32, i64, i128
 ///
+/// ## Config Attributes  
+/// You can use the `#[config(ConfigType)]` helper attribute to specify custom configuration types for fields.
+/// The overall `Cfg` type is built as an ordered tuple of field configs, with optimizations:
+/// - Unit type `()` fields are ignored
+/// - Single config field uses the type directly (not wrapped in tuple)
+/// - Fields without explicit `#[config]` use inferred defaults (e.g., `RangeCfg` for `Vec`, `String`)
+///
 /// # Example
 ///
 /// ```
-/// use commonware_codec::{Read, extensions::ReadExt};
+/// use commonware_codec::{Read, extensions::ReadExt, RangeCfg};
 /// use commonware_codec_derive::Read;
 ///
 /// #[derive(Read)]
@@ -40,9 +47,17 @@ use syn::{
 ///     y: i32,  // Encoded as SInt (signed varint)
 /// }
 ///
-/// // Read is now implemented for both structs
+/// #[derive(Read)]
+/// struct ConfigurableStruct {
+///     #[config(RangeCfg)]
+///     data: Vec<u8>,  // Uses RangeCfg for length limits
+///     count: u32,     // Uses () (no config needed)
+/// }
+/// // Cfg type is RangeCfg - single config type, not wrapped in tuple
+///
+/// // Read is now implemented for all structs
 /// ```
-#[proc_macro_derive(Read, attributes(codec))]
+#[proc_macro_derive(Read, attributes(codec, config))]
 pub fn derive_read(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand_read(&input)
@@ -83,7 +98,7 @@ pub fn derive_read(input: TokenStream) -> TokenStream {
 ///
 /// // Write is now implemented for both structs
 /// ```
-#[proc_macro_derive(Write, attributes(codec))]
+#[proc_macro_derive(Write, attributes(codec, config))]
 pub fn derive_write(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand_write(&input)
@@ -124,7 +139,7 @@ pub fn derive_write(input: TokenStream) -> TokenStream {
 ///
 /// // EncodeSize is now implemented for both structs
 /// ```
-#[proc_macro_derive(EncodeSize, attributes(codec))]
+#[proc_macro_derive(EncodeSize, attributes(codec, config))]
 pub fn derive_encode_size(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand_encode_size(&input)
@@ -136,11 +151,11 @@ fn expand_read(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 
-    let read_fields = match &input.data {
+    let (read_fields, cfg_type) = match &input.data {
         Data::Struct(data) => match &data.fields {
-            Fields::Named(fields) => expand_read_named_fields(fields)?,
-            Fields::Unnamed(fields) => expand_read_unnamed_fields(fields)?,
-            Fields::Unit => quote! { Ok(#name) },
+            Fields::Named(fields) => expand_read_named_fields_with_cfg(fields)?,
+            Fields::Unnamed(fields) => expand_read_unnamed_fields_with_cfg(fields)?,
+            Fields::Unit => (quote! { Ok(#name) }, syn::parse_quote!(())),
         },
         Data::Enum(_) => {
             return Err(syn::Error::new_spanned(
@@ -158,9 +173,9 @@ fn expand_read(input: &DeriveInput) -> syn::Result<TokenStream2> {
 
     Ok(quote! {
         impl #impl_generics ::commonware_codec::Read for #name #type_generics #where_clause {
-            type Cfg = ();
+            type Cfg = #cfg_type;
 
-            fn read_cfg(buf: &mut impl ::bytes::Buf, _cfg: &Self::Cfg) -> Result<Self, ::commonware_codec::Error> {
+            fn read_cfg(buf: &mut impl ::bytes::Buf, cfg: &Self::Cfg) -> Result<Self, ::commonware_codec::Error> {
                 #read_fields
             }
         }
@@ -233,53 +248,149 @@ fn expand_encode_size(input: &DeriveInput) -> syn::Result<TokenStream2> {
     })
 }
 
-fn expand_read_named_fields(fields: &FieldsNamed) -> syn::Result<TokenStream2> {
+fn expand_read_named_fields_with_cfg(
+    fields: &FieldsNamed,
+) -> syn::Result<(TokenStream2, syn::Type)> {
     if fields.named.is_empty() {
-        return Ok(quote! { Ok(Self) });
+        return Ok((quote! { Ok(Self) }, syn::parse_quote!(())));
     }
 
+    // Parse field configurations
+    let field_configs = fields
+        .named
+        .iter()
+        .map(parse_field_attributes)
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    let field_types: Vec<_> = fields.named.iter().map(|f| &f.ty).collect();
+    let cfg_type = build_cfg_type(&field_configs, &field_types);
+
+    // Generate field reads with cfg handling
+    let mut cfg_index = 0;
     let field_reads = fields
         .named
         .iter()
-        .map(|field| {
-            let field_name = &field.ident;
-            let wrapper = parse_codec_attributes(field)?;
-            Ok(generate_field_read(field_name.as_ref().unwrap(), &wrapper))
+        .zip(&field_configs)
+        .map(|(field, config)| {
+            let field_name = field.ident.as_ref().unwrap();
+
+            if is_unit_type(&field.ty) {
+                // Unit types don't need config and are constructed directly
+                return Ok(quote! {
+                    let #field_name = ();
+                });
+            }
+
+            let read_code = match &cfg_type {
+                syn::Type::Tuple(_) => {
+                    let index = syn::Index::from(cfg_index);
+                    cfg_index += 1;
+                    generate_field_read_with_cfg(
+                        field_name,
+                        &config.wrapper,
+                        quote! { &cfg.#index },
+                    )
+                }
+                _ if cfg_index == 0 => {
+                    cfg_index += 1;
+                    generate_field_read_with_cfg(field_name, &config.wrapper, quote! { cfg })
+                }
+                _ => {
+                    cfg_index += 1;
+                    generate_field_read_with_cfg(field_name, &config.wrapper, quote! { &() })
+                }
+            };
+            Ok(read_code)
         })
         .collect::<syn::Result<Vec<_>>>()?;
 
     let field_names = fields.named.iter().map(|field| &field.ident);
 
-    Ok(quote! {
+    let read_impl = quote! {
         #(#field_reads)*
         Ok(Self {
             #(#field_names,)*
         })
-    })
+    };
+
+    Ok((read_impl, cfg_type))
 }
 
-fn expand_read_unnamed_fields(fields: &FieldsUnnamed) -> syn::Result<TokenStream2> {
+fn expand_read_named_fields(fields: &FieldsNamed) -> syn::Result<TokenStream2> {
+    let (read_impl, _) = expand_read_named_fields_with_cfg(fields)?;
+    Ok(read_impl)
+}
+
+fn expand_read_unnamed_fields_with_cfg(
+    fields: &FieldsUnnamed,
+) -> syn::Result<(TokenStream2, syn::Type)> {
     if fields.unnamed.is_empty() {
-        return Ok(quote! { Ok(Self) });
+        return Ok((quote! { Ok(Self) }, syn::parse_quote!(())));
     }
 
+    // Parse field configurations
+    let field_configs = fields
+        .unnamed
+        .iter()
+        .map(parse_field_attributes)
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    let field_types: Vec<_> = fields.unnamed.iter().map(|f| &f.ty).collect();
+    let cfg_type = build_cfg_type(&field_configs, &field_types);
+
+    // Generate field reads with cfg handling
+    let mut cfg_index = 0;
     let field_reads = fields
         .unnamed
         .iter()
         .enumerate()
-        .map(|(i, field)| {
+        .zip(&field_configs)
+        .map(|((i, field), config)| {
             let field_name = format_ident!("field_{}", i);
-            let wrapper = parse_codec_attributes(field)?;
-            Ok(generate_field_read(&field_name, &wrapper))
+
+            if is_unit_type(&field.ty) {
+                // Unit types don't need config and are constructed directly
+                return Ok(quote! {
+                    let #field_name = ();
+                });
+            }
+
+            let read_code = match &cfg_type {
+                syn::Type::Tuple(_) => {
+                    let index = syn::Index::from(cfg_index);
+                    cfg_index += 1;
+                    generate_field_read_with_cfg(
+                        &field_name,
+                        &config.wrapper,
+                        quote! { &cfg.#index },
+                    )
+                }
+                _ if cfg_index == 0 => {
+                    cfg_index += 1;
+                    generate_field_read_with_cfg(&field_name, &config.wrapper, quote! { cfg })
+                }
+                _ => {
+                    cfg_index += 1;
+                    generate_field_read_with_cfg(&field_name, &config.wrapper, quote! { &() })
+                }
+            };
+            Ok(read_code)
         })
         .collect::<syn::Result<Vec<_>>>()?;
 
     let field_names = (0..fields.unnamed.len()).map(|i| format_ident!("field_{}", i));
 
-    Ok(quote! {
+    let read_impl = quote! {
         #(#field_reads)*
         Ok(Self(#(#field_names,)*))
-    })
+    };
+
+    Ok((read_impl, cfg_type))
+}
+
+fn expand_read_unnamed_fields(fields: &FieldsUnnamed) -> syn::Result<TokenStream2> {
+    let (read_impl, _) = expand_read_unnamed_fields_with_cfg(fields)?;
+    Ok(read_impl)
 }
 
 fn expand_write_named_fields(fields: &FieldsNamed) -> syn::Result<TokenStream2> {
@@ -369,8 +480,18 @@ enum CodecWrapper {
     SInt,
 }
 
-/// Parse codec attributes on a field to determine if it should be wrapped.
-fn parse_codec_attributes(field: &Field) -> syn::Result<CodecWrapper> {
+/// Configuration for a field - specifies both codec wrapper and config type.
+#[derive(Clone)]
+struct FieldConfig {
+    wrapper: CodecWrapper,
+    cfg_type: Option<syn::Type>,
+}
+
+/// Parse all relevant attributes on a field to determine configuration.
+fn parse_field_attributes(field: &Field) -> syn::Result<FieldConfig> {
+    let mut wrapper = CodecWrapper::None;
+    let mut cfg_type = None;
+
     for attr in &field.attrs {
         if attr.path().is_ident("codec") {
             match &attr.meta {
@@ -378,7 +499,7 @@ fn parse_codec_attributes(field: &Field) -> syn::Result<CodecWrapper> {
                     // Parse #[codec(varint)]
                     let nested = meta_list.parse_args::<syn::Ident>()?;
                     match nested.to_string().as_str() {
-                        "varint" => return infer_wrapper_from_type(&field.ty),
+                        "varint" => wrapper = infer_wrapper_from_type(&field.ty)?,
                         other => {
                             return Err(syn::Error::new_spanned(
                                 nested,
@@ -394,9 +515,29 @@ fn parse_codec_attributes(field: &Field) -> syn::Result<CodecWrapper> {
                     ));
                 }
             }
+        } else if attr.path().is_ident("config") {
+            match &attr.meta {
+                Meta::List(meta_list) => {
+                    // Parse #[config(RangeCfg)] or #[config(CustomType)]
+                    cfg_type = Some(meta_list.parse_args::<syn::Type>()?);
+                }
+                Meta::Path(_) | Meta::NameValue(_) => {
+                    return Err(syn::Error::new_spanned(
+                        attr,
+                        "Use #[config(ConfigType)] to specify the config type for this field",
+                    ));
+                }
+            }
         }
     }
-    Ok(CodecWrapper::None)
+
+    Ok(FieldConfig { wrapper, cfg_type })
+}
+
+/// Parse codec attributes on a field to determine if it should be wrapped.
+/// This is kept for backward compatibility but delegates to parse_field_attributes.
+fn parse_codec_attributes(field: &Field) -> syn::Result<CodecWrapper> {
+    Ok(parse_field_attributes(field)?.wrapper)
 }
 
 /// Infer the appropriate wrapper type based on the field's type.
@@ -421,9 +562,18 @@ fn infer_wrapper_from_type(ty: &syn::Type) -> syn::Result<CodecWrapper> {
 
 /// Generate appropriate field access for reading, based on codec wrapper.
 fn generate_field_read(field_name: &syn::Ident, wrapper: &CodecWrapper) -> TokenStream2 {
+    generate_field_read_with_cfg(field_name, wrapper, quote! { &() })
+}
+
+/// Generate appropriate field access for reading with custom cfg, based on codec wrapper.
+fn generate_field_read_with_cfg(
+    field_name: &syn::Ident,
+    wrapper: &CodecWrapper,
+    cfg_expr: TokenStream2,
+) -> TokenStream2 {
     match wrapper {
         CodecWrapper::None => quote! {
-            let #field_name = ::commonware_codec::Read::read_cfg(buf, &())?;
+            let #field_name = ::commonware_codec::Read::read_cfg(buf, #cfg_expr)?;
         },
         CodecWrapper::UInt => quote! {
             let #field_name = ::commonware_codec::varint::UInt::read_cfg(buf, &())?.into();
@@ -461,5 +611,86 @@ fn generate_field_encode_size(field_access: TokenStream2, wrapper: &CodecWrapper
         CodecWrapper::SInt => quote! {
             ::commonware_codec::EncodeSize::encode_size(&::commonware_codec::varint::SInt(#field_access))
         },
+    }
+}
+
+/// Check if a type is the unit type `()`.
+fn is_unit_type(ty: &syn::Type) -> bool {
+    matches!(ty, syn::Type::Tuple(tuple) if tuple.elems.is_empty())
+}
+
+/// Determine the default config type for a field based on its type.
+/// Returns None for types that don't need configuration.
+fn infer_default_cfg_type(ty: &syn::Type) -> Option<syn::Type> {
+    if is_unit_type(ty) {
+        return None;
+    }
+
+    if let syn::Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            match segment.ident.to_string().as_str() {
+                "Vec" | "String" | "Bytes" => {
+                    // These types typically need RangeCfg for length limits
+                    return Some(syn::parse_quote!(::commonware_codec::RangeCfg));
+                }
+                "HashMap" | "BTreeMap" | "HashSet" | "BTreeSet" => {
+                    // Maps and sets need RangeCfg for their size, plus their element configs
+                    return Some(syn::parse_quote!(::commonware_codec::RangeCfg));
+                }
+                "Option" => {
+                    // Option<T> uses T::Cfg
+                    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                        if let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first() {
+                            return infer_default_cfg_type(inner_ty);
+                        }
+                    }
+                }
+                // Primitive types don't need config
+                "u8" | "u16" | "u32" | "u64" | "u128" | "usize" |
+                "i8" | "i16" | "i32" | "i64" | "i128" | "isize" |
+                "f32" | "f64" | "bool" => {
+                    return None;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Default to None for types that don't need special config
+    None
+}
+
+/// Build the overall Cfg type from field configurations.
+fn build_cfg_type(field_configs: &[FieldConfig], field_types: &[&syn::Type]) -> syn::Type {
+    let mut cfg_types = Vec::new();
+
+    for (config, field_type) in field_configs.iter().zip(field_types.iter()) {
+        // Skip unit types
+        if is_unit_type(field_type) {
+            continue;
+        }
+
+        let cfg_type = config
+            .cfg_type
+            .clone()
+            .or_else(|| infer_default_cfg_type(field_type));
+
+        if let Some(cfg_type) = cfg_type {
+            cfg_types.push(cfg_type);
+        }
+    }
+
+    match cfg_types.len() {
+        0 => syn::parse_quote!(()),
+        1 => cfg_types.into_iter().next().unwrap(),
+        _ => {
+            let tuple_elems = cfg_types
+                .into_iter()
+                .collect::<syn::punctuated::Punctuated<_, syn::Token![,]>>();
+            syn::Type::Tuple(syn::TypeTuple {
+                paren_token: syn::token::Paren::default(),
+                elems: tuple_elems,
+            })
+        }
     }
 }

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -14,3 +14,8 @@ documentation = "https://docs.rs/commonware-codec"
 thiserror = { workspace = true }
 bytes = { workspace = true }
 paste = { workspace = true }
+commonware-codec-derive = { path = "../codec-derive", version = "0.0.54", optional = true }
+
+[features]
+default = ["derive"]
+derive = ["commonware-codec-derive"]

--- a/codec/src/config.rs
+++ b/codec/src/config.rs
@@ -52,6 +52,15 @@ impl RangeCfg {
     }
 }
 
+impl Default for RangeCfg {
+    fn default() -> Self {
+        RangeCfg {
+            start: Bound::Unbounded,
+            end: Bound::Unbounded,
+        }
+    }
+}
+
 // Allow conversion from any type that implements `RangeBounds<usize>` to `RangeCfg`.
 impl<R: RangeBounds<usize>> From<R> for RangeCfg {
     fn from(r: R) -> Self {

--- a/codec/src/debug_test.rs
+++ b/codec/src/debug_test.rs
@@ -1,0 +1,26 @@
+//! Debug test for macro issues
+
+use commonware_codec_derive::{Read, Write, EncodeSize};
+
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+enum SimpleEnum {
+    Unit,
+    Tuple(u32),
+    Struct { field: u16 },
+}
+
+// Manual implementation for comparison
+enum ManualEnum {
+    Tuple(u32),
+}
+
+impl crate::Write for ManualEnum {
+    fn write(&self, buf: &mut impl bytes::BufMut) {
+        match self {
+            Self::Tuple(field_0) => {
+                bytes::BufMut::put_u8(buf, 0);
+                crate::Write::write(&field_0, buf);
+            }
+        }
+    }
+}

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -194,6 +194,9 @@ pub mod varint;
 
 // Re-export main types and traits
 pub use codec::*;
+// Re-export derive macros
+#[cfg(feature = "derive")]
+pub use commonware_codec_derive::{EncodeSize, Read, Write};
 pub use config::RangeCfg;
 pub use error::Error;
 pub use extensions::*;

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -196,7 +196,7 @@ pub mod varint;
 pub use codec::*;
 // Re-export derive macros
 #[cfg(feature = "derive")]
-pub use commonware_codec_derive::{EncodeSize, Read, Write};
+pub use commonware_codec_derive::{EncodeSize, FixedSize, Read, Write};
 pub use config::RangeCfg;
 pub use error::Error;
 pub use extensions::*;

--- a/codec/src/manual_test.rs
+++ b/codec/src/manual_test.rs
@@ -1,0 +1,32 @@
+//! Manual implementation to understand the issue
+
+use crate::{Write, EncodeSize};
+use bytes::BufMut;
+
+enum TestEnum {
+    Tuple(u32),
+}
+
+impl Write for TestEnum {
+    fn write(&self, buf: &mut impl BufMut) {
+        match self {
+            Self::Tuple(ref field_0) => {
+                buf.put_u8(0);
+                // Try both approaches:
+                // field_0.write(buf);                // Method syntax
+                Write::write(field_0, buf);    // Static syntax with ref
+            }
+        }
+    }
+}
+
+impl EncodeSize for TestEnum {
+    fn encode_size(&self) -> usize {
+        match self {
+            Self::Tuple(field_0) => {
+                1 + field_0.encode_size()  // Method syntax
+                // 1 + EncodeSize::encode_size(&field_0)  // Static syntax
+            }
+        }
+    }
+}

--- a/codec/src/test_expand.rs
+++ b/codec/src/test_expand.rs
@@ -1,0 +1,10 @@
+//! Simple test to examine macro expansion
+
+use crate::{Write, EncodeSize};
+
+#[derive(Write, EncodeSize)]
+struct TestStruct {
+    #[codec(varint)]
+    a: u32,
+    b: bool,
+}

--- a/codec/tests/debug_derive.rs
+++ b/codec/tests/debug_derive.rs
@@ -1,0 +1,20 @@
+//! Debug test for derive macros in tests directory
+
+use commonware_codec::{EncodeSize, Read, ReadExt, Write};
+
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+enum SimpleEnum {
+    Unit,
+    Tuple(u32),
+    Struct { field: u16 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug() {
+        let _value = SimpleEnum::Unit;
+    }
+}

--- a/codec/tests/derive_test.rs
+++ b/codec/tests/derive_test.rs
@@ -7,22 +7,21 @@ use commonware_codec::{
     varint::{SInt, UInt},
     EncodeSize, Error, FixedSize, Read, Write,
 };
-use commonware_codec_derive::FixedSize;
 
-#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+#[derive(Debug, Clone, PartialEq, Read, Write, FixedSize)]
 struct SimpleStruct {
     a: u32,
     b: u64,
     c: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+#[derive(Debug, Clone, PartialEq, Read, Write, FixedSize)]
 struct TupleStruct(u32, u64, bool);
 
-#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+#[derive(Debug, Clone, PartialEq, Read, Write, FixedSize)]
 struct UnitStruct;
 
-#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+#[derive(Debug, Clone, PartialEq, Read, Write, FixedSize)]
 struct NestedStruct {
     simple: SimpleStruct,
     value: u16,
@@ -40,7 +39,7 @@ struct VarintStruct {
 #[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
 struct TupleVarintStruct(#[codec(varint)] u64, #[codec(varint)] i64, bool);
 
-#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+#[derive(Debug, Clone, PartialEq, Read, Write, FixedSize)]
 struct SimpleTest {
     count: u32,
 }
@@ -624,5 +623,35 @@ mod fixed_size_tests {
         // Arrays should have fixed size equal to their length
         assert_eq!(<[u8; 10]>::SIZE, 10);
         assert_eq!(<[u8; 256]>::SIZE, 256);
+    }
+
+    // Test generic FixedSize derives
+    #[derive(Debug, Clone, PartialEq, FixedSize)]
+    struct GenericPoint<T> {
+        x: T,
+        y: T,
+    }
+
+    #[derive(Debug, Clone, PartialEq, FixedSize)]
+    struct GenericTuple<T, U>(T, U);
+
+    #[derive(Debug, Clone, PartialEq, FixedSize)]
+    struct GenericWithBounds<T: Clone + PartialEq> {
+        value: T,
+        flag: bool,
+    }
+
+    #[test]
+    fn test_generic_fixed_size() {
+        // Test that generic FixedSize derives work correctly
+        assert_eq!(GenericPoint::<u32>::SIZE, 8); // 4 + 4
+        assert_eq!(GenericPoint::<u64>::SIZE, 16); // 8 + 8
+        assert_eq!(GenericPoint::<bool>::SIZE, 2); // 1 + 1
+
+        assert_eq!(GenericTuple::<u32, u64>::SIZE, 12); // 4 + 8
+        assert_eq!(GenericTuple::<bool, f32>::SIZE, 5); // 1 + 4
+
+        assert_eq!(GenericWithBounds::<u32>::SIZE, 5); // 4 + 1
+        assert_eq!(GenericWithBounds::<u64>::SIZE, 9); // 8 + 1
     }
 }

--- a/codec/tests/derive_test.rs
+++ b/codec/tests/derive_test.rs
@@ -1,0 +1,133 @@
+//! Integration tests for derive macros.
+
+use bytes::BytesMut;
+use commonware_codec::{codec::*, extensions::*, EncodeSize, Read, Write};
+
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct SimpleStruct {
+    a: u32,
+    b: u64,
+    c: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct TupleStruct(u32, u64, bool);
+
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct UnitStruct;
+
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct NestedStruct {
+    simple: SimpleStruct,
+    value: u16,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_struct_derive() {
+        let original = SimpleStruct {
+            a: 42,
+            b: 1337,
+            c: true,
+        };
+
+        // Test encode size
+        let expected_size = 4 + 8 + 1; // u32 + u64 + bool
+        assert_eq!(original.encode_size(), expected_size);
+
+        // Test encode/decode
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = SimpleStruct::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_tuple_struct_derive() {
+        let original = TupleStruct(42, 1337, true);
+
+        // Test encode size
+        let expected_size = 4 + 8 + 1; // u32 + u64 + bool
+        assert_eq!(original.encode_size(), expected_size);
+
+        // Test encode/decode
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = TupleStruct::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_unit_struct_derive() {
+        let original = UnitStruct;
+
+        // Test encode size
+        assert_eq!(original.encode_size(), 0);
+
+        // Test encode/decode
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), 0);
+
+        let decoded = UnitStruct::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_nested_struct_derive() {
+        let original = NestedStruct {
+            simple: SimpleStruct {
+                a: 42,
+                b: 1337,
+                c: true,
+            },
+            value: 256,
+        };
+
+        // Test encode size
+        let expected_size = (4 + 8 + 1) + 2; // SimpleStruct + u16
+        assert_eq!(original.encode_size(), expected_size);
+
+        // Test encode/decode
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = NestedStruct::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_write_implementation() {
+        let value = SimpleStruct {
+            a: 42,
+            b: 1337,
+            c: true,
+        };
+
+        let mut buf = BytesMut::with_capacity(value.encode_size());
+        value.write(&mut buf);
+
+        // Verify the buffer has the expected length
+        assert_eq!(buf.len(), value.encode_size());
+    }
+
+    #[test]
+    fn test_read_implementation() {
+        let original = SimpleStruct {
+            a: 42,
+            b: 1337,
+            c: true,
+        };
+
+        let encoded = original.encode();
+        let mut buf = &encoded[..];
+
+        let decoded = SimpleStruct::read_cfg(&mut buf, &()).unwrap();
+        assert_eq!(original, decoded);
+        assert_eq!(buf.len(), 0); // All bytes should be consumed
+    }
+}

--- a/codec/tests/fixed_size_derive_errors.rs
+++ b/codec/tests/fixed_size_derive_errors.rs
@@ -1,0 +1,89 @@
+//! Tests for FixedSize derive macro error cases.
+//!
+//! These tests verify that the FixedSize derive macro properly rejects
+//! invalid usage patterns with helpful error messages.
+
+use commonware_codec_derive::FixedSize;
+
+// These should compile successfully
+#[derive(FixedSize)]
+#[allow(dead_code)]
+struct ValidStruct {
+    a: u32,
+    b: bool,
+}
+
+#[derive(FixedSize)]
+#[allow(dead_code)]
+struct ValidTuple(u8, u16);
+
+#[derive(FixedSize)]
+struct ValidUnit;
+
+#[derive(FixedSize)]
+#[allow(dead_code)]
+struct ValidArray {
+    data: [u8; 16],
+}
+
+// Test that we can't use codec attributes with FixedSize
+// This should fail to compile with a helpful error message
+/*
+#[derive(FixedSize)]
+struct InvalidCodecAttr {
+    #[codec(varint)]
+    value: u32,  // varint encoding is variable-length!
+}
+*/
+
+// Test that we can't derive FixedSize for enums
+// This should fail to compile
+/*
+#[derive(FixedSize)]
+enum InvalidEnum {
+    A,
+    B(u32),
+}
+*/
+
+// Test that we can't derive FixedSize for unions
+// This should fail to compile
+/*
+#[derive(FixedSize)]
+union InvalidUnion {
+    a: u32,
+    b: f32,
+}
+*/
+
+// Test that we can't derive FixedSize for generic types
+// This should fail to compile
+/*
+#[derive(FixedSize)]
+struct InvalidGeneric<T> {
+    value: T,
+}
+*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_codec::{EncodeSize, FixedSize};
+
+    #[test]
+    fn test_valid_fixed_size_structs() {
+        // Test that valid structs compile and have correct sizes
+        assert_eq!(ValidStruct::SIZE, 5); // u32 (4) + bool (1) = 5
+        assert_eq!(ValidTuple::SIZE, 3); // u8 (1) + u16 (2) = 3
+        assert_eq!(ValidUnit::SIZE, 0); // no fields = 0
+        assert_eq!(ValidArray::SIZE, 16); // [u8; 16] = 16
+    }
+
+    #[test]
+    fn test_integration_with_existing_traits() {
+        // FixedSize should automatically provide EncodeSize
+        let instance = ValidStruct { a: 42, b: true };
+        assert_eq!(instance.encode_size(), ValidStruct::SIZE);
+        assert_eq!(instance.encode_size(), 5);
+    }
+}

--- a/codec/tests/generic_derive_test.rs
+++ b/codec/tests/generic_derive_test.rs
@@ -1,0 +1,454 @@
+//! Integration tests for derive macros with generic types.
+
+use bytes::BytesMut;
+use commonware_codec::{codec::*, extensions::*, varint::UInt, EncodeSize, Error, Read, Write};
+
+// Basic generic struct
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct GenericStruct<T>
+where
+    T: Read<Cfg = ()> + Write + EncodeSize,
+{
+    value: T,
+}
+
+// Generic struct with multiple fields
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct MultiFieldGeneric<T>
+where
+    T: Read<Cfg = ()> + Write + EncodeSize,
+{
+    first: T,
+    second: u32,
+    third: bool,
+}
+
+// Generic tuple struct
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct GenericTuple<T>(T, u16)
+where
+    T: Read<Cfg = ()> + Write + EncodeSize;
+
+// Generic struct with bounds
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct BoundedGeneric<T>
+where
+    T: Clone + Read<Cfg = ()> + Write + EncodeSize,
+{
+    data: T,
+}
+
+// Multiple type parameters
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct MultiGeneric<T, U>
+where
+    T: Read<Cfg = ()> + Write + EncodeSize,
+    U: Read<Cfg = ()> + Write + EncodeSize,
+{
+    first: T,
+    second: U,
+}
+
+// Generic with varint attributes
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct GenericVarint<T>
+where
+    T: Read<Cfg = ()> + Write + EncodeSize,
+{
+    #[codec(varint)]
+    count: u32,
+    value: T,
+}
+
+// Generic enum
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+enum GenericEnum<T>
+where
+    T: Read<Cfg = ()> + Write + EncodeSize,
+{
+    None,
+    Some(T),
+    Pair(T, T),
+    Named { value: T, tag: u8 },
+}
+
+// Generic enum with multiple type parameters
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+enum MultiGenericEnum<T, U>
+where
+    T: Read<Cfg = ()> + Write + EncodeSize,
+    U: Read<Cfg = ()> + Write + EncodeSize,
+{
+    First(T),
+    Second(U),
+    Both(T, U),
+}
+
+// Nested generic types
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct NestedGeneric<T>
+where
+    T: Read<Cfg = ()> + Write + EncodeSize,
+{
+    inner: GenericStruct<T>,
+    outer: u32,
+}
+
+// Generic with Option
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct GenericOption<T>
+where
+    T: Read<Cfg = ()> + Write + EncodeSize,
+{
+    maybe_value: Option<T>,
+    always_present: u64,
+}
+
+// Generic with Vec (requires config handling)
+#[derive(Debug, Clone, PartialEq, Read, Write, EncodeSize)]
+struct GenericVec<T>
+where
+    T: Read<Cfg = ()> + Write + EncodeSize,
+{
+    #[config(default)]
+    items: Vec<T>,
+    count: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generic_struct_u32() {
+        let original = GenericStruct { value: 42u32 };
+
+        let expected_size = 4; // u32
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = GenericStruct::<u32>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_struct_bool() {
+        let original = GenericStruct { value: true };
+
+        let expected_size = 1; // bool
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = GenericStruct::<bool>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_struct_nested() {
+        let original = GenericStruct {
+            value: GenericStruct { value: 123u64 },
+        };
+
+        let expected_size = 8; // u64
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = GenericStruct::<GenericStruct<u64>>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_multi_field_generic() {
+        let original = MultiFieldGeneric {
+            first: 1337u64,
+            second: 42u32,
+            third: false,
+        };
+
+        let expected_size = 8 + 4 + 1; // u64 + u32 + bool
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = MultiFieldGeneric::<u64>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_tuple() {
+        let original = GenericTuple(42u32, 1337u16);
+
+        let expected_size = 4 + 2; // u32 + u16
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = GenericTuple::<u32>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_bounded_generic() {
+        let original = BoundedGeneric { data: 999u32 };
+
+        let expected_size = 4; // u32
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = BoundedGeneric::<u32>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_multi_generic() {
+        let original = MultiGeneric {
+            first: 42u32,
+            second: true,
+        };
+
+        let expected_size = 4 + 1; // u32 + bool
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = MultiGeneric::<u32, bool>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_varint() {
+        let original = GenericVarint {
+            count: 1000,
+            value: std::f32::consts::PI,
+        };
+
+        let expected_count_size = UInt(original.count).encode_size();
+        let expected_size = expected_count_size + 4; // varint + f32
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = GenericVarint::<f32>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_enum_none() {
+        let original = GenericEnum::<u32>::None;
+
+        let expected_size = 1; // discriminant only
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+        assert_eq!(encoded[0], 0); // First variant
+
+        let decoded = GenericEnum::<u32>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_enum_some() {
+        let original = GenericEnum::Some(42u32);
+
+        let expected_size = 1 + 4; // discriminant + u32
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+        assert_eq!(encoded[0], 1); // Second variant
+
+        let decoded = GenericEnum::<u32>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_enum_pair() {
+        let original = GenericEnum::Pair(10u16, 20u16);
+
+        let expected_size = 1 + 2 + 2; // discriminant + u16 + u16
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+        assert_eq!(encoded[0], 2); // Third variant
+
+        let decoded = GenericEnum::<u16>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_enum_named() {
+        let original = GenericEnum::Named {
+            value: 123u64,
+            tag: 99u8,
+        };
+
+        let expected_size = 1 + 8 + 1; // discriminant + u64 + u8
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+        assert_eq!(encoded[0], 3); // Fourth variant
+
+        let decoded = GenericEnum::<u64>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_multi_generic_enum() {
+        let test_cases = [
+            MultiGenericEnum::First(42u32),
+            MultiGenericEnum::Second(true),
+            MultiGenericEnum::Both(100u32, false),
+        ];
+
+        for original in test_cases {
+            let encoded = original.encode();
+            let decoded = MultiGenericEnum::<u32, bool>::decode(encoded.clone()).unwrap();
+            assert_eq!(original, decoded);
+
+            // Verify that encode_size matches actual encoded length
+            assert_eq!(original.encode_size(), encoded.len());
+        }
+    }
+
+    #[test]
+    fn test_nested_generic() {
+        let original = NestedGeneric {
+            inner: GenericStruct { value: 999u32 },
+            outer: 777u32,
+        };
+
+        let expected_size = 4 + 4; // inner u32 + outer u32
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = NestedGeneric::<u32>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_option_some() {
+        let original = GenericOption {
+            maybe_value: Some(42u32),
+            always_present: 1337u64,
+        };
+
+        let expected_size = 1 + 4 + 8; // Option discriminant + u32 + u64
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = GenericOption::<u32>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_option_none() {
+        let original = GenericOption::<u32> {
+            maybe_value: None,
+            always_present: 1337u64,
+        };
+
+        let expected_size = 1 + 8; // Option discriminant + u64 (no u32 for None)
+        assert_eq!(original.encode_size(), expected_size);
+
+        let encoded = original.encode();
+        assert_eq!(encoded.len(), expected_size);
+
+        let decoded = GenericOption::<u32>::decode(encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_generic_vec() {
+        let original = GenericVec {
+            items: vec![1u32, 2u32, 3u32],
+            count: 42u32,
+        };
+
+        // Vec uses default config, so Cfg should be ()
+        let cfg = ();
+
+        let encoded = original.encode();
+        let decoded = GenericVec::<u32>::read_cfg(&mut encoded.as_ref(), &cfg).unwrap();
+        assert_eq!(original, decoded);
+
+        // Verify encode_size matches
+        assert_eq!(original.encode_size(), encoded.len());
+    }
+
+    #[test]
+    fn test_generic_write_implementation() {
+        let value = MultiGeneric {
+            first: 42u32,
+            second: true,
+        };
+
+        let mut buf = BytesMut::with_capacity(value.encode_size());
+        value.write(&mut buf);
+
+        // Verify the buffer has the expected length
+        assert_eq!(buf.len(), value.encode_size());
+    }
+
+    #[test]
+    fn test_generic_read_implementation() {
+        let original = GenericStruct { value: 1337u64 };
+
+        let encoded = original.encode();
+        let mut buf = &encoded[..];
+
+        let decoded = GenericStruct::<u64>::read_cfg(&mut buf, &()).unwrap();
+        assert_eq!(original, decoded);
+        assert_eq!(buf.len(), 0); // All bytes should be consumed
+    }
+
+    #[test]
+    fn test_complex_generic_combination() {
+        // Test a complex combination of nested generics
+        type ComplexType = GenericStruct<MultiGeneric<GenericEnum<u32>, GenericOption<bool>>>;
+
+        let original = GenericStruct {
+            value: MultiGeneric {
+                first: GenericEnum::Some(999u32),
+                second: GenericOption {
+                    maybe_value: Some(true),
+                    always_present: 12345u64,
+                },
+            },
+        };
+
+        let encoded = original.encode();
+        let decoded = ComplexType::decode(encoded.clone()).unwrap();
+        assert_eq!(original, decoded);
+
+        // Verify that encode_size matches actual encoded length
+        assert_eq!(original.encode_size(), encoded.len());
+    }
+
+    #[test]
+    fn test_generic_enum_invalid_discriminant() {
+        // Test that invalid discriminants return InvalidEnum error for generic enums
+        let invalid_data = vec![255u8]; // Invalid discriminant for GenericEnum<u32>
+        let result = GenericEnum::<u32>::decode(&mut invalid_data.as_slice());
+
+        assert!(matches!(result, Err(Error::InvalidEnum(255))));
+    }
+}

--- a/examples/bridge/src/types/inbound.rs
+++ b/examples/bridge/src/types/inbound.rs
@@ -85,7 +85,7 @@ impl<D: Digest> EncodeSize for Inbound<D> {
 }
 
 /// Message to store a new block in the indexer's storage.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Read, Write, EncodeSize)]
 pub struct PutBlock<D: Digest> {
     /// The network identifier for which the block belongs.
     pub network: <MinSig as Variant>::Public,
@@ -93,53 +93,13 @@ pub struct PutBlock<D: Digest> {
     pub block: BlockFormat<D>,
 }
 
-impl<D: Digest> Write for PutBlock<D> {
-    fn write(&self, buf: &mut impl BufMut) {
-        self.network.write(buf);
-        self.block.write(buf);
-    }
-}
-
-impl<D: Digest> Read for PutBlock<D> {
-    type Cfg = ();
-
-    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
-        let network = <MinSig as Variant>::Public::read(buf)?;
-        let block = BlockFormat::<D>::read(buf)?;
-        Ok(PutBlock { network, block })
-    }
-}
-
-impl<D: Digest> EncodeSize for PutBlock<D> {
-    fn encode_size(&self) -> usize {
-        <MinSig as Variant>::Public::SIZE + self.block.encode_size()
-    }
-}
-
 /// Message to retrieve a block from the indexer's storage.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Read, Write)]
 pub struct GetBlock<D: Digest> {
     /// The network identifier for which the block belongs.
     pub network: <MinSig as Variant>::Public,
     /// The digest of the block to retrieve.
     pub digest: D,
-}
-
-impl<D: Digest> Write for GetBlock<D> {
-    fn write(&self, buf: &mut impl BufMut) {
-        self.network.write(buf);
-        self.digest.write(buf);
-    }
-}
-
-impl<D: Digest> Read for GetBlock<D> {
-    type Cfg = ();
-
-    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
-        let network = <MinSig as Variant>::Public::read(buf)?;
-        let digest = D::read(buf)?;
-        Ok(GetBlock { network, digest })
-    }
 }
 
 impl<D: Digest> FixedSize for GetBlock<D> {

--- a/examples/bridge/src/types/inbound.rs
+++ b/examples/bridge/src/types/inbound.rs
@@ -94,16 +94,12 @@ pub struct PutBlock<D: Digest> {
 }
 
 /// Message to retrieve a block from the indexer's storage.
-#[derive(Debug, Clone, PartialEq, Eq, Read, Write)]
+#[derive(Debug, Clone, PartialEq, Eq, Read, Write, FixedSize)]
 pub struct GetBlock<D: Digest> {
     /// The network identifier for which the block belongs.
     pub network: <MinSig as Variant>::Public,
     /// The digest of the block to retrieve.
     pub digest: D,
-}
-
-impl<D: Digest> FixedSize for GetBlock<D> {
-    const SIZE: usize = <MinSig as Variant>::Public::SIZE + D::SIZE;
 }
 
 /// Message to store a finality certificate in the indexer's storage.

--- a/utils/src/array/fixed_bytes.rs
+++ b/utils/src/array/fixed_bytes.rs
@@ -1,6 +1,7 @@
 use crate::{hex, Array};
-use bytes::{Buf, BufMut};
-use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
+#[cfg(test)]
+use commonware_codec::{Error as CodecError, ReadExt};
+use commonware_codec::{FixedSize, Read, Write};
 use std::{
     cmp::{Ord, PartialOrd},
     fmt::{Debug, Display},
@@ -17,7 +18,7 @@ pub enum Error {
 }
 
 /// An `Array` implementation for fixed-length byte arrays.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Read, Write)]
 #[repr(transparent)]
 pub struct FixedBytes<const N: usize>([u8; N]);
 
@@ -25,20 +26,6 @@ impl<const N: usize> FixedBytes<N> {
     /// Creates a new `FixedBytes` instance from an array of length `N`.
     pub fn new(value: [u8; N]) -> Self {
         Self(value)
-    }
-}
-
-impl<const N: usize> Write for FixedBytes<N> {
-    fn write(&self, buf: &mut impl BufMut) {
-        self.0.write(buf);
-    }
-}
-
-impl<const N: usize> Read for FixedBytes<N> {
-    type Cfg = ();
-
-    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
-        Ok(Self(<[u8; N]>::read(buf)?))
     }
 }
 

--- a/utils/src/array/fixed_bytes.rs
+++ b/utils/src/array/fixed_bytes.rs
@@ -18,7 +18,7 @@ pub enum Error {
 }
 
 /// An `Array` implementation for fixed-length byte arrays.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Read, Write)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Read, Write, FixedSize)]
 #[repr(transparent)]
 pub struct FixedBytes<const N: usize>([u8; N]);
 
@@ -27,10 +27,6 @@ impl<const N: usize> FixedBytes<N> {
     pub fn new(value: [u8; N]) -> Self {
         Self(value)
     }
-}
-
-impl<const N: usize> FixedSize for FixedBytes<N> {
-    const SIZE: usize = N;
 }
 
 impl<const N: usize> Array for FixedBytes<N> {}


### PR DESCRIPTION
Adds procedural derive macros for `Read`, `Write`, `EncodeSize`, and `FixedSize` traits.
Fixes #623 

  - **New crate**: `commonware-codec-derive` with derive macro implementations
    - `#[derive(Read, Write, EncodeSize, FixedSize)]` support for structs
    - Support for named fields, tuple structs, and unit structs
    - `FixedSize` helper attribute for fixed-size types
    - Configuration via helper attributes
    - Enum support with discriminant encoding