### PR TITLE
[storage/metadata] Only Write Diffs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,11 +25,18 @@ jobs:
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Remove examples
-      # Reduces compilation time on code we exclude from coverage
       run: rm -rf examples
     - name: Remove examples from Cargo.toml
       run: |
         sed -i.bak '/examples/d' Cargo.toml
+    - name: Remove fuzz
+      run: |
+        rm -rf codec/fuzz
+        rm -rf cryptography/fuzz
+        rm -rf stream/fuzz
+    - name: Remove fuzz targets from Cargo.toml
+      run: |
+        sed -i.bak '/fuzz/d' Cargo.toml
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate coverage report

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -360,7 +360,7 @@ mod tests {
             let mut mailbox = mailboxes.get(&peers[0]).unwrap().clone();
             let mut messages = vec![];
             for i in 0..CACHE_SIZE + 1 {
-                messages.push(TestMessage::shared(format!("message {}", i).as_bytes()));
+                messages.push(TestMessage::shared(format!("message {i}").as_bytes()));
             }
             for message in messages.iter() {
                 let result = mailbox.broadcast(Recipients::All, message.clone()).await;
@@ -423,7 +423,7 @@ mod tests {
             // Peer A broadcasts 10 new messages to evict M1 from A's deque
             let mut new_messages_a = Vec::with_capacity(CACHE_SIZE);
             for i in 0..CACHE_SIZE {
-                new_messages_a.push(TestMessage::shared(format!("A{}", i).as_bytes()));
+                new_messages_a.push(TestMessage::shared(format!("A{i}").as_bytes()));
             }
             for msg in &new_messages_a {
                 let result = mailbox_a.broadcast(Recipients::All, msg.clone()).await;
@@ -439,7 +439,7 @@ mod tests {
             // Peer C broadcasts 10 new messages to evict M1 from C's deque
             let mut new_messages_c = Vec::with_capacity(CACHE_SIZE);
             for i in 0..CACHE_SIZE {
-                new_messages_c.push(TestMessage::shared(format!("C{}", i).as_bytes()));
+                new_messages_c.push(TestMessage::shared(format!("C{i}").as_bytes()));
             }
             for msg in &new_messages_c {
                 let result = mailbox_c.broadcast(Recipients::All, msg.clone()).await;

--- a/codec/src/varint.rs
+++ b/codec/src/varint.rs
@@ -530,8 +530,7 @@ mod tests {
             assert_eq!(
                 buf.len(),
                 calculated_size,
-                "Size mismatch for u16 value {}",
-                value
+                "Size mismatch for u16 value {value}",
             );
 
             // Also verify UInt wrapper
@@ -539,8 +538,7 @@ mod tests {
             assert_eq!(
                 uint.encode_size(),
                 buf.len(),
-                "UInt encode_size mismatch for value {}",
-                value
+                "UInt encode_size mismatch for value {value}",
             );
         }
     }
@@ -558,8 +556,7 @@ mod tests {
             assert_eq!(
                 buf.len(),
                 calculated_size,
-                "Size mismatch for i16 value {}",
-                value
+                "Size mismatch for i16 value {value}",
             );
 
             // Also verify SInt wrapper
@@ -567,18 +564,16 @@ mod tests {
             assert_eq!(
                 sint.encode_size(),
                 buf.len(),
-                "SInt encode_size mismatch for value {}",
-                value
+                "SInt encode_size mismatch for value {value}",
             );
 
             // Verify we can decode it back correctly
             let mut slice = &buf[..];
             let decoded: i16 = read_signed(&mut slice).unwrap();
-            assert_eq!(decoded, value, "Decode mismatch for value {}", value);
+            assert_eq!(decoded, value, "Decode mismatch for value {value}");
             assert!(
                 slice.is_empty(),
-                "Buffer not fully consumed for value {}",
-                value
+                "Buffer not fully consumed for value {value}",
             );
         }
     }
@@ -604,8 +599,7 @@ mod tests {
                 let calculated_size = size(value);
                 assert_eq!(
                     calculated_size, expected_size,
-                    "Size calculation wrong for {} with {} bits",
-                    val, bits
+                    "Size calculation wrong for {val} with {bits} bits",
                 );
 
                 // Compare encoded size
@@ -614,9 +608,7 @@ mod tests {
                 assert_eq!(
                     buf.len(),
                     expected_size,
-                    "Encoded size wrong for {} with {} bits",
-                    val,
-                    bits
+                    "Encoded size wrong for {val} with {bits} bits",
                 );
             }
         }
@@ -643,8 +635,7 @@ mod tests {
                 let calculated_size = size(value);
                 assert_eq!(
                     calculated_size, expected_size,
-                    "Size wrong for 1<<{} = {}",
-                    bit_pos, val
+                    "Size wrong for 1<<{bit_pos} = {val}",
                 );
 
                 // Compare encoded size
@@ -653,9 +644,7 @@ mod tests {
                 assert_eq!(
                     buf.len(),
                     expected_size,
-                    "Encoded size wrong for 1<<{} = {}",
-                    bit_pos,
-                    val
+                    "Encoded size wrong for 1<<{bit_pos} = {val}",
                 );
             }
         }

--- a/consensus/src/ordered_broadcast/mocks/automaton.rs
+++ b/consensus/src/ordered_broadcast/mocks/automaton.rs
@@ -31,7 +31,7 @@ impl<P: PublicKey> A for Automaton<P> {
         let (sender, receiver) = oneshot::channel();
 
         let Self::Context { sequencer, height } = context;
-        let payload = Bytes::from(format!("hello world, {} {}", sequencer, height));
+        let payload = Bytes::from(format!("hello world, {sequencer} {height}"));
         let mut hasher = Sha256::default();
         hasher.update(&payload);
 

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -234,7 +234,7 @@ mod tests {
                     journal_heights_per_section: 10,
                     journal_replay_buffer: 4096,
                     journal_write_buffer: 4096,
-                    journal_name_prefix: format!("ordered-broadcast-seq/{}/", validator),
+                    journal_name_prefix: format!("ordered-broadcast-seq/{validator}/"),
                     journal_compression: Some(3),
                 },
             );
@@ -864,7 +864,7 @@ mod tests {
                         journal_heights_per_section: 10,
                         journal_replay_buffer: 4096,
                         journal_write_buffer: 4096,
-                        journal_name_prefix: format!("ordered-broadcast-seq/{}/", validator),
+                        journal_name_prefix: format!("ordered-broadcast-seq/{validator}/"),
                         journal_compression: Some(3),
                     },
                 );

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -370,7 +370,7 @@ mod tests {
                             continue;
                         };
                         if payloads.len() > 1 {
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                         let (digest, notarizers) = payloads.iter().next().unwrap();
                         notarized.insert(view, *digest);
@@ -378,7 +378,7 @@ mod tests {
                         if notarizers.len() < threshold as usize {
                             // We can't verify that everyone participated at every view because some nodes may
                             // have started later.
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                         if notarizers.len() != n as usize {
                             exceptions += 1;
@@ -409,7 +409,7 @@ mod tests {
                             continue;
                         };
                         if payloads.len() > 1 {
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                         let (digest, finalizers) = payloads.iter().next().unwrap();
                         finalized.insert(view, *digest);
@@ -423,7 +423,7 @@ mod tests {
                         if finalizers.len() < threshold as usize {
                             // We can't verify that everyone participated at every view because some nodes may
                             // have started later.
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                         if finalizers.len() != n as usize {
                             exceptions += 1;
@@ -1016,7 +1016,7 @@ mod tests {
                     for (view, payloads) in notarizes.iter() {
                         for (_, participants) in payloads.iter() {
                             if participants.contains(offline) {
-                                panic!("view: {}", view);
+                                panic!("view: {view}");
                             }
                         }
                     }
@@ -1025,7 +1025,7 @@ mod tests {
                     let nullifies = supervisor.nullifies.lock().unwrap();
                     for (view, participants) in nullifies.iter() {
                         if participants.contains(offline) {
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                     }
                 }
@@ -1034,7 +1034,7 @@ mod tests {
                     for (view, payloads) in finalizes.iter() {
                         for (_, finalizers) in payloads.iter() {
                             if finalizers.contains(offline) {
-                                panic!("view: {}", view);
+                                panic!("view: {view}");
                             }
                         }
                     }
@@ -1058,7 +1058,7 @@ mod tests {
                     for view in offline_views.iter() {
                         let nullifies = nullifies.get(view).unwrap();
                         if nullifies.len() < threshold as usize {
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                     }
                 }
@@ -1242,7 +1242,7 @@ mod tests {
                     for (view, payloads) in notarizes.iter() {
                         for (_, participants) in payloads.iter() {
                             if participants.contains(slow) {
-                                panic!("view: {}", view);
+                                panic!("view: {view}");
                             }
                         }
                     }
@@ -1252,7 +1252,7 @@ mod tests {
                     for (view, participants) in nullifies.iter() {
                         // Start checking once all are online (leader may never have proposed)
                         if *view > 10 && participants.contains(slow) {
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                     }
                 }
@@ -1261,7 +1261,7 @@ mod tests {
                     for (view, payloads) in finalizes.iter() {
                         for (_, finalizers) in payloads.iter() {
                             if finalizers.contains(slow) {
-                                panic!("view: {}", view);
+                                panic!("view: {view}");
                             }
                         }
                     }
@@ -1449,7 +1449,7 @@ mod tests {
                             found += 1;
                         }
                     }
-                    assert!(found >= activity_timeout - 2, "found: {}", found);
+                    assert!(found >= activity_timeout - 2, "found: {found}");
                 }
             }
         });
@@ -1934,7 +1934,7 @@ mod tests {
                                 Activity::ConflictingFinalize(_) => {
                                     count_conflicting_finalize += 1;
                                 }
-                                _ => panic!("unexpected fault: {:?}", fault),
+                                _ => panic!("unexpected fault: {fault:?}"),
                             }
                         }
                     }
@@ -2098,7 +2098,7 @@ mod tests {
                                 Activity::NullifyFinalize(_) => {
                                     count_nullify_and_finalize += 1;
                                 }
-                                _ => panic!("unexpected fault: {:?}", fault),
+                                _ => panic!("unexpected fault: {fault:?}"),
                             }
                         }
                     }

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -448,7 +448,7 @@ mod tests {
                 relay: application.clone(),
                 reporter: supervisor.clone(),
                 supervisor: supervisor.clone(),
-                partition: format!("voter_actor_test_{}", validator),
+                partition: format!("voter_actor_test_{validator}"),
                 compression: None,
                 namespace: namespace.clone(),
                 mailbox_size: 128,

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -465,7 +465,7 @@ mod tests {
                     for view in 1..latest_complete {
                         // Ensure seed for every view
                         if !seeds.contains_key(&view) {
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                     }
                 }
@@ -481,7 +481,7 @@ mod tests {
                             continue;
                         };
                         if payloads.len() > 1 {
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                         let (digest, notarizers) = payloads.iter().next().unwrap();
                         notarized.insert(view, *digest);
@@ -489,7 +489,7 @@ mod tests {
                         if notarizers.len() < threshold as usize {
                             // We can't verify that everyone participated at every view because some nodes may
                             // have started later.
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                     }
                 }
@@ -514,7 +514,7 @@ mod tests {
                             continue;
                         };
                         if payloads.len() > 1 {
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                         let (digest, finalizers) = payloads.iter().next().unwrap();
                         finalized.insert(view, *digest);
@@ -528,7 +528,7 @@ mod tests {
                         if finalizers.len() < threshold as usize {
                             // We can't verify that everyone participated at every view because some nodes may
                             // have started later.
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
 
                         // Ensure no nullifies for any finalizers
@@ -933,7 +933,7 @@ mod tests {
             // Configure engine for first peer
             let scheme = schemes[0].clone();
             let validator = scheme.public_key();
-            let context = context.with_label(&format!("validator-{}", validator));
+            let context = context.with_label(&format!("validator-{validator}"));
 
             // Link first peer to all (except second)
             link_validators(
@@ -1195,7 +1195,7 @@ mod tests {
                     for (view, payloads) in notarizes.iter() {
                         for (_, participants) in payloads.iter() {
                             if participants.contains(offline) {
-                                panic!("view: {}", view);
+                                panic!("view: {view}");
                             }
                         }
                     }
@@ -1204,7 +1204,7 @@ mod tests {
                     let nullifies = supervisor.nullifies.lock().unwrap();
                     for (view, participants) in nullifies.iter() {
                         if participants.contains(offline) {
-                            panic!("view: {}", view);
+                            panic!("view: {view}");
                         }
                     }
                 }
@@ -1213,7 +1213,7 @@ mod tests {
                     for (view, payloads) in finalizes.iter() {
                         for (_, finalizers) in payloads.iter() {
                             if finalizers.contains(offline) {
-                                panic!("view: {}", view);
+                                panic!("view: {view}");
                             }
                         }
                     }
@@ -1458,7 +1458,7 @@ mod tests {
                     for (view, payloads) in notarizes.iter() {
                         for (_, participants) in payloads.iter() {
                             if participants.contains(slow) {
-                                panic!("view: {}", view);
+                                panic!("view: {view}");
                             }
                         }
                     }
@@ -1468,7 +1468,7 @@ mod tests {
                     for (view, payloads) in finalizes.iter() {
                         for (_, finalizers) in payloads.iter() {
                             if finalizers.contains(slow) {
-                                panic!("view: {}", view);
+                                panic!("view: {view}");
                             }
                         }
                     }
@@ -1681,7 +1681,7 @@ mod tests {
                             found += 1;
                         }
                     }
-                    assert!(found >= activity_timeout - 2, "found: {}", found);
+                    assert!(found >= activity_timeout - 2, "found: {found}");
                 }
             }
 
@@ -2235,7 +2235,7 @@ mod tests {
                                 Activity::ConflictingFinalize(_) => {
                                     count_conflicting += 1;
                                 }
-                                _ => panic!("unexpected fault: {:?}", fault),
+                                _ => panic!("unexpected fault: {fault:?}"),
                             }
                         }
                     }
@@ -2776,7 +2776,7 @@ mod tests {
                                 Activity::NullifyFinalize(_) => {
                                     count_nullify_and_finalize += 1;
                                 }
-                                _ => panic!("unexpected fault: {:?}", fault),
+                                _ => panic!("unexpected fault: {fault:?}"),
                             }
                         }
                     }

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -468,13 +468,7 @@ pub mod tests {
                         assert_eq!(res.0[i], larger.0[i]);
                     }
                 }
-                assert_eq!(
-                    res.degree(),
-                    larger.degree(),
-                    "deg1={}, deg2={}",
-                    deg1,
-                    deg2
-                );
+                assert_eq!(res.degree(), larger.degree(), "deg1={deg1}, deg2={deg2}");
             }
         }
     }
@@ -492,14 +486,12 @@ pub mod tests {
                 if num_evals > degree {
                     assert_eq!(
                         expected, recovered_constant,
-                        "degree={}, num_evals={}",
-                        degree, num_evals
+                        "degree={degree}, num_evals={num_evals}"
                     );
                 } else {
                     assert_ne!(
                         expected, recovered_constant,
-                        "degree={}, num_evals={}",
-                        degree, num_evals
+                        "degree={degree}, num_evals={num_evals}"
                     );
                 }
             }
@@ -530,7 +522,7 @@ pub mod tests {
                     sum.add(&var);
                 }
 
-                assert_eq!(sum, evaluation, "degree={}, idx={}", d, idx);
+                assert_eq!(sum, evaluation, "degree={d}, idx={idx}");
             }
         }
     }

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -401,7 +401,7 @@ mod tests {
 
     fn padding_odd_length_hex(value: &str) -> String {
         if value.len() % 2 != 0 {
-            return format!("0{}", value);
+            return format!("0{value}");
         }
         value.to_string()
     }
@@ -651,12 +651,7 @@ mod tests {
         for (n, test) in cases.iter() {
             let (public_key, exp_valid) = test;
             let res = PublicKey::decode(public_key.as_ref());
-            assert_eq!(
-                *exp_valid,
-                res.is_ok(),
-                "vector_public_key_validation_{}",
-                n
-            );
+            assert_eq!(*exp_valid, res.is_ok(), "vector_public_key_validation_{n}");
         }
     }
 

--- a/deployer/src/ec2/aws.rs
+++ b/deployer/src/ec2/aws.rs
@@ -248,7 +248,7 @@ pub async fn create_security_group_binary(
 ) -> Result<String, Ec2Error> {
     let sg_resp = client
         .create_security_group()
-        .group_name(format!("{}-binary", tag))
+        .group_name(format!("{tag}-binary"))
         .description("Security group for binary instances")
         .vpc_id(vpc_id)
         .tag_specifications(
@@ -862,8 +862,7 @@ pub async fn assert_arm64_support(
     for instance_type in instance_types {
         if !supported_instance_types.contains(instance_type) {
             return Err(Ec2Error::from(BuildError::other(format!(
-                "instance type {} not ARM64-based",
-                instance_type
+                "instance type {instance_type} not ARM64-based"
             ))));
         }
     }
@@ -916,8 +915,7 @@ pub async fn find_availability_zone(
 
     // If no availability zone supports all instance types, return an error
     Err(Ec2Error::from(BuildError::other(format!(
-        "no availability zone supports all required instance types: {:?}",
-        instance_types
+        "no availability zone supports all required instance types: {instance_types:?}"
     ))))
 }
 

--- a/deployer/src/ec2/create.rs
+++ b/deployer/src/ec2/create.rs
@@ -64,9 +64,9 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
     info!(ip = deployer_ip.as_str(), "recovered public IP");
 
     // Generate SSH key pair
-    let key_name = format!("deployer-{}", tag);
-    let private_key_path = tag_directory.join(format!("id_rsa_{}", tag));
-    let public_key_path = tag_directory.join(format!("id_rsa_{}.pub", tag));
+    let key_name = format!("deployer-{tag}");
+    let private_key_path = tag_directory.join(format!("id_rsa_{tag}"));
+    let public_key_path = tag_directory.join(format!("id_rsa_{tag}.pub"));
     let output = Command::new("ssh-keygen")
         .arg("-t")
         .arg("rsa")
@@ -127,7 +127,7 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
         );
 
         // Create VPC, IGW, route table, subnet, security groups, and key pair
-        let vpc_cidr = format!("10.{}.0.0/16", idx);
+        let vpc_cidr = format!("10.{idx}.0.0/16");
         vpc_cidrs.insert(region.clone(), vpc_cidr.clone());
         let vpc_id = create_vpc(&ec2_clients[region], &vpc_cidr, tag).await?;
         info!(
@@ -150,7 +150,7 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
             region = region.as_str(),
             "created route table"
         );
-        let subnet_cidr = format!("10.{}.1.0/24", idx);
+        let subnet_cidr = format!("10.{idx}.1.0/24");
         subnet_cidrs.insert(region.clone(), subnet_cidr.clone());
         let subnet_id = create_subnet(
             &ec2_clients[region],

--- a/deployer/src/ec2/destroy.rs
+++ b/deployer/src/ec2/destroy.rs
@@ -65,7 +65,7 @@ pub async fn destroy(config: &PathBuf) -> Result<(), Error> {
                 .any(|sg| sg.group_name() == Some(tag));
             let has_binary_sg = security_groups
                 .iter()
-                .any(|sg| sg.group_name() == Some(&format!("{}-binary", tag)));
+                .any(|sg| sg.group_name() == Some(&format!("{tag}-binary")));
             if region == MONITORING_REGION && has_monitoring_sg && has_binary_sg {
                 // Find the monitoring security group (named `tag`)
                 let monitoring_sg = security_groups
@@ -78,7 +78,7 @@ pub async fn destroy(config: &PathBuf) -> Result<(), Error> {
                 // Find the binary security group (named `{tag}-binary`)
                 let binary_sg = security_groups
                     .iter()
-                    .find(|sg| sg.group_name() == Some(&format!("{}-binary", tag)))
+                    .find(|sg| sg.group_name() == Some(&format!("{tag}-binary")))
                     .expect("Regular security group not found")
                     .group_id()
                     .unwrap();
@@ -200,7 +200,7 @@ pub async fn destroy(config: &PathBuf) -> Result<(), Error> {
                 info!(region = region.as_str(), igw_id, "deleted internet gateway");
             }
 
-            let key_name = format!("deployer-{}", tag);
+            let key_name = format!("deployer-{tag}");
             delete_key_pair(&ec2_client, &key_name).await?;
             info!(region = region.as_str(), key_name, "deleted key pair");
             Ok::<(), Error>(())

--- a/deployer/src/ec2/mod.rs
+++ b/deployer/src/ec2/mod.rs
@@ -230,7 +230,7 @@ cfg_if::cfg_if! {
         /// Directory where deployer files are stored
         fn deployer_directory(tag: &str) -> PathBuf {
             let base_dir = std::env::var("HOME").expect("$HOME is not configured");
-            PathBuf::from(format!("{}/.commonware_deployer/{}", base_dir, tag))
+            PathBuf::from(format!("{base_dir}/.commonware_deployer/{tag}"))
         }
 
         /// Errors that can occur when deploying infrastructure on AWS

--- a/deployer/src/ec2/services.rs
+++ b/deployer/src/ec2/services.rs
@@ -227,24 +227,18 @@ pub fn install_monitoring_cmd(
     tempo_version: &str,
 ) -> String {
     let prometheus_url = format!(
-    "https://github.com/prometheus/prometheus/releases/download/v{}/prometheus-{}.linux-arm64.tar.gz",
-    prometheus_version, prometheus_version
+    "https://github.com/prometheus/prometheus/releases/download/v{prometheus_version}/prometheus-{prometheus_version}.linux-arm64.tar.gz",
 );
-    let grafana_url = format!(
-        "https://dl.grafana.com/oss/release/grafana_{}_arm64.deb",
-        grafana_version
-    );
+    let grafana_url =
+        format!("https://dl.grafana.com/oss/release/grafana_{grafana_version}_arm64.deb");
     let loki_url = format!(
-        "https://github.com/grafana/loki/releases/download/v{}/loki-linux-arm64.zip",
-        loki_version
+        "https://github.com/grafana/loki/releases/download/v{loki_version}/loki-linux-arm64.zip",
     );
     let pyroscope_url = format!(
-      "https://github.com/grafana/pyroscope/releases/download/v{}/pyroscope_{}_linux_arm64.tar.gz",
-      pyroscope_version, pyroscope_version
-  );
+        "https://github.com/grafana/pyroscope/releases/download/v{pyroscope_version}/pyroscope_{pyroscope_version}_linux_arm64.tar.gz",
+    );
     let tempo_url = format!(
-        "https://github.com/grafana/tempo/releases/download/v{}/tempo_{}_linux_arm64.tar.gz",
-        tempo_version, tempo_version
+        "https://github.com/grafana/tempo/releases/download/v{tempo_version}/tempo_{tempo_version}_linux_arm64.tar.gz",
     );
     format!(
         r#"
@@ -253,31 +247,31 @@ sudo apt-get install -y wget curl unzip adduser libfontconfig1
 
 # Download Prometheus with retries
 for i in {{1..5}}; do
-  wget -O /home/ubuntu/prometheus.tar.gz {} && break
+  wget -O /home/ubuntu/prometheus.tar.gz {prometheus_url} && break
   sleep 10
 done
 
 # Download Grafana with retries
 for i in {{1..5}}; do
-  wget -O /home/ubuntu/grafana.deb {} && break
+  wget -O /home/ubuntu/grafana.deb {grafana_url} && break
   sleep 10
 done
 
 # Download Loki with retries
 for i in {{1..5}}; do
-  wget -O /home/ubuntu/loki.zip {} && break
+  wget -O /home/ubuntu/loki.zip {loki_url} && break
   sleep 10
 done
 
 # Download Pyroscope with retries
 for i in {{1..5}}; do
-  wget -O /home/ubuntu/pyroscope.tar.gz {} && break
+  wget -O /home/ubuntu/pyroscope.tar.gz {pyroscope_url} && break
   sleep 10
 done
 
 # Download Tempo with retries
 for i in {{1..5}}; do
-  wget -O /home/ubuntu/tempo.tar.gz {} && break
+  wget -O /home/ubuntu/tempo.tar.gz {tempo_url} && break
   sleep 10
 done
 
@@ -285,8 +279,8 @@ done
 sudo mkdir -p /opt/prometheus /opt/prometheus/data
 sudo chown -R ubuntu:ubuntu /opt/prometheus
 tar xvfz /home/ubuntu/prometheus.tar.gz -C /home/ubuntu
-sudo mv /home/ubuntu/prometheus-{}.linux-arm64 /opt/prometheus/prometheus-{}.linux-arm64
-sudo ln -s /opt/prometheus/prometheus-{}.linux-arm64/prometheus /opt/prometheus/prometheus
+sudo mv /home/ubuntu/prometheus-{prometheus_version}.linux-arm64 /opt/prometheus/prometheus-{prometheus_version}.linux-arm64
+sudo ln -s /opt/prometheus/prometheus-{prometheus_version}.linux-arm64/prometheus /opt/prometheus/prometheus
 sudo chmod +x /opt/prometheus/prometheus
 
 # Install Grafana
@@ -356,15 +350,7 @@ sudo systemctl start tempo
 sudo systemctl enable tempo
 sudo systemctl restart grafana-server
 sudo systemctl enable grafana-server
-"#,
-        prometheus_url,
-        grafana_url,
-        loki_url,
-        pyroscope_url,
-        tempo_url,
-        prometheus_version,
-        prometheus_version,
-        prometheus_version
+"#
     )
 }
 
@@ -414,8 +400,7 @@ sudo systemctl enable --now memleak-agent
 /// Command to set up Promtail on binary instances
 pub fn setup_promtail_cmd(promtail_version: &str) -> String {
     let promtail_url = format!(
-        "https://github.com/grafana/loki/releases/download/v{}/promtail-linux-arm64.zip",
-        promtail_version
+        "https://github.com/grafana/loki/releases/download/v{promtail_version}/promtail-linux-arm64.zip",
     );
     format!(
         r#"
@@ -424,7 +409,7 @@ sudo apt-get install -y wget unzip
 
 # Download Promtail with retries
 for i in {{1..5}}; do
-  wget -O /home/ubuntu/promtail.zip {} && break
+  wget -O /home/ubuntu/promtail.zip {promtail_url} && break
   sleep 10
 done
 
@@ -442,8 +427,7 @@ sudo chown root:root /etc/promtail/promtail.yml
 sudo systemctl daemon-reload
 sudo systemctl start promtail
 sudo systemctl enable promtail
-"#,
-        promtail_url
+"#
     )
 }
 
@@ -462,28 +446,26 @@ server:
 positions:
   filename: /tmp/positions.yaml
 clients:
-  - url: http://{}:3100/loki/api/v1/push
+  - url: http://{monitoring_private_ip}:3100/loki/api/v1/push
 scrape_configs:
   - job_name: binary_logs
     static_configs:
       - targets:
           - localhost
         labels:
-          deployer_name: {}
-          deployer_ip: {}
-          deployer_region: {}
+          deployer_name: {instance_name}
+          deployer_ip: {ip}
+          deployer_region: {region}
           __path__: /var/log/binary.log
-      "#,
-        monitoring_private_ip, instance_name, ip, region
+"#
     )
 }
 
 /// Command to install Node Exporter on instances
 pub fn setup_node_exporter_cmd(node_exporter_version: &str) -> String {
     let node_exporter_url = format!(
-      "https://github.com/prometheus/node_exporter/releases/download/v{}/node_exporter-{}.linux-arm64.tar.gz",
-      node_exporter_version, node_exporter_version
-  );
+        "https://github.com/prometheus/node_exporter/releases/download/v{node_exporter_version}/node_exporter-{node_exporter_version}.linux-arm64.tar.gz",
+    );
     format!(
         r#"
 sudo apt-get update -y
@@ -491,15 +473,15 @@ sudo apt-get install -y wget tar
 
 # Download Node Exporter with retries
 for i in {{1..5}}; do
-  wget -O /home/ubuntu/node_exporter.tar.gz {} && break
+  wget -O /home/ubuntu/node_exporter.tar.gz {node_exporter_url} && break
   sleep 10
 done
 
 # Install Node Exporter
 sudo mkdir -p /opt/node_exporter
 tar xvfz /home/ubuntu/node_exporter.tar.gz -C /home/ubuntu
-sudo mv /home/ubuntu/node_exporter-{}.linux-arm64 /opt/node_exporter/node_exporter-{}.linux-arm64
-sudo ln -s /opt/node_exporter/node_exporter-{}.linux-arm64/node_exporter /opt/node_exporter/node_exporter
+sudo mv /home/ubuntu/node_exporter-{node_exporter_version}.linux-arm64 /opt/node_exporter/node_exporter-{node_exporter_version}.linux-arm64
+sudo ln -s /opt/node_exporter/node_exporter-{node_exporter_version}.linux-arm64/node_exporter /opt/node_exporter/node_exporter
 sudo chmod +x /opt/node_exporter/node_exporter
 sudo mv /home/ubuntu/node_exporter.service /etc/systemd/system/node_exporter.service
 
@@ -507,8 +489,7 @@ sudo mv /home/ubuntu/node_exporter.service /etc/systemd/system/node_exporter.ser
 sudo systemctl daemon-reload
 sudo systemctl start node_exporter
 sudo systemctl enable node_exporter
-"#,
-        node_exporter_url, node_exporter_version, node_exporter_version, node_exporter_version
+"#
     )
 }
 
@@ -544,29 +525,28 @@ scrape_configs:
     for (name, ip, region) in instances {
         config.push_str(&format!(
             r#"
-  - job_name: '{}_binary'
+  - job_name: '{name}_binary'
     static_configs:
-      - targets: ['{}:9090']
+      - targets: ['{ip}:9090']
         labels:
-          deployer_name: '{}'
-          deployer_ip: '{}'
-          deployer_region: '{}'
-  - job_name: '{}_system'
+          deployer_name: '{name}'
+          deployer_ip: '{ip}'
+          deployer_region: '{region}'
+  - job_name: '{name}_system'
     static_configs:
-      - targets: ['{}:9100']
+      - targets: ['{ip}:9100']
         labels:
-          deployer_name: '{}'
-          deployer_ip: '{}'
-          deployer_region: '{}'
-  - job_name: '{}_memleak'
+          deployer_name: '{name}'
+          deployer_ip: '{ip}'
+          deployer_region: '{region}'
+  - job_name: '{name}_memleak'
     static_configs:
-      - targets: ['{}:9200']
+      - targets: ['{ip}:9200']
         labels:
-          deployer_name: '{}'
-          deployer_ip: '{}'
-          deployer_region: '{}'
-"#,
-            name, ip, name, ip, region, name, ip, name, ip, region, name, ip, name, ip, region
+          deployer_name: '{name}'
+          deployer_ip: '{ip}'
+          deployer_region: '{region}'
+"#
         ));
     }
     config

--- a/deployer/src/ec2/update.rs
+++ b/deployer/src/ec2/update.rs
@@ -33,7 +33,7 @@ pub async fn update(config_path: &PathBuf) -> Result<(), Error> {
     }
 
     // Construct private key path (assumes it exists from create command)
-    let private_key_path = tag_directory.join(format!("id_rsa_{}", tag));
+    let private_key_path = tag_directory.join(format!("id_rsa_{tag}"));
     if !private_key_path.exists() {
         return Err(Error::PrivateKeyNotFound);
     }

--- a/deployer/src/ec2/utils.rs
+++ b/deployer/src/ec2/utils.rs
@@ -49,11 +49,10 @@ pub async fn rsync_file(
             .arg("-az")
             .arg("-e")
             .arg(format!(
-                "ssh -i {} -o ServerAliveInterval=600 -o StrictHostKeyChecking=no",
-                key_file
+                "ssh -i {key_file} -o ServerAliveInterval=600 -o StrictHostKeyChecking=no"
             ))
             .arg(local_path)
-            .arg(format!("ubuntu@{}:{}", ip, remote_path))
+            .arg(format!("ubuntu@{ip}:{remote_path}"))
             .output()
             .await?;
         if output.status.success() {
@@ -75,7 +74,7 @@ pub async fn ssh_execute(key_file: &str, ip: &str, command: &str) -> Result<(), 
             .arg("ServerAliveInterval=600")
             .arg("-o")
             .arg("StrictHostKeyChecking=no")
-            .arg(format!("ubuntu@{}", ip))
+            .arg(format!("ubuntu@{ip}"))
             .arg(command)
             .output()
             .await?;
@@ -98,8 +97,8 @@ pub async fn poll_service_active(key_file: &str, ip: &str, service: &str) -> Res
             .arg("ServerAliveInterval=600")
             .arg("-o")
             .arg("StrictHostKeyChecking=no")
-            .arg(format!("ubuntu@{}", ip))
-            .arg(format!("systemctl is-active {}", service))
+            .arg(format!("ubuntu@{ip}"))
+            .arg(format!("systemctl is-active {service}"))
             .output()
             .await?;
         let parsed = String::from_utf8_lossy(&output.stdout);
@@ -127,8 +126,8 @@ pub async fn poll_service_inactive(key_file: &str, ip: &str, service: &str) -> R
             .arg("ServerAliveInterval=600")
             .arg("-o")
             .arg("StrictHostKeyChecking=no")
-            .arg(format!("ubuntu@{}", ip))
-            .arg(format!("systemctl is-active {}", service))
+            .arg(format!("ubuntu@{ip}"))
+            .arg(format!("systemctl is-active {service}"))
             .output()
             .await?;
         let parsed = String::from_utf8_lossy(&output.stdout);
@@ -167,5 +166,5 @@ pub async fn enable_bbr(key_file: &str, ip: &str, bbr_conf_local_path: &str) -> 
 
 /// Converts an IP address to a CIDR block
 pub fn exact_cidr(ip: &str) -> String {
-    format!("{}/32", ip)
+    format!("{ip}/32")
 }

--- a/examples/bridge/src/bin/dealer.rs
+++ b/examples/bridge/src/bin/dealer.rs
@@ -57,6 +57,6 @@ fn main() {
     println!("public: {}", poly::public::<MinSig>(&public));
     for share in shares {
         let validator = validators[share.index as usize].0;
-        println!("validator={}: {}", validator, share,);
+        println!("validator={validator}: {share}");
     }
 }

--- a/examples/chat/src/handler.rs
+++ b/examples/chat/src/handler.rs
@@ -153,9 +153,9 @@ pub async fn run(
                 //
                 // Show or hide the cursor in the input block
                 let input_with_cursor = if cursor_visible {
-                    format!("> {}_", input)
+                    format!("> {input}_")
                 } else {
-                    format!("> {}", input.clone())
+                    format!("> {input}")
                 };
                 let input_block = Paragraph::new(input_with_cursor)
                     .style(Style::default().fg(Color::Yellow))
@@ -266,7 +266,7 @@ pub async fn run(
                                 successful.sort();
                                 let mut friends = String::from_str("[").unwrap();
                                 for friend in successful {
-                                    friends.push_str(&format!("{:?},", friend));
+                                    friends.push_str(&format!("{friend:?},"));
                                 }
                                 friends.pop();
                                 friends.push(']');

--- a/examples/chat/src/logger.rs
+++ b/examples/chat/src/logger.rs
@@ -24,7 +24,7 @@ impl Writer {
             && key != "target"
             && key != "message"
         {
-            log_message.push_str(&format!("{}={} ", key, value));
+            log_message.push_str(&format!("{key}={value} "));
         }
     }
 }

--- a/examples/flood/src/bin/setup.rs
+++ b/examples/flood/src/bin/setup.rs
@@ -145,7 +145,7 @@ fn main() {
     for (index, scheme) in peer_schemes.iter().enumerate() {
         // Create peer config
         let name = scheme.public_key().to_string();
-        let peer_config_file = format!("{}.yaml", name);
+        let peer_config_file = format!("{name}.yaml");
         let peer_config = Config {
             private_key: scheme.to_string(),
             port: PORT,
@@ -196,7 +196,7 @@ fn main() {
     let raw_current_dir = std::env::current_dir().unwrap();
     let current_dir = raw_current_dir.to_str().unwrap();
     let output = matches.get_one::<String>("output").unwrap();
-    let output = format!("{}/{}", current_dir, output);
+    let output = format!("{current_dir}/{output}");
     assert!(
         !std::path::Path::new(&output).exists(),
         "output directory already exists"
@@ -204,16 +204,16 @@ fn main() {
     std::fs::create_dir_all(output.clone()).unwrap();
     let dashboard = matches.get_one::<String>("dashboard").unwrap().clone();
     std::fs::copy(
-        format!("{}/{}", current_dir, dashboard),
-        format!("{}/dashboard.json", output),
+        format!("{current_dir}/{dashboard}"),
+        format!("{output}/dashboard.json"),
     )
     .unwrap();
     for (peer_config_file, peer_config) in peer_configs {
-        let path = format!("{}/{}", output, peer_config_file);
+        let path = format!("{output}/{peer_config_file}");
         let file = std::fs::File::create(path).unwrap();
         serde_yaml::to_writer(file, &peer_config).unwrap();
     }
-    let path = format!("{}/config.yaml", output);
+    let path = format!("{output}/config.yaml");
     let file = std::fs::File::create(path.clone()).unwrap();
     serde_yaml::to_writer(file, &config).unwrap();
     info!(path, "wrote configuration files");

--- a/examples/log/src/gui.rs
+++ b/examples/log/src/gui.rs
@@ -62,7 +62,7 @@ impl Writer {
             && key != "target"
             && key != "message"
         {
-            log_message.push_str(&format!("{}={} ", key, value));
+            log_message.push_str(&format!("{key}={value} "));
         }
     }
 }
@@ -83,12 +83,12 @@ impl std::io::Write for Writer {
             .with_timezone(&chrono::Local)
             .format("%Y-%m-%dT%H:%M:%S");
         let (progress, mut formatted_msg) = if target.contains("commonware_log::application") {
-            (true, format!("[{}] => {} (", datetime_local, msg))
+            (true, format!("[{datetime_local}] => {msg} ("))
         } else {
             let level = json["level"].as_str().unwrap();
             (
                 false,
-                format!("[{}|{}] {} => {} (", datetime_local, level, target, msg),
+                format!("[{datetime_local}|{level}] {target} => {msg} ("),
             )
         };
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -221,7 +221,7 @@ pub fn select(input: TokenStream) -> TokenStream {
     ) in branches.into_iter().enumerate()
     {
         // Generate a unique identifier for each future
-        let future_ident = Ident::new(&format!("__select_future_{}", index), pattern.span());
+        let future_ident = Ident::new(&format!("__select_future_{index}"), pattern.span());
 
         // Fuse and pin each future
         let stmt = quote! {

--- a/p2p/src/authenticated/discovery/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/actor.rs
@@ -161,7 +161,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
                     // Panic since there is no way to recover from this.
                     let len = peers.len();
                     let max = self.max_peer_set_size;
-                    assert!(len <= max, "peer set too large: {} > {}", len, max);
+                    assert!(len <= max, "peer set too large: {len} > {max}");
 
                     self.directory.add_set(index, peers);
                 }

--- a/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
@@ -199,8 +199,7 @@ impl<E: Spawner + Metrics, C: PublicKey> Releaser<E, C> {
         };
         assert!(
             e.is_full(),
-            "Unexpected error trying to release reservation {:?}",
-            e
+            "Unexpected error trying to release reservation {e:?}"
         );
         false
     }

--- a/p2p/src/authenticated/discovery/actors/tracker/set.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/set.rs
@@ -103,9 +103,7 @@ mod tests {
             assert_eq!(
                 set.order.get(peer),
                 Some(&i),
-                "Peer {} should map to index {}",
-                peer,
-                i
+                "Peer {peer} should map to index {i}"
             );
         }
         assert_eq!(

--- a/p2p/src/authenticated/discovery/channels.rs
+++ b/p2p/src/authenticated/discovery/channels.rs
@@ -121,7 +121,7 @@ impl<P: PublicKey> Channels<P> {
     ) -> (Sender<P>, Receiver<P>) {
         let (sender, receiver) = mpsc::channel(backlog);
         if self.receivers.insert(channel, (rate, sender)).is_some() {
-            panic!("duplicate channel registration: {}", channel);
+            panic!("duplicate channel registration: {channel}");
         }
         (
             Sender::new(channel, self.max_size, self.messenger.clone()),

--- a/p2p/src/authenticated/discovery/metrics.rs
+++ b/p2p/src/authenticated/discovery/metrics.rs
@@ -29,7 +29,7 @@ impl EncodeLabelValue for MessageType {
         match self {
             MessageType::BitVec => encoder.write_str("bit_vec"),
             MessageType::Peers => encoder.write_str("peers"),
-            MessageType::Data(channel) => encoder.write_str(&format!("data_{}", channel)),
+            MessageType::Data(channel) => encoder.write_str(&format!("data_{channel}")),
             MessageType::Invalid => encoder.write_str("invalid"),
         }
     }

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -249,8 +249,7 @@ mod tests {
         let metrics = context.encode();
         assert!(
             !metrics.contains("messages_rate_limited_total{"),
-            "no messages should be rate limited: {}",
-            metrics
+            "no messages should be rate limited: {metrics}"
         );
     }
 
@@ -276,7 +275,7 @@ mod tests {
         let (complete_sender, mut complete_receiver) = mpsc::channel(peers.len());
         for (i, peer) in peers.iter().enumerate() {
             // Create peer context
-            let context = context.with_label(&format!("peer-{}", i));
+            let context = context.with_label(&format!("peer-{i}"));
 
             // Derive port
             let port = base_port + i as u16;
@@ -530,7 +529,7 @@ mod tests {
             let mut waiters = Vec::new();
             for (i, peer) in peers.iter().enumerate() {
                 // Create peer context
-                let context = context.with_label(&format!("peer-{}", i));
+                let context = context.with_label(&format!("peer-{i}"));
 
                 // Derive port
                 let port = base_port + i as u16;

--- a/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
@@ -140,8 +140,7 @@ impl<E: Spawner + Metrics, C: PublicKey> Releaser<E, C> {
         };
         assert!(
             e.is_full(),
-            "Unexpected error trying to release reservation {:?}",
-            e
+            "Unexpected error trying to release reservation {e:?}"
         );
         false
     }

--- a/p2p/src/authenticated/lookup/channels.rs
+++ b/p2p/src/authenticated/lookup/channels.rs
@@ -121,7 +121,7 @@ impl<P: PublicKey> Channels<P> {
     ) -> (Sender<P>, Receiver<P>) {
         let (sender, receiver) = mpsc::channel(backlog);
         if self.receivers.insert(channel, (rate, sender)).is_some() {
-            panic!("duplicate channel registration: {}", channel);
+            panic!("duplicate channel registration: {channel}");
         }
         (
             Sender::new(channel, self.max_size, self.messenger.clone()),

--- a/p2p/src/authenticated/lookup/metrics.rs
+++ b/p2p/src/authenticated/lookup/metrics.rs
@@ -26,7 +26,7 @@ pub enum MessageType {
 impl EncodeLabelValue for MessageType {
     fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
         match self {
-            MessageType::Data(channel) => encoder.write_str(&format!("data_{}", channel)),
+            MessageType::Data(channel) => encoder.write_str(&format!("data_{channel}")),
             MessageType::Invalid => encoder.write_str("invalid"),
             MessageType::Ping => encoder.write_str("ping"),
         }

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -186,8 +186,7 @@ mod tests {
         let metrics = context.encode();
         assert!(
             !metrics.contains("messages_rate_limited_total{"),
-            "no messages should be rate limited: {}",
-            metrics
+            "no messages should be rate limited: {metrics}"
         );
     }
 
@@ -221,7 +220,7 @@ mod tests {
             let public_key = public_key.clone();
 
             // Create peer context
-            let context = context.with_label(&format!("peer-{}", i));
+            let context = context.with_label(&format!("peer-{i}"));
 
             // Create network
             let config = Config::test(private_key.clone(), *address, max_message_size);
@@ -478,7 +477,7 @@ mod tests {
             let mut waiters = Vec::new();
             for (i, (peer_sk, peer_pk, peer_addr)) in peers_and_sks.iter().enumerate() {
                 // Create peer context
-                let context = context.with_label(&format!("peer-{}", i));
+                let context = context.with_label(&format!("peer-{i}"));
 
                 // Create network
                 let config = Config::test(

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -206,7 +206,7 @@ mod tests {
                     loop {
                         let index = context.gen_range(0..keys.len());
                         let sender = keys[index];
-                        let msg = format!("hello from {:?}", sender);
+                        let msg = format!("hello from {sender:?}");
                         let msg = Bytes::from(msg);
                         let mut message_sender = agents.get(sender).unwrap().clone();
                         let sent = message_sender

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -168,7 +168,7 @@ mod tests {
     ) -> Mailbox<Key> {
         let public_key = signer.public_key();
         let (engine, mailbox) = Engine::new(
-            context.with_label(&format!("actor_{}", public_key)),
+            context.with_label(&format!("actor_{public_key}")),
             Config {
                 coordinator: coordinator.clone(),
                 consumer,

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -821,7 +821,7 @@ impl crate::Metrics for Context {
             if prefix.is_empty() {
                 label.to_string()
             } else {
-                format!("{}_{}", prefix, label)
+                format!("{prefix}_{label}")
             }
         };
         assert!(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1557,7 +1557,7 @@ mod tests {
                 content_length: usize,
             ) -> Result<String, Error> {
                 let read = stream.recv(vec![0; content_length]).await?;
-                String::from_utf8(read.as_ref().to_vec()).map_err(|_| Error::ReadFailed)
+                String::from_utf8(read.into()).map_err(|_| Error::ReadFailed)
             }
 
             // Simulate a client connecting to the server

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -545,7 +545,7 @@ mod tests {
             for _ in 0..2 {
                 select! {
                     v = receiver.next() => {
-                        panic!("unexpected value: {:?}", v);
+                        panic!("unexpected value: {v:?}");
                     },
                     _ = context.sleep(Duration::from_millis(100)) => {
                         continue;
@@ -563,7 +563,7 @@ mod tests {
                     // Skip reading from channel even though populated
                 },
                 v = receiver.next() => {
-                    panic!("unexpected value: {:?}", v);
+                    panic!("unexpected value: {v:?}");
                 },
             };
 
@@ -1577,8 +1577,7 @@ mod tests {
 
                     // Send a GET request to the server
                     let request = format!(
-                        "GET /metrics HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
-                        address
+                        "GET /metrics HTTP/1.1\r\nHost: {address}\r\nConnection: close\r\n\r\n"
                     );
                     sink.send(Bytes::from(request).to_vec()).await.unwrap();
 
@@ -1588,7 +1587,7 @@ mod tests {
 
                     // Read and parse headers
                     let headers = read_headers(&mut stream).await.unwrap();
-                    println!("Headers: {:?}", headers);
+                    println!("Headers: {headers:?}");
                     let content_length = headers
                         .get("content-length")
                         .unwrap()

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -280,7 +280,7 @@ mod tests {
         executor.start(|context| async move {
             select! {
                 v = stream.recv(vec![0;5]) => {
-                    panic!("unexpected value: {:?}", v);
+                    panic!("unexpected value: {v:?}");
                 },
                 _ = context.sleep(Duration::from_millis(100)) => {
                     "timeout"

--- a/runtime/src/network/audited.rs
+++ b/runtime/src/network/audited.rs
@@ -234,8 +234,7 @@ mod tests {
             assert_eq!(
                 auditors[0].state(),
                 auditors[1].state(),
-                "Auditor states differ: {}",
-                msg
+                "Auditor states differ: {msg}"
             );
         };
 

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -305,7 +305,7 @@ impl crate::Blob for Blob {
                 return Err(Error::BlobSyncFailed(
                     self.partition.clone(),
                     hex(&self.name),
-                    IoError::other(format!("error code: {}", return_value)),
+                    IoError::other(format!("error code: {return_value}")),
                 ));
             }
 

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -290,7 +290,7 @@ pub(crate) mod tests {
         let mut read = vec![0u8; chunk_size].into();
         for i in 0..num_chunks {
             read = blob.read_at(read, (i * chunk_size) as u64).await.unwrap();
-            assert_eq!(read.as_ref(), data, "Chunk {} is incorrect", i);
+            assert_eq!(read.as_ref(), data, "Chunk {i} is incorrect");
         }
     }
 

--- a/runtime/src/telemetry/traces/status.rs
+++ b/runtime/src/telemetry/traces/status.rs
@@ -15,7 +15,7 @@ pub fn ok(span: &Span) {
 /// If `error` is provided, it will be recorded as an attribute on the span.
 pub fn error(span: &Span, status: &str, error: Option<&dyn Debug>) {
     if let Some(error) = error {
-        span.record("error", format!("{:?}", error));
+        span.record("error", format!("{error:?}"));
     }
     span.set_status(Status::error(status.to_string()));
 }

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -119,7 +119,7 @@ impl Config {
     /// Returns a new [Config] with default values.
     pub fn new() -> Self {
         let rng = OsRng.next_u64();
-        let storage_directory = env::temp_dir().join(format!("commonware_tokio_runtime_{}", rng));
+        let storage_directory = env::temp_dir().join(format!("commonware_tokio_runtime_{rng}"));
         Self {
             worker_threads: 2,
             max_blocking_threads: 512,
@@ -487,7 +487,7 @@ impl crate::Metrics for Context {
             if prefix.is_empty() {
                 label.to_string()
             } else {
-                format!("{}_{}", prefix, label)
+                format!("{prefix}_{label}")
             }
         };
         assert!(

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -179,8 +179,7 @@ mod tests {
                 // Verify data integrity
                 assert!(
                     buf[..to_read].iter().all(|&b| b == 0x42),
-                    "Data at position {} is not correct",
-                    total_read
+                    "Data at position {total_read} is not correct"
                 );
 
                 total_read += to_read;

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -49,7 +49,7 @@ fn extract_panic_message(err: &(dyn Any + Send)) -> String {
     } else if let Some(s) = err.downcast_ref::<String>() {
         s.clone()
     } else {
-        format!("{:?}", err)
+        format!("{err:?}")
     }
 }
 

--- a/storage/src/adb/benches/any_init.rs
+++ b/storage/src/adb/benches/any_init.rs
@@ -28,11 +28,11 @@ const THREADS: usize = 8;
 
 fn any_cfg(pool: ThreadPool) -> AConfig<EightCap> {
     AConfig::<EightCap> {
-        mmr_journal_partition: format!("journal_{}", PARTITION_SUFFIX),
-        mmr_metadata_partition: format!("metadata_{}", PARTITION_SUFFIX),
+        mmr_journal_partition: format!("journal_{PARTITION_SUFFIX}"),
+        mmr_metadata_partition: format!("metadata_{PARTITION_SUFFIX}"),
         mmr_items_per_blob: ITEMS_PER_BLOB,
         mmr_write_buffer: 1024,
-        log_journal_partition: format!("log_journal_{}", PARTITION_SUFFIX),
+        log_journal_partition: format!("log_journal_{PARTITION_SUFFIX}"),
         log_items_per_blob: ITEMS_PER_BLOB,
         log_write_buffer: 1024,
         translator: EightCap,

--- a/storage/src/adb/operation.rs
+++ b/storage/src/adb/operation.rs
@@ -145,9 +145,9 @@ impl<K: Array, V: Array> Read for Operation<K, V> {
 impl<K: Array, V: Array> Display for Operation<K, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Operation::Deleted(key) => write!(f, "[key:{} <deleted>]", key),
-            Operation::Update(key, value) => write!(f, "[key:{} value:{}]", key, value),
-            Operation::Commit(loc) => write!(f, "[commit with inactivity floor: {}]", loc),
+            Operation::Deleted(key) => write!(f, "[key:{key} <deleted>]"),
+            Operation::Update(key, value) => write!(f, "[key:{key} value:{value}]"),
+            Operation::Commit(loc) => write!(f, "[commit with inactivity floor: {loc}]"),
         }
     }
 }
@@ -242,17 +242,11 @@ mod tests {
         let key = U64::new(1234);
         let value = U64::new(56789);
         let update_op = Operation::Update(key.clone(), value.clone());
-        assert_eq!(
-            format!("{}", update_op),
-            format!("[key:{} value:{}]", key, value)
-        );
+        assert_eq!(format!("{update_op}"), format!("[key:{key} value:{value}]"));
 
         let key2 = U64::new(42);
         let delete_op = Operation::<U64, U64>::Deleted(key2.clone());
-        assert_eq!(
-            format!("{}", delete_op),
-            format!("[key:{} <deleted>]", key2)
-        );
+        assert_eq!(format!("{delete_op}"), format!("[key:{key2} <deleted>]"));
     }
 
     #[test]

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -803,7 +803,7 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            let tracked = format!("items_tracked {:?}", num_keys);
+            let tracked = format!("items_tracked {num_keys:?}");
             assert!(buffer.contains(&tracked));
             assert!(buffer.contains("pruned_total 0"));
 
@@ -881,7 +881,7 @@ mod tests {
             let buffer = context.encode();
             let tracked = format!("items_tracked {:?}", num_keys - removed);
             assert!(buffer.contains(&tracked));
-            let pruned = format!("indices_pruned_total {}", removed);
+            let pruned = format!("indices_pruned_total {removed}");
             assert!(buffer.contains(&pruned));
             assert!(buffer.contains("pruned_total 0")); // have not lazily removed keys yet
 

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -319,9 +319,7 @@ mod tests {
             let proof = tree.proof(i as u32).unwrap();
             assert!(
                 proof.verify(&mut hasher, leaf, i as u32, &root).is_ok(),
-                "correct fail for size={} leaf={}",
-                n,
-                i
+                "correct fail for size={n} leaf={i}"
             );
 
             // Serialize and deserialize the proof
@@ -331,9 +329,7 @@ mod tests {
                 deserialized
                     .verify(&mut hasher, leaf, i as u32, &root)
                     .is_ok(),
-                "deserialize fail for size={} leaf={}",
-                n,
-                i
+                "deserialize fail for size={n} leaf={i}"
             );
 
             // Modify a sibling hash and ensure the proof fails
@@ -344,9 +340,7 @@ mod tests {
                     update_tamper
                         .verify(&mut hasher, leaf, i as u32, &root)
                         .is_err(),
-                    "modify fail for size={} leaf={}",
-                    n,
-                    i
+                    "modify fail for size={n} leaf={i}"
                 );
             }
 
@@ -357,9 +351,7 @@ mod tests {
                 add_tamper
                     .verify(&mut hasher, leaf, i as u32, &root)
                     .is_err(),
-                "add fail for size={} leaf={}",
-                n,
-                i
+                "add fail for size={n} leaf={i}"
             );
 
             // Remove a sibling hash and ensure the proof fails
@@ -370,9 +362,7 @@ mod tests {
                     remove_tamper
                         .verify(&mut hasher, leaf, i as u32, &root)
                         .is_err(),
-                    "remove fail for size={} leaf={}",
-                    n,
-                    i
+                    "remove fail for size={n} leaf={i}"
                 );
             }
         }

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -31,7 +31,7 @@ async fn bench_run(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: us
             Ok(item) => {
                 black_box(item);
             }
-            Err(err) => panic!("Failed to read item: {}", err),
+            Err(err) => panic!("Failed to read item: {err}"),
         }
     }
 }

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -686,7 +686,7 @@ mod tests {
                             assert_eq!(test_digest(pos), item);
                             items.push(pos);
                         }
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
                 assert_eq!(items, Vec::<u64>::new());
@@ -740,7 +740,7 @@ mod tests {
                             assert_eq!(test_digest(pos), item);
                             items.push(pos);
                         }
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
 
@@ -914,16 +914,15 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((pos, item)) => {
-                            assert!(pos >= START_POS, "pos={}", pos);
+                            assert!(pos >= START_POS, "pos={pos}");
                             assert_eq!(
                                 test_digest(pos),
                                 item,
-                                "Item at position {} did not match expected digest",
-                                pos
+                                "Item at position {pos} did not match expected digest"
                             );
                             items.push(pos);
                         }
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
 

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -743,7 +743,7 @@ mod tests {
             while let Some(result) = stream.next().await {
                 match result {
                     Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                    Err(err) => panic!("Failed to read item: {}", err),
+                    Err(err) => panic!("Failed to read item: {err}"),
                 }
             }
 
@@ -809,7 +809,7 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
             }
@@ -893,7 +893,7 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
             }
@@ -996,7 +996,7 @@ mod tests {
             while let Some(result) = stream.next().await {
                 match result {
                     Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                    Err(err) => panic!("Failed to read item: {}", err),
+                    Err(err) => panic!("Failed to read item: {err}"),
                 }
             }
             assert!(items.is_empty());
@@ -1049,7 +1049,7 @@ mod tests {
             while let Some(result) = stream.next().await {
                 match result {
                     Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                    Err(err) => panic!("Failed to read item: {}", err),
+                    Err(err) => panic!("Failed to read item: {err}"),
                 }
             }
             assert!(items.is_empty());
@@ -1112,7 +1112,7 @@ mod tests {
             while let Some(result) = stream.next().await {
                 match result {
                     Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                    Err(err) => panic!("Failed to read item: {}", err),
+                    Err(err) => panic!("Failed to read item: {err}"),
                 }
             }
             assert!(items.is_empty());
@@ -1180,7 +1180,7 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
                 assert!(items.is_empty());
@@ -1255,7 +1255,7 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
             }
@@ -1290,7 +1290,7 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
             }
@@ -1339,7 +1339,7 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
             }
@@ -1416,7 +1416,7 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
             }
@@ -1465,7 +1465,7 @@ mod tests {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                        Err(err) => panic!("Failed to read item: {}", err),
+                        Err(err) => panic!("Failed to read item: {err}"),
                     }
                 }
             }
@@ -1542,7 +1542,7 @@ mod tests {
             while let Some(result) = stream.next().await {
                 match result {
                     Ok((blob_index, _, _, item)) => items.push((blob_index, item)),
-                    Err(err) => panic!("Failed to read item: {}", err),
+                    Err(err) => panic!("Failed to read item: {err}"),
                 }
             }
         });

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -35,8 +35,8 @@
 //! # Efficient Writes
 //!
 //! When an update is committed, only updated bytes are actually written to disk. This makes `Metadata`
-//! a great choice for maintaining even large collections of data (as there is no overhead to maintaining
-//! keys that aren't updated as long as new keys don't change the order of keys written).
+//! a great choice for maintaining even large collections of data (there is only overhead to maintaining
+//! keys that aren't updated if the order of keys is unstable).
 //!
 //! # Example
 //!

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -32,10 +32,11 @@
 //! not be guaranteed to recover the latest complete state from disk on restart as half of a blob
 //! could be old data and half new data).
 //!
-//! # Writing Differences
+//! # Efficient Writes
 //!
-//! When an update is committed, only updated bytes are actually written to disk. This makes it efficient
-//! to maintain large instances of `Metadata` without constantly rewriting the entire blob.
+//! When an update is committed, only updated bytes are actually written to disk. This makes `Metadata`
+//! a great choice for maintaining even large collections of data (as there is no overhead to maintaining
+//! keys that aren't updated as long as new keys don't change the order of keys written).
 //!
 //! # Example
 //!

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -25,7 +25,7 @@ pub struct Metadata<E: Clock + Storage + Metrics, K: Array> {
 
     syncs: Counter,
     keys: Gauge,
-    bytes_written: Counter,
+    skipped: Counter,
 }
 
 impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
@@ -68,13 +68,13 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         // Create metrics
         let syncs = Counter::default();
         let keys = Gauge::default();
-        let bytes_written = Counter::default();
+        let skipped = Counter::default();
         context.register("syncs", "number of syncs of data to disk", syncs.clone());
         context.register("keys", "number of tracked keys", keys.clone());
         context.register(
-            "bytes_written",
-            "total bytes written to disk",
-            bytes_written.clone(),
+            "skipped",
+            "total bytes not written to disk",
+            skipped.clone(),
         );
 
         // Return metadata
@@ -92,7 +92,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
 
             syncs,
             keys,
-            bytes_written,
+            skipped,
         })
     }
 
@@ -173,7 +173,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         }
 
         // Return info
-        Ok(Some((version, data, buf.as_ref().to_vec())))
+        Ok(Some((version, data, buf.into())))
     }
 
     /// Get a value from `Metadata` (if it exists).

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -231,7 +231,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         let (target_blob, target_data, target_version) = &mut self.blobs[target_cursor];
 
         // Compute byte-level diff and only write changed segments
-        let mut i = 0usize;
+        let mut i = 0;
         let mut skipped = 0;
         let mut writes = Vec::new();
         while i < next_data.len() {

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -18,10 +18,6 @@ pub struct Metadata<E: Clock + Storage + Metrics, K: Array> {
     data: BTreeMap<K, Vec<u8>>,
     cursor: usize,
     partition: String,
-    // Each entry contains:
-    // 0. The blob handle.
-    // 1. The last serialized bytes that reside on disk (in-memory copy) for diffing.
-    // 2. The version stored in the blob.
     blobs: [(E::Blob, Vec<u8>, u64); 2],
 
     syncs: Counter,

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -165,7 +165,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         }
 
         // Return info
-        Ok(Some((version, data, buf)))
+        Ok(Some((version, data, buf.as_ref().to_vec())))
     }
 
     /// Get a value from `Metadata` (if it exists).

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -265,7 +265,6 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         *old_version = next_version;
         self.cursor = next_cursor;
         self.skipped.inc_by(skipped);
-
         Ok(())
     }
 

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -254,6 +254,7 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
             writes.push(target_blob.write_at(next_data[start..end].to_vec(), start as u64));
         }
         try_join_all(writes).await?;
+        self.skipped.inc_by(skipped);
 
         // If the new file is shorter, truncate; if longer, resize was implicitly handled by write_at
         if next_data.len() < target_data.len() {
@@ -265,7 +266,6 @@ impl<E: Clock + Storage + Metrics, K: Array> Metadata<E, K> {
         *target_data = next_data;
         *target_version = next_version;
         self.cursor = target_cursor;
-        self.skipped.inc_by(skipped);
         Ok(())
     }
 

--- a/storage/src/mmr/tests/mod.rs
+++ b/storage/src/mmr/tests/mod.rs
@@ -17,7 +17,7 @@ pub async fn build_and_check_test_roots_mmr(mmr: &mut impl Builder<Sha256>) {
         let element = hasher.inner().finalize();
         let root = mmr.root(&mut hasher);
         let expected_root = ROOTS[i as usize];
-        assert_eq!(hex(&root), expected_root, "at: {}", i);
+        assert_eq!(hex(&root), expected_root, "at: {i}");
         mmr.add(&mut hasher, &element).await.unwrap();
     }
     assert_eq!(

--- a/stream/src/public_key/cipher.rs
+++ b/stream/src/public_key/cipher.rs
@@ -121,7 +121,7 @@ mod tests {
         let modified_info_ciphers = derive::<N>(base_ikm, base_salts, modified_infos).unwrap();
 
         let nonce = Default::default();
-        let plaintext = format!("{}_test", test_name);
+        let plaintext = format!("{test_name}_test");
 
         // All variants should produce different results
         for i in 0..N {
@@ -137,13 +137,11 @@ mod tests {
 
             assert_ne!(
                 base_ct, salt_ct,
-                "Cipher {} should be sensitive to salt changes in {}",
-                i, test_name
+                "Cipher {i} should be sensitive to salt changes in {test_name}"
             );
             assert_ne!(
                 base_ct, info_ct,
-                "Cipher {} should be sensitive to info changes in {}",
-                i, test_name
+                "Cipher {i} should be sensitive to info changes in {test_name}"
             );
         }
     }

--- a/utils/src/array/fixed_bytes.rs
+++ b/utils/src/array/fixed_bytes.rs
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn test_display() {
         let bytes = FixedBytes::new([0x01, 0x02, 0x03, 0x04]);
-        assert_eq!(format!("{}", bytes), "01020304");
+        assert_eq!(format!("{bytes}"), "01020304");
     }
 
     #[test]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -19,7 +19,7 @@ pub use stable_buf::StableBuf;
 pub fn hex(bytes: &[u8]) -> String {
     let mut hex = String::new();
     for byte in bytes.iter() {
-        hex.push_str(&format!("{:02x}", byte));
+        hex.push_str(&format!("{byte:02x}"));
     }
     hex
 }

--- a/utils/src/stable_buf.rs
+++ b/utils/src/stable_buf.rs
@@ -39,6 +39,15 @@ impl From<StableBuf> for Bytes {
     }
 }
 
+impl From<StableBuf> for Vec<u8> {
+    fn from(buf: StableBuf) -> Self {
+        match buf {
+            StableBuf::Vec(v) => v,
+            StableBuf::BytesMut(b) => b.to_vec(),
+        }
+    }
+}
+
 impl Index<usize> for StableBuf {
     type Output = u8;
 


### PR DESCRIPTION
Resolves: #1174 

Instead of rewriting the entire backing `Blob`, just write the modified portions of the `Blob`. This saves a TON of work for some users of `Metadata`.