### PR TITLE
[runtime] Make ReadFailed/WriteFailed wrap underlying error.

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -62,10 +62,10 @@ pub enum Error {
     BindFailed,
     #[error("connection failed")]
     ConnectionFailed,
-    #[error("write failed. error: {0}")]
-    WriteFailed(String),
-    #[error("read failed. error: {0}")]
-    ReadFailed(String),
+    #[error("write failed. context: {0}")]
+    WriteFailed(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("read failed. context: {0}")]
+    ReadFailed(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("send failed")]
     SendFailed,
     #[error("recv failed")]
@@ -1706,7 +1706,7 @@ mod tests {
                     }
                     line.push(byte[0]);
                 }
-                String::from_utf8(line).map_err(|e| Error::ReadFailed(e.utf8_error().to_string()))
+                String::from_utf8(line).map_err(|e| Error::ReadFailed(Box::new(e)))
             }
 
             async fn read_headers<St: Stream>(
@@ -1732,7 +1732,7 @@ mod tests {
             ) -> Result<String, Error> {
                 let read = stream.recv(vec![0; content_length]).await?;
                 String::from_utf8(read.as_ref().to_vec())
-                    .map_err(|err| Error::ReadFailed(err.utf8_error().to_string()))
+                    .map_err(|err| Error::ReadFailed(Box::new(err)))
             }
 
             // Simulate a client connecting to the server

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1732,7 +1732,7 @@ mod tests {
             ) -> Result<String, Error> {
                 let read = stream.recv(vec![0; content_length]).await?;
                 String::from_utf8(read.as_ref().to_vec())
-                    .map_err(|err| Error::ReadFailed(Box::new(err)))
+                    .map_err(|e| Error::ReadFailed(Box::new(e)))
             }
 
             // Simulate a client connecting to the server

--- a/runtime/src/network/deterministic.rs
+++ b/runtime/src/network/deterministic.rs
@@ -45,7 +45,10 @@ impl crate::Listener for Listener {
     async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), Error> {
         match self.listener.next().await {
             Some((socket, sender, receiver)) => Ok((socket, Sink { sender }, Stream { receiver })),
-            None => Err(Error::ReadFailed("listener closed".to_string())),
+            None => Err(Error::ReadFailed(Box::new(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "listener channel closed",
+            )))),
         }
     }
 

--- a/runtime/src/network/deterministic.rs
+++ b/runtime/src/network/deterministic.rs
@@ -43,8 +43,10 @@ impl crate::Listener for Listener {
     type Stream = Stream;
 
     async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), Error> {
-        let (socket, sender, receiver) = self.listener.next().await.ok_or(Error::ReadFailed)?;
-        Ok((socket, Sink { sender }, Stream { receiver }))
+        match self.listener.next().await {
+            Some((socket, sender, receiver)) => Ok((socket, Sink { sender }, Stream { receiver })),
+            None => Err(Error::ReadFailed("listener closed".to_string())),
+        }
     }
 
     fn local_addr(&self) -> Result<SocketAddr, std::io::Error> {

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -93,7 +93,10 @@ impl crate::Storage for Storage {
             .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e))?;
 
         // Get the file length
-        let len = file.metadata().map_err(Error::ReadFailed(Box::new))?.len();
+        let len = file
+            .metadata()
+            .map_err(|e| Error::ReadFailed(Box::new(e)))?
+            .len();
 
         Ok((
             Blob::new(partition.into(), name, file, self.io_sender.clone()),
@@ -121,8 +124,10 @@ impl crate::Storage for Storage {
 
         let mut blobs = Vec::new();
         for entry in entries {
-            let entry = entry.map_err(Error::ReadFailed(Box::new))?;
-            let file_type = entry.file_type().map_err(Error::ReadFailed(Box::new))?;
+            let entry = entry.map_err(|e| Error::ReadFailed(Box::new(e)))?;
+            let file_type = entry
+                .file_type()
+                .map_err(|e| Error::ReadFailed(Box::new(e)))?;
 
             if !file_type.is_file() {
                 return Err(Error::PartitionCorrupt(partition.into()));
@@ -211,17 +216,19 @@ impl crate::Blob for Blob {
                     buffer: Some(buf),
                 })
                 .await
-                .map_err(Error::ReadFailed(Box::new))?;
+                .map_err(|e| Error::ReadFailed(Box::new(e)))?;
 
             // Wait for the result
-            let (result, got_buf) = receiver.await.map_err(Error::ReadFailed(Box::new))?;
+            let (result, got_buf) = receiver.await.map_err(|e| Error::ReadFailed(Box::new(e)))?;
             buf = got_buf.unwrap();
             if should_retry(result) {
                 continue;
             }
 
             // A non-positive return value indicates an error.
-            let op_bytes_read: usize = result.try_into().map_err(Error::ReadFailed(Box::new))?;
+            let op_bytes_read: usize = result
+                .try_into()
+                .map_err(|e| Error::ReadFailed(Box::new(e)))?;
             if op_bytes_read == 0 {
                 // A return value of 0 indicates EOF, which shouldn't happen because we
                 // aren't done reading into `buf`. See `man pread`.
@@ -262,10 +269,12 @@ impl crate::Blob for Blob {
                     buffer: Some(buf),
                 })
                 .await
-                .map_err(Error::WriteFailed(Box::new))?;
+                .map_err(|e| Error::WriteFailed(Box::new(e)))?;
 
             // Wait for the result
-            let (return_value, got_buf) = receiver.await.map_err(Error::WriteFailed(Box::new))?;
+            let (return_value, got_buf) = receiver
+                .await
+                .map_err(|e| Error::WriteFailed(Box::new(e)))?;
             buf = got_buf.unwrap();
             if should_retry(return_value) {
                 continue;
@@ -274,7 +283,7 @@ impl crate::Blob for Blob {
             // A negative return value indicates an error.
             let op_bytes_written: usize = return_value
                 .try_into()
-                .map_err(|e| Error::WriteFailed(Box::new))?;
+                .map_err(|e| Error::WriteFailed(Box::new(e)))?;
 
             bytes_written += op_bytes_written;
         }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -35,6 +35,7 @@ use prometheus_client::registry::Registry;
 use std::{
     fs::{self, File},
     io::Error as IoError,
+    num::TryFromIntError,
     os::fd::AsRawFd,
     path::PathBuf,
     sync::Arc,
@@ -93,7 +94,10 @@ impl crate::Storage for Storage {
             .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e))?;
 
         // Get the file length
-        let len = file.metadata().map_err(|_| Error::ReadFailed)?.len();
+        let len = file
+            .metadata()
+            .map_err(|e| Error::ReadFailed(e.to_string()))?
+            .len();
 
         Ok((
             Blob::new(partition.into(), name, file, self.io_sender.clone()),
@@ -121,8 +125,10 @@ impl crate::Storage for Storage {
 
         let mut blobs = Vec::new();
         for entry in entries {
-            let entry = entry.map_err(|_| Error::ReadFailed)?;
-            let file_type = entry.file_type().map_err(|_| Error::ReadFailed)?;
+            let entry = entry.map_err(|e| Error::ReadFailed(e.to_string()))?;
+            let file_type = entry
+                .file_type()
+                .map_err(|e| Error::ReadFailed(e.to_string()))?;
 
             if !file_type.is_file() {
                 return Err(Error::PartitionCorrupt(partition.into()));
@@ -211,17 +217,21 @@ impl crate::Blob for Blob {
                     buffer: Some(buf),
                 })
                 .await
-                .map_err(|_| Error::ReadFailed)?;
+                .map_err(|e| Error::ReadFailed(e.to_string()))?;
 
             // Wait for the result
-            let (result, got_buf) = receiver.await.map_err(|_| Error::ReadFailed)?;
+            let (result, got_buf) = receiver
+                .await
+                .map_err(|e| Error::ReadFailed(e.to_string()))?;
             buf = got_buf.unwrap();
             if should_retry(result) {
                 continue;
             }
 
             // A non-positive return value indicates an error.
-            let op_bytes_read: usize = result.try_into().map_err(|_| Error::ReadFailed)?;
+            let op_bytes_read: usize = result
+                .try_into()
+                .map_err(|e: TryFromIntError| Error::ReadFailed(e.to_string()))?;
             if op_bytes_read == 0 {
                 // A return value of 0 indicates EOF, which shouldn't happen because we
                 // aren't done reading into `buf`. See `man pread`.
@@ -262,18 +272,21 @@ impl crate::Blob for Blob {
                     buffer: Some(buf),
                 })
                 .await
-                .map_err(|_| Error::WriteFailed)?;
+                .map_err(|e| Error::WriteFailed(e.to_string()))?;
 
             // Wait for the result
-            let (return_value, got_buf) = receiver.await.map_err(|_| Error::WriteFailed)?;
+            let (return_value, got_buf) = receiver
+                .await
+                .map_err(|e| Error::WriteFailed(e.to_string()))?;
             buf = got_buf.unwrap();
             if should_retry(return_value) {
                 continue;
             }
 
             // A negative return value indicates an error.
-            let op_bytes_written: usize =
-                return_value.try_into().map_err(|_| Error::WriteFailed)?;
+            let op_bytes_written: usize = return_value
+                .try_into()
+                .map_err(|e: TryFromIntError| Error::WriteFailed(e.to_string()))?;
 
             bytes_written += op_bytes_written;
         }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -35,7 +35,6 @@ use prometheus_client::registry::Registry;
 use std::{
     fs::{self, File},
     io::Error as IoError,
-    num::TryFromIntError,
     os::fd::AsRawFd,
     path::PathBuf,
     sync::Arc,
@@ -94,10 +93,7 @@ impl crate::Storage for Storage {
             .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e))?;
 
         // Get the file length
-        let len = file
-            .metadata()
-            .map_err(|e| Error::ReadFailed(e.to_string()))?
-            .len();
+        let len = file.metadata().map_err(Error::ReadFailed(Box::new))?.len();
 
         Ok((
             Blob::new(partition.into(), name, file, self.io_sender.clone()),
@@ -125,10 +121,8 @@ impl crate::Storage for Storage {
 
         let mut blobs = Vec::new();
         for entry in entries {
-            let entry = entry.map_err(|e| Error::ReadFailed(e.to_string()))?;
-            let file_type = entry
-                .file_type()
-                .map_err(|e| Error::ReadFailed(e.to_string()))?;
+            let entry = entry.map_err(Error::ReadFailed(Box::new))?;
+            let file_type = entry.file_type().map_err(Error::ReadFailed(Box::new))?;
 
             if !file_type.is_file() {
                 return Err(Error::PartitionCorrupt(partition.into()));
@@ -217,21 +211,17 @@ impl crate::Blob for Blob {
                     buffer: Some(buf),
                 })
                 .await
-                .map_err(|e| Error::ReadFailed(e.to_string()))?;
+                .map_err(Error::ReadFailed(Box::new))?;
 
             // Wait for the result
-            let (result, got_buf) = receiver
-                .await
-                .map_err(|e| Error::ReadFailed(e.to_string()))?;
+            let (result, got_buf) = receiver.await.map_err(Error::ReadFailed(Box::new))?;
             buf = got_buf.unwrap();
             if should_retry(result) {
                 continue;
             }
 
             // A non-positive return value indicates an error.
-            let op_bytes_read: usize = result
-                .try_into()
-                .map_err(|e: TryFromIntError| Error::ReadFailed(e.to_string()))?;
+            let op_bytes_read: usize = result.try_into().map_err(Error::ReadFailed(Box::new))?;
             if op_bytes_read == 0 {
                 // A return value of 0 indicates EOF, which shouldn't happen because we
                 // aren't done reading into `buf`. See `man pread`.
@@ -272,12 +262,10 @@ impl crate::Blob for Blob {
                     buffer: Some(buf),
                 })
                 .await
-                .map_err(|e| Error::WriteFailed(e.to_string()))?;
+                .map_err(Error::WriteFailed(Box::new))?;
 
             // Wait for the result
-            let (return_value, got_buf) = receiver
-                .await
-                .map_err(|e| Error::WriteFailed(e.to_string()))?;
+            let (return_value, got_buf) = receiver.await.map_err(Error::WriteFailed(Box::new))?;
             buf = got_buf.unwrap();
             if should_retry(return_value) {
                 continue;
@@ -286,7 +274,7 @@ impl crate::Blob for Blob {
             // A negative return value indicates an error.
             let op_bytes_written: usize = return_value
                 .try_into()
-                .map_err(|e: TryFromIntError| Error::WriteFailed(e.to_string()))?;
+                .map_err(|e| Error::WriteFailed(Box::new))?;
 
             bytes_written += op_bytes_written;
         }

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -37,10 +37,10 @@ impl crate::Blob for Blob {
         let mut buf = buf.into();
         file.seek(SeekFrom::Start(offset))
             .await
-            .map_err(|e| Error::ReadFailed(e.to_string()))?;
+            .map_err(Error::ReadFailed(Box::new))?;
         file.read_exact(buf.as_mut())
             .await
-            .map_err(|e| Error::ReadFailed(e.to_string()))?;
+            .map_err(Error::ReadFailed(Box::new))?;
         Ok(buf)
     }
 
@@ -48,25 +48,25 @@ impl crate::Blob for Blob {
         let mut file = self.file.lock().await;
         file.seek(SeekFrom::Start(offset))
             .await
-            .map_err(|e| Error::WriteFailed(e.to_string()))?;
+            .map_err(Error::WriteFailed(Box::new))?;
         file.write_all(buf.into().as_ref())
             .await
-            .map_err(|e| Error::WriteFailed(e.to_string()))?;
+            .map_err(Error::WriteFailed(Box::new))?;
         Ok(())
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {
         let file = self.file.lock().await;
-        file.set_len(len)
-            .await
-            .map_err(|e| Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e))?;
+        file.set_len(len).await.map_err(|e| {
+            Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), Box::new(e))
+        })?;
         Ok(())
     }
 
     async fn sync(&self) -> Result<(), Error> {
         let file = self.file.lock().await;
-        file.sync_all()
-            .await
-            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
+        file.sync_all().await.map_err(|e| {
+            Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), Box::new(e))
+        })
     }
 }

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -37,10 +37,10 @@ impl crate::Blob for Blob {
         let mut buf = buf.into();
         file.seek(SeekFrom::Start(offset))
             .await
-            .map_err(|_| Error::ReadFailed)?;
+            .map_err(|e| Error::ReadFailed(e.to_string()))?;
         file.read_exact(buf.as_mut())
             .await
-            .map_err(|_| Error::ReadFailed)?;
+            .map_err(|e| Error::ReadFailed(e.to_string()))?;
         Ok(buf)
     }
 
@@ -48,10 +48,10 @@ impl crate::Blob for Blob {
         let mut file = self.file.lock().await;
         file.seek(SeekFrom::Start(offset))
             .await
-            .map_err(|_| Error::WriteFailed)?;
+            .map_err(|e| Error::WriteFailed(e.to_string()))?;
         file.write_all(buf.into().as_ref())
             .await
-            .map_err(|_| Error::WriteFailed)?;
+            .map_err(|e| Error::WriteFailed(e.to_string()))?;
         Ok(())
     }
 

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -1,7 +1,7 @@
 use crate::Error;
 use commonware_utils::{hex, StableBuf};
 use std::{fs::File, os::unix::fs::FileExt, sync::Arc};
-use tokio::task::{self, JoinError};
+use tokio::task;
 
 #[derive(Clone)]
 pub struct Blob {
@@ -34,7 +34,7 @@ impl crate::Blob for Blob {
             Ok(buf)
         })
         .await
-        .map_err(|e: JoinError| Error::ReadFailed(Box::new(e)))?
+        .map_err(|e| Error::ReadFailed(Box::new(e)))?
     }
 
     async fn write_at(&self, buf: impl Into<StableBuf> + Send, offset: u64) -> Result<(), Error> {
@@ -46,7 +46,7 @@ impl crate::Blob for Blob {
             Ok(())
         })
         .await
-        .map_err(|e: JoinError| Error::WriteFailed(Box::new(e)))?
+        .map_err(|e| Error::WriteFailed(Box::new(e)))?
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -30,11 +30,11 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         task::spawn_blocking(move || {
             file.read_exact_at(buf.as_mut(), offset)
-                .map_err(|e| Error::ReadFailed(e.to_string()))?;
+                .map_err(|e| Error::ReadFailed(Box::new(e)))?;
             Ok(buf)
         })
         .await
-        .map_err(|e: JoinError| Error::ReadFailed(e.to_string()))?
+        .map_err(|e: JoinError| Error::ReadFailed(Box::new(e)))?
     }
 
     async fn write_at(&self, buf: impl Into<StableBuf> + Send, offset: u64) -> Result<(), Error> {
@@ -42,11 +42,11 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         task::spawn_blocking(move || {
             file.write_all_at(buf.as_ref(), offset)
-                .map_err(|e| Error::WriteFailed(e.to_string()))?;
+                .map_err(|e| Error::WriteFailed(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e: JoinError| Error::WriteFailed(e.to_string()))?
+        .map_err(|e: JoinError| Error::WriteFailed(Box::new(e)))?
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {

--- a/runtime/src/utils/buffer/pool.rs
+++ b/runtime/src/utils/buffer/pool.rs
@@ -202,7 +202,9 @@ impl PoolRef {
         let fetch_result = fetch_future.await;
         if !is_first_fetcher {
             // Copy the requested portion of the page into the buffer and return immediately.
-            let page_buf: Vec<u8> = fetch_result.map_err(|_| Error::ReadFailed)?.into();
+            let page_buf: Vec<u8> = fetch_result
+                .map_err(|e| Error::ReadFailed(e.to_string()))?
+                .into();
             let bytes_to_copy = std::cmp::min(buf.len(), page_size - offset_in_page);
             buf[..bytes_to_copy]
                 .copy_from_slice(&page_buf[offset_in_page..offset_in_page + bytes_to_copy]);
@@ -220,7 +222,7 @@ impl PoolRef {
 
         // Cache the result in the buffer pool.
         let Ok(page_buf) = fetch_result else {
-            return Err(Error::ReadFailed);
+            return Err(Error::ReadFailed(fetch_result.unwrap_err().to_string()));
         };
         pool.cache(page_size, blob_id, page_buf.as_ref(), page_num);
 

--- a/runtime/src/utils/buffer/pool.rs
+++ b/runtime/src/utils/buffer/pool.rs
@@ -203,7 +203,7 @@ impl PoolRef {
         if !is_first_fetcher {
             // Copy the requested portion of the page into the buffer and return immediately.
             let page_buf: Vec<u8> = fetch_result
-                .map_err(|e| Error::ReadFailed(e.to_string()))?
+                .map_err(|e| Error::ReadFailed(Box::new(e)))?
                 .into();
             let bytes_to_copy = std::cmp::min(buf.len(), page_size - offset_in_page);
             buf[..bytes_to_copy]
@@ -222,7 +222,7 @@ impl PoolRef {
 
         // Cache the result in the buffer pool.
         let Ok(page_buf) = fetch_result else {
-            return Err(Error::ReadFailed(fetch_result.unwrap_err().to_string()));
+            return Err(Error::ReadFailed(Box::new(fetch_result.unwrap_err())));
         };
         pool.cache(page_size, blob_id, page_buf.as_ref(), page_num);
 


### PR DESCRIPTION
Make ReadFailed/WriteFailed bubble up error context via #[source].