### PR TITLE
[release] v0.0.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-bridge"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "clap",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "chrono",
  "clap",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "paste",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-collector"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "blake3",
  "blst",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 dependencies = [
  "arbitrary",
  "blst",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "chrono",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bimap",
  "bytes",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "async-lock",
  "axum",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 dependencies = [
  "arbitrary",
  "commonware-cryptography",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 dependencies = [
  "arbitrary",
  "chacha20poly1305",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-sync"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "clap",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-vrf"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,19 +29,19 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.54", path = "broadcast" }
-commonware-codec = { version = "0.0.54", path = "codec" }
-commonware-collector = { version = "0.0.54", path = "collector" }
-commonware-consensus = { version = "0.0.54", path = "consensus" }
-commonware-cryptography = { version = "0.0.54", path = "cryptography" }
-commonware-deployer = { version = "0.0.54", path = "deployer", default-features = false }
-commonware-macros = { version = "0.0.54", path = "macros" }
-commonware-p2p = { version = "0.0.54", path = "p2p" }
-commonware-resolver = { version = "0.0.54", path = "resolver" }
-commonware-runtime = { version = "0.0.54", path = "runtime" }
-commonware-storage = { version = "0.0.54", path = "storage" }
-commonware-stream = { version = "0.0.54", path = "stream" }
-commonware-utils = { version = "0.0.54", path = "utils" }
+commonware-broadcast = { version = "0.0.55", path = "broadcast" }
+commonware-codec = { version = "0.0.55", path = "codec" }
+commonware-collector = { version = "0.0.55", path = "collector" }
+commonware-consensus = { version = "0.0.55", path = "consensus" }
+commonware-cryptography = { version = "0.0.55", path = "cryptography" }
+commonware-deployer = { version = "0.0.55", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.55", path = "macros" }
+commonware-p2p = { version = "0.0.55", path = "p2p" }
+commonware-resolver = { version = "0.0.55", path = "resolver" }
+commonware-runtime = { version = "0.0.55", path = "runtime" }
+commonware-storage = { version = "0.0.55", path = "storage" }
+commonware-stream = { version = "0.0.55", path = "stream" }
+commonware-utils = { version = "0.0.55", path = "utils" }
 thiserror = "2.0.12"
 bytes = "1.7.1"
 sha2 = "0.10.8"

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-broadcast"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Disseminate data over a wide-area network."
 readme = "README.md"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-codec"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Serialize structured data."
 readme = "README.md"

--- a/codec/fuzz/Cargo.toml
+++ b/codec/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-codec-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 publish = false
 edition = "2021"
 

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-collector"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Collect responses to committable requests."
 readme = "README.md"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-consensus"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Order opaque messages in a Byzantine environment."
 readme = "README.md"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify signatures."
 readme = "README.md"

--- a/cryptography/fuzz/Cargo.toml
+++ b/cryptography/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-cryptography-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 publish = false
 edition = "2021"
 

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-deployer"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Deploy infrastructure across cloud providers."
 readme = "README.md"

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-bridge"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Send succinct consensus certificates between two networks."
 readme = "README.md"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-flood"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Spam peers deployed to AWS EC2 with random messages."
 readme = "README.md"

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-log"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Commit to a secret log and agree to its hash."
 readme = "README.md"

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-sync"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Synchronize state between a server and client."
 readme = "README.md"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-vrf"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-macros"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Augment the development of primitives with procedural macros."
 readme = "README.md"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-resolver"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Resolve data identified by a fixed-length key."
 readme = "README.md"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-runtime"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Execute asynchronous tasks with a configurable scheduler."
 readme = "README.md"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-storage"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Persist and retrieve data from an abstract store."
 readme = "README.md"

--- a/storage/fuzz/Cargo.toml
+++ b/storage/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-storage-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 publish = false
 edition = "2021"
 

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-stream"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Exchange messages over arbitrary transport."
 readme = "README.md"

--- a/stream/fuzz/Cargo.toml
+++ b/stream/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-stream-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 publish = false
 edition = "2021"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-utils"
 edition = "2021"
 publish = true
-version = "0.0.54"
+version = "0.0.55"
 license = "MIT OR Apache-2.0"
 description = "Leverage common functionality across multiple primitives."
 readme = "README.md"

--- a/utils/fuzz/Cargo.toml
+++ b/utils/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-utils-fuzz"
-version = "0.0.1"
+version = "0.0.55"
 publish = false
 edition = "2021"
 


### PR DESCRIPTION
## Stats
```
 .github/actions/setup/action.yml                   |   17 +-
 .github/workflows/benchmark.yml                    |    3 +
 .github/workflows/coverage.yml                     |   18 +-
 .github/workflows/{tests.yml => fast.yml}          |   75 +-
 .github/workflows/publish.yml                      |   13 +
 .github/workflows/slow.yml                         |  107 +
 .gitignore                                         |    9 +-
 CONTRIBUTING.md                                    |    4 +-
 Cargo.lock                                         |  269 ++-
 Cargo.toml                                         |   43 +-
 FUZZING.md                                         |   60 +
 README.md                                          |    5 +-
 broadcast/Cargo.toml                               |    2 +-
 broadcast/src/buffered/config.rs                   |    6 +-
 broadcast/src/buffered/engine.rs                   |    9 +-
 broadcast/src/buffered/ingress.rs                  |   17 +-
 broadcast/src/buffered/metrics.rs                  |    6 +-
 broadcast/src/buffered/mod.rs                      |   12 +-
 codec/Cargo.toml                                   |    2 +-
 codec/fuzz/Cargo.toml                              |   25 +
 codec/fuzz/fuzz_targets/codec_roundtrip.rs         |  185 ++
 codec/src/codec.rs                                 |   24 +-
 codec/src/config.rs                                |    2 +-
 codec/src/error.rs                                 |   16 +-
 codec/src/extensions.rs                            |   16 +-
 codec/src/lib.rs                                   |   46 +-
 codec/src/types/bytes.rs                           |    2 +-
 codec/src/types/map.rs                             |    2 +-
 codec/src/types/primitives.rs                      |    4 +-
 codec/src/types/set.rs                             |    8 +-
 codec/src/types/vec.rs                             |    2 +-
 codec/src/varint.rs                                |   31 +-
 collector/Cargo.toml                               |   33 +
 collector/README.md                                |   10 +
 collector/src/lib.rs                               |   83 +
 collector/src/p2p/engine.rs                        |  251 +++
 collector/src/p2p/ingress.rs                       |   55 +
 collector/src/p2p/mocks/handler.rs                 |   95 +
 collector/src/p2p/mocks/mod.rs                     |    5 +
 collector/src/p2p/mocks/monitor.rs                 |   52 +
 collector/src/p2p/mocks/types.rs                   |   99 +
 collector/src/p2p/mod.rs                           |  740 +++++++
 consensus/Cargo.toml                               |    2 +-
 consensus/src/lib.rs                               |    9 +-
 consensus/src/ordered_broadcast/ack_manager.rs     |    7 +-
 consensus/src/ordered_broadcast/config.rs          |    5 +-
 consensus/src/ordered_broadcast/engine.rs          |   20 +-
 consensus/src/ordered_broadcast/metrics.rs         |    6 +-
 consensus/src/ordered_broadcast/mocks/automaton.rs |   13 +-
 .../src/ordered_broadcast/mocks/sequencers.rs      |    8 +-
 .../src/ordered_broadcast/mocks/validators.rs      |   20 +-
 consensus/src/ordered_broadcast/mod.rs             |   20 +-
 consensus/src/ordered_broadcast/types.rs           |   44 +-
 consensus/src/simplex/actors/voter/actor.rs        |    8 +-
 consensus/src/simplex/actors/voter/mod.rs          |   13 +-
 consensus/src/simplex/config.rs                    |    7 -
 consensus/src/simplex/engine.rs                    |    1 -
 consensus/src/simplex/mocks/application.rs         |    9 +-
 consensus/src/simplex/mocks/conflicter.rs          |    3 +-
 consensus/src/simplex/mocks/relay.rs               |   10 +-
 consensus/src/simplex/mod.rs                       |   53 +-
 consensus/src/simplex/types.rs                     |    2 +-
 .../threshold_simplex/actors/batcher/ingress.rs    |    9 +-
 .../src/threshold_simplex/actors/batcher/mod.rs    |    5 +-
 .../src/threshold_simplex/actors/voter/actor.rs    |    6 +-
 .../src/threshold_simplex/actors/voter/mod.rs      |   17 +-
 consensus/src/threshold_simplex/config.rs          |    7 -
 consensus/src/threshold_simplex/engine.rs          |    1 -
 .../src/threshold_simplex/mocks/application.rs     |    9 +-
 .../src/threshold_simplex/mocks/conflicter.rs      |    3 +-
 consensus/src/threshold_simplex/mocks/relay.rs     |   10 +-
 .../src/threshold_simplex/mocks/supervisor.rs      |   18 +-
 consensus/src/threshold_simplex/mod.rs             |   55 +-
 consensus/src/threshold_simplex/types.rs           |   10 +-
 cryptography/Cargo.toml                            |   13 +-
 cryptography/fuzz/Cargo.toml                       |   75 +
 cryptography/fuzz/fuzz_targets/bloomfilter.rs      |   51 +
 .../fuzz/fuzz_targets/bls12381_batch_verifier.rs   |  110 ++
 cryptography/fuzz/fuzz_targets/bls12381_decode.rs  |   79 +
 .../fuzz_targets/bls12381_primitive_operations.rs  |  868 +++++++++
 .../fuzz/fuzz_targets/ed25519_batch_verifier.rs    |  111 ++
 cryptography/fuzz/fuzz_targets/ed25519_decode.rs   |   45 +
 cryptography/fuzz/fuzz_targets/secp256r1_decode.rs |  167 ++
 cryptography/fuzz/fuzz_targets/sha256_hasher.rs    |  115 ++
 cryptography/src/blake3/benches/bench.rs           |    5 +
 cryptography/src/blake3/benches/hash_message.rs    |   22 +
 cryptography/src/blake3/mod.rs                     |  257 +++
 cryptography/src/bloomfilter.rs                    |  227 +++
 cryptography/src/bls12381/benches/dkg_recovery.rs  |   16 +-
 .../src/bls12381/benches/dkg_reshare_recovery.rs   |    3 +-
 .../benches/partial_verify_multiple_public_keys.rs |    3 +-
 cryptography/src/bls12381/dkg/arbiter.rs           |    6 +-
 cryptography/src/bls12381/dkg/dealer.rs            |    6 +-
 cryptography/src/bls12381/dkg/mod.rs               |   21 +-
 cryptography/src/bls12381/dkg/player.rs            |    6 +-
 cryptography/src/bls12381/mod.rs                   |    2 +-
 cryptography/src/bls12381/primitives/group.rs      |  135 +-
 cryptography/src/bls12381/primitives/ops.rs        |  128 +-
 cryptography/src/bls12381/primitives/poly.rs       |   51 +-
 cryptography/src/bls12381/primitives/variant.rs    |   11 +-
 cryptography/src/bls12381/scheme.rs                |    3 +-
 cryptography/src/ed25519/scheme.rs                 |   10 +-
 cryptography/src/lib.rs                            |   11 +-
 cryptography/src/secp256r1/scheme.rs               |   12 +-
 cryptography/src/sha256/benches/hash_message.rs    |    3 +-
 cryptography/src/sha256/mod.rs                     |   28 +
 deployer/Cargo.toml                                |    2 +-
 deployer/src/ec2/authorize.rs                      |   13 +-
 deployer/src/ec2/aws.rs                            |   30 +-
 deployer/src/ec2/create.rs                         |   20 +-
 deployer/src/ec2/destroy.rs                        |   10 +-
 deployer/src/ec2/mod.rs                            |    2 +-
 deployer/src/ec2/services.rs                       |  110 +-
 deployer/src/ec2/update.rs                         |    6 +-
 deployer/src/ec2/utils.rs                          |   23 +-
 docs/blogs/adb-any.html                            |    2 +-
 docs/blogs/adb-current.html                        |  121 ++
 docs/blogs/minimmit.html                           |  386 ++++
 docs/hiring.html                                   |   17 +
 docs/imgs/adb-activity.png                         |  Bin 0 -> 101658 bytes
 docs/imgs/adb-chunked.png                          |  Bin 0 -> 148697 bytes
 docs/imgs/adb-current.png                          |  Bin 0 -> 125073 bytes
 docs/imgs/adb-naive.png                            |  Bin 0 -> 181618 bytes
 docs/imgs/alpenglow-fallback.png                   |  Bin 0 -> 38007 bytes
 docs/imgs/faster-blocks.png                        |  Bin 0 -> 140801 bytes
 docs/imgs/phase-comparison.png                     |  Bin 0 -> 200135 bytes
 docs/index.html                                    |   16 +
 docs/shared.js                                     |    9 +-
 docs/style.css                                     |   61 +
 examples/bridge/Cargo.toml                         |    2 +-
 examples/bridge/src/application/actor.rs           |    5 +-
 examples/bridge/src/application/mod.rs             |    5 +-
 examples/bridge/src/application/supervisor.rs      |   25 +-
 examples/bridge/src/bin/dealer.rs                  |    2 +-
 examples/bridge/src/bin/validator.rs               |   15 +-
 examples/chat/Cargo.toml                           |    2 +-
 examples/chat/src/handler.rs                       |    6 +-
 examples/chat/src/logger.rs                        |    2 +-
 examples/chat/src/main.rs                          |   24 +-
 examples/flood/Cargo.toml                          |    2 +-
 examples/flood/src/bin/flood.rs                    |    7 +-
 examples/flood/src/bin/setup.rs                    |   12 +-
 examples/log/Cargo.toml                            |    2 +-
 examples/log/src/application/actor.rs              |    8 +-
 examples/log/src/application/mod.rs                |    5 +-
 examples/log/src/application/supervisor.rs         |   11 +-
 examples/log/src/gui.rs                            |    6 +-
 examples/log/src/main.rs                           |   17 +-
 examples/sync/Cargo.toml                           |   37 +
 examples/sync/README.md                            |  134 ++
 examples/sync/src/bin/client.rs                    |  254 +++
 examples/sync/src/bin/server.rs                    |  448 +++++
 examples/sync/src/lib.rs                           |  123 ++
 examples/sync/src/protocol.rs                      |  400 ++++
 examples/sync/src/resolver.rs                      |  202 ++
 examples/vrf/Cargo.toml                            |    2 +-
 examples/vrf/src/handlers/arbiter.rs               |   12 +-
 examples/vrf/src/handlers/contributor.rs           |   24 +-
 examples/vrf/src/handlers/utils.rs                 |    8 +-
 examples/vrf/src/handlers/vrf.rs                   |   38 +-
 examples/vrf/src/handlers/wire.rs                  |   49 +-
 examples/vrf/src/main.rs                           |   18 +-
 macros/Cargo.toml                                  |    2 +-
 macros/src/lib.rs                                  |    2 +-
 p2p/Cargo.toml                                     |    3 +-
 p2p/src/authenticated/actors/peer/ingress.rs       |  133 --
 p2p/src/authenticated/actors/spawner/ingress.rs    |   46 -
 .../authenticated/actors/tracker/reservation.rs    |   64 -
 p2p/src/authenticated/data.rs                      |   68 +
 .../authenticated/{ => discovery}/actors/dialer.rs |   65 +-
 .../{ => discovery}/actors/listener.rs             |   88 +-
 .../authenticated/{ => discovery}/actors/mod.rs    |    0
 .../{ => discovery}/actors/peer/actor.rs           |  151 +-
 .../authenticated/discovery/actors/peer/ingress.rs |   29 +
 .../{ => discovery}/actors/peer/mod.rs             |    8 +-
 .../{ => discovery}/actors/router/actor.rs         |   49 +-
 .../discovery/actors/router/ingress.rs             |   86 +
 .../{ => discovery}/actors/router/mod.rs           |    3 +-
 .../{ => discovery}/actors/spawner/actor.rs        |   43 +-
 .../discovery/actors/spawner/ingress.rs            |   32 +
 .../{ => discovery}/actors/spawner/mod.rs          |    3 +-
 .../{ => discovery}/actors/tracker/actor.rs        |  151 +-
 .../{ => discovery}/actors/tracker/directory.rs    |   99 +-
 .../{ => discovery}/actors/tracker/ingress.rs      |  167 +-
 .../{ => discovery}/actors/tracker/metadata.rs     |    6 +-
 .../{ => discovery}/actors/tracker/metrics.rs      |    4 +-
 .../{ => discovery}/actors/tracker/mod.rs          |   11 +-
 .../{ => discovery}/actors/tracker/record.rs       |   22 +-
 .../discovery/actors/tracker/reservation.rs        |   60 +
 .../{ => discovery}/actors/tracker/set.rs          |   90 +-
 p2p/src/authenticated/{ => discovery}/channels.rs  |   85 +-
 p2p/src/authenticated/{ => discovery}/config.rs    |    2 +-
 p2p/src/authenticated/{ => discovery}/metrics.rs   |    2 +-
 p2p/src/authenticated/discovery/mod.rs             |  742 +++++++
 p2p/src/authenticated/{ => discovery}/network.rs   |   10 +-
 p2p/src/authenticated/{ => discovery}/types.rs     |   63 +-
 p2p/src/authenticated/ip.rs                        |    6 +-
 p2p/src/authenticated/lookup/actors/dialer.rs      |  186 ++
 p2p/src/authenticated/lookup/actors/listener.rs    |  174 ++
 p2p/src/authenticated/lookup/actors/mod.rs         |    6 +
 p2p/src/authenticated/lookup/actors/peer/actor.rs  |  253 +++
 .../authenticated/lookup/actors/peer/ingress.rs    |   14 +
 p2p/src/authenticated/lookup/actors/peer/mod.rs    |   40 +
 .../authenticated/lookup/actors/router/actor.rs    |  178 ++
 .../{ => lookup}/actors/router/ingress.rs          |   56 +-
 p2p/src/authenticated/lookup/actors/router/mod.rs  |   10 +
 .../authenticated/lookup/actors/spawner/actor.rs   |  153 ++
 .../authenticated/lookup/actors/spawner/ingress.rs |   32 +
 p2p/src/authenticated/lookup/actors/spawner/mod.rs |   15 +
 .../authenticated/lookup/actors/tracker/actor.rs   |  514 +++++
 .../lookup/actors/tracker/directory.rs             |  321 +++
 .../authenticated/lookup/actors/tracker/ingress.rs |  213 ++
 .../lookup/actors/tracker/metadata.rs              |   29 +
 .../authenticated/lookup/actors/tracker/metrics.rs |   56 +
 p2p/src/authenticated/lookup/actors/tracker/mod.rs |   28 +
 .../authenticated/lookup/actors/tracker/record.rs  |  429 ++++
 .../lookup/actors/tracker/reservation.rs           |   60 +
 p2p/src/authenticated/lookup/channels.rs           |  135 ++
 p2p/src/authenticated/lookup/config.rs             |  173 ++
 p2p/src/authenticated/lookup/metrics.rs            |   61 +
 p2p/src/authenticated/lookup/mod.rs                |  672 +++++++
 p2p/src/authenticated/lookup/network.rs            |  196 ++
 p2p/src/authenticated/lookup/types.rs              |   92 +
 p2p/src/authenticated/mailbox.rs                   |   38 +
 p2p/src/authenticated/mod.rs                       |  649 +------
 p2p/src/authenticated/relay.rs                     |   61 +
 p2p/src/lib.rs                                     |   14 +-
 p2p/src/simulated/ingress.rs                       |   12 +-
 p2p/src/simulated/metrics.rs                       |    4 +-
 p2p/src/simulated/mod.rs                           |    2 +-
 p2p/src/simulated/network.rs                       |   26 +-
 p2p/src/utils/requester/config.rs                  |    4 +-
 p2p/src/utils/requester/metrics.rs                 |    4 +-
 p2p/src/utils/requester/requester.rs               |   15 +-
 pipeline/minimmit.md                               |  253 +++
 resolver/Cargo.toml                                |    2 +-
 resolver/src/p2p/config.rs                         |    3 +-
 resolver/src/p2p/engine.rs                         |   10 +-
 resolver/src/p2p/fetcher.rs                        |    5 +-
 resolver/src/p2p/mocks/consumer.rs                 |    3 +-
 resolver/src/p2p/mocks/coordinator.rs              |   13 +-
 resolver/src/p2p/mod.rs                            |    5 +-
 runtime/Cargo.toml                                 |    2 +-
 runtime/src/deterministic.rs                       |    2 +-
 runtime/src/iouring/mod.rs                         |   63 +-
 runtime/src/lib.rs                                 |  138 +-
 runtime/src/mocks.rs                               |    2 +-
 runtime/src/network/audited.rs                     |   19 +-
 runtime/src/network/deterministic.rs               |    3 +-
 runtime/src/network/iouring.rs                     |   24 +
 runtime/src/network/metered.rs                     |   11 +-
 runtime/src/network/tokio.rs                       |    3 +-
 runtime/src/storage/audited.rs                     |   14 +-
 runtime/src/storage/iouring.rs                     |   40 +-
 runtime/src/storage/memory.rs                      |   10 +-
 runtime/src/storage/metered.rs                     |   17 +-
 runtime/src/storage/mod.rs                         |   18 +-
 runtime/src/storage/tokio/fallback.rs              |   82 +
 runtime/src/storage/{tokio.rs => tokio/mod.rs}     |  128 +-
 runtime/src/storage/tokio/unix.rs                  |   75 +
 runtime/src/telemetry/traces/status.rs             |    2 +-
 runtime/src/tokio/runtime.rs                       |   30 +-
 runtime/src/tokio/telemetry.rs                     |    5 +-
 runtime/src/utils/buffer/append.rs                 |  382 ++++
 runtime/src/utils/buffer/mod.rs                    |  116 +-
 runtime/src/utils/buffer/pool.rs                   |  463 +++++
 runtime/src/utils/buffer/read.rs                   |   11 +-
 runtime/src/utils/buffer/tip.rs                    |  222 +++
 runtime/src/utils/buffer/write.rs                  |  300 +--
 runtime/src/utils/mod.rs                           |   16 +-
 rustfmt.toml                                       |    3 +
 storage/Cargo.toml                                 |   24 +-
 storage/fuzz/Cargo.toml                            |   87 +
 .../fuzz/fuzz_targets/adb_current_operations.rs    |  281 +++
 storage/fuzz/fuzz_targets/adb_operations.rs        |  261 +++
 storage/fuzz/fuzz_targets/archive_operations.rs    |  246 +++
 storage/fuzz/fuzz_targets/bmt_operations.rs        |  128 ++
 storage/fuzz/fuzz_targets/freezer_operations.rs    |   85 +
 storage/fuzz/fuzz_targets/index_operations.rs      |  175 ++
 storage/fuzz/fuzz_targets/journal_operations.rs    |  193 ++
 storage/fuzz/fuzz_targets/metadata_operations.rs   |  130 ++
 storage/fuzz/fuzz_targets/mmr_operations.rs        |  428 ++++
 storage/fuzz/fuzz_targets/rmap_operations.rs       |  151 ++
 storage/src/adb/any.rs                             | 1299 -------------
 storage/src/adb/any/mod.rs                         | 2052 ++++++++++++++++++++
 storage/src/adb/any/sync/client.rs                 |  673 +++++++
 storage/src/adb/any/sync/mod.rs                    |   74 +
 storage/src/adb/any/sync/resolver.rs               |   74 +
 storage/src/adb/benches/any_init.rs                |  150 ++
 storage/src/adb/benches/bench.rs                   |    5 +
 storage/src/adb/current.rs                         |  472 ++---
 storage/src/adb/mod.rs                             |    5 +-
 storage/src/adb/operation.rs                       |   16 +-
 storage/src/archive/benches/get.rs                 |  156 +-
 storage/src/archive/benches/put.rs                 |   53 +-
 storage/src/archive/benches/restart.rs             |   84 +-
 storage/src/archive/benches/utils.rs               |  170 +-
 storage/src/archive/immutable/mod.rs               |  108 ++
 storage/src/archive/immutable/storage.rs           |  342 ++++
 storage/src/archive/mod.rs                         | 1371 +++++--------
 storage/src/archive/prunable/mod.rs                |  669 +++++++
 storage/src/archive/{ => prunable}/storage.rs      |  202 +-
 storage/src/bmt/mod.rs                             |   20 +-
 storage/src/freezer/benches/bench.rs               |    8 +
 storage/src/freezer/benches/get.rs                 |  117 ++
 storage/src/freezer/benches/put.rs                 |   33 +
 storage/src/freezer/benches/restart.rs             |   51 +
 storage/src/freezer/benches/utils.rs               |   72 +
 storage/src/freezer/mod.rs                         | 1083 +++++++++++
 storage/src/freezer/storage.rs                     |  963 +++++++++
 storage/src/index/benches/insert.rs                |    2 +-
 storage/src/index/mod.rs                           |  110 +-
 storage/src/index/storage.rs                       |   48 +-
 storage/src/journal/benches/bench.rs               |   15 +-
 storage/src/journal/benches/fixed_replay.rs        |   13 +-
 storage/src/journal/fixed.rs                       | 1368 +++++++++----
 storage/src/journal/mod.rs                         |    2 +
 storage/src/journal/variable.rs                    |  332 +++-
 storage/src/lib.rs                                 |    3 +
 storage/src/metadata/benches/bench.rs              |    7 +
 storage/src/metadata/benches/restart.rs            |   57 +
 storage/src/metadata/benches/sync.rs               |   59 +
 storage/src/metadata/benches/utils.rs              |   50 +
 storage/src/metadata/mod.rs                        |  813 +++++++-
 storage/src/metadata/storage.rs                    |  453 +++--
 storage/src/mmr/benches/append.rs                  |    7 +-
 storage/src/mmr/benches/append_additional.rs       |   12 +-
 storage/src/mmr/benches/prove_many_elements.rs     |   26 +-
 storage/src/mmr/benches/prove_single_element.rs    |   25 +-
 storage/src/mmr/benches/update.rs                  |   89 +-
 storage/src/mmr/bitmap.rs                          |  279 +--
 storage/src/mmr/hasher.rs                          |  471 +++--
 storage/src/mmr/iterator.rs                        |    7 +-
 storage/src/mmr/journaled.rs                       |  748 +++++--
 storage/src/mmr/mem.rs                             |  512 +++--
 storage/src/mmr/mod.rs                             |   15 +-
 storage/src/mmr/storage.rs                         |    5 +-
 storage/src/mmr/tests/mod.rs                       |   13 +-
 storage/src/mmr/verification.rs                    | 1039 ++++++----
 storage/src/ordinal/benches/bench.rs               |    8 +
 storage/src/ordinal/benches/get.rs                 |   91 +
 storage/src/ordinal/benches/put.rs                 |   33 +
 storage/src/ordinal/benches/restart.rs             |   51 +
 storage/src/ordinal/benches/utils.rs               |   45 +
 storage/src/ordinal/mod.rs                         | 1905 ++++++++++++++++++
 storage/src/ordinal/storage.rs                     |  389 ++++
 storage/src/{index => }/translator.rs              |   32 +-
 stream/Cargo.toml                                  |    4 +-
 stream/fuzz/Cargo.toml                             |   61 +
 stream/fuzz/fuzz_targets/confirmation.rs           |   39 +
 stream/fuzz/fuzz_targets/connection.rs             |  169 ++
 stream/fuzz/fuzz_targets/e2e.rs                    |  596 ++++++
 stream/fuzz/fuzz_targets/handshake.rs              |  120 ++
 stream/fuzz/fuzz_targets/lazy_transport.rs         |  108 ++
 stream/fuzz/fuzz_targets/transport.rs              |   82 +
 stream/src/lib.rs                                  |   51 +-
 stream/src/public_key/benches/sender_send.rs       |    6 +-
 stream/src/public_key/cipher.rs                    |  589 ++++--
 stream/src/public_key/connection.rs                |  379 ++--
 stream/src/public_key/handshake.rs                 |  311 ++-
 stream/src/public_key/mod.rs                       |  154 +-
 stream/src/public_key/nonce.rs                     |  161 +-
 stream/src/public_key/x25519.rs                    |   10 +-
 utils/Cargo.toml                                   |    2 +-
 utils/fuzz/Cargo.toml                              |   50 +
 utils/fuzz/fuzz_targets/array.rs                   |  105 +
 utils/fuzz/fuzz_targets/bitvec.rs                  |  209 ++
 utils/fuzz/fuzz_targets/lib_functions.rs           |  153 ++
 utils/fuzz/fuzz_targets/priority_set.rs            |  163 ++
 utils/fuzz/fuzz_targets/stable_buf.rs              |  117 ++
 utils/src/array/fixed_bytes.rs                     |    2 +-
 utils/src/array/u64.rs                             |    6 +
 utils/src/bitvec.rs                                |   12 +-
 utils/src/futures.rs                               |   36 +-
 utils/src/lib.rs                                   |   69 +-
 utils/src/stable_buf.rs                            |   12 +-
 utils/src/time.rs                                  |   10 +-
 377 files changed, 35575 insertions(+), 7879 deletions(-)
```