### PR TITLE
[runtime] Make runtime's ReadError and WriteError propagate underlying ioerror

### DIFF
--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -37,10 +37,10 @@ impl crate::Blob for Blob {
         let mut buf = buf.into();
         file.seek(SeekFrom::Start(offset))
             .await
-            .map_err(|_| Error::ReadFailed)?;
+            .map_err(Error::ReadFailed)?;
         file.read_exact(buf.as_mut())
             .await
-            .map_err(|_| Error::ReadFailed)?;
+            .map_err(Error::ReadFailed)?;
         Ok(buf)
     }
 
@@ -48,10 +48,10 @@ impl crate::Blob for Blob {
         let mut file = self.file.lock().await;
         file.seek(SeekFrom::Start(offset))
             .await
-            .map_err(|_| Error::WriteFailed)?;
+            .map_err(Error::WriteFailed)?;
         file.write_all(buf.into().as_ref())
             .await
-            .map_err(|_| Error::WriteFailed)?;
+            .map_err(Error::WriteFailed)?;
         Ok(())
     }
 

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -74,7 +74,7 @@ impl crate::Storage for Storage {
         file.set_max_buf_size(self.cfg.maximum_buffer_size);
 
         // Get the file length
-        let len = file.metadata().await.map_err(|_| Error::ReadFailed)?.len();
+        let len = file.metadata().await.map_err(Error::ReadFailed)?.len();
 
         #[cfg(unix)]
         {
@@ -120,8 +120,8 @@ impl crate::Storage for Storage {
             .await
             .map_err(|_| Error::PartitionMissing(partition.into()))?;
         let mut blobs = Vec::new();
-        while let Some(entry) = entries.next_entry().await.map_err(|_| Error::ReadFailed)? {
-            let file_type = entry.file_type().await.map_err(|_| Error::ReadFailed)?;
+        while let Some(entry) = entries.next_entry().await.map_err(Error::ReadFailed)? {
+            let file_type = entry.file_type().await.map_err(Error::ReadFailed)?;
             if !file_type.is_file() {
                 return Err(Error::PartitionCorrupt(partition.into()));
             }


### PR DESCRIPTION
Propagate underlying ioerrors through ReadError and WriteError to aid in storage debugging, getting rid of the blanket IoError conversion which was being used where these other error types are more specific & appropriate.