### PR TITLE
[release] v0.0.56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "commonware-bridge"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "clap",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "chrono",
  "clap",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "paste",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-collector"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "blake3",
  "blst",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "arbitrary",
  "blst",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "chrono",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bimap",
  "bytes",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "async-lock",
  "axum",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "arbitrary",
  "commonware-codec",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "arbitrary",
  "chacha20poly1305",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-sync"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "clap",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-vrf"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,19 +30,20 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.55", path = "broadcast" }
-commonware-codec = { version = "0.0.55", path = "codec" }
-commonware-collector = { version = "0.0.55", path = "collector" }
-commonware-consensus = { version = "0.0.55", path = "consensus" }
-commonware-cryptography = { version = "0.0.55", path = "cryptography" }
-commonware-deployer = { version = "0.0.55", path = "deployer", default-features = false }
-commonware-macros = { version = "0.0.55", path = "macros" }
-commonware-p2p = { version = "0.0.55", path = "p2p" }
-commonware-resolver = { version = "0.0.55", path = "resolver" }
-commonware-runtime = { version = "0.0.55", path = "runtime" }
-commonware-storage = { version = "0.0.55", path = "storage" }
-commonware-stream = { version = "0.0.55", path = "stream" }
-commonware-utils = { version = "0.0.55", path = "utils" }
+commonware-broadcast = { version = "0.0.56", path = "broadcast" }
+commonware-codec = { version = "0.0.56", path = "codec" }
+commonware-coding = { version = "0.0.56", path = "coding" }
+commonware-collector = { version = "0.0.56", path = "collector" }
+commonware-consensus = { version = "0.0.56", path = "consensus" }
+commonware-cryptography = { version = "0.0.56", path = "cryptography" }
+commonware-deployer = { version = "0.0.56", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.56", path = "macros" }
+commonware-p2p = { version = "0.0.56", path = "p2p" }
+commonware-resolver = { version = "0.0.56", path = "resolver" }
+commonware-runtime = { version = "0.0.56", path = "runtime" }
+commonware-storage = { version = "0.0.56", path = "storage" }
+commonware-stream = { version = "0.0.56", path = "stream" }
+commonware-utils = { version = "0.0.56", path = "utils" }
 thiserror = "2.0.12"
 bytes = "1.7.1"
 sha2 = "0.10.8"

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-broadcast"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Disseminate data over a wide-area network."
 readme = "README.md"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-codec"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Serialize structured data."
 readme = "README.md"

--- a/codec/fuzz/Cargo.toml
+++ b/codec/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-codec-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 publish = false
 edition = "2021"
 

--- a/coding/Cargo.toml
+++ b/coding/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-coding"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Encode data to enable recovery from a subset of fragments."
 readme = "README.md"

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-collector"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Collect responses to committable requests."
 readme = "README.md"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-consensus"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Order opaque messages in a Byzantine environment."
 readme = "README.md"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify signatures."
 readme = "README.md"

--- a/cryptography/fuzz/Cargo.toml
+++ b/cryptography/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-cryptography-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 publish = false
 edition = "2021"
 

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-deployer"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Deploy infrastructure across cloud providers."
 readme = "README.md"

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-bridge"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Send succinct consensus certificates between two networks."
 readme = "README.md"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-flood"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Spam peers deployed to AWS EC2 with random messages."
 readme = "README.md"

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-log"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Commit to a secret log and agree to its hash."
 readme = "README.md"

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-sync"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Synchronize state between a server and client."
 readme = "README.md"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-vrf"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-macros"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Augment the development of primitives with procedural macros."
 readme = "README.md"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-resolver"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Resolve data identified by a fixed-length key."
 readme = "README.md"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-runtime"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Execute asynchronous tasks with a configurable scheduler."
 readme = "README.md"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-storage"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Persist and retrieve data from an abstract store."
 readme = "README.md"

--- a/storage/fuzz/Cargo.toml
+++ b/storage/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-storage-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 publish = false
 edition = "2021"
 

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-stream"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Exchange messages over arbitrary transport."
 readme = "README.md"

--- a/stream/fuzz/Cargo.toml
+++ b/stream/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-stream-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 publish = false
 edition = "2021"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-utils"
 edition = "2021"
 publish = true
-version = "0.0.55"
+version = "0.0.56"
 license = "MIT OR Apache-2.0"
 description = "Leverage common functionality across multiple primitives."
 readme = "README.md"

--- a/utils/fuzz/Cargo.toml
+++ b/utils/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-utils-fuzz"
-version = "0.0.55"
+version = "0.0.56"
 publish = false
 edition = "2021"
 


### PR DESCRIPTION
## Stats

```txt
 .github/workflows/publish.yml                  |    5 +
 .github/workflows/slow.yml                     |    4 +
 Cargo.lock                                     |   85 +-
 Cargo.toml                                     |   28 +-
 README.md                                      |    1 +
 broadcast/Cargo.toml                           |    2 +-
 codec/Cargo.toml                               |    2 +-
 codec/fuzz/Cargo.toml                          |    2 +-
 coding/Cargo.toml                              |   31 +
 coding/README.md                               |   10 +
 coding/src/lib.rs                              |    8 +
 coding/src/reed_solomon/benches/bench.rs       |    6 +
 coding/src/reed_solomon/benches/decode.rs      |   54 +
 coding/src/reed_solomon/benches/encode.rs      |   42 +
 coding/src/reed_solomon/mod.rs                 |  747 ++++++++++++++
 collector/Cargo.toml                           |    2 +-
 consensus/Cargo.toml                           |    2 +-
 consensus/src/aggregation/config.rs            |   74 ++
 consensus/src/aggregation/engine.rs            |  804 +++++++++++++++
 consensus/src/aggregation/metrics.rs           |   69 ++
 consensus/src/aggregation/mocks/application.rs |  110 +++
 consensus/src/aggregation/mocks/mod.rs         |   10 +
 consensus/src/aggregation/mocks/monitor.rs     |   56 ++
 consensus/src/aggregation/mocks/reporter.rs    |  232 +++++
 consensus/src/aggregation/mocks/supervisor.rs  |   97 ++
 consensus/src/aggregation/mod.rs               | 1247 ++++++++++++++++++++++++
 consensus/src/aggregation/safe_tip.rs          |  701 +++++++++++++
 consensus/src/aggregation/types.rs             |  385 ++++++++
 consensus/src/lib.rs                           |    5 +-
 consensus/src/ordered_broadcast/engine.rs      |    2 +-
 cryptography/Cargo.toml                        |    2 +-
 cryptography/fuzz/Cargo.toml                   |    2 +-
 cryptography/src/bls12381/primitives/ops.rs    |   36 +-
 deployer/Cargo.toml                            |    2 +-
 docs/index.html                                |    2 +
 examples/bridge/Cargo.toml                     |    2 +-
 examples/chat/Cargo.toml                       |    2 +-
 examples/flood/Cargo.toml                      |    2 +-
 examples/log/Cargo.toml                        |    2 +-
 examples/sync/Cargo.toml                       |    2 +-
 examples/vrf/Cargo.toml                        |    2 +-
 macros/Cargo.toml                              |    2 +-
 p2p/Cargo.toml                                 |    2 +-
 resolver/Cargo.toml                            |    2 +-
 runtime/Cargo.toml                             |    2 +-
 storage/Cargo.toml                             |    2 +-
 storage/fuzz/Cargo.toml                        |    3 +-
 storage/fuzz/fuzz_targets/bmt_operations.rs    |    5 +-
 storage/src/bmt/mod.rs                         |   76 +-
 storage/src/freezer/mod.rs                     |  153 ++-
 storage/src/freezer/storage.rs                 |  307 +++---
 stream/Cargo.toml                              |    2 +-
 stream/fuzz/Cargo.toml                         |    2 +-
 utils/Cargo.toml                               |    2 +-
 utils/fuzz/Cargo.toml                          |    2 +-
 utils/src/lib.rs                               |   66 ++
 56 files changed, 5244 insertions(+), 263 deletions(-)

```