### PR TITLE
Fix secp fuzz test

### DIFF
--- a/cryptography/fuzz/fuzz_targets/secp256r1_decode.rs
+++ b/cryptography/fuzz/fuzz_targets/secp256r1_decode.rs
@@ -148,9 +148,6 @@ fn test_public_key_derivation(private_key_data: &[u8]) {
 }
 
 fuzz_target!(|input: FuzzInput| {
-    test_private_key(&input.private_key_32);
-    test_private_key(&input.variable_data);
-    return;
     match input.case_selector % 10 {
         0 => test_private_key(&input.private_key_32),
         1 => test_public_key(&input.public_key_33),


### PR DESCRIPTION
This PR fixes https://github.com/commonwarexyz/monorepo/issues/1184.
The reason for the false positive is that the reference implementation also verified the validity of the key in all cases (<32 bytes).
The PR simplifies the test.