### PR TITLE
[adb] [sync]  Re-use existing persisted data during state sync

### DIFF
--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -91,7 +91,9 @@ pub struct SyncConfig<E: RStorage + Metrics, K: Array, V: Array, T: Translator, 
 
     /// The pinned nodes the MMR needs at the pruning boundary given by
     /// `lower_bound`, in the order specified by [Proof::nodes_to_pin].
-    pub pinned_nodes: Vec<D>,
+    /// If `None`, the pinned nodes will be computed from the MMR's journal and metadata,
+    /// which are expected to have the necessary pinned nodes.
+    pub pinned_nodes: Option<Vec<D>>,
 
     /// The maximum number of operations to keep in memory
     /// before committing the database while applying operations.
@@ -1503,7 +1505,7 @@ pub(super) mod test {
                 db_config: any_db_config("sync_basic"),
                 lower_bound: 0, // No pruning
                 upper_bound: 0,
-                pinned_nodes: vec![],
+                pinned_nodes: None,
                 log,
                 apply_batch_size: 1024,
             };
@@ -1590,7 +1592,7 @@ pub(super) mod test {
                     log,
                     lower_bound: lower_bound_ops,
                     upper_bound: upper_bound_ops,
-                    pinned_nodes,
+                    pinned_nodes: Some(pinned_nodes),
                     apply_batch_size: 1024,
                 },
             )
@@ -1690,7 +1692,7 @@ pub(super) mod test {
                         log,
                         lower_bound,
                         upper_bound,
-                        pinned_nodes,
+                        pinned_nodes: Some(pinned_nodes),
                         apply_batch_size: 1024,
                     },
                 )
@@ -1790,7 +1792,7 @@ pub(super) mod test {
                     log,
                     lower_bound: sync_lower_bound,
                     upper_bound: sync_upper_bound,
-                    pinned_nodes,
+                    pinned_nodes: Some(pinned_nodes),
                     apply_batch_size: 1024,
                 },
             )
@@ -1868,7 +1870,7 @@ pub(super) mod test {
                     log,
                     lower_bound: sync_lower_bound,
                     upper_bound: sync_upper_bound,
-                    pinned_nodes: vec![],
+                    pinned_nodes: None,
                     apply_batch_size: 1024,
                 },
             )

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -227,14 +227,19 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         .map_err(Error::MmrError)?;
 
         let mut hasher = Standard::<H>::new();
+        let initial_journal_size = mmr
+            .get_actual_journal_size()
+            .await
+            .map_err(Error::MmrError)?;
+        let has_existing_journal_data = initial_journal_size > 0;
+
         for i in cfg.lower_bound..cfg.log.size().await? {
             let op = cfg.log.read(i).await?;
             let digest = Self::op_digest(&mut hasher, &op);
             mmr.add_batched(&mut hasher, &digest).await?;
-            if i % cfg.apply_batch_size as u64 == 0 {
-                // Periodically sync the MMR to avoid memory bloat.
-                // Since the first value i takes is `cfg.lower_bound`, the first sync
-                // may occur before `apply_batch_size` operations are applied. This is fine.
+            if i % cfg.apply_batch_size as u64 == 0 && !has_existing_journal_data {
+                // Only sync periodically if there's no existing journal data
+                // If there's existing data, we'll sync at the end after setting journal_size correctly
                 mmr.sync(&mut hasher).await?;
             }
         }

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -1805,7 +1805,7 @@ pub(super) mod test {
             let AnyTest { ops, log, .. } = target_db;
 
             // Re-open `sync_db`
-            let db = Any::init_synced(
+            let sync_db = Any::init_synced(
                 context.clone(),
                 SyncConfig {
                     db_config: sync_db_config,
@@ -1820,15 +1820,15 @@ pub(super) mod test {
             .unwrap();
 
             // Verify database state
-            assert_eq!(db.op_count(), target_db_op_count);
-            assert_eq!(db.inactivity_floor_loc, target_db_inactivity_floor_loc);
-            assert_eq!(db.oldest_retained_loc(), target_db_oldest_retained_loc);
-            assert_eq!(db.log.size().await.unwrap(), target_db_log_size);
-            assert_eq!(db.ops.size(), target_db_mmr_size);
-            assert_eq!(db.ops.pruned_to_pos(), target_db_pruned_to_pos);
+            assert_eq!(sync_db.op_count(), target_db_op_count);
+            assert_eq!(sync_db.inactivity_floor_loc, target_db_inactivity_floor_loc);
+            assert_eq!(sync_db.oldest_retained_loc(), target_db_oldest_retained_loc);
+            assert_eq!(sync_db.log.size().await.unwrap(), target_db_log_size);
+            assert_eq!(sync_db.ops.size(), target_db_mmr_size);
+            assert_eq!(sync_db.ops.pruned_to_pos(), target_db_pruned_to_pos);
 
             // Verify the root hash matches the target
-            assert_eq!(db.root(&mut hasher), target_hash);
+            assert_eq!(sync_db.root(&mut hasher), target_hash);
 
             // Verify state matches the source operations
             let mut expected_kvs = HashMap::new();
@@ -1843,15 +1843,15 @@ pub(super) mod test {
                 }
             }
             for (key, value) in expected_kvs {
-                let synced_value = db.get(&key).await.unwrap().unwrap();
+                let synced_value = sync_db.get(&key).await.unwrap().unwrap();
                 assert_eq!(synced_value, value);
             }
             // Verify that deleted keys are absent
             for key in deleted_keys {
-                assert!(db.get(&key).await.unwrap().is_none(),);
+                assert!(sync_db.get(&key).await.unwrap().is_none(),);
             }
 
-            db.destroy().await.unwrap();
+            sync_db.destroy().await.unwrap();
             ops.destroy().await.unwrap();
         });
     }
@@ -1882,7 +1882,7 @@ pub(super) mod test {
             let mut hasher = Standard::<Sha256>::new();
             ops.close(&mut hasher).await.unwrap();
 
-            let db: AnyTest = Any::init_synced(
+            let sync_db: AnyTest = Any::init_synced(
                 context.clone(),
                 SyncConfig {
                     db_config,
@@ -1897,14 +1897,14 @@ pub(super) mod test {
             .unwrap();
 
             // Verify database state
-            assert_eq!(db.op_count(), target_db_op_count);
-            assert_eq!(db.inactivity_floor_loc, target_db_inactivity_floor_loc);
-            assert_eq!(db.oldest_retained_loc(), target_db_oldest_retained_loc);
-            assert_eq!(db.log.size().await.unwrap(), target_db_log_size);
-            assert_eq!(db.ops.size(), target_db_mmr_size);
-            assert_eq!(db.ops.pruned_to_pos(), target_db_pruned_to_pos);
+            assert_eq!(sync_db.op_count(), target_db_op_count);
+            assert_eq!(sync_db.inactivity_floor_loc, target_db_inactivity_floor_loc);
+            assert_eq!(sync_db.oldest_retained_loc(), target_db_oldest_retained_loc);
+            assert_eq!(sync_db.log.size().await.unwrap(), target_db_log_size);
+            assert_eq!(sync_db.ops.size(), target_db_mmr_size);
+            assert_eq!(sync_db.ops.pruned_to_pos(), target_db_pruned_to_pos);
 
-            db.destroy().await.unwrap();
+            sync_db.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -80,13 +80,13 @@ pub struct SyncConfig<E: RStorage + Metrics, K: Array, V: Array, T: Translator, 
     pub db_config: Config<T>,
 
     /// Log of operations from lower_bound to upper_bound.
-    /// Reports `lower_bound` operations as pruned.
+    /// Reports `lower_bound` as its pruning boundary (oldest retained operation index).
     pub log: Journal<E, Operation<K, V>>,
 
     /// Pruning boundary - operations below this are considered pruned.
     pub lower_bound: u64,
 
-    /// Sync boundary - operations above this are not included.
+    /// Sync boundary - operations above this are not synced.
     pub upper_bound: u64,
 
     /// The pinned nodes the MMR needs at the pruning boundary given by

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -207,7 +207,6 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         context: E,
         cfg: SyncConfig<E, K, V, T, H::Digest>,
     ) -> Result<Self, Error> {
-        // Use the MMR's init_sync method to properly handle the pruned state with pinned nodes
         let mut mmr = Mmr::init_sync(
             context.with_label("mmr"),
             crate::mmr::journaled::SyncConfig {
@@ -234,7 +233,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
             mmr.add_batched(&mut hasher, &digest).await?;
             if i % cfg.apply_batch_size as u64 == 0 {
                 // Periodically sync the MMR to avoid memory bloat.
-                // Since the first value i takes is `cfg.pruned_to_loc`, the first sync
+                // Since the first value i takes is `cfg.lower_bound`, the first sync
                 // may occur before `apply_batch_size` operations are applied. This is fine.
                 mmr.sync(&mut hasher).await?;
             }

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -79,17 +79,14 @@ pub struct SyncConfig<E: RStorage + Metrics, K: Array, V: Array, T: Translator, 
     /// Database configuration.
     pub db_config: Config<T>,
 
-    /// The [Any]'s log of operations.
-    /// This log is expected to be pruned to the lower_bound boundary
-    /// and contain all subsequent operations up to upper_bound.
+    /// Log of operations from lower_bound to upper_bound.
+    /// Reports `lower_bound` operations as pruned.
     pub log: Journal<E, Operation<K, V>>,
 
-    /// The lower bound of operations (pruning boundary, inclusive).
-    /// Operations below this will be considered pruned/inactive.
+    /// Pruning boundary - operations below this are considered pruned.
     pub lower_bound: u64,
 
-    /// The upper bound of operations (inclusive).
-    /// Operations above this will not be included in the sync.
+    /// Sync boundary - operations above this are not included.
     pub upper_bound: u64,
 
     /// The pinned nodes the MMR needs at the pruning boundary given by
@@ -201,8 +198,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         Ok(db)
     }
 
-    /// Initialize an [Any] database in a pruned state.
-    /// Removes all existing persisted data and applies the state given in `cfg`.
+    /// Initialize a database from data received during a sync.
     pub(super) async fn init_synced(
         context: E,
         cfg: SyncConfig<E, K, V, T, H::Digest>,

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -1520,7 +1520,7 @@ pub(super) mod test {
             .unwrap();
             let sync_config: SyncConfig<Context, Digest, Digest, TwoCap, Digest> = SyncConfig {
                 db_config: any_db_config("sync_basic"),
-                lower_bound: 0, // No pruning
+                lower_bound: 0,
                 upper_bound: 0,
                 pinned_nodes: None,
                 log,

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -230,6 +230,8 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
                     buffer_pool: cfg.db_config.buffer_pool.clone(),
                 },
                 lower_bound: leaf_num_to_pos(cfg.lower_bound),
+                // The last node of an MMR with `cfg.upper_bound` + 1 operations is at the position
+                // right before where the next leaf goes.
                 upper_bound: leaf_num_to_pos(cfg.upper_bound + 1) - 1,
                 pinned_nodes: cfg.pinned_nodes,
             },

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -205,8 +205,8 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
     /// # Behavior
     ///
     /// This method handles different initialization scenarios based on existing data:
-    /// - If the MMR journal is empty or before `lower_bound`, it creates a fresh MMR from
-    ///   the provided `pinned_nodes`
+    /// - If the MMR journal is empty or the last item is before `lower_bound`, it creates a
+    ///   fresh MMR from the provided `pinned_nodes`
     /// - If the MMR journal has data but is incomplete (< `upper_bound`), missing operations
     ///   from the log are applied to bring it up to the target state
     /// - If the MMR journal has data beyond the `upper_bound`, it is rewound to match the sync target

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -207,8 +207,8 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         context: E,
         cfg: SyncConfig<E, K, V, T, H::Digest>,
     ) -> Result<Self, Error> {
-        // Use the MMR's init_with_smart_reuse method to properly handle the pruned state with pinned nodes
-        let mut mmr = Mmr::init_with_smart_reuse(
+        // Use the MMR's init_sync method to properly handle the pruned state with pinned nodes
+        let mut mmr = Mmr::init_sync(
             context.with_label("mmr"),
             crate::mmr::journaled::SyncConfig {
                 config: crate::mmr::journaled::Config {
@@ -1566,8 +1566,8 @@ pub(super) mod test {
             let mut hasher = Standard::<Sha256>::new();
             let target_hash = source_db.root(&mut hasher);
 
-            // Create log with operations using smart reuse
-            let mut log = Journal::<_, Operation<Digest, Digest>>::init_with_smart_reuse(
+            // Create log
+            let mut log = Journal::<_, Operation<Digest, Digest>>::init_sync(
                 context.clone().with_label("ops_log"),
                 JConfig {
                     partition: format!("ops_log_{}", context.next_u64()),
@@ -1656,8 +1656,8 @@ pub(super) mod test {
             for lower_bound in [0, 50, 100, 150] {
                 let upper_bound = std::cmp::min(lower_bound + 49, total_ops - 1);
 
-                // Create log with operations using smart reuse
-                let mut log = Journal::<_, Operation<Digest, Digest>>::init_with_smart_reuse(
+                // Create log with operations
+                let mut log = Journal::<_, Operation<Digest, Digest>>::init_sync(
                     context.clone().with_label("boundary_log"),
                     JConfig {
                         partition: format!("boundary_log_{}_{}", lower_bound, context.next_u64()),

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -207,8 +207,8 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         context: E,
         cfg: SyncConfig<E, K, V, T, H::Digest>,
     ) -> Result<Self, Error> {
-        // Use the MMR's init_pruned method to properly handle the pruned state with pinned nodes
-        let mut mmr = Mmr::init_pruned(
+        // Use the MMR's init_with_smart_reuse method to properly handle the pruned state with pinned nodes
+        let mut mmr = Mmr::init_with_smart_reuse(
             context.with_label("mmr"),
             crate::mmr::journaled::SyncConfig {
                 config: crate::mmr::journaled::Config {
@@ -1566,8 +1566,8 @@ pub(super) mod test {
             let mut hasher = Standard::<Sha256>::new();
             let target_hash = source_db.root(&mut hasher);
 
-            // Create log with operations
-            let mut log = Journal::<_, Operation<Digest, Digest>>::init_pruned(
+            // Create log with operations using smart reuse
+            let mut log = Journal::<_, Operation<Digest, Digest>>::init_with_smart_reuse(
                 context.clone().with_label("ops_log"),
                 JConfig {
                     partition: format!("ops_log_{}", context.next_u64()),
@@ -1656,8 +1656,8 @@ pub(super) mod test {
             for lower_bound in [0, 50, 100, 150] {
                 let upper_bound = std::cmp::min(lower_bound + 49, total_ops - 1);
 
-                // Create log with operations
-                let mut log = Journal::<_, Operation<Digest, Digest>>::init_pruned(
+                // Create log with operations using smart reuse
+                let mut log = Journal::<_, Operation<Digest, Digest>>::init_with_smart_reuse(
                     context.clone().with_label("boundary_log"),
                     JConfig {
                         partition: format!("boundary_log_{}_{}", lower_bound, context.next_u64()),

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -200,7 +200,20 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
         Ok(db)
     }
 
-    /// Initialize an [Any] from data received during a sync.
+    /// Returns an [Any] initialized from sync data in `cfg` for use in state sync.
+    ///
+    /// # Behavior
+    ///
+    /// This method handles different initialization scenarios based on existing data:
+    /// - If the MMR journal is empty, it creates a fresh MMR from the provided `pinned_nodes`
+    /// - If the MMR journal has data but is incomplete (< `upper_bound`), missing operations
+    ///   from the log are applied to bring it up to the target state
+    /// - If the MMR journal has data beyond the `upper_bound`, it is rewound to match the sync target
+    ///
+    /// # Returns
+    ///
+    /// An [Any] db populated with the state from `cfg.lower_bound` to `cfg.upper_bound`, inclusive.
+    /// The pruning boundary is set to `cfg.lower_bound`.
     pub(super) async fn init_synced(
         context: E,
         cfg: SyncConfig<E, K, V, T, H::Digest>,

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -234,6 +234,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
                 // If there's existing data, we'll sync at the end after setting journal_size correctly
                 mmr.sync(&mut hasher).await?;
             }
+            mmr.sync(&mut hasher).await?;
         }
 
         let mut snapshot = Index::init(

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -150,29 +150,6 @@ pub enum UpdateResult {
     Updated(u64, u64),
 }
 
-/// Calculate the expected MMR size for a given number of operations.
-/// This is used to determine the upper bound for sync operations.
-fn calculate_mmr_size(num_operations: u64) -> u64 {
-    if num_operations == 0 {
-        return 0;
-    }
-
-    let mut size = 0u64;
-    let mut remaining = num_operations;
-
-    while remaining > 0 {
-        // Find largest power of 2 <= remaining
-        let height = 63 - remaining.leading_zeros();
-        let subtree_leaves = 1u64 << height;
-        let subtree_size = (2 * subtree_leaves) - 1;
-
-        size += subtree_size;
-        remaining -= subtree_leaves;
-    }
-
-    size
-}
-
 impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translator>
     Any<E, K, V, H, T>
 {
@@ -238,7 +215,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
                     buffer_pool: cfg.db_config.buffer_pool.clone(),
                 },
                 lower_bound: leaf_num_to_pos(cfg.lower_bound),
-                upper_bound: calculate_mmr_size(cfg.upper_bound + 1),
+                upper_bound: leaf_num_to_pos(cfg.upper_bound + 1) - 1,
                 pinned_nodes: cfg.pinned_nodes,
             },
         )

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -219,8 +219,8 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
                     thread_pool: cfg.db_config.thread_pool.clone(),
                     buffer_pool: cfg.db_config.buffer_pool.clone(),
                 },
-                lower_bound: cfg.lower_bound,
-                upper_bound: cfg.upper_bound,
+                lower_bound: leaf_num_to_pos(cfg.lower_bound),
+                upper_bound: leaf_num_to_pos(cfg.upper_bound),
                 pinned_nodes: cfg.pinned_nodes,
             },
         )

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -826,11 +826,11 @@ pub(crate) mod tests {
                 sync_db.log.size().await.unwrap(),
                 target_db.log.size().await.unwrap()
             );
+            assert_eq!(sync_db.ops.pruned_to_pos(), target_db.ops.pruned_to_pos());
             assert_eq!(
                 sync_db.oldest_retained_loc(),
                 target_db.oldest_retained_loc()
             );
-            assert_eq!(sync_db.ops.pruned_to_pos(), target_db.ops.pruned_to_pos());
             assert_eq!(sync_db.root(&mut hasher), target_hash);
             for i in 0..31u64 {
                 let target_op = &target_ops[i as usize];

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -314,6 +314,7 @@ where
 
                 debug!(operations_len, "Received operations from resolver");
 
+                // Verify the proof is valid over the given operations
                 let proof_valid = {
                     let _timer = metrics.proof_verification_duration.timer();
                     adb::any::Any::<E, K, V, H, T>::verify_proof(

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -823,8 +823,8 @@ pub(crate) mod tests {
             for i in 0..31u64 {
                 let target_op = &target_ops[i as usize];
                 if let Some(key) = target_op.to_key() {
-                    let target_value = target_db.get(&key).await.unwrap();
-                    let synced_value = sync_db.get(&key).await.unwrap();
+                    let target_value = target_db.get(key).await.unwrap();
+                    let synced_value = sync_db.get(key).await.unwrap();
                     assert_eq!(target_value, synced_value);
                 }
             }

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -185,8 +185,8 @@ where
             });
         }
 
-        // Initialize the log journal.
-        let log = Journal::<E, Operation<K, V>>::init_pruned(
+        // Initialize the log journal with smart reuse capabilities
+        let log = Journal::<E, Operation<K, V>>::init_with_smart_reuse(
             config.context.clone().with_label("log"),
             JConfig {
                 partition: config.db_config.log_journal_partition.clone(),

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -185,8 +185,8 @@ where
             });
         }
 
-        // Initialize the operations journal. If we have existing persisted data in the target
-        // range, `log` will contain that data.
+        // Initialize the operations journal.
+        // It may have data in the target range.
         let log = Journal::<E, Operation<K, V>>::init_sync(
             config.context.clone().with_label("log"),
             JConfig {

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -766,7 +766,7 @@ pub(crate) mod tests {
         });
     }
 
-    /// Test edge case where existing database exactly matches the sync target
+    /// Test case where existing database on disk exactly matches the sync target
     #[test]
     fn test_sync_exact_match() {
         let executor = deterministic::Runner::default();

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -185,8 +185,8 @@ where
             });
         }
 
-        // Initialize the log journal with smart reuse capabilities
-        let log = Journal::<E, Operation<K, V>>::init_with_smart_reuse(
+        // Initialize the log journal with sync capabilities
+        let log = Journal::<E, Operation<K, V>>::init_sync(
             config.context.clone().with_label("log"),
             JConfig {
                 partition: config.db_config.log_journal_partition.clone(),

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -185,7 +185,7 @@ where
             });
         }
 
-        // Initialize only the pruned operation log. No MMR or snapshot yet.
+        // Initialize the log journal.
         let log = Journal::<E, Operation<K, V>>::init_pruned(
             config.context.clone().with_label("log"),
             JConfig {
@@ -310,6 +310,7 @@ where
                 }
 
                 // Install pinned nodes on first successful batch.
+                // We need pinned nodes if we don't have them yet and we're starting from the lower bound
                 if log_size == config.lower_bound_ops {
                     let start_pos = leaf_num_to_pos(log_size);
                     let end_pos = leaf_num_to_pos(log_size + operations_len - 1);

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -336,7 +336,7 @@ where
                 }
 
                 // Install pinned nodes on first successful batch.
-                if log_size == config.lower_bound_ops {
+                if pinned_nodes.is_none() {
                     let start_pos = leaf_num_to_pos(log_size);
                     let end_pos = leaf_num_to_pos(log_size + operations_len - 1);
                     let Ok(new_pinned_nodes) = proof.extract_pinned_nodes(start_pos, end_pos)

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -710,7 +710,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_sync_data_use_existing_db() {
+    fn test_sync_use_existing_db_partial() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let target_ops = create_test_ops(50);
@@ -768,7 +768,7 @@ pub(crate) mod tests {
 
     /// Test case where existing database on disk exactly matches the sync target
     #[test]
-    fn test_sync_exact_match() {
+    fn test_sync_use_existing_db_exact_match() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let target_ops = create_test_ops(50);

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -826,12 +826,12 @@ pub(crate) mod tests {
                 sync_db.log.size().await.unwrap(),
                 target_db.log.size().await.unwrap()
             );
-            assert_eq!(sync_db.ops.pruned_to_pos(), target_db.ops.pruned_to_pos());
+            assert_eq!(sync_db.root(&mut hasher), target_hash);
             assert_eq!(
                 sync_db.oldest_retained_loc(),
                 target_db.oldest_retained_loc()
             );
-            assert_eq!(sync_db.root(&mut hasher), target_hash);
+            assert_eq!(sync_db.ops.pruned_to_pos(), target_db.ops.pruned_to_pos());
             for i in 0..31u64 {
                 let target_op = &target_ops[i as usize];
                 if let Some(key) = target_op.to_key() {

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -218,7 +218,7 @@ where
                     log,
                     lower_bound: config.lower_bound_ops,
                     upper_bound: config.upper_bound_ops,
-                    pinned_nodes: vec![],
+                    pinned_nodes: None,
                     apply_batch_size: config.apply_batch_size,
                 },
             )
@@ -415,7 +415,7 @@ where
                             log,
                             lower_bound: config.lower_bound_ops,
                             upper_bound: config.upper_bound_ops,
-                            pinned_nodes: pinned_nodes.unwrap(),
+                            pinned_nodes,
                             apply_batch_size: config.apply_batch_size,
                         },
                     )

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -773,7 +773,7 @@ pub(crate) mod tests {
     fn test_sync_use_existing_db_exact_match() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
-            let target_ops = create_test_ops(50);
+            let target_ops = create_test_ops(1_000);
 
             // Create two databases
             let target_config = create_test_config(context.next_u64());

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -195,6 +195,7 @@ where
                 buffer_pool: config.db_config.buffer_pool.clone(),
             },
             config.lower_bound_ops,
+            config.upper_bound_ops,
         )
         .await
         .map_err(adb::Error::JournalError)
@@ -384,7 +385,8 @@ where
                         SyncConfig {
                             db_config: config.db_config.clone(),
                             log,
-                            pruned_to_loc: config.lower_bound_ops,
+                            lower_bound: config.lower_bound_ops,
+                            upper_bound: config.upper_bound_ops,
                             pinned_nodes: pinned_nodes.unwrap(),
                             apply_batch_size: config.apply_batch_size,
                         },

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -715,7 +715,7 @@ pub(crate) mod tests {
     fn test_sync_use_existing_db_partial() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let target_ops = create_test_ops(50);
+            let target_ops = create_test_ops(1000);
 
             // Create two databases
             let mut target_db = create_test_db(context.clone()).await;
@@ -725,7 +725,7 @@ pub(crate) mod tests {
                 .unwrap();
 
             // Apply the same operations to both databases
-            let common_ops = target_ops[0..10].to_vec();
+            let common_ops = target_ops[0..999].to_vec();
             target_db = apply_ops(target_db, common_ops.clone()).await;
             sync_db = apply_ops(sync_db, common_ops).await;
             target_db.commit().await.unwrap();
@@ -735,7 +735,7 @@ pub(crate) mod tests {
             sync_db.close().await.unwrap();
 
             // Add one more operation (and commit) to target database
-            let more_ops = target_ops[10..11].to_vec(); // Just operation 10
+            let more_ops = target_ops[999..1000].to_vec();
             target_db = apply_ops(target_db, more_ops).await;
             target_db.commit().await.unwrap();
             let mut hasher = create_test_hasher();

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -791,6 +791,9 @@ pub(crate) mod tests {
             target_db.commit().await.unwrap();
             sync_db.commit().await.unwrap();
 
+            target_db.sync().await.unwrap();
+            sync_db.sync().await.unwrap();
+
             // Close sync_db
             sync_db.close().await.unwrap();
 

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -774,8 +774,7 @@ pub(crate) mod tests {
                 assert_eq!(expected_op, synced_op);
             }
 
-            for i in 0..ORIGINAL_DB_OPS {
-                let target_op = &original_ops[i as usize];
+            for target_op in &original_ops {
                 if let Some(key) = target_op.to_key() {
                     let target_value = target_db.get(key).await.unwrap();
                     let synced_value = sync_db.get(key).await.unwrap();
@@ -784,8 +783,8 @@ pub(crate) mod tests {
             }
             // Verify the last operation is present
             let last_key = last_op[0].to_key().unwrap();
-            let last_value = last_op[0].to_value().unwrap().clone();
-            assert_eq!(sync_db.get(&last_key).await.unwrap(), Some(last_value));
+            let last_value = *last_op[0].to_value().unwrap();
+            assert_eq!(sync_db.get(last_key).await.unwrap(), Some(last_value));
 
             sync_db.destroy().await.unwrap();
             target_db.destroy().await.unwrap();
@@ -862,8 +861,7 @@ pub(crate) mod tests {
             assert_eq!(sync_db.root(&mut hasher), target_hash);
 
             // Verify state matches for sample operations
-            for i in 0..NUM_OPS {
-                let target_op = &target_ops[i as usize];
+            for target_op in &target_ops {
                 if let Some(key) = target_op.to_key() {
                     let target_value = target_db.get(key).await.unwrap();
                     let synced_value = sync_db.get(key).await.unwrap();

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -795,7 +795,7 @@ pub(crate) mod tests {
             // Reopen sync_db
             let mut hasher = create_test_hasher();
             let target_hash = target_db.root(&mut hasher);
-            let lower_bound_ops = 0;
+            let lower_bound_ops = target_db.oldest_retained_loc().unwrap();
             let upper_bound_ops = target_db.op_count() - 1;
             let config = Config {
                 db_config: sync_config, // Use same config to access same partitions
@@ -817,8 +817,11 @@ pub(crate) mod tests {
                 sync_db.log.size().await.unwrap(),
                 target_db.log.size().await.unwrap()
             );
-            assert_eq!(sync_db.oldest_retained_loc(), Some(lower_bound_ops));
-            assert_eq!(sync_db.ops.pruned_to_pos(), lower_bound_ops);
+            assert_eq!(
+                sync_db.oldest_retained_loc(),
+                target_db.oldest_retained_loc()
+            );
+            assert_eq!(sync_db.ops.pruned_to_pos(), target_db.ops.pruned_to_pos());
             assert_eq!(sync_db.root(&mut hasher), target_hash);
             for i in 0..31u64 {
                 let target_op = &target_ops[i as usize];

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -208,6 +208,8 @@ where
             .await
             .map_err(|e| Error::Adb(adb::Error::JournalError(e)))?;
 
+        // Assert invariant from [Journal::init_sync]
+        assert!(log_size <= config.upper_bound_ops + 1);
         if log_size == config.upper_bound_ops + 1 {
             // We already have all the operations we need in the log.
             // Build the database immediately without fetching more operations.

--- a/storage/src/adb/any/sync/mod.rs
+++ b/storage/src/adb/any/sync/mod.rs
@@ -68,5 +68,9 @@ where
     T: Translator,
     R: Resolver<Digest = H::Digest, Key = K, Value = V>,
 {
-    Client::new(config).await?.sync().await
+    let client = Client::new(config).await?;
+    match client {
+        Client::Done { db } => Ok(db),
+        _ => client.sync().await,
+    }
 }

--- a/storage/src/adb/any/sync/mod.rs
+++ b/storage/src/adb/any/sync/mod.rs
@@ -57,7 +57,6 @@ pub enum Error {
 ///
 /// When the database's operation log is complete, we reconstruct the database's MMR and snapshot.
 //
-// TODO(#1213) Handle existing state: https://github.com/commonwarexyz/monorepo/issues/1213
 // TODO(#1214) Parallelize operation fetching: https://github.com/commonwarexyz/monorepo/issues/1214
 pub async fn sync<E, K, V, H, T, R>(
     config: Config<E, K, V, H, T, R>,

--- a/storage/src/adb/any/sync/resolver.rs
+++ b/storage/src/adb/any/sync/resolver.rs
@@ -263,3 +263,45 @@ where
             })
     }
 }
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::*;
+    use std::marker::PhantomData;
+
+    pub struct FailResolver<D, K, V> {
+        _digest: PhantomData<D>,
+        _key: PhantomData<K>,
+        _value: PhantomData<V>,
+    }
+
+    impl<D, K, V> Resolver for FailResolver<D, K, V>
+    where
+        D: Digest,
+        K: Array,
+        V: Array,
+    {
+        type Digest = D;
+        type Key = K;
+        type Value = V;
+
+        async fn get_operations(
+            &self,
+            _size: u64,
+            _start_loc: u64,
+            _max_ops: NonZeroU64,
+        ) -> Result<GetOperationsResult<Self::Digest, Self::Key, Self::Value>, Error> {
+            Err(Error::AlreadyComplete)
+        }
+    }
+
+    impl<D, K, V> FailResolver<D, K, V> {
+        pub fn new() -> Self {
+            Self {
+                _digest: PhantomData,
+                _key: PhantomData,
+                _value: PhantomData,
+            }
+        }
+    }
+}

--- a/storage/src/adb/any/sync/resolver.rs
+++ b/storage/src/adb/any/sync/resolver.rs
@@ -13,196 +13,27 @@ use futures::channel::oneshot;
 use std::{future::Future, num::NonZeroU64};
 
 /// Result of a call to [Resolver::get_operations].
-///
-/// This struct encapsulates the response from a resolver when requesting operations
-/// for database synchronization. It includes both the requested operations and a
-/// cryptographic proof that validates their authenticity and correctness.
-///
-/// # Purpose
-///
-/// The `GetOperationsResult` is designed to support secure database synchronization
-/// by providing:
-/// - **Operations**: The actual database operations requested by the sync client
-/// - **Proof**: A cryptographic proof that these operations were present in the
-///   database at the specified state
-/// - **Feedback Channel**: A mechanism for the client to report proof verification
-///   results back to the resolver
-///
-/// # Usage Pattern
-///
-/// ```rust,ignore
-/// // Resolver provides operations with proof
-/// let result = resolver.get_operations(target_size, start_loc, batch_size).await?;
-///
-/// // Client verifies the proof
-/// let proof_valid = verify_proof(&result.proof, &result.operations);
-///
-/// // Client reports verification result back to resolver
-/// let _ = result.success_tx.send(proof_valid);
-/// ```
-///
-/// # Security Model
-///
-/// The proof verification feedback mechanism enables:
-/// - **Reputation tracking**: Resolvers can track successful/failed verification rates
-/// - **Adaptive behavior**: Resolvers can adjust their behavior based on client feedback
-/// - **Debugging**: Failed verifications can be logged for investigation
 pub struct GetOperationsResult<D: Digest, K: Array, V: Array> {
-    /// Cryptographic proof that validates the authenticity of the operations.
-    ///
-    /// This proof demonstrates that the provided operations were present in the
-    /// database when it contained the specified number of operations. The proof
-    /// is verified using the MMR (Merkle Mountain Range) structure to ensure
-    /// cryptographic integrity.
+    /// Proof that the operations are valid.
     pub proof: Proof<D>,
-
-    /// The database operations in the requested range.
-    ///
-    /// These operations represent the actual database changes (updates, deletions, etc.)
-    /// that occurred at the specified locations in the database's operation log.
-    /// The operations are provided in the order they were applied to the database.
+    /// The operations in the requested range.
     pub operations: Vec<Operation<K, V>>,
-
-    /// Channel for reporting proof verification results back to the resolver.
-    ///
-    /// The sync client should send `true` if the proof verification succeeds,
-    /// or `false` if it fails. This feedback allows the resolver to:
-    /// - Track verification success rates
-    /// - Implement adaptive retry logic
-    /// - Log failed verifications for debugging
-    ///
-    /// **Note**: Clients should ignore any error when sending on this channel,
-    /// as the resolver may not be waiting for the result.
+    /// A channel to send the result of the proof verification.
+    /// Caller should send `true` if the proof is valid, `false` otherwise.
+    /// Caller should ignore error if the channel is closed.
     pub success_tx: oneshot::Sender<bool>,
 }
 
-/// Trait for resolving database operations during synchronization.
-///
-/// The `Resolver` trait defines the interface for fetching database operations
-/// with cryptographic proofs during the synchronization process. This trait
-/// abstracts the mechanism for obtaining operations, allowing for different
-/// implementations such as:
-/// - **Local resolver**: Reading from a local database instance
-/// - **Network resolver**: Fetching operations from remote peers
-/// - **Cached resolver**: Using cached operations with fallback to network
-///
-/// # Synchronization Context
-///
-/// During database synchronization, the sync client needs to:
-/// 1. Request batches of operations from a resolver
-/// 2. Verify cryptographic proofs for each batch
-/// 3. Apply verified operations to the local database
-/// 4. Provide feedback on verification results
-///
-/// The resolver plays a crucial role in this process by providing both the
-/// operations and the proofs needed to ensure data integrity.
-///
-/// # Security Considerations
-///
-/// Resolvers must provide cryptographically sound proofs that:
-/// - Prove the operations existed in the database at the specified state
-/// - Cannot be forged or manipulated by malicious actors
-/// - Are efficiently verifiable by the sync client
-///
-/// # Implementation Requirements
-///
-/// Implementors must ensure that:
-/// - Operations are returned in the correct order
-/// - Proofs are valid for the provided operations and database state
-/// - The `success_tx` channel is properly configured for feedback
-/// - Error handling is appropriate for the resolver's context
-///
-/// # Example Implementation
-///
-/// ```rust,ignore
-/// impl Resolver for MyNetworkResolver {
-///     type Digest = Sha256Hash;
-///     type Key = MyKey;
-///     type Value = MyValue;
-///
-///     async fn get_operations(
-///         &self,
-///         size: u64,
-///         start_loc: u64,
-///         max_ops: NonZeroU64,
-///     ) -> Result<GetOperationsResult<Self::Digest, Self::Key, Self::Value>, Error> {
-///         // Fetch operations from network
-///         let operations = self.fetch_operations(start_loc, max_ops).await?;
-///         
-///         // Generate proof for the operations
-///         let proof = self.generate_proof(size, &operations).await?;
-///         
-///         // Create feedback channel
-///         let (success_tx, success_rx) = oneshot::channel();
-///         
-///         // Handle feedback asynchronously
-///         self.handle_feedback(success_rx);
-///         
-///         Ok(GetOperationsResult {
-///             proof,
-///             operations,
-///             success_tx,
-///         })
-///     }
-/// }
-/// ```
+/// Trait for network communication with the sync server
 pub trait Resolver {
-    /// The digest type used for cryptographic operations.
-    ///
-    /// This type must implement the `Digest` trait and will be used for
-    /// proof generation and verification.
     type Digest: Digest;
-
-    /// The key type for database operations.
-    ///
-    /// This type represents the keys used in database operations and must
-    /// implement the `Array` trait for efficient serialization.
     type Key: Array;
-
-    /// The value type for database operations.
-    ///
-    /// This type represents the values used in database operations and must
-    /// implement the `Array` trait for efficient serialization.
     type Value: Array;
 
-    /// Retrieve operations from the database with cryptographic proof.
-    ///
-    /// This method fetches a batch of database operations starting from a specific
-    /// location, along with a cryptographic proof that validates their authenticity
-    /// and correctness.
-    ///
-    /// # Arguments
-    ///
-    /// * `size` - The target size of the database state for proof generation.
-    ///   This represents the number of operations the database should contain
-    ///   when the proof is generated.
-    /// * `start_loc` - The starting location (position) in the database's operation
-    ///   log from which to retrieve operations.
-    /// * `max_ops` - The maximum number of operations to retrieve in this batch.
-    ///   The actual number returned may be less than this value.
-    ///
-    /// # Returns
-    ///
-    /// A `GetOperationsResult` containing:
-    /// - The requested operations
-    /// - A cryptographic proof validating the operations
-    /// - A feedback channel for reporting verification results
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The requested operations cannot be retrieved
-    /// - Proof generation fails
-    /// - The resolver encounters a network or storage error
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// let result = resolver.get_operations(1000, 100, NonZeroU64::new(50).unwrap()).await?;
-    ///
-    /// // This would retrieve up to 50 operations starting from location 100,
-    /// // with a proof valid for a database state of 1000 operations.
-    /// ```
+    /// The digest type of the resolver.
+    /// Get the operations starting at `start_loc` in the database, up to `max_ops` operations.
+    /// Returns the operations and a proof that they were present in the database when it had
+    /// `size` operations.
     #[allow(clippy::type_complexity)]
     fn get_operations(
         &self,
@@ -212,24 +43,6 @@ pub trait Resolver {
     ) -> impl Future<Output = Result<GetOperationsResult<Self::Digest, Self::Key, Self::Value>, Error>>;
 }
 
-/// Implementation of [Resolver] for local database instances.
-///
-/// This implementation allows a local database to act as a resolver for
-/// synchronization operations. It's commonly used in testing scenarios
-/// or when synchronizing from a local "source of truth" database.
-///
-/// # Usage
-///
-/// This implementation is automatically available for any `Any` database
-/// instance and can be used directly in sync operations:
-///
-/// ```rust,ignore
-/// let source_db = Any::init(context, config).await?;
-/// let sync_config = SyncConfig {
-///     resolver: &source_db,  // Uses this implementation
-///     // ... other config
-/// };
-/// ```
 impl<E, K, V, H, T> Resolver for &Any<E, K, V, H, T>
 where
     E: Storage + Clock + Metrics,
@@ -248,17 +61,13 @@ where
         start_loc: u64,
         max_ops: NonZeroU64,
     ) -> Result<GetOperationsResult<H::Digest, Self::Key, Self::Value>, Error> {
-        // Generate historical proof for the requested operations
-        // This creates a proof that the operations were present in the database
-        // when it had the specified size
         self.historical_proof(size, start_loc, max_ops.get())
             .await
             .map_err(Error::Adb)
             .map(|(proof, operations)| GetOperationsResult {
                 proof,
                 operations,
-                // For local database resolver, we don't need feedback since
-                // we're not tracking network reliability or reputation
+                // Result of proof verification isn't used by this implementation.
                 success_tx: oneshot::channel().0,
             })
     }

--- a/storage/src/adb/any/sync/resolver.rs
+++ b/storage/src/adb/any/sync/resolver.rs
@@ -13,27 +13,196 @@ use futures::channel::oneshot;
 use std::{future::Future, num::NonZeroU64};
 
 /// Result of a call to [Resolver::get_operations].
+///
+/// This struct encapsulates the response from a resolver when requesting operations
+/// for database synchronization. It includes both the requested operations and a
+/// cryptographic proof that validates their authenticity and correctness.
+///
+/// # Purpose
+///
+/// The `GetOperationsResult` is designed to support secure database synchronization
+/// by providing:
+/// - **Operations**: The actual database operations requested by the sync client
+/// - **Proof**: A cryptographic proof that these operations were present in the
+///   database at the specified state
+/// - **Feedback Channel**: A mechanism for the client to report proof verification
+///   results back to the resolver
+///
+/// # Usage Pattern
+///
+/// ```rust,ignore
+/// // Resolver provides operations with proof
+/// let result = resolver.get_operations(target_size, start_loc, batch_size).await?;
+///
+/// // Client verifies the proof
+/// let proof_valid = verify_proof(&result.proof, &result.operations);
+///
+/// // Client reports verification result back to resolver
+/// let _ = result.success_tx.send(proof_valid);
+/// ```
+///
+/// # Security Model
+///
+/// The proof verification feedback mechanism enables:
+/// - **Reputation tracking**: Resolvers can track successful/failed verification rates
+/// - **Adaptive behavior**: Resolvers can adjust their behavior based on client feedback
+/// - **Debugging**: Failed verifications can be logged for investigation
 pub struct GetOperationsResult<D: Digest, K: Array, V: Array> {
-    /// Proof that the operations are valid.
+    /// Cryptographic proof that validates the authenticity of the operations.
+    ///
+    /// This proof demonstrates that the provided operations were present in the
+    /// database when it contained the specified number of operations. The proof
+    /// is verified using the MMR (Merkle Mountain Range) structure to ensure
+    /// cryptographic integrity.
     pub proof: Proof<D>,
-    /// The operations in the requested range.
+
+    /// The database operations in the requested range.
+    ///
+    /// These operations represent the actual database changes (updates, deletions, etc.)
+    /// that occurred at the specified locations in the database's operation log.
+    /// The operations are provided in the order they were applied to the database.
     pub operations: Vec<Operation<K, V>>,
-    /// A channel to send the result of the proof verification.
-    /// Caller should send `true` if the proof is valid, `false` otherwise.
-    /// Caller should ignore error if the channel is closed.
+
+    /// Channel for reporting proof verification results back to the resolver.
+    ///
+    /// The sync client should send `true` if the proof verification succeeds,
+    /// or `false` if it fails. This feedback allows the resolver to:
+    /// - Track verification success rates
+    /// - Implement adaptive retry logic
+    /// - Log failed verifications for debugging
+    ///
+    /// **Note**: Clients should ignore any error when sending on this channel,
+    /// as the resolver may not be waiting for the result.
     pub success_tx: oneshot::Sender<bool>,
 }
 
-/// Trait for network communication with the sync server
+/// Trait for resolving database operations during synchronization.
+///
+/// The `Resolver` trait defines the interface for fetching database operations
+/// with cryptographic proofs during the synchronization process. This trait
+/// abstracts the mechanism for obtaining operations, allowing for different
+/// implementations such as:
+/// - **Local resolver**: Reading from a local database instance
+/// - **Network resolver**: Fetching operations from remote peers
+/// - **Cached resolver**: Using cached operations with fallback to network
+///
+/// # Synchronization Context
+///
+/// During database synchronization, the sync client needs to:
+/// 1. Request batches of operations from a resolver
+/// 2. Verify cryptographic proofs for each batch
+/// 3. Apply verified operations to the local database
+/// 4. Provide feedback on verification results
+///
+/// The resolver plays a crucial role in this process by providing both the
+/// operations and the proofs needed to ensure data integrity.
+///
+/// # Security Considerations
+///
+/// Resolvers must provide cryptographically sound proofs that:
+/// - Prove the operations existed in the database at the specified state
+/// - Cannot be forged or manipulated by malicious actors
+/// - Are efficiently verifiable by the sync client
+///
+/// # Implementation Requirements
+///
+/// Implementors must ensure that:
+/// - Operations are returned in the correct order
+/// - Proofs are valid for the provided operations and database state
+/// - The `success_tx` channel is properly configured for feedback
+/// - Error handling is appropriate for the resolver's context
+///
+/// # Example Implementation
+///
+/// ```rust,ignore
+/// impl Resolver for MyNetworkResolver {
+///     type Digest = Sha256Hash;
+///     type Key = MyKey;
+///     type Value = MyValue;
+///
+///     async fn get_operations(
+///         &self,
+///         size: u64,
+///         start_loc: u64,
+///         max_ops: NonZeroU64,
+///     ) -> Result<GetOperationsResult<Self::Digest, Self::Key, Self::Value>, Error> {
+///         // Fetch operations from network
+///         let operations = self.fetch_operations(start_loc, max_ops).await?;
+///         
+///         // Generate proof for the operations
+///         let proof = self.generate_proof(size, &operations).await?;
+///         
+///         // Create feedback channel
+///         let (success_tx, success_rx) = oneshot::channel();
+///         
+///         // Handle feedback asynchronously
+///         self.handle_feedback(success_rx);
+///         
+///         Ok(GetOperationsResult {
+///             proof,
+///             operations,
+///             success_tx,
+///         })
+///     }
+/// }
+/// ```
 pub trait Resolver {
+    /// The digest type used for cryptographic operations.
+    ///
+    /// This type must implement the `Digest` trait and will be used for
+    /// proof generation and verification.
     type Digest: Digest;
+
+    /// The key type for database operations.
+    ///
+    /// This type represents the keys used in database operations and must
+    /// implement the `Array` trait for efficient serialization.
     type Key: Array;
+
+    /// The value type for database operations.
+    ///
+    /// This type represents the values used in database operations and must
+    /// implement the `Array` trait for efficient serialization.
     type Value: Array;
 
-    /// The digest type of the resolver.
-    /// Get the operations starting at `start_loc` in the database, up to `max_ops` operations.
-    /// Returns the operations and a proof that they were present in the database when it had
-    /// `size` operations.
+    /// Retrieve operations from the database with cryptographic proof.
+    ///
+    /// This method fetches a batch of database operations starting from a specific
+    /// location, along with a cryptographic proof that validates their authenticity
+    /// and correctness.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The target size of the database state for proof generation.
+    ///   This represents the number of operations the database should contain
+    ///   when the proof is generated.
+    /// * `start_loc` - The starting location (position) in the database's operation
+    ///   log from which to retrieve operations.
+    /// * `max_ops` - The maximum number of operations to retrieve in this batch.
+    ///   The actual number returned may be less than this value.
+    ///
+    /// # Returns
+    ///
+    /// A `GetOperationsResult` containing:
+    /// - The requested operations
+    /// - A cryptographic proof validating the operations
+    /// - A feedback channel for reporting verification results
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The requested operations cannot be retrieved
+    /// - Proof generation fails
+    /// - The resolver encounters a network or storage error
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let result = resolver.get_operations(1000, 100, NonZeroU64::new(50).unwrap()).await?;
+    ///
+    /// // This would retrieve up to 50 operations starting from location 100,
+    /// // with a proof valid for a database state of 1000 operations.
+    /// ```
     #[allow(clippy::type_complexity)]
     fn get_operations(
         &self,
@@ -43,6 +212,24 @@ pub trait Resolver {
     ) -> impl Future<Output = Result<GetOperationsResult<Self::Digest, Self::Key, Self::Value>, Error>>;
 }
 
+/// Implementation of [Resolver] for local database instances.
+///
+/// This implementation allows a local database to act as a resolver for
+/// synchronization operations. It's commonly used in testing scenarios
+/// or when synchronizing from a local "source of truth" database.
+///
+/// # Usage
+///
+/// This implementation is automatically available for any `Any` database
+/// instance and can be used directly in sync operations:
+///
+/// ```rust,ignore
+/// let source_db = Any::init(context, config).await?;
+/// let sync_config = SyncConfig {
+///     resolver: &source_db,  // Uses this implementation
+///     // ... other config
+/// };
+/// ```
 impl<E, K, V, H, T> Resolver for &Any<E, K, V, H, T>
 where
     E: Storage + Clock + Metrics,
@@ -61,13 +248,17 @@ where
         start_loc: u64,
         max_ops: NonZeroU64,
     ) -> Result<GetOperationsResult<H::Digest, Self::Key, Self::Value>, Error> {
+        // Generate historical proof for the requested operations
+        // This creates a proof that the operations were present in the database
+        // when it had the specified size
         self.historical_proof(size, start_loc, max_ops.get())
             .await
             .map_err(Error::Adb)
             .map(|(proof, operations)| GetOperationsResult {
                 proof,
                 operations,
-                // Result of proof verification isn't used by this implementation.
+                // For local database resolver, we don't need feedback since
+                // we're not tracking network reliability or reputation
                 success_tx: oneshot::channel().0,
             })
     }

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -31,7 +31,7 @@
 //! All `Blobs` in a given `partition` are kept open during the lifetime of `Journal`. You can limit
 //! the number of open blobs by using a higher number of `items_per_blob` or pruning old items.
 //!
-//! # Persistence
+//! # Consistency
 //!
 //! Data written to `Journal` may not be immediately persisted to `Storage`. It is up to the caller
 //! to determine when to force pending data to be written to `Storage` using the `sync` method. When

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -44,7 +44,7 @@
 //!
 //! # State Sync
 //!
-//! [Journal::init_sync] allows for initializing a journal for use in state sync.
+//! `Journal::init_sync` allows for initializing a journal for use in state sync.
 //! When opened in this mode, we attempt to populate the journal within the given range
 //! with persisted data.
 //! If the journal is empty, we create a fresh journal at the specified position.

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -263,7 +263,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
                     existing_journal.destroy().await?;
                 } else {
                     let last_existing_loc = existing_size - 1;
-                    if existing_size < lower_bound {
+                    if last_existing_loc < lower_bound {
                         // Strategy 1: Fresh Start
                         // Existing data is stale and cannot be reused
                         debug!(

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -299,7 +299,6 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
         match Self::init(context.clone(), cfg.clone()).await {
             Ok(mut existing_journal) => {
                 let existing_size = existing_journal.size().await?;
-
                 if existing_size < lower_bound {
                     // Strategy 1: Fresh Start
                     // Existing data is stale and cannot be reused

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -273,7 +273,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
                 lower_bound, "Existing journal data is stale, re-initializing in pruned state"
             );
             journal.destroy().await?;
-            Self::init_empty_at_size(context, cfg, lower_bound).await?
+            Self::init_at_size(context, cfg, lower_bound).await?
         } else if journal_size <= upper_bound + 1 {
             debug!(
                 journal_size,
@@ -323,11 +323,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
     /// - Reading from positions 0-19 will return `ItemPruned` since those blobs don't exist
     /// - This represents a journal that had operations 0-24, with operations 0-19 pruned,
     ///   leaving operations 20-24 in tail blob 2.
-    pub(crate) async fn init_empty_at_size(
-        context: E,
-        cfg: Config,
-        size: u64,
-    ) -> Result<Self, Error> {
+    pub(crate) async fn init_at_size(context: E, cfg: Config, size: u64) -> Result<Self, Error> {
         // Calculate the tail blob index and number of items in the tail
         let tail_index = size / cfg.items_per_blob;
         let tail_items = size % cfg.items_per_blob;

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -313,7 +313,11 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
     /// **Returns**: A journal that appears to have `position` items without actual data.
     /// Operations 0 to position-1 are considered pruned. Creates the appropriate blob
     /// structure with correct size but no real content.
-    async fn init_fresh_at_position(context: E, cfg: Config, position: u64) -> Result<Self, Error> {
+    pub(crate) async fn init_fresh_at_position(
+        context: E,
+        cfg: Config,
+        position: u64,
+    ) -> Result<Self, Error> {
         // Remove all existing blobs to ensure clean state
         match context.scan(&cfg.partition).await {
             Ok(blobs) => {

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -256,7 +256,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
         lower_bound: u64,
         upper_bound: u64,
     ) -> Result<Self, Error> {
-        // Try to load existing journal first to check if we can reuse it
+        // Read existing journal data to check if we can reuse some of it.
         match Self::init(context.clone(), cfg.clone()).await {
             Ok(mut existing_journal) => {
                 let existing_size = existing_journal.size().await?;
@@ -2009,17 +2009,13 @@ mod tests {
             // Verify we can read operations that should still exist
             for i in 10..15 {
                 let result = reused_journal.read(i).await;
-                assert!(result.is_ok(), "Should be able to read operation {}", i);
+                assert!(result.is_ok());
             }
 
             // Verify operations before pruning boundary are gone
             for i in 0..10 {
                 let result = reused_journal.read(i).await;
-                assert!(
-                    matches!(result, Err(Error::ItemPruned(_))),
-                    "Operation {} should be pruned",
-                    i
-                );
+                assert!(matches!(result, Err(Error::ItemPruned(_))),);
             }
             reused_journal.destroy().await.unwrap();
 
@@ -2259,17 +2255,13 @@ mod tests {
                 // Should be able to read operations from 10 to 25
                 for i in 10..26 {
                     let result = reused_journal.read(i).await;
-                    assert!(result.is_ok(), "Should be able to read operation {}", i);
+                    assert!(result.is_ok());
                 }
 
                 // Operations before 10 should be pruned
                 for i in 0..10 {
                     let result = reused_journal.read(i).await;
-                    assert!(
-                        matches!(result, Err(crate::journal::Error::ItemPruned(_))),
-                        "Operation {} should be pruned",
-                        i
-                    );
+                    assert!(matches!(result, Err(crate::journal::Error::ItemPruned(_))),);
                 }
 
                 // Operations after 25 should not exist
@@ -2287,10 +2279,7 @@ mod tests {
                             // For now, we'll accept this as the rewind did remove the data
                         }
                         _ => {
-                            panic!(
-                                "Operation {} should not exist after rewind, got {:?}",
-                                i, result
-                            );
+                            panic!("Operation {i} should not exist after rewind, got {result:?}");
                         }
                     }
                 }

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -267,7 +267,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
     ) -> Result<Self, Error> {
         let mut journal = Self::init(context.clone(), cfg.clone()).await?;
         let journal_size = journal.size().await?;
-        if journal_size < lower_bound + 1 {
+        if journal_size <= lower_bound {
             debug!(
                 journal_size,
                 lower_bound, "Existing journal data is stale, re-initializing in pruned state"
@@ -296,7 +296,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
         }
     }
 
-    /// Initialize a new [Journal] instance in an pruned state at a given size.
+    /// Initialize a new [Journal] instance in a pruned state at a given size.
     ///
     /// # Arguments
     /// * `context` - The storage context

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -45,4 +45,6 @@ pub enum Error {
     CompressionFailed,
     #[error("decompression failed")]
     DecompressionFailed,
+    #[error("invalid sync range: lower_bound={0} upper_bound={1}")]
+    InvalidSyncRange(u64, u64),
 }

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -312,8 +312,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         metadata.sync().await.map_err(Error::MetadataError)?;
 
         // Create the MMR in a fully pruned state starting from the lower_bound
-        // Everything before cfg.lower_bound is considered pruned
-        let journal_size = journal.size().await?;
+        // Everything before cfg.lower_bound is pruned
         let has_pinned_nodes = !cfg.pinned_nodes.is_empty();
 
         // Set up pinned nodes if not provided
@@ -332,14 +331,16 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
 
         let mem_mmr = MemMmr::init(MemConfig {
             nodes: vec![],
-            pruned_to_pos: cfg.lower_bound, // Lower bound is what's pruned
+            pruned_to_pos: cfg.lower_bound,
             pinned_nodes: pinned_nodes_vec,
             pool: cfg.config.thread_pool,
         });
+
+        let journal_size = journal.size().await?;
         Ok(Self {
             mem_mmr,
             journal,
-            journal_size, // Use actual journal size to match reused data
+            journal_size,
             metadata,
             pruned_to_pos: cfg.lower_bound,
         })

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -1163,7 +1163,7 @@ mod tests {
                     buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 },
                 lower_bound: PRUNED_TO_POS,
-                upper_bound: 1000,
+                upper_bound: NUM_OPERATIONS as u64,
                 pinned_nodes,
             };
             let synced_mmr: Mmr<_, Sha256> = Mmr::init_pruned(context.clone(), sync_config)
@@ -1221,7 +1221,7 @@ mod tests {
                     buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 },
                 lower_bound: source_mmr_size,
-                upper_bound: 1000,
+                upper_bound: source_mmr_size,
                 pinned_nodes,
             };
 
@@ -1571,6 +1571,7 @@ mod tests {
             for i in 0..5 {
                 initial_mmr.add(&mut hasher, &test_digest(i)).await.unwrap();
             }
+            let initial_size = initial_mmr.size();
             initial_mmr.sync(&mut hasher).await.unwrap();
             initial_mmr.close(&mut hasher).await.unwrap();
 
@@ -1590,7 +1591,7 @@ mod tests {
                     buffer_pool: initial_config.buffer_pool.clone(),
                 },
                 lower_bound: pruned_to_pos,
-                upper_bound: 1000,
+                upper_bound: initial_size - 1,
                 pinned_nodes,
             };
 
@@ -1624,6 +1625,7 @@ mod tests {
                 initial_mmr.add(&mut hasher, &test_digest(i)).await.unwrap();
             }
             initial_mmr.sync(&mut hasher).await.unwrap();
+            let initial_size = initial_mmr.size();
             initial_mmr.close(&mut hasher).await.unwrap();
 
             // Test init_pruned with reuse
@@ -1642,7 +1644,7 @@ mod tests {
                     buffer_pool: initial_config.buffer_pool.clone(),
                 },
                 lower_bound: pruned_to_pos,
-                upper_bound: 1000,
+                upper_bound: initial_size - 1,
                 pinned_nodes,
             };
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -279,7 +279,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         } else {
             // Get pinned nodes for the lower bound (what we're pruned to)
             let mut pinned_nodes_vec = Vec::new();
-            for pos in Proof::<H::Digest>::nodes_to_pin(cfg.lower_bound) {
+            for pos in Proof::<H::Digest>::nodes_to_pin(journal_size) {
                 let digest =
                     Mmr::<E, H>::get_from_metadata_or_journal(&metadata, &journal, pos).await?;
                 pinned_nodes_vec.push(digest);
@@ -289,7 +289,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
 
         let mem_mmr = MemMmr::init(MemConfig {
             nodes: vec![],
-            pruned_to_pos: cfg.lower_bound,
+            pruned_to_pos: journal_size,
             pinned_nodes: pinned_nodes_vec,
             pool: cfg.config.thread_pool,
         });
@@ -299,7 +299,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             journal,
             journal_size,
             metadata,
-            pruned_to_pos: cfg.lower_bound,
+            pruned_to_pos: journal_size,
         })
     }
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -670,11 +670,6 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         // Don't actually prune the journal to simulate failure
         Ok(())
     }
-
-    /// Get the actual journal size (for sync scenarios)
-    pub(crate) async fn get_actual_journal_size(&self) -> Result<u64, Error> {
-        self.journal.size().await.map_err(Error::JournalError)
-    }
 }
 
 #[cfg(test)]

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -302,6 +302,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         });
 
         if cfg.lower_bound < journal_size {
+            // We need to add the pinned nodes required for proving at the given pruning boundary.
             let mut additional_pinned_nodes = HashMap::new();
             for pos in Proof::<H::Digest>::nodes_to_pin(cfg.lower_bound) {
                 let digest =

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -67,7 +67,9 @@ pub struct SyncConfig<D: Digest> {
 
     /// The pinned nodes the MMR needs at the pruning boundary given by
     /// `lower_bound`, in the order specified by [Proof::nodes_to_pin].
-    pub pinned_nodes: Vec<D>,
+    /// If `None`, the pinned nodes will be computed from the journal and metadata,
+    /// which are expected to have the necessary pinned nodes.
+    pub pinned_nodes: Option<Vec<D>>,
 }
 
 /// A MMR backed by a fixed-item-length journal.
@@ -278,10 +280,9 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         let journal_size = journal.size().await?;
         assert!(journal_size <= cfg.upper_bound + 1);
 
-        let pinned_nodes_empty = cfg.pinned_nodes.is_empty();
         // Set up pinned nodes if not provided
-        let pinned_nodes = if !pinned_nodes_empty {
-            cfg.pinned_nodes
+        let pinned_nodes = if let Some(pinned_nodes) = cfg.pinned_nodes {
+            pinned_nodes
         } else {
             // Get pinned nodes for the lower bound (what we're pruned to)
             let mut pinned_nodes = Vec::new();

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -299,7 +299,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             journal,
             journal_size,
             metadata,
-            pruned_to_pos: journal_size,
+            pruned_to_pos: cfg.lower_bound,
         })
     }
 

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -118,4 +118,6 @@ pub enum Error {
     HistoricalSizeTooLarge(u64, u64),
     #[error("given historical size <= start location: ({0}) <= ({1})")]
     HistoricalSizeTooSmall(u64, u64),
+    #[error("invalid size: {0}")]
+    InvalidSize(u64),
 }


### PR DESCRIPTION
This PR addresses #1213 by allowing for the re-use of existing persisted data when entering state sync.