### PR TITLE
add zeroization for chacha20

### DIFF
--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -21,7 +21,7 @@ bytes = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
 zeroize = { workspace = true }
-chacha20poly1305 = "0.10.1"
+chacha20poly1305 = { version = "0.10.1", features = ["zeroize"] }
 hkdf = "0.12.4"
 x25519-dalek = "2.0.1"
 


### PR DESCRIPTION
This PR enables zeroization for internal sensitive data inside chacha20-poly1305. 
The current implementation zeroes keys that are passed into Chacha20, but it does not control internal mechanisms.