### PR TITLE
[storage/mmr/verification.rs] remove Error being returned from proof verification functions

### DIFF
--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -16,7 +16,7 @@ use crate::{
         hasher::{Grafting, GraftingVerifier, Hasher, Standard},
         iterator::{leaf_num_to_pos, leaf_pos_to_num},
         storage::Grafting as GStorage,
-        verification::{Proof, ReconstructionError},
+        verification::Proof,
     },
 };
 use commonware_codec::FixedSize;
@@ -525,12 +525,8 @@ impl<
         // Reconstruct the MMR root.
         let mmr_root = match proof.reconstruct_root(&mut verifier, digests, start_pos, end_pos) {
             Ok(root) => root,
-            Err(ReconstructionError::MissingDigests) => {
-                debug!("Not enough digests in proof to reconstruct root");
-                return false;
-            }
-            Err(ReconstructionError::ExtraDigests) => {
-                debug!("Not all digests in proof were used to reconstruct root");
+            Err(error) => {
+                debug!(error = ?error, "invalid proof input");
                 return false;
             }
         };
@@ -649,12 +645,8 @@ impl<
         // Reconstruct the MMR root.
         let mmr_root = match proof.reconstruct_root(&mut verifier, &[digest], pos, pos) {
             Ok(root) => root,
-            Err(ReconstructionError::MissingDigests) => {
-                debug!("Not enough digests in proof to reconstruct root");
-                return false;
-            }
-            Err(ReconstructionError::ExtraDigests) => {
-                debug!("Not all digests in proof were used to reconstruct root");
+            Err(error) => {
+                debug!(error = ?error, "invalid proof input");
                 return false;
             }
         };

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -16,8 +16,7 @@ use crate::{
         hasher::{Grafting, GraftingVerifier, Hasher, Standard},
         iterator::{leaf_num_to_pos, leaf_pos_to_num},
         storage::Grafting as GStorage,
-        verification::Proof,
-        Error::*,
+        verification::{Proof, ReconstructionError},
     },
 };
 use commonware_codec::FixedSize;
@@ -475,11 +474,11 @@ impl<
         ops: &[Operation<K, V>],
         chunks: &[[u8; N]],
         root_digest: &H::Digest,
-    ) -> Result<bool, Error> {
+    ) -> bool {
         let op_count = leaf_pos_to_num(proof.size);
         let Some(op_count) = op_count else {
             debug!("verification failed, invalid proof size");
-            return Ok(false);
+            return false;
         };
         let end_loc = start_loc + ops.len() as u64 - 1;
         if end_loc >= op_count {
@@ -487,7 +486,7 @@ impl<
                 loc = end_loc,
                 op_count, "proof verification failed, invalid range"
             );
-            return Ok(false);
+            return false;
         }
 
         let start_pos = leaf_num_to_pos(start_loc);
@@ -506,15 +505,19 @@ impl<
         );
 
         if op_count % Bitmap::<H, N>::CHUNK_SIZE_BITS == 0 {
-            return proof
-                .verify_range_inclusion(&mut verifier, digests, start_pos, end_pos, root_digest)
-                .map_err(Error::MmrError);
+            return proof.verify_range_inclusion(
+                &mut verifier,
+                digests,
+                start_pos,
+                end_pos,
+                root_digest,
+            );
         }
 
         // The proof must contain the partial chunk digest as its last hash.
         if proof.digests.is_empty() {
             debug!("proof has no digests");
-            return Ok(false);
+            return false;
         }
         let mut proof = proof.clone();
         let last_chunk_digest = proof.digests.pop().unwrap();
@@ -522,15 +525,14 @@ impl<
         // Reconstruct the MMR root.
         let mmr_root = match proof.reconstruct_root(&mut verifier, digests, start_pos, end_pos) {
             Ok(root) => root,
-            Err(MissingDigests) => {
+            Err(ReconstructionError::MissingDigests) => {
                 debug!("Not enough digests in proof to reconstruct root");
-                return Ok(false);
+                return false;
             }
-            Err(ExtraDigests) => {
+            Err(ReconstructionError::ExtraDigests) => {
                 debug!("Not all digests in proof were used to reconstruct root");
-                return Ok(false);
+                return false;
             }
-            Err(e) => return Err(Error::MmrError(e)),
         };
 
         let next_bit = op_count % Bitmap::<H, N>::CHUNK_SIZE_BITS;
@@ -541,7 +543,7 @@ impl<
             &last_chunk_digest,
         );
 
-        Ok(reconstructed_root == *root_digest)
+        reconstructed_root == *root_digest
     }
 
     /// Generate and return a proof of the current value of `key`, along with the other
@@ -590,15 +592,15 @@ impl<
 
     /// Return true if the proof authenticates that `key` currently has value `value` in the db with
     /// the given root.
-    pub async fn verify_key_value_proof(
+    pub fn verify_key_value_proof(
         hasher: &mut H,
         proof: &Proof<H::Digest>,
         info: &KeyValueProofInfo<K, V, N>,
         root_digest: &H::Digest,
-    ) -> Result<bool, Error> {
+    ) -> bool {
         let Some(op_count) = leaf_pos_to_num(proof.size) else {
             debug!("verification failed, invalid proof size");
-            return Ok(false);
+            return false;
         };
 
         // Make sure that the bit for the operation in the bitmap chunk is actually a 1 (indicating
@@ -608,7 +610,7 @@ impl<
                 loc = info.loc,
                 "proof verification failed, operation is inactive"
             );
-            return Ok(false);
+            return false;
         }
 
         let pos = leaf_num_to_pos(info.loc);
@@ -620,15 +622,13 @@ impl<
         );
 
         if op_count % Bitmap::<H, N>::CHUNK_SIZE_BITS == 0 {
-            return proof
-                .verify_element_inclusion(&mut verifier, &digest, pos, root_digest)
-                .map_err(Error::MmrError);
+            return proof.verify_element_inclusion(&mut verifier, &digest, pos, root_digest);
         }
 
         // The proof must contain the partial chunk digest as its last hash.
         if proof.digests.is_empty() {
             debug!("proof has no digests");
-            return Ok(false);
+            return false;
         }
 
         let mut proof = proof.clone();
@@ -642,29 +642,28 @@ impl<
             let expected_last_chunk_digest = verifier.digest(&info.chunk);
             if last_chunk_digest != expected_last_chunk_digest {
                 debug!("last chunk digest does not match expected value");
-                return Ok(false);
+                return false;
             }
         }
 
         // Reconstruct the MMR root.
         let mmr_root = match proof.reconstruct_root(&mut verifier, &[digest], pos, pos) {
             Ok(root) => root,
-            Err(MissingDigests) => {
+            Err(ReconstructionError::MissingDigests) => {
                 debug!("Not enough digests in proof to reconstruct root");
-                return Ok(false);
+                return false;
             }
-            Err(ExtraDigests) => {
+            Err(ReconstructionError::ExtraDigests) => {
                 debug!("Not all digests in proof were used to reconstruct root");
-                return Ok(false);
+                return false;
             }
-            Err(e) => return Err(Error::MmrError(e)),
         };
 
         let next_bit = op_count % Bitmap::<H, N>::CHUNK_SIZE_BITS;
         let reconstructed_root =
             Bitmap::<H, N>::partial_chunk_root(hasher, &mmr_root, next_bit, &last_chunk_digest);
 
-        Ok(reconstructed_root == *root_digest)
+        reconstructed_root == *root_digest
     }
 
     /// Close the db. Operations that have not been committed will be lost.
@@ -752,14 +751,14 @@ pub mod test {
 
     fn current_db_config(partition_prefix: &str) -> Config<TwoCap> {
         Config {
-            mmr_journal_partition: format!("{}_journal_partition", partition_prefix),
-            mmr_metadata_partition: format!("{}_metadata_partition", partition_prefix),
+            mmr_journal_partition: format!("{partition_prefix}_journal_partition"),
+            mmr_metadata_partition: format!("{partition_prefix}_metadata_partition"),
             mmr_items_per_blob: 11,
             mmr_write_buffer: 1024,
-            log_journal_partition: format!("{}_partition_prefix", partition_prefix),
+            log_journal_partition: format!("{partition_prefix}_partition_prefix"),
             log_items_per_blob: 7,
             log_write_buffer: 1024,
-            bitmap_metadata_partition: format!("{}_bitmap_metadata_partition", partition_prefix),
+            bitmap_metadata_partition: format!("{partition_prefix}_bitmap_metadata_partition"),
             translator: TwoCap,
             pool: None,
         }
@@ -871,9 +870,7 @@ pub mod test {
                     &proof.0,
                     &info,
                     &root,
-                )
-                .await
-                .unwrap()
+                ),
             );
 
             let v2 = Sha256::fill(0xA2);
@@ -886,9 +883,7 @@ pub mod test {
                     &proof.0,
                     &bad_info,
                     &root,
-                )
-                .await
-                .unwrap()
+                ),
             );
 
             // update the key to invalidate its previous update
@@ -903,9 +898,7 @@ pub mod test {
                     &proof.0,
                     &info,
                     &root,
-                )
-                .await
-                .unwrap()
+                ),
             );
 
             // Create a proof of the now-inactive operation.
@@ -927,9 +920,7 @@ pub mod test {
                     &proof_inactive.0,
                     &proof_inactive_info,
                     &root,
-                )
-                .await
-                .unwrap()
+                ),
             );
 
             // Attempt #1 to "fool" the verifier:  change the location to that of an active
@@ -950,9 +941,7 @@ pub mod test {
                     &proof_inactive.0,
                     &proof_inactive_info,
                     &root,
-                )
-                .await
-                .unwrap()
+                ),
             );
 
             // Attempt #2 to "fool" the verifier: Modify the chunk in the proof info to make it look
@@ -973,9 +962,7 @@ pub mod test {
                     &proof_inactive.0,
                     &info_with_modified_chunk,
                     &root,
-                )
-                .await
-                .unwrap()
+                ),
             );
 
             db.destroy().await.unwrap();
@@ -1052,8 +1039,7 @@ pub mod test {
                         &ops,
                         &chunks,
                         &root
-                    )
-                    .unwrap(),
+                    ),
                     "failed to verify range at start_loc {start_loc}",
                 );
             }
@@ -1097,8 +1083,6 @@ pub mod test {
                         &info,
                         &root
                     )
-                    .await
-                    .unwrap()
                 );
                 // Proof should fail against the wrong value.
                 let wrong_val = Sha256::fill(0xFF);
@@ -1110,9 +1094,7 @@ pub mod test {
                         &proof,
                         &bad_info,
                         &root
-                    )
-                    .await
-                    .unwrap()
+                    ),
                 );
                 // Proof should fail against the wrong key.
                 let wrong_key = Sha256::fill(0xEE);
@@ -1124,9 +1106,7 @@ pub mod test {
                         &proof,
                         &bad_info,
                         &root
-                    )
-                    .await
-                    .unwrap()
+                    ),
                 );
                 // Proof should fail against the wrong root.
                 let wrong_root = Sha256::fill(0xDD);
@@ -1136,10 +1116,8 @@ pub mod test {
                         &proof,
                         &info,
                         &wrong_root,
-                    )
-                    .await
-                    .unwrap()
-                )
+                    ),
+                );
             }
 
             db.destroy().await.unwrap();
@@ -1209,9 +1187,7 @@ pub mod test {
                         &proof,
                         &info,
                         &root
-                    )
-                    .await
-                    .unwrap(),
+                    ),
                     "proof of update {i} failed to verify"
                 );
                 // Ensure the proof does NOT verify if we use the previous value.
@@ -1221,9 +1197,7 @@ pub mod test {
                         &proof,
                         &old_info,
                         &root
-                    )
-                    .await
-                    .unwrap(),
+                    ),
                     "proof of update {i} failed to verify"
                 );
                 old_info = info.clone();

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -58,15 +58,13 @@ fn bench_prove_many_elements(c: &mut Criterion) {
                             block_on(async {
                                 for ((start_index, end_index), (start_pos, end_pos)) in samples {
                                     let proof = mmr.range_proof(start_pos, end_pos).await.unwrap();
-                                    assert!(proof
-                                        .verify_range_inclusion(
-                                            &mut hasher,
-                                            &elements[start_index..=end_index],
-                                            start_pos,
-                                            end_pos,
-                                            &root_digest,
-                                        )
-                                        .unwrap());
+                                    assert!(proof.verify_range_inclusion(
+                                        &mut hasher,
+                                        &elements[start_index..=end_index],
+                                        start_pos,
+                                        end_pos,
+                                        &root_digest,
+                                    ));
                                 }
                             })
                         },

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -39,14 +39,12 @@ fn bench_prove_single_element(c: &mut Criterion) {
                             let mut hasher = Standard::<Sha256>::new();
                             for (pos, element) in samples {
                                 let proof = mmr.proof(pos).await.unwrap();
-                                assert!(proof
-                                    .verify_element_inclusion(
-                                        &mut hasher,
-                                        &element,
-                                        pos,
-                                        &root_digest,
-                                    )
-                                    .unwrap());
+                                assert!(proof.verify_element_inclusion(
+                                    &mut hasher,
+                                    &element,
+                                    pos,
+                                    &root_digest,
+                                ));
                             }
                         });
                     },

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -15,7 +15,7 @@ use crate::{
     mmr::{
         iterator::leaf_num_to_pos,
         mem::{Config as MemConfig, Mmr},
-        verification::Proof,
+        verification::{Proof, ReconstructionError},
         Error,
         Error::*,
         Hasher,
@@ -364,17 +364,9 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
     ///
     /// Panics if the bit doesn't exist or has been pruned.
     fn chunk_index(&self, bit_offset: u64) -> usize {
-        assert!(
-            bit_offset < self.bit_count(),
-            "out of bounds: {}",
-            bit_offset
-        );
+        assert!(bit_offset < self.bit_count(), "out of bounds: {bit_offset}");
         let chunk_num = Self::chunk_num(bit_offset);
-        assert!(
-            chunk_num >= self.pruned_chunks,
-            "bit pruned: {}",
-            bit_offset
-        );
+        assert!(chunk_num >= self.pruned_chunks, "bit pruned: {bit_offset}");
 
         chunk_num - self.pruned_chunks
     }
@@ -574,17 +566,17 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
 
     /// Verify whether `proof` proves that the `chunk` containing the referenced bit belongs to the
     /// bitmap corresponding to `root_digest`.
-    pub async fn verify_bit_inclusion(
+    pub fn verify_bit_inclusion(
         hasher: &mut impl Hasher<H>,
         proof: &Proof<H::Digest>,
         chunk: &[u8; N],
         bit_offset: u64,
         root_digest: &H::Digest,
-    ) -> Result<bool, Error> {
+    ) -> bool {
         let bit_count = proof.size;
         if bit_offset >= bit_count {
             debug!(bit_count, bit_offset, "tried to verify non-existent bit");
-            return Ok(false);
+            return false;
         }
         let leaf_pos = Self::leaf_pos(bit_offset);
 
@@ -599,7 +591,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
 
         if proof.digests.is_empty() {
             debug!("proof has no digests");
-            return Ok(false);
+            return false;
         }
         let last_digest = mmr_proof.digests.pop().unwrap();
 
@@ -612,7 +604,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
                     digests = mmr_proof.digests.len() + 1,
                     "proof over partial chunk should have exactly 1 digest"
                 );
-                return Ok(false);
+                return false;
             }
             let last_chunk_digest = hasher.digest(chunk);
             let next_bit = bit_count % Self::CHUNK_SIZE_BITS;
@@ -622,29 +614,28 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
                 next_bit,
                 &last_chunk_digest,
             );
-            return Ok(reconstructed_root == *root_digest);
+            return reconstructed_root == *root_digest;
         };
 
         // For the case where the proof is over a bit in a full chunk, `last_digest` contains the
         // digest of that chunk.
         let mmr_root = match mmr_proof.reconstruct_root(hasher, &[chunk], leaf_pos, leaf_pos) {
             Ok(root) => root,
-            Err(MissingDigests) => {
+            Err(ReconstructionError::MissingDigests) => {
                 debug!("Not enough digests in proof to reconstruct root");
-                return Ok(false);
+                return false;
             }
-            Err(ExtraDigests) => {
+            Err(ReconstructionError::ExtraDigests) => {
                 debug!("Not all digests in proof were used to reconstruct root");
-                return Ok(false);
+                return false;
             }
-            Err(e) => return Err(e),
         };
 
         let next_bit = bit_count % Self::CHUNK_SIZE_BITS;
         let reconstructed_root =
             Self::partial_chunk_root(hasher.inner(), &mmr_root, next_bit, &last_digest);
 
-        Ok(reconstructed_root == *root_digest)
+        reconstructed_root == *root_digest
     }
 }
 
@@ -685,9 +676,7 @@ mod tests {
                     &[0u8; SHA256_SIZE],
                     0,
                     &Sha256::fill(0x00),
-                )
-                .await
-                .unwrap(),
+                ),
                 "proof without digests shouldn't verify or panic"
             );
         });
@@ -734,16 +723,12 @@ mod tests {
             // Chunk should be provable.
             let (proof, chunk) = bitmap.proof(&mut hasher, 0).await.unwrap();
             assert!(
-                Bitmap::verify_bit_inclusion(&mut hasher, &proof, &chunk, 255, &root)
-                    .await
-                    .unwrap(),
+                Bitmap::verify_bit_inclusion(&mut hasher, &proof, &chunk, 255, &root),
                 "failed to prove bit in only chunk"
             );
             // bit outside range should not verify
             assert!(
-                !Bitmap::verify_bit_inclusion(&mut hasher, &proof, &chunk, 256, &root)
-                    .await
-                    .unwrap(),
+                !Bitmap::verify_bit_inclusion(&mut hasher, &proof, &chunk, 256, &root),
                 "should not be able to prove bit outside of chunk"
             );
 
@@ -935,7 +920,7 @@ mod tests {
                 bitmap.set_bit(bit_pos, !bit);
                 bitmap.sync(&mut hasher).await.unwrap();
                 let new_root = bitmap.root(&mut hasher).await.unwrap();
-                assert_ne!(root, new_root, "failed at bit {}", bit_pos);
+                assert_ne!(root, new_root, "failed at bit {bit_pos}");
                 // flip it back
                 bitmap.set_bit(bit_pos, bit);
                 bitmap.sync(&mut hasher).await.unwrap();
@@ -951,7 +936,7 @@ mod tests {
                 bitmap.set_bit(bit_pos, !bit);
                 bitmap.sync(&mut hasher).await.unwrap();
                 let new_root = bitmap.root(&mut hasher).await.unwrap();
-                assert_ne!(root, new_root, "failed at bit {}", bit_pos);
+                assert_ne!(root, new_root, "failed at bit {bit_pos}");
                 // flip it back
                 bitmap.set_bit(bit_pos, bit);
                 bitmap.sync(&mut hasher).await.unwrap();
@@ -982,7 +967,7 @@ mod tests {
             let mut hasher = Standard::new();
             let mut bitmap = Bitmap::<Sha256, N>::new();
             for i in 0u32..10 {
-                bitmap.append_chunk_unchecked(&test_chunk(format!("test{}", i).as_bytes()));
+                bitmap.append_chunk_unchecked(&test_chunk(format!("test{i}").as_bytes()));
             }
             // Add a few extra bits to exercise not being on a chunk or byte boundary.
             bitmap.append_byte_unchecked(0xA6);
@@ -1005,11 +990,8 @@ mod tests {
 
                     // Proof should verify for the original chunk containing the bit.
                     assert!(
-                        Bitmap::<_, N>::verify_bit_inclusion(&mut hasher, &proof, &chunk, i, &root)
-                            .await
-                            .unwrap(),
-                        "failed to prove bit {}",
-                        i
+                        Bitmap::<_, N>::verify_bit_inclusion(&mut hasher, &proof, &chunk, i, &root),
+                        "failed to prove bit {i}",
                     );
 
                     // Flip the bit in the chunk and make sure the proof fails.
@@ -1021,11 +1003,8 @@ mod tests {
                             &corrupted,
                             i,
                             &root
-                        )
-                        .await
-                        .unwrap(),
-                        "proving bit {} after flipping should have failed",
-                        i
+                        ),
+                        "proving bit {i} after flipping should have failed",
                     );
                 }
             }
@@ -1049,7 +1028,7 @@ mod tests {
             // Add a non-trivial amount of data.
             let mut hasher = Standard::new();
             for i in 0..FULL_CHUNK_COUNT {
-                bitmap.append_chunk_unchecked(&test_chunk(format!("test{}", i).as_bytes()));
+                bitmap.append_chunk_unchecked(&test_chunk(format!("test{i}").as_bytes()));
             }
             bitmap.sync(&mut hasher).await.unwrap();
             let chunk_aligned_root = bitmap.root(&mut hasher).await.unwrap();
@@ -1076,7 +1055,7 @@ mod tests {
 
                 // Replay missing chunks.
                 for j in i..FULL_CHUNK_COUNT {
-                    bitmap.append_chunk_unchecked(&test_chunk(format!("test{}", j).as_bytes()));
+                    bitmap.append_chunk_unchecked(&test_chunk(format!("test{j}").as_bytes()));
                 }
                 assert_eq!(bitmap.pruned_chunks, i);
                 assert_eq!(bitmap.bit_count(), FULL_CHUNK_COUNT as u64 * 256);

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -15,7 +15,7 @@ use crate::{
     mmr::{
         iterator::leaf_num_to_pos,
         mem::{Config as MemConfig, Mmr},
-        verification::{Proof, ReconstructionError},
+        verification::Proof,
         Error,
         Error::*,
         Hasher,
@@ -621,12 +621,8 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
         // digest of that chunk.
         let mmr_root = match mmr_proof.reconstruct_root(hasher, &[chunk], leaf_pos, leaf_pos) {
             Ok(root) => root,
-            Err(ReconstructionError::MissingDigests) => {
-                debug!("Not enough digests in proof to reconstruct root");
-                return false;
-            }
-            Err(ReconstructionError::ExtraDigests) => {
-                debug!("Not all digests in proof were used to reconstruct root");
+            Err(error) => {
+                debug!(error = ?error, "invalid proof input");
                 return false;
             }
         };

--- a/storage/src/mmr/hasher.rs
+++ b/storage/src/mmr/hasher.rs
@@ -318,7 +318,7 @@ impl<H: CHasher> Hasher<H> for Grafting<'_, H> {
     fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest {
         let grafted_digest = self.grafted_digests.get(&pos);
         let Some(grafted_digest) = grafted_digest else {
-            panic!("missing grafted digest for leaf_pos {}", pos);
+            panic!("missing grafted digest for leaf_pos {pos}");
         };
 
         // We do not include position in the digest material here since the position information is
@@ -369,7 +369,7 @@ impl<H: CHasher> Hasher<H> for GraftingFork<'_, H> {
     fn leaf_digest(&mut self, pos: u64, element: &[u8]) -> H::Digest {
         let grafted_digest = self.grafted_digests.get(&pos);
         let Some(grafted_digest) = grafted_digest else {
-            panic!("missing grafted digest for leaf_pos {}", pos);
+            panic!("missing grafted digest for leaf_pos {pos}");
         };
 
         // We do not include position in the digest material here since the position information is
@@ -813,17 +813,23 @@ mod tests {
 
                     let mut verifier =
                         GraftingVerifier::<Sha256>::new(GRAFTING_HEIGHT, 0, vec![&p1]);
-                    assert!(proof
-                        .verify_element_inclusion(&mut verifier, &b1, pos, &grafted_storage_root)
-                        .unwrap());
+                    assert!(proof.verify_element_inclusion(
+                        &mut verifier,
+                        &b1,
+                        pos,
+                        &grafted_storage_root
+                    ));
 
                     let pos = 1;
                     let proof = Proof::<Digest>::range_proof(&grafted_mmr, pos, pos)
                         .await
                         .unwrap();
-                    assert!(proof
-                        .verify_element_inclusion(&mut verifier, &b2, pos, &grafted_storage_root)
-                        .unwrap());
+                    assert!(proof.verify_element_inclusion(
+                        &mut verifier,
+                        &b2,
+                        pos,
+                        &grafted_storage_root
+                    ));
 
                     let pos = 3;
                     let proof = Proof::<Digest>::range_proof(&grafted_mmr, pos, pos)
@@ -831,17 +837,23 @@ mod tests {
                         .unwrap();
                     let mut verifier =
                         GraftingVerifier::<Sha256>::new(GRAFTING_HEIGHT, 1, vec![&p2]);
-                    assert!(proof
-                        .verify_element_inclusion(&mut verifier, &b3, pos, &grafted_storage_root)
-                        .unwrap());
+                    assert!(proof.verify_element_inclusion(
+                        &mut verifier,
+                        &b3,
+                        pos,
+                        &grafted_storage_root
+                    ));
 
                     let pos = 4;
                     let proof = Proof::<Digest>::range_proof(&grafted_mmr, pos, pos)
                         .await
                         .unwrap();
-                    assert!(proof
-                        .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
-                        .unwrap());
+                    assert!(proof.verify_element_inclusion(
+                        &mut verifier,
+                        &b4,
+                        pos,
+                        &grafted_storage_root
+                    ));
                 }
 
                 // Confirm element inclusion proof verification fails for various manipulations of the input.
@@ -853,38 +865,51 @@ mod tests {
                         .unwrap();
                     let mut verifier =
                         GraftingVerifier::<Sha256>::new(GRAFTING_HEIGHT, 1, vec![&p2]);
-                    assert!(proof
-                        .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
-                        .unwrap());
+                    assert!(proof.verify_element_inclusion(
+                        &mut verifier,
+                        &b4,
+                        pos,
+                        &grafted_storage_root
+                    ));
 
                     // Proof should fail if we try to verify the wrong leaf element.
-                    assert!(!proof
-                        .verify_element_inclusion(&mut verifier, &b3, pos, &grafted_storage_root)
-                        .unwrap());
+                    assert!(!proof.verify_element_inclusion(
+                        &mut verifier,
+                        &b3,
+                        pos,
+                        &grafted_storage_root
+                    ));
 
                     // Proof should fail if we use the wrong root.
-                    assert!(!proof
-                        .verify_element_inclusion(&mut verifier, &b4, pos, &peak_root)
-                        .unwrap());
+                    assert!(!proof.verify_element_inclusion(&mut verifier, &b4, pos, &peak_root));
 
                     // Proof should fail if we use the wrong position
-                    assert!(!proof
-                        .verify_element_inclusion(&mut verifier, &b4, 3, &grafted_storage_root)
-                        .unwrap());
+                    assert!(!proof.verify_element_inclusion(
+                        &mut verifier,
+                        &b4,
+                        3,
+                        &grafted_storage_root
+                    ));
 
                     // Proof should fail if we inject the wrong peak element into the verifier.
                     let mut verifier =
                         GraftingVerifier::<Sha256>::new(GRAFTING_HEIGHT, 1, vec![&p1]);
-                    assert!(!proof
-                        .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
-                        .unwrap());
+                    assert!(!proof.verify_element_inclusion(
+                        &mut verifier,
+                        &b4,
+                        pos,
+                        &grafted_storage_root
+                    ));
 
                     // Proof should fail if we give the verifier the wrong peak tree leaf number.
                     let mut verifier =
                         GraftingVerifier::<Sha256>::new(GRAFTING_HEIGHT, 2, vec![&p1]);
-                    assert!(!proof
-                        .verify_element_inclusion(&mut verifier, &b4, pos, &grafted_storage_root)
-                        .unwrap());
+                    assert!(!proof.verify_element_inclusion(
+                        &mut verifier,
+                        &b4,
+                        pos,
+                        &grafted_storage_root
+                    ));
                 }
 
                 // test range proving
@@ -896,16 +921,24 @@ mod tests {
                     let range = vec![&b1, &b2, &b3, &b4];
                     let mut verifier =
                         GraftingVerifier::<Sha256>::new(GRAFTING_HEIGHT, 0, vec![&p1, &p2]);
-                    assert!(proof
-                        .verify_range_inclusion(&mut verifier, &range, 0, 4, &grafted_storage_root)
-                        .unwrap());
+                    assert!(proof.verify_range_inclusion(
+                        &mut verifier,
+                        &range,
+                        0,
+                        4,
+                        &grafted_storage_root
+                    ));
 
                     // Confirm same proof fails with shortened verifier range.
                     let mut verifier =
                         GraftingVerifier::<Sha256>::new(GRAFTING_HEIGHT, 0, vec![&p1]);
-                    assert!(!proof
-                        .verify_range_inclusion(&mut verifier, &range, 0, 4, &grafted_storage_root)
-                        .unwrap());
+                    assert!(!proof.verify_range_inclusion(
+                        &mut verifier,
+                        &range,
+                        0,
+                        4,
+                        &grafted_storage_root
+                    ));
                 }
             }
 
@@ -925,18 +958,14 @@ mod tests {
                 .unwrap();
 
             let mut verifier = GraftingVerifier::<Sha256>::new(GRAFTING_HEIGHT, 0, vec![&p1]);
-            assert!(proof
-                .verify_element_inclusion(&mut verifier, &b1, pos, &grafted_storage_root)
-                .unwrap());
+            assert!(proof.verify_element_inclusion(&mut verifier, &b1, pos, &grafted_storage_root));
 
             let mut verifier = GraftingVerifier::<Sha256>::new(GRAFTING_HEIGHT, 0, vec![]);
             let pos = 7;
             let proof = Proof::<Digest>::range_proof(&grafted_mmr, pos, pos)
                 .await
                 .unwrap();
-            assert!(proof
-                .verify_element_inclusion(&mut verifier, &b5, pos, &grafted_storage_root)
-                .unwrap());
+            assert!(proof.verify_element_inclusion(&mut verifier, &b5, pos, &grafted_storage_root));
         });
     }
 }

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -717,14 +717,12 @@ mod tests {
 
             let proof = mmr.proof(test_element_pos).await.unwrap();
             let root = mmr.root(&mut hasher);
-            assert!(proof
-                .verify_element_inclusion(
-                    &mut hasher,
-                    &leaves[TEST_ELEMENT],
-                    test_element_pos,
-                    &root,
-                )
-                .unwrap());
+            assert!(proof.verify_element_inclusion(
+                &mut hasher,
+                &leaves[TEST_ELEMENT],
+                test_element_pos,
+                &root,
+            ));
 
             // Sync the MMR, make sure it flushes the in-mem MMR as expected.
             mmr.sync(&mut hasher).await.unwrap();
@@ -743,15 +741,13 @@ mod tests {
                 .range_proof(test_element_pos, last_element_pos)
                 .await
                 .unwrap();
-            assert!(proof
-                .verify_range_inclusion(
-                    &mut hasher,
-                    &leaves[TEST_ELEMENT..last_element + 1],
-                    test_element_pos,
-                    last_element_pos,
-                    &root
-                )
-                .unwrap());
+            assert!(proof.verify_range_inclusion(
+                &mut hasher,
+                &leaves[TEST_ELEMENT..last_element + 1],
+                test_element_pos,
+                last_element_pos,
+                &root
+            ));
 
             mmr.destroy().await.unwrap();
         });

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -297,7 +297,7 @@ impl<H: CHasher> Mmr<H> {
     /// - Use of this method will prevent using this structure as a base mmr for grafting.
     pub fn update_leaf(&mut self, hasher: &mut impl Hasher<H>, pos: u64, element: &[u8]) {
         if pos < self.pruned_to_pos {
-            panic!("element pruned: pos={}", pos);
+            panic!("element pruned: pos={pos}");
         }
 
         // Update the digest of the leaf node.
@@ -349,7 +349,7 @@ impl<H: CHasher> Mmr<H> {
 
         for (pos, element) in updates {
             if *pos < self.pruned_to_pos {
-                panic!("element pruned: pos={}", pos);
+                panic!("element pruned: pos={pos}");
             }
 
             // Update the digest of the leaf node and mark its ancestors as dirty.
@@ -879,8 +879,7 @@ mod tests {
                 for size in old_size + 1..mmr.size() {
                     assert!(
                         !PeakIterator::check_validity(size),
-                        "mmr of size {} should be invalid",
-                        size
+                        "mmr of size {size} should be invalid",
                     );
                 }
             }
@@ -931,7 +930,7 @@ mod tests {
             for i in 0u64..199 {
                 let root = mmr.root(&mut hasher);
                 let expected_root = ROOTS[i as usize];
-                assert_eq!(hex(&root), expected_root, "at: {}", i);
+                assert_eq!(hex(&root), expected_root, "at: {i}");
                 hasher.inner().update(&i.to_be_bytes());
                 let element = hasher.inner().finalize();
                 mmr.add(&mut hasher, &element);

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -109,10 +109,6 @@ pub enum Error {
     MissingNode(u64),
     #[error("MMR is empty")]
     Empty,
-    #[error("missing digests in proof")]
-    MissingDigests,
-    #[error("extra digests in proof")]
-    ExtraDigests,
     #[error("invalid update")]
     InvalidUpdate,
 }

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -4,15 +4,22 @@
 use crate::mmr::{
     iterator::{leaf_pos_to_num, PathIterator, PeakIterator},
     storage::Storage,
-    Error,
-    Error::*,
-    Hasher,
+    Error, Hasher,
 };
 use bytes::{Buf, BufMut};
 use commonware_codec::{varint::UInt, EncodeSize, Read, ReadExt, ReadRangeExt, Write};
 use commonware_cryptography::{Digest, Hasher as CHasher};
 use futures::future::try_join_all;
 use tracing::debug;
+
+/// Errors that can occur when reconstructing a digest from a proof due to invalid input.
+#[derive(Error, Debug)]
+pub enum ReconstructionError {
+    #[error("missing digests in proof")]
+    MissingDigests,
+    #[error("extra digests in proof")]
+    ExtraDigests,
+}
 
 /// Contains the information necessary for proving the inclusion of an element, or some range of
 /// elements, in the MMR from its root digest.
@@ -79,7 +86,7 @@ impl<D: Digest> Proof<D> {
         element: &[u8],
         element_pos: u64,
         root_digest: &D,
-    ) -> Result<bool, Error>
+    ) -> bool
     where
         I: CHasher<Digest = D>,
         H: Hasher<I>,
@@ -97,7 +104,7 @@ impl<D: Digest> Proof<D> {
         start_element_pos: u64,
         end_element_pos: u64,
         root_digest: &D,
-    ) -> Result<bool, Error>
+    ) -> bool
     where
         I: CHasher<Digest = D>,
         H: Hasher<I>,
@@ -105,35 +112,34 @@ impl<D: Digest> Proof<D> {
     {
         if leaf_pos_to_num(start_element_pos).is_none() {
             debug!(pos = start_element_pos, "start pos is not a leaf");
-            return Ok(false);
+            return false;
         }
         if end_element_pos != start_element_pos && leaf_pos_to_num(end_element_pos).is_none() {
             debug!(pos = end_element_pos, "end pos is not a leaf");
-            return Ok(false);
+            return false;
         }
         match self.reconstruct_root(hasher, elements, start_element_pos, end_element_pos) {
-            Ok(reconstructed_root) => Ok(*root_digest == reconstructed_root),
-            Err(MissingDigests) => {
+            Ok(reconstructed_root) => *root_digest == reconstructed_root,
+            Err(ReconstructionError::MissingDigests) => {
                 debug!("Not enough digests in proof to reconstruct peak digests");
-                Ok(false)
+                false
             }
-            Err(ExtraDigests) => {
+            Err(ReconstructionError::ExtraDigests) => {
                 debug!("Not all digests in proof were used to reconstruct peak digests");
-                Ok(false)
+                false
             }
-            Err(e) => Err(e),
         }
     }
 
     /// Reconstructs the root digest of the MMR from the digests in the proof and the provided range
-    /// of elements.
+    /// of elements, or returns a `ReconstructionError` if the input data is invalid.
     pub fn reconstruct_root<I, H, E>(
         &self,
         hasher: &mut H,
         elements: E,
         start_element_pos: u64,
         end_element_pos: u64,
-    ) -> Result<D, Error>
+    ) -> Result<D, ReconstructionError>
     where
         I: CHasher<Digest = D>,
         H: Hasher<I>,
@@ -154,7 +160,7 @@ impl<D: Digest> Proof<D> {
         elements: E,
         start_element_pos: u64,
         end_element_pos: u64,
-    ) -> Result<Vec<D>, Error>
+    ) -> Result<Vec<D>, ReconstructionError>
     where
         I: CHasher<Digest = D>,
         H: Hasher<I>,
@@ -185,19 +191,19 @@ impl<D: Digest> Proof<D> {
                 proof_digests_used += 1;
                 peak_digests.push(*hash);
             } else {
-                return Err(MissingDigests);
+                return Err(ReconstructionError::MissingDigests);
             }
         }
 
         if elements_iter.next().is_some() {
-            return Err(ExtraDigests);
+            return Err(ReconstructionError::ExtraDigests);
         }
         let next_sibling = siblings_iter.next();
         if (proof_digests_used == 0 && next_sibling.is_some())
             || (next_sibling.is_some()
                 && *next_sibling.unwrap() != self.digests[proof_digests_used - 1])
         {
-            return Err(ExtraDigests);
+            return Err(ReconstructionError::ExtraDigests);
         }
 
         Ok(peak_digests)
@@ -328,7 +334,7 @@ fn peak_digest_from_range<'a, I, H, E, S>(
     rightmost_pos: u64, // rightmost leaf in the tree to be traversed
     elements: &mut E,
     sibling_digests: &mut S,
-) -> Result<I::Digest, Error>
+) -> Result<I::Digest, ReconstructionError>
 where
     I: CHasher,
     H: Hasher<I>,
@@ -340,7 +346,7 @@ where
         // we are at a leaf
         match elements.next() {
             Some(element) => return Ok(hasher.leaf_digest(pos, element.as_ref())),
-            None => return Err(MissingDigests),
+            None => return Err(ReconstructionError::MissingDigests),
         }
     }
 
@@ -377,13 +383,13 @@ where
     if left_digest.is_none() {
         match sibling_digests.next() {
             Some(hash) => left_digest = Some(*hash),
-            None => return Err(MissingDigests),
+            None => return Err(ReconstructionError::MissingDigests),
         }
     }
     if right_digest.is_none() {
         match sibling_digests.next() {
             Some(hash) => right_digest = Some(*hash),
-            None => return Err(MissingDigests),
+            None => return Err(ReconstructionError::MissingDigests),
         }
     }
 
@@ -422,9 +428,7 @@ mod tests {
             for leaf in leaves.iter().by_ref() {
                 let proof: Proof<Digest> = mmr.proof(*leaf).await.unwrap();
                 assert!(
-                    proof
-                        .verify_element_inclusion(&mut hasher, &element, *leaf, &root_digest)
-                        .unwrap(),
+                    proof.verify_element_inclusion(&mut hasher, &element, *leaf, &root_digest),
                     "valid proof should verify successfully"
                 );
             }
@@ -433,67 +437,49 @@ mod tests {
             const POS: u64 = 18;
             let proof = mmr.proof(POS).await.unwrap();
             assert!(
-                proof
-                    .verify_element_inclusion(&mut hasher, &element, POS, &root_digest)
-                    .unwrap(),
+                proof.verify_element_inclusion(&mut hasher, &element, POS, &root_digest),
                 "proof verification should be successful"
             );
             assert!(
-                !proof
-                    .verify_element_inclusion(&mut hasher, &element, POS + 1, &root_digest)
-                    .unwrap(),
+                !proof.verify_element_inclusion(&mut hasher, &element, POS + 1, &root_digest),
                 "proof verification should fail with incorrect element position"
             );
             assert!(
-                !proof
-                    .verify_element_inclusion(&mut hasher, &element, POS - 1, &root_digest)
-                    .unwrap(),
+                !proof.verify_element_inclusion(&mut hasher, &element, POS - 1, &root_digest),
                 "proof verification should fail with incorrect element position 2"
             );
             assert!(
-                !proof
-                    .verify_element_inclusion(&mut hasher, &test_digest(0), POS, &root_digest)
-                    .unwrap(),
+                !proof.verify_element_inclusion(&mut hasher, &test_digest(0), POS, &root_digest),
                 "proof verification should fail with mangled element"
             );
             let root_digest2 = test_digest(0);
             assert!(
-                !proof
-                    .verify_element_inclusion(&mut hasher, &element, POS, &root_digest2)
-                    .unwrap(),
+                !proof.verify_element_inclusion(&mut hasher, &element, POS, &root_digest2),
                 "proof verification should fail with mangled root_digest"
             );
             let mut proof2 = proof.clone();
             proof2.digests[0] = test_digest(0);
             assert!(
-                !proof2
-                    .verify_element_inclusion(&mut hasher, &element, POS, &root_digest)
-                    .unwrap(),
+                !proof2.verify_element_inclusion(&mut hasher, &element, POS, &root_digest),
                 "proof verification should fail with mangled proof hash"
             );
             proof2 = proof.clone();
             proof2.size = 10;
             assert!(
-                !proof2
-                    .verify_element_inclusion(&mut hasher, &element, POS, &root_digest)
-                    .unwrap(),
+                !proof2.verify_element_inclusion(&mut hasher, &element, POS, &root_digest),
                 "proof verification should fail with incorrect size"
             );
             proof2 = proof.clone();
             proof2.digests.push(test_digest(0));
             assert!(
-                !proof2
-                    .verify_element_inclusion(&mut hasher, &element, POS, &root_digest)
-                    .unwrap(),
+                !proof2.verify_element_inclusion(&mut hasher, &element, POS, &root_digest),
                 "proof verification should fail with extra hash"
             );
             proof2 = proof.clone();
             while !proof2.digests.is_empty() {
                 proof2.digests.pop();
                 assert!(
-                    !proof2
-                        .verify_element_inclusion(&mut hasher, &element, 7, &root_digest)
-                        .unwrap(),
+                    !proof2.verify_element_inclusion(&mut hasher, &element, 7, &root_digest),
                     "proof verification should fail with missing digests"
                 );
             }
@@ -510,9 +496,9 @@ mod tests {
                 .digests
                 .extend(proof.digests[PEAK_COUNT - 1..].iter().cloned());
             assert!(
-            !proof2.verify_element_inclusion(&mut hasher, &element, POS, &root_digest).unwrap(),
-            "proof verification should fail with extra hash even if it's unused by the computation"
-        );
+                !proof2.verify_element_inclusion(&mut hasher, &element, POS, &root_digest),
+                "proof verification should fail with extra hash even if it's unused by the computation"
+            );
         });
     }
 
@@ -539,18 +525,14 @@ mod tests {
                     let end_pos = element_positions[j];
                     let range_proof = mmr.range_proof(start_pos, end_pos).await.unwrap();
                     assert!(
-                        range_proof
-                            .verify_range_inclusion(
-                                &mut hasher,
-                                &elements[i..j + 1],
-                                start_pos,
-                                end_pos,
-                                &root_digest,
-                            )
-                            .unwrap(),
-                        "valid range proof should verify successfully {}:{}",
-                        i,
-                        j
+                        range_proof.verify_range_inclusion(
+                            &mut hasher,
+                            &elements[i..j + 1],
+                            start_pos,
+                            end_pos,
+                            &root_digest,
+                        ),
+                        "valid range proof should verify successfully {i}:{j}",
                     );
                 }
             }
@@ -563,30 +545,26 @@ mod tests {
             let range_proof = mmr.range_proof(start_pos, end_pos).await.unwrap();
             let valid_elements = &elements[start_index..end_index + 1];
             assert!(
-                range_proof
-                    .verify_range_inclusion(
-                        &mut hasher,
-                        valid_elements,
-                        start_pos,
-                        end_pos,
-                        &root_digest,
-                    )
-                    .unwrap(),
+                range_proof.verify_range_inclusion(
+                    &mut hasher,
+                    valid_elements,
+                    start_pos,
+                    end_pos,
+                    &root_digest,
+                ),
                 "valid range proof should verify successfully"
             );
             let mut invalid_proof = range_proof.clone();
             for _i in 0..range_proof.digests.len() {
                 invalid_proof.digests.remove(0);
                 assert!(
-                    !range_proof
-                        .verify_range_inclusion(
-                            &mut hasher,
-                            Vec::<&[u8]>::new(),
-                            start_pos,
-                            end_pos,
-                            &root_digest,
-                        )
-                        .unwrap(),
+                    !range_proof.verify_range_inclusion(
+                        &mut hasher,
+                        Vec::<&[u8]>::new(),
+                        start_pos,
+                        end_pos,
+                        &root_digest,
+                    ),
                     "range proof with removed elements should fail"
                 );
             }
@@ -598,48 +576,40 @@ mod tests {
                         continue;
                     }
                     assert!(
-                        !range_proof
-                            .verify_range_inclusion(
-                                &mut hasher,
-                                &elements[i..j + 1],
-                                start_pos,
-                                end_pos,
-                                &root_digest,
-                            )
-                            .unwrap(),
-                        "range proof with invalid elements should fail {}:{}",
-                        i,
-                        j
+                        !range_proof.verify_range_inclusion(
+                            &mut hasher,
+                            &elements[i..j + 1],
+                            start_pos,
+                            end_pos,
+                            &root_digest,
+                        ),
+                        "range proof with invalid elements should fail {i}:{j}",
                     );
                 }
             }
             // confirm proof fails with invalid root
             let invalid_root_digest = test_digest(1);
             assert!(
-                !range_proof
-                    .verify_range_inclusion(
-                        &mut hasher,
-                        valid_elements,
-                        start_pos,
-                        end_pos,
-                        &invalid_root_digest,
-                    )
-                    .unwrap(),
+                !range_proof.verify_range_inclusion(
+                    &mut hasher,
+                    valid_elements,
+                    start_pos,
+                    end_pos,
+                    &invalid_root_digest,
+                ),
                 "range proof with invalid root should fail"
             );
             // mangle the proof and confirm it fails
             let mut invalid_proof = range_proof.clone();
             invalid_proof.digests[1] = test_digest(0);
             assert!(
-                !invalid_proof
-                    .verify_range_inclusion(
-                        &mut hasher,
-                        valid_elements,
-                        start_pos,
-                        end_pos,
-                        &root_digest,
-                    )
-                    .unwrap(),
+                !invalid_proof.verify_range_inclusion(
+                    &mut hasher,
+                    valid_elements,
+                    start_pos,
+                    end_pos,
+                    &root_digest,
+                ),
                 "mangled range proof should fail verification"
             );
             // inserting elements into the proof should also cause it to fail (malleability check)
@@ -647,17 +617,14 @@ mod tests {
                 let mut invalid_proof = range_proof.clone();
                 invalid_proof.digests.insert(i, test_digest(0));
                 assert!(
-                    !invalid_proof
-                        .verify_range_inclusion(
-                            &mut hasher,
-                            valid_elements,
-                            start_pos,
-                            end_pos,
-                            &root_digest,
-                        )
-                        .unwrap(),
-                    "mangled range proof should fail verification. inserted element at: {}",
-                    i
+                    !invalid_proof.verify_range_inclusion(
+                        &mut hasher,
+                        valid_elements,
+                        start_pos,
+                        end_pos,
+                        &root_digest,
+                    ),
+                    "mangled range proof should fail verification. inserted element at: {i}",
                 );
             }
             // removing proof elements should cause verification to fail
@@ -665,15 +632,13 @@ mod tests {
             for _ in 0..range_proof.digests.len() {
                 invalid_proof.digests.remove(0);
                 assert!(
-                    !invalid_proof
-                        .verify_range_inclusion(
-                            &mut hasher,
-                            valid_elements,
-                            start_pos,
-                            end_pos,
-                            &root_digest,
-                        )
-                        .unwrap(),
+                    !invalid_proof.verify_range_inclusion(
+                        &mut hasher,
+                        valid_elements,
+                        start_pos,
+                        end_pos,
+                        &root_digest,
+                    ),
                     "shortened range proof should fail verification"
                 );
             }
@@ -686,18 +651,14 @@ mod tests {
                         continue;
                     }
                     assert!(
-                        !range_proof
-                            .verify_range_inclusion(
-                                &mut hasher,
-                                valid_elements,
-                                start_pos2,
-                                end_pos2,
-                                &root_digest,
-                            )
-                            .unwrap(),
-                        "bad element range should fail verification {}:{}",
-                        i,
-                        j
+                        !range_proof.verify_range_inclusion(
+                            &mut hasher,
+                            valid_elements,
+                            start_pos2,
+                            end_pos2,
+                            &root_digest,
+                        ),
+                        "bad element range should fail verification {i}:{j}",
                     );
                 }
             }
@@ -730,10 +691,12 @@ mod tests {
                         assert!(proof.is_err());
                     } else {
                         assert!(proof.is_ok());
-                        assert!(proof
-                            .unwrap()
-                            .verify_element_inclusion(&mut hasher, &elements[j], *pos, &root)
-                            .unwrap());
+                        assert!(proof.unwrap().verify_element_inclusion(
+                            &mut hasher,
+                            &elements[j],
+                            *pos,
+                            &root
+                        ));
                     }
                 }
             }
@@ -780,7 +743,7 @@ mod tests {
                             start_pos,
                             end_pos,
                             &root_digest,
-                        ).unwrap(),
+                        ),
                         "valid range proof over remaining elements should verify successfully",
                     );
                 }
@@ -812,7 +775,7 @@ mod tests {
                     start_pos,
                     end_pos,
                     &updated_root_digest,
-                ).unwrap(),
+                ),
                 "valid range proof over remaining elements after 2 pruning rounds should verify successfully",
             );
         });


### PR DESCRIPTION
Having these functions potentially return Error is a holdover from when we had them "async" due to how grafting was previously implemented. This is no longer necessary, errors would have never been returned, since the only possible errors (MissingDigest/ExtraDigests) get captured and converted to verification failures (false).