### PR TITLE
[stream] Add fuzz tests for handshake

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -107,6 +107,8 @@ jobs:
       run: cargo +nightly fuzz build --fuzz-dir codec/fuzz
     - name: Build cryptography
       run: cargo +nightly fuzz build --fuzz-dir cryptography/fuzz
+    - name: Build stream
+      run: cargo +nightly fuzz build --fuzz-dir stream/fuzz
 
   WASM:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "commonware-stream-fuzz"
+version = "0.0.1"
+dependencies = [
+ "arbitrary",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-runtime",
+ "commonware-stream",
+ "futures",
+ "libfuzzer-sys",
+]
+
+[[package]]
 name = "commonware-utils"
 version = "0.0.54"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ members = [
 
     # Fuzz builds
     "codec/fuzz",
-    "cryptography/fuzz"
+    "cryptography/fuzz",
+    "stream/fuzz"
 ]
 resolver = "2"
 

--- a/stream/fuzz/Cargo.toml
+++ b/stream/fuzz/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "commonware-stream-fuzz"
+version = "0.0.1"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+commonware-codec = { workspace = true }
+commonware-cryptography = { workspace = true }
+commonware-stream = { workspace = true}
+commonware-runtime = { workspace = true }
+arbitrary = { workspace = true, features = ["derive"] }
+futures = { workspace = true }
+libfuzzer-sys = { workspace = true }
+
+[[bin]]
+name = "handshake"
+path = "fuzz_targets/handshake.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "transport"
+path = "fuzz_targets/transport.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "lazy_transport"
+path = "fuzz_targets/lazy_transport.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "connection"
+path = "fuzz_targets/connection.rs"
+test = false
+doc = false
+bench = false

--- a/stream/fuzz/fuzz_targets/connection.rs
+++ b/stream/fuzz/fuzz_targets/connection.rs
@@ -1,0 +1,165 @@
+#![no_main]
+
+use commonware_cryptography::{ed25519::PrivateKey, PrivateKeyExt as _, Signer};
+use commonware_runtime::{deterministic, mocks, Metrics, Runner, Spawner};
+use commonware_stream::{
+    public_key::{Config, Connection, IncomingConnection},
+    Receiver as _, Sender as _,
+};
+use libfuzzer_sys::fuzz_target;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub struct FuzzInput {
+    // Seeds for cryptographic identities
+    dialer_seed: u64,
+    listener_seed: u64,
+
+    // Configuration parameters
+    namespace: Vec<u8>,
+    max_message_size: usize,
+    synchrony_bound_secs: u64,
+    max_handshake_age_secs: u64,
+    handshake_timeout_secs: u64,
+
+    // Messages to exchange
+    messages_to_listener: Vec<Vec<u8>>,
+    messages_to_dialer: Vec<Vec<u8>>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Generate basic seeds
+        let dialer_seed = u64::arbitrary(u)?;
+        let listener_seed = dialer_seed.wrapping_add(1);
+
+        // Generate namespace (reasonable size)
+        let namespace_len = u.int_in_range(0..=256)?;
+        let namespace = (0..namespace_len)
+            .map(|_| u8::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Generate constrained parameters
+        let max_message_size = u.int_in_range(161..=1024 * 1023)?;
+        let synchrony_bound_secs = u.int_in_range(1..=12)?;
+        let max_handshake_age_secs = u.int_in_range(1..=12)?;
+        let handshake_timeout_secs = u.int_in_range(1..=12)?;
+
+        // Generate messages with size constraints
+        let num_messages_to_listener = u.int_in_range(0..=10)?; // Reasonable number of messages
+        let mut messages_to_listener = Vec::new();
+        for _ in 0..num_messages_to_listener {
+            let msg_len = u.int_in_range(0..=max_message_size)?;
+            let msg = (0..msg_len)
+                .map(|_| u8::arbitrary(u))
+                .collect::<Result<Vec<_>, _>>()?;
+            messages_to_listener.push(msg);
+        }
+
+        let num_messages_to_dialer = u.int_in_range(0..=10)?;
+        let mut messages_to_dialer = Vec::new();
+        for _ in 0..num_messages_to_dialer {
+            let msg_len = u.int_in_range(0..=max_message_size)?;
+            let msg = (0..msg_len)
+                .map(|_| u8::arbitrary(u))
+                .collect::<Result<Vec<_>, _>>()?;
+            messages_to_dialer.push(msg);
+        }
+
+        Ok(FuzzInput {
+            dialer_seed,
+            listener_seed,
+            namespace,
+            max_message_size,
+            synchrony_bound_secs,
+            max_handshake_age_secs,
+            handshake_timeout_secs,
+            messages_to_listener,
+            messages_to_dialer,
+        })
+    }
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let max_message_size = input.max_message_size;
+        let synchrony_bound = Duration::from_secs(input.synchrony_bound_secs);
+        let max_handshake_age = Duration::from_secs(input.max_handshake_age_secs);
+        let handshake_timeout = Duration::from_secs(input.handshake_timeout_secs);
+
+        let dialer_crypto = PrivateKey::from_seed(input.dialer_seed);
+        let listener_crypto = PrivateKey::from_seed(input.listener_seed);
+
+        let (dialer_sink, listener_stream) = mocks::Channel::init();
+        let (listener_sink, dialer_stream) = mocks::Channel::init();
+
+        let dialer_config = Config {
+            crypto: dialer_crypto.clone(),
+            namespace: input.namespace.clone(),
+            max_message_size,
+            synchrony_bound,
+            max_handshake_age,
+            handshake_timeout,
+        };
+
+        let listener_config = Config {
+            crypto: listener_crypto.clone(),
+            namespace: input.namespace.clone(),
+            max_message_size,
+            synchrony_bound,
+            max_handshake_age,
+            handshake_timeout,
+        };
+
+        let listener_handle = context.with_label("listener").spawn({
+            move |context| async move {
+                let incoming = IncomingConnection::verify(
+                    &context,
+                    listener_config,
+                    listener_sink,
+                    listener_stream,
+                )
+                .await?;
+                Connection::upgrade_listener(context, incoming).await
+            }
+        });
+
+        let dialer_result = Connection::upgrade_dialer(
+            context.clone(),
+            dialer_config,
+            dialer_sink,
+            dialer_stream,
+            listener_crypto.public_key(),
+        )
+        .await
+        .unwrap();
+
+        let dialer_connection = dialer_result;
+        let listener_connection = listener_handle.await.unwrap().unwrap();
+        let (mut dialer_sender, mut dialer_receiver) = dialer_connection.split();
+        let (mut listener_sender, mut listener_receiver) = listener_connection.split();
+
+        // Exchange messages from dialer to listener
+        for (i, msg) in input.messages_to_listener.iter().enumerate() {
+            if msg.is_empty() || msg.len() > max_message_size {
+                continue;
+            }
+
+            dialer_sender.send(msg).await.unwrap();
+            let received = listener_receiver.receive().await.unwrap();
+            assert_eq!(&received[..], &msg[..], "Message {i} mismatch");
+        }
+
+        // Exchange messages from listener to dialer
+        for (i, msg) in input.messages_to_dialer.iter().enumerate() {
+            if msg.is_empty() || msg.len() > max_message_size {
+                continue;
+            }
+
+            listener_sender.send(msg).await.unwrap();
+            let received = dialer_receiver.receive().await.unwrap();
+            assert_eq!(&received[..], &msg[..], "Message {i} mismatch");
+        }
+    });
+});

--- a/stream/fuzz/fuzz_targets/handshake.rs
+++ b/stream/fuzz/fuzz_targets/handshake.rs
@@ -83,11 +83,11 @@ fuzz_target!(|input: FuzzInput| {
         let handshake = Signed::sign(
             &mut dialer_crypto,
             input.namespace.as_slice(),
-            Info {
-                timestamp: input.timestamp,
-                recipient: input.random_peer,
-                ephemeral_public_key: input.ephemeral_public_key,
-            },
+            Info::new(
+                input.random_peer,
+                input.ephemeral_public_key,
+                input.timestamp,
+            ),
         );
 
         let (sink, _) = mocks::Channel::init();

--- a/stream/fuzz/fuzz_targets/handshake.rs
+++ b/stream/fuzz/fuzz_targets/handshake.rs
@@ -1,0 +1,124 @@
+#![no_main]
+
+use commonware_codec::Encode;
+use commonware_cryptography::{
+    ed25519::{PrivateKey, PublicKey},
+    PrivateKeyExt as _, Signer,
+};
+use commonware_runtime::{deterministic, mocks, Metrics, Runner, Spawner};
+use commonware_stream::{
+    public_key::{
+        handshake::{Info, Signed},
+        x25519, Config, IncomingConnection,
+    },
+    utils::codec::send_frame,
+};
+use libfuzzer_sys::fuzz_target;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub struct FuzzInput {
+    dialer_seed: u64,
+    listener_seed: u64,
+    random_peer: PublicKey,
+    ephemeral_public_key: x25519::PublicKey,
+    namespace: Vec<u8>,
+    max_message_size: usize,
+    timestamp: u64,
+    synchrony_bound_secs: u64,
+    max_handshake_age_secs: u64,
+    handshake_timeout_secs: u64,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let dialer_seed = u64::arbitrary(u)?;
+        let dialer_crypto = PrivateKey::from_seed(dialer_seed);
+        let listener_seed = dialer_seed.wrapping_add(1);
+        let ephemeral_public_key = x25519::PublicKey::from_bytes(u.arbitrary::<[u8; 32]>()?);
+
+        let use_valid_pub_key = u.int_in_range(0..=1)? == 1;
+        let random_peer = if use_valid_pub_key {
+            dialer_crypto.public_key()
+        } else {
+            let seed = u64::arbitrary(u)?;
+            PrivateKey::from_seed(seed).public_key()
+        };
+
+        let namespace_len = u.int_in_range(0..=256)?;
+        let namespace = (0..namespace_len)
+            .map(|_| u8::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let max_message_size = u.int_in_range(0..=1024 * 1023)?;
+        let timestamp = u.int_in_range(0..=1000)?;
+        let synchrony_bound_secs = u.int_in_range(0..=1000)?;
+        let max_handshake_age_secs = u.int_in_range(0..=1000)?;
+        let handshake_timeout_secs = u.int_in_range(0..=1000)?;
+
+        Ok(FuzzInput {
+            dialer_seed,
+            listener_seed,
+            namespace,
+            max_message_size,
+            timestamp,
+            synchrony_bound_secs,
+            max_handshake_age_secs,
+            handshake_timeout_secs,
+            ephemeral_public_key,
+            random_peer,
+        })
+    }
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let mut dialer_crypto = PrivateKey::from_seed(input.dialer_seed);
+        let listener_crypto = PrivateKey::from_seed(input.listener_seed);
+        let synchrony_bound = Duration::from_secs(input.synchrony_bound_secs);
+        let max_handshake_age = Duration::from_secs(input.max_handshake_age_secs);
+        let handshake_timeout = Duration::from_secs(input.handshake_timeout_secs);
+
+        let handshake = Signed::sign(
+            &mut dialer_crypto,
+            input.namespace.as_slice(),
+            Info {
+                timestamp: input.timestamp,
+                recipient: input.random_peer,
+                ephemeral_public_key: input.ephemeral_public_key,
+            },
+        );
+
+        let (sink, _) = mocks::Channel::init();
+        let (mut stream_sender, stream) = mocks::Channel::init();
+
+        context
+            .with_label("stream_sender")
+            .spawn(move |_| async move {
+                send_frame(
+                    &mut stream_sender,
+                    &handshake.encode(),
+                    input.max_message_size,
+                )
+                .await
+                // Our target is panic.
+                .unwrap_or(());
+            });
+
+        let config = Config {
+            crypto: listener_crypto,
+            namespace: Vec::from(input.namespace.as_slice()),
+            max_message_size: input.max_message_size,
+            synchrony_bound,
+            max_handshake_age,
+            handshake_timeout,
+        };
+
+        // Our target is panic.
+        if IncomingConnection::verify(&context, config, sink, stream)
+            .await
+            .is_ok()
+        {}
+    });
+});

--- a/stream/fuzz/fuzz_targets/lazy_transport.rs
+++ b/stream/fuzz/fuzz_targets/lazy_transport.rs
@@ -1,0 +1,104 @@
+#![no_main]
+
+use commonware_cryptography::{ed25519::PrivateKey, PrivateKeyExt as _, Signer};
+use commonware_runtime::{deterministic, mocks, Runner, Spawner};
+use commonware_stream::{
+    public_key::{Config, Connection, IncomingConnection, Receiver, Sender},
+    Receiver as _, Sender as _,
+};
+use futures::executor::block_on;
+use libfuzzer_sys::fuzz_target;
+use std::{cell::RefCell, time::Duration};
+
+static NAMESPACE: &[u8] = b"lazy_fuzz_transport";
+const MAX_MESSAGE_SIZE: usize = 1023 * 1024; // 64KB buffer
+
+struct TransportPair {
+    dialer_sender: Sender<mocks::Sink>,
+    listener_receiver: Receiver<mocks::Stream>,
+}
+
+thread_local! {
+    static TRANSPORT: RefCell<Option<TransportPair>> = RefCell::new({
+        let executor = deterministic::Runner::default();
+
+        let transport_pair = executor.start(|context| async move {
+            let dialer_crypto = PrivateKey::from_seed(42);
+            let listener_crypto = PrivateKey::from_seed(24);
+
+            let (dialer_sink, listener_stream) = mocks::Channel::init();
+            let (listener_sink, dialer_stream) = mocks::Channel::init();
+
+            let dialer_config = Config {
+                crypto: dialer_crypto.clone(),
+                namespace: NAMESPACE.to_vec(),
+                max_message_size: MAX_MESSAGE_SIZE,
+                synchrony_bound: Duration::from_secs(3),
+                max_handshake_age: Duration::from_secs(5),
+                handshake_timeout: Duration::from_secs(2),
+            };
+
+            let listener_config = Config {
+                crypto: listener_crypto.clone(),
+                namespace: NAMESPACE.to_vec(),
+                max_message_size: MAX_MESSAGE_SIZE,
+                synchrony_bound: Duration::from_secs(3),
+                max_handshake_age: Duration::from_secs(5),
+                handshake_timeout: Duration::from_secs(2),
+            };
+
+            let listener_handle = context.clone().spawn(move |context| async move {
+                let incoming = IncomingConnection::verify(
+                    &context,
+                    listener_config,
+                    listener_sink,
+                    listener_stream,
+                ).await?;
+                Connection::upgrade_listener(context, incoming).await
+            });
+
+            let dialer_connection = Connection::upgrade_dialer(
+                context.clone(),
+                dialer_config,
+                dialer_sink,
+                dialer_stream,
+                listener_crypto.public_key(),
+            ).await.expect("Dialer connection should succeed");
+
+            let listener_connection = listener_handle.await
+                .expect("Listener handle should succeed")
+                .expect("Listener connection should succeed");
+
+            let (dialer_sender, _) = dialer_connection.split();
+            let (_, listener_receiver) = listener_connection.split();
+
+            TransportPair {
+                dialer_sender,
+                listener_receiver,
+            }
+        });
+
+        Some(transport_pair)
+    });
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() || data.len() > MAX_MESSAGE_SIZE {
+        return;
+    }
+
+    TRANSPORT.with(|transport_cell| {
+        let mut transport_opt = transport_cell.borrow_mut();
+        let transport = match transport_opt.as_mut() {
+            Some(t) => t,
+            None => return,
+        };
+
+        for chunk in data.chunks(1024) {
+            block_on(transport.dialer_sender.send(chunk)).unwrap();
+
+            let received = block_on(transport.listener_receiver.receive()).unwrap();
+            assert_eq!(&received[..], chunk, "Data corruption detected");
+        }
+    });
+});

--- a/stream/fuzz/fuzz_targets/transport.rs
+++ b/stream/fuzz/fuzz_targets/transport.rs
@@ -1,0 +1,78 @@
+#![no_main]
+
+use commonware_cryptography::{ed25519::PrivateKey, PrivateKeyExt as _, Signer};
+use commonware_runtime::{deterministic, mocks, Runner, Spawner};
+use commonware_stream::{
+    public_key::{Config, Connection, IncomingConnection},
+    Receiver as _, Sender as _,
+};
+use libfuzzer_sys::fuzz_target;
+use std::time::Duration;
+
+static NAMESPACE: &[u8] = b"fuzz_transport";
+const MAX_MESSAGE_SIZE: usize = 64 * 1024; // 64KB buffer
+
+fuzz_target!(|data: &[u8]| {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let dialer_crypto = PrivateKey::from_seed(42);
+        let listener_crypto = PrivateKey::from_seed(24);
+
+        let (dialer_sink, listener_stream) = mocks::Channel::init();
+        let (listener_sink, dialer_stream) = mocks::Channel::init();
+
+        let dialer_config = Config {
+            crypto: dialer_crypto.clone(),
+            namespace: NAMESPACE.to_vec(),
+            max_message_size: MAX_MESSAGE_SIZE,
+            synchrony_bound: Duration::from_secs(1),
+            max_handshake_age: Duration::from_secs(1),
+            handshake_timeout: Duration::from_secs(1),
+        };
+
+        let listener_config = Config {
+            crypto: listener_crypto.clone(),
+            namespace: NAMESPACE.to_vec(),
+            max_message_size: MAX_MESSAGE_SIZE,
+            synchrony_bound: Duration::from_secs(1),
+            max_handshake_age: Duration::from_secs(1),
+            handshake_timeout: Duration::from_secs(1),
+        };
+
+        let listener_handle = context.clone().spawn(move |context| async move {
+            let incoming = IncomingConnection::verify(
+                &context,
+                listener_config,
+                listener_sink,
+                listener_stream,
+            )
+            .await?;
+            Connection::upgrade_listener(context, incoming).await
+        });
+
+        let dialer_connection = Connection::upgrade_dialer(
+            context.clone(),
+            dialer_config,
+            dialer_sink,
+            dialer_stream,
+            listener_crypto.public_key(),
+        )
+        .await
+        .unwrap();
+
+        let listener_connection = listener_handle.await.unwrap().unwrap();
+
+        let (mut dialer_sender, mut dialer_receiver) = dialer_connection.split();
+        let (mut listener_sender, mut listener_receiver) = listener_connection.split();
+
+        for chunk in data.chunks(1024) {
+            dialer_sender.send(chunk).await.unwrap();
+            let recv_result = listener_receiver.receive().await.unwrap();
+            assert_eq!(recv_result, chunk);
+
+            listener_sender.send(chunk).await.unwrap();
+            let recv_result = dialer_receiver.receive().await.unwrap();
+            assert_eq!(recv_result, chunk);
+        }
+    });
+});

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -12,15 +12,15 @@ use std::time::Duration;
 /// Handshake information that is signed over by the sender.
 pub struct Info<C: PublicKey> {
     /// The public key of the recipient.
-    recipient: C,
+    pub recipient: C,
 
     /// The ephemeral public key of the sender.
     ///
     /// This is used to derive the shared secret for the encrypted connection.
-    ephemeral_public_key: x25519::PublicKey,
+    pub ephemeral_public_key: x25519::PublicKey,
 
     /// Timestamp of the handshake (in epoch milliseconds).
-    timestamp: u64,
+    pub timestamp: u64,
 }
 
 impl<C: PublicKey> Info<C> {

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -12,15 +12,15 @@ use std::time::Duration;
 /// Handshake information that is signed over by the sender.
 pub struct Info<C: PublicKey> {
     /// The public key of the recipient.
-    pub recipient: C,
+    recipient: C,
 
     /// The ephemeral public key of the sender.
     ///
     /// This is used to derive the shared secret for the encrypted connection.
-    pub ephemeral_public_key: x25519::PublicKey,
+    ephemeral_public_key: x25519::PublicKey,
 
     /// Timestamp of the handshake (in epoch milliseconds).
-    pub timestamp: u64,
+    timestamp: u64,
 }
 
 impl<C: PublicKey> Info<C> {

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -68,9 +68,9 @@ mod cipher;
 mod connection;
 use commonware_cryptography::Signer;
 pub use connection::{Connection, IncomingConnection, Receiver, Sender};
-mod handshake;
+pub mod handshake;
 mod nonce;
-mod x25519;
+pub mod x25519;
 
 /// Configuration for a connection.
 ///

--- a/stream/src/public_key/x25519.rs
+++ b/stream/src/public_key/x25519.rs
@@ -15,7 +15,6 @@ impl PublicKey {
         }
     }
 
-    #[cfg(test)]
     pub fn from_bytes(array: [u8; 32]) -> Self {
         PublicKey {
             inner: X25519PublicKey::from(array),

--- a/stream/src/public_key/x25519.rs
+++ b/stream/src/public_key/x25519.rs
@@ -1,20 +1,25 @@
+//! Operations over x25519 keys.
+
 use bytes::{Buf, BufMut};
 use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use rand::{CryptoRng, Rng};
 use x25519_dalek::{EphemeralSecret, PublicKey as X25519PublicKey};
 
+/// x25519 Public Key.
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
 pub struct PublicKey {
     inner: X25519PublicKey,
 }
 
 impl PublicKey {
+    /// Derive a public key from a secret key.
     pub fn from_secret(secret: &EphemeralSecret) -> Self {
         PublicKey {
             inner: X25519PublicKey::from(secret),
         }
     }
 
+    /// Parse a public key from a byte array.
     pub fn from_bytes(array: [u8; 32]) -> Self {
         PublicKey {
             inner: X25519PublicKey::from(array),
@@ -49,6 +54,7 @@ impl FixedSize for PublicKey {
     const SIZE: usize = 32;
 }
 
+/// Generate a new ephemeral secret.
 pub fn new<R: Rng + CryptoRng>(rng: &mut R) -> EphemeralSecret {
     EphemeralSecret::random_from_rng(rng)
 }


### PR DESCRIPTION
This PR adds basic fuzz tests for `stream`.

`handshake` fuzzes the low-level primitive of the handshake protocol, which is why it requires some private handshake types.

Now I just made them public and also removed `cfg(test)` for x25519's `PublicKey::from_bytes`. I think you may have better ideas on how to implement that more correctly. If you do not want to make any changes to your type system, then we can remove the `handshake` test.