### PR TITLE
[p2p] Use existing `Error::InvalidChannel` + Assert on Invalid Message Sends

### DIFF
--- a/p2p/src/authenticated/discovery/actors/peer/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/actor.rs
@@ -80,7 +80,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
             None => return Err(Error::PeerDisconnected),
         };
         assert!(
-            !rate_limits.contains_key(&data.channel),
+            rate_limits.contains_key(&data.channel),
             "outbound message on invalid channel"
         );
         Ok(data)

--- a/p2p/src/authenticated/discovery/actors/peer/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/actor.rs
@@ -206,12 +206,12 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                         types::Payload::Data(data) => {
                             match rate_limits.get(&data.channel) {
                                 Some(rate_limit) => rate_limit,
-                                None => { // Treat unknown channels as malformed
-                                    debug!(?peer, channel = data.channel, "unknown channel");
+                                None => { // Treat unknown channels as invalid
+                                    debug!(?peer, channel = data.channel, "invalid channel");
                                     self.received_messages
                                         .get_or_create(&metrics::Message::new_invalid(&peer))
                                         .inc();
-                                    return Err(Error::UnknownChannel);
+                                    return Err(Error::InvalidChannel);
                                 }
                             }
                         }

--- a/p2p/src/authenticated/discovery/actors/peer/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/actor.rs
@@ -71,14 +71,18 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
     }
 
     /// Unpack `msg` and verify the underlying `channel` is registered.
-    fn validate_msg<V>(msg: Option<Data>, rate_limits: &HashMap<u32, V>) -> Result<Data, Error> {
+    fn validate_outbound_msg<V>(
+        msg: Option<Data>,
+        rate_limits: &HashMap<u32, V>,
+    ) -> Result<Data, Error> {
         let data = match msg {
             Some(data) => data,
             None => return Err(Error::PeerDisconnected),
         };
-        if !rate_limits.contains_key(&data.channel) {
-            return Err(Error::InvalidChannel);
-        }
+        assert!(
+            !rate_limits.contains_key(&data.channel),
+            "outbound message on invalid channel"
+        );
         Ok(data)
     }
 
@@ -151,12 +155,12 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                                 .await?;
                         },
                         msg_high = self.high.next() => {
-                            let msg = Self::validate_msg(msg_high, &rate_limits)?;
+                            let msg = Self::validate_outbound_msg(msg_high, &rate_limits)?;
                             Self::send(&mut conn_sender, &self.sent_messages, metrics::Message::new_data(&peer, msg.channel), types::Payload::Data(msg))
                                 .await?;
                         },
                         msg_low = self.low.next() => {
-                            let msg = Self::validate_msg(msg_low, &rate_limits)?;
+                            let msg = Self::validate_outbound_msg(msg_low, &rate_limits)?;
                             Self::send(&mut conn_sender, &self.sent_messages, metrics::Message::new_data(&peer, msg.channel), types::Payload::Data(msg))
                                 .await?;
                         }

--- a/p2p/src/authenticated/discovery/actors/peer/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/actor.rs
@@ -70,7 +70,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
         )
     }
 
-    /// Unpack `msg` and verify the underlying `channel` is registered.
+    /// Unpack outbound `msg` and assert the underlying `channel` is registered.
     fn validate_outbound_msg<V>(
         msg: Option<Data>,
         rate_limits: &HashMap<u32, V>,

--- a/p2p/src/authenticated/discovery/actors/peer/mod.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/mod.rs
@@ -42,6 +42,4 @@ pub enum Error {
     UnexpectedFailure(commonware_runtime::Error),
     #[error("invalid channel")]
     InvalidChannel,
-    #[error("unknown channel")]
-    UnknownChannel,
 }

--- a/p2p/src/authenticated/lookup/actors/peer/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/peer/actor.rs
@@ -71,7 +71,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
             None => return Err(Error::PeerDisconnected),
         };
         assert!(
-            !rate_limits.contains_key(&data.channel),
+            rate_limits.contains_key(&data.channel),
             "outbound message on invalid channel"
         );
         Ok(data)

--- a/p2p/src/authenticated/lookup/actors/peer/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/peer/actor.rs
@@ -62,14 +62,18 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
     }
 
     /// Unpack `msg` and verify the underlying `channel` is registered.
-    fn validate_msg<V>(msg: Option<Data>, rate_limits: &HashMap<u32, V>) -> Result<Data, Error> {
+    fn validate_outbound_msg<V>(
+        msg: Option<Data>,
+        rate_limits: &HashMap<u32, V>,
+    ) -> Result<Data, Error> {
         let data = match msg {
             Some(data) => data,
             None => return Err(Error::PeerDisconnected),
         };
-        if !rate_limits.contains_key(&data.channel) {
-            return Err(Error::InvalidChannel);
-        }
+        assert!(
+            !rate_limits.contains_key(&data.channel),
+            "outbound message on invalid channel"
+        );
         Ok(data)
     }
 
@@ -140,12 +144,12 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                             }
                         },
                         msg_high = self.high.next() => {
-                            let msg = Self::validate_msg(msg_high, &rate_limits)?;
+                            let msg = Self::validate_outbound_msg(msg_high, &rate_limits)?;
                             Self::send(&mut conn_sender, &self.sent_messages, metrics::Message::new_data(&peer, msg.channel), msg.into())
                                 .await?;
                         },
                         msg_low = self.low.next() => {
-                            let msg = Self::validate_msg(msg_low, &rate_limits)?;
+                            let msg = Self::validate_outbound_msg(msg_low, &rate_limits)?;
                             Self::send(&mut conn_sender, &self.sent_messages, metrics::Message::new_data(&peer, msg.channel), msg.into())
                                 .await?;
                         }
@@ -190,7 +194,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                         types::Message::Data(data) => {
                             match rate_limits.get(&data.channel) {
                                 Some(rate_limit) => rate_limit,
-                                None => { // Treat unknown channels as invalid
+                                None => { // Treat unknown channels as malformed
                                     debug!(?peer, channel = data.channel, "invalid channel");
                                     self.received_messages
                                         .get_or_create(&metrics::Message::new_invalid(&peer))

--- a/p2p/src/authenticated/lookup/actors/peer/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/peer/actor.rs
@@ -194,7 +194,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                         types::Message::Data(data) => {
                             match rate_limits.get(&data.channel) {
                                 Some(rate_limit) => rate_limit,
-                                None => { // Treat unknown channels as malformed
+                                None => { // Treat unknown channels as invalid
                                     debug!(?peer, channel = data.channel, "invalid channel");
                                     self.received_messages
                                         .get_or_create(&metrics::Message::new_invalid(&peer))

--- a/p2p/src/authenticated/lookup/actors/peer/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/peer/actor.rs
@@ -190,12 +190,12 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                         types::Message::Data(data) => {
                             match rate_limits.get(&data.channel) {
                                 Some(rate_limit) => rate_limit,
-                                None => { // Treat unknown channels as malformed
-                                    debug!(?peer, channel = data.channel, "unknown channel");
+                                None => { // Treat unknown channels as invalid
+                                    debug!(?peer, channel = data.channel, "invalid channel");
                                     self.received_messages
                                         .get_or_create(&metrics::Message::new_invalid(&peer))
                                         .inc();
-                                    return Err(Error::UnknownChannel);
+                                    return Err(Error::InvalidChannel);
                                 }
                             }
                         }

--- a/p2p/src/authenticated/lookup/actors/peer/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/peer/actor.rs
@@ -61,7 +61,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
         )
     }
 
-    /// Unpack `msg` and verify the underlying `channel` is registered.
+    /// Unpack outbound `msg` and assert the underlying `channel` is registered.
     fn validate_outbound_msg<V>(
         msg: Option<Data>,
         rate_limits: &HashMap<u32, V>,

--- a/p2p/src/authenticated/lookup/actors/peer/mod.rs
+++ b/p2p/src/authenticated/lookup/actors/peer/mod.rs
@@ -37,6 +37,4 @@ pub enum Error {
     UnexpectedFailure(commonware_runtime::Error),
     #[error("invalid channel")]
     InvalidChannel,
-    #[error("unknown channel")]
-    UnknownChannel,
 }


### PR DESCRIPTION
Related: #1133 

We should align the error (which already exists) with the metric name.