### PR TITLE
[runtime/storage] Optimize `unix` Performance + Consistent `resize` Behavior

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,8 +13,14 @@ runs:
     - name: Cache cargo registry
       uses: actions/cache@v4
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ~/AppData/Local/cargo/registry
+          ~/AppData/Local/cargo/git
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-registry-
     - name: Cache cargo git
       uses: actions/cache@v4
       with:
@@ -28,10 +34,13 @@ runs:
       id: cargo-cache-cache
       uses: actions/cache@v4
       with:
-        path: ~/.cargo/bin/cargo-cache
+        path: |
+          ~/.cargo/bin/cargo-cache
+          ~/AppData/Local/cargo/bin/cargo-cache.exe
         key: ${{ runner.os }}-cargo-cache-${{ steps.rust-version.outputs.rust_version }}
     - name: Maintain cargo cache
+      continue-on-error: true
       shell: bash
       run: |
-        cargo install cargo-cache || true
+        cargo install cargo-cache
         cargo cache --autoclean

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -15,14 +15,21 @@ env:
 
 jobs:
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
       matrix:
-        flags:
-          - "--features commonware-runtime/iouring-storage"
-          - "--features commonware-runtime/iouring-network"
-          - ""
+        include:
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-storage"
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-network"
+          - os: ubuntu-latest
+            flags: ""
+          - os: windows-latest
+            flags: ""
+          - os: macos-latest
+            flags: ""
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -40,14 +47,21 @@ jobs:
         RUSTDOCFLAGS: "-D warnings"
 
   Tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
     strategy:
       matrix:
-        flags:
-          - "--features commonware-runtime/iouring-storage"
-          - "--features commonware-runtime/iouring-network"
-          - ""
+        include:
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-storage"
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-network"
+          - os: ubuntu-latest
+            flags: ""
+          - os: windows-latest
+            flags: ""
+          - os: macos-latest
+            flags: ""
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -97,7 +97,6 @@ jobs:
 
   Fuzz:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -11,7 +11,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   UDEPS_VERSION: 0.1.50
-  FUZZ_VERSION: 0.12.0
 
 jobs:
   Lint:
@@ -94,36 +93,6 @@ jobs:
       run: cargo +nightly install cargo-udeps --version ${{ env.UDEPS_VERSION }}
     - name: Check for unused dependencies
       run: cargo +nightly udeps --all-targets
-
-  Fuzz:
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Install nightly Rust toolchain
-      run: rustup toolchain install nightly
-    - name: Get Rust version
-      id: rust-version
-      run: echo "rust_version=$(rustc +nightly --version)" >> "$GITHUB_OUTPUT"
-    - name: Run setup
-      uses: ./.github/actions/setup
-    - name: Cache cargo-fuzz
-      id: cargo-fuzz-cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/bin/cargo-fuzz
-        key: ${{ runner.os }}-${{ env.FUZZ_VERSION }}-cargo-fuzz-${{ steps.rust-version.outputs.rust_version }}
-    - name: Install cargo-fuzz
-      if: steps.cargo-fuzz-cache.outputs.cache-hit != 'true'
-      run: cargo +nightly install cargo-fuzz --version ${{ env.FUZZ_VERSION }}
-    - name: Test all targets
-      run: |
-        for dir in codec/fuzz cryptography/fuzz stream/fuzz; do
-          for target in $(cargo +nightly fuzz list --fuzz-dir $dir); do
-            cargo +nightly fuzz run $target --fuzz-dir $dir -- -max_total_time=60
-          done
-        done
 
   WASM:
     runs-on: ubuntu-latest

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -116,12 +116,13 @@ jobs:
     - name: Install cargo-fuzz
       if: steps.cargo-fuzz-cache.outputs.cache-hit != 'true'
       run: cargo +nightly install cargo-fuzz --version ${{ env.FUZZ_VERSION }}
-    - name: Build codec
-      run: cargo +nightly fuzz build --fuzz-dir codec/fuzz
-    - name: Build cryptography
-      run: cargo +nightly fuzz build --fuzz-dir cryptography/fuzz
-    - name: Build stream
-      run: cargo +nightly fuzz build --fuzz-dir stream/fuzz
+    - name: Test all targets
+      run: |
+        for dir in codec/fuzz cryptography/fuzz stream/fuzz; do
+          for target in $(cargo +nightly fuzz list --fuzz-dir $dir); do
+            cargo +nightly fuzz run $target --fuzz-dir $dir -- -max_total_time=60
+          done
+        done
 
   WASM:
     runs-on: ubuntu-latest

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   Lint:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -48,7 +48,7 @@ jobs:
 
   Tests:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       matrix:
         include:
@@ -72,7 +72,7 @@ jobs:
 
   Dependencies:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -97,6 +97,7 @@ jobs:
 
   Fuzz:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -149,6 +150,7 @@ jobs:
 
   Scripts:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -17,14 +17,21 @@ env:
 
 jobs:
   Tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 180
     strategy:
       matrix:
-        flags:
-          - "--features commonware-runtime/iouring-storage"
-          - "--features commonware-runtime/iouring-network"
-          - ""
+        include:
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-storage"
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-network"
+          - os: ubuntu-latest
+            flags: ""
+          - os: windows-latest
+            flags: ""
+          - os: macos-latest
+            flags: ""
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -32,3 +39,37 @@ jobs:
       uses: ./.github/actions/setup
     - name: Run ignored tests
       run: cargo test ${{ matrix.flags }} --verbose -- --ignored
+
+  Benchmarks:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - package: commonware-cryptography
+            cargo_flags: ""
+            file_suffix: ""
+            benchmark_name: "commonware-cryptography"
+          - package: commonware-storage
+            cargo_flags: ""
+            file_suffix: ""
+            benchmark_name: "commonware-storage"
+          - package: commonware-storage
+            cargo_flags: "--features commonware-runtime/iouring-storage" # Additional features can be added here
+            file_suffix: "-features"
+            benchmark_name: "commonware-storage --features"
+          - package: commonware-stream
+            cargo_flags: ""
+            file_suffix: ""
+            benchmark_name: "commonware-stream"
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install nightly Rust toolchain
+      run: rustup toolchain install nightly
+    - name: Run setup
+      uses: ./.github/actions/setup
+    - name: Test benchmarks
+      run: |
+        cargo bench ${{ matrix.cargo_flags }} \
+          --benches -p ${{ matrix.package }} \
+          -- --test --verbose

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -14,6 +14,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  FUZZ_VERSION: 0.12.0
 
 jobs:
   Tests:
@@ -73,3 +74,36 @@ jobs:
         cargo bench ${{ matrix.cargo_flags }} \
           --benches -p ${{ matrix.package }} \
           -- --test --verbose
+
+  Fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      matrix:
+        fuzz_dir: [codec/fuzz, cryptography/fuzz, stream/fuzz]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install nightly Rust toolchain
+      run: rustup toolchain install nightly
+    - name: Get Rust version
+      id: rust-version
+      run: echo "rust_version=$(rustc +nightly --version)" >> "$GITHUB_OUTPUT"
+    - name: Run setup
+      uses: ./.github/actions/setup
+    - name: Cache cargo-fuzz
+      id: cargo-fuzz-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/cargo-fuzz
+        key: ${{ runner.os }}-${{ env.FUZZ_VERSION }}-cargo-fuzz-${{ steps.rust-version.outputs.rust_version }}
+    - name: Install cargo-fuzz
+      if: steps.cargo-fuzz-cache.outputs.cache-hit != 'true'
+      run: cargo +nightly install cargo-fuzz --version ${{ env.FUZZ_VERSION }}
+    - name: Test all targets
+      env:
+        ASAN_OPTIONS: "detect_leaks=0"
+      run: |
+        for target in $(cargo +nightly fuzz list --fuzz-dir ${{ matrix.fuzz_dir }}); do
+          cargo +nightly fuzz run $target --fuzz-dir ${{ matrix.fuzz_dir }} -- -max_total_time=60 -detect_leaks=0
+        done

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -90,6 +90,8 @@ pub enum Error {
     BlobInsufficientLength,
     #[error("offset overflow")]
     OffsetOverflow,
+    #[error("io error: {0}")]
+    Io(#[from] IoError),
 }
 
 /// Interface that any task scheduler must implement to start

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -695,11 +695,27 @@ mod tests {
             assert_eq!(&read.as_ref()[..5], data1);
             assert_eq!(&read.as_ref()[5..], data2);
 
+            // Read past end of blob
+            let result = blob.read_at(vec![0u8; 10], 10).await;
+            assert!(result.is_err());
+
             // Rewrite data without affecting length
             let data3 = b"Store";
             blob.write_at(Vec::from(data3), 5)
                 .await
                 .expect("Failed to write data3");
+
+            // Read data back
+            let read = blob
+                .read_at(vec![0u8; 10], 0)
+                .await
+                .expect("Failed to read data");
+            assert_eq!(&read.as_ref()[..5], data1);
+            assert_eq!(&read.as_ref()[5..], data3);
+
+            // Read past end of blob
+            let result = blob.read_at(vec![0u8; 10], 10).await;
+            assert!(result.is_err());
         });
     }
 

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -85,13 +85,13 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         self.inner.write_at(buf, offset).await
     }
 
-    async fn truncate(&self, len: u64) -> Result<(), Error> {
-        self.auditor.event(b"truncate", |hasher| {
+    async fn resize(&self, len: u64) -> Result<(), Error> {
+        self.auditor.event(b"resize", |hasher| {
             hasher.update(self.partition.as_bytes());
             hasher.update(&self.name);
             hasher.update(&len.to_be_bytes());
         });
-        self.inner.truncate(len).await
+        self.inner.resize(len).await
     }
 
     async fn sync(&self) -> Result<(), Error> {
@@ -177,13 +177,13 @@ mod tests {
             "Hashes do not match after read"
         );
 
-        // Truncate the blobs
-        blob1.truncate(5).await.unwrap();
-        blob2.truncate(5).await.unwrap();
+        // Resize the blobs
+        blob1.resize(5).await.unwrap();
+        blob2.resize(5).await.unwrap();
         assert_eq!(
             auditor1.state(),
             auditor2.state(),
-            "Hashes do not match after truncate"
+            "Hashes do not match after resize"
         );
 
         // Sync the blobs

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -259,9 +259,9 @@ impl crate::Blob for Blob {
     }
 
     // TODO: Make this async. See https://github.com/commonwarexyz/monorepo/issues/831
-    async fn truncate(&self, len: u64) -> Result<(), Error> {
+    async fn resize(&self, len: u64) -> Result<(), Error> {
         self.file.set_len(len).map_err(|e| {
-            Error::BlobTruncateFailed(self.partition.clone(), hex(&self.name), IoError::other(e))
+            Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), IoError::other(e))
         })
     }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -135,7 +135,7 @@ impl crate::Blob for Blob {
     async fn truncate(&self, len: u64) -> Result<(), crate::Error> {
         let len = len.try_into().map_err(|_| crate::Error::OffsetOverflow)?;
         let mut content = self.content.write().unwrap();
-        content.truncate(len);
+        content.resize(len, 0);
         Ok(())
     }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -132,7 +132,7 @@ impl crate::Blob for Blob {
         Ok(())
     }
 
-    async fn truncate(&self, len: u64) -> Result<(), crate::Error> {
+    async fn resize(&self, len: u64) -> Result<(), crate::Error> {
         let len = len.try_into().map_err(|_| crate::Error::OffsetOverflow)?;
         let mut content = self.content.write().unwrap();
         content.resize(len, 0);

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -123,8 +123,8 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         Ok(())
     }
 
-    async fn truncate(&self, len: u64) -> Result<(), Error> {
-        self.inner.truncate(len).await
+    async fn resize(&self, len: u64) -> Result<(), Error> {
+        self.inner.resize(len).await
     }
 
     async fn sync(&self) -> Result<(), Error> {

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod tests {
         test_sequential_chunk_read_write(&storage).await;
         test_read_empty_blob(&storage).await;
         test_overlapping_writes(&storage).await;
-        test_truncate_then_open(&storage).await;
+        test_resize_then_open(&storage).await;
     }
 
     /// Test opening a blob, writing to it, and reading back the data.
@@ -336,35 +336,35 @@ pub(crate) mod tests {
         );
     }
 
-    async fn test_truncate_then_open<S>(storage: &S)
+    async fn test_resize_then_open<S>(storage: &S)
     where
         S: Storage + Send + Sync,
         S::Blob: Send + Sync,
     {
         {
             let (blob, _) = storage
-                .open("test_truncate_then_open", b"test_blob")
+                .open("test_resize_then_open", b"test_blob")
                 .await
                 .unwrap();
 
             // Write some data
             blob.write_at(b"hello world".to_vec(), 0).await.unwrap();
 
-            // Truncate the blob
-            blob.truncate(5).await.unwrap();
+            // Resize the blob
+            blob.resize(5).await.unwrap();
 
             blob.close().await.unwrap();
         }
 
         // Reopen the blob
         let (blob, len) = storage
-            .open("test_truncate_then_open", b"test_blob")
+            .open("test_resize_then_open", b"test_blob")
             .await
             .unwrap();
-        assert_eq!(len, 5, "Blob length after truncate is incorrect");
+        assert_eq!(len, 5, "Blob length after resize is incorrect");
 
         // Read back the data
         let read = blob.read_at(vec![0; 5], 0).await.unwrap();
-        assert_eq!(read.as_ref(), b"hello", "Truncated data is incorrect");
+        assert_eq!(read.as_ref(), b"hello", "Resized data is incorrect");
     }
 }

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -1,11 +1,10 @@
 use crate::Error;
-use commonware_utils::{from_hex, hex, StableBuf};
-use std::{fs::File, io::SeekFrom, path::PathBuf, sync::Arc};
+use commonware_utils::{hex, StableBuf};
+use std::{io::SeekFrom, sync::Arc};
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
     sync::Mutex,
-    task,
 };
 
 #[derive(Clone)]

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -1,0 +1,83 @@
+use crate::Error;
+use commonware_utils::{from_hex, hex, StableBuf};
+use std::{fs::File, io::SeekFrom, path::PathBuf, sync::Arc};
+use tokio::{
+    fs,
+    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
+    sync::Mutex,
+    task,
+};
+
+#[derive(Clone)]
+pub struct Blob {
+    partition: String,
+    name: Vec<u8>,
+    // Files must be seeked prior to any read or write operation and are thus
+    // not safe to concurrently interact with. If we switched to mapping files
+    // we could remove this lock.
+    file: Arc<Mutex<fs::File>>,
+}
+
+impl Blob {
+    pub fn new(partition: String, name: &[u8], file: fs::File) -> Self {
+        Self {
+            partition,
+            name: name.into(),
+            file: Arc::new(Mutex::new(file)),
+        }
+    }
+}
+
+impl crate::Blob for Blob {
+    async fn read_at(
+        &self,
+        buf: impl Into<StableBuf> + Send,
+        offset: u64,
+    ) -> Result<StableBuf, Error> {
+        let mut file = self.file.lock().await;
+        let mut buf = buf.into();
+        file.seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|_| Error::ReadFailed)?;
+        file.read_exact(buf.as_mut())
+            .await
+            .map_err(|_| Error::ReadFailed)?;
+        Ok(buf)
+    }
+
+    async fn write_at(&self, buf: impl Into<StableBuf> + Send, offset: u64) -> Result<(), Error> {
+        let mut file = self.file.lock().await;
+        file.seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|_| Error::WriteFailed)?;
+        file.write_all(buf.into().as_ref())
+            .await
+            .map_err(|_| Error::WriteFailed)?;
+        Ok(())
+    }
+
+    async fn truncate(&self, len: u64) -> Result<(), Error> {
+        let file = self.file.lock().await;
+        file.set_len(len)
+            .await
+            .map_err(|e| Error::BlobTruncateFailed(self.partition.clone(), hex(&self.name), e))?;
+        Ok(())
+    }
+
+    async fn sync(&self) -> Result<(), Error> {
+        let file = self.file.lock().await;
+        file.sync_all()
+            .await
+            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
+    }
+
+    async fn close(self) -> Result<(), Error> {
+        let mut file = self.file.lock().await;
+        file.sync_all()
+            .await
+            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))?;
+        file.shutdown()
+            .await
+            .map_err(|e| Error::BlobCloseFailed(self.partition.clone(), hex(&self.name), e))
+    }
+}

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -55,11 +55,11 @@ impl crate::Blob for Blob {
         Ok(())
     }
 
-    async fn truncate(&self, len: u64) -> Result<(), Error> {
+    async fn resize(&self, len: u64) -> Result<(), Error> {
         let file = self.file.lock().await;
         file.set_len(len)
             .await
-            .map_err(|e| Error::BlobTruncateFailed(self.partition.clone(), hex(&self.name), e))?;
+            .map_err(|e| Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e))?;
         Ok(())
     }
 

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -78,7 +78,7 @@ impl crate::Storage for Storage {
 
         #[cfg(unix)]
         {
-            // Convert to a blocking std::fs::File to use positional IO.
+            // Convert to a blocking std::fs::File
             let file = file.into_std().await;
 
             // Construct the blob

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -1,0 +1,75 @@
+use crate::Error;
+use commonware_utils::{hex, StableBuf};
+use std::{fs::File, os::unix::fs::FileExt, sync::Arc};
+use tokio::task;
+
+#[derive(Clone)]
+pub struct Blob {
+    partition: String,
+    name: Vec<u8>,
+    file: Arc<File>,
+}
+
+impl Blob {
+    pub fn new(partition: String, name: &[u8], file: File) -> Self {
+        Self {
+            partition,
+            name: name.into(),
+            file: Arc::new(file),
+        }
+    }
+}
+
+impl crate::Blob for Blob {
+    async fn read_at(
+        &self,
+        buf: impl Into<StableBuf> + Send,
+        offset: u64,
+    ) -> Result<StableBuf, Error> {
+        let mut buf = buf.into();
+        let file = self.file.clone();
+        task::spawn_blocking(move || {
+            file.read_exact_at(buf.as_mut(), offset)?;
+            Ok(buf)
+        })
+        .await
+        .map_err(|_| Error::ReadFailed)?
+    }
+
+    async fn write_at(&self, buf: impl Into<StableBuf> + Send, offset: u64) -> Result<(), Error> {
+        let buf = buf.into();
+        let file = self.file.clone();
+        task::spawn_blocking(move || {
+            file.write_all_at(buf.as_ref(), offset)?;
+            Ok(())
+        })
+        .await
+        .map_err(|_| Error::WriteFailed)?
+    }
+
+    async fn truncate(&self, len: u64) -> Result<(), Error> {
+        let file = self.file.clone();
+        task::spawn_blocking(move || file.set_len(len))
+            .await
+            .map_err(|e| e.into())
+            .and_then(|r| r)
+            .map_err(|e| Error::BlobTruncateFailed(self.partition.clone(), hex(&self.name), e))?;
+        Ok(())
+    }
+
+    async fn sync(&self) -> Result<(), Error> {
+        let file = self.file.clone();
+        task::spawn_blocking(move || file.sync_all())
+            .await
+            .map_err(|e| e.into())
+            .and_then(|r| r)
+            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))?;
+        Ok(())
+    }
+
+    async fn close(self) -> Result<(), Error> {
+        self.sync().await
+
+        // When the file is dropped, it will be closed.
+    }
+}

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -47,13 +47,13 @@ impl crate::Blob for Blob {
         .map_err(|_| Error::WriteFailed)?
     }
 
-    async fn truncate(&self, len: u64) -> Result<(), Error> {
+    async fn resize(&self, len: u64) -> Result<(), Error> {
         let file = self.file.clone();
         task::spawn_blocking(move || file.set_len(len))
             .await
             .map_err(|e| e.into())
             .and_then(|r| r)
-            .map_err(|e| Error::BlobTruncateFailed(self.partition.clone(), hex(&self.name), e))?;
+            .map_err(|e| Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e))?;
         Ok(())
     }
 

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_read_truncate() {
+    fn test_read_resize() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Create a memory blob with some test data
@@ -340,13 +340,13 @@ mod tests {
             let buffer_size = 10;
             let reader = Read::new(blob.clone(), data_len, buffer_size);
 
-            // Truncate the blob to half its size
-            let truncate_len = data_len / 2;
-            reader.truncate(truncate_len).await.unwrap();
+            // Resize the blob to half its size
+            let resize_len = data_len / 2;
+            reader.resize(resize_len).await.unwrap();
 
             // Reopen to check truncation
             let (blob, size) = context.open("partition", b"test").await.unwrap();
-            assert_eq!(size, truncate_len, "Blob should be truncated to half size");
+            assert_eq!(size, resize_len, "Blob should be resized to half size");
 
             // Create a new buffer and read to verify truncation
             let mut new_reader = Read::new(blob, size, buffer_size);
@@ -357,17 +357,37 @@ mod tests {
                 .read_exact(&mut buf, size as usize)
                 .await
                 .unwrap();
-            assert_eq!(&buf, b"ABCDEFGHIJKLM", "Truncated content should match");
+            assert_eq!(&buf, b"ABCDEFGHIJKLM", "Resized content should match");
 
-            // Reading beyond truncated size should fail
+            // Reading beyond resized size should fail
             let mut extra_buf = [0u8; 1];
             let result = new_reader.read_exact(&mut extra_buf, 1).await;
             assert!(matches!(result, Err(Error::BlobInsufficientLength)));
+
+            // Test resize to larger size
+            new_reader.resize(data_len * 2).await.unwrap();
+
+            // Reopen to check resize
+            let (blob, new_size) = context.open("partition", b"test").await.unwrap();
+            assert_eq!(new_size, data_len * 2);
+
+            // Create a new buffer and read to verify resize
+            let mut new_reader = Read::new(blob, new_size, buffer_size);
+            let mut buf = vec![0u8; new_size as usize];
+            new_reader
+                .read_exact(&mut buf, new_size as usize)
+                .await
+                .unwrap();
+            assert_eq!(&buf[..size as usize], b"ABCDEFGHIJKLM");
+            assert_eq!(
+                &buf[size as usize..],
+                vec![0u8; new_size as usize - size as usize]
+            );
         });
     }
 
     #[test_traced]
-    fn test_read_truncate_to_zero() {
+    fn test_read_resize_to_zero() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Create a memory blob with some test data
@@ -381,17 +401,17 @@ mod tests {
             let buffer_size = 10;
             let reader = Read::new(blob.clone(), data_len, buffer_size);
 
-            // Truncate the blob to zero
-            reader.truncate(0).await.unwrap();
+            // Resize the blob to zero
+            reader.resize(0).await.unwrap();
 
             // Reopen to check truncation
             let (blob, size) = context.open("partition", b"test").await.unwrap();
-            assert_eq!(size, 0, "Blob should be truncated to zero");
+            assert_eq!(size, 0, "Blob should be resized to zero");
 
             // Create a new buffer and try to read (should fail)
             let mut new_reader = Read::new(blob, size, buffer_size);
 
-            // Reading from truncated blob should fail
+            // Reading from resized blob should fail
             let mut buf = [0u8; 1];
             let result = new_reader.read_exact(&mut buf, 1).await;
             assert!(matches!(result, Err(Error::BlobInsufficientLength)));
@@ -603,11 +623,11 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_write_truncate() {
+    fn test_write_resize() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // Test blob truncation functionality and subsequent writes
-            let (blob, size) = context.open("partition", b"truncate_write").await.unwrap();
+            // Test blob resize functionality and subsequent writes
+            let (blob, size) = context.open("partition", b"resize_write").await.unwrap();
             let writer = Write::new(blob, size, 10);
 
             // Write initial data
@@ -617,38 +637,52 @@ mod tests {
             assert_eq!(writer.size().await, 11);
 
             let (blob_check, size_check) =
-                context.open("partition", b"truncate_write").await.unwrap();
+                context.open("partition", b"resize_write").await.unwrap();
             assert_eq!(size_check, 11);
             drop(blob_check);
 
-            // Truncate to smaller size
-            writer.truncate(5).await.unwrap();
+            // Resize to smaller size
+            writer.resize(5).await.unwrap();
             assert_eq!(writer.size().await, 5);
             writer.sync().await.unwrap();
 
-            // Verify truncation
-            let (blob, size) = context.open("partition", b"truncate_write").await.unwrap();
+            // Verify resize
+            let (blob, size) = context.open("partition", b"resize_write").await.unwrap();
             assert_eq!(size, 5);
             let mut reader = Read::new(blob, size, 5);
             let mut buf = vec![0u8; 5];
             reader.read_exact(&mut buf, 5).await.unwrap();
             assert_eq!(&buf, b"hello");
 
-            // Write to truncated blob
+            // Write to resized blob
             writer.write_at(b"X".to_vec(), 0).await.unwrap();
             assert_eq!(writer.size().await, 5);
             writer.sync().await.unwrap();
 
             // Verify overwrite
-            let (blob, size) = context.open("partition", b"truncate_write").await.unwrap();
+            let (blob, size) = context.open("partition", b"resize_write").await.unwrap();
             assert_eq!(size, 5);
             let mut reader = Read::new(blob, size, 5);
             let mut buf = vec![0u8; 5];
             reader.read_exact(&mut buf, 5).await.unwrap();
             assert_eq!(&buf, b"Xello");
 
-            // Test truncate to zero
-            let (blob_zero, size) = context.open("partition", b"truncate_zero").await.unwrap();
+            // Test resize to larger size
+            writer.resize(10).await.unwrap();
+            assert_eq!(writer.size().await, 10);
+            writer.sync().await.unwrap();
+
+            // Verify resize
+            let (blob, size) = context.open("partition", b"resize_write").await.unwrap();
+            assert_eq!(size, 10);
+            let mut reader = Read::new(blob, size, 10);
+            let mut buf = vec![0u8; 10];
+            reader.read_exact(&mut buf, 10).await.unwrap();
+            assert_eq!(&buf[0..5], b"Xello");
+            assert_eq!(&buf[5..10], [0u8; 5]);
+
+            // Test resize to zero
+            let (blob_zero, size) = context.open("partition", b"resize_zero").await.unwrap();
             let writer_zero = Write::new(blob_zero.clone(), size, 10);
             writer_zero
                 .write_at(b"some data".to_vec(), 0)
@@ -657,13 +691,13 @@ mod tests {
             assert_eq!(writer_zero.size().await, 9);
             writer_zero.sync().await.unwrap();
             assert_eq!(writer_zero.size().await, 9);
-            writer_zero.truncate(0).await.unwrap();
+            writer_zero.resize(0).await.unwrap();
             assert_eq!(writer_zero.size().await, 0);
             writer_zero.sync().await.unwrap();
             assert_eq!(writer_zero.size().await, 0);
 
             // Ensure the blob is empty
-            let (_, size_z) = context.open("partition", b"truncate_zero").await.unwrap();
+            let (_, size_z) = context.open("partition", b"resize_zero").await.unwrap();
             assert_eq!(size_z, 0);
         });
     }
@@ -1036,12 +1070,12 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_truncate_then_append_at_size() {
+    fn test_resize_then_append_at_size() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Test truncating, then appending at the new size
             let (blob, size) = context
-                .open("partition", b"truncate_then_append_at_size")
+                .open("partition", b"resize_then_append_at_size")
                 .await
                 .unwrap();
             let writer = Write::new(blob.clone(), size, 10);
@@ -1055,28 +1089,28 @@ mod tests {
             writer.sync().await.unwrap(); // inner.position = 16, buffer empty
             assert_eq!(writer.size().await, 16);
 
-            // Truncate
-            let truncate_to = 5;
-            writer.truncate(truncate_to).await.unwrap();
-            // after truncate, inner.position should be `truncate_to` (5)
+            // Resize
+            let resize_to = 5;
+            writer.resize(resize_to).await.unwrap();
+            // after resize, inner.position should be `resize_to` (5)
             // buffer should be empty
-            assert_eq!(writer.size().await, truncate_to);
+            assert_eq!(writer.size().await, resize_to);
             writer.sync().await.unwrap(); // Ensure truncation is persisted for verify step
-            assert_eq!(writer.size().await, truncate_to);
+            assert_eq!(writer.size().await, resize_to);
 
-            // Append at the new (truncated) size
+            // Append at the new (resized) size
             writer
                 .write_at(b"XXXXX".to_vec(), writer.size().await)
                 .await
                 .unwrap(); // 5 bytes
                            // inner.buffer = "XXXXX", inner.position = 5
-            assert_eq!(writer.size().await, 10); // 5 (truncated) + 5 (XXXXX)
+            assert_eq!(writer.size().await, 10); // 5 (resized) + 5 (XXXXX)
             writer.sync().await.unwrap();
             assert_eq!(writer.size().await, 10);
 
             // Verify final content
             let (blob_check, size_check) = context
-                .open("partition", b"truncate_then_append_at_size")
+                .open("partition", b"resize_then_append_at_size")
                 .await
                 .unwrap();
             assert_eq!(size_check, 10);

--- a/runtime/src/utils/buffer/read.rs
+++ b/runtime/src/utils/buffer/read.rs
@@ -172,11 +172,11 @@ impl<B: Blob> Read<B> {
         Ok(())
     }
 
-    /// Truncates the blob to the specified len and syncs the blob.
+    /// Resizes the blob to the specified len and syncs the blob.
     ///
     /// This may be useful if reading some blob after unclean shutdown.
-    pub async fn truncate(self, len: u64) -> Result<(), Error> {
-        self.blob.truncate(len).await?;
+    pub async fn resize(self, len: u64) -> Result<(), Error> {
+        self.blob.resize(len).await?;
         self.blob.sync().await
     }
 }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -286,33 +286,20 @@ impl<B: Blob> Blob for Write<B> {
         Ok(())
     }
 
-    async fn truncate(&self, len: u64) -> Result<(), Error> {
+    async fn resize(&self, len: u64) -> Result<(), Error> {
         // Acquire a write lock on the inner state
         let mut inner = self.inner.write().await;
 
-        // Determine the current buffer boundaries
-        let buffer_start = inner.position;
-        let buffer_end = buffer_start + inner.buffer.len() as u64;
+        // Flush any pending writes to the underlying blob
+        inner.flush().await?;
 
-        // Adjust buffer content based on truncation point
-        if len <= buffer_start {
-            // Truncation point is before or at the start of the buffer.
-            //
-            // All buffered data is now beyond the new length and should be discarded.
-            inner.buffer.clear();
-            inner.blob.truncate(len).await?;
-            inner.position = len;
-        } else if len < buffer_end {
-            // Truncation point is within the buffer.
-            //
-            // Keep only the portion of the buffer up to the truncation point.
-            let new_buffer_len = (len - buffer_start) as usize;
-            inner.buffer.truncate(new_buffer_len);
-        } else {
-            // Truncation point is at or after the end of the buffer.
-            //
-            // No changes needed to the buffer content.
-        }
+        // Resize the underlying blob
+        inner.blob.resize(len).await?;
+
+        // Update the buffer's position to the new logical end of the blob.
+        // The buffer is empty after the flush.
+        inner.position = len;
+
         Ok(())
     }
 

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -464,7 +464,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
                                         found,
                                         "corruption detected: truncating"
                                     );
-                                    reader.truncate(valid_size).await.ok()?;
+                                    reader.resize(valid_size).await.ok()?;
                                     None
                                 }
                                 Err(Error::Runtime(RError::BlobInsufficientLength)) => {
@@ -477,7 +477,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
                                         new_size = valid_size,
                                         "trailing bytes detected: truncating"
                                     );
-                                    reader.truncate(valid_size).await.ok()?;
+                                    reader.resize(valid_size).await.ok()?;
                                     None
                                 }
                                 Err(err) => {
@@ -1237,7 +1237,7 @@ mod tests {
                 .open(&cfg.partition, &2u64.to_be_bytes())
                 .await
                 .expect("Failed to open blob");
-            blob.truncate(blob_size - 4)
+            blob.resize(blob_size - 4)
                 .await
                 .expect("Failed to corrupt blob");
             blob.close().await.expect("Failed to close blob");
@@ -1398,7 +1398,7 @@ mod tests {
                 .open(&cfg.partition, &2u64.to_be_bytes())
                 .await
                 .expect("Failed to open blob");
-            blob.truncate(blob_size - 4)
+            blob.resize(blob_size - 4)
                 .await
                 .expect("Failed to corrupt blob");
             blob.close().await.expect("Failed to close blob");
@@ -1569,7 +1569,7 @@ mod tests {
             Ok(())
         }
 
-        async fn truncate(&self, _len: u64) -> Result<(), RError> {
+        async fn resize(&self, _len: u64) -> Result<(), RError> {
             Ok(())
         }
 

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -389,7 +389,7 @@ mod tests {
 
             // Corrupt the metadata store
             let (blob, len) = context.open("test", b"left").await.unwrap();
-            blob.truncate(len - 8).await.unwrap();
+            blob.resize(len - 8).await.unwrap();
             blob.close().await.unwrap();
 
             // Reopen the metadata store
@@ -437,7 +437,7 @@ mod tests {
 
             // Corrupt the metadata store
             let (blob, _) = context.open("test", b"left").await.unwrap();
-            blob.truncate(5).await.unwrap();
+            blob.resize(5).await.unwrap();
             blob.close().await.unwrap();
 
             // Reopen the metadata store

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -10,11 +10,11 @@
 //! "left" or "right" blob:
 //!
 //! ```text
-//! +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-//! | 0 | 1 |    ...    |15 |16 |17 |18 |19 |20 |21 |22 |23 |24 |  ...  |50 |...|90 |91 |92 |93 |
-//! +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-//! |   Timestamp (u128)    |  Key1 (u32)   | Len(V1) (u32) |    Value1     |...|  CRC32(u32)   |
-//! +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+//! +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+//! | 0 | 1 |    ...    | 8 | 9 |10 |11 |12 |13 |14 |15 |16 |  ...  |50 |...|90 |91 |92 |93 |
+//! +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+//! |    Version (u64)  |  Key1 (u32)   | Len(V1) (u32) |    Value1     |...|  CRC32(u32)   |
+//! +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
 //!
 //! Len(V1) = Length of Value1
 //! ... = Other key-value pairs (Key2|VLen2|Value2, Key3|VLen3|Value3, ...)
@@ -23,15 +23,11 @@
 //! _To ensure the integrity of the data, a CRC32 checksum is appended to the end of the blob.
 //! This ensures that partial writes are detected before any data is relied on._
 //!
-//! _In the unlikely event that the current timestamp since the last `sync` is unchanged (as measured
-//! in nanoseconds), the timestamp is incremented by one to ensure that the latest update is always
-//! considered the most recent on restart._
-//!
 //! # Atomic Updates
 //!
 //! To provide support for atomic updates, `Metadata` maintains two blobs: a "left" and a "right"
 //! blob. When a new update is committed, it is written to the "older" of the two blobs (indicated
-//! by the timestamp persisted). Writes to `Storage` are not atomic and may only complete partially,
+//! by the version persisted). Writes to `Storage` are not atomic and may only complete partially,
 //! so we only overwrite the "newer" blob once the "older" blob has been synced (otherwise, we would
 //! not be guaranteed to recover the latest complete state from disk on restart as half of a blob
 //! could be old data and half new data).
@@ -95,7 +91,6 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
     use commonware_utils::array::U64;
-    use std::time::UNIX_EPOCH;
 
     #[test_traced]
     fn test_put_get_clear() {
@@ -107,10 +102,6 @@ mod tests {
                 partition: "test".to_string(),
             };
             let mut metadata = Metadata::init(context.clone(), cfg).await.unwrap();
-
-            // Check last update
-            let last_update = metadata.last_update();
-            assert!(last_update.is_none());
 
             // Get a key that doesn't exist
             let key = U64::new(42);
@@ -148,13 +139,6 @@ mod tests {
                 partition: "test".to_string(),
             };
             let mut metadata = Metadata::init(context.clone(), cfg).await.unwrap();
-
-            // Check last update (increment by 1 over the previous)
-            let last_update = metadata.last_update().unwrap();
-            assert_eq!(
-                last_update.duration_since(UNIX_EPOCH).unwrap().as_nanos(),
-                1
-            );
 
             // Check metrics
             let buffer = context.encode();
@@ -197,11 +181,6 @@ mod tests {
 
             // Sync the metadata store
             metadata.sync().await.unwrap();
-            let last_update = metadata.last_update().unwrap();
-            assert_eq!(
-                last_update.duration_since(UNIX_EPOCH).unwrap().as_nanos(),
-                1
-            );
 
             // Check metrics
             let buffer = context.encode();
@@ -245,11 +224,6 @@ mod tests {
 
             // Sync the metadata store
             metadata.sync().await.unwrap();
-            let last_update = metadata.last_update().unwrap();
-            assert_eq!(
-                last_update.duration_since(UNIX_EPOCH).unwrap().as_nanos(),
-                3 // Incremented by 1 during call to close
-            );
 
             // Check metrics
             let buffer = context.encode();

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -2,16 +2,12 @@ use super::{Config, Error};
 use bytes::BufMut;
 use commonware_codec::{FixedSize, ReadExt};
 use commonware_runtime::{Blob, Clock, Metrics, Storage};
-use commonware_utils::{Array, SystemTimeExt as _};
+use commonware_utils::Array;
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
-use std::{
-    collections::BTreeMap,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
-use tracing::{debug, trace, warn};
+use std::collections::BTreeMap;
+use tracing::{debug, warn};
 
 const BLOB_NAMES: [&[u8]; 2] = [b"left", b"right"];
-const SECONDS_IN_NANOSECONDS: u128 = 1_000_000_000;
 
 /// Implementation of `Metadata` storage.
 pub struct Metadata<E: Clock + Storage + Metrics, K: Array> {
@@ -21,7 +17,7 @@ pub struct Metadata<E: Clock + Storage + Metrics, K: Array> {
     data: BTreeMap<K, Vec<u8>>,
     cursor: usize,
     partition: String,
-    blobs: [(E::Blob, u64, u128); 2],
+    blobs: [(E::Blob, u64, u64); 2],
 
     syncs: Counter,
     keys: Gauge,
@@ -39,23 +35,23 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         let right_result = Self::load(1, &right_blob, right_len).await?;
 
         // Set checksums
-        let mut left_timestamp = 0;
+        let mut left_version = 0;
         let mut left_data = BTreeMap::new();
-        if let Some((timestamp, data)) = left_result {
-            left_timestamp = timestamp;
+        if let Some((version, data)) = left_result {
+            left_version = version;
             left_data = data;
         }
-        let mut right_timestamp = 0;
+        let mut right_version = 0;
         let mut right_data = BTreeMap::new();
-        if let Some((timestamp, data)) = right_result {
-            right_timestamp = timestamp;
+        if let Some((version, data)) = right_result {
+            right_version = version;
             right_data = data;
         }
 
         // Choose latest blob
         let mut data = left_data;
         let mut cursor = 0;
-        if right_timestamp > left_timestamp {
+        if right_version > left_version {
             cursor = 1;
             data = right_data;
         }
@@ -75,8 +71,8 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
             cursor,
             partition: cfg.partition,
             blobs: [
-                (left_blob, left_len, left_timestamp),
-                (right_blob, right_len, right_timestamp),
+                (left_blob, left_len, left_version),
+                (right_blob, right_len, right_version),
             ],
 
             syncs,
@@ -88,7 +84,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         index: usize,
         blob: &E::Blob,
         len: u64,
-    ) -> Result<Option<(u128, BTreeMap<K, Vec<u8>>)>, Error<K>> {
+    ) -> Result<Option<(u64, BTreeMap<K, Vec<u8>>)>, Error<K>> {
         // Get blob length
         if len == 0 {
             // Empty blob
@@ -99,8 +95,10 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         let len = len.try_into().map_err(|_| Error::BlobTooLarge(len))?;
         let buf = blob.read_at(vec![0u8; len], 0).await?;
 
-        // Verify integrity
-        if buf.len() < 20 {
+        // Verify integrity.
+        //
+        // 8 bytes for version + 4 bytes for checksum.
+        if buf.len() < 12 {
             // Truncate and return none
             warn!(
                 blob = index,
@@ -131,14 +129,14 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         }
 
         // Get parent
-        let timestamp = u128::from_be_bytes(buf.as_ref()[..16].try_into().unwrap());
+        let version = u64::from_be_bytes(buf.as_ref()[..8].try_into().unwrap());
 
         // Extract data
         //
         // If the checksum is correct, we assume data is correctly packed and we don't perform
         // length checks on the cursor.
         let mut data = BTreeMap::new();
-        let mut cursor = u128::SIZE;
+        let mut cursor = u64::SIZE;
         while cursor < checksum_index {
             // Read key
             let next_cursor = cursor + K::SIZE;
@@ -159,7 +157,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         }
 
         // Return info
-        Ok(Some((timestamp, data)))
+        Ok(Some((version, data)))
     }
 
     /// Get a value from `Metadata` (if it exists).
@@ -189,43 +187,18 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         self.keys.set(self.data.len() as i64);
     }
 
-    /// Get the timestamp of the last update to `Metadata` (if a previous
-    /// update exists).
-    pub fn last_update(&self) -> Option<SystemTime> {
-        let timestamp = self.blobs[self.cursor].2;
-        if timestamp == 0 {
-            return None;
-        }
-        let timestamp = Duration::new(
-            (timestamp / SECONDS_IN_NANOSECONDS) as u64,
-            (timestamp % SECONDS_IN_NANOSECONDS) as u32,
-        );
-        Some(UNIX_EPOCH + timestamp)
-    }
-
     /// Atomically commit the current state of `Metadata`.
     pub async fn sync(&mut self) -> Result<(), Error<K>> {
-        // Compute next timestamp
-        let past_timestamp = &self.blobs[self.cursor].2;
-        let mut next_timestamp = self.context.current().epoch().as_nanos();
-        if next_timestamp <= *past_timestamp {
-            // While it is possible that extremely high-frequency updates to `Metadata` (more than
-            // one update per nanosecond) could cause an eventual overflow of the timestamp, this
-            // is not treated as a serious concern (as any call to `sync` will take longer than this).
-            //
-            // The nice benefit of this is that we also can provide the caller with some timestamp
-            // of the last update, which can be useful for a variety of things.
-            trace!(
-                past = *past_timestamp,
-                next = next_timestamp,
-                "timestamps are not monotonically increasing: adjusting next"
-            );
-            next_timestamp = *past_timestamp + 1;
-        }
+        // Compute next version.
+        //
+        // While it is possible that extremely high-frequency updates to `Metadata` could cause an eventual
+        // overflow of version, syncing once per millisecond would overflow in 584,942,417 years.
+        let past_version = &self.blobs[self.cursor].2;
+        let next_version = past_version.checked_add(1).expect("version overflow");
 
         // Create buffer
         let mut buf = Vec::new();
-        buf.put_u128(next_timestamp);
+        buf.put_u64(next_version);
         for (key, value) in &self.data {
             buf.put_slice(key.as_ref());
             let value_len = value
@@ -248,7 +221,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         next_blob.0.truncate(buf_len).await?;
         next_blob.0.sync().await?;
         next_blob.1 = buf_len;
-        next_blob.2 = next_timestamp;
+        next_blob.2 = next_version;
 
         // Switch blobs
         self.cursor = next_cursor;

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -105,7 +105,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
                 len = buf.len(),
                 "blob is too short: truncating"
             );
-            blob.truncate(0).await?;
+            blob.resize(0).await?;
             blob.sync().await?;
             return Ok(None);
         }
@@ -123,7 +123,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
                 computed = computed_checksum,
                 "checksum mismatch: truncating"
             );
-            blob.truncate(0).await?;
+            blob.resize(0).await?;
             blob.sync().await?;
             return Ok(None);
         }
@@ -218,7 +218,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         // Write and truncate blob
         let buf_len = buf.len() as u64;
         next_blob.0.write_at(buf, 0).await?;
-        next_blob.0.truncate(buf_len).await?;
+        next_blob.0.resize(buf_len).await?;
         next_blob.0.sync().await?;
         next_blob.1 = buf_len;
         next_blob.2 = next_version;

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -790,9 +790,7 @@ mod tests {
             assert_eq!(len, 36); // N+4 = 36 bytes per node, 1 node in the last blob
 
             // truncate the blob by one byte to corrupt the checksum of the last parent node.
-            blob.truncate(len - 1)
-                .await
-                .expect("Failed to corrupt blob");
+            blob.resize(len - 1).await.expect("Failed to corrupt blob");
             blob.close().await.expect("Failed to close blob");
 
             let mmr = Mmr::init(context.clone(), &mut hasher, test_config())
@@ -825,7 +823,7 @@ mod tests {
             assert_eq!(len, 36 * 7); // this blob should be full.
 
             // The last leaf should be in slot 5 of this blob, truncate last byte of its checksum.
-            blob.truncate(36 * 5 + 35)
+            blob.resize(36 * 5 + 35)
                 .await
                 .expect("Failed to corrupt blob");
             blob.close().await.expect("Failed to close blob");

--- a/stream/fuzz/fuzz_targets/handshake.rs
+++ b/stream/fuzz/fuzz_targets/handshake.rs
@@ -96,14 +96,13 @@ fuzz_target!(|input: FuzzInput| {
         context
             .with_label("stream_sender")
             .spawn(move |_| async move {
-                send_frame(
+                // Our target is panic.
+                let _ = send_frame(
                     &mut stream_sender,
                     &handshake.encode(),
                     input.max_message_size,
                 )
-                .await
-                // Our target is panic.
-                .unwrap_or(());
+                .await;
             });
 
         let config = Config {
@@ -116,9 +115,6 @@ fuzz_target!(|input: FuzzInput| {
         };
 
         // Our target is panic.
-        if IncomingConnection::verify(&context, config, sink, stream)
-            .await
-            .is_ok()
-        {}
+        let _ = IncomingConnection::verify(&context, config, sink, stream).await;
     });
 });

--- a/stream/src/public_key/benches/sender_send.rs
+++ b/stream/src/public_key/benches/sender_send.rs
@@ -22,11 +22,11 @@ fn benchmark_sender_send(c: &mut Criterion) {
                         cipher1,
                         cipher2,
                     );
-                    let (sender, _receiver) = connection.split();
+                    let (sender, receiver) = connection.split();
                     let msg = msg.clone();
-                    (sender, msg)
+                    (sender, receiver, msg)
                 },
-                |(mut sender, msg)| {
+                |(mut sender, _receiver, msg)| {
                     block_on(async move {
                         sender.send(&msg).await.unwrap();
                     });

--- a/utils/src/array/u64.rs
+++ b/utils/src/array/u64.rs
@@ -57,6 +57,12 @@ impl From<[u8; U64::SIZE]> for U64 {
     }
 }
 
+impl From<u64> for U64 {
+    fn from(value: u64) -> Self {
+        Self(value.to_be_bytes())
+    }
+}
+
 impl AsRef<[u8]> for U64 {
     fn as_ref(&self) -> &[u8] {
         &self.0

--- a/utils/src/bitvec.rs
+++ b/utils/src/bitvec.rs
@@ -288,7 +288,7 @@ impl BitVec {
     }
 
     /// Creates an iterator over the bits.
-    pub fn iter(&self) -> BitIterator {
+    pub fn iter(&self) -> BitIterator<'_> {
         BitIterator { vec: self, pos: 0 }
     }
 

--- a/utils/src/futures.rs
+++ b/utils/src/futures.rs
@@ -155,26 +155,29 @@ mod tests {
         block_on(async move {
             let mut pool = Pool::<i32>::default();
 
-            // Futures resolve in order of completion time, not addition order
+            // Futures resolve in order of completion, not addition order
+            let (finisher_1, finished_1) = oneshot::channel();
+            let (finisher_3, finished_3) = oneshot::channel();
             pool.push(async move {
-                delay(Duration::from_millis(100)).await;
+                finished_1.await.unwrap();
+                finisher_3.send(()).unwrap();
                 1
             });
             pool.push(async move {
-                delay(Duration::from_millis(50)).await;
+                finisher_1.send(()).unwrap();
                 2
             });
             pool.push(async move {
-                delay(Duration::from_millis(150)).await;
+                finished_3.await.unwrap();
                 3
             });
 
             let first = pool.next_completed().await;
-            assert_eq!(first, 2, "First resolved should be 2 (50ms)");
+            assert_eq!(first, 2, "First resolved should be 2");
             let second = pool.next_completed().await;
-            assert_eq!(second, 1, "Second resolved should be 1 (100ms)");
+            assert_eq!(second, 1, "Second resolved should be 1");
             let third = pool.next_completed().await;
-            assert_eq!(third, 3, "Third resolved should be 3 (150ms)");
+            assert_eq!(third, 3, "Third resolved should be 3");
             assert!(pool.is_empty(),);
         });
     }
@@ -186,20 +189,24 @@ mod tests {
             let flag_clone = flag.clone();
             let mut pool = Pool::<i32>::default();
 
+            // Push a future that will set the flag to true when it resolves.
+            let (finisher, finished) = oneshot::channel();
             pool.push(async move {
-                delay(Duration::from_millis(100)).await;
+                finished.await.unwrap();
                 flag_clone.store(true, Ordering::SeqCst);
                 42
             });
             assert_eq!(pool.len(), 1);
 
+            // Cancel all futures.
             pool.cancel_all();
             assert!(pool.is_empty());
-
-            delay(Duration::from_millis(150)).await; // Wait longer than future’s delay
             assert!(!flag.load(Ordering::SeqCst));
 
-            // Stream should not resolve future after cancellation
+            // Send the finisher signal (should be ignored).
+            let _ = finisher.send(());
+
+            // Stream should not resolve future after cancellation.
             let stream_future = pool.next_completed();
             let timeout_future = async {
                 delay(Duration::from_millis(100)).await;
@@ -210,11 +217,12 @@ mod tests {
             match result {
                 Either::Left((_, _)) => panic!("Stream resolved after cancellation"),
                 Either::Right((_, _)) => {
-                    // Timeout occurred, which is expected
+                    // Wait for the timeout to trigger.
                 }
             }
+            assert!(!flag.load(Ordering::SeqCst));
 
-            // Push and await a new future
+            // Push and await a new future.
             pool.push(future::ready(42));
             assert_eq!(pool.len(), 1);
             let result = pool.next_completed().await;

--- a/utils/src/futures.rs
+++ b/utils/src/futures.rs
@@ -52,7 +52,7 @@ impl<T: Send> Pool<T> {
     /// Returns a futures that resolves to the next future in the pool that resolves.
     ///
     /// If the pool is empty, the future will never resolve.
-    pub fn next_completed(&mut self) -> SelectNextSome<FuturesUnordered<PooledFuture<T>>> {
+    pub fn next_completed(&mut self) -> SelectNextSome<'_, FuturesUnordered<PooledFuture<T>>> {
         self.pool.select_next_some()
     }
 

--- a/utils/src/time.rs
+++ b/utils/src/time.rs
@@ -68,11 +68,9 @@ mod tests {
         let time = SystemTime::UNIX_EPOCH + Duration::from_secs(1) + Duration::from_nanos(999_999);
         assert_eq!(time.epoch_millis(), 1_000);
 
-        // Saturates at u64::MAX
-        let time = SystemTime::UNIX_EPOCH + Duration::from_millis(u64::MAX);
-        assert_eq!(time.epoch_millis(), u64::MAX);
-        let time = time + Duration::from_millis(1);
-        assert_eq!(time.epoch_millis(), u64::MAX);
+        // Add 5 minutes
+        let time = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
+        assert_eq!(time.epoch_millis(), 300_000);
     }
 
     #[test]


### PR DESCRIPTION
Related: #1135 

## Changes
- [x] Run `fuzz` for 60s instead of just compiling
  - [x] Fix `fuzz` timeout on `main`: https://github.com/commonwarexyz/monorepo/actions/runs/15935358573/job/44953850493
- [x] Test benchmarks
- [x] Fix `truncate` consistency: https://github.com/commonwarexyz/monorepo/pull/1169
- [x] Use `version` instead of `timestamp` for metadata