### PR TITLE
[storage/mmr] handle case of proving an MMR is empty

### DIFF
--- a/storage/src/adb/any.rs
+++ b/storage/src/adb/any.rs
@@ -543,15 +543,13 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         root_digest: &H::Digest,
     ) -> bool {
         let start_pos = leaf_num_to_pos(start_loc);
-        let end_loc = start_loc + ops.len() as u64 - 1;
-        let end_pos = leaf_num_to_pos(end_loc);
 
         let digests = ops
             .iter()
             .map(|op| Any::<E, _, _, _, T>::op_digest(hasher, op))
             .collect::<Vec<_>>();
 
-        proof.verify_range_inclusion(hasher, digests, start_pos, end_pos, root_digest)
+        proof.verify_range_inclusion(hasher, &digests, start_pos, root_digest)
     }
 
     /// Commit any pending operations to the db, ensuring they are persisted to disk & recoverable

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -490,7 +490,6 @@ impl<
         }
 
         let start_pos = leaf_num_to_pos(start_loc);
-        let end_pos = leaf_num_to_pos(end_loc);
 
         let digests = ops
             .iter()
@@ -517,7 +516,7 @@ impl<
         let last_chunk_digest = proof.digests.pop().unwrap();
 
         // Reconstruct the MMR root.
-        let mmr_root = match proof.reconstruct_root(&mut verifier, &digests, start_pos, end_pos) {
+        let mmr_root = match proof.reconstruct_root(&mut verifier, &digests, start_pos) {
             Ok(root) => root,
             Err(error) => {
                 debug!(error = ?error, "invalid proof input");
@@ -637,7 +636,7 @@ impl<
         }
 
         // Reconstruct the MMR root.
-        let mmr_root = match proof.reconstruct_root(&mut verifier, &[digest], pos, pos) {
+        let mmr_root = match proof.reconstruct_root(&mut verifier, &[digest], pos) {
             Ok(root) => root,
             Err(error) => {
                 debug!(error = ?error, "invalid proof input");

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -505,13 +505,7 @@ impl<
         );
 
         if op_count % Bitmap::<H, N>::CHUNK_SIZE_BITS == 0 {
-            return proof.verify_range_inclusion(
-                &mut verifier,
-                digests,
-                start_pos,
-                end_pos,
-                root_digest,
-            );
+            return proof.verify_range_inclusion(&mut verifier, &digests, start_pos, root_digest);
         }
 
         // The proof must contain the partial chunk digest as its last hash.
@@ -523,7 +517,7 @@ impl<
         let last_chunk_digest = proof.digests.pop().unwrap();
 
         // Reconstruct the MMR root.
-        let mmr_root = match proof.reconstruct_root(&mut verifier, digests, start_pos, end_pos) {
+        let mmr_root = match proof.reconstruct_root(&mut verifier, &digests, start_pos, end_pos) {
             Ok(root) => root,
             Err(error) => {
                 debug!(error = ?error, "invalid proof input");

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -62,7 +62,6 @@ fn bench_prove_many_elements(c: &mut Criterion) {
                                         &mut hasher,
                                         &elements[start_index..=end_index],
                                         start_pos,
-                                        end_pos,
                                         &root_digest,
                                     ));
                                 }

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -619,7 +619,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
 
         // For the case where the proof is over a bit in a full chunk, `last_digest` contains the
         // digest of that chunk.
-        let mmr_root = match mmr_proof.reconstruct_root(hasher, &[chunk], leaf_pos, leaf_pos) {
+        let mmr_root = match mmr_proof.reconstruct_root(hasher, &[chunk], leaf_pos) {
             Ok(root) => root,
             Err(error) => {
                 debug!(error = ?error, "invalid proof input");

--- a/storage/src/mmr/hasher.rs
+++ b/storage/src/mmr/hasher.rs
@@ -925,7 +925,6 @@ mod tests {
                         &mut verifier,
                         &range,
                         0,
-                        4,
                         &grafted_storage_root
                     ));
 
@@ -936,7 +935,6 @@ mod tests {
                         &mut verifier,
                         &range,
                         0,
-                        4,
                         &grafted_storage_root
                     ));
                 }

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -745,7 +745,6 @@ mod tests {
                 &mut hasher,
                 &leaves[TEST_ELEMENT..last_element + 1],
                 test_element_pos,
-                last_element_pos,
                 &root
             ));
 

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -2,7 +2,7 @@
 //! the [Storage] trait, and functions for verifying them against a root digest.
 
 use crate::mmr::{
-    iterator::{leaf_pos_to_num, PathIterator, PeakIterator},
+    iterator::{leaf_num_to_pos, leaf_pos_to_num, PathIterator, PeakIterator},
     storage::Storage,
     Error, Hasher,
 };
@@ -77,6 +77,15 @@ impl<D: Digest> Read for Proof<D> {
     }
 }
 
+impl<D: Digest> Default for Proof<D> {
+    fn default() -> Self {
+        Self {
+            size: 0,
+            digests: vec![],
+        }
+    }
+}
+
 impl<D: Digest> Proof<D> {
     /// Return true if `proof` proves that `element` appears at position `element_pos` within the
     /// MMR with root `root_digest`.
@@ -91,33 +100,39 @@ impl<D: Digest> Proof<D> {
         I: CHasher<Digest = D>,
         H: Hasher<I>,
     {
-        self.verify_range_inclusion(hasher, &[element], element_pos, element_pos, root_digest)
+        self.verify_range_inclusion(hasher, &[element], element_pos, root_digest)
     }
 
-    /// Return true if `proof` proves that the `elements` appear consecutively between positions
-    /// `start_element_pos` through `end_element_pos` (inclusive) within the MMR with root
-    /// `root_digest`.
+    /// Return true if `proof` proves that the `elements` appear consecutively starting at position
+    /// `start_element_pos` within the MMR with root `root_digest`.
     pub fn verify_range_inclusion<I, H, E>(
         &self,
         hasher: &mut H,
-        elements: E,
+        elements: &[E],
         start_element_pos: u64,
-        end_element_pos: u64,
         root_digest: &D,
     ) -> bool
     where
         I: CHasher<Digest = D>,
         H: Hasher<I>,
-        E: IntoIterator<Item: AsRef<[u8]>>,
+        E: AsRef<[u8]>,
     {
-        if leaf_pos_to_num(start_element_pos).is_none() {
+        if elements.is_empty() {
+            if start_element_pos == 0 {
+                return root_digest == &hasher.root_digest(self.size, self.digests.iter());
+            }
+            debug!("empty range");
+            return false;
+        }
+        let Some(start_leaf) = leaf_pos_to_num(start_element_pos) else {
             debug!(pos = start_element_pos, "start pos is not a leaf");
             return false;
-        }
-        if end_element_pos != start_element_pos && leaf_pos_to_num(end_element_pos).is_none() {
-            debug!(pos = end_element_pos, "end pos is not a leaf");
-            return false;
-        }
+        };
+        let end_element_pos = if elements.len() == 1 {
+            start_element_pos
+        } else {
+            leaf_num_to_pos(start_leaf + elements.len() as u64 - 1)
+        };
 
         match self.reconstruct_root(hasher, elements, start_element_pos, end_element_pos) {
             Ok(reconstructed_root) => *root_digest == reconstructed_root,
@@ -133,14 +148,14 @@ impl<D: Digest> Proof<D> {
     pub(crate) fn reconstruct_root<I, H, E>(
         &self,
         hasher: &mut H,
-        elements: E,
+        elements: &[E],
         start_element_pos: u64,
         end_element_pos: u64,
     ) -> Result<D, ReconstructionError>
     where
         I: CHasher<Digest = D>,
         H: Hasher<I>,
-        E: IntoIterator<Item: AsRef<[u8]>>,
+        E: AsRef<[u8]>,
     {
         let peak_digests =
             self.reconstruct_peak_digests(hasher, elements, start_element_pos, end_element_pos)?;
@@ -155,23 +170,23 @@ impl<D: Digest> Proof<D> {
     fn reconstruct_peak_digests<I, H, E>(
         &self,
         hasher: &mut H,
-        elements: E,
+        elements: &[E],
         start_element_pos: u64,
         end_element_pos: u64,
     ) -> Result<Vec<D>, ReconstructionError>
     where
         I: CHasher<Digest = D>,
         H: Hasher<I>,
-        E: IntoIterator<Item: AsRef<[u8]>>,
+        E: AsRef<[u8]>,
     {
         let mut proof_digests_iter = self.digests.iter();
         let mut siblings_iter = self.digests.iter().rev();
-        let mut elements_iter = elements.into_iter();
 
         // Include peak digests only for trees that have no elements from the range, and keep track
         // of the starting and ending trees of those that do contain some.
         let mut peak_digests: Vec<D> = Vec::new();
         let mut proof_digests_used = 0;
+        let mut elements_iter = elements.iter();
         for (peak_pos, height) in PeakIterator::new(self.size) {
             let leftmost_pos = peak_pos + 2 - (1 << (height + 1));
             if peak_pos >= start_element_pos && leftmost_pos <= end_element_pos {
@@ -224,21 +239,13 @@ impl<D: Digest> Proof<D> {
     }
 
     /// Return the list of node positions required by the range proof for the specified range of
-    /// elements, inclusive of both endpoints. Panics if the range is empty and not the degenerate
-    /// case of proving that the MMR is empty (positions 0 and 0).
+    /// elements, inclusive of both endpoints.
     pub fn nodes_required_for_range_proof(
         size: u64,
         start_element_pos: u64,
         end_element_pos: u64,
     ) -> Vec<u64> {
         let mut positions = Vec::new();
-        if start_element_pos == end_element_pos {
-            if start_element_pos == 0 {
-                // Handle degenerate case proving that the MMR is empty.
-                return positions;
-            }
-            panic!("empty range");
-        }
 
         // Find the mountains that contain no elements from the range. The peaks of these mountains
         // are required to prove the range, so they are added to the result.
@@ -304,8 +311,8 @@ impl<D: Digest> Proof<D> {
         positions
     }
 
-    /// Return an inclusion proof for the specified range of elements, inclusive of both endpoints. Returns
-    /// ElementPruned error if some element needed to generate the proof has been pruned.
+    /// Return an inclusion proof for the specified range of elements, inclusive of both endpoints.
+    /// Returns ElementPruned error if some element needed to generate the proof has been pruned.
     pub async fn range_proof<S: Storage<D>>(
         mmr: &S,
         start_element_pos: u64,
@@ -349,7 +356,6 @@ where
 {
     assert_ne!(two_h, 0);
     if two_h == 1 {
-        // we are at a leaf
         match elements.next() {
             Some(element) => return Ok(hasher.leaf_digest(pos, element.as_ref())),
             None => return Err(ReconstructionError::MissingDigests),
@@ -409,44 +415,34 @@ mod tests {
     use bytes::Bytes;
     use commonware_codec::{Decode, Encode};
     use commonware_cryptography::{hash, sha256::Digest, Sha256};
+    use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Runner};
 
     fn test_digest(v: u8) -> Digest {
         hash(&[v])
     }
 
-    #[test]
+    #[test_traced]
     fn test_verification_empty_proof() {
         // Test that an empty proof authenticates an empty MMR.
-        let executor = deterministic::Runner::default();
-        executor.start(|_| async move {
-            let mmr = Mmr::new();
-            let mut hasher: Standard<Sha256> = Standard::new();
-            let root_digest = mmr.root(&mut hasher);
-            let proof = mmr.range_proof(0, 0).await.unwrap();
-            assert!(proof.digests.is_empty());
-            assert_eq!(proof.size, 0);
-            assert!(proof.verify_range_inclusion(
-                &mut hasher,
-                &[] as &[Digest],
-                0,
-                0,
-                &root_digest
-            ));
-        });
+        let mmr = Mmr::new();
+        let mut hasher: Standard<Sha256> = Standard::new();
+        let root_digest = mmr.root(&mut hasher);
+        let proof = Proof::default();
+        assert!(proof.verify_range_inclusion(&mut hasher, &[] as &[Digest], 0, &root_digest));
+
+        // Any starting position other than 0 should fail to verify.
+        assert!(!proof.verify_range_inclusion(&mut hasher, &[] as &[Digest], 1, &root_digest));
+
+        // Invalid root should fail to verify.
+        let test_digest = test_digest(0);
+        assert!(!proof.verify_range_inclusion(&mut hasher, &[] as &[Digest], 0, &test_digest));
+
+        // Non-empty elements list should fail to verify.
+        assert!(!proof.verify_range_inclusion(&mut hasher, &[test_digest], 0, &root_digest));
     }
 
-    #[test]
-    #[should_panic(expected = "empty range")]
-    fn test_verification_non_degenerate_empty_range_panics() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_| async move {
-            let mmr: Mmr<Sha256> = Mmr::new();
-            mmr.range_proof(1, 1).await.unwrap();
-        });
-    }
-
-    #[test]
+    #[test_traced]
     fn test_verification_verify_element() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
@@ -539,7 +535,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     fn test_verification_verify_range() {
         let executor = deterministic::Runner::default();
 
@@ -566,7 +562,6 @@ mod tests {
                             &mut hasher,
                             &elements[i..j + 1],
                             start_pos,
-                            end_pos,
                             &root_digest,
                         ),
                         "valid range proof should verify successfully {i}:{j}",
@@ -586,7 +581,6 @@ mod tests {
                     &mut hasher,
                     valid_elements,
                     start_pos,
-                    end_pos,
                     &root_digest,
                 ),
                 "valid range proof should verify successfully"
@@ -597,9 +591,8 @@ mod tests {
                 assert!(
                     !range_proof.verify_range_inclusion(
                         &mut hasher,
-                        Vec::<&[u8]>::new(),
+                        &[] as &[Digest],
                         start_pos,
-                        end_pos,
                         &root_digest,
                     ),
                     "range proof with removed elements should fail"
@@ -617,7 +610,6 @@ mod tests {
                             &mut hasher,
                             &elements[i..j + 1],
                             start_pos,
-                            end_pos,
                             &root_digest,
                         ),
                         "range proof with invalid elements should fail {i}:{j}",
@@ -631,7 +623,6 @@ mod tests {
                     &mut hasher,
                     valid_elements,
                     start_pos,
-                    end_pos,
                     &invalid_root_digest,
                 ),
                 "range proof with invalid root should fail"
@@ -644,7 +635,6 @@ mod tests {
                     &mut hasher,
                     valid_elements,
                     start_pos,
-                    end_pos,
                     &root_digest,
                 ),
                 "mangled range proof should fail verification"
@@ -658,7 +648,6 @@ mod tests {
                         &mut hasher,
                         valid_elements,
                         start_pos,
-                        end_pos,
                         &root_digest,
                     ),
                     "mangled range proof should fail verification. inserted element at: {i}",
@@ -673,7 +662,6 @@ mod tests {
                         &mut hasher,
                         valid_elements,
                         start_pos,
-                        end_pos,
                         &root_digest,
                     ),
                     "shortened range proof should fail verification"
@@ -683,8 +671,7 @@ mod tests {
             for i in 0..elements.len() {
                 for j in 0..elements.len() {
                     let start_pos2 = element_positions[i];
-                    let end_pos2 = element_positions[j];
-                    if start_pos2 == start_pos && end_pos2 == end_pos {
+                    if start_pos2 == start_pos {
                         continue;
                     }
                     assert!(
@@ -692,7 +679,6 @@ mod tests {
                             &mut hasher,
                             valid_elements,
                             start_pos2,
-                            end_pos2,
                             &root_digest,
                         ),
                         "bad element range should fail verification {i}:{j}",
@@ -702,7 +688,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     fn test_verification_retained_nodes_provable_after_pruning() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
@@ -740,7 +726,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     fn test_verification_ranges_provable_after_pruning() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
@@ -767,7 +753,6 @@ mod tests {
 
             // test range proofs over all possible ranges of at least 2 elements
             let root_digest = mmr.root(&mut hasher);
-                        let mut hasher: Standard<Sha256> = Standard::new();
             for i in 0..elements.len() {
                 for j in i + 1..elements.len() {
                     let start_pos = element_positions[i];
@@ -778,7 +763,6 @@ mod tests {
                             &mut hasher,
                             &elements[i..j + 1],
                             start_pos,
-                            end_pos,
                             &root_digest,
                         ),
                         "valid range proof over remaining elements should verify successfully",
@@ -808,9 +792,8 @@ mod tests {
             assert!(
                 range_proof.verify_range_inclusion(
                     &mut hasher,
-                    elements,
-                    start_pos,
-                    end_pos,
+                    &elements,
+                        start_pos,
                     &updated_root_digest,
                 ),
                 "valid range proof over remaining elements after 2 pruning rounds should verify successfully",
@@ -818,7 +801,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[test_traced]
     fn test_verification_proof_serialization() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -78,6 +78,8 @@ impl<D: Digest> Read for Proof<D> {
 }
 
 impl<D: Digest> Default for Proof<D> {
+    /// Create an empty proof. The empty proof will verify only against the root hash of an empty
+    /// (`size == 0`) MMR.
     fn default() -> Self {
         Self {
             size: 0,

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -668,8 +668,8 @@ mod tests {
                 );
             }
             // bad element range should cause verification to fail
-            for i in 0..elements.len() {
-                for j in 0..elements.len() {
+            for (i, _) in elements.iter().enumerate() {
+                for (j, _) in elements.iter().enumerate() {
                     let start_pos2 = element_positions[i];
                     if start_pos2 == start_pos {
                         continue;


### PR DESCRIPTION
- Allow an empty proof to authenticate an empty MMR.
- Simplify verification APIs by not requiring the user to provide the end element position, which can be derived from the starting position and the number of elements in the input.
- Perform more strict validation of the element range provided to verification (elements that fall outside of the MMR range result in error).