### PR TITLE
[storage] add Proof::extract_pinned_nodes

### DIFF
--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -111,4 +111,8 @@ pub enum Error {
     Empty,
     #[error("invalid update")]
     InvalidUpdate,
+    #[error("invalid proof length")]
+    InvalidProofLength,
+    #[error("proof missing digest at position: {0}")]
+    MissingDigest(u64),
 }

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -966,7 +966,7 @@ mod tests {
                     } else {
                         // Multi-element case: test with various end positions
                         let mut ends = vec![start_pos]; // Single element proof
-                        
+
                         // Add a few more end positions if available
                         let start_idx = element_positions.iter().position(|&pos| pos == start_pos).unwrap();
                         if start_idx + 1 < element_positions.len() {
@@ -979,7 +979,7 @@ mod tests {
                         if *element_positions.last().unwrap() != start_pos {
                             ends.push(*element_positions.last().unwrap());
                         }
-                        
+
                         ends.into_iter().collect::<std::collections::HashSet<_>>().into_iter().collect()
                     };
 

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -351,7 +351,7 @@ impl<D: Digest> Proof<D> {
                 required_positions_len = required_positions.len(),
                 "Proof digest count doesn't match required positions",
             );
-            return Err(Error::MissingDigests);
+            return Err(Error::InvalidProofLength);
         }
 
         // Happy path: we can extract the pinned nodes directly from the proof.
@@ -374,7 +374,7 @@ impl<D: Digest> Proof<D> {
         for pinned_pos in pinned_positions {
             let Some(&digest) = position_to_digest.get(&pinned_pos) else {
                 debug!(pinned_pos, "Pinned node not found in proof");
-                return Err(Error::MissingDigests);
+                return Err(Error::MissingDigest(pinned_pos));
             };
             result.push(digest);
         }

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -351,6 +351,7 @@ impl<D: Digest> Proof<D> {
         }
 
         // Happy path: we can extract the pinned nodes directly from the proof.
+        // This happens when the `end_element_pos` is the last element in the MMR.
         if pinned_positions
             == required_positions[required_positions.len() - pinned_positions.len()..]
         {

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -338,11 +338,11 @@ impl<D: Digest> Proof<D> {
         // Get the positions of all nodes that should be pinned
         let pinned_positions: Vec<u64> = Self::nodes_to_pin(start_element_pos).collect();
 
-        // Get all positions required for the proof to understand the structure
+        // Get all positions required for the proof
         let required_positions =
             Self::nodes_required_for_range_proof(self.size, start_element_pos, end_element_pos);
 
-        // The proof digests correspond 1:1 with required_positions
+        // Should be the nodes in the proof
         if required_positions.len() != self.digests.len() {
             debug!(
                 "Proof digest count ({}) doesn't match required positions ({})",

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -350,6 +350,13 @@ impl<D: Digest> Proof<D> {
             return Err(Error::MissingDigests);
         }
 
+        // Happy path: we can extract the pinned nodes directly from the proof.
+        if pinned_positions
+            == required_positions[required_positions.len() - pinned_positions.len()..]
+        {
+            return Ok(self.digests[required_positions.len() - pinned_positions.len()..].to_vec());
+        }
+
         // Create a mapping from position to digest.
         let position_to_digest: HashMap<u64, D> = required_positions
             .iter()

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -335,35 +335,33 @@ impl<D: Digest> Proof<D> {
         start_element_pos: u64,
         end_element_pos: u64,
     ) -> Result<Vec<D>, Error> {
-        // Get the positions of all nodes that should be pinned
+        // Get the positions of all nodes that should be pinned.
         let pinned_positions: Vec<u64> = Self::nodes_to_pin(start_element_pos).collect();
 
-        // Get all positions required for the proof
+        // Get all positions required for the proof.
         let required_positions =
             Self::nodes_required_for_range_proof(self.size, start_element_pos, end_element_pos);
-
-        // Should be the nodes in the proof
         if required_positions.len() != self.digests.len() {
             debug!(
-                "Proof digest count ({}) doesn't match required positions ({})",
-                self.digests.len(),
-                required_positions.len()
+                digests_len = self.digests.len(),
+                required_positions_len = required_positions.len(),
+                "Proof digest count doesn't match required positions",
             );
             return Err(Error::MissingDigests);
         }
 
-        // Create a mapping from position to digest
+        // Create a mapping from position to digest.
         let position_to_digest: HashMap<u64, D> = required_positions
             .iter()
             .zip(self.digests.iter())
             .map(|(&pos, &digest)| (pos, digest))
             .collect();
 
-        // Extract the pinned nodes in the same order as nodes_to_pin
+        // Extract the pinned nodes in the same order as nodes_to_pin.
         let mut result = Vec::with_capacity(pinned_positions.len());
         for pinned_pos in pinned_positions {
             let Some(&digest) = position_to_digest.get(&pinned_pos) else {
-                debug!("Pinned node at position {} not found in proof", pinned_pos);
+                debug!(pinned_pos, "Pinned node not found in proof");
                 return Err(Error::MissingDigests);
             };
             result.push(digest);

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -959,11 +959,7 @@ mod tests {
                         let extract_result = proof.extract_pinned_nodes(start_pos, end_pos);
                         assert!(
                             extract_result.is_ok(),
-                            "Failed to extract pinned nodes for {} elements, boundary={}, range=[{}, {}]",
-                            num_elements,
-                            start_pos,
-                            start_pos,
-                            end_pos
+                            "Failed to extract pinned nodes for {num_elements} elements, boundary={start_pos}, range=[{start_pos}, {end_pos}]"
                         );
 
                         let pinned_nodes = extract_result.unwrap();
@@ -973,11 +969,7 @@ mod tests {
                         assert_eq!(
                             pinned_nodes.len(),
                             expected_pinned.len(),
-                            "Pinned node count mismatch for {} elements, boundary={}, range=[{}, {}]",
-                            num_elements,
-                            start_pos,
-                            start_pos,
-                            end_pos
+                            "Pinned node count mismatch for {num_elements} elements, boundary={start_pos}, range=[{start_pos}, {end_pos}]"
                         );
 
                         // Verify extracted hashes match actual node values
@@ -987,13 +979,7 @@ mod tests {
                             let actual_hash = mmr.get_node(expected_pos).unwrap();
                             assert_eq!(
                                 extracted_hash, actual_hash,
-                                "Hash mismatch at position {} (index {}) for {} elements, boundary={}, range=[{}, {}]",
-                                expected_pos,
-                                i,
-                                num_elements,
-                                start_pos,
-                                start_pos,
-                                end_pos
+                                "Hash mismatch at position {expected_pos} (index {i}) for {num_elements} elements, boundary={start_pos}, range=[{start_pos}, {end_pos}]"
                             );
                         }
                     }


### PR DESCRIPTION
Adds a helper that allows us to infer the hashes of pinned nodes from a proof. This will be used in syncing.

As with https://github.com/commonwarexyz/monorepo/pull/1156, I'll keep this in draft mode until we've staged more syncing code (i.e. code that uses this new method.)