### PR TITLE
title: Optimize test_add_jittered by moving avg calculation outside t…

### DIFF
--- a/utils/src/time.rs
+++ b/utils/src/time.rs
@@ -88,11 +88,11 @@ mod tests {
 
         // Ensure we generate values both below and above the average time.
         let (mut below, mut above) = (false, false);
+        let avg = time + jitter;
         for _ in 0..100 {
             let new_time = time.add_jittered(&mut rng, jitter);
 
             // Record values higher or lower than the average
-            let avg = time + jitter;
             below |= new_time < avg;
             above |= new_time > avg;
 


### PR DESCRIPTION
Moved the calculation of avg = time + jitter outside the loop in test_add_jittered function, as its value doesn't change between iterations. This eliminates 99 redundant addition operations, improving test performance.