### PR TITLE
ci: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/quint.yml
+++ b/.github/workflows/quint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           check-latest: true
       - name: Install quint
         run: npm i @informalsystems/quint@${{ env.QUINT_VERSION }} -g


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of 20.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)