### PR TITLE
[adb] [sync] update sync example to use dynamic target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "clap",
  "commonware-codec",
  "commonware-cryptography",
+ "commonware-macros",
  "commonware-runtime",
  "commonware-storage",
  "commonware-stream",

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -25,6 +25,7 @@ commonware-codec = { workspace = true }
 commonware-utils = { workspace = true }
 commonware-cryptography = { workspace = true }
 commonware-stream = { workspace = true }
+commonware-macros = { workspace = true }
 
 tokio = {workspace = true }
 bytes = { workspace = true }

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -33,7 +33,7 @@ cargo test
 cargo run --bin server
 
 # Start server with custom settings
-cargo run --bin server -- --port 8080 --initial-ops 50 --storage-dir /tmp/my_server --seed 1337 --metrics-port 9090
+cargo run --bin server -- --port 8080 --initial-ops 50 --storage-dir /tmp/my_server --seed 1337 --metrics-port 9090 --operation-interval 5 --ops-per-interval 10
 ```
 
 Server options:
@@ -42,6 +42,8 @@ Server options:
 - `-d, --storage-dir <PATH>`: Storage directory (default: /tmp/commonware-sync/server)
 - `-s, --seed <SEED>`: Seed for generating test operations (default: 1337)
 - `-m, --metrics-port <PORT>`: Port on which metrics are exposed (default: 9090)
+- `-t, --operation-interval <SECONDS>`: Interval for adding new operations (default: 5)
+- `-o, --ops-per-interval <COUNT>`: Number of operations to add each interval (default: 10)
 
 ### Running the Client
 
@@ -50,14 +52,15 @@ Server options:
 cargo run --bin client
 
 # Connect with custom settings
-cargo run --bin client -- --server 127.0.0.1:8080 --batch-size 25 --storage-dir /tmp/my_client --metrics-port 9091
+cargo run --bin client -- --server 127.0.0.1:8080 --batch-size 25 --storage-dir /tmp/my_client --metrics-port 9091 --target-update-interval 3
 ```
 
 Client options:
 - `-s, --server <ADDRESS>`: Server address to connect to (default: 127.0.0.1:8080)
 - `-b, --batch-size <SIZE>`: Batch size for fetching operations (default: 50)
-- `-d, --storage-dir <PATH>`: Storage directory (default:/tmp/commonware-sync/client)
+- `-d, --storage-dir <PATH>`: Storage directory (default: /tmp/commonware-sync/client)
 - `-m, --metrics-port <PORT>`: Port on which metrics are exposed (default: 9091)
+- `-t, --target-update-interval <SECONDS>`: Interval for requesting target updates (default: 3)
 
 ## Example Session
 
@@ -69,26 +72,28 @@ Client options:
    You should see output like:
    ```
    INFO  Sync Server starting
-   INFO  Configuration port=8080 initial_ops=50 storage_dir=/tmp/adb_sync_server seed=1337 metrics_port=9091
+   INFO  Configuration port=8080 initial_ops=50 storage_dir=/tmp/commonware-sync/server seed=1337 metrics_port=9090 operation_interval=5 ops_per_interval=10
    INFO  Initializing database
    INFO  Database ready op_count=51 root_hash=abc123...
-   INFO  Server listening addr=127.0.0.1:8080
+   INFO  Server listening - will continuously add operations addr=127.0.0.1:8080 operation_interval=5 ops_per_interval=10
    ```
 
 2. **In another terminal, run the client:**
    ```bash
-   cargo run --bin client -- --batch-size 25
+   cargo run --bin client -- --batch-size 25 --target-update-interval 3
    ```
 
    You should see output like:
    ```
    INFO Sync Client starting
-   INFO Configuration server=127.0.0.1:8080 batch_size=25 storage_dir=/tmp/adb_sync_client metrics_port=9090
+   INFO Configuration server=127.0.0.1:8080 batch_size=25 storage_dir=/tmp/commonware-sync/client metrics_port=9091 target_update_interval=3
    INFO Starting sync to server's database state server=127.0.0.1:8080
    INFO Establishing connection server_addr=127.0.0.1:8080
    INFO Connected server_addr=127.0.0.1:8080
    INFO Received server metadata
+   INFO Sync configuration - will check for target updates every 3 seconds batch_size=25 lower_bound=0 upper_bound=50 target_update_interval=3
    INFO Beginning sync operation...
+   INFO Target unchanged from server
    INFO ✅ Sync completed successfully database_ops=51 root_hash=abc123...
    ```
 
@@ -105,12 +110,12 @@ curl http://localhost:9090/metrics
 
 ## Sync Process
 
-1. Server starts, populates database, listening for connections
-2. Client establishes connection to server
-3. Client requests server metadata to determine sync target
-4. Client repeatedly fetches, applies operations served by Server
-5. Client continues until all operations applied, state matches Server
-6. Client disconnects and stops; Server keeps running
+1. **Server Setup**: Server starts, populates database, and listens for connections
+2. **Client Connection**: Client establishes connection to server
+3. **Initial Sync Target**: Client requests server metadata to determine initial sync target
+4. **Dynamic Target Updates**: Client periodically requests target updates during sync
+5. **Completion**: Client continues until all operations applied, state matches server's latest target
+6. **Cleanup**: Client disconnects and stops; Server keeps running
 
 ## Adapting to Production
 
@@ -126,9 +131,15 @@ to implement authenticated networking.
 
 ### Sourcing a Sync Target
 
-When instantiating the client, it asks the server for a target root hash (to sync to).
+When instantiating the client, it asks the server for a target root hash (to sync to) and periodically
+requests updates.
 
-In a real application, the client should source this information from a trusted source (like a
-[commonware_consensus::threshold_simplex](https://docs.rs/commonware-consensus/latest/commonware_consensus/threshold_simplex/index.html)
+In a real application, the client should source this information from a trusted source 
+(like a [commonware_consensus::threshold_simplex](https://docs.rs/commonware-consensus/latest/commonware_consensus/threshold_simplex/index.html)
 consensus certificate) and only use the server for data that can be cryptographically verified against
 this target root hash.
+
+### Rate Limiting
+
+The current implementation doesn't implement rate limiting for target update requests. In production,
+you should implement appropriate rate limiting to prevent excessive server load.

--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -538,6 +538,12 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Array, H: CHasher, T: Translato
             .map(|pos| leaf_pos_to_num(pos).unwrap())
     }
 
+    /// Return the inactivity floor location.
+    /// This is the location before which all operations are "inactive".
+    pub fn inactivity_floor_loc(&self) -> u64 {
+        self.inactivity_floor_loc
+    }
+
     /// Updates `key` to have value `value`. If the key already has this same value, then this is a
     /// no-op. The operation is reflected in the snapshot, but will be subject to rollback until the
     /// next successful `commit`.


### PR DESCRIPTION
This PR will update the sync example so that:

1. The server continuously adds new operations
2. The client repeatedly updates its target to a newer target