### PR TITLE
[storage/metadata] Improve Delta Write Efficiency for Common Case

### DIFF
--- a/storage/src/metadata/benches/sync.rs
+++ b/storage/src/metadata/benches/sync.rs
@@ -6,17 +6,12 @@ use std::time::{Duration, Instant};
 fn bench_sync(c: &mut Criterion) {
     let runner = tokio::Runner::default();
     for &num_keys in &[100, 1_000, 10_000] {
-        for &modified_pct in &[0, 1, 5, 25, 50, 75, 100] {
-            let label = format!(
-                "{}/keys={} modified_pct={}",
-                module_path!(),
-                num_keys,
-                modified_pct
-            );
+        for &modified in &[0, 1, 5, 25, 50, 75, 100] {
+            let label = format!("{}/keys={} modified={}", module_path!(), num_keys, modified);
 
             // Generate key-value pairs for the benchmark
             let initial_kvs = get_random_kvs(num_keys);
-            let modified_kvs = get_modified_kvs(&initial_kvs, modified_pct);
+            let modified_kvs = get_modified_kvs(&initial_kvs, modified);
 
             // Run the benchmark
             c.bench_function(&label, |b| {

--- a/storage/src/metadata/benches/sync.rs
+++ b/storage/src/metadata/benches/sync.rs
@@ -16,13 +16,13 @@ fn bench_sync(c: &mut Criterion) {
 
             // Generate key-value pairs for the benchmark
             let initial_kvs = get_random_kvs(num_keys);
-            let second_kvs = get_modified_kvs(&initial_kvs, modified_pct);
+            let modified_kvs = get_modified_kvs(&initial_kvs, modified_pct);
 
             // Run the benchmark
             c.bench_function(&label, |b| {
                 b.to_async(&runner).iter_custom(|iters| {
                     let initial_kvs = initial_kvs.clone();
-                    let second_kvs = second_kvs.clone();
+                    let modified_kvs = modified_kvs.clone();
                     async move {
                         let ctx = context::get::<commonware_runtime::tokio::Context>();
                         let mut total = Duration::ZERO;
@@ -38,7 +38,7 @@ fn bench_sync(c: &mut Criterion) {
                             metadata.sync().await.unwrap();
 
                             // Update some keys
-                            for (k, v) in &second_kvs {
+                            for (k, v) in &modified_kvs {
                                 metadata.put(k.clone(), v.clone());
                             }
 

--- a/storage/src/metadata/benches/sync.rs
+++ b/storage/src/metadata/benches/sync.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 fn bench_sync(c: &mut Criterion) {
     let runner = tokio::Runner::default();
     for &num_keys in &[100, 1_000, 10_000] {
-        for &modified_pct in &[0, 5, 25, 50, 75, 100] {
+        for &modified_pct in &[0, 1, 5, 25, 50, 75, 100] {
             let label = format!(
                 "{}/keys={} modified_pct={}",
                 module_path!(),

--- a/storage/src/metadata/benches/utils.rs
+++ b/storage/src/metadata/benches/utils.rs
@@ -38,7 +38,7 @@ pub fn get_random_kvs(count: usize) -> Vec<(Key, Val)> {
 /// Modify `modified_pct` of keys and emit a new set of keys.
 pub fn get_modified_kvs(kvs: &[(Key, Val)], modified_pct: usize) -> Vec<(Key, Val)> {
     let mut rng = StdRng::seed_from_u64(0);
-    let mut new_kvs = kvs.to_vec();
+    let mut motified_kvs = Vec::with_capacity(kvs.len());
     if modified_pct > 0 {
         let modified_count = (kvs.len() * modified_pct) / 100;
         let mut indices: Vec<usize> = (0..kvs.len()).collect();
@@ -46,8 +46,8 @@ pub fn get_modified_kvs(kvs: &[(Key, Val)], modified_pct: usize) -> Vec<(Key, Va
         for &idx in indices.iter().take(modified_count) {
             let mut val = vec![0; 100];
             rng.fill(&mut val[..]);
-            new_kvs[idx].1 = val;
+            motified_kvs.push((kvs[idx].0.clone(), val));
         }
     }
-    new_kvs
+    motified_kvs
 }

--- a/storage/src/metadata/benches/utils.rs
+++ b/storage/src/metadata/benches/utils.rs
@@ -35,19 +35,16 @@ pub fn get_random_kvs(count: usize) -> Vec<(Key, Val)> {
     kvs
 }
 
-/// Modify `modified_pct` of keys and emit a new set of keys.
-pub fn get_modified_kvs(kvs: &[(Key, Val)], modified_pct: usize) -> Vec<(Key, Val)> {
+/// Modify `modified` of keys and emit a new set of keys.
+pub fn get_modified_kvs(kvs: &[(Key, Val)], modified: usize) -> Vec<(Key, Val)> {
     let mut rng = StdRng::seed_from_u64(0);
     let mut modified_kvs = Vec::with_capacity(kvs.len());
-    if modified_pct > 0 {
-        let modified_count = (kvs.len() * modified_pct) / 100;
-        let mut indices: Vec<usize> = (0..kvs.len()).collect();
-        indices.shuffle(&mut rng);
-        for &idx in indices.iter().take(modified_count) {
-            let mut val = vec![0; 100];
-            rng.fill(&mut val[..]);
-            modified_kvs.push((kvs[idx].0.clone(), val));
-        }
+    let mut indices: Vec<usize> = (0..kvs.len()).collect();
+    indices.shuffle(&mut rng);
+    for &idx in indices.iter().take(modified) {
+        let mut val = vec![0; 100];
+        rng.fill(&mut val[..]);
+        modified_kvs.push((kvs[idx].0.clone(), val));
     }
     modified_kvs
 }

--- a/storage/src/metadata/benches/utils.rs
+++ b/storage/src/metadata/benches/utils.rs
@@ -38,7 +38,7 @@ pub fn get_random_kvs(count: usize) -> Vec<(Key, Val)> {
 /// Modify `modified_pct` of keys and emit a new set of keys.
 pub fn get_modified_kvs(kvs: &[(Key, Val)], modified_pct: usize) -> Vec<(Key, Val)> {
     let mut rng = StdRng::seed_from_u64(0);
-    let mut motified_kvs = Vec::with_capacity(kvs.len());
+    let mut modified_kvs = Vec::with_capacity(kvs.len());
     if modified_pct > 0 {
         let modified_count = (kvs.len() * modified_pct) / 100;
         let mut indices: Vec<usize> = (0..kvs.len()).collect();
@@ -46,8 +46,8 @@ pub fn get_modified_kvs(kvs: &[(Key, Val)], modified_pct: usize) -> Vec<(Key, Va
         for &idx in indices.iter().take(modified_count) {
             let mut val = vec![0; 100];
             rng.fill(&mut val[..]);
-            motified_kvs.push((kvs[idx].0.clone(), val));
+            modified_kvs.push((kvs[idx].0.clone(), val));
         }
     }
-    motified_kvs
+    modified_kvs
 }

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -619,7 +619,7 @@ mod tests {
             assert!(buffer.contains("sync_rewrites_total 2"), "{buffer}");
             assert!(buffer.contains("sync_overwrites_total 1"), "{buffer}");
             assert!(
-                buffer.contains("runtime_storage_write_bytes_total 21836"),
+                buffer.contains("runtime_storage_write_bytes_total 21937"),
                 "{buffer}",
             );
 
@@ -631,7 +631,7 @@ mod tests {
             assert!(buffer.contains("sync_rewrites_total 2"), "{buffer}");
             assert!(buffer.contains("sync_overwrites_total 2"), "{buffer}");
             assert!(
-                buffer.contains("runtime_storage_write_bytes_total 21848"),
+                buffer.contains("runtime_storage_write_bytes_total 21949"),
                 "{buffer}",
             );
 

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -201,7 +201,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 1"));
+            assert!(buffer.contains("sync_rewrites_total 1"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 1"));
 
             // Put an overlapping key and a new key
@@ -216,7 +217,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 2"));
+            assert!(buffer.contains("sync_rewrites_total 2"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 2"));
 
             // Reopen the metadata store
@@ -230,7 +232,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 0"));
+            assert!(buffer.contains("sync_rewrites_total 0"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 2"));
 
             // Get the key
@@ -247,7 +250,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 1"));
+            assert!(buffer.contains("sync_rewrites_total 1"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 1"));
 
             // Close the metadata store
@@ -264,7 +268,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 0"));
+            assert!(buffer.contains("sync_rewrites_total 0"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 1"));
 
             // Get the key

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -391,7 +391,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 0"));
+            assert!(buffer.contains("sync_rewrites_total 0"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 0"));
 
             metadata.destroy().await.unwrap();
@@ -538,7 +539,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 0"));
+            assert!(buffer.contains("sync_rewrites_total 0"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 0"));
 
             metadata.destroy().await.unwrap();

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -116,7 +116,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 0"));
+            assert!(buffer.contains("sync_rewrites_total 0"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 0"));
 
             // Put a key
@@ -129,7 +130,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 0"));
+            assert!(buffer.contains("sync_rewrites_total 0"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 1"));
 
             // Close the metadata store
@@ -137,7 +139,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 1"));
+            assert!(buffer.contains("sync_rewrites_total 1"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 1"));
 
             // Reopen the metadata store
@@ -151,7 +154,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 0"));
+            assert!(buffer.contains("sync_rewrites_total 0"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 1"));
 
             // Get the key
@@ -165,7 +169,8 @@ mod tests {
 
             // Check metrics
             let buffer = context.encode();
-            assert!(buffer.contains("syncs_total 0"));
+            assert!(buffer.contains("sync_rewrites_total 1"));
+            assert!(buffer.contains("sync_overwrites_total 0"));
             assert!(buffer.contains("keys 0"));
 
             metadata.destroy().await.unwrap();

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -591,7 +591,8 @@ mod tests {
             // 100 keys * (8 bytes for key + 1 bytes for len + 100 bytes for value) + 8 bytes for version + 4 bytes for checksum
             metadata.sync().await.unwrap();
             let buffer = context.encode();
-            assert!(buffer.contains("skipped_total 0"), "{buffer}");
+            assert!(buffer.contains("sync_rewrites_total 1"), "{buffer}");
+            assert!(buffer.contains("sync_overwrites_total 0"), "{buffer}");
             assert!(
                 buffer.contains("runtime_storage_write_bytes_total 10912"),
                 "{buffer}",
@@ -603,7 +604,8 @@ mod tests {
             // Sync again - should write everything to the second blob
             metadata.sync().await.unwrap();
             let buffer = context.encode();
-            assert!(buffer.contains("skipped_total 0"), "{buffer}");
+            assert!(buffer.contains("sync_rewrites_total 2"), "{buffer}");
+            assert!(buffer.contains("sync_overwrites_total 0"), "{buffer}");
             assert!(
                 buffer.contains("runtime_storage_write_bytes_total 21824"),
                 "{buffer}",
@@ -611,23 +613,25 @@ mod tests {
 
             // Sync again - should write only diff from the first blob
             //
-            // 100 bytes for value + 1 byte for version (first 7 bytes are same) + 4 bytes for checksum
+            // 100 bytes for value + 8 byte for version + 4 bytes for checksum
             metadata.sync().await.unwrap();
             let buffer = context.encode();
-            assert!(buffer.contains("skipped_total 10807"), "{buffer}");
+            assert!(buffer.contains("sync_rewrites_total 2"), "{buffer}");
+            assert!(buffer.contains("sync_overwrites_total 1"), "{buffer}");
             assert!(
-                buffer.contains("runtime_storage_write_bytes_total 21929"),
+                buffer.contains("runtime_storage_write_bytes_total 21836"),
                 "{buffer}",
             );
 
             // Sync again - should write only diff from the second blob
             //
-            // 1 byte for version (first 7 bytes are same) + 4 bytes for checksum
+            // 8 byte for version + 4 bytes for checksum
             metadata.sync().await.unwrap();
             let buffer = context.encode();
-            assert!(buffer.contains("skipped_total 21714"), "{buffer}");
+            assert!(buffer.contains("sync_rewrites_total 2"), "{buffer}");
+            assert!(buffer.contains("sync_overwrites_total 2"), "{buffer}");
             assert!(
-                buffer.contains("runtime_storage_write_bytes_total 21934"),
+                buffer.contains("runtime_storage_write_bytes_total 21848"),
                 "{buffer}",
             );
 

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -29,11 +29,11 @@
 //! (otherwise, we would not be guaranteed to recover the latest complete state from disk on
 //! restart as half of a blob could be old data and half new data).
 //!
-//! # Efficient Writes
+//! # Delta Writes
 //!
-//! When an update is committed, only updated bytes are actually written to disk. This makes [Metadata]
-//! a great choice for maintaining even large collections of data (there is only overhead to maintaining
-//! keys that aren't updated if the order of keys is unstable).
+//! If the set of keys and the length of values are stable, [Metadata] will only write an update's
+//! delta to disk (rather than rewriting the entire metadata). This makes [Metadata] a great choice
+//! for maintaining even large collections of data (with the majority rarely modified).
 //!
 //! # Example
 //!

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -298,13 +298,13 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
             writes.push(target.blob.write_at(version.as_slice().into(), 0));
 
             // Update checksum
-            let checksum_start = target.data.len() - 4;
-            let checksum = crc32fast::hash(&target.data[..checksum_start]).to_be_bytes();
-            target.data[checksum_start..].copy_from_slice(&checksum);
+            let checksum_index = target.data.len() - 4;
+            let checksum = crc32fast::hash(&target.data[..checksum_index]).to_be_bytes();
+            target.data[checksum_index..].copy_from_slice(&checksum);
             writes.push(
                 target
                     .blob
-                    .write_at(checksum.as_slice().into(), checksum_start as u64),
+                    .write_at(checksum.as_slice().into(), checksum_index as u64),
             );
 
             // Persist changes

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -202,9 +202,10 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
 
     /// Get a mutable reference to a value from [Metadata] (if it exists).
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        let value = self.map.get_mut(key)?;
         self.blobs[self.cursor].modified.insert(key.clone());
         self.blobs[1 - self.cursor].modified.insert(key.clone());
-        self.map.get_mut(key)
+        Some(value)
     }
 
     /// Clear all values from [Metadata]. The new state will not be persisted until [Self::sync] is

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -286,8 +286,8 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
             let target_len = target.data.len();
             target.data[target_len - 4..].copy_from_slice(&checksum.to_be_bytes());
             writes.push(target.blob.write_at(
-                target.data[target.data.len() - 4..].into(),
-                (target.data.len() - 4) as u64,
+                target.data[target_len - 4..].into(),
+                (target_len - 4) as u64,
             ));
 
             // Persist changes

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -286,8 +286,11 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
                 }
             }
         } else {
+            // If the key order has changed, we need to rewrite all data
             overwrite = false;
         }
+
+        // Clear modified keys to avoid writing the same data
         target.modified.clear();
 
         // Overwrite existing data

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -233,8 +233,6 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
         let modified = self.map.remove(key).is_some();
         self.keys.set(self.map.len() as i64);
         if modified {
-            self.modified.insert(key.clone());
-        } else {
             self.unstable = self.blobs[self.cursor]
                 .version
                 .checked_add(1)

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -95,7 +95,7 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
         );
         context.register(
             "sync_overwrites",
-            "number of syncs that modified data in-place",
+            "number of syncs that modified existing data",
             sync_overwrites.clone(),
         );
         context.register("keys", "number of tracked keys", keys.clone());

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -275,6 +275,7 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
         } else {
             rewrite = true;
         }
+        self.modified.clear();
 
         // If we can rewrite in-place, do so
         if !rewrite {

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -47,7 +47,6 @@ impl<B: Blob> Wrapper<B> {
 pub struct Metadata<E: Clock + Storage + Metrics, K: Array, V: Codec> {
     context: E,
 
-    // Data is stored in a BTreeMap to enable deterministic serialization.
     map: BTreeMap<K, V>,
     cursor: usize,
     partition: String,
@@ -231,7 +230,7 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
         let mut next_data = Vec::with_capacity(past_length);
         next_data.put_u64(next_version);
         for (key, value) in &self.map {
-            next_data.put_slice(key.as_ref());
+            key.write(&mut next_data);
             value.write(&mut next_data);
         }
         let checksum = crc32fast::hash(&next_data[..]);

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -262,11 +262,11 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
         let past_version = self.blobs[self.cursor].version;
         let next_next_version = self.next_version.checked_add(1).expect("version overflow");
 
-        // Get target blob (the one we will overwrite)
+        // Get target blob (the one we will modify)
         let target_cursor = 1 - self.cursor;
         let target = &mut self.blobs[target_cursor];
 
-        // Attempt to modify in-place (as long as values are unmodified)
+        // Attempt to overwrite existing data
         let mut overwrite = true;
         let mut writes = Vec::with_capacity(target.modified.len());
         if self.key_order_changed < past_version {
@@ -274,7 +274,7 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
                 let (value_cursor, prev_length) = target.lengths.get(key).expect("key must exist");
                 let new_value = self.map.get(key).expect("key must exist");
                 if *prev_length == new_value.encode_size() {
-                    // Overwrite value in-place
+                    // Overwrite existing value
                     let encoded = new_value.encode();
                     target.data[*value_cursor..*value_cursor + *prev_length]
                         .copy_from_slice(&encoded);

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -232,8 +232,7 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
             key.write(&mut next_data);
             value.write(&mut next_data);
         }
-        let checksum = crc32fast::hash(&next_data[..]);
-        next_data.put_u32(checksum);
+        next_data.put_u32(crc32fast::hash(&next_data[..]));
 
         // Get target blob (the one we will overwrite)
         let target_cursor = 1 - self.cursor;


### PR DESCRIPTION
Modifying 1 key on a 100, 1000, and 10000 key store takes ~roughly the same time (and modifies the same amount of data on disk):
```
metadata::sync/keys=100 modified=1
                        time:   [3.3392 ms 3.4057 ms 3.4644 ms]

metadata::sync/keys=1000 modified=1
                        time:   [3.2514 ms 3.3059 ms 3.3589 ms]

metadata::sync/keys=10000 modified=1
                        time:   [3.2269 ms 3.5963 ms 3.8910 ms]
```