### PR TITLE
[adb][sync] Target With Same Lower Bound

### DIFF
--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -1507,7 +1507,7 @@ pub(crate) mod tests {
                 "Expected at least one batch to be processed"
             );
 
-            // Send rapid target update to the extended target with SAME lower bound but higher upper bound
+            // Send target update to the extended target with SAME lower bound but higher upper bound
             update_sender
                 .send(SyncTarget {
                     hash: final_hash,
@@ -1517,7 +1517,7 @@ pub(crate) mod tests {
                 .await
                 .unwrap();
 
-            // Complete the sync - this should fail with hash mismatch if the bug is present
+            // Complete the sync
             let synced_db = client.sync().await.unwrap();
 
             // Verify the synced database has the expected final state


### PR DESCRIPTION
Failing with:
```
thread 'adb::any::sync::client::tests::test_target_same_lower_bound' panicked at storage/src/adb/any/mod.rs:287:9:
assertion `left == right` failed
  left: 111
 right: 101
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:75:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:388:5
   4: commonware_storage::adb::any::Any<E,K,V,H,T>::init_synced::{{closure}}
             at ./src/adb/any/mod.rs:287:9
   5: commonware_storage::adb::any::sync::client::Client<E,K,V,H,T,R>::step::{{closure}}
             at ./src/adb/any/sync/client.rs:558:22
   6: commonware_storage::adb::any::sync::client::Client<E,K,V,H,T,R>::sync::{{closure}}
             at ./src/adb/any/sync/client.rs:600:32
   7: commonware_storage::adb::any::sync::client::tests::test_target_same_lower_bound::{{closure}}::{{closure}}::{{closure}}
             at ./src/adb/any/sync/client.rs:1521:43
   8: <commonware_runtime::deterministic::Runner as commonware_runtime::Runner>::start
             at /Users/patrickogrady/code/monorepo/runtime/src/deterministic.rs:362:54
   9: commonware_storage::adb::any::sync::client::tests::test_target_same_lower_bound::{{closure}}
             at ./src/adb/any/sync/client.rs:1445:9
  10: tracing_core::dispatcher::with_default
             at /Users/patrickogrady/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-core-0.1.33/src/dispatcher.rs:263:5
  11: commonware_storage::adb::any::sync::client::tests::test_target_same_lower_bound
             at ./src/adb/any/sync/client.rs:1442:5
  12: commonware_storage::adb::any::sync::client::tests::test_target_same_lower_bound::{{closure}}
             at ./src/adb/any/sync/client.rs:1443:38
  13: core::ops::function::FnOnce::call_once
             at /Users/patrickogrady/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  14: core::ops::function::FnOnce::call_once
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

```