### PR TITLE
[adb] [sync] Fix peristence bug causing checksum mismatch on synced database open

### DIFF
--- a/storage/src/adb/any/mod.rs
+++ b/storage/src/adb/any/mod.rs
@@ -1800,6 +1800,14 @@ pub(super) mod test {
             target_db.commit().await.unwrap();
             apply_ops(&mut sync_db, original_ops.clone()).await;
             sync_db.commit().await.unwrap();
+            let sync_db_original_size = sync_db.op_count();
+
+            // Get pinned nodes before closing the database
+            let pinned_nodes_map = sync_db.ops.get_pinned_nodes();
+            let pinned_nodes =
+                Proof::<Digest>::nodes_to_pin(leaf_num_to_pos(sync_db_original_size))
+                    .map(|pos| *pinned_nodes_map.get(&pos).unwrap())
+                    .collect::<Vec<_>>();
 
             // Close the sync db
             sync_db.close().await.unwrap();
@@ -1817,11 +1825,6 @@ pub(super) mod test {
 
             let sync_lower_bound = target_db.inactivity_floor_loc;
             let sync_upper_bound = target_db.op_count() - 1;
-
-            let pinned_nodes_map = target_db.ops.get_pinned_nodes();
-            let pinned_nodes = Proof::<Digest>::nodes_to_pin(leaf_num_to_pos(target_db_log_size))
-                .map(|pos| *pinned_nodes_map.get(&pos).unwrap())
-                .collect::<Vec<_>>();
 
             let mut hasher = Standard::<Sha256>::new();
             let target_hash = target_db.root(&mut hasher);

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -1608,4 +1608,62 @@ pub(crate) mod tests {
             target_db.destroy().await.unwrap();
         });
     }
+
+    /// Test demonstrating that a synced database can be reopened and retain its state.
+    #[test_traced("WARN")]
+    fn test_sync_database_persistence() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Create and populate a simple target database
+            let mut target_db = create_test_db(context.clone()).await;
+            let target_ops = create_test_ops(10);
+            apply_ops(&mut target_db, target_ops.clone()).await;
+            target_db.commit().await.unwrap();
+
+            // Capture target state
+            let mut hasher = create_test_hasher();
+            let target_root = target_db.root(&mut hasher);
+            let lower_bound = target_db.inactivity_floor_loc;
+            let upper_bound = target_db.op_count() - 1;
+
+            // Create sync configuration with stable partition names
+            let db_config = create_test_config(42); // Fixed seed for stable partitions
+            let context_clone = context.clone();
+            let config = Config {
+                db_config: db_config.clone(),
+                fetch_batch_size: NZU64!(5),
+                target: SyncTarget {
+                    root: target_root,
+                    lower_bound_ops: lower_bound,
+                    upper_bound_ops: upper_bound,
+                },
+                context,
+                resolver: &target_db,
+                hasher: create_test_hasher(),
+                apply_batch_size: 1024,
+                update_receiver: None,
+            };
+
+            // Perform sync
+            let synced_db = sync(config).await.unwrap();
+
+            // Verify initial sync worked
+            let mut hasher = create_test_hasher();
+            assert_eq!(synced_db.root(&mut hasher), target_root);
+
+            // Close the database
+            synced_db.close().await.unwrap();
+
+            // This will panic due to journal corruption on reopen - this is the known issue
+            let _reopened_db =
+                adb::any::Any::<_, Digest, Digest, TestDigest, TestTranslator>::init(
+                    context_clone,
+                    db_config,
+                )
+                .await
+                .unwrap();
+
+            target_db.destroy().await.unwrap();
+        });
+    }
 }

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -728,15 +728,16 @@ pub(crate) mod tests {
                 }
             }
 
+            let db_config = create_test_config(context.next_u64());
             let config = Config {
-                db_config: create_test_config(context.next_u64()),
+                db_config: db_config.clone(),
                 fetch_batch_size,
                 target: SyncTarget {
                     root: target_root,
                     lower_bound_ops,
                     upper_bound_ops: target_op_count - 1, // target_op_count is the count, operations are 0-indexed
                 },
-                context,
+                context: context.clone(),
                 resolver: &target_db,
                 hasher,
                 apply_batch_size: 1024,
@@ -789,7 +790,51 @@ pub(crate) mod tests {
                 assert_eq!(got_value, target_value);
                 assert_eq!(got_value, *value);
             }
-            assert_eq!(got_db.root(&mut hasher), target_db.root(&mut hasher));
+            let target_root = target_db.root(&mut hasher);
+            assert_eq!(got_db.root(&mut hasher), target_root);
+
+            // Close the database
+            got_db.close().await.unwrap();
+
+            // Reopen the database using the same configuration and verify the state is still right
+            let reopened_db = adb::any::Any::<_, Digest, Digest, TestDigest, TestTranslator>::init(
+                context, db_config,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(reopened_db.op_count(), target_op_count);
+            assert_eq!(reopened_db.inactivity_floor_loc, target_inactivity_floor);
+            assert_eq!(reopened_db.log.size().await.unwrap(), target_log_size);
+            assert_eq!(
+                reopened_db.oldest_retained_loc(),
+                target_db.oldest_retained_loc(),
+            );
+            assert_eq!(
+                reopened_db.ops.pruned_to_pos(),
+                target_db.ops.pruned_to_pos(),
+            );
+            assert_eq!(reopened_db.root(&mut hasher), target_root);
+
+            // Verify that the original key-value pairs are still correct
+            for (key, &(value, _loc)) in &expected_kvs {
+                let reopened_value = reopened_db.get(key).await.unwrap();
+                assert_eq!(reopened_value, Some(value));
+            }
+
+            // Verify all new key-value pairs are still correct
+            for (key, &value) in &new_kvs {
+                let reopened_value = reopened_db.get(key).await.unwrap().unwrap();
+                assert_eq!(reopened_value, value);
+            }
+
+            // Verify that deleted keys are still absent
+            for key in &deleted_keys {
+                assert!(reopened_db.get(key).await.unwrap().is_none());
+            }
+
+            // Cleanup
+            reopened_db.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -67,8 +67,7 @@ pub struct SyncConfig<D: Digest> {
 
     /// The pinned nodes the MMR needs at the pruning boundary given by
     /// `lower_bound`, in the order specified by [Proof::nodes_to_pin].
-    /// If `None`, the pinned nodes will be computed from the journal and metadata,
-    /// which are expected to have the necessary pinned nodes.
+    /// If `None`, the pinned nodes are expected to already be in the MMR's metadata/journal.
     pub pinned_nodes: Option<Vec<D>>,
 }
 
@@ -266,56 +265,52 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             cfg.upper_bound,
         )
         .await?;
+        let journal_size = journal.size().await?;
+        assert!(journal_size <= cfg.upper_bound + 1);
 
-        // Update the metadata with the new pruning boundary.
+        // Open the metadata.
         let metadata_cfg = MConfig {
             partition: cfg.config.metadata_partition,
             codec_config: ((0..).into(), ()),
         };
         let mut metadata = Metadata::init(context.with_label("mmr_metadata"), metadata_cfg).await?;
-        let pruning_boundary_key: U64 = U64::new(PRUNE_TO_POS_PREFIX, 0);
+
+        // Write the pruning boundary.
+        let pruning_boundary_key = U64::new(PRUNE_TO_POS_PREFIX, 0);
         metadata.put(pruning_boundary_key, cfg.lower_bound.to_be_bytes().into());
-        metadata.sync().await.map_err(Error::MetadataError)?;
 
-        let journal_size = journal.size().await?;
-        assert!(journal_size <= cfg.upper_bound + 1);
-
-        // Set up pinned nodes if not provided
-        let nodes_to_pin = Proof::<H::Digest>::nodes_to_pin(journal_size);
-        let pinned_nodes = if let Some(pinned_nodes) = cfg.pinned_nodes {
-            for (pos, digest) in nodes_to_pin.zip(pinned_nodes.iter()) {
+        // Write the required pinned nodes to metadata.
+        if let Some(pinned_nodes) = cfg.pinned_nodes {
+            let nodes_to_pin_persisted = Proof::<H::Digest>::nodes_to_pin(cfg.lower_bound);
+            for (pos, digest) in nodes_to_pin_persisted.zip(pinned_nodes.iter()) {
                 metadata.put(U64::new(NODE_PREFIX, pos), digest.to_vec());
             }
-            pinned_nodes
-        } else {
-            // Calculate pinned nodes from existing data
-            let mut pinned_nodes = Vec::new();
-            for pos in nodes_to_pin {
-                let digest =
-                    Mmr::<E, H>::get_from_metadata_or_journal(&metadata, &journal, pos).await?;
-                pinned_nodes.push(digest);
-                metadata.put(U64::new(NODE_PREFIX, pos), digest.to_vec());
-            }
-            pinned_nodes
-        };
+        }
 
+        // Create the [MemMmr] with the pinned nodes required for its size.
+        let nodes_to_pin_mem = Proof::<H::Digest>::nodes_to_pin(journal_size);
+        let mut mem_pinned_nodes = Vec::new();
+        for pos in nodes_to_pin_mem {
+            let digest =
+                Mmr::<E, H>::get_from_metadata_or_journal(&metadata, &journal, pos).await?;
+            mem_pinned_nodes.push(digest);
+        }
         let mut mem_mmr = MemMmr::init(MemConfig {
             nodes: vec![],
             pruned_to_pos: journal_size,
-            pinned_nodes,
+            pinned_nodes: mem_pinned_nodes,
             pool: cfg.config.thread_pool,
         });
 
+        // Add the additional pinned nodes required for the pruning boundary, if applicable.
         if cfg.lower_bound < journal_size {
-            // We need to add the pinned nodes required for proving at the given pruning boundary.
-            let mut additional_pinned_nodes = HashMap::new();
+            let mut pinned_nodes_pruning_boundary = HashMap::new();
             for pos in Proof::<H::Digest>::nodes_to_pin(cfg.lower_bound) {
                 let digest =
                     Mmr::<E, H>::get_from_metadata_or_journal(&metadata, &journal, pos).await?;
-                metadata.put(U64::new(NODE_PREFIX, pos), digest.to_vec());
-                additional_pinned_nodes.insert(pos, digest);
+                pinned_nodes_pruning_boundary.insert(pos, digest);
             }
-            mem_mmr.add_pinned_nodes(additional_pinned_nodes);
+            mem_mmr.add_pinned_nodes(pinned_nodes_pruning_boundary);
         }
 
         Ok(Self {

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -287,7 +287,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             }
         }
 
-        // Create the [MemMmr] with the pinned nodes required for its size.
+        // Create the in-memory MMR with the pinned nodes required for its size.
         let nodes_to_pin_mem = Proof::<H::Digest>::nodes_to_pin(journal_size);
         let mut mem_pinned_nodes = Vec::new();
         for pos in nodes_to_pin_mem {


### PR DESCRIPTION
We weren't writing pinned nodes to the metadata, meaning that re-opening a synced database would fail if we didn't update/persist the metadata before closing the database.