### PR TITLE
[storage/bmt] Add Range Proofs

### DIFF
--- a/coding/fuzz/fuzz_targets/reed_solomon.rs
+++ b/coding/fuzz/fuzz_targets/reed_solomon.rs
@@ -65,8 +65,8 @@ fn fuzz(input: FuzzInput) {
 
     assert_eq!(chunks.len(), total as usize);
 
-    for chunk in &chunks {
-        assert!(chunk.verify(&root), "failed to verify chunk");
+    for (i, chunk) in chunks.iter().enumerate() {
+        assert!(chunk.verify(i as u16, &root), "failed to verify chunk");
     }
 
     let decoded = match decode::<Sha256>(total, min, &root, chunks.clone()) {

--- a/coding/src/reed_solomon/mod.rs
+++ b/coding/src/reed_solomon/mod.rs
@@ -437,7 +437,7 @@ pub fn translate<H: Hasher>(
 
     // Generate range proof for minimal proof
     let proof = tree
-        .range_proof(0, min as u32)
+        .range_proof(0, (min - 1) as u32)
         .map_err(|_| Error::InvalidProof)?;
     let proof = Data::new(shards, proof);
 

--- a/storage/fuzz/fuzz_targets/bmt_operations.rs
+++ b/storage/fuzz/fuzz_targets/bmt_operations.rs
@@ -200,9 +200,7 @@ fn fuzz(input: FuzzInput) {
                         .iter()
                         .map(|v| hash(&v.to_be_bytes()))
                         .collect();
-                    if !leaf_digests.is_empty() {
-                        let _ = rp.verify(&mut hasher, *start_position, &leaf_digests, &root);
-                    }
+                    let _ = rp.verify(&mut hasher, *start_position, &leaf_digests, &root);
                 }
             }
 
@@ -292,9 +290,7 @@ fn fuzz(input: FuzzInput) {
                         .iter()
                         .map(|v| hash(&v.to_be_bytes()))
                         .collect();
-                    if !tampered_digests.is_empty() {
-                        let _ = rp.verify(&mut hasher, *start, &tampered_digests, &root);
-                    }
+                    let _ = rp.verify(&mut hasher, *start, &tampered_digests, &root);
                 }
             }
         }

--- a/storage/fuzz/fuzz_targets/bmt_operations.rs
+++ b/storage/fuzz/fuzz_targets/bmt_operations.rs
@@ -217,17 +217,25 @@ fn fuzz(input: FuzzInput) {
                 if let Some(ref t) = tree {
                     // Generate a range proof at proof_start position
                     let count = (*leaf_count as usize).clamp(1, 10);
-                    let end = proof_start.saturating_add(count as u32 - 1);
-                    if let Ok(rp) = t.range_proof(*proof_start, end) {
-                        // Create some leaf digests for verification
-                        let mut hasher = Sha256::default();
-                        let leaf_digests: Vec<_> = (0..count)
-                            .map(|i| hash(&(i as u64).to_be_bytes()))
-                            .collect();
+                    let start_idx = *proof_start as usize;
 
-                        // Verify with wrong position (verify_start instead of proof_start)
-                        let root = t.root();
-                        let _ = rp.verify(&mut hasher, *verify_start, &leaf_digests, &root);
+                    // Ensure we have enough leaves and the range is valid
+                    if start_idx < leaf_values.len() {
+                        let actual_count = count.min(leaf_values.len() - start_idx);
+                        let end = proof_start.saturating_add(actual_count as u32 - 1);
+                        if let Ok(rp) = t.range_proof(*proof_start, end) {
+                            // Use real leaf values from the tree starting at proof_start
+                            let mut hasher = Sha256::default();
+                            let leaf_digests: Vec<_> = leaf_values
+                                [start_idx..start_idx + actual_count]
+                                .iter()
+                                .map(|v| hash(&v.to_be_bytes()))
+                                .collect();
+
+                            // Verify with wrong position (verify_start instead of proof_start)
+                            let root = t.root();
+                            let _ = rp.verify(&mut hasher, *verify_start, &leaf_digests, &root);
+                        }
                     }
                 }
             }

--- a/storage/fuzz/fuzz_targets/bmt_operations.rs
+++ b/storage/fuzz/fuzz_targets/bmt_operations.rs
@@ -3,23 +3,75 @@
 use arbitrary::Arbitrary;
 use commonware_codec::{DecodeExt, Encode};
 use commonware_cryptography::{hash, sha256::Sha256};
-use commonware_storage::bmt::{Builder, Proof};
+use commonware_storage::bmt::{Builder, Proof, RangeProof};
 use libfuzzer_sys::fuzz_target;
 
 #[derive(Arbitrary, Debug, Clone)]
 enum BmtOperation {
-    BuildTree { leaf_count: u8 },
-    AddLeaf { value: u64 },
+    // Tree operations
+    BuildTree {
+        leaf_count: u8,
+    },
+    AddLeaf {
+        value: u64,
+    },
     BuildFromLeaves,
     GetRoot,
-    GenerateProof { position: u32 },
-    VerifyProof { leaf_value: u64, position: u32 },
+    // Proof operations
+    GenerateProof {
+        position: u32,
+    },
+    VerifyProof {
+        leaf_value: u64,
+        position: u32,
+    },
     SerializeProof,
-    DeserializeProof { data: Vec<u8> },
+    DeserializeProof {
+        data: Vec<u8>,
+    },
     // Edge case operations
     BuildEmptyTree,
-    BuildLargeTree { size: u8 },
-    ProofOutOfBounds { position: u32 },
+    BuildLargeTree {
+        size: u8,
+    },
+    ProofOutOfBounds {
+        position: u32,
+    },
+    // Range proof operations
+    GenerateRangeProof {
+        start: u32,
+        end: u32,
+    },
+    VerifyRangeProof {
+        start_position: u32,
+        leaf_values: Vec<u64>,
+    },
+    SerializeRangeProof,
+    DeserializeRangeProof {
+        data: Vec<u8>,
+    },
+    // Range proof edge cases
+    RangeProofInvalidRange {
+        start: u32,
+        end: u32,
+    },
+    RangeProofOutOfBounds {
+        start: u32,
+        end: u32,
+    },
+    RangeProofSingleElement {
+        position: u32,
+    },
+    RangeProofFullTree,
+    VerifyRangeProofWrongPosition {
+        proof_start: u32,
+        verify_start: u32,
+        leaf_count: u8,
+    },
+    VerifyRangeProofWrongLeaves {
+        start: u32,
+        tampered_values: Vec<u64>,
+    },
 }
 
 #[derive(Arbitrary, Debug)]
@@ -31,6 +83,7 @@ fn fuzz(input: FuzzInput) {
     let mut builder: Option<Builder<Sha256>> = None;
     let mut tree = None;
     let mut proof = None;
+    let mut range_proof = None;
     let mut leaf_values = Vec::new();
 
     for op in input.operations.iter() {
@@ -88,12 +141,12 @@ fn fuzz(input: FuzzInput) {
 
             BmtOperation::SerializeProof => {
                 if let Some(ref p) = proof {
-                    let _serialized = p.encode();
+                    let _ = p.encode();
                 }
             }
 
             BmtOperation::DeserializeProof { data } => {
-                if Proof::<Sha256>::decode(&mut data.as_slice()).is_ok() {}
+                let _ = Proof::<Sha256>::decode(&mut data.as_slice());
             }
 
             BmtOperation::BuildEmptyTree => {
@@ -117,7 +170,136 @@ fn fuzz(input: FuzzInput) {
 
             BmtOperation::ProofOutOfBounds { position } => {
                 if let Some(ref t) = tree {
-                    if t.proof(*position).is_ok() {}
+                    let _ = t.proof(*position);
+                }
+            }
+
+            // Range proof operations
+            BmtOperation::GenerateRangeProof { start, end } => {
+                if let Some(ref t) = tree {
+                    // Ensure start <= end to avoid panic in range_proof
+                    let safe_start = *start;
+                    let safe_end = *end;
+
+                    if safe_start <= safe_end {
+                        if let Ok(rp) = t.range_proof(safe_start, safe_end) {
+                            range_proof = Some(rp);
+                        }
+                    }
+                }
+            }
+
+            BmtOperation::VerifyRangeProof {
+                start_position,
+                leaf_values: verify_values,
+            } => {
+                if let (Some(ref rp), Some(ref t)) = (&range_proof, &tree) {
+                    let mut hasher = Sha256::default();
+                    let root = t.root();
+
+                    // Convert leaf values to digests
+                    let leaf_digests: Vec<_> = verify_values
+                        .iter()
+                        .map(|v| hash(&v.to_be_bytes()))
+                        .collect();
+
+                    if !leaf_digests.is_empty() {
+                        // Don't panic on verification failures - they're expected
+                        let _ = rp.verify(&mut hasher, *start_position, &leaf_digests, &root);
+                    }
+                }
+            }
+
+            BmtOperation::SerializeRangeProof => {
+                if let Some(ref rp) = range_proof {
+                    let _ = rp.encode();
+                }
+            }
+
+            BmtOperation::DeserializeRangeProof { data } => {
+                let _ = RangeProof::<Sha256>::decode(&mut data.as_slice());
+            }
+
+            // Range proof edge cases
+            BmtOperation::RangeProofInvalidRange { start, end } => {
+                if let Some(ref t) = tree {
+                    // Test invalid ranges (start > end)
+                    if *start > *end {
+                        let _ = t.range_proof(*start, *end);
+                    }
+                }
+            }
+
+            BmtOperation::RangeProofOutOfBounds { start, end } => {
+                if let Some(ref t) = tree {
+                    // Test out of bounds ranges
+                    let _ = t.range_proof(*start, *end);
+                }
+            }
+
+            BmtOperation::RangeProofSingleElement { position } => {
+                if let Some(ref t) = tree {
+                    // Test single element range proof
+                    if let Ok(rp) = t.range_proof(*position, *position) {
+                        range_proof = Some(rp);
+                    }
+                }
+            }
+
+            BmtOperation::RangeProofFullTree => {
+                if let Some(ref t) = tree {
+                    // Test full tree range proof
+                    if !leaf_values.is_empty() {
+                        let last_idx = (leaf_values.len() - 1) as u32;
+                        if let Ok(rp) = t.range_proof(0, last_idx) {
+                            range_proof = Some(rp);
+                        }
+                    }
+                }
+            }
+
+            BmtOperation::VerifyRangeProofWrongPosition {
+                proof_start,
+                verify_start,
+                leaf_count,
+            } => {
+                if let Some(ref t) = tree {
+                    // Generate a range proof at proof_start position
+                    let count = (*leaf_count as usize).clamp(1, 10);
+                    let end = proof_start.saturating_add(count as u32 - 1);
+
+                    if let Ok(rp) = t.range_proof(*proof_start, end) {
+                        let mut hasher = Sha256::default();
+                        let root = t.root();
+
+                        // Create some leaf digests for verification
+                        let leaf_digests: Vec<_> = (0..count)
+                            .map(|i| hash(&(i as u64).to_be_bytes()))
+                            .collect();
+
+                        // Verify with wrong position (verify_start instead of proof_start)
+                        let _ = rp.verify(&mut hasher, *verify_start, &leaf_digests, &root);
+                    }
+                }
+            }
+
+            BmtOperation::VerifyRangeProofWrongLeaves {
+                start,
+                tampered_values,
+            } => {
+                if let (Some(ref rp), Some(ref t)) = (&range_proof, &tree) {
+                    let mut hasher = Sha256::default();
+                    let root = t.root();
+
+                    // Verify with tampered values
+                    let tampered_digests: Vec<_> = tampered_values
+                        .iter()
+                        .map(|v| hash(&v.to_be_bytes()))
+                        .collect();
+
+                    if !tampered_digests.is_empty() {
+                        let _ = rp.verify(&mut hasher, *start, &tampered_digests, &root);
+                    }
                 }
             }
         }

--- a/storage/fuzz/fuzz_targets/bmt_operations.rs
+++ b/storage/fuzz/fuzz_targets/bmt_operations.rs
@@ -133,8 +133,6 @@ fn fuzz(input: FuzzInput) {
                     let mut hasher = Sha256::default();
                     let leaf_digest = hash(&leaf_value.to_be_bytes());
                     let root = t.root();
-
-                    // Don't panic on verification failures - they're expected
                     let _ = p.verify(&mut hasher, &leaf_digest, *position, &root);
                 }
             }
@@ -202,9 +200,7 @@ fn fuzz(input: FuzzInput) {
                         .iter()
                         .map(|v| hash(&v.to_be_bytes()))
                         .collect();
-
                     if !leaf_digests.is_empty() {
-                        // Don't panic on verification failures - they're expected
                         let _ = rp.verify(&mut hasher, *start_position, &leaf_digests, &root);
                     }
                 }
@@ -296,7 +292,6 @@ fn fuzz(input: FuzzInput) {
                         .iter()
                         .map(|v| hash(&v.to_be_bytes()))
                         .collect();
-
                     if !tampered_digests.is_empty() {
                         let _ = rp.verify(&mut hasher, *start, &tampered_digests, &root);
                     }

--- a/storage/src/bmt/benches/bench.rs
+++ b/storage/src/bmt/benches/bench.rs
@@ -1,6 +1,11 @@
 use criterion::criterion_main;
 
 mod build;
+mod prove_range;
 mod prove_single_element;
 
-criterion_main!(build::benches, prove_single_element::benches);
+criterion_main!(
+    build::benches,
+    prove_single_element::benches,
+    prove_range::benches
+);

--- a/storage/src/bmt/benches/bench.rs
+++ b/storage/src/bmt/benches/bench.rs
@@ -2,10 +2,6 @@ use criterion::criterion_main;
 
 mod build;
 mod prove_range;
-mod prove_single_element;
+mod prove_single;
 
-criterion_main!(
-    build::benches,
-    prove_single_element::benches,
-    prove_range::benches
-);
+criterion_main!(build::benches, prove_single::benches, prove_range::benches);

--- a/storage/src/bmt/benches/prove_range.rs
+++ b/storage/src/bmt/benches/prove_range.rs
@@ -38,20 +38,19 @@ fn bench_prove_range(c: &mut Criterion) {
                     b.iter_batched(
                         || {
                             // Generate random starting positions for range proofs
-                            let mut positions = Vec::with_capacity(SAMPLE_SIZE);
+                            let mut range_proofs = Vec::with_capacity(SAMPLE_SIZE);
                             for _ in 0..SAMPLE_SIZE {
                                 let start = sampler.gen_range(0..=(n - range_size));
-                                positions.push(start);
+                                range_proofs.push((
+                                    start,
+                                    tree.range_proof(start as u32, range_size as u32).unwrap(),
+                                ));
                             }
-                            positions
+                            range_proofs
                         },
-                        |positions| {
+                        |range_proofs| {
                             let mut hasher = Sha256::new();
-                            for start in positions {
-                                // Generate range proof
-                                let proof =
-                                    tree.range_proof(start as u32, range_size as u32).unwrap();
-
+                            for (start, proof) in range_proofs {
                                 // Verify range proof
                                 let range_leaves = &elements[start..start + range_size];
                                 assert!(proof

--- a/storage/src/bmt/benches/prove_range.rs
+++ b/storage/src/bmt/benches/prove_range.rs
@@ -54,7 +54,9 @@ fn bench_prove_range(c: &mut Criterion) {
 
                                 // Verify range proof
                                 let range_leaves = &elements[start..start + range_size];
-                                assert!(proof.verify(&mut hasher, range_leaves, &root).is_ok());
+                                assert!(proof
+                                    .verify(&mut hasher, start as u32, range_leaves, &root)
+                                    .is_ok());
                             }
                         },
                         criterion::BatchSize::SmallInput,

--- a/storage/src/bmt/benches/prove_range.rs
+++ b/storage/src/bmt/benches/prove_range.rs
@@ -43,7 +43,8 @@ fn bench_prove_range(c: &mut Criterion) {
                                 let start = sampler.gen_range(0..=(n - range_size));
                                 range_proofs.push((
                                     start,
-                                    tree.range_proof(start as u32, (start + range_size - 1) as u32).unwrap(),
+                                    tree.range_proof(start as u32, (start + range_size - 1) as u32)
+                                        .unwrap(),
                                 ));
                             }
                             range_proofs

--- a/storage/src/bmt/benches/prove_range.rs
+++ b/storage/src/bmt/benches/prove_range.rs
@@ -43,7 +43,7 @@ fn bench_prove_range(c: &mut Criterion) {
                                 let start = sampler.gen_range(0..=(n - range_size));
                                 range_proofs.push((
                                     start,
-                                    tree.range_proof(start as u32, range_size as u32).unwrap(),
+                                    tree.range_proof(start as u32, (start + range_size - 1) as u32).unwrap(),
                                 ));
                             }
                             range_proofs

--- a/storage/src/bmt/benches/prove_range.rs
+++ b/storage/src/bmt/benches/prove_range.rs
@@ -1,0 +1,72 @@
+use commonware_cryptography::{sha256, Digest as _, Hasher, Sha256};
+use commonware_storage::bmt::Builder;
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+const SAMPLE_SIZE: usize = 100;
+
+fn bench_prove_range(c: &mut Criterion) {
+    for n in [100, 1_000, 5_000, 10_000, 25_000, 50_000, 100_000] {
+        for range_size in [10, 50, 100, 500] {
+            // Skip if range size is larger than tree size
+            if range_size > n {
+                continue;
+            }
+
+            // Populate Binary Merkle Tree
+            let mut builder = Builder::<Sha256>::new(n);
+            let mut elements = Vec::with_capacity(n);
+            let mut sampler = StdRng::seed_from_u64(0);
+            for _ in 0..n {
+                let element = sha256::Digest::random(&mut sampler);
+                builder.add(&element);
+                elements.push(element);
+            }
+            let tree = builder.build();
+            let root = tree.root();
+
+            // Benchmark range proof generation and verification
+            c.bench_function(
+                &format!(
+                    "{}/n={} range_size={} samples={}",
+                    module_path!(),
+                    n,
+                    range_size,
+                    SAMPLE_SIZE
+                ),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            // Generate random starting positions for range proofs
+                            let mut positions = Vec::with_capacity(SAMPLE_SIZE);
+                            for _ in 0..SAMPLE_SIZE {
+                                let start = sampler.gen_range(0..=(n - range_size));
+                                positions.push(start);
+                            }
+                            positions
+                        },
+                        |positions| {
+                            let mut hasher = Sha256::new();
+                            for start in positions {
+                                // Generate range proof
+                                let proof =
+                                    tree.range_proof(start as u32, range_size as u32).unwrap();
+
+                                // Verify range proof
+                                let range_leaves = &elements[start..start + range_size];
+                                assert!(proof.verify(&mut hasher, range_leaves, &root).is_ok());
+                            }
+                        },
+                        criterion::BatchSize::SmallInput,
+                    )
+                },
+            );
+        }
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_prove_range
+}

--- a/storage/src/bmt/benches/prove_single.rs
+++ b/storage/src/bmt/benches/prove_single.rs
@@ -5,8 +5,8 @@ use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
 const SAMPLE_SIZE: usize = 100;
 
-fn bench_prove_single_element(c: &mut Criterion) {
-    for n in [100, 1_000, 5_000, 10_000, 25_000, 50_000, 100_000] {
+fn bench_prove_single(c: &mut Criterion) {
+    for n in [250, 1_000, 5_000, 10_000, 25_000, 50_000, 100_000] {
         // Populate Binary Merkle Tree
         let mut builder = Builder::<Sha256>::new(n);
         let mut queries = Vec::with_capacity(n);
@@ -21,7 +21,7 @@ fn bench_prove_single_element(c: &mut Criterion) {
 
         // Select SAMPLE_SIZE random elements without replacement and create/verify proofs
         c.bench_function(
-            &format!("{}/n={} samples={}", module_path!(), n, SAMPLE_SIZE),
+            &format!("{}/n={} items={}", module_path!(), n, SAMPLE_SIZE),
             |b| {
                 b.iter_batched(
                     || {
@@ -47,5 +47,5 @@ fn bench_prove_single_element(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = bench_prove_single_element
+    targets = bench_prove_single
 }

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -60,10 +60,6 @@ pub enum Error {
     NoLeaves,
     #[error("unaligned proof")]
     UnalignedProof,
-    #[error("too many levels: {0}")]
-    TooManyLevels(usize),
-    #[error("invalid digest")]
-    InvalidDigest,
 }
 
 /// Constructor for a Binary Merkle Tree (BMT).

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -415,12 +415,10 @@ impl<H: Hasher> RangeProof<H> {
         leaves: &[H::Digest],
         root: &H::Digest,
     ) -> Result<(), Error> {
-        // Check that we have leaves
+        // Check that we have leaves and the position is valid
         if leaves.is_empty() {
             return Err(Error::NoLeaves);
         }
-
-        // Check for integer overflow - critical for preventing attacks
         if position.checked_add(leaves.len() as u32).is_none() {
             return Err(Error::InvalidPosition(position));
         }
@@ -1277,7 +1275,7 @@ mod tests {
         let mut hasher = Sha256::default();
         let range_leaves = &digests[2..5];
 
-        // Try to verify with wrong position - should fail
+        // Try to verify with wrong position
         assert!(range_proof
             .verify(&mut hasher, 3, range_leaves, &root)
             .is_err());
@@ -1303,7 +1301,7 @@ mod tests {
         let range_proof = tree.range_proof(2, 3).unwrap();
         let mut hasher = Sha256::default();
 
-        // Try to verify with reordered leaves - should fail
+        // Try to verify with reordered leaves
         let reordered_leaves = vec![digests[3], digests[2], digests[4]];
         assert!(range_proof
             .verify(&mut hasher, 2, &reordered_leaves, &root)

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -210,8 +210,8 @@ impl<H: Hasher> Tree<H> {
         }
         let end_position = position
             .checked_add(count)
-            .and_then(|p| p.checked_sub(1))
-            .ok_or(Error::InvalidPosition(position))?;
+            .ok_or(Error::InvalidPosition(position))?
+            - 1;
         if end_position >= leaf_count {
             return Err(Error::InvalidPosition(end_position));
         }

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -237,15 +237,17 @@ impl<H: Hasher> Tree<H> {
 
             // Check if we need a right sibling
             let mut right = None;
-            if level_end % 2 == 0 && level_end + 1 < level.len() {
-                // Our range ends at an even index, so we need the odd sibling to the right
-                right = Some(level[level_end + 1]);
-            } else if level_end % 2 == 0 && level_end + 1 >= level.len() {
-                // If no right child exists, use a duplicate of the current node.
-                //
-                // This doesn't affect the robustness of the proof (allow a non-existent position
-                // to be proven or enable multiple proofs to be generated from a single leaf).
-                right = Some(level[level_end]);
+            if level_end % 2 == 0 {
+                if level_end + 1 < level.len() {
+                    // Our range ends at an even index, so we need the odd sibling to the right
+                    right = Some(level[level_end + 1]);
+                } else {
+                    // If no right child exists, use a duplicate of the current node.
+                    //
+                    // This doesn't affect the robustness of the proof (allow a non-existent position
+                    // to be proven or enable multiple proofs to be generated from a single leaf).
+                    right = Some(level[level_end]);
+                }
             }
 
             siblings.push(Bounds { left, right });

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -442,8 +442,6 @@ impl<H: Hasher> RangeProof<H> {
             let last_pos = nodes[nodes.len() - 1].position;
             let needs_left = first_pos % 2 == 1;
             let needs_right = last_pos % 2 == 0;
-
-            // Validate that we have exactly the siblings we need
             if needs_left != bounds.left.is_some() {
                 return Err(Error::UnalignedProof);
             }

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -1147,12 +1147,10 @@ mod tests {
 
         // Test with tampered proof
         let mut tampered_proof = range_proof.clone();
-        if !tampered_proof.siblings.is_empty() && !tampered_proof.siblings[0].is_empty() {
-            tampered_proof.siblings[0][0] = hash(b"tampered");
-            assert!(tampered_proof
-                .verify(&mut hasher, 2, range_leaves, &root)
-                .is_err());
-        }
+        tampered_proof.siblings[0][0] = hash(b"tampered");
+        assert!(tampered_proof
+            .verify(&mut hasher, 2, range_leaves, &root)
+            .is_err());
 
         // Test with wrong root
         let wrong_root = hash(b"wrong_root");
@@ -1264,12 +1262,10 @@ mod tests {
         let range_leaves = &digests[2..4];
 
         // Add extra sibling to a level
-        if !range_proof.siblings.is_empty() {
-            range_proof.siblings[0].push(hash(b"extra"));
-            assert!(range_proof
-                .verify(&mut hasher, 2, range_leaves, &root)
-                .is_err());
-        }
+        range_proof.siblings[0].push(hash(b"extra"));
+        assert!(range_proof
+            .verify(&mut hasher, 2, range_leaves, &root)
+            .is_err());
     }
 
     #[test]
@@ -1291,12 +1287,10 @@ mod tests {
         let range_leaves = &digests[2..4];
 
         // Remove a sibling from a level
-        if !range_proof.siblings.is_empty() && !range_proof.siblings[0].is_empty() {
-            range_proof.siblings[0].pop();
-            assert!(range_proof
-                .verify(&mut hasher, 2, range_leaves, &root)
-                .is_err());
-        }
+        range_proof.siblings[0].pop();
+        assert!(range_proof
+            .verify(&mut hasher, 2, range_leaves, &root)
+            .is_err());
     }
 
     #[test]
@@ -1343,12 +1337,10 @@ mod tests {
 
         // Remove a level (if possible)
         let mut range_proof = tree.range_proof(2, 2).unwrap();
-        if !range_proof.siblings.is_empty() {
-            range_proof.siblings.pop();
-            assert!(range_proof
-                .verify(&mut hasher, 2, range_leaves, &root)
-                .is_err());
-        }
+        range_proof.siblings.pop();
+        assert!(range_proof
+            .verify(&mut hasher, 2, range_leaves, &root)
+            .is_err());
     }
 
     #[test]

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -49,6 +49,10 @@ use thiserror::Error;
 /// has more than 2^255 leaves).
 const MAX_LEVELS: usize = u8::MAX as usize;
 
+/// Because range proofs require contiguous leaves, there should never be more than 2 siblings
+/// per level.
+const MAX_LEVEL_SIBLINGS: usize = 2;
+
 /// Errors that can occur when working with a Binary Merkle Tree (BMT).
 #[derive(Error, Debug)]
 pub enum Error {
@@ -458,7 +462,8 @@ impl<H: Hasher> Read for RangeProof<H> {
 
     fn read_cfg(reader: &mut impl Buf, _: &Self::Cfg) -> Result<Self, commonware_codec::Error> {
         let levels: RangeCfg = (..=MAX_LEVELS).into();
-        let siblings = Vec::<Vec<H::Digest>>::read_cfg(reader, &(levels, (levels, ())))?;
+        let level_siblings: RangeCfg = (..=MAX_LEVEL_SIBLINGS).into();
+        let siblings = Vec::<Vec<H::Digest>>::read_cfg(reader, &(levels, (level_siblings, ())))?;
 
         Ok(Self { siblings })
     }

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -1147,6 +1147,8 @@ mod tests {
 
         // Test with tampered proof
         let mut tampered_proof = range_proof.clone();
+        assert!(!tampered_proof.siblings.is_empty());
+        assert!(!tampered_proof.siblings[0].is_empty());
         tampered_proof.siblings[0][0] = hash(b"tampered");
         assert!(tampered_proof
             .verify(&mut hasher, 2, range_leaves, &root)
@@ -1262,6 +1264,7 @@ mod tests {
         let range_leaves = &digests[2..4];
 
         // Add extra sibling to a level
+        assert!(!range_proof.siblings.is_empty());
         range_proof.siblings[0].push(hash(b"extra"));
         assert!(range_proof
             .verify(&mut hasher, 2, range_leaves, &root)
@@ -1281,10 +1284,14 @@ mod tests {
         let tree = builder.build();
         let root = tree.root();
 
-        // Get valid range proof
-        let mut range_proof = tree.range_proof(2, 2).unwrap();
+        // Get valid range proof for a single element (which needs siblings)
+        let mut range_proof = tree.range_proof(2, 1).unwrap();
         let mut hasher = Sha256::default();
-        let range_leaves = &digests[2..4];
+        let range_leaves = &digests[2..3];
+
+        // The proof should have siblings at the first level
+        assert!(!range_proof.siblings.is_empty());
+        assert!(!range_proof.siblings[0].is_empty());
 
         // Remove a sibling from a level
         range_proof.siblings[0].pop();
@@ -1335,8 +1342,9 @@ mod tests {
             .verify(&mut hasher, 2, range_leaves, &root)
             .is_err());
 
-        // Remove a level (if possible)
+        // Remove a level
         let mut range_proof = tree.range_proof(2, 2).unwrap();
+        assert!(!range_proof.siblings.is_empty());
         range_proof.siblings.pop();
         assert!(range_proof
             .verify(&mut hasher, 2, range_leaves, &root)

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -403,11 +403,9 @@ impl<H: Hasher> RangeProof<H> {
                 let parent_pos = pos / 2;
 
                 // Check if next node is the sibling
-                // For this to be true, the next node must be at position+1 if current is even,
-                // or impossible if current is odd (since we process in order)
-                let expected_sibling_pos = if pos % 2 == 0 { pos + 1 } else { usize::MAX };
+                let expected_sibling_pos = if pos % 2 == 0 { Some(pos + 1) } else { None };
                 let has_paired_sibling =
-                    i + 1 < nodes.len() && nodes[i + 1].0 == expected_sibling_pos;
+                    i + 1 < nodes.len() && expected_sibling_pos == Some(nodes[i + 1].0);
                 if has_paired_sibling {
                     // Both children are in our range - no proof sibling needed
                     hasher.update(node);

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -384,7 +384,7 @@ impl<H: Hasher> RangeProof<H> {
         }
 
         // Check for integer overflow - critical for preventing attacks
-        if position.saturating_add(leaves.len() as u32) < position {
+        if position.checked_add(leaves.len() as u32).is_none() {
             return Err(Error::InvalidPosition(position));
         }
 
@@ -450,13 +450,11 @@ impl<H: Hasher> RangeProof<H> {
         if nodes.len() != 1 {
             return Err(Error::UnalignedProof);
         }
-        if nodes[0].1 == *root {
+        let computed = nodes[0].1;
+        if computed == *root {
             Ok(())
         } else {
-            Err(Error::InvalidProof(
-                nodes[0].1.to_string(),
-                root.to_string(),
-            ))
+            Err(Error::InvalidProof(computed.to_string(), root.to_string()))
         }
     }
 }

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -363,14 +363,8 @@ impl<H: Hasher> RangeProof<H> {
     /// Verifies that a given range of `leaves` starting at `position` are included
     /// in a Binary Merkle Tree with `root` using the provided `hasher`.
     ///
-    /// The proof contains the minimal set of sibling digests needed to reconstruct
+    /// The proof contains the set of sibling digests needed to reconstruct
     /// the root for all elements in the range.
-    ///
-    /// # Security
-    /// - Validates that leaves are non-empty and position doesn't overflow
-    /// - Ensures all siblings in the proof are consumed exactly once
-    /// - Rejects proofs with extra siblings or missing siblings
-    /// - Position is included in leaf hash to prevent positional attacks
     pub fn verify(
         &self,
         hasher: &mut H,

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -1407,13 +1407,11 @@ mod tests {
             let mut hasher = Sha256::default();
 
             // Test range including the last element (which may require duplicate handling)
-            if tree_size >= 2 {
-                let start = tree_size - 2;
-                let proof = tree.range_proof(start as u32, 2).unwrap();
-                assert!(proof
-                    .verify(&mut hasher, start as u32, &digests[start..tree_size], &root)
-                    .is_ok());
-            }
+            let start = tree_size - 2;
+            let proof = tree.range_proof(start as u32, 2).unwrap();
+            assert!(proof
+                .verify(&mut hasher, start as u32, &digests[start..tree_size], &root)
+                .is_ok());
         }
     }
 }


### PR DESCRIPTION
Resolves: #1312 

> Why not just use an MMR?

* BMT is stupid simple to reason about (not to say MMR is "that" much harder 😉 ).
* The MMR contains additional logic to handle appends and historical proofs (not applicable to fixed-size datasets).
* MMR proof size varies based on the position being proven (BMTs are equal size).

TL; DR using an MMR would "probably be fine" but it just feels like the wrong tool for the job.