### PR TITLE
[storage] Require proofs have at least 1 operation

### DIFF
--- a/storage/src/adb/mod.rs
+++ b/storage/src/adb/mod.rs
@@ -32,4 +32,7 @@ pub enum Error {
     /// The requested key was not found in the snapshot.
     #[error("key not found")]
     KeyNotFound(),
+
+    #[error("empty proof")]
+    EmptyProof,
 }


### PR DESCRIPTION
I don't think proofs with 0 operations are well-defined: no operations are actually being proven.

This PR changes proof generation (`proof()`) and validation (`verify_proof()`) to require that the number of operations in non-zero.