### PR TITLE
[storage/adb/immutable] pruning support

### DIFF
--- a/storage/src/adb/mod.rs
+++ b/storage/src/adb/mod.rs
@@ -29,6 +29,9 @@ pub enum Error {
     #[error("journal error: {0}")]
     JournalError(#[from] crate::journal::Error),
 
+    #[error("operation pruned: {0}")]
+    OperationPruned(u64),
+
     /// The requested key was not found in the snapshot.
     #[error("key not found")]
     KeyNotFound,


### PR DESCRIPTION
Adds pruning support to adb::immutable.

- Keys whose operation precedes the boundary will no longer be retrievable (requests will return None).
- Index is not lazily cleaned up, but will be cleaned on restart.