### PR TITLE
fix typo

### DIFF
--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -336,7 +336,7 @@ impl<D: Digest> Proof<D> {
         Self::historical_range_proof(mmr, mmr.size(), start_element_pos, end_element_pos).await
     }
 
-    /// Analagous to range_proof but for a previous database state.
+    /// Analogous to range_proof but for a previous database state.
     /// Specifically, the state when the MMR had `size` elements.
     pub async fn historical_range_proof<S: Storage<D>>(
         mmr: &S,


### PR DESCRIPTION



## Changes
- **Fix:** Corrected "Analagous" → "Analogous" in documentation comment


