### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -57,7 +57,7 @@ jobs:
             file_suffix: ""
             benchmark_name: "commonware-coding"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install nightly Rust toolchain
         run: rustup toolchain install nightly
       - name: Run setup

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 90
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Remove examples

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -31,7 +31,7 @@ jobs:
             flags: ""
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install nightly Rust toolchain
       run: rustup toolchain install nightly && rustup component add --toolchain nightly rustfmt
     - name: Run setup
@@ -63,7 +63,7 @@ jobs:
             flags: ""
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Run tests
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install nightly Rust toolchain
       run: rustup toolchain install nightly
     - name: Get Rust version
@@ -99,7 +99,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Build entire workspace
@@ -119,7 +119,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Add WASM target
@@ -142,7 +142,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Install miri
@@ -160,6 +160,6 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Run shellcheck
       run: find scripts -name "*.sh" -exec shellcheck -o all {} +

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Publish macros

--- a/.github/workflows/quint.yml
+++ b/.github/workflows/quint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -35,7 +35,7 @@ jobs:
             flags: ""
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Run ignored tests
@@ -68,7 +68,7 @@ jobs:
             benchmark_name: "commonware-coding"
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install nightly Rust toolchain
       run: rustup toolchain install nightly
     - name: Run setup
@@ -87,7 +87,7 @@ jobs:
         fuzz_dir: [codec/fuzz, coding/fuzz, cryptography/fuzz, storage/fuzz, stream/fuzz, utils/fuzz]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install nightly Rust toolchain
       run: rustup toolchain install nightly
     - name: Get Rust version


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0