### PR TITLE
[release] v0.0.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-bridge"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "clap",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "chrono",
  "clap",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "paste",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "arbitrary",
  "commonware-coding",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-collector"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "blake3",
  "blst",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "arbitrary",
  "blake3",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-estimator"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "clap",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "chrono",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bimap",
  "bytes",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "async-lock",
  "axum",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "arbitrary",
  "commonware-codec",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "arbitrary",
  "chacha20poly1305",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-sync"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "clap",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-vrf"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,20 +32,20 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.56", path = "broadcast" }
-commonware-codec = { version = "0.0.56", path = "codec" }
-commonware-coding = { version = "0.0.56", path = "coding" }
-commonware-collector = { version = "0.0.56", path = "collector" }
-commonware-consensus = { version = "0.0.56", path = "consensus" }
-commonware-cryptography = { version = "0.0.56", path = "cryptography" }
-commonware-deployer = { version = "0.0.56", path = "deployer", default-features = false }
-commonware-macros = { version = "0.0.56", path = "macros" }
-commonware-p2p = { version = "0.0.56", path = "p2p" }
-commonware-resolver = { version = "0.0.56", path = "resolver" }
-commonware-runtime = { version = "0.0.56", path = "runtime" }
-commonware-storage = { version = "0.0.56", path = "storage" }
-commonware-stream = { version = "0.0.56", path = "stream" }
-commonware-utils = { version = "0.0.56", path = "utils" }
+commonware-broadcast = { version = "0.0.57", path = "broadcast" }
+commonware-codec = { version = "0.0.57", path = "codec" }
+commonware-coding = { version = "0.0.57", path = "coding" }
+commonware-collector = { version = "0.0.57", path = "collector" }
+commonware-consensus = { version = "0.0.57", path = "consensus" }
+commonware-cryptography = { version = "0.0.57", path = "cryptography" }
+commonware-deployer = { version = "0.0.57", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.57", path = "macros" }
+commonware-p2p = { version = "0.0.57", path = "p2p" }
+commonware-resolver = { version = "0.0.57", path = "resolver" }
+commonware-runtime = { version = "0.0.57", path = "runtime" }
+commonware-storage = { version = "0.0.57", path = "storage" }
+commonware-stream = { version = "0.0.57", path = "stream" }
+commonware-utils = { version = "0.0.57", path = "utils" }
 thiserror = "2.0.12"
 bytes = "1.7.1"
 sha2 = "0.10.8"

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-broadcast"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Disseminate data over a wide-area network."
 readme = "README.md"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-codec"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Serialize structured data."
 readme = "README.md"

--- a/codec/fuzz/Cargo.toml
+++ b/codec/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-codec-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 publish = false
 edition = "2021"
 

--- a/coding/Cargo.toml
+++ b/coding/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-coding"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Encode data to enable recovery from a subset of fragments."
 readme = "README.md"

--- a/coding/fuzz/Cargo.toml
+++ b/coding/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-coding-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 publish = false
 edition = "2021"
 

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-collector"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Collect responses to committable requests."
 readme = "README.md"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-consensus"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Order opaque messages in a Byzantine environment."
 readme = "README.md"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify signatures."
 readme = "README.md"

--- a/cryptography/fuzz/Cargo.toml
+++ b/cryptography/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-cryptography-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 publish = false
 edition = "2021"
 

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-deployer"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Deploy infrastructure across cloud providers."
 readme = "README.md"

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-bridge"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Send succinct consensus certificates between two networks."
 readme = "README.md"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/examples/estimator/Cargo.toml
+++ b/examples/estimator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-estimator"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Simulate mechanism performance under realistic network conditions."
 readme = "README.md"

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-flood"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Spam peers deployed to AWS EC2 with random messages."
 readme = "README.md"

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-log"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Commit to a secret log and agree to its hash."
 readme = "README.md"

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-sync"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Synchronize state between a server and client."
 readme = "README.md"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-vrf"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-macros"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Augment the development of primitives with procedural macros."
 readme = "README.md"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-resolver"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Resolve data identified by a fixed-length key."
 readme = "README.md"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-runtime"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Execute asynchronous tasks with a configurable scheduler."
 readme = "README.md"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-storage"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Persist and retrieve data from an abstract store."
 readme = "README.md"

--- a/storage/fuzz/Cargo.toml
+++ b/storage/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-storage-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 publish = false
 edition = "2021"
 

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-stream"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Exchange messages over arbitrary transport."
 readme = "README.md"

--- a/stream/fuzz/Cargo.toml
+++ b/stream/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-stream-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 publish = false
 edition = "2021"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-utils"
 edition = "2021"
 publish = true
-version = "0.0.56"
+version = "0.0.57"
 license = "MIT OR Apache-2.0"
 description = "Leverage common functionality across multiple primitives."
 readme = "README.md"

--- a/utils/fuzz/Cargo.toml
+++ b/utils/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-utils-fuzz"
-version = "0.0.56"
+version = "0.0.57"
 publish = false
 edition = "2021"
 


### PR DESCRIPTION
## Stats

```
 .github/workflows/benchmark.yml                    |    4 +
 .github/workflows/coverage.yml                     |    1 +
 .github/workflows/fast.yml                         |   20 +
 .github/workflows/publish.yml                      |    5 +
 .github/workflows/quint.yml                        |   28 +
 .github/workflows/slow.yml                         |    2 +-
 .gitignore                                         |    3 +-
 Cargo.lock                                         |  303 ++-
 Cargo.toml                                         |   30 +-
 README.md                                          |    1 +
 broadcast/Cargo.toml                               |    2 +-
 codec/Cargo.toml                                   |    2 +-
 codec/fuzz/Cargo.toml                              |    2 +-
 codec/src/codec.rs                                 |    2 +-
 coding/Cargo.toml                                  |    2 +-
 coding/fuzz/Cargo.toml                             |   24 +
 coding/fuzz/fuzz_targets/reed_solomon.rs           |   90 +
 coding/src/reed_solomon/mod.rs                     |  251 ++-
 collector/Cargo.toml                               |    2 +-
 consensus/Cargo.toml                               |    5 +-
 consensus/src/lib.rs                               |   28 +
 consensus/src/marshal/actor.rs                     |  944 ++++++++
 consensus/src/marshal/config.rs                    |   68 +
 consensus/src/marshal/finalizer.rs                 |  113 +
 consensus/src/marshal/ingress/handler.rs           |  489 +++++
 consensus/src/marshal/ingress/mailbox.rs           |  162 ++
 consensus/src/marshal/ingress/mod.rs               |    3 +
 consensus/src/marshal/ingress/orchestrator.rs      |   87 +
 consensus/src/marshal/mocks/application.rs         |   37 +
 consensus/src/marshal/mocks/block.rs               |  101 +
 consensus/src/marshal/mocks/mod.rs                 |    3 +
 consensus/src/marshal/mocks/resolver.rs            |   27 +
 consensus/src/marshal/mod.rs                       |  405 ++++
 consensus/src/reporter.rs                          |   88 +
 consensus/src/simplex/actors/resolver/actor.rs     |    4 +-
 consensus/src/simplex/actors/voter/actor.rs        |    4 +-
 consensus/src/simplex/actors/voter/ingress.rs      |    7 +-
 consensus/src/simplex/actors/voter/mod.rs          |   11 +-
 consensus/src/simplex/mocks/conflicter.rs          |    4 +-
 consensus/src/simplex/mocks/nuller.rs              |    4 +-
 consensus/src/simplex/mocks/outdated.rs            |    4 +-
 consensus/src/simplex/mocks/supervisor.rs          |    4 +-
 consensus/src/simplex/types.rs                     |   32 +-
 .../src/threshold_simplex/actors/batcher/actor.rs  |    4 +-
 .../src/threshold_simplex/actors/resolver/actor.rs |    6 +-
 .../src/threshold_simplex/actors/voter/actor.rs    |    4 +-
 .../src/threshold_simplex/actors/voter/mod.rs      |   11 +-
 .../src/threshold_simplex/mocks/conflicter.rs      |    4 +-
 .../src/threshold_simplex/mocks/impersonator.rs    |    4 +-
 consensus/src/threshold_simplex/mocks/invalid.rs   |    4 +-
 consensus/src/threshold_simplex/mocks/nuller.rs    |    4 +-
 consensus/src/threshold_simplex/mocks/outdated.rs  |    4 +-
 .../src/threshold_simplex/mocks/supervisor.rs      |    3 +-
 consensus/src/threshold_simplex/mod.rs             |  173 +-
 consensus/src/threshold_simplex/types.rs           |   34 +-
 cryptography/Cargo.toml                            |    7 +-
 cryptography/fuzz/Cargo.toml                       |   45 +-
 cryptography/fuzz/fuzz_targets/blake3_hasher.rs    |  120 ++
 .../fuzz_targets/bls12381_aggregate_operations.rs  |  213 ++
 .../fuzz_targets/bls12381_primitive_operations.rs  |    4 +-
 .../fuzz_targets/bls12381_threshold_operations.rs  |  558 +++++
 cryptography/fuzz/fuzz_targets/bls12381_tle.rs     |  380 ++++
 cryptography/fuzz/fuzz_targets/common/mod.rs       |  320 +++
 .../fuzz/fuzz_targets/lthash_operations.rs         |  151 ++
 cryptography/fuzz/fuzz_targets/metamorph_lthash.rs |  166 ++
 cryptography/src/blake3/mod.rs                     |    6 +-
 cryptography/src/bls12381/benches/bench.rs         |    4 +
 cryptography/src/bls12381/benches/tle_decrypt.rs   |   34 +
 cryptography/src/bls12381/benches/tle_encrypt.rs   |   31 +
 cryptography/src/bls12381/mod.rs                   |    1 +
 cryptography/src/bls12381/primitives/group.rs      |  172 +-
 cryptography/src/bls12381/primitives/ops.rs        |   12 +-
 cryptography/src/bls12381/primitives/poly.rs       |    4 +-
 cryptography/src/bls12381/primitives/variant.rs    |   41 +-
 cryptography/src/bls12381/scheme.rs                |    8 +-
 cryptography/src/bls12381/tle.rs                   |  598 ++++++
 cryptography/src/ed25519/scheme.rs                 |    8 +-
 cryptography/src/lib.rs                            |    6 +-
 cryptography/src/lthash/benches/add.rs             |   19 +
 cryptography/src/lthash/benches/bench.rs           |   15 +
 cryptography/src/lthash/benches/checksum.rs        |   14 +
 cryptography/src/lthash/benches/combine.rs         |   22 +
 cryptography/src/lthash/benches/subtract.rs        |   23 +
 cryptography/src/lthash/benches/update.rs          |   39 +
 cryptography/src/lthash/mod.rs                     |  354 +++
 cryptography/src/secp256r1/scheme.rs               |    8 +-
 cryptography/src/sha256/mod.rs                     |    6 +-
 deployer/Cargo.toml                                |    2 +-
 docs/blogs/minimmit.html                           |    4 +-
 docs/index.html                                    |    2 +
 examples/bridge/Cargo.toml                         |    2 +-
 examples/bridge/src/application/actor.rs           |    2 +-
 examples/bridge/src/bin/indexer.rs                 |    2 +-
 examples/bridge/src/types/block.rs                 |    2 +-
 examples/bridge/src/types/inbound.rs               |    4 +-
 examples/bridge/src/types/outbound.rs              |    2 +-
 examples/chat/Cargo.toml                           |    2 +-
 examples/chat/README.md                            |    1 -
 examples/estimator/Cargo.toml                      |   37 +
 examples/estimator/README.md                       |  178 ++
 examples/estimator/echo.lazy                       |   11 +
 examples/estimator/hotstuff.lazy                   |   23 +
 examples/estimator/minimmit.lazy                   |   14 +
 examples/estimator/simplex.lazy                    |   15 +
 examples/estimator/simplex_with_certificates.lazy  |   17 +
 examples/estimator/src/lib.rs                      | 1268 +++++++++++
 examples/estimator/src/main.rs                     |  824 +++++++
 examples/estimator/src/p50.json                    | 1159 ++++++++++
 examples/estimator/src/p90.json                    | 1159 ++++++++++
 examples/estimator/stall.lazy                      |    7 +
 examples/flood/Cargo.toml                          |    2 +-
 examples/flood/README.md                           |    1 -
 examples/log/Cargo.toml                            |    2 +-
 examples/log/src/application/supervisor.rs         |    4 +-
 examples/sync/Cargo.toml                           |    3 +-
 examples/sync/README.md                            |   79 +-
 examples/sync/src/bin/client.rs                    |  313 ++-
 examples/sync/src/bin/server.rs                    |  457 ++--
 examples/sync/src/error.rs                         |   96 +
 examples/sync/src/lib.rs                           |    5 +-
 examples/sync/src/protocol.rs                      |  286 ++-
 examples/sync/src/resolver.rs                      |  334 +--
 examples/vrf/Cargo.toml                            |    2 +-
 examples/vrf/README.md                             |    1 -
 examples/vrf/src/handlers/contributor.rs           |    2 +-
 examples/vrf/src/handlers/wire.rs                  |    6 +-
 macros/Cargo.toml                                  |    2 +-
 p2p/Cargo.toml                                     |    2 +-
 p2p/src/utils/codec.rs                             |    1 +
 pipeline/{ => minimmit}/minimmit.md                |   14 +-
 pipeline/minimmit/quint/README.md                  |   74 +
 pipeline/minimmit/quint/defs.qnt                   |   13 +
 pipeline/minimmit/quint/main_n6f0.qnt              |   14 +
 pipeline/minimmit/quint/main_n6f1.qnt              |   14 +
 pipeline/minimmit/quint/main_n6f2.qnt              |   14 +
 pipeline/minimmit/quint/main_n7f1.qnt              |   14 +
 pipeline/minimmit/quint/makefile                   |   34 +
 pipeline/minimmit/quint/option.qnt                 |   47 +
 pipeline/minimmit/quint/replica.qnt                |  885 ++++++++
 pipeline/minimmit/quint/scripts/verify.sh          |  190 ++
 pipeline/minimmit/quint/tests/tests_n6f0.qnt       |  851 ++++++++
 pipeline/minimmit/quint/tests/tests_n6f1.qnt       |  167 ++
 pipeline/minimmit/quint/types.qnt                  |  111 +
 resolver/Cargo.toml                                |    5 +-
 resolver/src/lib.rs                                |   15 +-
 resolver/src/p2p/config.rs                         |    4 +-
 resolver/src/p2p/engine.rs                         |   28 +-
 resolver/src/p2p/fetcher.rs                        |  584 ++++-
 resolver/src/p2p/ingress.rs                        |   34 +-
 resolver/src/p2p/mocks/consumer.rs                 |    8 +-
 resolver/src/p2p/mocks/key.rs                      |   19 +-
 resolver/src/p2p/mocks/producer.rs                 |    8 +-
 resolver/src/p2p/mod.rs                            |    6 +-
 resolver/src/p2p/wire.rs                           |   20 +-
 runtime/Cargo.toml                                 |    2 +-
 runtime/src/deterministic.rs                       |   14 +-
 runtime/src/telemetry/metrics/status.rs            |    6 +
 storage/Cargo.toml                                 |    2 +-
 storage/fuzz/Cargo.toml                            |    9 +-
 .../fuzz/fuzz_targets/adb_current_operations.rs    |    3 +-
 storage/fuzz/fuzz_targets/adb_operations.rs        |    3 +-
 storage/fuzz/fuzz_targets/adb_sync.rs              |  163 ++
 storage/fuzz/fuzz_targets/archive_operations.rs    |    2 +-
 storage/fuzz/fuzz_targets/bmt_operations.rs        |  172 +-
 storage/fuzz/fuzz_targets/freezer_operations.rs    |    2 +-
 storage/fuzz/fuzz_targets/journal_operations.rs    |    3 +-
 storage/fuzz/fuzz_targets/metadata_operations.rs   |    2 +-
 storage/src/adb/any/mod.rs                         |  776 +++++--
 storage/src/adb/any/sync/client.rs                 | 2266 ++++++++++++++++----
 storage/src/adb/any/sync/metrics.rs                |   68 +
 storage/src/adb/any/sync/mod.rs                    |   94 +-
 storage/src/adb/any/sync/resolver.rs               |  103 +-
 storage/src/adb/benches/any_init.rs                |    7 +-
 storage/src/adb/current.rs                         |  293 ++-
 storage/src/adb/immutable.rs                       | 1013 +++++++++
 storage/src/adb/mod.rs                             |    4 +
 storage/src/adb/operation.rs                       |  203 +-
 storage/src/archive/benches/utils.rs               |    2 +-
 storage/src/archive/immutable/mod.rs               |   69 +
 storage/src/archive/immutable/storage.rs           |   14 +-
 storage/src/archive/mod.rs                         |    2 +-
 storage/src/archive/prunable/mod.rs                |    2 +-
 storage/src/bmt/benches/bench.rs                   |    5 +-
 storage/src/bmt/benches/prove_range.rs             |   54 +
 .../{prove_single_element.rs => prove_single.rs}   |    8 +-
 storage/src/bmt/mod.rs                             |  909 +++++++-
 storage/src/freezer/benches/utils.rs               |    2 +-
 storage/src/freezer/mod.rs                         |    4 +-
 storage/src/freezer/storage.rs                     |   34 +-
 storage/src/index/mod.rs                           |   13 +
 storage/src/index/storage.rs                       |   13 +
 storage/src/journal/benches/bench.rs               |    2 +-
 storage/src/journal/benches/fixed_read_random.rs   |    2 +-
 .../src/journal/benches/fixed_read_sequential.rs   |    2 +-
 storage/src/journal/benches/fixed_replay.rs        |    2 +-
 storage/src/journal/fixed.rs                       |  795 ++++---
 storage/src/journal/mod.rs                         |    2 +
 storage/src/journal/variable.rs                    |   72 +-
 storage/src/metadata/benches/utils.rs              |    2 +-
 storage/src/metadata/mod.rs                        |    4 +-
 storage/src/metadata/storage.rs                    |    2 +-
 storage/src/mmr/benches/prove_many_elements.rs     |    4 +-
 storage/src/mmr/benches/prove_single_element.rs    |    4 +-
 storage/src/mmr/bitmap.rs                          |   12 +-
 storage/src/mmr/hasher.rs                          |   35 +-
 storage/src/mmr/journaled.rs                       |  374 ++--
 storage/src/mmr/mem.rs                             |   14 +-
 storage/src/mmr/mod.rs                             |    5 +-
 storage/src/mmr/storage.rs                         |    2 +-
 storage/src/mmr/verification.rs                    |   85 +-
 storage/src/ordinal/benches/utils.rs               |    2 +-
 storage/src/ordinal/mod.rs                         |    4 +-
 stream/Cargo.toml                                  |    2 +-
 stream/fuzz/Cargo.toml                             |    2 +-
 stream/src/public_key/connection.rs                |    4 +-
 utils/Cargo.toml                                   |    2 +-
 utils/fuzz/Cargo.toml                              |    2 +-
 utils/fuzz/fuzz_targets/array.rs                   |    2 +-
 utils/src/lib.rs                                   |    6 +-
 utils/src/priority_set.rs                          |   57 +
 utils/src/{array => sequence}/fixed_bytes.rs       |    6 +-
 utils/src/{array => sequence}/mod.rs               |   28 +-
 utils/src/{array => sequence}/prefixed_u64.rs      |    4 +-
 utils/src/sequence/u32.rs                          |  120 ++
 utils/src/{array => sequence}/u64.rs               |    4 +-
 utils/src/time.rs                                  |  250 +++
 226 files changed, 22608 insertions(+), 2208 deletions(-)
```