### PR TITLE
[lint/fmt] set rust edition

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
+edition = "2021"
+
 # Imports
 imports_granularity = "Crate"
 group_imports = "One"


### PR DESCRIPTION
When running rustfmt directly (not through `cargo fmt`) it defaults to 2015 edition and fails to format the code.

```
$ rustfmt --quiet --emit stdout

error[E0670]: `async fn` is not permitted in Rust 2015
   --> <stdin>:449:9
    |
449 |         async fn error_future() -> Result<&'static str, &'static str> {
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
    = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide

...
```

