### PR TITLE
[stream] replace unused named variables with underscore in connection.rs

### DIFF
--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -1004,8 +1004,8 @@ mod tests {
             };
 
             // Set up mock channels (not fully utilized due to early error).
-            let (dialer_sink, _unused_stream) = mocks::Channel::init();
-            let (_unused_sink, dialer_stream) = mocks::Channel::init();
+            let (dialer_sink, _) = mocks::Channel::init();
+            let (_, dialer_stream) = mocks::Channel::init();
 
             // Attempt to upgrade dialer connection, targeting self.
             let result = Connection::upgrade_dialer(


### PR DESCRIPTION
Replace variables with `_unused_` prefix with the Rust idiomatic underscore pattern (`_`) in the test_upgrade_dialer_rejects_connecting_to_self function. This improves code readability and follows Rust best practices for handling unused values from destructuring assignments