### PR TITLE
[cleanup] change all buffer capacities from usize to NonZeroUsize

### DIFF
--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -80,7 +80,7 @@ mod tests {
             .map(|i| PrivateKey::from_seed(i as u64))
             .collect::<Vec<_>>();
         schemes.sort_by_key(|s| s.public_key());
-        let peers: Vec<PublicKey> = schemes.iter().map(|c| (c.public_key())).collect();
+        let peers: Vec<PublicKey> = schemes.iter().map(|c| c.public_key()).collect();
 
         let mut registrations: Registrations = BTreeMap::new();
         for peer in peers.iter() {

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -33,6 +33,7 @@ use std::{
     cmp::max,
     collections::{BTreeMap, HashMap},
     marker::PhantomData,
+    num::NonZeroUsize,
     time::{Duration, SystemTime},
 };
 use tracing::{debug, error, trace, warn};
@@ -137,8 +138,8 @@ pub struct Engine<
     /// Journal for storing acks signed by this node.
     journal: Option<Journal<E, Activity<V, D>>>,
     journal_partition: String,
-    journal_write_buffer: usize,
-    journal_replay_buffer: usize,
+    journal_write_buffer: NonZeroUsize,
+    journal_replay_buffer: NonZeroUsize,
     journal_heights_per_section: u64,
     journal_compression: Option<u8>,
 
@@ -197,8 +198,8 @@ impl<
             rebroadcast_deadlines: PrioritySet::new(),
             journal: None,
             journal_partition: cfg.journal_partition,
-            journal_write_buffer: cfg.journal_write_buffer.into(),
-            journal_replay_buffer: cfg.journal_replay_buffer.into(),
+            journal_write_buffer: cfg.journal_write_buffer,
+            journal_replay_buffer: cfg.journal_replay_buffer,
             journal_heights_per_section: cfg.journal_heights_per_section.into(),
             journal_compression: cfg.journal_compression,
             priority_acks: cfg.priority_acks,

--- a/consensus/src/marshal/config.rs
+++ b/consensus/src/marshal/config.rs
@@ -2,6 +2,7 @@ use crate::Block;
 use commonware_cryptography::{bls12381::primitives::variant::Variant, PublicKey};
 use commonware_resolver::p2p::Coordinator;
 use governor::Quota;
+use std::num::NonZeroUsize;
 
 /// Marshal configuration.
 #[derive(Debug)]
@@ -55,10 +56,10 @@ pub struct Config<V: Variant, P: PublicKey, Z: Coordinator<PublicKey = P>, B: Bl
     pub freezer_journal_compression: Option<u8>,
 
     /// The size of the replay buffer for storage archives.
-    pub replay_buffer: usize,
+    pub replay_buffer: NonZeroUsize,
 
     /// The size of the write buffer for storage archives.
-    pub write_buffer: usize,
+    pub write_buffer: NonZeroUsize,
 
     /// Codec configuration for block type.
     pub codec_config: B::Cfg,

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -101,6 +101,7 @@ mod tests {
     use commonware_p2p::simulated::{self, Link, Network, Oracle};
     use commonware_resolver::p2p as resolver;
     use commonware_runtime::{deterministic, Clock, Metrics, Runner};
+    use commonware_utils::NZUsize;
     use governor::Quota;
     use rand::{seq::SliceRandom, Rng};
     use std::{collections::BTreeMap, num::NonZeroU32, time::Duration};
@@ -311,8 +312,8 @@ mod tests {
             codec_config: (),
             partition_prefix: format!("validator-{}", secret.public_key()),
             prunable_items_per_section: 10u64,
-            replay_buffer: 1024,
-            write_buffer: 1024,
+            replay_buffer: NZUsize!(1024),
+            write_buffer: NZUsize!(1024),
             freezer_table_initial_size: 64,
             freezer_table_resize_frequency: 10,
             freezer_table_resize_chunk_size: 10,

--- a/consensus/src/ordered_broadcast/config.rs
+++ b/consensus/src/ordered_broadcast/config.rs
@@ -1,7 +1,7 @@
 use super::types::{Activity, Context, Epoch};
 use crate::{Automaton, Monitor, Relay, Reporter, Supervisor, ThresholdSupervisor};
 use commonware_cryptography::{bls12381::primitives::variant::Variant, Digest, Signer};
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 /// Configuration for the [super::Engine].
 pub struct Config<
@@ -75,10 +75,10 @@ pub struct Config<
     pub journal_heights_per_section: u64,
 
     /// The number of bytes to buffer when replaying a journal.
-    pub journal_replay_buffer: usize,
+    pub journal_replay_buffer: NonZeroUsize,
 
     /// The size of the write buffer to use for each blob in the journal.
-    pub journal_write_buffer: usize,
+    pub journal_write_buffer: NonZeroUsize,
 
     /// Compression level for the journal.
     pub journal_compression: Option<u8>,

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -39,6 +39,7 @@ use futures::{
 use std::{
     collections::BTreeMap,
     marker::PhantomData,
+    num::NonZeroUsize,
     time::{Duration, SystemTime},
 };
 use tracing::{debug, error, info, warn};
@@ -140,10 +141,10 @@ pub struct Engine<
     journal_heights_per_section: u64,
 
     // The number of bytes to buffer when replaying a journal.
-    journal_replay_buffer: usize,
+    journal_replay_buffer: NonZeroUsize,
 
     // The size of the write buffer to use for each blob in the journal.
-    journal_write_buffer: usize,
+    journal_write_buffer: NonZeroUsize,
 
     // A prefix for the journal names.
     // The rest of the name is the hex-encoded public keys of the relevant sequencer.

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -74,7 +74,7 @@ mod tests {
         deterministic::{self, Context},
         Clock, Metrics, Runner, Spawner,
     };
-    use commonware_utils::quorum;
+    use commonware_utils::{quorum, NZUsize};
     use futures::{channel::oneshot, future::join_all};
     use rand::{rngs::StdRng, SeedableRng as _};
     use std::{
@@ -232,8 +232,8 @@ mod tests {
                     priority_acks: false,
                     priority_proposals: false,
                     journal_heights_per_section: 10,
-                    journal_replay_buffer: 4096,
-                    journal_write_buffer: 4096,
+                    journal_replay_buffer: NZUsize!(4096),
+                    journal_write_buffer: NZUsize!(4096),
                     journal_name_prefix: format!("ordered-broadcast-seq/{validator}/"),
                     journal_compression: Some(3),
                 },
@@ -862,8 +862,8 @@ mod tests {
                         priority_acks: false,
                         priority_proposals: false,
                         journal_heights_per_section: 10,
-                        journal_replay_buffer: 4096,
-                        journal_write_buffer: 4096,
+                        journal_replay_buffer: NZUsize!(4096),
+                        journal_write_buffer: NZUsize!(4096),
                         journal_name_prefix: format!("ordered-broadcast-seq/{validator}/"),
                         journal_compression: Some(3),
                     },
@@ -912,8 +912,8 @@ mod tests {
                         priority_acks: false,
                         priority_proposals: false,
                         journal_heights_per_section: 10,
-                        journal_replay_buffer: 4096,
-                        journal_write_buffer: 4096,
+                        journal_replay_buffer: NZUsize!(4096),
+                        journal_write_buffer: NZUsize!(4096),
                         journal_name_prefix: format!(
                             "ordered-broadcast-seq/{}/",
                             sequencer.public_key()

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -32,6 +32,7 @@ use rand::Rng;
 use std::{
     cmp::max,
     collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap},
+    num::NonZeroUsize,
     sync::atomic::AtomicI64,
     time::{Duration, SystemTime},
 };
@@ -194,7 +195,7 @@ impl<
         false
     }
 
-    fn notarizable(&mut self, threshold: u32, force: bool) -> Notarizable<C::Signature, D> {
+    fn notarizable(&mut self, threshold: u32, force: bool) -> Notarizable<'_, C::Signature, D> {
         if !force && (self.broadcast_notarization || self.broadcast_nullification) {
             // We want to broadcast a notarization, even if we haven't yet verified a proposal.
             return None;
@@ -218,7 +219,7 @@ impl<
         None
     }
 
-    fn nullifiable(&mut self, threshold: u32, force: bool) -> Nullifiable<C::Signature> {
+    fn nullifiable(&mut self, threshold: u32, force: bool) -> Nullifiable<'_, C::Signature> {
         if !force && (self.broadcast_nullification || self.broadcast_notarization) {
             return None;
         }
@@ -270,7 +271,7 @@ impl<
         true
     }
 
-    fn finalizable(&mut self, threshold: u32, force: bool) -> Finalizable<C::Signature, D> {
+    fn finalizable(&mut self, threshold: u32, force: bool) -> Finalizable<'_, C::Signature, D> {
         if !force && self.broadcast_finalization {
             // We want to broadcast a finalization, even if we haven't yet verified a proposal.
             return None;
@@ -326,8 +327,8 @@ pub struct Actor<
 
     partition: String,
     compression: Option<u8>,
-    replay_buffer: usize,
-    write_buffer: usize,
+    replay_buffer: NonZeroUsize,
+    write_buffer: NonZeroUsize,
     journal: Option<Journal<E, Voter<C::Signature, D>>>,
 
     genesis: Option<D>,

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 pub use actor::Actor;
 use commonware_cryptography::{Digest, Signer};
 pub use ingress::{Mailbox, Message};
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 pub struct Config<
     C: Signer,
@@ -34,8 +34,8 @@ pub struct Config<
     pub max_participants: usize,
     pub activity_timeout: View,
     pub skip_timeout: View,
-    pub replay_buffer: usize,
-    pub write_buffer: usize,
+    pub replay_buffer: NonZeroUsize,
+    pub write_buffer: NonZeroUsize,
 }
 
 #[cfg(test)]
@@ -57,7 +57,7 @@ mod tests {
         Receiver, Recipients, Sender,
     };
     use commonware_runtime::{deterministic, Metrics, Runner, Spawner};
-    use commonware_utils::quorum;
+    use commonware_utils::{quorum, NZUsize};
     use futures::{channel::mpsc, StreamExt};
     use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
@@ -134,8 +134,8 @@ mod tests {
                 max_participants: n as usize,
                 activity_timeout: 10,
                 skip_timeout: 10,
-                replay_buffer: 1024 * 1024,
-                write_buffer: 1024 * 1024,
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 
@@ -330,8 +330,8 @@ mod tests {
                 max_participants: n as usize,
                 activity_timeout,
                 skip_timeout: 10,
-                replay_buffer: 1024 * 1024,
-                write_buffer: 1024 * 1024,
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
             };
             let (actor, _mailbox) = Actor::new(context.clone(), cfg);
 

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -2,7 +2,7 @@ use super::types::{Activity, Context, View};
 use crate::{Automaton, Relay, Reporter, Supervisor};
 use commonware_cryptography::{Digest, Signer};
 use governor::Quota;
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 /// Configuration for the consensus engine.
 pub struct Config<
@@ -42,10 +42,10 @@ pub struct Config<
     pub namespace: Vec<u8>,
 
     /// Number of bytes to buffer when replaying during startup.
-    pub replay_buffer: usize,
+    pub replay_buffer: NonZeroUsize,
 
     /// The size of the write buffer to use for each blob in the journal.
-    pub write_buffer: usize,
+    pub write_buffer: NonZeroUsize,
 
     /// Amount of time to wait for a leader to propose a payload
     /// in a view.

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -142,7 +142,7 @@ mod tests {
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{deterministic, Clock, Metrics, Runner, Spawner};
-    use commonware_utils::{quorum, NZU32};
+    use commonware_utils::{quorum, NZUsize, NZU32};
     use engine::Engine;
     use futures::{future::join_all, StreamExt};
     use governor::Quota;
@@ -326,8 +326,8 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
                 let (voter, resolver) = registrations
@@ -570,8 +570,8 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     let (voter_network, resolver_network) = registrations
@@ -739,8 +739,8 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -857,8 +857,8 @@ mod tests {
                 max_participants: n as usize,
                 fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                 fetch_concurrent: 1,
-                replay_buffer: 1024 * 1024,
-                write_buffer: 1024 * 1024,
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
             };
             let (voter, resolver) = registrations
                 .remove(&validator)
@@ -979,8 +979,8 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1205,8 +1205,8 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1363,8 +1363,8 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1546,8 +1546,8 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1725,8 +1725,8 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1892,8 +1892,8 @@ mod tests {
                         max_participants: n as usize,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2060,8 +2060,8 @@ mod tests {
                         max_participants: n as usize,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2224,8 +2224,8 @@ mod tests {
                         max_participants: n as usize,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2360,8 +2360,8 @@ mod tests {
                     max_participants: n as usize,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -43,6 +43,7 @@ use prometheus_client::metrics::{
 use rand::Rng;
 use std::{
     collections::BTreeMap,
+    num::NonZeroUsize,
     sync::{atomic::AtomicI64, Arc},
     time::{Duration, SystemTime},
 };
@@ -449,8 +450,8 @@ pub struct Actor<
 
     partition: String,
     compression: Option<u8>,
-    replay_buffer: usize,
-    write_buffer: usize,
+    replay_buffer: NonZeroUsize,
+    write_buffer: NonZeroUsize,
     journal: Option<Journal<E, Voter<V, D>>>,
 
     genesis: Option<D>,

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -12,7 +12,7 @@ use commonware_cryptography::{
 };
 use commonware_p2p::Blocker;
 pub use ingress::{Mailbox, Message};
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 pub struct Config<
     C: Signer,
@@ -39,8 +39,8 @@ pub struct Config<
     pub notarization_timeout: Duration,
     pub nullify_retry: Duration,
     pub activity_timeout: View,
-    pub replay_buffer: usize,
-    pub write_buffer: usize,
+    pub replay_buffer: NonZeroUsize,
+    pub write_buffer: NonZeroUsize,
 }
 
 #[cfg(test)]
@@ -68,7 +68,7 @@ mod tests {
         Receiver, Recipients, Sender,
     };
     use commonware_runtime::{deterministic, Metrics, Runner, Spawner};
-    use commonware_utils::quorum;
+    use commonware_utils::{quorum, NZUsize};
     use futures::{channel::mpsc, StreamExt};
     use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
@@ -151,8 +151,8 @@ mod tests {
                 notarization_timeout: Duration::from_secs(5),
                 nullify_retry: Duration::from_secs(5),
                 activity_timeout: 10,
-                replay_buffer: 1024 * 1024,
-                write_buffer: 1024 * 1024,
+                replay_buffer: NonZeroUsize::new(1024 * 1024).unwrap(),
+                write_buffer: NonZeroUsize::new(1024 * 1024).unwrap(),
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 
@@ -459,8 +459,8 @@ mod tests {
                 notarization_timeout: Duration::from_millis(1000),
                 nullify_retry: Duration::from_millis(1000),
                 activity_timeout,
-                replay_buffer: 10240,
-                write_buffer: 10240,
+                replay_buffer: NZUsize!(10240),
+                write_buffer: NZUsize!(10240),
             };
             let (actor, _mailbox) = Actor::new(context.clone(), voter_config);
 

--- a/consensus/src/threshold_simplex/config.rs
+++ b/consensus/src/threshold_simplex/config.rs
@@ -6,7 +6,7 @@ use commonware_cryptography::{
 };
 use commonware_p2p::Blocker;
 use governor::Quota;
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 /// Configuration for the consensus engine.
 pub struct Config<
@@ -59,10 +59,10 @@ pub struct Config<
     pub namespace: Vec<u8>,
 
     /// Number of bytes to buffer when replaying during startup.
-    pub replay_buffer: usize,
+    pub replay_buffer: NonZeroUsize,
 
     /// The size of the write buffer to use for each blob in the journal.
-    pub write_buffer: usize,
+    pub write_buffer: NonZeroUsize,
 
     /// Amount of time to wait for a leader to propose a payload
     /// in a view.

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -225,7 +225,7 @@ mod tests {
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{deterministic, Clock, Metrics, Runner, Spawner};
-    use commonware_utils::{quorum, NZU32};
+    use commonware_utils::{quorum, NZUsize, NZU32};
     use engine::Engine;
     use futures::{future::join_all, StreamExt};
     use governor::Quota;
@@ -424,8 +424,8 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -690,8 +690,8 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -884,8 +884,8 @@ mod tests {
                     max_fetch_count: 1, // force many fetches
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1007,8 +1007,8 @@ mod tests {
                 max_fetch_count: 1,
                 fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                 fetch_concurrent: 1,
-                replay_buffer: 1024 * 1024,
-                write_buffer: 1024 * 1024,
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
             };
             let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1152,8 +1152,8 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1417,8 +1417,8 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1591,8 +1591,8 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1801,8 +1801,8 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -2007,8 +2007,8 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -2201,8 +2201,8 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2391,8 +2391,8 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2572,8 +2572,8 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2745,8 +2745,8 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2932,8 +2932,8 @@ mod tests {
                         max_fetch_count: 1,
                         fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                         fetch_concurrent: 1,
-                        replay_buffer: 1024 * 1024,
-                        write_buffer: 1024 * 1024,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -3083,8 +3083,8 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -3243,8 +3243,8 @@ mod tests {
                     max_fetch_count: 1,
                     fetch_rate_per_peer: Quota::per_second(NZU32!(10)),
                     fetch_concurrent: 1,
-                    replay_buffer: 1024 * 1024,
-                    write_buffer: 1024 * 1024,
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -15,7 +15,7 @@ use commonware_cryptography::{
 use commonware_p2p::authenticated;
 use commonware_runtime::{tokio, Metrics, Network, Runner};
 use commonware_stream::public_key::{self, Connection};
-use commonware_utils::{from_hex, quorum, union, NZU32};
+use commonware_utils::{from_hex, quorum, union, NZUsize, NZU32};
 use governor::Quota;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -236,8 +236,8 @@ fn main() {
                 compression: Some(3),
                 namespace: consensus_namespace,
                 mailbox_size: 1024,
-                replay_buffer: 1024 * 1024,
-                write_buffer: 1024 * 1024,
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
                 leader_timeout: Duration::from_secs(1),
                 notarization_timeout: Duration::from_secs(2),
                 nullify_retry: Duration::from_secs(10),

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -52,7 +52,7 @@ use commonware_consensus::simplex;
 use commonware_cryptography::{ed25519, PrivateKeyExt as _, Sha256, Signer as _};
 use commonware_p2p::authenticated::discovery;
 use commonware_runtime::{tokio, Metrics, Runner};
-use commonware_utils::{union, NZU32};
+use commonware_utils::{union, NZUsize, NZU32};
 use governor::Quota;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -202,8 +202,8 @@ fn main() {
             partition: String::from("log"),
             compression: Some(3),
             mailbox_size: 1024,
-            replay_buffer: 1024 * 1024,
-            write_buffer: 1024 * 1024,
+            replay_buffer: NZUsize!(1024 * 1024),
+            write_buffer: NZUsize!(1024 * 1024),
             leader_timeout: Duration::from_secs(1),
             notarization_timeout: Duration::from_secs(2),
             nullify_retry: Duration::from_secs(10),

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -11,6 +11,7 @@
 //! - Use [commonware_storage::adb::any::sync] to synchronize the client's database state with the server's state
 
 use commonware_cryptography::Hasher as CryptoHasher;
+use commonware_runtime::buffer::PoolRef;
 use commonware_storage::adb::any::fixed::{Any, Config};
 
 pub mod error;

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -14,6 +14,7 @@ use commonware_cryptography::Hasher as CryptoHasher;
 use commonware_storage::adb::any::fixed::{Any, Config};
 
 pub mod error;
+use commonware_utils::NZUsize;
 pub use error::Error;
 pub mod protocol;
 pub use protocol::*;
@@ -49,10 +50,10 @@ pub fn create_adb_config() -> Config<Translator> {
         mmr_journal_partition: "mmr_journal".into(),
         mmr_metadata_partition: "mmr_metadata".into(),
         mmr_items_per_blob: 4096,
-        mmr_write_buffer: 1024,
+        mmr_write_buffer: NZUsize!(1024),
         log_journal_partition: "log_journal".into(),
         log_items_per_blob: 4096,
-        log_write_buffer: 1024,
+        log_write_buffer: NZUsize!(1024),
         translator: Translator::default(),
         thread_pool: None,
         buffer_pool: commonware_runtime::buffer::PoolRef::new(1024, 10),

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -56,7 +56,7 @@ pub fn create_adb_config() -> Config<Translator> {
         log_write_buffer: NZUsize!(1024),
         translator: Translator::default(),
         thread_pool: None,
-        buffer_pool: commonware_runtime::buffer::PoolRef::new(1024, 10),
+        buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
         pruning_delay: 10,
     }
 }

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -411,10 +411,10 @@ impl crate::Runner for Runner {
                         }
                     }
                 }
-                if skip.is_some() {
+                if let Some(skip_time) = skip {
                     {
                         let mut time = executor.time.lock().unwrap();
-                        *time = skip.unwrap();
+                        *time = skip_time;
                         current = *time;
                     }
                     trace!(now = current.epoch_millis(), "time skipped");

--- a/runtime/src/utils/buffer/append.rs
+++ b/runtime/src/utils/buffer/append.rs
@@ -236,7 +236,7 @@ mod tests {
                 .open("test", "blob".as_bytes())
                 .await
                 .expect("Failed to open blob");
-            let pool_ref = PoolRef::new(PAGE_SIZE, 10);
+            let pool_ref = PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(10));
             let blob = Append::new(blob, size, NZUsize!(BUFFER_SIZE), pool_ref.clone())
                 .await
                 .unwrap();
@@ -258,7 +258,7 @@ mod tests {
             assert_eq!(size, 0);
 
             // Wrap the blob, then append 11 consecutive pages of data.
-            let pool_ref = PoolRef::new(PAGE_SIZE, 10);
+            let pool_ref = PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(10));
             let blob = Append::new(blob, size, NZUsize!(BUFFER_SIZE), pool_ref.clone())
                 .await
                 .unwrap();
@@ -292,7 +292,7 @@ mod tests {
                 .expect("Failed to open blob");
             assert_eq!(size, 0);
 
-            let pool_ref = PoolRef::new(PAGE_SIZE, 10);
+            let pool_ref = PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(10));
             let blob = Append::new(blob, size, NZUsize!(BUFFER_SIZE), pool_ref.clone())
                 .await
                 .unwrap();

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -16,6 +16,7 @@ mod tests {
     use super::*;
     use crate::{deterministic, Blob as _, Error, Runner, Storage};
     use commonware_macros::test_traced;
+    use commonware_utils::NZUsize;
 
     #[test_traced]
     fn test_read_basic() {
@@ -29,8 +30,7 @@ mod tests {
             let size = data.len() as u64;
 
             // Create a buffered reader with small buffer to test refilling
-            let buffer_size = 10;
-            let mut reader = Read::new(blob, size, buffer_size);
+            let mut reader = Read::new(blob, size, NZUsize!(10));
 
             // Read some data
             let mut buf = [0u8; 5];
@@ -70,8 +70,7 @@ mod tests {
             let size = data.len() as u64;
 
             // This should panic
-            let buffer_size = 0;
-            Read::new(blob, size, buffer_size);
+            Read::new(blob, size, NZUsize!(0));
         });
     }
 
@@ -87,8 +86,7 @@ mod tests {
             let size = data.len() as u64;
 
             // Use a buffer smaller than the total data size
-            let buffer_size = 10;
-            let mut reader = Read::new(blob, size, buffer_size);
+            let mut reader = Read::new(blob, size, NZUsize!(10));
 
             // Read data that crosses buffer boundaries
             let mut buf = [0u8; 15];
@@ -120,8 +118,7 @@ mod tests {
             blob.write_at(data.to_vec(), 0).await.unwrap();
             let size = data.len() as u64;
 
-            let buffer_size = 20;
-            let mut reader = Read::new(blob, size, buffer_size);
+            let mut reader = Read::new(blob, size, NZUsize!(20));
 
             // Read data that crosses buffer boundaries
             let mut buf = [0u8; 21];
@@ -156,8 +153,7 @@ mod tests {
             let size = data.len() as u64;
 
             // Create a buffered reader with buffer smaller than total data
-            let buffer_size = 10;
-            let mut reader = Read::new(blob, size, buffer_size);
+            let mut reader = Read::new(blob, size, NZUsize!(10));
 
             // Check initial remaining bytes
             assert_eq!(reader.blob_remaining(), size);
@@ -201,8 +197,7 @@ mod tests {
             let size = data.len() as u64;
 
             // Use a buffer much smaller than the total data
-            let buffer_size = 64 * 1024; // 64KB buffer
-            let mut reader = Read::new(blob, size, buffer_size);
+            let mut reader = Read::new(blob, size, NZUsize!(64 * 1024)); // 64KB buffer
 
             // Read all data in smaller chunks
             let mut total_read = 0;
@@ -249,7 +244,7 @@ mod tests {
             blob.write_at(data.clone(), 0).await.unwrap();
             let size = data.len() as u64;
 
-            let mut reader = Read::new(blob, size, buffer_size);
+            let mut reader = Read::new(blob, size, NZUsize!(buffer_size));
 
             // Read exactly one buffer size
             let mut buf1 = vec![0u8; buffer_size];
@@ -285,8 +280,7 @@ mod tests {
             let size = data.len() as u64;
 
             // Create a buffer reader
-            let buffer_size = 10;
-            let mut reader = Read::new(blob, size, buffer_size);
+            let mut reader = Read::new(blob, size, NZUsize!(10));
 
             // Read some data to advance the position
             let mut buf = [0u8; 5];
@@ -338,8 +332,7 @@ mod tests {
             let size = data.len() as u64;
 
             // Create a buffer reader with small buffer
-            let buffer_size = 10;
-            let mut reader = Read::new(blob, size, buffer_size);
+            let mut reader = Read::new(blob, size, NZUsize!(10));
 
             // Read some data
             let mut buf = [0u8; 5];
@@ -376,8 +369,7 @@ mod tests {
             let data_len = data.len() as u64;
 
             // Create a buffer reader
-            let buffer_size = 10;
-            let reader = Read::new(blob.clone(), data_len, buffer_size);
+            let reader = Read::new(blob.clone(), data_len, NZUsize!(10));
 
             // Resize the blob to half its size
             let resize_len = data_len / 2;
@@ -388,7 +380,7 @@ mod tests {
             assert_eq!(size, resize_len, "Blob should be resized to half size");
 
             // Create a new buffer and read to verify truncation
-            let mut new_reader = Read::new(blob, size, buffer_size);
+            let mut new_reader = Read::new(blob, size, NZUsize!(10));
 
             // Read the content
             let mut buf = vec![0u8; size as usize];
@@ -411,7 +403,7 @@ mod tests {
             assert_eq!(new_size, data_len * 2);
 
             // Create a new buffer and read to verify resize
-            let mut new_reader = Read::new(blob, new_size, buffer_size);
+            let mut new_reader = Read::new(blob, new_size, NZUsize!(10));
             let mut buf = vec![0u8; new_size as usize];
             new_reader
                 .read_exact(&mut buf, new_size as usize)
@@ -437,8 +429,7 @@ mod tests {
             blob.write_at(data.to_vec(), 0).await.unwrap();
 
             // Create a buffer reader
-            let buffer_size = 10;
-            let reader = Read::new(blob.clone(), data_len, buffer_size);
+            let reader = Read::new(blob.clone(), data_len, NZUsize!(10));
 
             // Resize the blob to zero
             reader.resize(0).await.unwrap();
@@ -448,7 +439,7 @@ mod tests {
             assert_eq!(size, 0, "Blob should be resized to zero");
 
             // Create a new buffer and try to read (should fail)
-            let mut new_reader = Read::new(blob, size, buffer_size);
+            let mut new_reader = Read::new(blob, size, NZUsize!(10));
 
             // Reading from resized blob should fail
             let mut buf = [0u8; 1];
@@ -465,7 +456,7 @@ mod tests {
             let (blob, size) = context.open("partition", b"write_basic").await.unwrap();
             assert_eq!(size, 0);
 
-            let writer = Write::new(blob.clone(), size, 8);
+            let writer = Write::new(blob.clone(), size, NZUsize!(8));
             writer.write_at(b"hello".to_vec(), 0).await.unwrap();
             assert_eq!(writer.size().await, 5);
             writer.sync().await.unwrap();
@@ -474,7 +465,7 @@ mod tests {
             // Verify data was written correctly
             let (blob, size) = context.open("partition", b"write_basic").await.unwrap();
             assert_eq!(size, 5);
-            let mut reader = Read::new(blob, size, 8);
+            let mut reader = Read::new(blob, size, NZUsize!(8));
             let mut buf = [0u8; 5];
             reader.read_exact(&mut buf, 5).await.unwrap();
             assert_eq!(&buf, b"hello");
@@ -489,7 +480,7 @@ mod tests {
             let (blob, size) = context.open("partition", b"write_multi").await.unwrap();
             assert_eq!(size, 0);
 
-            let writer = Write::new(blob.clone(), size, 4);
+            let writer = Write::new(blob.clone(), size, NZUsize!(4));
             writer.write_at(b"abc".to_vec(), 0).await.unwrap();
             assert_eq!(writer.size().await, 3);
             writer.write_at(b"defg".to_vec(), 3).await.unwrap();
@@ -499,7 +490,7 @@ mod tests {
             // Verify the final result
             let (blob, size) = context.open("partition", b"write_multi").await.unwrap();
             assert_eq!(size, 7);
-            let mut reader = Read::new(blob, size, 4);
+            let mut reader = Read::new(blob, size, NZUsize!(4));
             let mut buf = [0u8; 7];
             reader.read_exact(&mut buf, 7).await.unwrap();
             assert_eq!(&buf, b"abcdefg");
@@ -514,7 +505,7 @@ mod tests {
             let (blob, size) = context.open("partition", b"write_large").await.unwrap();
             assert_eq!(size, 0);
 
-            let writer = Write::new(blob.clone(), size, 4);
+            let writer = Write::new(blob.clone(), size, NZUsize!(4));
             writer.write_at(b"abc".to_vec(), 0).await.unwrap();
             assert_eq!(writer.size().await, 3);
             writer
@@ -528,7 +519,7 @@ mod tests {
             // Verify the complete data
             let (blob, size) = context.open("partition", b"write_large").await.unwrap();
             assert_eq!(size, 26);
-            let mut reader = Read::new(blob, size, 4);
+            let mut reader = Read::new(blob, size, NZUsize!(4));
             let mut buf = [0u8; 26];
             reader.read_exact(&mut buf, 26).await.unwrap();
             assert_eq!(&buf, b"abcdefghijklmnopqrstuvwxyz");
@@ -543,7 +534,7 @@ mod tests {
             // Test that creating a writer with zero buffer capacity panics
             let (blob, size) = context.open("partition", b"write_empty").await.unwrap();
             assert_eq!(size, 0);
-            Write::new(blob, size, 0);
+            Write::new(blob, size, NZUsize!(0));
         });
     }
 
@@ -553,7 +544,7 @@ mod tests {
         executor.start(|context| async move {
             // Test sequential appends that exceed buffer capacity
             let (blob, size) = context.open("partition", b"append_buf").await.unwrap();
-            let writer = Write::new(blob.clone(), size, 10);
+            let writer = Write::new(blob.clone(), size, NZUsize!(10));
 
             // Write data that fits in buffer
             writer.write_at(b"hello".to_vec(), 0).await.unwrap();
@@ -567,7 +558,7 @@ mod tests {
             // Verify the complete result
             let (blob, size) = context.open("partition", b"append_buf").await.unwrap();
             assert_eq!(size, 11);
-            let mut reader = Read::new(blob, size, 10);
+            let mut reader = Read::new(blob, size, NZUsize!(10));
             let mut buf = vec![0u8; 11];
             reader.read_exact(&mut buf, 11).await.unwrap();
             assert_eq!(&buf, b"hello world");
@@ -580,7 +571,7 @@ mod tests {
         executor.start(|context| async move {
             // Test overwriting data within the buffer and extending it
             let (blob, size) = context.open("partition", b"middle_buf").await.unwrap();
-            let writer = Write::new(blob.clone(), size, 20);
+            let writer = Write::new(blob.clone(), size, NZUsize!(20));
 
             // Initial write
             writer.write_at(b"abcdefghij".to_vec(), 0).await.unwrap();
@@ -594,7 +585,7 @@ mod tests {
             // Verify overwrite result
             let (blob, size) = context.open("partition", b"middle_buf").await.unwrap();
             assert_eq!(size, 10);
-            let mut reader = Read::new(blob, size, 10);
+            let mut reader = Read::new(blob, size, NZUsize!(10));
             let mut buf = vec![0u8; 10];
             reader.read_exact(&mut buf, 10).await.unwrap();
             assert_eq!(&buf, b"ab01234hij");
@@ -609,7 +600,7 @@ mod tests {
             // Verify final result
             let (blob, size) = context.open("partition", b"middle_buf").await.unwrap();
             assert_eq!(size, 20);
-            let mut reader = Read::new(blob, size, 20);
+            let mut reader = Read::new(blob, size, NZUsize!(20));
             let mut buf = vec![0u8; 20];
             reader.read_exact(&mut buf, 20).await.unwrap();
             assert_eq!(&buf, b"ab01234hiwxyznopqrst");
@@ -622,7 +613,7 @@ mod tests {
         executor.start(|context| async move {
             // Test writing at offsets before the current buffer position
             let (blob, size) = context.open("partition", b"before_buf").await.unwrap();
-            let writer = Write::new(blob.clone(), size, 10);
+            let writer = Write::new(blob.clone(), size, NZUsize!(10));
 
             // Write data at a later offset first
             writer.write_at(b"0123456789".to_vec(), 10).await.unwrap();
@@ -636,7 +627,7 @@ mod tests {
             // Verify data placement with gap
             let (blob, size) = context.open("partition", b"before_buf").await.unwrap();
             assert_eq!(size, 20);
-            let mut reader = Read::new(blob, size, 20);
+            let mut reader = Read::new(blob, size, NZUsize!(20));
             let mut buf = vec![0u8; 20];
             reader.read_exact(&mut buf, 20).await.unwrap();
             let mut expected = vec![0u8; 20];
@@ -653,7 +644,7 @@ mod tests {
             // Verify gap is filled
             let (blob, size) = context.open("partition", b"before_buf").await.unwrap();
             assert_eq!(size, 20);
-            let mut reader = Read::new(blob, size, 20);
+            let mut reader = Read::new(blob, size, NZUsize!(20));
             let mut buf = vec![0u8; 20];
             reader.read_exact(&mut buf, 20).await.unwrap();
             expected[0..10].copy_from_slice("abcdefghij".as_bytes());
@@ -667,7 +658,7 @@ mod tests {
         executor.start(|context| async move {
             // Test blob resize functionality and subsequent writes
             let (blob, size) = context.open("partition", b"resize_write").await.unwrap();
-            let writer = Write::new(blob, size, 10);
+            let writer = Write::new(blob, size, NZUsize!(10));
 
             // Write initial data
             writer.write_at(b"hello world".to_vec(), 0).await.unwrap();
@@ -688,7 +679,7 @@ mod tests {
             // Verify resize
             let (blob, size) = context.open("partition", b"resize_write").await.unwrap();
             assert_eq!(size, 5);
-            let mut reader = Read::new(blob, size, 5);
+            let mut reader = Read::new(blob, size, NZUsize!(5));
             let mut buf = vec![0u8; 5];
             reader.read_exact(&mut buf, 5).await.unwrap();
             assert_eq!(&buf, b"hello");
@@ -701,7 +692,7 @@ mod tests {
             // Verify overwrite
             let (blob, size) = context.open("partition", b"resize_write").await.unwrap();
             assert_eq!(size, 5);
-            let mut reader = Read::new(blob, size, 5);
+            let mut reader = Read::new(blob, size, NZUsize!(5));
             let mut buf = vec![0u8; 5];
             reader.read_exact(&mut buf, 5).await.unwrap();
             assert_eq!(&buf, b"Xello");
@@ -714,7 +705,7 @@ mod tests {
             // Verify resize
             let (blob, size) = context.open("partition", b"resize_write").await.unwrap();
             assert_eq!(size, 10);
-            let mut reader = Read::new(blob, size, 10);
+            let mut reader = Read::new(blob, size, NZUsize!(10));
             let mut buf = vec![0u8; 10];
             reader.read_exact(&mut buf, 10).await.unwrap();
             assert_eq!(&buf[0..5], b"Xello");
@@ -722,7 +713,7 @@ mod tests {
 
             // Test resize to zero
             let (blob_zero, size) = context.open("partition", b"resize_zero").await.unwrap();
-            let writer_zero = Write::new(blob_zero.clone(), size, 10);
+            let writer_zero = Write::new(blob_zero.clone(), size, NZUsize!(10));
             writer_zero
                 .write_at(b"some data".to_vec(), 0)
                 .await
@@ -747,7 +738,7 @@ mod tests {
         executor.start(|context| async move {
             // Test reading through writer's read_at method (buffer + blob reads)
             let (blob, size) = context.open("partition", b"read_at_writer").await.unwrap();
-            let writer = Write::new(blob.clone(), size, 10);
+            let writer = Write::new(blob.clone(), size, NZUsize!(10));
 
             // Write data that stays in buffer
             writer.write_at(b"buffered".to_vec(), 0).await.unwrap();
@@ -800,7 +791,7 @@ mod tests {
             let (final_blob, final_size) =
                 context.open("partition", b"read_at_writer").await.unwrap();
             assert_eq!(final_size, 30);
-            let mut final_reader = Read::new(final_blob, final_size, 30);
+            let mut final_reader = Read::new(final_blob, final_size, NZUsize!(30));
             let mut full_content = vec![0u8; 30];
             final_reader
                 .read_exact(&mut full_content, 30)
@@ -816,7 +807,7 @@ mod tests {
         executor.start(|context| async move {
             // Test writes that cannot be merged into buffer (non-contiguous/too large)
             let (blob, size) = context.open("partition", b"write_straddle").await.unwrap();
-            let writer = Write::new(blob.clone(), size, 10);
+            let writer = Write::new(blob.clone(), size, NZUsize!(10));
 
             // Fill buffer completely
             writer.write_at(b"0123456789".to_vec(), 0).await.unwrap();
@@ -832,7 +823,7 @@ mod tests {
             let (blob_check, size_check) =
                 context.open("partition", b"write_straddle").await.unwrap();
             assert_eq!(size_check, 18);
-            let mut reader = Read::new(blob_check, size_check, 20);
+            let mut reader = Read::new(blob_check, size_check, NZUsize!(20));
             let mut buf = vec![0u8; 18];
             reader.read_exact(&mut buf, 18).await.unwrap();
 
@@ -843,7 +834,7 @@ mod tests {
 
             // Test write that exceeds buffer capacity
             let (blob2, size) = context.open("partition", b"write_straddle2").await.unwrap();
-            let writer2 = Write::new(blob2.clone(), size, 10);
+            let writer2 = Write::new(blob2.clone(), size, NZUsize!(10));
             writer2.write_at(b"0123456789".to_vec(), 0).await.unwrap();
             assert_eq!(writer2.size().await, 10);
 
@@ -857,7 +848,7 @@ mod tests {
             let (blob_check2, size_check2) =
                 context.open("partition", b"write_straddle2").await.unwrap();
             assert_eq!(size_check2, 17);
-            let mut reader2 = Read::new(blob_check2, size_check2, 20);
+            let mut reader2 = Read::new(blob_check2, size_check2, NZUsize!(20));
             let mut buf2 = vec![0u8; 17];
             reader2.read_exact(&mut buf2, 17).await.unwrap();
             assert_eq!(&buf2, b"01234ABCDEFGHIJKL");
@@ -870,7 +861,7 @@ mod tests {
         executor.start(|context| async move {
             // Test that closing writer flushes and persists buffered data
             let (blob_orig, size) = context.open("partition", b"write_close").await.unwrap();
-            let writer = Write::new(blob_orig.clone(), size, 8);
+            let writer = Write::new(blob_orig.clone(), size, NZUsize!(8));
             writer.write_at(b"pending".to_vec(), 0).await.unwrap();
             assert_eq!(writer.size().await, 7);
 
@@ -880,7 +871,7 @@ mod tests {
             // Verify data persistence
             let (blob_check, size_check) = context.open("partition", b"write_close").await.unwrap();
             assert_eq!(size_check, 7);
-            let mut reader = Read::new(blob_check, size_check, 8);
+            let mut reader = Read::new(blob_check, size_check, NZUsize!(8));
             let mut buf = [0u8; 7];
             reader.read_exact(&mut buf, 7).await.unwrap();
             assert_eq!(&buf, b"pending");
@@ -896,7 +887,7 @@ mod tests {
                 .open("partition", b"write_direct_size")
                 .await
                 .unwrap();
-            let writer = Write::new(blob.clone(), size, 5);
+            let writer = Write::new(blob.clone(), size, NZUsize!(5));
 
             // Write data larger than buffer capacity (should write directly)
             let data_large = b"0123456789";
@@ -912,7 +903,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(size_check, 10);
-            let mut reader = Read::new(blob_check, size_check, 10);
+            let mut reader = Read::new(blob_check, size_check, NZUsize!(10));
             let mut buf = vec![0u8; 10];
             reader.read_exact(&mut buf, 10).await.unwrap();
             assert_eq!(&buf, data_large.as_slice());
@@ -934,7 +925,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(size_check2, 13);
-            let mut reader2 = Read::new(blob_check2, size_check2, 13);
+            let mut reader2 = Read::new(blob_check2, size_check2, NZUsize!(13));
             let mut buf2 = vec![0u8; 13];
             reader2.read_exact(&mut buf2, 13).await.unwrap();
             assert_eq!(&buf2[10..], b"abc".as_slice());
@@ -950,7 +941,7 @@ mod tests {
                 .open("partition", b"overwrite_extend_buf")
                 .await
                 .unwrap();
-            let writer = Write::new(blob.clone(), size, 15);
+            let writer = Write::new(blob.clone(), size, NZUsize!(15));
 
             // Write initial data
             writer.write_at(b"0123456789".to_vec(), 0).await.unwrap();
@@ -973,7 +964,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(size_check, 15);
-            let mut reader = Read::new(blob_check, size_check, 15);
+            let mut reader = Read::new(blob_check, size_check, NZUsize!(15));
             let mut final_buf = vec![0u8; 15];
             reader.read_exact(&mut final_buf, 15).await.unwrap();
             assert_eq!(&final_buf, b"01234ABCDEFGHIJ".as_slice());
@@ -986,7 +977,7 @@ mod tests {
         executor.start(|context| async move {
             // Test writing at the current logical end of the blob
             let (blob, size) = context.open("partition", b"write_end").await.unwrap();
-            let writer = Write::new(blob.clone(), size, 20);
+            let writer = Write::new(blob.clone(), size, NZUsize!(20));
 
             // Write initial data
             writer.write_at(b"0123456789".to_vec(), 0).await.unwrap();
@@ -1004,7 +995,7 @@ mod tests {
             // Verify complete result
             let (blob_check, size_check) = context.open("partition", b"write_end").await.unwrap();
             assert_eq!(size_check, 13);
-            let mut reader = Read::new(blob_check, size_check, 13);
+            let mut reader = Read::new(blob_check, size_check, NZUsize!(13));
             let mut buf = vec![0u8; 13];
             reader.read_exact(&mut buf, 13).await.unwrap();
             assert_eq!(&buf, b"0123456789abc");
@@ -1020,7 +1011,7 @@ mod tests {
                 .open("partition", b"write_multiple_appends_at_size")
                 .await
                 .unwrap();
-            let writer = Write::new(blob.clone(), size, 5); // Small buffer
+            let writer = Write::new(blob.clone(), size, NZUsize!(5)); // Small buffer
 
             // First write
             writer.write_at(b"AAA".to_vec(), 0).await.unwrap();
@@ -1052,7 +1043,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(size_check, 9);
-            let mut reader = Read::new(blob_check, size_check, 9);
+            let mut reader = Read::new(blob_check, size_check, NZUsize!(9));
             let mut buf = vec![0u8; 9];
             reader.read_exact(&mut buf, 9).await.unwrap();
             assert_eq!(&buf, b"AAABBBCCC");
@@ -1068,7 +1059,7 @@ mod tests {
                 .open("partition", b"write_non_contiguous_then_append")
                 .await
                 .unwrap();
-            let writer = Write::new(blob.clone(), size, 10);
+            let writer = Write::new(blob.clone(), size, NZUsize!(10));
 
             // Initial buffered write
             writer.write_at(b"INITIAL".to_vec(), 0).await.unwrap(); // 7 bytes
@@ -1096,7 +1087,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(size_check, 35);
-            let mut reader = Read::new(blob_check, size_check, 35);
+            let mut reader = Read::new(blob_check, size_check, NZUsize!(35));
             let mut buf = vec![0u8; 35];
             reader.read_exact(&mut buf, 35).await.unwrap();
 
@@ -1117,7 +1108,7 @@ mod tests {
                 .open("partition", b"resize_then_append_at_size")
                 .await
                 .unwrap();
-            let writer = Write::new(blob.clone(), size, 10);
+            let writer = Write::new(blob.clone(), size, NZUsize!(10));
 
             // Write initial data and sync
             writer
@@ -1153,7 +1144,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(size_check, 10);
-            let mut reader = Read::new(blob_check, size_check, 10);
+            let mut reader = Read::new(blob_check, size_check, NZUsize!(10));
             let mut buf = vec![0u8; 10];
             reader.read_exact(&mut buf, 10).await.unwrap();
             assert_eq!(&buf, b"01234XXXXX");

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -58,23 +58,6 @@ mod tests {
     }
 
     #[test_traced]
-    #[should_panic(expected = "buffer size must be greater than zero")]
-    fn test_read_empty() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            // Test that creating a reader with zero buffer size panics
-            let data = b"Hello, world! This is a test.";
-            let (blob, size) = context.open("partition", b"test").await.unwrap();
-            assert_eq!(size, 0);
-            blob.write_at(data.to_vec(), 0).await.unwrap();
-            let size = data.len() as u64;
-
-            // This should panic
-            Read::new(blob, size, NZUsize!(0));
-        });
-    }
-
-    #[test_traced]
     fn test_read_cross_boundary() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -523,18 +506,6 @@ mod tests {
             let mut buf = [0u8; 26];
             reader.read_exact(&mut buf, 26).await.unwrap();
             assert_eq!(&buf, b"abcdefghijklmnopqrstuvwxyz");
-        });
-    }
-
-    #[test_traced]
-    #[should_panic(expected = "buffer capacity must be greater than zero")]
-    fn test_write_empty() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            // Test that creating a writer with zero buffer capacity panics
-            let (blob, size) = context.open("partition", b"write_empty").await.unwrap();
-            assert_eq!(size, 0);
-            Write::new(blob, size, NZUsize!(0));
         });
     }
 

--- a/runtime/src/utils/buffer/pool.rs
+++ b/runtime/src/utils/buffer/pool.rs
@@ -4,6 +4,7 @@ use futures::{future::Shared, FutureExt};
 use std::{
     collections::{hash_map::Entry, HashMap},
     future::Future,
+    num::NonZeroUsize,
     pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -83,10 +84,10 @@ pub struct PoolRef {
 
 impl PoolRef {
     /// Returns a new [PoolRef] with the given `page_size` and `capacity`.
-    pub fn new(page_size: usize, capacity: usize) -> Self {
+    pub fn new(page_size: NonZeroUsize, capacity: NonZeroUsize) -> Self {
         Self {
-            page_size,
-            pool: Arc::new(RwLock::new(Pool::new(capacity))),
+            page_size: page_size.get(),
+            pool: Arc::new(RwLock::new(Pool::new(capacity.get()))),
         }
     }
 
@@ -371,6 +372,7 @@ mod tests {
     use super::*;
     use crate::{deterministic, Runner as _, Storage as _};
     use commonware_macros::test_traced;
+    use commonware_utils::NZUsize;
 
     const PAGE_SIZE: usize = 1024;
 
@@ -435,7 +437,7 @@ mod tests {
             }
 
             // Fill the buffer pool with the blob's data.
-            let pool_ref = PoolRef::new(PAGE_SIZE, 10);
+            let pool_ref = PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(10));
             for i in 0..11 {
                 let mut buf = vec![0; PAGE_SIZE];
                 pool_ref

--- a/runtime/src/utils/buffer/read.rs
+++ b/runtime/src/utils/buffer/read.rs
@@ -1,5 +1,6 @@
 use crate::{Blob, Error};
 use commonware_utils::StableBuf;
+use std::num::NonZeroUsize;
 
 /// A reader that buffers content from a [Blob] to optimize the performance
 /// of a full scan of contents.
@@ -53,16 +54,15 @@ impl<B: Blob> Read<B> {
     /// # Panics
     ///
     /// Panics if `buffer_size` is zero.
-    pub fn new(blob: B, blob_size: u64, buffer_size: usize) -> Self {
-        assert!(buffer_size > 0, "buffer size must be greater than zero");
+    pub fn new(blob: B, blob_size: u64, buffer_size: NonZeroUsize) -> Self {
         Self {
             blob,
-            buffer: vec![0; buffer_size].into(),
+            buffer: vec![0; buffer_size.get()].into(),
             blob_position: 0,
             blob_size,
             buffer_position: 0,
             buffer_valid_len: 0,
-            buffer_size,
+            buffer_size: buffer_size.get(),
         }
     }
 

--- a/runtime/src/utils/buffer/read.rs
+++ b/runtime/src/utils/buffer/read.rs
@@ -8,6 +8,7 @@ use std::num::NonZeroUsize;
 /// # Example
 ///
 /// ```
+/// use commonware_utils::NZUsize;
 /// use commonware_runtime::{Runner, buffer::Read, Blob, Error, Storage, deterministic};
 ///
 /// let executor = deterministic::Runner::default();
@@ -20,7 +21,7 @@ use std::num::NonZeroUsize;
 ///
 ///     // Create a buffer
 ///     let buffer = 64 * 1024;
-///     let mut reader = Read::new(blob, size, buffer);
+///     let mut reader = Read::new(blob, size, NZUsize!(buffer));
 ///
 ///     // Read data sequentially
 ///     let mut header = [0u8; 16];

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 /// A buffer for caching data written to the tip of a blob.
 ///
 /// The buffer always represents data at the "tip" of the logical blob, starting at `offset` and
@@ -18,11 +20,11 @@ pub(super) struct Buffer {
 
 impl Buffer {
     /// Creates a new buffer with the provided `size` and `capacity`.
-    pub(super) fn new(size: u64, capacity: usize) -> Self {
+    pub(super) fn new(size: u64, capacity: NonZeroUsize) -> Self {
         Self {
-            data: Vec::with_capacity(capacity),
+            data: Vec::with_capacity(capacity.get()),
             offset: size,
-            capacity,
+            capacity: capacity.get(),
         }
     }
 
@@ -158,10 +160,11 @@ impl Buffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use commonware_utils::NZUsize;
 
     #[test]
     fn test_tip_append() {
-        let mut buffer = Buffer::new(50, 100);
+        let mut buffer = Buffer::new(50, NZUsize!(100));
         assert_eq!(buffer.size(), 50);
         assert!(buffer.is_empty());
         assert_eq!(buffer.take(), None);
@@ -190,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_tip_resize() {
-        let mut buffer = Buffer::new(50, 100);
+        let mut buffer = Buffer::new(50, NZUsize!(100));
         buffer.append(&[1, 2, 3]);
         assert_eq!(buffer.size(), 53);
 

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -9,6 +9,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 ///
 /// ```
 /// use commonware_runtime::{Runner, buffer::{Write, Read}, Blob, Error, Storage, deterministic};
+/// use commonware_utils::NZUsize;
 ///
 /// let executor = deterministic::Runner::default();
 /// executor.start(|context| async move {
@@ -17,7 +18,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 ///     assert_eq!(size, 0);
 ///
 ///     // Create a buffered writer with 16-byte buffer
-///     let mut blob = Write::new(blob, 0, 16);
+///     let mut blob = Write::new(blob, 0, NZUsize!(16));
 ///     blob.write_at(b"hello".to_vec(), 0).await.expect("write failed");
 ///     blob.sync().await.expect("sync failed");
 ///
@@ -28,7 +29,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 ///
 ///     // Read back the data to verify
 ///     let (blob, size) = context.open("my_partition", b"my_data").await.expect("unable to reopen blob");
-///     let mut reader = Read::new(blob, size, 8);
+///     let mut reader = Read::new(blob, size, NZUsize!(8));
 ///     let mut buf = vec![0u8; size as usize];
 ///     reader.read_exact(&mut buf, size as usize).await.expect("read failed");
 ///     assert_eq!(&buf, b"hello world!");

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -1,6 +1,6 @@
 use crate::{buffer::tip::Buffer, Blob, Error, RwLock};
 use commonware_utils::StableBuf;
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 /// A writer that buffers content to a [Blob] to optimize the performance
 /// of appending or updating data.
@@ -50,9 +50,7 @@ impl<B: Blob> Write<B> {
     /// # Panics
     ///
     /// Panics if `capacity` is zero.
-    pub fn new(blob: B, size: u64, capacity: usize) -> Self {
-        assert!(capacity > 0, "buffer capacity must be greater than zero");
-
+    pub fn new(blob: B, size: u64, capacity: NonZeroUsize) -> Self {
         Self {
             blob,
             buffer: Arc::new(RwLock::new(Buffer::new(size, capacity))),

--- a/storage/fuzz/fuzz_targets/adb_current_operations.rs
+++ b/storage/fuzz/fuzz_targets/adb_current_operations.rs
@@ -53,7 +53,7 @@ fn fuzz(data: FuzzInput) {
             log_write_buffer: NZUsize!(1024),
             bitmap_metadata_partition: "fuzz_current_bitmap_metadata".into(),
             translator: TwoCap,
-            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             thread_pool: None,
             pruning_delay: 10,
         };

--- a/storage/fuzz/fuzz_targets/adb_current_operations.rs
+++ b/storage/fuzz/fuzz_targets/adb_current_operations.rs
@@ -8,7 +8,7 @@ use commonware_storage::{
     mmr::hasher::{Hasher, Standard},
     translator::TwoCap,
 };
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{sequence::FixedBytes, NZUsize};
 use libfuzzer_sys::fuzz_target;
 use std::collections::HashMap;
 
@@ -47,10 +47,10 @@ fn fuzz(data: FuzzInput) {
             mmr_journal_partition: "fuzz_current_mmr_journal".into(),
             mmr_metadata_partition: "fuzz_current_mmr_metadata".into(),
             mmr_items_per_blob: 11,
-            mmr_write_buffer: 1024,
+            mmr_write_buffer: NZUsize!(1024),
             log_journal_partition: "fuzz_current_log_journal".into(),
             log_items_per_blob: 7,
-            log_write_buffer: 1024,
+            log_write_buffer: NZUsize!(1024),
             bitmap_metadata_partition: "fuzz_current_bitmap_metadata".into(),
             translator: TwoCap,
             buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),

--- a/storage/fuzz/fuzz_targets/adb_operations.rs
+++ b/storage/fuzz/fuzz_targets/adb_operations.rs
@@ -52,7 +52,7 @@ fn fuzz(data: FuzzInput) {
             log_write_buffer: NZUsize!(1024),
             translator: EightCap,
             thread_pool: None,
-            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             pruning_delay: 10,
         };
 

--- a/storage/fuzz/fuzz_targets/adb_operations.rs
+++ b/storage/fuzz/fuzz_targets/adb_operations.rs
@@ -8,7 +8,7 @@ use commonware_storage::{
     mmr::hasher::Standard,
     translator::EightCap,
 };
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{sequence::FixedBytes, NZUsize};
 use libfuzzer_sys::fuzz_target;
 use std::collections::{HashMap, HashSet};
 
@@ -45,11 +45,11 @@ fn fuzz(data: FuzzInput) {
         let cfg = Config::<EightCap> {
             mmr_journal_partition: "test_adb_mmr_journal".into(),
             mmr_items_per_blob: 500000,
-            mmr_write_buffer: 1024,
+            mmr_write_buffer: NZUsize!(1024),
             mmr_metadata_partition: "test_adb_mmr_metadata".into(),
             log_journal_partition: "test_adb_log_journal".into(),
             log_items_per_blob: 500000,
-            log_write_buffer: 1024,
+            log_write_buffer: NZUsize!(1024),
             translator: EightCap,
             thread_pool: None,
             buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),

--- a/storage/fuzz/fuzz_targets/adb_sync.rs
+++ b/storage/fuzz/fuzz_targets/adb_sync.rs
@@ -11,7 +11,7 @@ use commonware_storage::{
     mmr::hasher::Standard,
     translator::TwoCap,
 };
-use commonware_utils::{sequence::FixedBytes, NZU64};
+use commonware_utils::{sequence::FixedBytes, NZUsize, NZU64};
 use libfuzzer_sys::fuzz_target;
 use std::sync::Arc;
 
@@ -42,10 +42,10 @@ fn test_config(test_name: &str, pruning_delay: u64) -> Config<TwoCap> {
         mmr_journal_partition: format!("{test_name}_mmr"),
         mmr_metadata_partition: format!("{test_name}_meta"),
         mmr_items_per_blob: 3,
-        mmr_write_buffer: 1024,
+        mmr_write_buffer: NZUsize!(1024),
         log_journal_partition: format!("{test_name}_log"),
         log_items_per_blob: 3,
-        log_write_buffer: 1024,
+        log_write_buffer: NZUsize!(1024),
         translator: TwoCap,
         thread_pool: None,
         buffer_pool: PoolRef::new(PAGE_SIZE, 1),

--- a/storage/fuzz/fuzz_targets/adb_sync.rs
+++ b/storage/fuzz/fuzz_targets/adb_sync.rs
@@ -48,7 +48,7 @@ fn test_config(test_name: &str, pruning_delay: u64) -> Config<TwoCap> {
         log_write_buffer: NZUsize!(1024),
         translator: TwoCap,
         thread_pool: None,
-        buffer_pool: PoolRef::new(PAGE_SIZE, 1),
+        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(1)),
         pruning_delay: (pruning_delay % 1000) + 1,
     }
 }

--- a/storage/fuzz/fuzz_targets/archive_operations.rs
+++ b/storage/fuzz/fuzz_targets/archive_operations.rs
@@ -9,7 +9,7 @@ use commonware_storage::{
     },
     translator::EightCap,
 };
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{sequence::FixedBytes, NZUsize};
 use libfuzzer_sys::fuzz_target;
 
 type Key = FixedBytes<16>;
@@ -46,9 +46,9 @@ fn fuzz(data: FuzzInput) {
         let cfg = Config {
             partition: "test".into(),
             items_per_section: 1024,
-            write_buffer: 1024,
+            write_buffer: NZUsize!(1024),
             translator: EightCap,
-            replay_buffer: 1024*1024,
+            replay_buffer: NZUsize!(1024*1024),
             compression: None,
             codec_config: (),
         };

--- a/storage/fuzz/fuzz_targets/freezer_operations.rs
+++ b/storage/fuzz/fuzz_targets/freezer_operations.rs
@@ -3,7 +3,7 @@
 use arbitrary::Arbitrary;
 use commonware_runtime::{deterministic, Runner};
 use commonware_storage::freezer::{Config, Freezer, Identifier};
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{sequence::FixedBytes, NZUsize};
 use libfuzzer_sys::fuzz_target;
 use std::collections::HashMap;
 
@@ -35,13 +35,13 @@ fn fuzz(input: FuzzInput) {
         let cfg = Config {
             journal_partition: "fuzz_journal".into(),
             journal_compression: None,
-            journal_write_buffer: 1024 * 1024,
+            journal_write_buffer: NZUsize!(1024 * 1024),
             journal_target_size: 10 * 1024 * 1024,
             table_partition: "fuzz_table".into(),
             table_initial_size: 256,
             table_resize_frequency: 4,
             table_resize_chunk_size: 128,
-            table_replay_buffer: 64 * 1024,
+            table_replay_buffer: NZUsize!(64 * 1024),
             codec_config: (),
         };
         let mut freezer = Freezer::<_, FixedBytes<32>, i32>::init(context.clone(), cfg.clone())

--- a/storage/fuzz/fuzz_targets/journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/journal_operations.rs
@@ -76,13 +76,13 @@ fn fuzz(input: FuzzInput) {
                 partition: "fixed_journal_operations_fuzz_test".to_string(),
                 items_per_blob: 3,
                 write_buffer: NZUsize!(MAX_WRITE_BUF),
-                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             },
             JournalType::Variable => VariableConfig {
                 partition: "variable_journal_operations_fuzz_test".to_string(),
                 items_per_blob: 3,
                 write_buffer: NZUsize!(MAX_WRITE_BUF),
-                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             },
         };
 

--- a/storage/fuzz/fuzz_targets/journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/journal_operations.rs
@@ -10,6 +10,7 @@ use commonware_storage::journal::{
     },
     Error,
 };
+use commonware_utils::NZUsize;
 use futures::{pin_mut, StreamExt};
 use libfuzzer_sys::fuzz_target;
 
@@ -74,13 +75,13 @@ fn fuzz(input: FuzzInput) {
             JournalType::Fixed => FixedConfig {
                 partition: "fixed_journal_operations_fuzz_test".to_string(),
                 items_per_blob: 3,
-                write_buffer: MAX_WRITE_BUF,
+                write_buffer: NZUsize!(MAX_WRITE_BUF),
                 buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             },
             JournalType::Variable => VariableConfig {
                 partition: "variable_journal_operations_fuzz_test".to_string(),
                 items_per_blob: 3,
-                write_buffer: MAX_WRITE_BUF,
+                write_buffer: NZUsize!(MAX_WRITE_BUF),
                 buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             },
         };
@@ -136,7 +137,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 JournalOperation::Replay { buffer, start_pos } => {
-                    match journal.replay(*buffer, *start_pos).await {
+                    match journal.replay(NZUsize!(*buffer), *start_pos).await {
                         Ok(stream) => {
                             pin_mut!(stream);
                             // Consume first few items to test stream - panic on stream errors

--- a/storage/fuzz/fuzz_targets/rmap_operations.rs
+++ b/storage/fuzz/fuzz_targets/rmap_operations.rs
@@ -44,9 +44,7 @@ fn fuzz(data: FuzzInput) {
 
                 // Verify removal
                 for value in start..=end.min(start.saturating_add(1000)) {
-                    let range = rmap.get(&value);
-                    if range.is_some() {
-                        let (range_start, range_end) = range.unwrap();
+                    if let Some((range_start, range_end)) = rmap.get(&value) {
                         // The value should not be in a range that was fully contained in [start, end]
                         assert!(
                             !(range_start >= start && range_end <= end),

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -887,7 +887,7 @@ pub(crate) mod tests {
             log_write_buffer: NZUsize!(64),
             translator: TestTranslator::default(),
             thread_pool: None,
-            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             pruning_delay: 100,
         }
     }

--- a/storage/src/adb/any/sync/client.rs
+++ b/storage/src/adb/any/sync/client.rs
@@ -857,7 +857,7 @@ pub(crate) mod tests {
     use commonware_cryptography::{sha256::Digest, Digest as _, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{buffer::PoolRef, deterministic, Runner as _};
-    use commonware_utils::NZU64;
+    use commonware_utils::{NZUsize, NZU64};
     use futures::{channel::mpsc, SinkExt as _};
     use rand::{rngs::StdRng, RngCore as _, SeedableRng as _};
     use std::{
@@ -881,10 +881,10 @@ pub(crate) mod tests {
             mmr_journal_partition: format!("mmr_journal_{seed}"),
             mmr_metadata_partition: format!("mmr_metadata_{seed}"),
             mmr_items_per_blob: 1024,
-            mmr_write_buffer: 64,
+            mmr_write_buffer: NZUsize!(64),
             log_journal_partition: format!("log_journal_{seed}"),
             log_items_per_blob: 1024,
-            log_write_buffer: 64,
+            log_write_buffer: NZUsize!(64),
             translator: TestTranslator::default(),
             thread_pool: None,
             buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),

--- a/storage/src/adb/any/variable.rs
+++ b/storage/src/adb/any/variable.rs
@@ -23,9 +23,9 @@ use crate::{
 use commonware_codec::{Codec, Encode as _, Read};
 use commonware_cryptography::Hasher as CHasher;
 use commonware_runtime::{buffer::PoolRef, Clock, Metrics, Storage as RStorage, ThreadPool};
-use commonware_utils::{sequence::U32, Array};
+use commonware_utils::{sequence::U32, Array, NZUsize};
 use futures::{future::TryFutureExt, pin_mut, try_join, StreamExt};
-use std::collections::HashMap;
+use std::{collections::HashMap, num::NonZeroUsize};
 use tracing::{debug, warn};
 
 /// The size of the read buffer to use for replaying the operations log when rebuilding the
@@ -42,7 +42,7 @@ pub struct Config<T: Translator, C> {
     pub mmr_items_per_blob: u64,
 
     /// The size of the write buffer to use for each blob in the MMR journal.
-    pub mmr_write_buffer: usize,
+    pub mmr_write_buffer: NonZeroUsize,
 
     /// The name of the [RStorage] partition used for the MMR's metadata.
     pub mmr_metadata_partition: String,
@@ -51,7 +51,7 @@ pub struct Config<T: Translator, C> {
     pub log_journal_partition: String,
 
     /// The size of the write buffer to use for each blob in the log journal.
-    pub log_write_buffer: usize,
+    pub log_write_buffer: NonZeroUsize,
 
     /// Optional compression level (using `zstd`) to apply to log data before storing.
     pub log_compression: Option<u8>,
@@ -237,7 +237,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         // Replay the log from inception to build the snapshot, keeping track of any uncommitted
         // operations, and any log operations that need to be re-added to the MMR & locations.
         {
-            let stream = self.log.replay(SNAPSHOT_READ_BUFFER_SIZE).await?;
+            let stream = self.log.replay(NZUsize!(SNAPSHOT_READ_BUFFER_SIZE)).await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 match result {
@@ -794,17 +794,17 @@ pub(super) mod test {
             mmr_journal_partition: format!("journal_{suffix}"),
             mmr_metadata_partition: format!("metadata_{suffix}"),
             mmr_items_per_blob: 11,
-            mmr_write_buffer: 1024,
+            mmr_write_buffer: NZUsize!(1024),
             log_journal_partition: format!("log_journal_{suffix}"),
             log_items_per_section: 7,
-            log_write_buffer: 1024,
+            log_write_buffer: NZUsize!(1024),
             log_compression: None,
             log_codec_config: ((0..=10000).into(), ()),
             locations_journal_partition: format!("locations_journal_{suffix}"),
             locations_items_per_blob: 7,
             translator: TwoCap,
             thread_pool: None,
-            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
         }
     }
 

--- a/storage/src/adb/benches/any_init.rs
+++ b/storage/src/adb/benches/any_init.rs
@@ -45,7 +45,7 @@ fn any_cfg(pool: ThreadPool) -> AConfig<EightCap> {
         log_write_buffer: NZUsize!(1024),
         translator: EightCap,
         thread_pool: Some(pool),
-        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
         pruning_delay: 10,
     }
 }

--- a/storage/src/adb/benches/any_init.rs
+++ b/storage/src/adb/benches/any_init.rs
@@ -10,6 +10,7 @@ use commonware_storage::{
     adb::any::fixed::{Any, Config as AConfig},
     translator::EightCap,
 };
+use commonware_utils::NZUsize;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use std::time::Instant;
@@ -38,10 +39,10 @@ fn any_cfg(pool: ThreadPool) -> AConfig<EightCap> {
         mmr_journal_partition: format!("journal_{PARTITION_SUFFIX}"),
         mmr_metadata_partition: format!("metadata_{PARTITION_SUFFIX}"),
         mmr_items_per_blob: ITEMS_PER_BLOB,
-        mmr_write_buffer: 1024,
+        mmr_write_buffer: NZUsize!(1024),
         log_journal_partition: format!("log_journal_{PARTITION_SUFFIX}"),
         log_items_per_blob: ITEMS_PER_BLOB,
-        log_write_buffer: 1024,
+        log_write_buffer: NZUsize!(1024),
         translator: EightCap,
         thread_pool: Some(pool),
         buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -761,7 +761,7 @@ pub mod test {
             bitmap_metadata_partition: format!("{partition_prefix}_bitmap_metadata_partition"),
             translator: TwoCap,
             thread_pool: None,
-            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             pruning_delay: 10,
         }
     }

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -25,6 +25,7 @@ use commonware_cryptography::Hasher as CHasher;
 use commonware_runtime::{buffer::PoolRef, Clock, Metrics, Storage as RStorage, ThreadPool};
 use commonware_utils::Array;
 use futures::future::try_join_all;
+use std::num::NonZeroUsize;
 use tracing::{debug, warn};
 
 /// Configuration for a [Current] authenticated db.
@@ -37,7 +38,7 @@ pub struct Config<T: Translator> {
     pub mmr_items_per_blob: u64,
 
     /// The size of the write buffer to use for each blob in the MMR journal.
-    pub mmr_write_buffer: usize,
+    pub mmr_write_buffer: NonZeroUsize,
 
     /// The name of the [RStorage] partition used for the MMR's metadata.
     pub mmr_metadata_partition: String,
@@ -49,7 +50,7 @@ pub struct Config<T: Translator> {
     pub log_items_per_blob: u64,
 
     /// The size of the write buffer to use for each blob in the log journal.
-    pub log_write_buffer: usize,
+    pub log_write_buffer: NonZeroUsize,
 
     /// The name of the [RStorage] partition used for the bitmap metadata.
     pub bitmap_metadata_partition: String,
@@ -742,6 +743,7 @@ pub mod test {
     use commonware_cryptography::{hash, sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Runner as _};
+    use commonware_utils::NZUsize;
     use rand::{rngs::StdRng, RngCore, SeedableRng};
 
     const PAGE_SIZE: usize = 88;
@@ -752,10 +754,10 @@ pub mod test {
             mmr_journal_partition: format!("{partition_prefix}_journal_partition"),
             mmr_metadata_partition: format!("{partition_prefix}_metadata_partition"),
             mmr_items_per_blob: 11,
-            mmr_write_buffer: 1024,
+            mmr_write_buffer: NZUsize!(1024),
             log_journal_partition: format!("{partition_prefix}_partition_prefix"),
             log_items_per_blob: 7,
-            log_write_buffer: 1024,
+            log_write_buffer: NZUsize!(1024),
             bitmap_metadata_partition: format!("{partition_prefix}_bitmap_metadata_partition"),
             translator: TwoCap,
             thread_pool: None,

--- a/storage/src/adb/immutable.rs
+++ b/storage/src/adb/immutable.rs
@@ -662,7 +662,7 @@ pub(super) mod test {
             locations_items_per_blob: 7,
             translator: TwoCap,
             thread_pool: None,
-            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
         }
     }
 

--- a/storage/src/adb/immutable.rs
+++ b/storage/src/adb/immutable.rs
@@ -20,8 +20,9 @@ use crate::{
 use commonware_codec::{Codec, Encode as _, Read};
 use commonware_cryptography::Hasher as CHasher;
 use commonware_runtime::{buffer::PoolRef, Clock, Metrics, Storage as RStorage, ThreadPool};
-use commonware_utils::{sequence::U32, Array};
+use commonware_utils::{sequence::U32, Array, NZUsize};
 use futures::{future::TryFutureExt, pin_mut, try_join, StreamExt};
+use std::num::NonZeroUsize;
 use tracing::warn;
 
 /// The size of the read buffer to use for replaying the operations log when rebuilding the
@@ -39,7 +40,7 @@ pub struct Config<T: Translator, C> {
     pub mmr_items_per_blob: u64,
 
     /// The size of the write buffer to use for each blob in the MMR journal.
-    pub mmr_write_buffer: usize,
+    pub mmr_write_buffer: NonZeroUsize,
 
     /// The name of the [RStorage] partition used for the MMR's metadata.
     pub mmr_metadata_partition: String,
@@ -48,7 +49,7 @@ pub struct Config<T: Translator, C> {
     pub log_journal_partition: String,
 
     /// The size of the write buffer to use for each blob in the log journal.
-    pub log_write_buffer: usize,
+    pub log_write_buffer: NonZeroUsize,
 
     /// Optional compression level (using `zstd`) to apply to log data before storing.
     pub log_compression: Option<u8>,
@@ -240,7 +241,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         // operations that must be rolled back, and any log operations that need to be re-added to
         // the MMR & locations.
         {
-            let stream = log.replay(SNAPSHOT_READ_BUFFER_SIZE).await?;
+            let stream = log.replay(NZUsize!(SNAPSHOT_READ_BUFFER_SIZE)).await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 match result {
@@ -640,6 +641,7 @@ pub(super) mod test {
         deterministic::{self},
         Runner as _,
     };
+    use commonware_utils::NZUsize;
 
     const PAGE_SIZE: usize = 77;
     const PAGE_CACHE_SIZE: usize = 9;
@@ -650,12 +652,12 @@ pub(super) mod test {
             mmr_journal_partition: format!("journal_{suffix}"),
             mmr_metadata_partition: format!("metadata_{suffix}"),
             mmr_items_per_blob: 11,
-            mmr_write_buffer: 1024,
+            mmr_write_buffer: NZUsize!(1024),
             log_journal_partition: format!("log_journal_{suffix}"),
             log_items_per_section: ITEMS_PER_SECTION,
             log_compression: None,
             log_codec_config: ((0..=10000).into(), ()),
-            log_write_buffer: 1024,
+            log_write_buffer: NZUsize!(1024),
             locations_journal_partition: format!("locations_journal_{suffix}"),
             locations_items_per_blob: 7,
             translator: TwoCap,

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -5,7 +5,7 @@ use commonware_storage::{
     archive::{immutable, prunable, Archive as ArchiveTrait, Identifier},
     translator::TwoCap,
 };
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{sequence::FixedBytes, NZUsize};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
 /// Number of bytes that can be buffered in a section before being written to a
@@ -61,8 +61,8 @@ impl Archive {
                     freezer_journal_compression: compression,
                     ordinal_partition: "archive_bench_ordinal".into(),
                     items_per_section: ITEMS_PER_SECTION,
-                    write_buffer: WRITE_BUFFER,
-                    replay_buffer: REPLAY_BUFFER,
+                    write_buffer: NZUsize!(WRITE_BUFFER),
+                    replay_buffer: NZUsize!(REPLAY_BUFFER),
                     codec_config: (),
                 };
                 Archive::Immutable(immutable::Archive::init(ctx, cfg).await.unwrap())
@@ -74,8 +74,8 @@ impl Archive {
                     compression,
                     codec_config: (),
                     items_per_section: ITEMS_PER_SECTION,
-                    write_buffer: WRITE_BUFFER,
-                    replay_buffer: REPLAY_BUFFER,
+                    write_buffer: NZUsize!(WRITE_BUFFER),
+                    replay_buffer: NZUsize!(REPLAY_BUFFER),
                 };
                 Archive::Prunable(prunable::Archive::init(ctx, cfg).await.unwrap())
             }

--- a/storage/src/archive/immutable/mod.rs
+++ b/storage/src/archive/immutable/mod.rs
@@ -32,6 +32,7 @@
 //!         immutable::{Archive, Config},
 //!     },
 //! };
+//! use commonware_utils::NZUsize;
 //!
 //! let executor = deterministic::Runner::default();
 //! executor.start(|context| async move {
@@ -47,8 +48,8 @@
 //!         freezer_journal_compression: Some(3),
 //!         ordinal_partition: "ordinal".into(),
 //!         items_per_section: 1024,
-//!         write_buffer: 1024,
-//!         replay_buffer: 1024,
+//!         write_buffer: NZUsize!(1024),
+//!         replay_buffer: NZUsize!(1024),
 //!         codec_config: (),
 //!     };
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
@@ -61,6 +62,7 @@
 //! });
 
 mod storage;
+use std::num::NonZeroUsize;
 pub use storage::Archive;
 
 /// Configuration for [Archive] storage.
@@ -98,10 +100,10 @@ pub struct Config<C> {
 
     /// The amount of bytes that can be buffered in a section before being written to a
     /// [commonware_runtime::Blob].
-    pub write_buffer: usize,
+    pub write_buffer: NonZeroUsize,
 
     /// The buffer size to use when replaying a [commonware_runtime::Blob].
-    pub replay_buffer: usize,
+    pub replay_buffer: NonZeroUsize,
 
     /// The [commonware_codec::Codec] configuration to use for the value stored in the archive.
     pub codec_config: C,
@@ -113,6 +115,7 @@ mod tests {
     use crate::archive::Archive as ArchiveTrait;
     use commonware_cryptography::{hash, sha256::Digest};
     use commonware_runtime::{deterministic, Runner};
+    use commonware_utils::NZUsize;
 
     #[test]
     fn test_unclean_shutdown() {
@@ -129,8 +132,8 @@ mod tests {
                 freezer_journal_compression: Some(3),
                 ordinal_partition: "test_ordinal2".into(),
                 items_per_section: 512,
-                write_buffer: 1024,
-                replay_buffer: 1024,
+                write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(1024),
                 codec_config: (),
             };
 

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -108,7 +108,7 @@ mod tests {
         deterministic::{self, Context},
         Runner,
     };
-    use commonware_utils::sequence::FixedBytes;
+    use commonware_utils::{sequence::FixedBytes, NZUsize};
     use rand::Rng;
     use std::collections::BTreeMap;
 
@@ -130,8 +130,8 @@ mod tests {
             compression,
             codec_config: (),
             items_per_section: 1024,
-            write_buffer: 1024,
-            replay_buffer: 1024,
+            write_buffer: NZUsize!(1024),
+            replay_buffer: NZUsize!(1024),
         };
         prunable::Archive::init(context, cfg).await.unwrap()
     }
@@ -151,8 +151,8 @@ mod tests {
             freezer_journal_compression: compression,
             ordinal_partition: "test_ordinal".into(),
             items_per_section: 1024,
-            write_buffer: 1024 * 1024,
-            replay_buffer: 1024 * 1024,
+            write_buffer: NZUsize!(1024 * 1024),
+            replay_buffer: NZUsize!(1024 * 1024),
             codec_config: (),
         };
         immutable::Archive::init(context, cfg).await.unwrap()

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -111,6 +111,7 @@
 //!         prunable::{Archive, Config},
 //!     },
 //! };
+//! use commonware_utils::NZUsize;
 //!
 //! let executor = deterministic::Runner::default();
 //! executor.start(|context| async move {
@@ -121,8 +122,8 @@
 //!         compression: Some(3),
 //!         codec_config: (),
 //!         items_per_section: 1024,
-//!         write_buffer: 1024 * 1024,
-//!         replay_buffer: 4096,
+//!         write_buffer: NZUsize!(1024 * 1024),
+//!         replay_buffer: NZUsize!(4096),
 //!     };
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
 //!
@@ -135,6 +136,7 @@
 //! ```
 
 use crate::translator::Translator;
+use std::num::NonZeroUsize;
 
 mod storage;
 pub use storage::Archive;
@@ -162,10 +164,10 @@ pub struct Config<T: Translator, C> {
 
     /// The amount of bytes that can be buffered in a section before being written to a
     /// [commonware_runtime::Blob].
-    pub write_buffer: usize,
+    pub write_buffer: NonZeroUsize,
 
     /// The buffer size to use when replaying a [commonware_runtime::Blob].
-    pub replay_buffer: usize,
+    pub replay_buffer: NonZeroUsize,
 }
 
 #[cfg(test)]
@@ -179,7 +181,7 @@ mod tests {
     use commonware_codec::{varint::UInt, DecodeExt, EncodeSize, Error as CodecError};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
-    use commonware_utils::sequence::FixedBytes;
+    use commonware_utils::{sequence::FixedBytes, NZUsize};
     use rand::Rng;
     use std::collections::BTreeMap;
 
@@ -206,8 +208,8 @@ mod tests {
                 translator: FourCap,
                 codec_config: (),
                 compression: Some(3),
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -232,8 +234,8 @@ mod tests {
                 translator: FourCap,
                 codec_config: (),
                 compression: None,
-                write_buffer: 1024,
-                replay_buffer: 4096,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
             };
             let result = Archive::<_, _, FixedBytes<64>, i32>::init(context, cfg.clone()).await;
@@ -255,8 +257,8 @@ mod tests {
                 translator: FourCap,
                 codec_config: (),
                 compression: None,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -294,8 +296,8 @@ mod tests {
                     translator: FourCap,
                     codec_config: (),
                     compression: None,
-                    write_buffer: DEFAULT_WRITE_BUFFER,
-                    replay_buffer: DEFAULT_REPLAY_BUFFER,
+                    write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                    replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                     items_per_section: DEFAULT_ITEMS_PER_SECTION,
                 },
             )
@@ -321,8 +323,8 @@ mod tests {
                 translator: FourCap,
                 codec_config: (),
                 compression: None,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -383,8 +385,8 @@ mod tests {
                 translator: FourCap,
                 codec_config: (),
                 compression: None,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -439,8 +441,8 @@ mod tests {
                 translator: FourCap,
                 codec_config: (),
                 compression: None,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: 1, // no mask - each item is its own section
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -524,8 +526,8 @@ mod tests {
                 translator: TwoCap,
                 codec_config: (),
                 compression: None,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section,
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
@@ -581,8 +583,8 @@ mod tests {
                 translator: TwoCap,
                 codec_config: (),
                 compression: None,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section,
             };
             let mut archive =

--- a/storage/src/freezer/benches/utils.rs
+++ b/storage/src/freezer/benches/utils.rs
@@ -2,7 +2,7 @@
 
 use commonware_runtime::tokio::Context;
 use commonware_storage::freezer::{Config, Freezer};
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{sequence::FixedBytes, NZUsize};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
 /// Number of bytes that can be buffered before being written to disk.
@@ -41,13 +41,13 @@ pub async fn init(ctx: Context) -> FreezerType {
     let cfg = Config {
         journal_partition: JOURNAL_PARTITION.into(),
         journal_compression: None,
-        journal_write_buffer: JOURNAL_WRITE_BUFFER,
+        journal_write_buffer: NZUsize!(JOURNAL_WRITE_BUFFER),
         journal_target_size: JOURNAL_TARGET_SIZE,
         table_partition: TABLE_PARTITION.into(),
         table_initial_size: TABLE_INITIAL_SIZE,
         table_resize_frequency: TABLE_RESIZE_FREQUENCY,
         table_resize_chunk_size: TABLE_RESIZE_CHUNK_SIZE,
-        table_replay_buffer: TABLE_REPLAY_BUFFER,
+        table_replay_buffer: NZUsize!(TABLE_REPLAY_BUFFER),
         codec_config: (),
     };
     Freezer::init(ctx, cfg).await.unwrap()

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -140,7 +140,7 @@
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, deterministic};
 //! use commonware_storage::freezer::{Freezer, Config, Identifier};
-//! use commonware_utils::sequence::FixedBytes;
+//! use commonware_utils::{sequence::FixedBytes, NZUsize};
 //!
 //! let executor = deterministic::Runner::default();
 //! executor.start(|context| async move {
@@ -148,13 +148,13 @@
 //!     let cfg = Config {
 //!         journal_partition: "freezer_journal".into(),
 //!         journal_compression: Some(3),
-//!         journal_write_buffer: 1024 * 1024, // 1MB
+//!         journal_write_buffer: NZUsize!(1024 * 1024), // 1MB
 //!         journal_target_size: 100 * 1024 * 1024, // 100MB
 //!         table_partition: "freezer_table".into(),
 //!         table_initial_size: 65_536, // ~3MB initial table size
 //!         table_resize_frequency: 4, // Force resize once 4 writes to the same entry occur
 //!         table_resize_chunk_size: 16_384, // ~1MB of table entries rewritten per sync
-//!         table_replay_buffer: 1024 * 1024, // 1MB
+//!         table_replay_buffer: NZUsize!(1024 * 1024), // 1MB
 //!         codec_config: (),
 //!     };
 //!     let mut freezer = Freezer::<_, FixedBytes<32>, i32>::init(context, cfg).await.unwrap();
@@ -177,6 +177,7 @@
 
 mod storage;
 use commonware_utils::Array;
+use std::num::NonZeroUsize;
 pub use storage::{Checkpoint, Cursor, Freezer};
 use thiserror::Error;
 
@@ -207,7 +208,7 @@ pub struct Config<C> {
     pub journal_compression: Option<u8>,
 
     /// The size of the write buffer to use for the journal.
-    pub journal_write_buffer: usize,
+    pub journal_write_buffer: NonZeroUsize,
 
     /// The target size of each journal before creating a new one.
     pub journal_target_size: u64,
@@ -226,7 +227,7 @@ pub struct Config<C> {
     pub table_resize_chunk_size: u32,
 
     /// The size of the read buffer to use when scanning the table (e.g., during recovery or resize).
-    pub table_replay_buffer: usize,
+    pub table_replay_buffer: NonZeroUsize,
 
     /// The codec configuration to use for the value stored in the freezer.
     pub codec_config: C,
@@ -238,7 +239,7 @@ mod tests {
     use commonware_codec::DecodeExt;
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
-    use commonware_utils::sequence::FixedBytes;
+    use commonware_utils::{sequence::FixedBytes, NZUsize};
     use rand::{Rng, RngCore};
 
     const DEFAULT_JOURNAL_WRITE_BUFFER: usize = 1024;
@@ -264,13 +265,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: compression,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
             let mut freezer = Freezer::<_, FixedBytes<64>, i32>::init(context.clone(), cfg.clone())
@@ -331,13 +332,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
             let mut freezer = Freezer::<_, FixedBytes<64>, i32>::init(context.clone(), cfg.clone())
@@ -381,13 +382,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: 4, // Very small to force collisions
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
             let mut freezer = Freezer::<_, FixedBytes<64>, i32>::init(context.clone(), cfg.clone())
@@ -441,13 +442,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
 
@@ -510,13 +511,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
 
@@ -608,13 +609,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
             {
@@ -666,13 +667,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
             let checkpoint = {
@@ -723,13 +724,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
 
@@ -786,13 +787,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
 
@@ -860,13 +861,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: 2, // Very small initial size to force multiple resizes
                 table_resize_frequency: 2, // Resize after 2 items per entry
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
             let mut freezer = Freezer::<_, FixedBytes<64>, i32>::init(context.clone(), cfg.clone())
@@ -928,13 +929,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: 2,
                 table_resize_frequency: 1,
                 table_resize_chunk_size: 1, // Process one at a time
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
             let mut freezer = Freezer::<_, FixedBytes<64>, i32>::init(context.clone(), cfg.clone())
@@ -995,13 +996,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
                 table_partition: "test_table".into(),
                 table_initial_size: 2,
                 table_resize_frequency: 1,
                 table_resize_chunk_size: 1, // Process one at a time
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
 
@@ -1056,13 +1057,13 @@ mod tests {
             let cfg = Config {
                 journal_partition: "test_journal".into(),
                 journal_compression: None,
-                journal_write_buffer: DEFAULT_JOURNAL_WRITE_BUFFER,
+                journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: 128, // Force multiple journal sections
                 table_partition: "test_table".into(),
                 table_initial_size: 8,     // Small table to force collisions
                 table_resize_frequency: 2, // Force resize frequently
                 table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
-                table_replay_buffer: DEFAULT_TABLE_REPLAY_BUFFER,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
                 codec_config: (),
             };
             let mut freezer =

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -6,7 +6,9 @@ use commonware_runtime::{buffer, Blob, Clock, Metrics, Storage};
 use commonware_utils::{Array, Span};
 use futures::future::{try_join, try_join_all};
 use prometheus_client::metrics::counter::Counter;
-use std::{cmp::Ordering, collections::BTreeSet, marker::PhantomData, ops::Deref};
+use std::{
+    cmp::Ordering, collections::BTreeSet, marker::PhantomData, num::NonZeroUsize, ops::Deref,
+};
 use tracing::debug;
 
 /// The percentage of table entries that must reach `table_resize_frequency`
@@ -392,7 +394,7 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> Freezer<E, K, V> {
         table_size: u32,
         table_resize_frequency: u8,
         max_valid_epoch: Option<u64>,
-        table_replay_buffer: usize,
+        table_replay_buffer: NonZeroUsize,
     ) -> Result<(bool, u64, u64, u32), Error> {
         // Create a buffered reader for efficient scanning
         let blob_size = Self::table_offset(table_size);

--- a/storage/src/journal/benches/bench.rs
+++ b/storage/src/journal/benches/bench.rs
@@ -37,7 +37,7 @@ async fn get_journal<const ITEM_SIZE: usize>(
         partition: partition_name.to_string(),
         items_per_blob,
         write_buffer: NZUsize!(WRITE_BUFFER),
-        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
     };
     Journal::init(context, journal_config).await.unwrap()
 }

--- a/storage/src/journal/benches/bench.rs
+++ b/storage/src/journal/benches/bench.rs
@@ -1,6 +1,6 @@
 use commonware_runtime::{buffer::PoolRef, tokio::Context};
 use commonware_storage::journal::fixed::{Config as JConfig, Journal};
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{sequence::FixedBytes, NZUsize};
 use criterion::criterion_main;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
@@ -36,7 +36,7 @@ async fn get_journal<const ITEM_SIZE: usize>(
     let journal_config = JConfig {
         partition: partition_name.to_string(),
         items_per_blob,
-        write_buffer: WRITE_BUFFER,
+        write_buffer: NZUsize!(WRITE_BUFFER),
         buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
     };
     Journal::init(context, journal_config).await.unwrap()

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -5,7 +5,7 @@ use commonware_runtime::{
     Runner as _,
 };
 use commonware_storage::journal::fixed::Journal;
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{sequence::FixedBytes, NZUsize};
 use criterion::{black_box, criterion_group, Criterion};
 use futures::{pin_mut, StreamExt};
 use std::time::{Duration, Instant};
@@ -22,7 +22,7 @@ const ITEM_SIZE: usize = 32;
 /// Replay all items in the given `journal`.
 async fn bench_run(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: usize) {
     let stream = journal
-        .replay(buffer, 0)
+        .replay(NZUsize!(buffer), 0)
         .await
         .expect("failed to replay journal");
     pin_mut!(stream);

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -69,7 +69,7 @@ use futures::{
     StreamExt,
 };
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::{collections::BTreeMap, marker::PhantomData, num::NonZeroUsize};
 use tracing::{debug, trace, warn};
 
 /// Configuration for `Journal` storage.
@@ -88,7 +88,7 @@ pub struct Config {
     pub buffer_pool: PoolRef,
 
     /// The size of the write buffer to use for each blob.
-    pub write_buffer: usize,
+    pub write_buffer: NonZeroUsize,
 }
 
 /// Implementation of `Journal` storage.
@@ -584,7 +584,7 @@ impl<E: Storage + Metrics, A: Codec<Cfg = ()> + FixedSize> Journal<E, A> {
     /// If any corrupted data is found, the stream will return an error.
     pub async fn replay(
         &self,
-        buffer: usize,
+        buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + '_, Error> {
         if start_pos > self.size().await? {
@@ -741,6 +741,7 @@ mod tests {
         deterministic::{self, Context},
         Blob, Runner, Storage,
     };
+    use commonware_utils::NZUsize;
     use futures::{pin_mut, StreamExt};
 
     const PAGE_SIZE: usize = 44;
@@ -756,7 +757,7 @@ mod tests {
             partition: "test_partition".into(),
             items_per_blob,
             buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
-            write_buffer: 2048,
+            write_buffer: NZUsize!(2048),
         }
     }
 
@@ -890,7 +891,7 @@ mod tests {
 
             {
                 let stream = journal
-                    .replay(1024, 0)
+                    .replay(NZUsize!(1024), 0)
                     .await
                     .expect("failed to replay journal");
                 pin_mut!(stream);
@@ -977,7 +978,7 @@ mod tests {
             // Replay should return all items
             {
                 let stream = journal
-                    .replay(1024, 0)
+                    .replay(NZUsize!(1024), 0)
                     .await
                     .expect("failed to replay journal");
                 let mut items = Vec::new();
@@ -1031,7 +1032,7 @@ mod tests {
             // Replay all items, making sure the checksum mismatch error is handled correctly.
             {
                 let stream = journal
-                    .replay(1024, 0)
+                    .replay(NZUsize!(1024), 0)
                     .await
                     .expect("failed to replay journal");
                 let mut items = Vec::new();
@@ -1210,7 +1211,7 @@ mod tests {
             // Replay should return all items except the first `START_POS`.
             {
                 let stream = journal
-                    .replay(1024, START_POS)
+                    .replay(NZUsize!(1024), START_POS)
                     .await
                     .expect("failed to replay journal");
                 let mut items = Vec::new();
@@ -1600,7 +1601,7 @@ mod tests {
             let cfg = Config {
                 partition: "test_fresh_start".into(),
                 items_per_blob: 5,
-                write_buffer: 1024,
+                write_buffer: NZUsize!(1024),
                 buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
 
@@ -1655,7 +1656,7 @@ mod tests {
             let cfg = Config {
                 partition: "test_overlap".into(),
                 items_per_blob: 4,
-                write_buffer: 1024,
+                write_buffer: NZUsize!(1024),
                 buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
 
@@ -1729,7 +1730,7 @@ mod tests {
             let cfg = Config {
                 partition: "test_exact_match".into(),
                 items_per_blob: 3,
-                write_buffer: 1024,
+                write_buffer: NZUsize!(1024),
                 buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
 
@@ -1803,7 +1804,7 @@ mod tests {
             let cfg = Config {
                 partition: "test_rewind".into(),
                 items_per_blob: 4,
-                write_buffer: 1024,
+                write_buffer: NZUsize!(1024),
                 buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
 
@@ -1883,7 +1884,7 @@ mod tests {
             let cfg = Config {
                 partition: "test_invalid_range".into(),
                 items_per_blob: 4,
-                write_buffer: 1024,
+                write_buffer: NZUsize!(1024),
                 buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
 
@@ -1916,7 +1917,7 @@ mod tests {
             let cfg = Config {
                 partition: "test_init_at_size".into(),
                 items_per_blob: 5,
-                write_buffer: 1024,
+                write_buffer: NZUsize!(1024),
                 buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
 

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -756,7 +756,7 @@ mod tests {
         Config {
             partition: "test_partition".into(),
             items_per_blob,
-            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             write_buffer: NZUsize!(2048),
         }
     }
@@ -1602,7 +1602,7 @@ mod tests {
                 partition: "test_fresh_start".into(),
                 items_per_blob: 5,
                 write_buffer: NZUsize!(1024),
-                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
 
             // Initialize journal with sync boundaries when no existing data exists
@@ -1657,7 +1657,7 @@ mod tests {
                 partition: "test_overlap".into(),
                 items_per_blob: 4,
                 write_buffer: NZUsize!(1024),
-                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
 
             // Create initial journal with 20 operations
@@ -1731,7 +1731,7 @@ mod tests {
                 partition: "test_exact_match".into(),
                 items_per_blob: 3,
                 write_buffer: NZUsize!(1024),
-                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
 
             // Create initial journal with 20 operations (0-19)
@@ -1805,7 +1805,7 @@ mod tests {
                 partition: "test_rewind".into(),
                 items_per_blob: 4,
                 write_buffer: NZUsize!(1024),
-                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
 
             // Create initial journal with 30 operations (0-29)
@@ -1885,7 +1885,7 @@ mod tests {
                 partition: "test_invalid_range".into(),
                 items_per_blob: 4,
                 write_buffer: NZUsize!(1024),
-                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
 
             let lower_bound = 6;
@@ -1918,7 +1918,7 @@ mod tests {
                 partition: "test_init_at_size".into(),
                 items_per_blob: 5,
                 write_buffer: NZUsize!(1024),
-                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
 
             // Test 1: Initialize at size 0 (empty journal)

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -311,7 +311,7 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
     /// - Assumes self.next_bit is currently byte aligned, and panics otherwise.
     pub fn append_byte_unchecked(&mut self, byte: u8) {
         assert!(
-            self.next_bit % 8 == 0,
+            self.next_bit.is_multiple_of(8),
             "cannot add byte when not byte aligned"
         );
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -716,7 +716,7 @@ mod tests {
             items_per_blob: 7,
             write_buffer: NZUsize!(1024),
             thread_pool: None,
-            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
         }
     }
 
@@ -1236,7 +1236,7 @@ mod tests {
                     items_per_blob: 7,
                     write_buffer: NZUsize!(1024),
                     thread_pool: None,
-                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 },
             )
             .await
@@ -1288,7 +1288,7 @@ mod tests {
                     items_per_blob: 7,
                     write_buffer: NZUsize!(1024),
                     thread_pool: None,
-                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 },
             )
             .await
@@ -1314,7 +1314,7 @@ mod tests {
                     items_per_blob: 7,
                     write_buffer: NZUsize!(1024),
                     thread_pool: None,
-                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 },
             )
             .await

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -21,7 +21,7 @@ use commonware_codec::DecodeExt;
 use commonware_cryptography::{Digest, Hasher as CHasher};
 use commonware_runtime::{buffer::PoolRef, Clock, Metrics, Storage as RStorage, ThreadPool};
 use commonware_utils::sequence::prefixed_u64::U64;
-use std::collections::HashMap;
+use std::{collections::HashMap, num::NonZeroUsize};
 use tracing::{debug, error, warn};
 
 /// Configuration for a journal-backed MMR.
@@ -40,7 +40,7 @@ pub struct Config {
     pub items_per_blob: u64,
 
     /// The size of the write buffer to use for each blob in the backing journal.
-    pub write_buffer: usize,
+    pub write_buffer: NonZeroUsize,
 
     /// Optional thread pool to use for parallelizing batch operations.
     pub thread_pool: Option<ThreadPool>,
@@ -244,7 +244,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
     ///    - Deletes existing data (if any)
     ///    - Creates new [Journal] with pruning boundary and size `lower_bound`
     ///
-    /// 2. **Prune and Reuse**: lower_bound ≤ existing_size ≤ upper_bound  
+    /// 2. **Prune and Reuse**: lower_bound ≤ existing_size ≤ upper_bound
     ///    - Sets in-memory MMR size to `existing_size`
     ///    - Prunes the journal to `lower_bound`
     ///
@@ -700,7 +700,7 @@ mod tests {
     use commonware_cryptography::{hash, sha256::Digest, Hasher, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{buffer::PoolRef, deterministic, Blob as _, Runner};
-    use commonware_utils::hex;
+    use commonware_utils::{hex, NZUsize};
 
     fn test_digest(v: usize) -> Digest {
         hash(&v.to_be_bytes())
@@ -714,7 +714,7 @@ mod tests {
             journal_partition: "journal_partition".into(),
             metadata_partition: "metadata_partition".into(),
             items_per_blob: 7,
-            write_buffer: 1024,
+            write_buffer: NZUsize!(1024),
             thread_pool: None,
             buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
         }
@@ -995,7 +995,7 @@ mod tests {
                 journal_partition: "unpruned_journal_partition".into(),
                 metadata_partition: "unpruned_metadata_partition".into(),
                 items_per_blob: 7,
-                write_buffer: 1024,
+                write_buffer: NZUsize!(1024),
                 thread_pool: None,
                 buffer_pool: cfg_pruned.buffer_pool.clone(),
             };
@@ -1234,7 +1234,7 @@ mod tests {
                     journal_partition: "ref_journal_pruned".into(),
                     metadata_partition: "ref_metadata_pruned".into(),
                     items_per_blob: 7,
-                    write_buffer: 1024,
+                    write_buffer: NZUsize!(1024),
                     thread_pool: None,
                     buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 },
@@ -1286,7 +1286,7 @@ mod tests {
                     journal_partition: "server_journal".into(),
                     metadata_partition: "server_metadata".into(),
                     items_per_blob: 7,
-                    write_buffer: 1024,
+                    write_buffer: NZUsize!(1024),
                     thread_pool: None,
                     buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 },
@@ -1312,7 +1312,7 @@ mod tests {
                     journal_partition: "client_journal".into(),
                     metadata_partition: "client_metadata".into(),
                     items_per_blob: 7,
-                    write_buffer: 1024,
+                    write_buffer: NZUsize!(1024),
                     thread_pool: None,
                     buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 },

--- a/storage/src/ordinal/benches/utils.rs
+++ b/storage/src/ordinal/benches/utils.rs
@@ -1,6 +1,6 @@
 use commonware_runtime::tokio::Context;
 use commonware_storage::ordinal;
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{sequence::FixedBytes, NZUsize};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 
 /// Number of bytes that can be buffered before being written to disk.
@@ -23,8 +23,8 @@ pub async fn init(ctx: Context) -> Ordinal {
     let cfg = ordinal::Config {
         partition: PARTITION.into(),
         items_per_blob: ITEMS_PER_BLOB,
-        write_buffer: WRITE_BUFFER,
-        replay_buffer: REPLAY_BUFFER,
+        write_buffer: NZUsize!(WRITE_BUFFER),
+        replay_buffer: NZUsize!(REPLAY_BUFFER),
     };
     ordinal::Ordinal::init(ctx, cfg).await.unwrap()
 }

--- a/storage/src/ordinal/mod.rs
+++ b/storage/src/ordinal/mod.rs
@@ -61,7 +61,7 @@
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, deterministic};
 //! use commonware_storage::ordinal::{Ordinal, Config};
-//! use commonware_utils::sequence::FixedBytes;
+//! use commonware_utils::{sequence::FixedBytes, NZUsize};
 //!
 //! let executor = deterministic::Runner::default();
 //! executor.start(|context| async move {
@@ -69,8 +69,8 @@
 //!     let cfg = Config {
 //!         partition: "ordinal_store".into(),
 //!         items_per_blob: 10000,
-//!         write_buffer: 4096,
-//!         replay_buffer: 1024 * 1024,
+//!         write_buffer: NZUsize!(4096),
+//!         replay_buffer: NZUsize!(1024 * 1024),
 //!     };
 //!     let mut store = Ordinal::<_, FixedBytes<32>>::init(context, cfg).await.unwrap();
 //!
@@ -95,6 +95,7 @@
 
 mod storage;
 
+use std::num::NonZeroUsize;
 pub use storage::Ordinal;
 use thiserror::Error;
 
@@ -123,10 +124,10 @@ pub struct Config {
     pub items_per_blob: u64,
 
     /// The size of the write buffer to use when writing to the index.
-    pub write_buffer: usize,
+    pub write_buffer: NonZeroUsize,
 
     /// The size of the read buffer to use on restart.
-    pub replay_buffer: usize,
+    pub replay_buffer: NonZeroUsize,
 }
 
 #[cfg(test)]
@@ -134,7 +135,7 @@ mod tests {
     use super::*;
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
-    use commonware_utils::{sequence::FixedBytes, BitVec};
+    use commonware_utils::{sequence::FixedBytes, BitVec, NZUsize};
     use rand::RngCore;
     use std::collections::BTreeMap;
 
@@ -151,8 +152,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
                 .await
@@ -210,8 +211,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
                 .await
@@ -257,8 +258,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100, // Smaller blobs for testing
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
                 .await
@@ -308,8 +309,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
                 .await
@@ -356,8 +357,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Insert data and close
@@ -419,8 +420,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data
@@ -472,8 +473,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
             let store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
                 .await
@@ -496,8 +497,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data
@@ -542,8 +543,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data
@@ -609,8 +610,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data
@@ -670,8 +671,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 10, // Small blob size for testing
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data across multiple blobs
@@ -740,8 +741,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data
@@ -814,8 +815,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: DEFAULT_ITEMS_PER_BLOB,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create blob with zero-filled space
@@ -866,8 +867,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100, // Smaller blobs to test multiple blob handling
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Initialize the store
@@ -972,8 +973,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100, // Small blobs to test multiple blob handling
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
@@ -1051,8 +1052,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
@@ -1103,8 +1104,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
@@ -1144,8 +1145,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
@@ -1169,8 +1170,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store and add data
@@ -1233,8 +1234,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 50, // Smaller blobs for more granular testing
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
@@ -1290,8 +1291,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
@@ -1341,8 +1342,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
@@ -1403,8 +1404,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 100,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
             let mut store = Ordinal::<_, FixedBytes<32>>::init(context.clone(), cfg.clone())
                 .await
@@ -1455,8 +1456,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 10, // Small blob size for testing
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data across multiple sections
@@ -1524,8 +1525,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 10,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data
@@ -1568,8 +1569,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 10,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data in multiple sections
@@ -1664,8 +1665,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 5,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with all records in a section
@@ -1717,8 +1718,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 5,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with missing record in a section
@@ -1763,8 +1764,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 5,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data in multiple sections
@@ -1850,8 +1851,8 @@ mod tests {
             let cfg = Config {
                 partition: "test_ordinal".into(),
                 items_per_blob: 5,
-                write_buffer: DEFAULT_WRITE_BUFFER,
-                replay_buffer: DEFAULT_REPLAY_BUFFER,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             };
 
             // Create store with data and corrupt one record

--- a/storage/src/store/benches/restart.rs
+++ b/storage/src/store/benches/restart.rs
@@ -9,6 +9,7 @@ use commonware_storage::{
     store::{Config as SConfig, Store},
     translator::EightCap,
 };
+use commonware_utils::NZUsize;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use std::time::Instant;
@@ -29,14 +30,14 @@ const PAGE_CACHE_SIZE: usize = 10_000;
 fn store_cfg() -> SConfig<EightCap, ()> {
     SConfig::<EightCap, ()> {
         log_journal_partition: format!("log_{PARTITION_SUFFIX}"),
-        log_write_buffer: 64 * 1024,
+        log_write_buffer: NZUsize!(64 * 1024),
         log_compression: None,
         log_codec_config: (),
         log_items_per_section: ITEMS_PER_BLOB,
         locations_journal_partition: format!("locations_{PARTITION_SUFFIX}"),
         locations_items_per_blob: ITEMS_PER_BLOB,
         translator: EightCap,
-        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
     }
 }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -27,7 +27,7 @@ pub fn hex(bytes: &[u8]) -> String {
 
 /// Converts a hexadecimal string to bytes.
 pub fn from_hex(hex: &str) -> Option<Vec<u8>> {
-    if hex.len() % 2 != 0 {
+    if !hex.len().is_multiple_of(2) {
         return None;
     }
 


### PR DESCRIPTION
Changes all buffer capacity config parameters to "NonZero" types since values of 0 would/should otherwise panic.

Addresses: https://github.com/commonwarexyz/monorepo/issues/1355

Partially addresses: https://github.com/commonwarexyz/monorepo/issues/902
