### PR TITLE
[storage] remove async from signatures of methods that don't need it

### DIFF
--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -535,7 +535,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
 
     /// Return true if the given sequence of `ops` were applied starting at location `start_loc` in
     /// the log with the provided root.
-    pub async fn verify_proof(
+    pub fn verify_proof(
         hasher: &mut Standard<H>,
         proof: &Proof<H>,
         start_loc: u64,
@@ -553,7 +553,6 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
 
         proof
             .verify_range_inclusion(hasher, digests, start_pos, end_pos, root_digest)
-            .await
             .map_err(Error::MmrError)
     }
 
@@ -1052,7 +1051,6 @@ mod test {
                         &log,
                         &root
                     )
-                    .await
                     .unwrap()
                 );
             }

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -468,7 +468,7 @@ impl<
 
     /// Return true if the given sequence of `ops` were applied starting at location `start_loc` in
     /// the log with the provided root.
-    pub async fn verify_range_proof(
+    pub fn verify_range_proof(
         hasher: &mut Standard<H>,
         proof: &Proof<H>,
         start_loc: u64,
@@ -508,7 +508,6 @@ impl<
         if op_count % Bitmap::<H, N>::CHUNK_SIZE_BITS == 0 {
             return proof
                 .verify_range_inclusion(&mut verifier, digests, start_pos, end_pos, root_digest)
-                .await
                 .map_err(Error::MmrError);
         }
 
@@ -521,10 +520,7 @@ impl<
         let last_chunk_digest = proof.digests.pop().unwrap();
 
         // Reconstruct the MMR root.
-        let mmr_root = match proof
-            .reconstruct_root(&mut verifier, digests, start_pos, end_pos)
-            .await
-        {
+        let mmr_root = match proof.reconstruct_root(&mut verifier, digests, start_pos, end_pos) {
             Ok(root) => root,
             Err(MissingDigests) => {
                 debug!("Not enough digests in proof to reconstruct root");
@@ -626,7 +622,6 @@ impl<
         if op_count % Bitmap::<H, N>::CHUNK_SIZE_BITS == 0 {
             return proof
                 .verify_element_inclusion(&mut verifier, &digest, pos, root_digest)
-                .await
                 .map_err(Error::MmrError);
         }
 
@@ -652,10 +647,7 @@ impl<
         }
 
         // Reconstruct the MMR root.
-        let mmr_root = match proof
-            .reconstruct_root(&mut verifier, &[digest], pos, pos)
-            .await
-        {
+        let mmr_root = match proof.reconstruct_root(&mut verifier, &[digest], pos, pos) {
             Ok(root) => root,
             Err(MissingDigests) => {
                 debug!("Not enough digests in proof to reconstruct root");
@@ -1061,7 +1053,6 @@ pub mod test {
                         &chunks,
                         &root
                     )
-                    .await
                     .unwrap(),
                     "failed to verify range at start_loc {start_loc}",
                 );

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -66,7 +66,6 @@ fn bench_prove_many_elements(c: &mut Criterion) {
                                             end_pos,
                                             &root_digest,
                                         )
-                                        .await
                                         .unwrap());
                                 }
                             })

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -46,7 +46,6 @@ fn bench_prove_single_element(c: &mut Criterion) {
                                         pos,
                                         &root_digest,
                                     )
-                                    .await
                                     .unwrap());
                             }
                         });

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -594,9 +594,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
         };
 
         if bit_count % Self::CHUNK_SIZE_BITS == 0 {
-            return mmr_proof
-                .verify_element_inclusion(hasher, chunk, leaf_pos, root_digest)
-                .await;
+            return mmr_proof.verify_element_inclusion(hasher, chunk, leaf_pos, root_digest);
         }
 
         if proof.digests.is_empty() {
@@ -629,10 +627,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
 
         // For the case where the proof is over a bit in a full chunk, `last_digest` contains the
         // digest of that chunk.
-        let mmr_root = match mmr_proof
-            .reconstruct_root(hasher, &[chunk], leaf_pos, leaf_pos)
-            .await
-        {
+        let mmr_root = match mmr_proof.reconstruct_root(hasher, &[chunk], leaf_pos, leaf_pos) {
             Ok(root) => root,
             Err(MissingDigests) => {
                 debug!("Not enough digests in proof to reconstruct root");

--- a/storage/src/mmr/hasher.rs
+++ b/storage/src/mmr/hasher.rs
@@ -814,7 +814,6 @@ mod tests {
                     let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![&p1]);
                     assert!(proof
                         .verify_element_inclusion(&mut verifier, &b1, pos, &grafted_storage_root)
-                        .await
                         .unwrap());
 
                     let pos = 1;
@@ -823,7 +822,6 @@ mod tests {
                         .unwrap();
                     assert!(proof
                         .verify_element_inclusion(&mut verifier, &b2, pos, &grafted_storage_root)
-                        .await
                         .unwrap());
 
                     let pos = 3;
@@ -833,7 +831,6 @@ mod tests {
                     let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 1, vec![&p2]);
                     assert!(proof
                         .verify_element_inclusion(&mut verifier, &b3, pos, &grafted_storage_root)
-                        .await
                         .unwrap());
 
                     let pos = 4;
@@ -842,7 +839,6 @@ mod tests {
                         .unwrap();
                     assert!(proof
                         .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
-                        .await
                         .unwrap());
                 }
 
@@ -856,39 +852,33 @@ mod tests {
                     let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 1, vec![&p2]);
                     assert!(proof
                         .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
-                        .await
                         .unwrap());
 
                     // Proof should fail if we try to verify the wrong leaf element.
                     assert!(!proof
                         .verify_element_inclusion(&mut verifier, &b3, pos, &grafted_storage_root)
-                        .await
                         .unwrap());
 
                     // Proof should fail if we use the wrong root.
                     assert!(!proof
                         .verify_element_inclusion(&mut verifier, &b4, pos, &peak_root)
-                        .await
                         .unwrap());
 
                     // Proof should fail if we use the wrong position
                     assert!(!proof
                         .verify_element_inclusion(&mut verifier, &b4, 3, &grafted_storage_root)
-                        .await
                         .unwrap());
 
                     // Proof should fail if we inject the wrong peak element into the verifier.
                     let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 1, vec![&p1]);
                     assert!(!proof
                         .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
-                        .await
                         .unwrap());
 
                     // Proof should fail if we give the verifier the wrong peak tree leaf number.
                     let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 2, vec![&p1]);
                     assert!(!proof
                         .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
-                        .await
                         .unwrap());
                 }
 
@@ -902,14 +892,12 @@ mod tests {
                     let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![&p1, &p2]);
                     assert!(proof
                         .verify_range_inclusion(&mut verifier, &range, 0, 4, &grafted_storage_root)
-                        .await
                         .unwrap());
 
                     // Confirm same proof fails with shortened verifier range.
                     let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![&p1]);
                     assert!(!proof
                         .verify_range_inclusion(&mut verifier, &range, 0, 4, &grafted_storage_root)
-                        .await
                         .unwrap());
                 }
             }
@@ -932,7 +920,6 @@ mod tests {
             let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![&p1]);
             assert!(proof
                 .verify_element_inclusion(&mut verifier, &b1, pos, &grafted_storage_root)
-                .await
                 .unwrap());
 
             let mut verifier = GraftingVerifier::new(GRAFTING_HEIGHT, 0, vec![]);
@@ -942,7 +929,6 @@ mod tests {
                 .unwrap();
             assert!(proof
                 .verify_element_inclusion(&mut verifier, &b5, pos, &grafted_storage_root)
-                .await
                 .unwrap());
         });
     }

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -724,7 +724,6 @@ mod tests {
                     test_element_pos,
                     &root,
                 )
-                .await
                 .unwrap());
 
             // Sync the MMR, make sure it flushes the in-mem MMR as expected.
@@ -752,7 +751,6 @@ mod tests {
                     last_element_pos,
                     &root
                 )
-                .await
                 .unwrap());
 
             mmr.destroy().await.unwrap();


### PR DESCRIPTION
These functions never `await` anything. (In the old code, they `await`ed completion of function calls which are no longer `async` after this change.)