### PR TITLE
[storage/journal/variable] use Append wrapper

### DIFF
--- a/consensus/src/aggregation/config.rs
+++ b/consensus/src/aggregation/config.rs
@@ -2,6 +2,7 @@ use super::types::{Activity, Epoch, Index};
 use crate::{Automaton, Monitor, Reporter, ThresholdSupervisor};
 use commonware_cryptography::{bls12381::primitives::variant::Variant, Digest};
 use commonware_p2p::Blocker;
+use commonware_runtime::buffer::PoolRef;
 use commonware_utils::{Array, NonZeroDuration};
 use std::num::{NonZeroU64, NonZeroUsize};
 
@@ -71,4 +72,7 @@ pub struct Config<
 
     /// Compression level for the journal.
     pub journal_compression: Option<u8>,
+
+    /// Buffer pool for the journal.
+    pub journal_buffer_pool: PoolRef,
 }

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -17,6 +17,7 @@ use commonware_p2p::{
     Blocker, Receiver, Recipients, Sender,
 };
 use commonware_runtime::{
+    buffer::PoolRef,
     telemetry::metrics::{
         histogram,
         status::{CounterExt, Status},
@@ -142,6 +143,7 @@ pub struct Engine<
     journal_replay_buffer: NonZeroUsize,
     journal_heights_per_section: u64,
     journal_compression: Option<u8>,
+    journal_buffer_pool: PoolRef,
 
     // ---------- Network ----------
     /// Whether to send acks as priority messages.
@@ -202,6 +204,7 @@ impl<
             journal_replay_buffer: cfg.journal_replay_buffer,
             journal_heights_per_section: cfg.journal_heights_per_section.into(),
             journal_compression: cfg.journal_compression,
+            journal_buffer_pool: cfg.journal_buffer_pool,
             priority_acks: cfg.priority_acks,
             _phantom: PhantomData,
             metrics,
@@ -235,6 +238,7 @@ impl<
             partition: self.journal_partition.clone(),
             compression: self.journal_compression,
             codec_config: (),
+            buffer_pool: self.journal_buffer_pool.clone(),
             write_buffer: self.journal_write_buffer,
         };
         let journal = Journal::init(self.context.with_label("journal"), journal_cfg)

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -77,10 +77,11 @@ mod tests {
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{
+        buffer::PoolRef,
         deterministic::{self, Context},
         Clock, Metrics, Runner, Spawner,
     };
-    use commonware_utils::NonZeroDuration;
+    use commonware_utils::{NZUsize, NonZeroDuration};
     use futures::{channel::oneshot, future::join_all};
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use std::{
@@ -229,6 +230,7 @@ mod tests {
                     journal_replay_buffer: std::num::NonZeroUsize::new(4096).unwrap(),
                     journal_heights_per_section: std::num::NonZeroU64::new(6).unwrap(),
                     journal_compression: Some(3),
+                    journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
                 },
             );
 
@@ -438,6 +440,7 @@ mod tests {
                                 journal_replay_buffer: std::num::NonZeroUsize::new(4096).unwrap(),
                                 journal_heights_per_section: std::num::NonZeroU64::new(6).unwrap(),
                                 journal_compression: Some(3),
+                                journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
                             },
                         );
 

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -86,12 +86,16 @@ mod tests {
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use std::{
         collections::{BTreeMap, HashMap},
+        num::NonZeroUsize,
         sync::{Arc, Mutex},
         time::Duration,
     };
     use tracing::debug;
 
     type Registrations<P> = BTreeMap<P, (Sender<P>, Receiver<P>)>;
+
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     /// Reliable network link configuration for testing.
     const RELIABLE_LINK: Link = Link {
@@ -226,11 +230,11 @@ mod tests {
                     epoch_bounds: (1, 1),
                     window: std::num::NonZeroU64::new(10).unwrap(),
                     journal_partition: format!("aggregation/{validator}"),
-                    journal_write_buffer: std::num::NonZeroUsize::new(4096).unwrap(),
-                    journal_replay_buffer: std::num::NonZeroUsize::new(4096).unwrap(),
+                    journal_write_buffer: NZUsize!(4096),
+                    journal_replay_buffer: NZUsize!(4096),
                     journal_heights_per_section: std::num::NonZeroU64::new(6).unwrap(),
                     journal_compression: Some(3),
-                    journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+                    journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 },
             );
 
@@ -436,11 +440,11 @@ mod tests {
                                 window: std::num::NonZeroU64::new(10).unwrap(),
                                 // Use validator-specific partition for journal recovery
                                 journal_partition: format!("unclean_shutdown_test/{validator}"),
-                                journal_write_buffer: std::num::NonZeroUsize::new(4096).unwrap(),
-                                journal_replay_buffer: std::num::NonZeroUsize::new(4096).unwrap(),
+                                journal_write_buffer: NZUsize!(4096),
+                                journal_replay_buffer: NZUsize!(4096),
                                 journal_heights_per_section: std::num::NonZeroU64::new(6).unwrap(),
                                 journal_compression: Some(3),
-                                journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+                                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                             },
                         );
 

--- a/consensus/src/marshal/actor.rs
+++ b/consensus/src/marshal/actor.rs
@@ -198,6 +198,7 @@ impl<
                 ),
                 freezer_journal_target_size: config.freezer_journal_target_size,
                 freezer_journal_compression: config.freezer_journal_compression,
+                freezer_journal_buffer_pool: config.freezer_journal_buffer_pool.clone(),
                 ordinal_partition: format!(
                     "{}-finalizations-by-height-ordinal",
                     config.partition_prefix
@@ -234,6 +235,7 @@ impl<
                 ),
                 freezer_journal_target_size: config.freezer_journal_target_size,
                 freezer_journal_compression: config.freezer_journal_compression,
+                freezer_journal_buffer_pool: config.freezer_journal_buffer_pool,
                 ordinal_partition: format!("{}-finalized_blocks-ordinal", config.partition_prefix),
                 items_per_section: config.immutable_items_per_section,
                 codec_config: config.codec_config.clone(),
@@ -675,6 +677,7 @@ impl<
             items_per_section: config.prunable_items_per_section,
             compression: None,
             codec_config,
+            buffer_pool: config.freezer_journal_buffer_pool.clone(),
             replay_buffer: config.replay_buffer,
             write_buffer: config.write_buffer,
         };

--- a/consensus/src/marshal/config.rs
+++ b/consensus/src/marshal/config.rs
@@ -1,11 +1,11 @@
 use crate::Block;
 use commonware_cryptography::{bls12381::primitives::variant::Variant, PublicKey};
 use commonware_resolver::p2p::Coordinator;
+use commonware_runtime::buffer::PoolRef;
 use governor::Quota;
 use std::num::NonZeroUsize;
 
 /// Marshal configuration.
-#[derive(Debug)]
 pub struct Config<V: Variant, P: PublicKey, Z: Coordinator<PublicKey = P>, B: Block> {
     /// The public key of the validator.
     pub public_key: P,
@@ -54,6 +54,9 @@ pub struct Config<V: Variant, P: PublicKey, Z: Coordinator<PublicKey = P>, B: Bl
 
     /// The compression level to use for the freezer journal.
     pub freezer_journal_compression: Option<u8>,
+
+    /// The buffer pool to use for the freezer journal.
+    pub freezer_journal_buffer_pool: PoolRef,
 
     /// The size of the replay buffer for storage archives.
     pub replay_buffer: NonZeroUsize,

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -104,7 +104,11 @@ mod tests {
     use commonware_utils::NZUsize;
     use governor::Quota;
     use rand::{seq::SliceRandom, Rng};
-    use std::{collections::BTreeMap, num::NonZeroU32, time::Duration};
+    use std::{
+        collections::BTreeMap,
+        num::{NonZeroU32, NonZeroUsize},
+        time::Duration,
+    };
 
     type D = Sha256Digest;
     type B = Block<D>;
@@ -112,6 +116,9 @@ mod tests {
     type V = MinPk;
     type Sh = Share;
     type E = PrivateKey;
+
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     const NAMESPACE: &[u8] = b"test";
     const NUM_VALIDATORS: u32 = 4;
@@ -319,7 +326,7 @@ mod tests {
             freezer_table_resize_chunk_size: 10,
             freezer_journal_target_size: 1024,
             freezer_journal_compression: None,
-            freezer_journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+            freezer_journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             immutable_items_per_section: 10u64,
         };
 

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -100,7 +100,7 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_p2p::simulated::{self, Link, Network, Oracle};
     use commonware_resolver::p2p as resolver;
-    use commonware_runtime::{deterministic, Clock, Metrics, Runner};
+    use commonware_runtime::{buffer::PoolRef, deterministic, Clock, Metrics, Runner};
     use commonware_utils::NZUsize;
     use governor::Quota;
     use rand::{seq::SliceRandom, Rng};
@@ -319,6 +319,7 @@ mod tests {
             freezer_table_resize_chunk_size: 10,
             freezer_journal_target_size: 1024,
             freezer_journal_compression: None,
+            freezer_journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
             immutable_items_per_section: 10u64,
         };
 

--- a/consensus/src/ordered_broadcast/config.rs
+++ b/consensus/src/ordered_broadcast/config.rs
@@ -1,6 +1,7 @@
 use super::types::{Activity, Context, Epoch};
 use crate::{Automaton, Monitor, Relay, Reporter, Supervisor, ThresholdSupervisor};
 use commonware_cryptography::{bls12381::primitives::variant::Variant, Digest, Signer};
+use commonware_runtime::buffer::PoolRef;
 use std::{num::NonZeroUsize, time::Duration};
 
 /// Configuration for the [super::Engine].
@@ -82,4 +83,7 @@ pub struct Config<
 
     /// Compression level for the journal.
     pub journal_compression: Option<u8>,
+
+    /// Buffer pool for the journal.
+    pub journal_buffer_pool: PoolRef,
 }

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -23,6 +23,7 @@ use commonware_p2p::{
     Receiver, Recipients, Sender,
 };
 use commonware_runtime::{
+    buffer::PoolRef,
     telemetry::metrics::{
         histogram,
         status::{CounterExt, Status},
@@ -153,6 +154,9 @@ pub struct Engine<
     // Compression level for the journal.
     journal_compression: Option<u8>,
 
+    // Buffer pool for the journal.
+    journal_buffer_pool: PoolRef,
+
     // A map of sequencer public keys to their journals.
     #[allow(clippy::type_complexity)]
     journals: BTreeMap<C::PublicKey, Journal<E, Node<C::PublicKey, V, D>>>,
@@ -243,6 +247,7 @@ impl<
             journal_write_buffer: cfg.journal_write_buffer,
             journal_name_prefix: cfg.journal_name_prefix,
             journal_compression: cfg.journal_compression,
+            journal_buffer_pool: cfg.journal_buffer_pool,
             journals: BTreeMap::new(),
             tip_manager: TipManager::<C::PublicKey, V, D>::new(),
             ack_manager: AckManager::<C::PublicKey, V, D>::new(),
@@ -963,6 +968,7 @@ impl<
             partition: format!("{}{}", &self.journal_name_prefix, sequencer),
             compression: self.journal_compression,
             codec_config: (),
+            buffer_pool: self.journal_buffer_pool.clone(),
             write_buffer: self.journal_write_buffer,
         };
         let journal =

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -80,10 +80,14 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng as _};
     use std::{
         collections::{BTreeMap, HashMap, HashSet},
+        num::NonZeroUsize,
         sync::{Arc, Mutex},
         time::Duration,
     };
     use tracing::debug;
+
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     type Registrations<P> = BTreeMap<P, ((Sender<P>, Receiver<P>), (Sender<P>, Receiver<P>))>;
 
@@ -237,7 +241,7 @@ mod tests {
                     journal_write_buffer: NZUsize!(4096),
                     journal_name_prefix: format!("ordered-broadcast-seq/{validator}/"),
                     journal_compression: Some(3),
-                    journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+                    journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 },
             );
 
@@ -868,7 +872,7 @@ mod tests {
                         journal_write_buffer: NZUsize!(4096),
                         journal_name_prefix: format!("ordered-broadcast-seq/{validator}/"),
                         journal_compression: Some(3),
-                        journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+                        journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     },
                 );
 
@@ -922,7 +926,7 @@ mod tests {
                             sequencer.public_key()
                         ),
                         journal_compression: Some(3),
-                        journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+                        journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     },
                 );
 

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -71,6 +71,7 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_p2p::simulated::{Link, Network, Oracle, Receiver, Sender};
     use commonware_runtime::{
+        buffer::PoolRef,
         deterministic::{self, Context},
         Clock, Metrics, Runner, Spawner,
     };
@@ -236,6 +237,7 @@ mod tests {
                     journal_write_buffer: NZUsize!(4096),
                     journal_name_prefix: format!("ordered-broadcast-seq/{validator}/"),
                     journal_compression: Some(3),
+                    journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
                 },
             );
 
@@ -866,6 +868,7 @@ mod tests {
                         journal_write_buffer: NZUsize!(4096),
                         journal_name_prefix: format!("ordered-broadcast-seq/{validator}/"),
                         journal_compression: Some(3),
+                        journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
                     },
                 );
 
@@ -919,6 +922,7 @@ mod tests {
                             sequencer.public_key()
                         ),
                         journal_compression: Some(3),
+                        journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
                     },
                 );
 

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -17,7 +17,7 @@ use commonware_p2p::{
     utils::codec::{wrap, WrappedSender},
     Receiver, Recipients, Sender,
 };
-use commonware_runtime::{Clock, Handle, Metrics, Spawner, Storage};
+use commonware_runtime::{buffer::PoolRef, Clock, Handle, Metrics, Spawner, Storage};
 use commonware_storage::journal::variable::{Config as JConfig, Journal};
 use commonware_utils::quorum;
 use futures::{
@@ -329,6 +329,7 @@ pub struct Actor<
     compression: Option<u8>,
     replay_buffer: NonZeroUsize,
     write_buffer: NonZeroUsize,
+    buffer_pool: PoolRef,
     journal: Option<Journal<E, Voter<C::Signature, D>>>,
 
     genesis: Option<D>,
@@ -421,6 +422,7 @@ impl<
                 compression: cfg.compression,
                 replay_buffer: cfg.replay_buffer,
                 write_buffer: cfg.write_buffer,
+                buffer_pool: cfg.buffer_pool,
                 journal: None,
 
                 genesis: None,
@@ -1702,6 +1704,7 @@ impl<
                 partition: self.partition.clone(),
                 compression: self.compression,
                 codec_config: usize::MAX, // anything we read from journal is already verified
+                buffer_pool: self.buffer_pool.clone(),
                 write_buffer: self.write_buffer,
             },
         )

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 pub use actor::Actor;
 use commonware_cryptography::{Digest, Signer};
+use commonware_runtime::buffer::PoolRef;
 pub use ingress::{Mailbox, Message};
 use std::{num::NonZeroUsize, time::Duration};
 
@@ -36,6 +37,7 @@ pub struct Config<
     pub skip_timeout: View,
     pub replay_buffer: NonZeroUsize,
     pub write_buffer: NonZeroUsize,
+    pub buffer_pool: PoolRef,
 }
 
 #[cfg(test)]

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -138,6 +138,7 @@ mod tests {
                 skip_timeout: 10,
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
+                buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 
@@ -334,6 +335,7 @@ mod tests {
                 skip_timeout: 10,
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
+                buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
             };
             let (actor, _mailbox) = Actor::new(context.clone(), cfg);
 

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -63,6 +63,9 @@ mod tests {
     use futures::{channel::mpsc, StreamExt};
     use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
+
     /// Trigger processing of an uninteresting view from the resolver after
     /// jumping ahead to a new finalize view:
     ///
@@ -138,7 +141,7 @@ mod tests {
                 skip_timeout: 10,
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
-                buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 
@@ -335,7 +338,7 @@ mod tests {
                 skip_timeout: 10,
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
-                buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let (actor, _mailbox) = Actor::new(context.clone(), cfg);
 

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -1,6 +1,7 @@
 use super::types::{Activity, Context, View};
 use crate::{Automaton, Relay, Reporter, Supervisor};
 use commonware_cryptography::{Digest, Signer};
+use commonware_runtime::buffer::PoolRef;
 use governor::Quota;
 use std::{num::NonZeroUsize, time::Duration};
 
@@ -46,6 +47,9 @@ pub struct Config<
 
     /// The size of the write buffer to use for each blob in the journal.
     pub write_buffer: NonZeroUsize,
+
+    /// Buffer pool for the journal.
+    pub buffer_pool: PoolRef,
 
     /// Amount of time to wait for a leader to propose a payload
     /// in a view.

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -67,6 +67,7 @@ impl<
                 skip_timeout: cfg.skip_timeout,
                 replay_buffer: cfg.replay_buffer,
                 write_buffer: cfg.write_buffer,
+                buffer_pool: cfg.buffer_pool,
             },
         );
 

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -149,14 +149,15 @@ mod tests {
     use rand::Rng as _;
     use std::{
         collections::{BTreeMap, HashMap},
+        num::NonZeroUsize,
         sync::{Arc, Mutex},
         time::Duration,
     };
     use tracing::debug;
     use types::Activity;
 
-    const PAGE_SIZE: usize = 1024;
-    const PAGE_CACHE_SIZE: usize = 10;
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     /// Registers all validators using the oracle.
     async fn register_validators<P: CPublicKey>(
@@ -331,7 +332,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
                 let (voter, resolver) = registrations
@@ -576,7 +577,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     let (voter_network, resolver_network) = registrations
@@ -746,7 +747,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -865,7 +866,7 @@ mod tests {
                 fetch_concurrent: 1,
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let (voter, resolver) = registrations
                 .remove(&validator)
@@ -988,7 +989,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1215,7 +1216,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1374,7 +1375,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1558,7 +1559,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1738,7 +1739,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1906,7 +1907,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2075,7 +2076,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2240,7 +2241,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2377,7 +2378,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -141,7 +141,7 @@ mod tests {
     };
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
-    use commonware_runtime::{deterministic, Clock, Metrics, Runner, Spawner};
+    use commonware_runtime::{buffer::PoolRef, deterministic, Clock, Metrics, Runner, Spawner};
     use commonware_utils::{quorum, NZUsize, NZU32};
     use engine::Engine;
     use futures::{future::join_all, StreamExt};
@@ -154,6 +154,9 @@ mod tests {
     };
     use tracing::debug;
     use types::Activity;
+
+    const PAGE_SIZE: usize = 1024;
+    const PAGE_CACHE_SIZE: usize = 10;
 
     /// Registers all validators using the oracle.
     async fn register_validators<P: CPublicKey>(
@@ -328,6 +331,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
                 let (voter, resolver) = registrations
@@ -572,6 +576,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     let (voter_network, resolver_network) = registrations
@@ -741,6 +746,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -859,6 +865,7 @@ mod tests {
                 fetch_concurrent: 1,
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let (voter, resolver) = registrations
                 .remove(&validator)
@@ -981,6 +988,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1207,6 +1215,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1365,6 +1374,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1548,6 +1558,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1727,6 +1738,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)
@@ -1894,6 +1906,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2062,6 +2075,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2226,6 +2240,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let (voter, resolver) = registrations
                         .remove(&validator)
@@ -2362,6 +2377,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let (voter, resolver) = registrations
                     .remove(&validator)

--- a/consensus/src/threshold_simplex/actors/voter/actor.rs
+++ b/consensus/src/threshold_simplex/actors/voter/actor.rs
@@ -26,6 +26,7 @@ use commonware_p2p::{
     Blocker, Receiver, Recipients, Sender,
 };
 use commonware_runtime::{
+    buffer::PoolRef,
     telemetry::metrics::histogram::{self, Buckets},
     Clock, Handle, Metrics, Spawner, Storage,
 };
@@ -452,6 +453,7 @@ pub struct Actor<
     compression: Option<u8>,
     replay_buffer: NonZeroUsize,
     write_buffer: NonZeroUsize,
+    buffer_pool: PoolRef,
     journal: Option<Journal<E, Voter<V, D>>>,
 
     genesis: Option<D>,
@@ -559,6 +561,7 @@ impl<
                 compression: cfg.compression,
                 replay_buffer: cfg.replay_buffer,
                 write_buffer: cfg.write_buffer,
+                buffer_pool: cfg.buffer_pool,
                 journal: None,
 
                 genesis: None,
@@ -1673,6 +1676,7 @@ impl<
                 partition: self.partition.clone(),
                 compression: self.compression,
                 codec_config: (),
+                buffer_pool: self.buffer_pool.clone(),
                 write_buffer: self.write_buffer,
             },
         )

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -11,6 +11,7 @@ use commonware_cryptography::{
     Digest, Signer,
 };
 use commonware_p2p::Blocker;
+use commonware_runtime::buffer::PoolRef;
 pub use ingress::{Mailbox, Message};
 use std::{num::NonZeroUsize, time::Duration};
 
@@ -41,6 +42,7 @@ pub struct Config<
     pub activity_timeout: View,
     pub replay_buffer: NonZeroUsize,
     pub write_buffer: NonZeroUsize,
+    pub buffer_pool: PoolRef,
 }
 
 #[cfg(test)]

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -155,6 +155,7 @@ mod tests {
                 activity_timeout: 10,
                 replay_buffer: NonZeroUsize::new(1024 * 1024).unwrap(),
                 write_buffer: NonZeroUsize::new(1024 * 1024).unwrap(),
+                buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 
@@ -463,6 +464,7 @@ mod tests {
                 activity_timeout,
                 replay_buffer: NZUsize!(10240),
                 write_buffer: NZUsize!(10240),
+                buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
             };
             let (actor, _mailbox) = Actor::new(context.clone(), voter_config);
 

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -74,6 +74,9 @@ mod tests {
     use futures::{channel::mpsc, StreamExt};
     use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
+
     /// Trigger processing of an uninteresting view from the resolver after
     /// jumping ahead to a new finalize view:
     ///
@@ -155,7 +158,7 @@ mod tests {
                 activity_timeout: 10,
                 replay_buffer: NonZeroUsize::new(1024 * 1024).unwrap(),
                 write_buffer: NonZeroUsize::new(1024 * 1024).unwrap(),
-                buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let (actor, mut mailbox) = Actor::new(context.clone(), cfg);
 
@@ -464,7 +467,7 @@ mod tests {
                 activity_timeout,
                 replay_buffer: NZUsize!(10240),
                 write_buffer: NZUsize!(10240),
-                buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let (actor, _mailbox) = Actor::new(context.clone(), voter_config);
 

--- a/consensus/src/threshold_simplex/config.rs
+++ b/consensus/src/threshold_simplex/config.rs
@@ -5,6 +5,7 @@ use commonware_cryptography::{
     Digest, Signer,
 };
 use commonware_p2p::Blocker;
+use commonware_runtime::buffer::PoolRef;
 use governor::Quota;
 use std::{num::NonZeroUsize, time::Duration};
 
@@ -63,6 +64,9 @@ pub struct Config<
 
     /// The size of the write buffer to use for each blob in the journal.
     pub write_buffer: NonZeroUsize,
+
+    /// Buffer pool for the journal.
+    pub buffer_pool: PoolRef,
 
     /// Amount of time to wait for a leader to propose a payload
     /// in a view.

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -104,6 +104,7 @@ impl<
                 activity_timeout: cfg.activity_timeout,
                 replay_buffer: cfg.replay_buffer,
                 write_buffer: cfg.write_buffer,
+                buffer_pool: cfg.buffer_pool,
             },
         );
 

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -224,7 +224,7 @@ mod tests {
     };
     use commonware_macros::{select, test_traced};
     use commonware_p2p::simulated::{Config, Link, Network, Oracle, Receiver, Sender};
-    use commonware_runtime::{deterministic, Clock, Metrics, Runner, Spawner};
+    use commonware_runtime::{buffer::PoolRef, deterministic, Clock, Metrics, Runner, Spawner};
     use commonware_utils::{quorum, NZUsize, NZU32};
     use engine::Engine;
     use futures::{future::join_all, StreamExt};
@@ -237,6 +237,9 @@ mod tests {
     };
     use tracing::{debug, warn};
     use types::Activity;
+
+    const PAGE_SIZE: usize = 1024;
+    const PAGE_CACHE_SIZE: usize = 10;
 
     /// Registers all validators using the oracle.
     async fn register_validators<P: PublicKey>(
@@ -426,6 +429,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -692,6 +696,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -886,6 +891,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1009,6 +1015,7 @@ mod tests {
                 fetch_concurrent: 1,
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1154,6 +1161,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1419,6 +1427,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1593,6 +1602,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1803,6 +1813,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -2009,6 +2020,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -2203,6 +2215,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2393,6 +2406,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2574,6 +2588,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2747,6 +2762,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2934,6 +2950,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
+                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -3085,6 +3102,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -3245,6 +3263,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -232,14 +232,15 @@ mod tests {
     use rand::{rngs::StdRng, Rng as _, SeedableRng as _};
     use std::{
         collections::{BTreeMap, HashMap},
+        num::NonZeroUsize,
         sync::{Arc, Mutex},
         time::Duration,
     };
     use tracing::{debug, warn};
     use types::Activity;
 
-    const PAGE_SIZE: usize = 1024;
-    const PAGE_CACHE_SIZE: usize = 10;
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     /// Registers all validators using the oracle.
     async fn register_validators<P: PublicKey>(
@@ -429,7 +430,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -696,7 +697,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -891,7 +892,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1015,7 +1016,7 @@ mod tests {
                 fetch_concurrent: 1,
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1161,7 +1162,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1427,7 +1428,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1602,7 +1603,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -1813,7 +1814,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -2020,7 +2021,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -2215,7 +2216,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2406,7 +2407,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2588,7 +2589,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2762,7 +2763,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -2950,7 +2951,7 @@ mod tests {
                         fetch_concurrent: 1,
                         replay_buffer: NZUsize!(1024 * 1024),
                         write_buffer: NZUsize!(1024 * 1024),
-                        buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                        buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -3102,7 +3103,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 
@@ -3263,7 +3264,7 @@ mod tests {
                     fetch_concurrent: 1,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 let engine = Engine::new(context.with_label("engine"), cfg);
 

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -247,7 +247,7 @@ fn main() {
                 max_fetch_count: 32,
                 fetch_concurrent: 2,
                 fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
-                buffer_pool: PoolRef::new(NZUsize!(16384), NZUsize!(10_000)),
+                buffer_pool: PoolRef::new(NZUsize!(16_384), NZUsize!(10_000)),
             },
         );
 

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -13,7 +13,7 @@ use commonware_cryptography::{
     ed25519, PrivateKeyExt as _, Sha256, Signer as _,
 };
 use commonware_p2p::authenticated;
-use commonware_runtime::{tokio, Metrics, Network, Runner};
+use commonware_runtime::{buffer::PoolRef, tokio, Metrics, Network, Runner};
 use commonware_stream::public_key::{self, Connection};
 use commonware_utils::{from_hex, quorum, union, NZUsize, NZU32};
 use governor::Quota;
@@ -247,6 +247,7 @@ fn main() {
                 max_fetch_count: 32,
                 fetch_concurrent: 2,
                 fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
+                buffer_pool: PoolRef::new(NZUsize!(16384), NZUsize!(10_000)),
             },
         );
 

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -214,7 +214,7 @@ fn main() {
             max_participants: participants.len(),
             fetch_concurrent: 2,
             fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
-            buffer_pool: PoolRef::new(NZUsize!(16384), NZUsize!(10_000)),
+            buffer_pool: PoolRef::new(NZUsize!(16_384), NZUsize!(10_000)),
         };
         let engine = simplex::Engine::new(context.with_label("engine"), cfg);
 

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -51,7 +51,7 @@ use clap::{value_parser, Arg, Command};
 use commonware_consensus::simplex;
 use commonware_cryptography::{ed25519, PrivateKeyExt as _, Sha256, Signer as _};
 use commonware_p2p::authenticated::discovery;
-use commonware_runtime::{tokio, Metrics, Runner};
+use commonware_runtime::{buffer::PoolRef, tokio, Metrics, Runner};
 use commonware_utils::{union, NZUsize, NZU32};
 use governor::Quota;
 use std::{
@@ -214,6 +214,7 @@ fn main() {
             max_participants: participants.len(),
             fetch_concurrent: 2,
             fetch_rate_per_peer: Quota::per_second(NZU32!(1)),
+            buffer_pool: PoolRef::new(NZUsize!(16384), NZUsize!(10_000)),
         };
         let engine = simplex::Engine::new(context.with_label("engine"), cfg);
 

--- a/storage/fuzz/fuzz_targets/archive_operations.rs
+++ b/storage/fuzz/fuzz_targets/archive_operations.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use commonware_runtime::{deterministic, Runner};
+use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
 use commonware_storage::{
     archive::{
         prunable::{Archive, Config},
@@ -39,6 +39,9 @@ struct FuzzInput {
     operations: Vec<ArchiveOperation>,
 }
 
+const PAGE_SIZE: usize = 555;
+const PAGE_CACHE_SIZE: usize = 100;
+
 fn fuzz(data: FuzzInput) {
     let runner = deterministic::Runner::default();
 
@@ -51,6 +54,7 @@ fn fuzz(data: FuzzInput) {
             replay_buffer: NZUsize!(1024*1024),
             compression: None,
             codec_config: (),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
         };
 
         let mut archive = Archive::<_, _, Key, Value>::init(context.clone(), cfg.clone()).await.expect("init failed");

--- a/storage/fuzz/fuzz_targets/archive_operations.rs
+++ b/storage/fuzz/fuzz_targets/archive_operations.rs
@@ -11,6 +11,7 @@ use commonware_storage::{
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use libfuzzer_sys::fuzz_target;
+use std::num::NonZeroUsize;
 
 type Key = FixedBytes<16>;
 type Value = FixedBytes<32>;
@@ -39,8 +40,8 @@ struct FuzzInput {
     operations: Vec<ArchiveOperation>,
 }
 
-const PAGE_SIZE: usize = 555;
-const PAGE_CACHE_SIZE: usize = 100;
+const PAGE_SIZE: NonZeroUsize = NZUsize!(555);
+const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(100);
 
 fn fuzz(data: FuzzInput) {
     let runner = deterministic::Runner::default();
@@ -54,7 +55,7 @@ fn fuzz(data: FuzzInput) {
             replay_buffer: NZUsize!(1024*1024),
             compression: None,
             codec_config: (),
-            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
         };
 
         let mut archive = Archive::<_, _, Key, Value>::init(context.clone(), cfg.clone()).await.expect("init failed");

--- a/storage/fuzz/fuzz_targets/freezer_operations.rs
+++ b/storage/fuzz/fuzz_targets/freezer_operations.rs
@@ -5,7 +5,7 @@ use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
 use commonware_storage::freezer::{Config, Freezer, Identifier};
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use libfuzzer_sys::fuzz_target;
-use std::collections::HashMap;
+use std::{collections::HashMap, num::NonZeroUsize};
 
 #[derive(Arbitrary, Debug)]
 enum Op {
@@ -28,8 +28,8 @@ fn vec_to_key(v: &[u8]) -> FixedBytes<32> {
     FixedBytes::<32>::new(buf)
 }
 
-const PAGE_SIZE: usize = 555;
-const PAGE_CACHE_SIZE: usize = 100;
+const PAGE_SIZE: NonZeroUsize = NZUsize!(555);
+const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(100);
 
 fn fuzz(input: FuzzInput) {
     let runner = deterministic::Runner::default();
@@ -40,7 +40,7 @@ fn fuzz(input: FuzzInput) {
             journal_compression: None,
             journal_write_buffer: NZUsize!(1024 * 1024),
             journal_target_size: 10 * 1024 * 1024,
-            journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+            journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             table_partition: "fuzz_table".into(),
             table_initial_size: 256,
             table_resize_frequency: 4,

--- a/storage/fuzz/fuzz_targets/freezer_operations.rs
+++ b/storage/fuzz/fuzz_targets/freezer_operations.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use commonware_runtime::{deterministic, Runner};
+use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
 use commonware_storage::freezer::{Config, Freezer, Identifier};
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use libfuzzer_sys::fuzz_target;
@@ -28,6 +28,9 @@ fn vec_to_key(v: &[u8]) -> FixedBytes<32> {
     FixedBytes::<32>::new(buf)
 }
 
+const PAGE_SIZE: usize = 555;
+const PAGE_CACHE_SIZE: usize = 100;
+
 fn fuzz(input: FuzzInput) {
     let runner = deterministic::Runner::default();
 
@@ -37,6 +40,7 @@ fn fuzz(input: FuzzInput) {
             journal_compression: None,
             journal_write_buffer: NZUsize!(1024 * 1024),
             journal_target_size: 10 * 1024 * 1024,
+            journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             table_partition: "fuzz_table".into(),
             table_initial_size: 256,
             table_resize_frequency: 4,

--- a/storage/src/adb/any/variable.rs
+++ b/storage/src/adb/any/variable.rs
@@ -166,6 +166,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
                 partition: cfg.log_journal_partition,
                 compression: cfg.log_compression,
                 codec_config: cfg.log_codec_config,
+                buffer_pool: cfg.buffer_pool.clone(),
                 write_buffer: cfg.log_write_buffer,
             },
         )
@@ -177,7 +178,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
                 partition: cfg.locations_journal_partition,
                 items_per_blob: cfg.locations_items_per_blob,
                 write_buffer: cfg.log_write_buffer,
-                buffer_pool: cfg.buffer_pool.clone(),
+                buffer_pool: cfg.buffer_pool,
             },
         )
         .await?;

--- a/storage/src/adb/benches/any_init.rs
+++ b/storage/src/adb/benches/any_init.rs
@@ -24,7 +24,7 @@ const ITEMS_PER_BLOB: u64 = 500_000;
 const PARTITION_SUFFIX: &str = "any_bench_partition";
 
 /// Use a "prod sized" page size to test the performance of the journal.
-const PAGE_SIZE: usize = 16384;
+const PAGE_SIZE: usize = 16_384;
 
 /// The number of pages to cache in the buffer pool.
 const PAGE_CACHE_SIZE: usize = 10_000;

--- a/storage/src/adb/benches/any_init.rs
+++ b/storage/src/adb/benches/any_init.rs
@@ -24,7 +24,7 @@ const ITEMS_PER_BLOB: u64 = 500_000;
 const PARTITION_SUFFIX: &str = "any_bench_partition";
 
 /// Use a "prod sized" page size to test the performance of the journal.
-const PAGE_SIZE: usize = 16_384;
+const PAGE_SIZE: usize = 16384;
 
 /// The number of pages to cache in the buffer pool.
 const PAGE_CACHE_SIZE: usize = 10_000;

--- a/storage/src/adb/immutable.rs
+++ b/storage/src/adb/immutable.rs
@@ -148,6 +148,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
                 partition: cfg.log_journal_partition,
                 compression: cfg.log_compression,
                 codec_config: cfg.log_codec_config,
+                buffer_pool: cfg.buffer_pool.clone(),
                 write_buffer: cfg.log_write_buffer,
             },
         )
@@ -159,7 +160,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
                 partition: cfg.locations_journal_partition,
                 items_per_blob: cfg.locations_items_per_blob,
                 write_buffer: cfg.log_write_buffer,
-                buffer_pool: cfg.buffer_pool.clone(),
+                buffer_pool: cfg.buffer_pool,
             },
         )
         .await?;

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -20,7 +20,7 @@ const ITEMS_PER_SECTION: u64 = 1_024;
 const REPLAY_BUFFER: usize = 1024 * 1024; // 1MB
 
 /// Use a "prod sized" page size to test the performance of the journal.
-const PAGE_SIZE: NonZeroUsize = NZUsize!(16384);
+const PAGE_SIZE: NonZeroUsize = NZUsize!(16_384);
 
 /// The number of pages to cache in the buffer pool.
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10_000);

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -7,6 +7,7 @@ use commonware_storage::{
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
+use std::num::NonZeroUsize;
 
 /// Number of bytes that can be buffered in a section before being written to a
 /// [commonware_runtime::Blob].
@@ -19,10 +20,10 @@ const ITEMS_PER_SECTION: u64 = 1_024;
 const REPLAY_BUFFER: usize = 1024 * 1024; // 1MB
 
 /// Use a "prod sized" page size to test the performance of the journal.
-const PAGE_SIZE: usize = 16384;
+const PAGE_SIZE: NonZeroUsize = NZUsize!(16384);
 
 /// The number of pages to cache in the buffer pool.
-const PAGE_CACHE_SIZE: usize = 10_000;
+const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10_000);
 
 /// Fixed-length key and value types.
 pub type Key = FixedBytes<64>;
@@ -65,10 +66,7 @@ impl Archive {
                     freezer_journal_partition: "archive_bench_journal".into(),
                     freezer_journal_target_size: 1024 * 1024 * 10, // 10MB
                     freezer_journal_compression: compression,
-                    freezer_journal_buffer_pool: PoolRef::new(
-                        NZUsize!(PAGE_SIZE),
-                        NZUsize!(PAGE_CACHE_SIZE),
-                    ),
+                    freezer_journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     ordinal_partition: "archive_bench_ordinal".into(),
                     items_per_section: ITEMS_PER_SECTION,
                     write_buffer: NZUsize!(WRITE_BUFFER),
@@ -86,7 +84,7 @@ impl Archive {
                     items_per_section: ITEMS_PER_SECTION,
                     write_buffer: NZUsize!(WRITE_BUFFER),
                     replay_buffer: NZUsize!(REPLAY_BUFFER),
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 };
                 Archive::Prunable(prunable::Archive::init(ctx, cfg).await.unwrap())
             }

--- a/storage/src/archive/immutable/mod.rs
+++ b/storage/src/archive/immutable/mod.rs
@@ -119,8 +119,11 @@ mod tests {
     use super::*;
     use crate::archive::Archive as ArchiveTrait;
     use commonware_cryptography::{hash, sha256::Digest};
-    use commonware_runtime::{deterministic, Runner};
+    use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
     use commonware_utils::NZUsize;
+
+    const PAGE_SIZE: usize = 1024;
+    const PAGE_CACHE_SIZE: usize = 10;
 
     #[test]
     fn test_unclean_shutdown() {
@@ -135,6 +138,10 @@ mod tests {
                 freezer_journal_partition: "test_journal2".into(),
                 freezer_journal_target_size: 1024 * 1024,
                 freezer_journal_compression: Some(3),
+                freezer_journal_buffer_pool: PoolRef::new(
+                    NZUsize!(PAGE_SIZE),
+                    NZUsize!(PAGE_CACHE_SIZE),
+                ),
                 ordinal_partition: "test_ordinal2".into(),
                 items_per_section: 512,
                 write_buffer: NZUsize!(1024),

--- a/storage/src/archive/immutable/mod.rs
+++ b/storage/src/archive/immutable/mod.rs
@@ -122,8 +122,8 @@ mod tests {
     use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
     use commonware_utils::NZUsize;
 
-    const PAGE_SIZE: usize = 1024;
-    const PAGE_CACHE_SIZE: usize = 10;
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     #[test]
     fn test_unclean_shutdown() {
@@ -138,10 +138,7 @@ mod tests {
                 freezer_journal_partition: "test_journal2".into(),
                 freezer_journal_target_size: 1024 * 1024,
                 freezer_journal_compression: Some(3),
-                freezer_journal_buffer_pool: PoolRef::new(
-                    NZUsize!(PAGE_SIZE),
-                    NZUsize!(PAGE_CACHE_SIZE),
-                ),
+                freezer_journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 ordinal_partition: "test_ordinal2".into(),
                 items_per_section: 512,
                 write_buffer: NZUsize!(1024),

--- a/storage/src/archive/immutable/mod.rs
+++ b/storage/src/archive/immutable/mod.rs
@@ -24,7 +24,7 @@
 //! # Example
 //!
 //! ```rust
-//! use commonware_runtime::{Spawner, Runner, deterministic};
+//! use commonware_runtime::{Spawner, Runner, deterministic, buffer::PoolRef};
 //! use commonware_cryptography::hash;
 //! use commonware_storage::{
 //!     archive::{
@@ -46,6 +46,7 @@
 //!         freezer_journal_partition: "journal".into(),
 //!         freezer_journal_target_size: 1024,
 //!         freezer_journal_compression: Some(3),
+//!         freezer_journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
 //!         ordinal_partition: "ordinal".into(),
 //!         items_per_section: 1024,
 //!         write_buffer: NZUsize!(1024),
@@ -62,6 +63,7 @@
 //! });
 
 mod storage;
+use commonware_runtime::buffer::PoolRef;
 use std::num::NonZeroUsize;
 pub use storage::Archive;
 
@@ -91,6 +93,9 @@ pub struct Config<C> {
 
     /// The compression level to use for the archive's freezer journal.
     pub freezer_journal_compression: Option<u8>,
+
+    /// The buffer pool to use for the archive's freezer journal.
+    pub freezer_journal_buffer_pool: PoolRef,
 
     /// The partition to use for the archive's ordinal.
     pub ordinal_partition: String,

--- a/storage/src/archive/immutable/storage.rs
+++ b/storage/src/archive/immutable/storage.rs
@@ -129,6 +129,7 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> Archive<E, K, V> {
                 journal_compression: cfg.freezer_journal_compression,
                 journal_write_buffer: cfg.write_buffer,
                 journal_target_size: cfg.freezer_journal_target_size,
+                journal_buffer_pool: cfg.freezer_journal_buffer_pool,
                 table_partition: cfg.freezer_table_partition,
                 table_initial_size: cfg.freezer_table_initial_size,
                 table_resize_frequency: cfg.freezer_table_resize_frequency,

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -105,12 +105,16 @@ mod tests {
     use commonware_codec::DecodeExt;
     use commonware_macros::test_traced;
     use commonware_runtime::{
+        buffer::PoolRef,
         deterministic::{self, Context},
         Runner,
     };
     use commonware_utils::{sequence::FixedBytes, NZUsize};
     use rand::Rng;
     use std::collections::BTreeMap;
+
+    const PAGE_SIZE: usize = 1024;
+    const PAGE_CACHE_SIZE: usize = 10;
 
     fn test_key(key: &str) -> FixedBytes<64> {
         let mut buf = [0u8; 64];
@@ -132,6 +136,7 @@ mod tests {
             items_per_section: 1024,
             write_buffer: NZUsize!(1024),
             replay_buffer: NZUsize!(1024),
+            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
         };
         prunable::Archive::init(context, cfg).await.unwrap()
     }
@@ -149,6 +154,10 @@ mod tests {
             freezer_journal_partition: "test_journal".into(),
             freezer_journal_target_size: 1024 * 1024,
             freezer_journal_compression: compression,
+            freezer_journal_buffer_pool: PoolRef::new(
+                NZUsize!(PAGE_SIZE),
+                NZUsize!(PAGE_CACHE_SIZE),
+            ),
             ordinal_partition: "test_ordinal".into(),
             items_per_section: 1024,
             write_buffer: NZUsize!(1024 * 1024),

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -111,10 +111,10 @@ mod tests {
     };
     use commonware_utils::{sequence::FixedBytes, NZUsize};
     use rand::Rng;
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, num::NonZeroUsize};
 
-    const PAGE_SIZE: usize = 1024;
-    const PAGE_CACHE_SIZE: usize = 10;
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     fn test_key(key: &str) -> FixedBytes<64> {
         let mut buf = [0u8; 64];
@@ -136,7 +136,7 @@ mod tests {
             items_per_section: 1024,
             write_buffer: NZUsize!(1024),
             replay_buffer: NZUsize!(1024),
-            buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+            buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
         };
         prunable::Archive::init(context, cfg).await.unwrap()
     }
@@ -154,10 +154,7 @@ mod tests {
             freezer_journal_partition: "test_journal".into(),
             freezer_journal_target_size: 1024 * 1024,
             freezer_journal_compression: compression,
-            freezer_journal_buffer_pool: PoolRef::new(
-                NZUsize!(PAGE_SIZE),
-                NZUsize!(PAGE_CACHE_SIZE),
-            ),
+            freezer_journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             ordinal_partition: "test_ordinal".into(),
             items_per_section: 1024,
             write_buffer: NZUsize!(1024 * 1024),

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -193,8 +193,8 @@ mod tests {
     const DEFAULT_ITEMS_PER_SECTION: u64 = 65536;
     const DEFAULT_WRITE_BUFFER: usize = 1024;
     const DEFAULT_REPLAY_BUFFER: usize = 4096;
-    const PAGE_SIZE: usize = 1024;
-    const PAGE_CACHE_SIZE: usize = 10;
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     fn test_key(key: &str) -> FixedBytes<64> {
         let mut buf = [0u8; 64];
@@ -218,7 +218,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -245,7 +245,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let result = Archive::<_, _, FixedBytes<64>, i32>::init(context, cfg.clone()).await;
             assert!(matches!(
@@ -269,7 +269,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -309,7 +309,7 @@ mod tests {
                     write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                     replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                     items_per_section: DEFAULT_ITEMS_PER_SECTION,
-                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 },
             )
             .await.expect("Failed to initialize archive");
@@ -337,7 +337,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -400,7 +400,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -457,7 +457,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: 1, // no mask - each item is its own section
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -543,7 +543,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section,
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -601,7 +601,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section,
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let mut archive =
                 Archive::<_, _, _, FixedBytes<1024>>::init(context.clone(), cfg.clone())

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -102,7 +102,7 @@
 //! # Example
 //!
 //! ```rust
-//! use commonware_runtime::{Spawner, Runner, deterministic};
+//! use commonware_runtime::{Spawner, Runner, deterministic, buffer::PoolRef};
 //! use commonware_cryptography::hash;
 //! use commonware_storage::{
 //!     translator::FourCap,
@@ -124,6 +124,7 @@
 //!         items_per_section: 1024,
 //!         write_buffer: NZUsize!(1024 * 1024),
 //!         replay_buffer: NZUsize!(4096),
+//!         buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
 //!     };
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
 //!
@@ -136,6 +137,7 @@
 //! ```
 
 use crate::translator::Translator;
+use commonware_runtime::buffer::PoolRef;
 use std::num::NonZeroUsize;
 
 mod storage;
@@ -168,6 +170,9 @@ pub struct Config<T: Translator, C> {
 
     /// The buffer size to use when replaying a [commonware_runtime::Blob].
     pub replay_buffer: NonZeroUsize,
+
+    /// The buffer pool to use for the archive's [crate::journal] storage.
+    pub buffer_pool: PoolRef,
 }
 
 #[cfg(test)]

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -193,6 +193,8 @@ mod tests {
     const DEFAULT_ITEMS_PER_SECTION: u64 = 65536;
     const DEFAULT_WRITE_BUFFER: usize = 1024;
     const DEFAULT_REPLAY_BUFFER: usize = 4096;
+    const PAGE_SIZE: usize = 1024;
+    const PAGE_CACHE_SIZE: usize = 10;
 
     fn test_key(key: &str) -> FixedBytes<64> {
         let mut buf = [0u8; 64];
@@ -216,6 +218,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -242,6 +245,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let result = Archive::<_, _, FixedBytes<64>, i32>::init(context, cfg.clone()).await;
             assert!(matches!(
@@ -265,6 +269,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -304,6 +309,7 @@ mod tests {
                     write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                     replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                     items_per_section: DEFAULT_ITEMS_PER_SECTION,
+                    buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 },
             )
             .await.expect("Failed to initialize archive");
@@ -331,6 +337,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -393,6 +400,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: DEFAULT_ITEMS_PER_SECTION,
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -449,6 +457,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section: 1, // no mask - each item is its own section
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -534,6 +543,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section,
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let mut archive = Archive::init(context.clone(), cfg.clone())
                 .await
@@ -591,6 +601,7 @@ mod tests {
                 write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
                 replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
                 items_per_section,
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
             };
             let mut archive =
                 Archive::<_, _, _, FixedBytes<1024>>::init(context.clone(), cfg.clone())

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -101,6 +101,7 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
                 partition: cfg.partition,
                 compression: cfg.compression,
                 codec_config: cfg.codec_config,
+                buffer_pool: cfg.buffer_pool,
                 write_buffer: cfg.write_buffer,
             },
         )

--- a/storage/src/freezer/benches/utils.rs
+++ b/storage/src/freezer/benches/utils.rs
@@ -1,6 +1,6 @@
 //! Helpers shared by the Freezer benchmarks.
 
-use commonware_runtime::tokio::Context;
+use commonware_runtime::{buffer::PoolRef, tokio::Context};
 use commonware_storage::freezer::{Config, Freezer};
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
@@ -29,6 +29,12 @@ pub const JOURNAL_PARTITION: &str = "freezer_bench_journal";
 /// Partition for [Freezer] table benchmarks.
 pub const TABLE_PARTITION: &str = "freezer_bench_table";
 
+/// Use a "prod sized" page size to test the performance of the journal.
+const PAGE_SIZE: usize = 16384;
+
+/// The number of pages to cache in the buffer pool.
+const PAGE_CACHE_SIZE: usize = 10_000;
+
 /// Fixed-length key and value types.
 pub type Key = FixedBytes<64>;
 pub type Val = FixedBytes<128>;
@@ -43,6 +49,7 @@ pub async fn init(ctx: Context) -> FreezerType {
         journal_compression: None,
         journal_write_buffer: NZUsize!(JOURNAL_WRITE_BUFFER),
         journal_target_size: JOURNAL_TARGET_SIZE,
+        journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
         table_partition: TABLE_PARTITION.into(),
         table_initial_size: TABLE_INITIAL_SIZE,
         table_resize_frequency: TABLE_RESIZE_FREQUENCY,

--- a/storage/src/freezer/benches/utils.rs
+++ b/storage/src/freezer/benches/utils.rs
@@ -4,6 +4,7 @@ use commonware_runtime::{buffer::PoolRef, tokio::Context};
 use commonware_storage::freezer::{Config, Freezer};
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
+use std::num::NonZeroUsize;
 
 /// Number of bytes that can be buffered before being written to disk.
 const JOURNAL_WRITE_BUFFER: usize = 1024 * 1024; // 1MB
@@ -30,10 +31,10 @@ pub const JOURNAL_PARTITION: &str = "freezer_bench_journal";
 pub const TABLE_PARTITION: &str = "freezer_bench_table";
 
 /// Use a "prod sized" page size to test the performance of the journal.
-const PAGE_SIZE: usize = 16384;
+const PAGE_SIZE: NonZeroUsize = NZUsize!(16384);
 
 /// The number of pages to cache in the buffer pool.
-const PAGE_CACHE_SIZE: usize = 10_000;
+const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10_000);
 
 /// Fixed-length key and value types.
 pub type Key = FixedBytes<64>;
@@ -49,7 +50,7 @@ pub async fn init(ctx: Context) -> FreezerType {
         journal_compression: None,
         journal_write_buffer: NZUsize!(JOURNAL_WRITE_BUFFER),
         journal_target_size: JOURNAL_TARGET_SIZE,
-        journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+        journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
         table_partition: TABLE_PARTITION.into(),
         table_initial_size: TABLE_INITIAL_SIZE,
         table_resize_frequency: TABLE_RESIZE_FREQUENCY,

--- a/storage/src/freezer/benches/utils.rs
+++ b/storage/src/freezer/benches/utils.rs
@@ -31,7 +31,7 @@ pub const JOURNAL_PARTITION: &str = "freezer_bench_journal";
 pub const TABLE_PARTITION: &str = "freezer_bench_table";
 
 /// Use a "prod sized" page size to test the performance of the journal.
-const PAGE_SIZE: NonZeroUsize = NZUsize!(16384);
+const PAGE_SIZE: NonZeroUsize = NZUsize!(16_384);
 
 /// The number of pages to cache in the buffer pool.
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10_000);

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -253,8 +253,8 @@ mod tests {
     const DEFAULT_TABLE_RESIZE_FREQUENCY: u8 = 4;
     const DEFAULT_TABLE_RESIZE_CHUNK_SIZE: u32 = 128; // force multiple chunks
     const DEFAULT_TABLE_REPLAY_BUFFER: usize = 64 * 1024; // 64KB
-    const PAGE_SIZE: usize = 1024;
-    const PAGE_CACHE_SIZE: usize = 10;
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     fn test_key(key: &str) -> FixedBytes<64> {
         let mut buf = [0u8; 64];
@@ -274,7 +274,7 @@ mod tests {
                 journal_compression: compression,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -342,7 +342,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -393,7 +393,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: 4, // Very small to force collisions
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -454,7 +454,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -524,7 +524,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -623,7 +623,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -682,7 +682,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -740,7 +740,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -804,7 +804,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -879,7 +879,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: 2, // Very small initial size to force multiple resizes
                 table_resize_frequency: 2, // Resize after 2 items per entry
@@ -948,7 +948,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: 2,
                 table_resize_frequency: 1,
@@ -1016,7 +1016,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: 2,
                 table_resize_frequency: 1,
@@ -1078,7 +1078,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: 128, // Force multiple journal sections
-                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 table_partition: "test_table".into(),
                 table_initial_size: 8,     // Small table to force collisions
                 table_resize_frequency: 2, // Force resize frequently

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -253,6 +253,8 @@ mod tests {
     const DEFAULT_TABLE_RESIZE_FREQUENCY: u8 = 4;
     const DEFAULT_TABLE_RESIZE_CHUNK_SIZE: u32 = 128; // force multiple chunks
     const DEFAULT_TABLE_REPLAY_BUFFER: usize = 64 * 1024; // 64KB
+    const PAGE_SIZE: usize = 1024;
+    const PAGE_CACHE_SIZE: usize = 10;
 
     fn test_key(key: &str) -> FixedBytes<64> {
         let mut buf = [0u8; 64];
@@ -272,6 +274,7 @@ mod tests {
                 journal_compression: compression,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -339,6 +342,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -389,6 +393,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: 4, // Very small to force collisions
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -449,6 +454,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -518,6 +524,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -616,6 +623,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -674,6 +682,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -731,6 +740,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -794,6 +804,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
                 table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
@@ -868,6 +879,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: 2, // Very small initial size to force multiple resizes
                 table_resize_frequency: 2, // Resize after 2 items per entry
@@ -936,6 +948,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: 2,
                 table_resize_frequency: 1,
@@ -1003,6 +1016,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: DEFAULT_JOURNAL_TARGET_SIZE,
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: 2,
                 table_resize_frequency: 1,
@@ -1064,6 +1078,7 @@ mod tests {
                 journal_compression: None,
                 journal_write_buffer: NZUsize!(DEFAULT_JOURNAL_WRITE_BUFFER),
                 journal_target_size: 128, // Force multiple journal sections
+                journal_buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 table_partition: "test_table".into(),
                 table_initial_size: 8,     // Small table to force collisions
                 table_resize_frequency: 2, // Force resize frequently

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -138,7 +138,7 @@
 //! # Example
 //!
 //! ```rust
-//! use commonware_runtime::{Spawner, Runner, deterministic};
+//! use commonware_runtime::{Spawner, Runner, deterministic, buffer::PoolRef};
 //! use commonware_storage::freezer::{Freezer, Config, Identifier};
 //! use commonware_utils::{sequence::FixedBytes, NZUsize};
 //!
@@ -150,6 +150,7 @@
 //!         journal_compression: Some(3),
 //!         journal_write_buffer: NZUsize!(1024 * 1024), // 1MB
 //!         journal_target_size: 100 * 1024 * 1024, // 100MB
+//!         journal_buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
 //!         table_partition: "freezer_table".into(),
 //!         table_initial_size: 65_536, // ~3MB initial table size
 //!         table_resize_frequency: 4, // Force resize once 4 writes to the same entry occur
@@ -176,6 +177,7 @@
 //! ```
 
 mod storage;
+use commonware_runtime::buffer::PoolRef;
 use commonware_utils::Array;
 use std::num::NonZeroUsize;
 pub use storage::{Checkpoint, Cursor, Freezer};
@@ -212,6 +214,9 @@ pub struct Config<C> {
 
     /// The target size of each journal before creating a new one.
     pub journal_target_size: u64,
+
+    /// The buffer pool to use for the journal.
+    pub journal_buffer_pool: PoolRef,
 
     /// The [commonware_runtime::Storage] partition to use for storing the table.
     pub table_partition: String,

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -541,6 +541,7 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> Freezer<E, K, V> {
             compression: config.journal_compression,
             codec_config: config.codec_config,
             write_buffer: config.journal_write_buffer,
+            buffer_pool: config.journal_buffer_pool,
         };
         let mut journal = Journal::init(context.clone(), journal_config).await?;
 

--- a/storage/src/journal/benches/bench.rs
+++ b/storage/src/journal/benches/bench.rs
@@ -21,7 +21,7 @@ criterion_main!(
 const WRITE_BUFFER: NonZeroUsize = NZUsize!(1_024 * 1024); // 1MB
 
 /// Use a "prod sized" page size to test the performance of the journal.
-const PAGE_SIZE: NonZeroUsize = NZUsize!(16384);
+const PAGE_SIZE: NonZeroUsize = NZUsize!(16_384);
 
 /// The number of pages to cache in the buffer pool. Make it big enough to be
 /// fast, but not so big we avoid any page faults for the larger benchmarks.

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -77,7 +77,7 @@
 //! # Example
 //!
 //! ```rust
-//! use commonware_runtime::{Spawner, Runner, deterministic};
+//! use commonware_runtime::{Spawner, Runner, deterministic, buffer::PoolRef};
 //! use commonware_storage::journal::variable::{Journal, Config};
 //! use commonware_utils::NZUsize;
 //!
@@ -88,6 +88,7 @@
 //!         partition: "partition".to_string(),
 //!         compression: None,
 //!         codec_config: (),
+//!         buffer_pool: PoolRef::new(NZUsize!(1024), NZUsize!(10)),
 //!         write_buffer: NZUsize!(1024 * 1024),
 //!     }).await.unwrap();
 //!
@@ -103,11 +104,14 @@ use super::Error;
 use bytes::BufMut;
 use commonware_codec::Codec;
 use commonware_runtime::{
-    buffer::{Read, Write},
+    buffer::{Append, PoolRef, Read},
     Blob, Error as RError, Metrics, Storage,
 };
 use commonware_utils::hex;
-use futures::stream::{self, Stream, StreamExt};
+use futures::{
+    future::try_join_all,
+    stream::{self, Stream, StreamExt},
+};
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
@@ -130,6 +134,9 @@ pub struct Config<C> {
 
     /// The codec configuration to use for encoding and decoding items.
     pub codec_config: C,
+
+    /// The buffer pool to use for caching data.
+    pub buffer_pool: PoolRef,
 
     /// The size of the write buffer to use for each blob.
     pub write_buffer: NonZeroUsize,
@@ -157,7 +164,7 @@ pub struct Journal<E: Storage + Metrics, V: Codec> {
 
     oldest_allowed: Option<u64>,
 
-    blobs: BTreeMap<u64, Write<E::Blob>>,
+    blobs: BTreeMap<u64, Append<E::Blob>>,
 
     tracked: Gauge,
     synced: Counter,
@@ -188,8 +195,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
                 Err(_) => return Err(Error::InvalidBlobName(hex_name)),
             };
             debug!(section, blob = hex_name, size, "loaded section");
-            let blob = Write::new(blob, size, cfg.write_buffer);
-            blobs.insert(section, blob);
+            blobs.insert(section, (blob, size));
         }
 
         // Initialize metrics
@@ -201,6 +207,16 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
         context.register("pruned", "Number of blobs pruned", pruned.clone());
         tracked.set(blobs.len() as i64);
 
+        // Wrap all blobs with Append wrappers
+        let blobs = try_join_all(blobs.into_iter().map(|(section, (blob, size))| {
+            let pool = cfg.buffer_pool.clone();
+            async move {
+                let blob = Append::new(blob, size, cfg.write_buffer, pool).await?;
+                Ok::<_, Error>((section, blob))
+            }
+        }))
+        .await?;
+
         // Create journal instance
         Ok(Self {
             context,
@@ -208,7 +224,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
 
             oldest_allowed: None,
 
-            blobs,
+            blobs: blobs.into_iter().collect(),
             tracked,
             synced,
             pruned,
@@ -231,7 +247,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     async fn read(
         compressed: bool,
         cfg: &V::Cfg,
-        blob: &Write<E::Blob>,
+        blob: &Append<E::Blob>,
         offset: u32,
     ) -> Result<(u32, u32, V), Error> {
         // Read item size
@@ -279,7 +295,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
 
     /// Helper function to read an item from a [Read].
     async fn read_buffered(
-        reader: &mut Read<Write<E::Blob>>,
+        reader: &mut Read<Append<E::Blob>>,
         offset: u32,
         cfg: &V::Cfg,
         compressed: bool,
@@ -340,7 +356,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     async fn read_exact(
         compressed: bool,
         cfg: &V::Cfg,
-        blob: &Write<E::Blob>,
+        blob: &Append<E::Blob>,
         offset: u32,
         len: u32,
     ) -> Result<V, Error> {
@@ -550,25 +566,44 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
             Entry::Vacant(entry) => {
                 let name = section.to_be_bytes();
                 let (blob, size) = self.context.open(&self.cfg.partition, &name).await?;
-                let blob = Write::new(blob, size, self.cfg.write_buffer);
+                let blob = Append::new(
+                    blob,
+                    size,
+                    self.cfg.write_buffer,
+                    self.cfg.buffer_pool.clone(),
+                )
+                .await?;
                 self.tracked.inc();
                 entry.insert(blob)
             }
         };
 
-        // Populate buffer
-        let mut buf = Vec::with_capacity(entry_len);
-        buf.put_u32(item_len);
-        buf.put_slice(&encoded);
-        let checksum = crc32fast::hash(&buf);
-        buf.put_u32(checksum);
-        assert_eq!(buf.len(), entry_len);
-
-        // Append item to blob
+        // Calculate alignment
         let cursor = blob.size().await;
         let offset = compute_next_offset(cursor)?;
         let aligned_cursor = offset as u64 * ITEM_ALIGNMENT;
-        blob.write_at(buf, aligned_cursor).await?;
+        let padding = (aligned_cursor - cursor) as usize;
+
+        // Populate buffer
+        let mut buf = Vec::with_capacity(padding + entry_len);
+
+        // Add padding bytes if necessary
+        if padding > 0 {
+            buf.resize(padding, 0);
+        }
+
+        // Add entry data
+        let entry_start = buf.len();
+        buf.put_u32(item_len);
+        buf.put_slice(&encoded);
+
+        // Calculate checksum only for the entry data (without padding)
+        let checksum = crc32fast::hash(&buf[entry_start..]);
+        buf.put_u32(checksum);
+        assert_eq!(buf[entry_start..].len(), entry_len);
+
+        // Append item to blob
+        blob.append(buf).await?;
         trace!(blob = section, offset, "appended item");
         Ok((offset, item_len))
     }

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -816,10 +816,15 @@ mod tests {
     use bytes::BufMut;
     use commonware_cryptography::hash;
     use commonware_macros::test_traced;
-    use commonware_runtime::{deterministic, Blob, Error as RError, Runner, Storage};
+    use commonware_runtime::{
+        buffer::PoolRef, deterministic, Blob, Error as RError, Runner, Storage,
+    };
     use commonware_utils::{NZUsize, StableBuf};
     use futures::{pin_mut, StreamExt};
     use prometheus_client::registry::Metric;
+
+    const PAGE_SIZE: usize = 1024;
+    const PAGE_CACHE_SIZE: usize = 10;
 
     #[test_traced]
     fn test_journal_append_and_read() {
@@ -833,6 +838,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
             let index = 1u64;
@@ -859,6 +865,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
             let journal = Journal::<_, i32>::init(context.clone(), cfg.clone())
@@ -902,6 +909,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -975,6 +983,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1073,6 +1082,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1104,6 +1114,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1156,6 +1167,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1212,6 +1224,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1278,6 +1291,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1358,6 +1372,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1528,6 +1543,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1661,6 +1677,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1798,6 +1815,7 @@ mod tests {
                 partition: "partition".to_string(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
             let context = MockStorage {
@@ -1825,6 +1843,7 @@ mod tests {
                 partition: "partition".to_string(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
             let context = MockStorage {
@@ -1849,6 +1868,7 @@ mod tests {
                 partition: "test_partition".to_string(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
             let mut journal = Journal::init(context, cfg).await.unwrap();
@@ -1903,6 +1923,7 @@ mod tests {
                 partition: "test_partition".to_string(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
             let mut journal = Journal::init(context, cfg).await.unwrap();
@@ -1960,6 +1981,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
+                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
                 write_buffer: NZUsize!(1024),
             };
 

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -811,8 +811,8 @@ mod tests {
     use futures::{pin_mut, StreamExt};
     use prometheus_client::registry::Metric;
 
-    const PAGE_SIZE: usize = 1024;
-    const PAGE_CACHE_SIZE: usize = 10;
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
     #[test_traced]
     fn test_journal_append_and_read() {
@@ -826,7 +826,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
             let index = 1u64;
@@ -853,7 +853,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
             let journal = Journal::<_, i32>::init(context.clone(), cfg.clone())
@@ -897,7 +897,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -971,7 +971,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1070,7 +1070,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1102,7 +1102,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1155,7 +1155,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1212,7 +1212,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1279,7 +1279,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1360,7 +1360,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1531,7 +1531,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1665,7 +1665,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 
@@ -1803,7 +1803,7 @@ mod tests {
                 partition: "partition".to_string(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
             let context = MockStorage {
@@ -1831,7 +1831,7 @@ mod tests {
                 partition: "partition".to_string(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
             let context = MockStorage {
@@ -1856,7 +1856,7 @@ mod tests {
                 partition: "test_partition".to_string(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
             let mut journal = Journal::init(context, cfg).await.unwrap();
@@ -1911,7 +1911,7 @@ mod tests {
                 partition: "test_partition".to_string(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
             let mut journal = Journal::init(context, cfg).await.unwrap();
@@ -1969,7 +1969,7 @@ mod tests {
                 partition: "test_partition".into(),
                 compression: None,
                 codec_config: (),
-                buffer_pool: PoolRef::new(NZUsize!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE)),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: NZUsize!(1024),
             };
 

--- a/storage/src/store/benches/restart.rs
+++ b/storage/src/store/benches/restart.rs
@@ -25,7 +25,7 @@ const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(500_000);
 const PARTITION_SUFFIX: &str = "store_bench_partition";
 
 /// Use a "prod sized" page size to test the performance of the journal.
-const PAGE_SIZE: NonZeroUsize = NZUsize!(16384);
+const PAGE_SIZE: NonZeroUsize = NZUsize!(16_384);
 
 /// The number of pages to cache in the buffer pool.
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10_000);

--- a/storage/src/store/mod.rs
+++ b/storage/src/store/mod.rs
@@ -157,7 +157,6 @@ pub struct Config<T: Translator, C> {
     pub translator: T,
 
     /// The buffer pool to use for caching data.
-    // TODO: Use this for the variable journal as well (#1223)
     pub buffer_pool: PoolRef,
 }
 
@@ -226,6 +225,7 @@ where
                 partition: cfg.log_journal_partition,
                 compression: cfg.log_compression,
                 codec_config: cfg.log_codec_config,
+                buffer_pool: cfg.buffer_pool.clone(),
                 write_buffer: cfg.log_write_buffer,
             },
         )
@@ -237,7 +237,7 @@ where
                 partition: cfg.locations_journal_partition,
                 items_per_blob: cfg.locations_items_per_blob,
                 write_buffer: cfg.log_write_buffer,
-                buffer_pool: cfg.buffer_pool.clone(),
+                buffer_pool: cfg.buffer_pool,
             },
         )
         .await?;


### PR DESCRIPTION
Updates the variable journal to use the `Append` blob wrapper for read caching through the buffer pool.
This PR touches a lot of things because of the fallout of having to pass along the `PoolRef` through multiple components, it can be reviewed commit by commit.

Fixes #1223.

