### PR TITLE
[stream] Add explicit key-confirmation to handshake

### DIFF
--- a/stream/src/lib.rs
+++ b/stream/src/lib.rs
@@ -50,8 +50,8 @@ pub enum Error {
     EncryptionFailed,
     #[error("decryption failed")]
     DecryptionFailed,
-    #[error("invalid authentication proof")]
-    InvalidAuthenticationProof,
+    #[error("invalid key confirmation")]
+    InvalidKeyConfirmation,
     #[error("timestamp too old: {0}")]
     InvalidTimestampOld(u64),
     #[error("timestamp too future: {0}")]

--- a/stream/src/lib.rs
+++ b/stream/src/lib.rs
@@ -12,18 +12,35 @@ use thiserror::Error;
 /// Errors that can occur when interacting with a stream.
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("unable to decode: {0}")]
-    UnableToDecode(CodecError),
+    // Handshake errors
     #[error("handshake not for us")]
     HandshakeNotForUs,
     #[error("handshake uses our public key")]
     HandshakeUsesOurKey,
     #[error("handshake timeout")]
     HandshakeTimeout,
-    #[error("cannot dial self")]
-    DialSelf,
     #[error("invalid signature")]
     InvalidSignature,
+    #[error("timestamp too old: {0}")]
+    InvalidTimestampOld(u64),
+    #[error("timestamp too future: {0}")]
+    InvalidTimestampFuture(u64),
+
+    // Cipher errors
+    #[error("shared secret was not contributory")]
+    SharedSecretNotContributory,
+    #[error("cipher creation failed")]
+    CipherCreation,
+    #[error("HKDF expansion failed")]
+    HKDFExpansion,
+    #[error("key confirmation failed")]
+    KeyConfirmationFailed,
+    #[error("invalid key confirmation")]
+    InvalidKeyConfirmation,
+
+    // Connection errors
+    #[error("cannot dial self")]
+    DialSelf,
     #[error("wrong peer")]
     WrongPeer,
     #[error("recv failed")]
@@ -38,24 +55,18 @@ pub enum Error {
     SendTooLarge(usize),
     #[error("connection closed")]
     StreamClosed,
-    #[error("shared secret was not contributory")]
-    SharedSecretNotContributory,
-    #[error("cipher creation failed")]
-    CipherCreation,
-    #[error("HKDF expansion failed")]
-    HKDFExpansion,
+
+    // Encryption errors
     #[error("nonce overflow")]
     NonceOverflow,
     #[error("encryption failed")]
     EncryptionFailed,
     #[error("decryption failed")]
     DecryptionFailed,
-    #[error("invalid key confirmation")]
-    InvalidKeyConfirmation,
-    #[error("timestamp too old: {0}")]
-    InvalidTimestampOld(u64),
-    #[error("timestamp too future: {0}")]
-    InvalidTimestampFuture(u64),
+
+    // Codec errors
+    #[error("unable to decode: {0}")]
+    UnableToDecode(CodecError),
 }
 
 /// A trait for sending messages.

--- a/stream/src/lib.rs
+++ b/stream/src/lib.rs
@@ -50,6 +50,8 @@ pub enum Error {
     EncryptionFailed,
     #[error("decryption failed")]
     DecryptionFailed,
+    #[error("invalid authentication proof")]
+    InvalidAuthenticationProof,
     #[error("timestamp too old: {0}")]
     InvalidTimestampOld(u64),
     #[error("timestamp too future: {0}")]

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -91,6 +91,8 @@ pub fn derive<const N: usize>(
     }
     buf.zeroize();
 
+    // The `map_err` should never happen, but is needed to satisfy compilation due to
+    // `ChaCha20Poly1305` not implementing `Debug`.
     Ok(result
         .try_into()
         .map_err(|_| Error::CipherCreation)
@@ -102,269 +104,433 @@ mod tests {
     use super::*;
     use chacha20poly1305::aead::Aead;
 
-    #[test]
-    fn test_derive_success() {
-        let ikm = [1u8; CHACHA_KEY_SIZE];
-        let salt_data1 = b"test_salt_data_success_1";
-        let salt_data2 = b"test_salt_data_success_2";
-        let salts_arr: [&[u8]; 2] = [salt_data1, salt_data2];
-        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
+    // Helper function to test parameter sensitivity (reduces code duplication)
+    fn test_parameter_sensitivity<const N: usize>(
+        base_ikm: &[u8],
+        base_salts: &[&[u8]],
+        base_infos: &[&[u8]],
+        modified_salts: &[&[u8]],
+        modified_infos: &[&[u8]],
+        test_name: &str,
+    ) {
+        let base_ciphers = derive::<N>(base_ikm, base_salts, base_infos).unwrap();
+        let modified_salt_ciphers = derive::<N>(base_ikm, modified_salts, base_infos).unwrap();
+        let modified_info_ciphers = derive::<N>(base_ikm, base_salts, modified_infos).unwrap();
 
-        let result = derive::<2>(&ikm, &salts_arr, &infos_arr);
-        assert!(result.is_ok());
+        let nonce = Default::default();
+        let plaintext = format!("{}_test", test_name);
+
+        // All variants should produce different results
+        for i in 0..N {
+            let base_ct = base_ciphers[i]
+                .encrypt(&nonce, plaintext.as_bytes())
+                .unwrap();
+            let salt_ct = modified_salt_ciphers[i]
+                .encrypt(&nonce, plaintext.as_bytes())
+                .unwrap();
+            let info_ct = modified_info_ciphers[i]
+                .encrypt(&nonce, plaintext.as_bytes())
+                .unwrap();
+
+            assert_ne!(
+                base_ct, salt_ct,
+                "Cipher {} should be sensitive to salt changes in {}",
+                i, test_name
+            );
+            assert_ne!(
+                base_ct, info_ct,
+                "Cipher {} should be sensitive to info changes in {}",
+                i, test_name
+            );
+        }
+    }
+
+    #[test]
+    fn test_derive_basic_functionality() {
+        let ikm = [1u8; CHACHA_KEY_SIZE];
+        let salts: &[&[u8]] = &[b"salt1", b"salt2"];
+        let infos: &[&[u8]] = &[b"info1", b"info2"];
+
+        let result = derive::<2>(&ikm, salts, infos);
+        assert!(result.is_ok(), "Basic derivation should succeed");
         let [cipher1, cipher2] = result.unwrap();
 
-        // Basic check: encrypt something and ensure ciphers are different
+        // Test that different ciphers produce different outputs
         let nonce = Default::default();
-        let plaintext = b"test_encryption";
-        let ciphertext1 = cipher1
-            .encrypt(&nonce, plaintext.as_ref())
-            .expect("Cipher1 encryption failed");
-        let ciphertext2 = cipher2
-            .encrypt(&nonce, plaintext.as_ref())
-            .expect("Cipher2 encryption failed");
+        let plaintext = b"test_message";
+        let ct1 = cipher1.encrypt(&nonce, plaintext.as_ref()).unwrap();
+        let ct2 = cipher2.encrypt(&nonce, plaintext.as_ref()).unwrap();
+
         assert_ne!(
-            ciphertext1, ciphertext2,
-            "Derived ciphers (d2l and l2d) should be different due to KDF info params"
+            ct1, ct2,
+            "Different ciphers should produce different ciphertexts"
         );
     }
 
     #[test]
     fn test_derive_consistency() {
         let ikm = [2u8; CHACHA_KEY_SIZE];
-        let salt_data1 = b"consistency_salt_1";
-        let salt_data2 = b"consistency_salt_2";
-        let salts_arr: [&[u8]; 2] = [salt_data1, salt_data2];
-        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
+        let salts: &[&[u8]] = &[b"consistent_salt"];
+        let infos: &[&[u8]] = &[b"info1", b"info2"];
 
-        let [cipher1_a, cipher2_a] = derive::<2>(&ikm, &salts_arr, &infos_arr).unwrap();
-        let [cipher1_b, cipher2_b] = derive::<2>(&ikm, &salts_arr, &infos_arr).unwrap();
+        let [c1_a, c2_a] = derive::<2>(&ikm, salts, infos).unwrap();
+        let [c1_b, c2_b] = derive::<2>(&ikm, salts, infos).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"consistency_test";
+
+        assert_eq!(
+            c1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            c1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "Same inputs should produce identical ciphers"
+        );
+        assert_eq!(
+            c2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            c2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "Same inputs should produce identical ciphers"
+        );
+    }
+
+    #[test]
+    fn test_parameter_sensitivity_comprehensive() {
+        let ikm = [3u8; CHACHA_KEY_SIZE];
+
+        // Test content sensitivity
+        test_parameter_sensitivity::<2>(
+            &ikm,
+            &[b"salt_A", b"salt_C"],
+            &[b"info_A", b"info_C"],
+            &[b"salt_B", b"salt_D"], // Changed both salts
+            &[b"info_B", b"info_D"], // Changed both infos
+            "content_sensitivity",
+        );
+
+        // Test order sensitivity
+        test_parameter_sensitivity::<2>(
+            &ikm,
+            &[b"first", b"second"],
+            &[b"info_first", b"info_second"],
+            &[b"second", b"first"],           // Swapped order
+            &[b"info_second", b"info_first"], // Swapped order
+            "order_sensitivity",
+        );
+
+        // Test count sensitivity
+        let [cipher_single] = derive::<1>(&ikm, &[b"single_salt"], &[b"single_info"]).unwrap();
+        let [cipher_multi, _] = derive::<2>(
+            &ikm,
+            &[b"multi_salt1", b"multi_salt2"],
+            &[b"single_info", b"extra_info"],
+        )
+        .unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"count_test";
+        assert_ne!(
+            cipher_single.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher_multi.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "Different parameter counts should produce different ciphers"
+        );
+    }
+
+    #[test]
+    fn test_ikm_sensitivity() {
+        let salts: &[&[u8]] = &[b"common_salt"];
+        let infos: &[&[u8]] = &[b"info1", b"info2"];
+
+        let ikm1 = [1u8; CHACHA_KEY_SIZE];
+        let ikm2 = [2u8; CHACHA_KEY_SIZE];
+
+        let [c1_ikm1, c2_ikm1] = derive::<2>(&ikm1, salts, infos).unwrap();
+        let [c1_ikm2, c2_ikm2] = derive::<2>(&ikm2, salts, infos).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"ikm_test";
+
+        assert_ne!(
+            c1_ikm1.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            c1_ikm2.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "Different IKM should produce different ciphers"
+        );
+        assert_ne!(
+            c2_ikm1.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            c2_ikm2.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "Different IKM should produce different ciphers"
+        );
+    }
+
+    #[test]
+    fn test_empty_parameters() {
+        let ikm = [4u8; CHACHA_KEY_SIZE];
+
+        // Empty arrays should work
+        let empty_salts: [&[u8]; 0] = [];
+        let empty_infos: [&[u8]; 0] = [];
+        let result = derive::<0>(&ikm, &empty_salts, &empty_infos);
+        assert!(result.is_ok(), "Empty parameter arrays should work");
+        assert_eq!(result.unwrap().len(), 0);
+
+        // Empty content should work but be different from non-empty
+        let [cipher_empty] = derive::<1>(&ikm, &[b""], &[b""]).unwrap();
+        let [cipher_non_empty] = derive::<1>(&ikm, &[b"salt"], &[b"info"]).unwrap();
+
+        let nonce = Default::default();
+        let plaintext = b"empty_test";
+        assert_ne!(
+            cipher_empty.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            cipher_non_empty
+                .encrypt(&nonce, plaintext.as_ref())
+                .unwrap(),
+            "Empty and non-empty parameters should produce different results"
+        );
+    }
+
+    #[test]
+    fn test_round_trip_encryption() {
+        let ikm = [5u8; CHACHA_KEY_SIZE];
+        let salts: &[&[u8]] = &[b"encryption_salt"];
+        let infos: &[&[u8]] = &[b"encryption_info"];
+        let [cipher] = derive::<1>(&ikm, salts, infos).unwrap();
+
+        let nonce = Default::default();
+        let original_plaintext = b"secret message that should round-trip correctly";
+
+        // Encrypt then decrypt
+        let ciphertext = cipher.encrypt(&nonce, original_plaintext.as_ref()).unwrap();
+        let decrypted = cipher.decrypt(&nonce, ciphertext.as_ref()).unwrap();
+
+        assert_eq!(
+            original_plaintext.as_ref(),
+            decrypted,
+            "Round-trip encryption/decryption should preserve the original message"
+        );
+
+        // Verify ciphertext is actually different from plaintext
+        assert_ne!(
+            original_plaintext.as_ref(),
+            ciphertext.as_slice(),
+            "Ciphertext should be different from plaintext"
+        );
+    }
+
+    #[test]
+    fn test_different_nonces_produce_different_ciphertexts() {
+        let ikm = [6u8; CHACHA_KEY_SIZE];
+        let [cipher] = derive::<1>(&ikm, &[b"nonce_test_salt"], &[b"nonce_test_info"]).unwrap();
+
+        let plaintext = b"same message";
+        let nonce1 = [0u8; 12];
+        let nonce2 = [1u8; 12];
+
+        let ct1 = cipher.encrypt(&nonce1.into(), plaintext.as_ref()).unwrap();
+        let ct2 = cipher.encrypt(&nonce2.into(), plaintext.as_ref()).unwrap();
+
+        assert_ne!(
+            ct1, ct2,
+            "Same message with different nonces should produce different ciphertexts"
+        );
+    }
+
+    #[test]
+    fn test_various_const_generic_sizes() {
+        let ikm = [7u8; CHACHA_KEY_SIZE];
+        let salts: &[&[u8]] = &[b"size_test_salt"];
+
+        // Test different sizes
+        let infos1: &[&[u8]] = &[b"info1"];
+        let infos3: &[&[u8]] = &[b"info1", b"info2", b"info3"];
+        let infos4: &[&[u8]] = &[b"info1", b"info2", b"info3", b"info4"];
+
+        let result1 = derive::<1>(&ikm, salts, infos1);
+        let result3 = derive::<3>(&ikm, salts, infos3);
+        let result4 = derive::<4>(&ikm, salts, infos4);
+
+        assert!(result1.is_ok(), "N=1 should work");
+        assert!(result3.is_ok(), "N=3 should work");
+        assert!(result4.is_ok(), "N=4 should work");
+
+        assert_eq!(result1.unwrap().len(), 1);
+        assert_eq!(result3.unwrap().len(), 3);
+        assert_eq!(result4.unwrap().len(), 4);
+    }
+
+    #[test]
+    fn test_zero_length_ikm() {
+        let empty_ikm = [];
+        let salts: &[&[u8]] = &[b"salt"];
+        let infos: &[&[u8]] = &[b"info"];
+
+        // This should still work - HKDF can handle empty IKM
+        let result = derive::<1>(&empty_ikm, salts, infos);
+        assert!(
+            result.is_ok(),
+            "Zero-length IKM should be handled gracefully"
+        );
+    }
+
+    #[test]
+    fn test_large_inputs() {
+        let large_ikm = [42u8; 1024]; // Much larger than typical
+        let large_salt = vec![0u8; 1024];
+        let large_info = vec![1u8; 1024];
+
+        let salts: &[&[u8]] = &[large_salt.as_slice()];
+        let infos: &[&[u8]] = &[large_info.as_slice()];
+
+        let result = derive::<1>(&large_ikm, salts, infos);
+        assert!(result.is_ok(), "Large inputs should be handled correctly");
+    }
+
+    #[test]
+    fn test_derive_directional_functionality() {
+        let ikm = b"directional_test_ikm";
+        let namespace = b"test_namespace";
+        let dialer_handshake = b"dialer_message";
+        let listener_handshake = b"listener_message";
+
+        let result = derive_directional(ikm, namespace, dialer_handshake, listener_handshake);
+        assert!(result.is_ok(), "derive_directional should succeed");
+
+        let directional = result.unwrap();
+
+        // Test that all four ciphers produce different outputs
+        let nonce = Default::default();
+        let plaintext = b"directional_test";
+
+        let d2l_ct = directional.d2l.encrypt(&nonce, plaintext.as_ref()).unwrap();
+        let l2d_ct = directional.l2d.encrypt(&nonce, plaintext.as_ref()).unwrap();
+        let d2l_conf_ct = directional
+            .d2l_confirmation
+            .encrypt(&nonce, plaintext.as_ref())
+            .unwrap();
+        let l2d_conf_ct = directional
+            .l2d_confirmation
+            .encrypt(&nonce, plaintext.as_ref())
+            .unwrap();
+
+        let ciphertexts = [&d2l_ct, &l2d_ct, &d2l_conf_ct, &l2d_conf_ct];
+
+        // Ensure all are unique
+        for i in 0..ciphertexts.len() {
+            for j in (i + 1)..ciphertexts.len() {
+                assert_ne!(
+                    ciphertexts[i], ciphertexts[j],
+                    "All directional ciphertexts should be different (cipher {} vs {})",
+                    i, j
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_derive_directional_consistency() {
+        let ikm = b"consistency_ikm";
+        let namespace = b"consistency_namespace";
+        let dialer_handshake = b"consistency_dialer";
+        let listener_handshake = b"consistency_listener";
+
+        let dir1 =
+            derive_directional(ikm, namespace, dialer_handshake, listener_handshake).unwrap();
+        let dir2 =
+            derive_directional(ikm, namespace, dialer_handshake, listener_handshake).unwrap();
 
         let nonce = Default::default();
         let plaintext = b"consistency_check";
 
+        // All corresponding ciphers should be identical
         assert_eq!(
-            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "D2L ciphers should be consistent for the same inputs"
+            dir1.d2l.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            dir2.d2l.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "d2l should be consistent"
         );
         assert_eq!(
-            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "L2D ciphers should be consistent for the same inputs"
+            dir1.l2d.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            dir2.l2d.encrypt(&nonce, plaintext.as_ref()).unwrap(),
+            "l2d should be consistent"
         );
     }
 
     #[test]
-    fn test_derive_sensitivity_to_ikm() {
-        let salt_data = b"common_salt_for_ikm_test";
-        let salts_arr: [&[u8]; 1] = [salt_data];
-        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
+    fn test_derive_directional_input_sensitivity() {
+        let base_ikm = b"base_ikm";
+        let base_namespace = b"base_namespace";
+        let base_dialer = b"base_dialer";
+        let base_listener = b"base_listener";
 
-        let ikm1 = [3u8; CHACHA_KEY_SIZE];
-        let [cipher1_a, cipher2_a] = derive::<2>(&ikm1, &salts_arr, &infos_arr).unwrap();
+        let base_dir =
+            derive_directional(base_ikm, base_namespace, base_dialer, base_listener).unwrap();
 
-        let ikm2 = [4u8; CHACHA_KEY_SIZE]; // Different IKM
-        let [cipher1_b, cipher2_b] = derive::<2>(&ikm2, &salts_arr, &infos_arr).unwrap();
-
-        let nonce = Default::default();
-        let plaintext = b"ikm_sensitivity_check";
-
-        assert_ne!(
-            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "D2L cipher should change with IKM"
-        );
-        assert_ne!(
-            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "L2D cipher should change with IKM"
-        );
-    }
-
-    #[test]
-    fn test_derive_sensitivity_to_salt_element_content() {
-        let ikm = [5u8; CHACHA_KEY_SIZE];
-        let common_salt_element = b"common_element";
-        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
-
-        let salts1_data: [&[u8]; 2] = [b"salt_A", common_salt_element];
-        let [cipher1_a, cipher2_a] = derive::<2>(&ikm, &salts1_data, &infos_arr).unwrap();
-
-        let salts2_data: [&[u8]; 2] = [b"salt_B", common_salt_element]; // Different content in first salt element
-        let [cipher1_b, cipher2_b] = derive::<2>(&ikm, &salts2_data, &infos_arr).unwrap();
-
-        let nonce = Default::default();
-        let plaintext = b"salt_content_sensitivity";
-
-        assert_ne!(
-            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "D2L cipher should change with salt element content"
-        );
-        assert_ne!(
-            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "L2D cipher should change with salt element content"
-        );
-    }
-
-    #[test]
-    fn test_derive_sensitivity_to_number_of_salt_elements() {
-        let ikm = [6u8; CHACHA_KEY_SIZE];
-        let salt_element_a = b"element_A";
-        let salt_element_b = b"element_B";
-        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
-
-        let salts1_data: [&[u8]; 1] = [salt_element_a]; // One salt element
-        let [cipher1_a, cipher2_a] = derive::<2>(&ikm, &salts1_data, &infos_arr).unwrap();
-
-        let salts2_data: [&[u8]; 2] = [salt_element_a, salt_element_b]; // Two salt elements
-        let [cipher1_b, cipher2_b] = derive::<2>(&ikm, &salts2_data, &infos_arr).unwrap();
-
-        let nonce = Default::default();
-        let plaintext = b"num_salts_sensitivity";
-
-        assert_ne!(
-            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "D2L cipher should change with the number of salt elements"
-        );
-        assert_ne!(
-            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "L2D cipher should change with the number of salt elements"
-        );
-    }
-
-    #[test]
-    fn test_derive_sensitivity_to_order_of_salt_elements() {
-        let ikm = [7u8; CHACHA_KEY_SIZE];
-        let salt_element_x = b"element_X";
-        let salt_element_y = b"element_Y";
-        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
-
-        let salts1_data: [&[u8]; 2] = [salt_element_x, salt_element_y];
-        let [cipher1_a, cipher2_a] = derive::<2>(&ikm, &salts1_data, &infos_arr).unwrap();
-
-        let salts2_data: [&[u8]; 2] = [salt_element_y, salt_element_x]; // Different order
-        let [cipher1_b, cipher2_b] = derive::<2>(&ikm, &salts2_data, &infos_arr).unwrap();
-
-        let nonce = Default::default();
-        let plaintext = b"order_salts_sensitivity";
-
-        assert_ne!(
-            cipher1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "D2L cipher should change with the order of salt elements"
-        );
-        assert_ne!(
-            cipher2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "L2D cipher should change with the order of salt elements"
-        );
-    }
-
-    #[test]
-    fn test_derive_with_empty_salts_slice() {
-        let ikm = [8u8; CHACHA_KEY_SIZE];
-        let empty_salts: [&[u8]; 0] = []; // Empty slice of salts
-        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
-
-        let result = derive::<2>(&ikm, &empty_salts, &infos_arr);
-        assert!(
-            result.is_ok(),
-            "Derivation with empty salts slice should succeed"
-        );
-
-        // Further check: ensure it's different from derivation with non-empty salts
-        let salt_data = b"some_salt";
-        let non_empty_salts: [&[u8]; 1] = [salt_data];
-        let [cipher1_empty, cipher2_empty] = result.unwrap();
-        let [cipher1_non_empty, cipher2_non_empty] =
-            derive::<2>(&ikm, &non_empty_salts, &infos_arr).unwrap();
-
-        let nonce = Default::default();
-        let plaintext = b"empty_salts_check";
-
-        assert_ne!(
-            cipher1_empty.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher1_non_empty
-                .encrypt(&nonce, plaintext.as_ref())
+        // Test sensitivity to each parameter
+        let variants = [
+            derive_directional(b"different_ikm", base_namespace, base_dialer, base_listener)
                 .unwrap(),
-            "D2L cipher with empty salts should differ from non-empty"
-        );
-        assert_ne!(
-            cipher2_empty.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            cipher2_non_empty
-                .encrypt(&nonce, plaintext.as_ref())
+            derive_directional(base_ikm, b"different_namespace", base_dialer, base_listener)
                 .unwrap(),
-            "L2D cipher with empty salts should differ from non-empty"
+            derive_directional(base_ikm, base_namespace, b"different_dialer", base_listener)
+                .unwrap(),
+            derive_directional(base_ikm, base_namespace, base_dialer, b"different_listener")
+                .unwrap(),
+        ];
+
+        let nonce = Default::default();
+        let plaintext = b"sensitivity_test";
+        let base_ct = base_dir.d2l.encrypt(&nonce, plaintext.as_ref()).unwrap();
+
+        for (i, variant) in variants.iter().enumerate() {
+            let variant_ct = variant.d2l.encrypt(&nonce, plaintext.as_ref()).unwrap();
+            assert_ne!(
+                base_ct, variant_ct,
+                "Variant {} should produce different result",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_realistic_sizes() {
+        // Test with realistic sizes for production use
+        let ikm = [42u8; 32]; // Typical ECDH shared secret size
+        let namespace = b"production-app-v2.1.0";
+        let dialer_handshake = [0u8; 64]; // Realistic handshake message size
+        let listener_handshake = [1u8; 64];
+
+        let result = derive_directional(&ikm, namespace, &dialer_handshake, &listener_handshake);
+        assert!(result.is_ok(), "Realistic inputs should work correctly");
+
+        let directional = result.unwrap();
+
+        // Test that we can actually use these ciphers
+        let nonce = Default::default();
+        let message = b"Hello, this is a realistic message that might be sent over the network";
+
+        let encrypted = directional.d2l.encrypt(&nonce, message.as_ref()).unwrap();
+        let decrypted = directional.d2l.decrypt(&nonce, encrypted.as_ref()).unwrap();
+
+        assert_eq!(
+            message.as_ref(),
+            decrypted,
+            "Realistic scenario should work end-to-end"
         );
     }
 
     #[test]
-    fn test_derive_with_empty_salt_element_in_slice() {
-        let ikm = [9u8; CHACHA_KEY_SIZE];
-        let empty_salt_element: &[u8] = b"";
-        let salts_with_empty_element: [&[u8]; 1] = [empty_salt_element];
-        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
+    fn test_constants_are_unique() {
+        // Ensure all constant info strings are different
+        let constants = [
+            D2L_TRAFFIC_INFO,
+            L2D_TRAFFIC_INFO,
+            D2L_CONFIRMATION_INFO,
+            L2D_CONFIRMATION_INFO,
+        ];
 
-        let result = derive::<2>(&ikm, &salts_with_empty_element, &infos_arr);
-        assert!(
-            result.is_ok(),
-            "Derivation with an empty salt element should succeed"
-        );
-
-        // Further check: ensure it's different from derivation with non-empty salt or fully empty salts
-        let [cipher1_with_empty_el, cipher2_with_empty_el] = result.unwrap();
-
-        let salt_data = b"non_empty_salt_element";
-        let salts_with_non_empty_el: [&[u8]; 1] = [salt_data];
-        let [cipher1_non_empty_el, cipher2_non_empty_el] =
-            derive::<2>(&ikm, &salts_with_non_empty_el, &infos_arr).unwrap();
-
-        let nonce = Default::default();
-        let plaintext = b"empty_salt_element_check";
-
-        assert_ne!(
-            cipher1_with_empty_el
-                .encrypt(&nonce, plaintext.as_ref())
-                .unwrap(),
-            cipher1_non_empty_el
-                .encrypt(&nonce, plaintext.as_ref())
-                .unwrap(),
-            "D2L cipher with empty salt element should differ from one with non-empty salt element"
-        );
-        assert_ne!(
-            cipher2_with_empty_el
-                .encrypt(&nonce, plaintext.as_ref())
-                .unwrap(),
-            cipher2_non_empty_el
-                .encrypt(&nonce, plaintext.as_ref())
-                .unwrap(),
-            "L2D cipher with empty salt element should differ from one with non-empty salt element"
-        );
-    }
-
-    #[test]
-    fn test_d2l_and_l2d_are_different() {
-        let ikm = [10u8; CHACHA_KEY_SIZE];
-        let salt_data = b"test_salt_for_d2l_l2d_diff";
-        let salts_arr: [&[u8]; 1] = [salt_data];
-        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
-        let [d2l_cipher, l2d_cipher] = derive::<2>(&ikm, &salts_arr, &infos_arr).unwrap();
-
-        let nonce = Default::default();
-        let plaintext = b"d2l_l2d_test_message";
-
-        let ciphertext_d2l = d2l_cipher
-            .encrypt(&nonce, plaintext.as_ref())
-            .expect("D2L encryption failed");
-        let ciphertext_l2d = l2d_cipher
-            .encrypt(&nonce, plaintext.as_ref())
-            .expect("L2D encryption failed");
-
-        assert_ne!(ciphertext_d2l, ciphertext_l2d, "D2L and L2D ciphers should produce different ciphertexts for the same input due to different KDF info parameters.");
+        for i in 0..constants.len() {
+            for j in (i + 1)..constants.len() {
+                assert_ne!(
+                    constants[i], constants[j],
+                    "Constants should be unique (constant {} vs {})",
+                    i, j
+                );
+            }
+        }
     }
 }

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -10,23 +10,63 @@ const CHACHA_KEY_SIZE: usize = <ChaCha20Poly1305 as KeySizeUser>::KeySize::USIZE
 // A constant prefix used for the salt hash in the HKDF key derivation.
 const BASE_KDF_PREFIX: &[u8] = b"commonware-stream/KDF/v1/";
 
-/// Key Derivation Function (KDF) to derive directional ChaCha20Poly1305 ciphers using HKDF-SHA256.
+// Constant infos for directional ciphers.
+const D2L_TRAFFIC_INFO: &[u8] = b"l2d/traffic";
+const L2D_TRAFFIC_INFO: &[u8] = b"d2l/traffic";
+const D2L_CONFIRMATION_INFO: &[u8] = b"l2d/confirmation";
+const L2D_CONFIRMATION_INFO: &[u8] = b"d2l/confirmation";
+
+/// Return value when deriving directional ciphers.
+pub struct DirectionalCipher {
+    /// The cipher used for sending messages from the dialer to the listener.
+    pub d2l: ChaCha20Poly1305,
+    /// The cipher used for sending messages from the listener to the dialer.
+    pub l2d: ChaCha20Poly1305,
+    /// The cipher used for key confirmation by the dialer during the handshake.
+    pub d2l_confirmation: ChaCha20Poly1305,
+    /// The cipher used for key confirmation by the listener during the handshake.
+    pub l2d_confirmation: ChaCha20Poly1305,
+}
+
+/// Derive directional ChaCha20Poly1305 ciphers from a given input key material, a unique
+/// application namespace, and the dialer and listener handshake messages.
 ///
-/// This function derives two ChaCha20Poly1305 ciphers based on:
+/// Returns a DirectionalCipher struct containing the four directional ciphers.
+pub fn derive_directional(
+    ikm: &[u8],
+    namespace: &[u8],
+    dialer_handshake: &[u8],
+    listener_handshake: &[u8],
+) -> Result<DirectionalCipher, Error> {
+    let infos = [
+        D2L_TRAFFIC_INFO,
+        L2D_TRAFFIC_INFO,
+        D2L_CONFIRMATION_INFO,
+        L2D_CONFIRMATION_INFO,
+    ];
+    let salts = [namespace, dialer_handshake, listener_handshake];
+    let ciphers = derive::<4>(ikm, &salts, &infos)?;
+    let [d2l, l2d, d2l_confirmation, l2d_confirmation] = ciphers;
+    Ok(DirectionalCipher {
+        d2l,
+        l2d,
+        d2l_confirmation,
+        l2d_confirmation,
+    })
+}
+
+/// Key Derivation Function (KDF) to derive ChaCha20Poly1305 ciphers using HKDF-SHA256.
+///
+/// This function derives ChaCha20Poly1305 ciphers based on:
 /// - The input key material (IKM), usually the shared secret from the Diffie-Hellman key exchange
 /// - An ordered list of byte slices (salts), where the order is critical for consistent derivation
-///   between the dialer and the listener. The list usually contains:
-///   - The unique application namespace
-///   - The dialer handshake message bytes
-///   - The listener handshake message bytes
 ///
-/// Returns two ChaCha20Poly1305 ciphers, intended for use as:
-/// - The dialer-to-listener cipher
-/// - The listener-to-dialer cipher
-///
-/// The dialer and listener must use the ciphers in the same order to ensure proper encryption and
-/// decryption.
-pub fn derive(ikm: &[u8], salts: &[&[u8]]) -> Result<(ChaCha20Poly1305, ChaCha20Poly1305), Error> {
+/// Returns a vector of ChaCha20Poly1305 ciphers, one for each info.
+pub fn derive<const N: usize>(
+    ikm: &[u8],
+    salts: &[&[u8]],
+    infos: &[&[u8]],
+) -> Result<[ChaCha20Poly1305; N], Error> {
     // Create a unique salt for the HKDF expansion.
     // The salt is generated from a commonware-specific prefix and the list of salts provided.
     let mut hasher = Sha256::default();
@@ -40,17 +80,21 @@ pub fn derive(ikm: &[u8], salts: &[&[u8]]) -> Result<(ChaCha20Poly1305, ChaCha20
     let prk = Hkdf::<CoreSha256>::new(Some(salt.as_ref()), ikm);
     salt.zeroize();
 
-    // Expand the PRK to derive two ChaCha20Poly1305 keys.
-    let mut buf = [0u8; CHACHA_KEY_SIZE * 2];
-    prk.expand(&[], &mut buf)
-        .map_err(|_| Error::HKDFExpansion)?;
-    let d2l_cipher = ChaCha20Poly1305::new_from_slice(&buf[..CHACHA_KEY_SIZE])
-        .map_err(|_| Error::CipherCreation)?;
-    let l2d_cipher = ChaCha20Poly1305::new_from_slice(&buf[CHACHA_KEY_SIZE..])
-        .map_err(|_| Error::CipherCreation)?;
+    // Expand the PRK to derive a ChaCha20Poly1305 key for each info.
+    let mut result = Vec::with_capacity(N);
+    let mut buf = [0u8; CHACHA_KEY_SIZE];
+    for info in infos.iter() {
+        prk.expand(info, &mut buf)
+            .map_err(|_| Error::HKDFExpansion)?;
+        let cipher = ChaCha20Poly1305::new_from_slice(&buf).map_err(|_| Error::CipherCreation)?;
+        result.push(cipher);
+    }
     buf.zeroize();
 
-    Ok((d2l_cipher, l2d_cipher))
+    Ok(result
+        .try_into()
+        .map_err(|_| Error::CipherCreation)
+        .expect("Failed to convert Vec to array"))
 }
 
 #[cfg(test)]
@@ -64,10 +108,11 @@ mod tests {
         let salt_data1 = b"test_salt_data_success_1";
         let salt_data2 = b"test_salt_data_success_2";
         let salts_arr: [&[u8]; 2] = [salt_data1, salt_data2];
+        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
 
-        let result = derive(&ikm, &salts_arr);
+        let result = derive::<2>(&ikm, &salts_arr, &infos_arr);
         assert!(result.is_ok());
-        let (cipher1, cipher2) = result.unwrap();
+        let [cipher1, cipher2] = result.unwrap();
 
         // Basic check: encrypt something and ensure ciphers are different
         let nonce = Default::default();
@@ -90,9 +135,10 @@ mod tests {
         let salt_data1 = b"consistency_salt_1";
         let salt_data2 = b"consistency_salt_2";
         let salts_arr: [&[u8]; 2] = [salt_data1, salt_data2];
+        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
 
-        let (cipher1_a, cipher2_a) = derive(&ikm, &salts_arr).unwrap();
-        let (cipher1_b, cipher2_b) = derive(&ikm, &salts_arr).unwrap();
+        let [cipher1_a, cipher2_a] = derive::<2>(&ikm, &salts_arr, &infos_arr).unwrap();
+        let [cipher1_b, cipher2_b] = derive::<2>(&ikm, &salts_arr, &infos_arr).unwrap();
 
         let nonce = Default::default();
         let plaintext = b"consistency_check";
@@ -113,12 +159,13 @@ mod tests {
     fn test_derive_sensitivity_to_ikm() {
         let salt_data = b"common_salt_for_ikm_test";
         let salts_arr: [&[u8]; 1] = [salt_data];
+        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
 
         let ikm1 = [3u8; CHACHA_KEY_SIZE];
-        let (cipher1_a, cipher2_a) = derive(&ikm1, &salts_arr).unwrap();
+        let [cipher1_a, cipher2_a] = derive::<2>(&ikm1, &salts_arr, &infos_arr).unwrap();
 
         let ikm2 = [4u8; CHACHA_KEY_SIZE]; // Different IKM
-        let (cipher1_b, cipher2_b) = derive(&ikm2, &salts_arr).unwrap();
+        let [cipher1_b, cipher2_b] = derive::<2>(&ikm2, &salts_arr, &infos_arr).unwrap();
 
         let nonce = Default::default();
         let plaintext = b"ikm_sensitivity_check";
@@ -139,12 +186,13 @@ mod tests {
     fn test_derive_sensitivity_to_salt_element_content() {
         let ikm = [5u8; CHACHA_KEY_SIZE];
         let common_salt_element = b"common_element";
+        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
 
         let salts1_data: [&[u8]; 2] = [b"salt_A", common_salt_element];
-        let (cipher1_a, cipher2_a) = derive(&ikm, &salts1_data).unwrap();
+        let [cipher1_a, cipher2_a] = derive::<2>(&ikm, &salts1_data, &infos_arr).unwrap();
 
         let salts2_data: [&[u8]; 2] = [b"salt_B", common_salt_element]; // Different content in first salt element
-        let (cipher1_b, cipher2_b) = derive(&ikm, &salts2_data).unwrap();
+        let [cipher1_b, cipher2_b] = derive::<2>(&ikm, &salts2_data, &infos_arr).unwrap();
 
         let nonce = Default::default();
         let plaintext = b"salt_content_sensitivity";
@@ -166,12 +214,13 @@ mod tests {
         let ikm = [6u8; CHACHA_KEY_SIZE];
         let salt_element_a = b"element_A";
         let salt_element_b = b"element_B";
+        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
 
         let salts1_data: [&[u8]; 1] = [salt_element_a]; // One salt element
-        let (cipher1_a, cipher2_a) = derive(&ikm, &salts1_data).unwrap();
+        let [cipher1_a, cipher2_a] = derive::<2>(&ikm, &salts1_data, &infos_arr).unwrap();
 
         let salts2_data: [&[u8]; 2] = [salt_element_a, salt_element_b]; // Two salt elements
-        let (cipher1_b, cipher2_b) = derive(&ikm, &salts2_data).unwrap();
+        let [cipher1_b, cipher2_b] = derive::<2>(&ikm, &salts2_data, &infos_arr).unwrap();
 
         let nonce = Default::default();
         let plaintext = b"num_salts_sensitivity";
@@ -193,12 +242,13 @@ mod tests {
         let ikm = [7u8; CHACHA_KEY_SIZE];
         let salt_element_x = b"element_X";
         let salt_element_y = b"element_Y";
+        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
 
         let salts1_data: [&[u8]; 2] = [salt_element_x, salt_element_y];
-        let (cipher1_a, cipher2_a) = derive(&ikm, &salts1_data).unwrap();
+        let [cipher1_a, cipher2_a] = derive::<2>(&ikm, &salts1_data, &infos_arr).unwrap();
 
         let salts2_data: [&[u8]; 2] = [salt_element_y, salt_element_x]; // Different order
-        let (cipher1_b, cipher2_b) = derive(&ikm, &salts2_data).unwrap();
+        let [cipher1_b, cipher2_b] = derive::<2>(&ikm, &salts2_data, &infos_arr).unwrap();
 
         let nonce = Default::default();
         let plaintext = b"order_salts_sensitivity";
@@ -219,8 +269,9 @@ mod tests {
     fn test_derive_with_empty_salts_slice() {
         let ikm = [8u8; CHACHA_KEY_SIZE];
         let empty_salts: [&[u8]; 0] = []; // Empty slice of salts
+        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
 
-        let result = derive(&ikm, &empty_salts);
+        let result = derive::<2>(&ikm, &empty_salts, &infos_arr);
         assert!(
             result.is_ok(),
             "Derivation with empty salts slice should succeed"
@@ -229,8 +280,9 @@ mod tests {
         // Further check: ensure it's different from derivation with non-empty salts
         let salt_data = b"some_salt";
         let non_empty_salts: [&[u8]; 1] = [salt_data];
-        let (cipher1_empty, cipher2_empty) = result.unwrap();
-        let (cipher1_non_empty, cipher2_non_empty) = derive(&ikm, &non_empty_salts).unwrap();
+        let [cipher1_empty, cipher2_empty] = result.unwrap();
+        let [cipher1_non_empty, cipher2_non_empty] =
+            derive::<2>(&ikm, &non_empty_salts, &infos_arr).unwrap();
 
         let nonce = Default::default();
         let plaintext = b"empty_salts_check";
@@ -256,20 +308,21 @@ mod tests {
         let ikm = [9u8; CHACHA_KEY_SIZE];
         let empty_salt_element: &[u8] = b"";
         let salts_with_empty_element: [&[u8]; 1] = [empty_salt_element];
+        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
 
-        let result = derive(&ikm, &salts_with_empty_element);
+        let result = derive::<2>(&ikm, &salts_with_empty_element, &infos_arr);
         assert!(
             result.is_ok(),
             "Derivation with an empty salt element should succeed"
         );
 
         // Further check: ensure it's different from derivation with non-empty salt or fully empty salts
-        let (cipher1_with_empty_el, cipher2_with_empty_el) = result.unwrap();
+        let [cipher1_with_empty_el, cipher2_with_empty_el] = result.unwrap();
 
         let salt_data = b"non_empty_salt_element";
         let salts_with_non_empty_el: [&[u8]; 1] = [salt_data];
-        let (cipher1_non_empty_el, cipher2_non_empty_el) =
-            derive(&ikm, &salts_with_non_empty_el).unwrap();
+        let [cipher1_non_empty_el, cipher2_non_empty_el] =
+            derive::<2>(&ikm, &salts_with_non_empty_el, &infos_arr).unwrap();
 
         let nonce = Default::default();
         let plaintext = b"empty_salt_element_check";
@@ -299,7 +352,8 @@ mod tests {
         let ikm = [10u8; CHACHA_KEY_SIZE];
         let salt_data = b"test_salt_for_d2l_l2d_diff";
         let salts_arr: [&[u8]; 1] = [salt_data];
-        let (d2l_cipher, l2d_cipher) = derive(&ikm, &salts_arr).unwrap();
+        let infos_arr: [&[u8]; 2] = [b"info1", b"info2"];
+        let [d2l_cipher, l2d_cipher] = derive::<2>(&ikm, &salts_arr, &infos_arr).unwrap();
 
         let nonce = Default::default();
         let plaintext = b"d2l_l2d_test_message";

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -164,10 +164,7 @@ mod tests {
         let ct1 = cipher1.encrypt(&nonce, plaintext.as_ref()).unwrap();
         let ct2 = cipher2.encrypt(&nonce, plaintext.as_ref()).unwrap();
 
-        assert_ne!(
-            ct1, ct2,
-            "Different ciphers should produce different ciphertexts"
-        );
+        assert_ne!(ct1, ct2);
     }
 
     #[test]
@@ -185,12 +182,10 @@ mod tests {
         assert_eq!(
             c1_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
             c1_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "Same inputs should produce identical ciphers"
         );
         assert_eq!(
             c2_a.encrypt(&nonce, plaintext.as_ref()).unwrap(),
             c2_b.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "Same inputs should produce identical ciphers"
         );
     }
 
@@ -232,7 +227,6 @@ mod tests {
         assert_ne!(
             cipher_single.encrypt(&nonce, plaintext.as_ref()).unwrap(),
             cipher_multi.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "Different parameter counts should produce different ciphers"
         );
     }
 
@@ -253,12 +247,10 @@ mod tests {
         assert_ne!(
             c1_ikm1.encrypt(&nonce, plaintext.as_ref()).unwrap(),
             c1_ikm2.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "Different IKM should produce different ciphers"
         );
         assert_ne!(
             c2_ikm1.encrypt(&nonce, plaintext.as_ref()).unwrap(),
             c2_ikm2.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "Different IKM should produce different ciphers"
         );
     }
 
@@ -284,7 +276,6 @@ mod tests {
             cipher_non_empty
                 .encrypt(&nonce, plaintext.as_ref())
                 .unwrap(),
-            "Empty and non-empty parameters should produce different results"
         );
     }
 
@@ -302,18 +293,10 @@ mod tests {
         let ciphertext = cipher.encrypt(&nonce, original_plaintext.as_ref()).unwrap();
         let decrypted = cipher.decrypt(&nonce, ciphertext.as_ref()).unwrap();
 
-        assert_eq!(
-            original_plaintext.as_ref(),
-            decrypted,
-            "Round-trip encryption/decryption should preserve the original message"
-        );
+        assert_eq!(original_plaintext.as_ref(), decrypted);
 
         // Verify ciphertext is actually different from plaintext
-        assert_ne!(
-            original_plaintext.as_ref(),
-            ciphertext.as_slice(),
-            "Ciphertext should be different from plaintext"
-        );
+        assert_ne!(original_plaintext.as_ref(), ciphertext.as_slice());
     }
 
     #[test]
@@ -328,10 +311,7 @@ mod tests {
         let ct1 = cipher.encrypt(&nonce1.into(), plaintext.as_ref()).unwrap();
         let ct2 = cipher.encrypt(&nonce2.into(), plaintext.as_ref()).unwrap();
 
-        assert_ne!(
-            ct1, ct2,
-            "Same message with different nonces should produce different ciphertexts"
-        );
+        assert_ne!(ct1, ct2);
     }
 
     #[test]
@@ -365,10 +345,7 @@ mod tests {
 
         // This should still work - HKDF can handle empty IKM
         let result = derive::<1>(&empty_ikm, salts, infos);
-        assert!(
-            result.is_ok(),
-            "Zero-length IKM should be handled gracefully"
-        );
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -381,7 +358,7 @@ mod tests {
         let infos: &[&[u8]] = &[large_info.as_slice()];
 
         let result = derive::<1>(&large_ikm, salts, infos);
-        assert!(result.is_ok(), "Large inputs should be handled correctly");
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -415,11 +392,7 @@ mod tests {
         // Ensure all are unique
         for i in 0..ciphertexts.len() {
             for j in (i + 1)..ciphertexts.len() {
-                assert_ne!(
-                    ciphertexts[i], ciphertexts[j],
-                    "All directional ciphertexts should be different (cipher {} vs {})",
-                    i, j
-                );
+                assert_ne!(ciphertexts[i], ciphertexts[j]);
             }
         }
     }
@@ -440,12 +413,10 @@ mod tests {
         assert_eq!(
             dir1.d2l.encrypt(&nonce, plaintext.as_ref()).unwrap(),
             dir2.d2l.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "d2l should be consistent"
         );
         assert_eq!(
             dir1.l2d.encrypt(&nonce, plaintext.as_ref()).unwrap(),
             dir2.l2d.encrypt(&nonce, plaintext.as_ref()).unwrap(),
-            "l2d should be consistent"
         );
     }
 
@@ -469,13 +440,9 @@ mod tests {
         let plaintext = b"sensitivity_test";
         let base_ct = base_dir.d2l.encrypt(&nonce, plaintext.as_ref()).unwrap();
 
-        for (i, variant) in variants.iter().enumerate() {
+        for variant in variants.iter() {
             let variant_ct = variant.d2l.encrypt(&nonce, plaintext.as_ref()).unwrap();
-            assert_ne!(
-                base_ct, variant_ct,
-                "Variant {} should produce different result",
-                i
-            );
+            assert_ne!(base_ct, variant_ct);
         }
     }
 
@@ -498,11 +465,7 @@ mod tests {
         let encrypted = directional.d2l.encrypt(&nonce, message.as_ref()).unwrap();
         let decrypted = directional.d2l.decrypt(&nonce, encrypted.as_ref()).unwrap();
 
-        assert_eq!(
-            message.as_ref(),
-            decrypted,
-            "Realistic scenario should work end-to-end"
-        );
+        assert_eq!(message.as_ref(), decrypted);
     }
 
     #[test]
@@ -517,11 +480,7 @@ mod tests {
 
         for i in 0..constants.len() {
             for j in (i + 1)..constants.len() {
-                assert_ne!(
-                    constants[i], constants[j],
-                    "Constants should be unique (constant {} vs {})",
-                    i, j
-                );
+                assert_ne!(constants[i], constants[j]);
             }
         }
     }

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -11,10 +11,10 @@ const CHACHA_KEY_SIZE: usize = <ChaCha20Poly1305 as KeySizeUser>::KeySize::USIZE
 const BASE_KDF_PREFIX: &[u8] = b"commonware-stream/KDF/v1/";
 
 // Constant infos for directional ciphers.
-const D2L_TRAFFIC_INFO: &[u8] = b"l2d/traffic";
-const L2D_TRAFFIC_INFO: &[u8] = b"d2l/traffic";
-const D2L_CONFIRMATION_INFO: &[u8] = b"l2d/confirmation";
-const L2D_CONFIRMATION_INFO: &[u8] = b"d2l/confirmation";
+const TRAFFIC_INFO_D2L: &[u8] = b"d2l/traffic";
+const TRAFFIC_INFO_L2D: &[u8] = b"l2d/traffic";
+const CONFIRMATION_INFO_D2L: &[u8] = b"d2l/confirmation";
+const CONFIRMATION_INFO_L2D: &[u8] = b"l2d/confirmation";
 
 /// Return value when deriving directional ciphers.
 pub struct DirectionalCipher {
@@ -38,10 +38,10 @@ pub fn derive_directional(
     handshake_transcript: &[u8],
 ) -> Result<DirectionalCipher, Error> {
     let infos = [
-        D2L_TRAFFIC_INFO,
-        L2D_TRAFFIC_INFO,
-        D2L_CONFIRMATION_INFO,
-        L2D_CONFIRMATION_INFO,
+        TRAFFIC_INFO_D2L,
+        TRAFFIC_INFO_L2D,
+        CONFIRMATION_INFO_D2L,
+        CONFIRMATION_INFO_L2D,
     ];
     let salts = [namespace, handshake_transcript];
     let ciphers = derive::<4>(ikm, &salts, &infos)?;
@@ -505,10 +505,10 @@ mod tests {
     fn test_constants_are_unique() {
         // Ensure all constant info strings are different
         let constants = [
-            D2L_TRAFFIC_INFO,
-            L2D_TRAFFIC_INFO,
-            D2L_CONFIRMATION_INFO,
-            L2D_CONFIRMATION_INFO,
+            TRAFFIC_INFO_D2L,
+            TRAFFIC_INFO_L2D,
+            CONFIRMATION_INFO_D2L,
+            CONFIRMATION_INFO_L2D,
         ];
 
         for i in 0..constants.len() {

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -4,10 +4,11 @@ use commonware_cryptography::{CoreSha256, Hasher, Sha256};
 use hkdf::{hmac::digest::typenum::Unsigned, Hkdf};
 use zeroize::Zeroize;
 
-// The size of the key used by the ChaCha20Poly1305 cipher.
+/// The size of the key used by the ChaCha20Poly1305 cipher.
 const CHACHA_KEY_SIZE: usize = <ChaCha20Poly1305 as KeySizeUser>::KeySize::USIZE;
 
-// A constant prefix used for the salt hash in the HKDF key derivation.
+/// A constant prefix used for the salt hash in the HKDF key derivation.
+/// This prevents key derivation collisions with other applications.
 const BASE_KDF_PREFIX: &[u8] = b"commonware-stream/KDF/v1/";
 
 // Constant infos for directional ciphers.
@@ -17,6 +18,9 @@ const CONFIRMATION_INFO_D2L: &[u8] = b"d2l/confirmation";
 const CONFIRMATION_INFO_L2D: &[u8] = b"l2d/confirmation";
 
 /// Return value when deriving directional ciphers.
+///
+/// Contains all four ciphers needed for a complete bidirectional encrypted connection:
+/// two for traffic (one per direction) and two for key confirmation during handshake.
 pub struct DirectionalCipher {
     /// The cipher used for sending messages from the dialer to the listener.
     pub d2l: ChaCha20Poly1305,

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -757,7 +757,7 @@ mod tests {
             // Spawn a mock peer that responds with a ListenerResponse containing an all-zero ephemeral key
             context.with_label("mock_peer").spawn({
                 let namespace = dialer_config.namespace.clone();
-                let recipient = dialer_config.crypto.public_key();
+                let recipient_pk = dialer_config.crypto.public_key();
                 move |context| async move {
                     use chacha20poly1305::KeyInit;
 
@@ -772,7 +772,7 @@ mod tests {
                     // Create a custom handshake info bytes with zero ephemeral key
                     let timestamp = context.current().epoch_millis();
                     let info = handshake::Info::new(
-                        recipient,
+                        recipient_pk,
                         x25519::PublicKey::from_bytes([0u8; 32]),
                         timestamp,
                     );

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -1,4 +1,4 @@
-use super::{cipher, handshake, nonce, x25519, Config, ENCRYPTION_TAG_LENGTH};
+use super::{cipher, handshake, nonce, x25519, Config, AUTHENTICATION_TAG_LENGTH};
 use crate::{
     public_key::cipher::DirectionalCipher,
     utils::codec::{recv_frame, send_frame},
@@ -384,7 +384,7 @@ impl<Si: Sink> crate::Sender for Sender<Si> {
         send_frame(
             &mut self.sink,
             &msg,
-            self.max_message_size + ENCRYPTION_TAG_LENGTH,
+            self.max_message_size + AUTHENTICATION_TAG_LENGTH,
         )
         .await?;
         Ok(())
@@ -404,7 +404,7 @@ impl<St: Stream> crate::Receiver for Receiver<St> {
         // Read data
         let msg = recv_frame(
             &mut self.stream,
-            self.max_message_size + ENCRYPTION_TAG_LENGTH,
+            self.max_message_size + AUTHENTICATION_TAG_LENGTH,
         )
         .await?;
 
@@ -475,7 +475,7 @@ mod tests {
             };
 
             let result = sender.send(message).await;
-            let expected_length = message.len() + ENCRYPTION_TAG_LENGTH;
+            let expected_length = message.len() + AUTHENTICATION_TAG_LENGTH;
             assert!(matches!(result, Err(Error::SendTooLarge(n)) if n == expected_length));
         });
     }
@@ -503,7 +503,7 @@ mod tests {
 
             sender.send(message).await.unwrap();
             let result = receiver.receive().await;
-            let expected_length = message.len() + ENCRYPTION_TAG_LENGTH;
+            let expected_length = message.len() + AUTHENTICATION_TAG_LENGTH;
             assert!(matches!(result, Err(Error::RecvTooLarge(n)) if n == expected_length));
         });
     }

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -216,8 +216,14 @@ pub struct KeyConfirmation {
 impl KeyConfirmation {
     /// Create a new key confirmation using the provided cipher and handshake transcript.
     ///
-    /// The confirmation encrypts the handshake transcript to demonstrate
-    /// knowledge of the shared secret and bind the confirmation to the entire handshake exchange.
+    /// The confirmation encrypts the handshake transcript to demonstrate knowledge of the shared
+    /// secret and bind the confirmation to the entire handshake exchange.
+    ///
+    /// # Security
+    ///
+    /// To prevent nonce-reuse, the cipher should **not** be the same cipher used for future
+    /// encrypted messages, but should be generated from the same shared secret. The function takes
+    /// ownership of the cipher to help prevent this.
     pub fn create(mut cipher: ChaCha20Poly1305, transcript: &[u8]) -> Result<Self, Error> {
         // Encrypt the confirmation using the transcript as associated data
         let tag = cipher

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -119,11 +119,6 @@ impl<C: PublicKey> Signed<C> {
         self.info.ephemeral_public_key
     }
 
-    /// Get the timestamp from the handshake message.
-    pub fn timestamp(&self) -> u64 {
-        self.info.timestamp
-    }
-
     /// Verify a signed handshake message.
     pub fn verify<E: Clock>(
         &self,

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -119,6 +119,7 @@ impl<C: PublicKey> Signed<C> {
         self.info.ephemeral_public_key
     }
 
+    /// Get the timestamp from the handshake message.
     pub fn timestamp(&self) -> u64 {
         self.info.timestamp
     }
@@ -206,12 +207,12 @@ impl<C: PublicKey> EncodeSize for Signed<C> {
     }
 }
 
-/// Cryptographic proof that a party can correctly derive the shared secret.
+/// Key confirmation message used during the handshake process.
 ///
-/// This is used in the 3-message handshake protocol to ensure mutual authentication.
-/// Each party encrypts the handshake transcript using the derived shared secret,
-/// producing an AEAD tag that serves as proof of knowledge of the correct key material
-/// and binds the confirmation to the complete handshake exchange.
+/// This struct contains cryptographic proof that a party can correctly derive
+/// the shared secret from the Diffie-Hellman exchange. It prevents attacks where
+/// an adversary might forward handshake messages without actually knowing the
+/// corresponding private keys.
 pub struct KeyConfirmation {
     /// AEAD tag of the encrypted proof demonstrating knowledge of the shared secret.
     tag: Tag<ChaCha20Poly1305>,
@@ -276,6 +277,7 @@ pub struct ListenerResponse<C: PublicKey> {
 }
 
 impl<C: PublicKey> ListenerResponse<C> {
+    /// Create a new listener response with the given handshake and key confirmation.
     pub fn new(handshake: Signed<C>, key_confirmation: KeyConfirmation) -> Self {
         Self {
             handshake,
@@ -283,6 +285,10 @@ impl<C: PublicKey> ListenerResponse<C> {
         }
     }
 
+    /// Extract the handshake and key confirmation from this response.
+    ///
+    /// This consumes the response and returns its constituent parts,
+    /// which is useful during the handshake verification process.
     pub fn into_parts(self) -> (Signed<C>, KeyConfirmation) {
         (self.handshake, self.key_confirmation)
     }

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -1,6 +1,6 @@
 //! Operations over handshake messages.
 
-use super::{x25519, ENCRYPTION_TAG_LENGTH};
+use super::{x25519, AUTHENTICATION_TAG_LENGTH};
 use crate::Error;
 use bytes::{Buf, BufMut};
 use chacha20poly1305::{
@@ -245,7 +245,7 @@ impl KeyConfirmation {
 
 impl Write for KeyConfirmation {
     fn write(&self, buf: &mut impl BufMut) {
-        let tag_bytes: [u8; ENCRYPTION_TAG_LENGTH] = self.tag.into();
+        let tag_bytes: [u8; AUTHENTICATION_TAG_LENGTH] = self.tag.into();
         tag_bytes.write(buf);
     }
 }
@@ -254,13 +254,13 @@ impl Read for KeyConfirmation {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
-        let tag = <[u8; ENCRYPTION_TAG_LENGTH]>::read_cfg(buf, &())?;
+        let tag = <[u8; AUTHENTICATION_TAG_LENGTH]>::read_cfg(buf, &())?;
         Ok(Self { tag: tag.into() })
     }
 }
 
 impl FixedSize for KeyConfirmation {
-    const SIZE: usize = ENCRYPTION_TAG_LENGTH;
+    const SIZE: usize = AUTHENTICATION_TAG_LENGTH;
 }
 
 /// Message 2 in the 3-message handshake protocol: Listener's response with key confirmation.

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -268,15 +268,15 @@ pub struct ListenerResponse<C: PublicKey> {
     handshake: Signed<C>,
 
     /// Key confirmation that the listener can derive the shared secret
-    key_confirmation: KeyConfirmation,
+    confirmation: KeyConfirmation,
 }
 
 impl<C: PublicKey> ListenerResponse<C> {
     /// Create a new listener response with the given handshake and key confirmation.
-    pub fn new(handshake: Signed<C>, key_confirmation: KeyConfirmation) -> Self {
+    pub fn new(handshake: Signed<C>, confirmation: KeyConfirmation) -> Self {
         Self {
             handshake,
-            key_confirmation,
+            confirmation,
         }
     }
 
@@ -285,14 +285,14 @@ impl<C: PublicKey> ListenerResponse<C> {
     /// This consumes the response and returns its constituent parts,
     /// which is useful during the handshake verification process.
     pub fn into_parts(self) -> (Signed<C>, KeyConfirmation) {
-        (self.handshake, self.key_confirmation)
+        (self.handshake, self.confirmation)
     }
 }
 
 impl<C: PublicKey> Write for ListenerResponse<C> {
     fn write(&self, buf: &mut impl BufMut) {
         self.handshake.write(buf);
-        self.key_confirmation.write(buf);
+        self.confirmation.write(buf);
     }
 }
 
@@ -301,17 +301,17 @@ impl<C: PublicKey> Read for ListenerResponse<C> {
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let handshake = Signed::read(buf)?;
-        let key_confirmation = KeyConfirmation::read(buf)?;
+        let confirmation = KeyConfirmation::read(buf)?;
         Ok(Self {
             handshake,
-            key_confirmation,
+            confirmation,
         })
     }
 }
 
 impl<C: PublicKey> EncodeSize for ListenerResponse<C> {
     fn encode_size(&self) -> usize {
-        self.handshake.encode_size() + self.key_confirmation.encode_size()
+        self.handshake.encode_size() + self.confirmation.encode_size()
     }
 }
 

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -64,6 +64,10 @@
 
 use std::time::Duration;
 
+// When encrypting data, an encryption tag is appended to the ciphertext.
+// This constant represents the size of the encryption tag in bytes.
+const ENCRYPTION_TAG_LENGTH: usize = 16;
+
 mod cipher;
 mod connection;
 use commonware_cryptography::Signer;

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -21,6 +21,7 @@
 //! and the **listener** receives this connection. The protocol works as follows:
 //!
 //! ### Message 1: Dialer → Listener (Initial Handshake)
+//!
 //! Upon establishing a TCP connection, the dialer sends a signed handshake message to the listener.
 //! This message contains the dialer's signature and static public key, plus:
 //!
@@ -29,6 +30,7 @@
 //! - The current timestamp (for replay attack prevention)
 //!
 //! ### Message 2: Listener → Dialer (Response with Key Confirmation)
+//!
 //! The listener verifies:
 //! - Public keys are well-formatted
 //! - Timestamp is valid (not too old, not too far in the future)
@@ -43,6 +45,7 @@
 //! 4. Sends back a `ListenerResponse` containing both the signed handshake and key confirmation
 //!
 //! ### Message 3: Dialer → Listener (Final Confirmation)
+//!
 //! The dialer:
 //!
 //! 1. Verifies the listener's signed handshake message
@@ -52,6 +55,7 @@
 //! 5. Sends the key confirmation to complete mutual authentication
 //!
 //! ### Security Properties
+//!
 //! This protocol provides:
 //!
 //! - **Mutual Authentication**: Both parties prove knowledge of their static private keys through
@@ -62,14 +66,14 @@
 //! - **Forward Secrecy**: Ephemeral keys ensure compromise of long-term static keys doesn't affect past
 //!   or future sessions
 //!
-//! A configurable deadline is enforced for handshake completion to protect against DOS attacks by
+//! A configurable deadline is enforced for handshake completion to protect against DoS attacks by
 //! malicious peers that create connections but abandon handshakes.
 //!
 //! ## Encryption
 //!
 //! During the handshake, a shared X25519 secret is established using
 //! Diffie-Hellman key exchange. This secret is combined with the handshake
-//! transcript to derive separate ChaCha20-Poly1305 ciphers:
+//! transcript to derive four separate ChaCha20-Poly1305 ciphers:
 //!
 //! - **Confirmation Ciphers**: One cipher per direction for key confirmation during the handshake
 //! - **Traffic Ciphers**: One cipher per direction for encrypting post-handshake traffic
@@ -81,10 +85,10 @@
 //! Each direction of communication uses a 12-byte nonce derived from a counter that is
 //! incremented for each message sent. This provides a maximum of 2^96 messages per sender,
 //! which would be sufficient for over 2.5 trillion years of continuous communication at a rate of
-//! 1 billion messages per second—sufficient for all practical use cases. This
-//! approach ensures that well-behaving peers can remain connected
-//! indefinitely as long as they both stay online (maximizing p2p network stability). In the unlikely case of
-//! counter overflow, a new connection should be established.
+//! 1 billion messages per second—sufficient for all practical use cases. This approach ensures that
+//! well-behaving peers can remain connected indefinitely as long as they both stay online
+//! (maximizing p2p network stability). In the unlikely case of counter overflow, the connection
+//! will be terminated and a new connection should be established.
 //!
 //! This prevents nonce reuse (which would compromise message confidentiality)
 //! and saves bandwidth (as there is no need to transmit nonces alongside encrypted messages).

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -11,9 +11,9 @@
 //!
 //! ## Handshake
 //!
-//! When establishing a connection with a peer, a simple handshake is performed
+//! When establishing a connection with a peer, a 3-message handshake is performed
 //! to authenticate each other and to establish a shared secret for connection
-//! encryption (explained below). This simple handshake is done in lieu of using
+//! encryption (explained below). This handshake is done in lieu of using
 //! TLS, Noise, WireGuard, etc. because it supports the usage of arbitrary
 //! cryptographic schemes, there is no protocol negotiation (only one way to
 //! connect), because it only takes a few hundred lines of code to implement
@@ -21,22 +21,49 @@
 //! it can be simulated deterministically.
 //!
 //! In any handshake, the dialer is the party that attempts to connect to some known address/identity (public key)
-//! and the recipient of this connection is the listener. Upon forming a TCP connection, the dialer sends a signed
-//! handshake message to the listener. Besides the signature and the public key of the dialer, the handshake message
-//! contains:
+//! and the recipient of this connection is the listener. The 3-message handshake protocol works as follows:
+//!
+//! ### Message 1: Dialer → Listener (Initial Handshake)
+//! Upon forming a TCP connection, the dialer sends a signed handshake message to the listener.
+//! Besides the signature and the public key of the dialer, the handshake message contains:
 //!
 //! - The receiver's public key.
 //! - The sender's ephemeral public key (used to establish a shared secret).
 //! - The current timestamp (used to prevent replay attacks).
 //!
+//! ### Message 2: Listener → Dialer (Response with Key Confirmation)
 //! The listener verifies the public keys are well-formatted, the timestamp is valid (not too old/not too far in the future),
 //! and that the signature is valid. If all these checks pass, the listener checks to see if it is already connected or dialing
-//! this peer. If it is, it drops the connection. If it isn't, it sends back its own signed handshake message (same as above)
-//! and considers the connection established.
+//! this peer. If it is, it drops the connection. If it isn't, the listener:
 //!
-//! Upon receiving the listener's handshake message, the dialer verifies the same data as the listener and additionally verifies
-//! that the public key returned matches what they expected at the address. If all these checks pass, the dialer considers the
-//! connection established. If not, the dialer drops the connection.
+//! 1. Creates its own signed handshake message (same format as above)
+//! 2. Derives the shared secret from the ephemeral keys
+//! 3. Creates a key confirmation by encrypting the complete handshake transcript using the derived shared secret
+//! 4. Sends back a `ListenerResponse` containing both the signed handshake and key confirmation
+//!
+//! This key confirmation serves as cryptographic proof that the listener can correctly derive the shared secret,
+//! ensuring that only parties with the correct key material can proceed.
+//!
+//! ### Message 3: Dialer → Listener (Final Confirmation)
+//! Upon receiving the listener's response, the dialer:
+//!
+//! 1. Verifies the listener's signed handshake message (same checks as the listener performed)
+//! 2. Additionally verifies that the public key returned matches what they expected at the address
+//! 3. Derives the shared secret and verifies the listener's key confirmation
+//! 4. Creates its own key confirmation using the same handshake transcript
+//! 5. Sends the key confirmation to the listener to complete mutual authentication
+//!
+//! The listener then verifies the dialer's key confirmation. If all checks pass, both parties
+//! consider the connection established with mutual authentication.
+//!
+//! ### Security Properties
+//! This 3-message protocol provides several important security properties:
+//!
+//! - **Mutual Authentication**: Both parties prove knowledge of their private keys through signatures
+//! - **Key Confirmation**: Both parties prove they can derive the correct shared secret
+//! - **Transcript Binding**: Key confirmations are bound to the complete handshake exchange
+//! - **Replay Protection**: Timestamps prevent reuse of old handshake messages
+//! - **Forward Secrecy**: Ephemeral keys ensure compromise of long-term keys doesn't affect past sessions
 //!
 //! To better protect against malicious peers that create and/or accept connections but do not participate in handshakes,
 //! a configurable deadline is enforced for any handshake to be completed. This allows for the underlying runtime to maintain
@@ -46,8 +73,13 @@
 //!
 //! During the handshake (described above), a shared x25519 secret is established using a
 //! Diffie-Hellman Key Exchange. This x25519 secret is then used in-conjunction with the handshake
-//! data in a key-derivation-function to create a pair of ChaCha20-Poly1305 ciphers. One cipher per
-//! direction allows for encryption of all messages.
+//! transcript in a key-derivation-function to create multiple ChaCha20-Poly1305 ciphers:
+//!
+//! - **Confirmation Ciphers**: One cipher per direction for key-confirmation during the handshake
+//! - **Traffic Ciphers**: One cipher per direction for encrypting normal traffic
+//!
+//! The use of the complete handshake transcript in the key derivation ensures that the derived keys
+//! are bound to the specific handshake exchange, providing additional security against various attacks.
 //!
 //! Each direction of communication also uses a 12-byte nonce derived from a counter that is
 //! incremented for each message sent. This provides for a maximum of 2^96 messages per sender,
@@ -62,11 +94,11 @@
 //! message). This also avoids accidental reuse of a nonce over long-lived connections (for example
 //! when setting it to be a small hash as in XChaCha20-Poly1305).
 
+use chacha20poly1305::{
+    aead::{generic_array::typenum::Unsigned, AeadCore},
+    ChaCha20Poly1305,
+};
 use std::time::Duration;
-
-// When encrypting data, an encryption tag is appended to the ciphertext.
-// This constant represents the size of the encryption tag in bytes.
-const ENCRYPTION_TAG_LENGTH: usize = 16;
 
 mod cipher;
 mod connection;
@@ -75,6 +107,10 @@ pub use connection::{Connection, IncomingConnection, Receiver, Sender};
 pub mod handshake;
 mod nonce;
 pub mod x25519;
+
+// When encrypting data, an authentication tag is appended to the ciphertext.
+// This constant represents the size of the authentication tag in bytes.
+const AUTHENTICATION_TAG_LENGTH: usize = <ChaCha20Poly1305 as AeadCore>::TagSize::USIZE;
 
 /// Configuration for a connection.
 ///

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -35,7 +35,6 @@
 //! - Public keys are well-formatted
 //! - Timestamp is valid (not too old, not too far in the future)
 //! - Signature is valid
-//! - It is not already connected to or dialing this peer
 //!
 //! If all checks pass, the listener:
 //!

--- a/stream/src/public_key/nonce.rs
+++ b/stream/src/public_key/nonce.rs
@@ -5,7 +5,7 @@ use chacha20poly1305::Nonce;
 /// the nonce is used. Is able to be incremented up-to 96 bits (12 bytes) before overflowing.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Info {
-    pub counter: u128,
+    counter: u128,
 }
 
 /// If the counter is greater-than-or-equal to this value, it is considered to have overflowed.
@@ -13,6 +13,11 @@ pub struct Info {
 const OVERFLOW_VALUE: u128 = 1 << 96;
 
 impl Info {
+    /// Create a new nonce with the given counter value.
+    pub fn new(counter: u128) -> Self {
+        Self { counter }
+    }
+
     /// Encodes the nonce information into a 12-byte array and increments the nonce by 1 (to prevent
     /// reuse).
     ///

--- a/stream/src/public_key/nonce.rs
+++ b/stream/src/public_key/nonce.rs
@@ -5,7 +5,7 @@ use chacha20poly1305::Nonce;
 /// the nonce is used. Is able to be incremented up-to 96 bits (12 bytes) before overflowing.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Info {
-    counter: u128,
+    pub counter: u128,
 }
 
 /// If the counter is greater-than-or-equal to this value, it is considered to have overflowed.

--- a/stream/src/public_key/nonce.rs
+++ b/stream/src/public_key/nonce.rs
@@ -13,11 +13,6 @@ pub struct Info {
 const OVERFLOW_VALUE: u128 = 1 << 96;
 
 impl Info {
-    /// Create a new nonce with the given counter value.
-    pub fn new(counter: u128) -> Self {
-        Self { counter }
-    }
-
     /// Encodes the nonce information into a 12-byte array and increments the nonce by 1 (to prevent
     /// reuse).
     ///

--- a/stream/src/public_key/nonce.rs
+++ b/stream/src/public_key/nonce.rs
@@ -1,15 +1,29 @@
 use crate::Error;
 use chacha20poly1305::Nonce;
 
-/// A struct that holds the nonce information. Holds a counter value that is incremented each time
-/// the nonce is used. Is able to be incremented up-to 96 bits (12 bytes) before overflowing.
+/// A struct that holds the nonce information for ChaCha20-Poly1305 encryption.
+///
+/// This struct manages a 96-bit counter that is used to generate unique nonces
+/// for each message. The counter can be incremented up to 2^96 times before
+/// overflowing, providing sufficient nonces for practical use cases.
+///
+/// # Security
+///
+/// Nonce reuse with the same key would allow an attacker to decrypt messages
+/// or forge authentication tags. This implementation prevents reuse by:
+/// - Using a monotonically increasing counter
+/// - Preventing overflow back to zero
+/// - Returning errors when the counter would overflow
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Info {
     counter: u128,
 }
 
-/// If the counter is greater-than-or-equal to this value, it is considered to have overflowed.
-/// This is 2^96 or, in binary, one followed by 96 zeros.
+/// Maximum valid counter value before overflow (2^96).
+///
+/// If the counter reaches this value, it is considered to have overflowed
+/// the 96-bit nonce space. This prevents wrapping back to zero which would
+/// cause nonce reuse.
 const OVERFLOW_VALUE: u128 = 1 << 96;
 
 impl Info {

--- a/stream/src/public_key/x25519.rs
+++ b/stream/src/public_key/x25519.rs
@@ -54,7 +54,10 @@ impl FixedSize for PublicKey {
     const SIZE: usize = 32;
 }
 
-/// Generate a new ephemeral secret.
+/// Generate a new ephemeral secret for X25519 key exchange.
+///
+/// This creates a fresh ephemeral secret key that should be used for a single
+/// key exchange and then discarded. The ephemeral nature provides forward secrecy.
 pub fn new<R: Rng + CryptoRng>(rng: &mut R) -> EphemeralSecret {
     EphemeralSecret::random_from_rng(rng)
 }


### PR DESCRIPTION
Fixes #1076 
Fixes #1018 by not letting a "spoofing" party keep the connection open longer than the handshake timeout (see https://github.com/commonwarexyz/monorepo/pull/1132#discussion_r2158034085)

TODO:
- [x] Rename `AuthenticationProof` as `KeyConfirmation`
  - [x] See if there's a good way to simplify this type as well, and have it implement `FixedSize`
- [x] Update documentation to reflect the new behavior
- [x] Ensure tests look good and have full coverage