### PR TITLE
[release] v0.0.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-bridge"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "clap",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "chrono",
  "clap",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "paste",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "arbitrary",
  "commonware-coding",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-collector"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "blake3",
  "blst",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "arbitrary",
  "blake3",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-estimator"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "clap",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "chrono",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bimap",
  "bytes",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "async-lock",
  "axum",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "arbitrary",
  "commonware-codec",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "arbitrary",
  "chacha20poly1305",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-sync"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "clap",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-vrf"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,20 +32,20 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.57", path = "broadcast" }
-commonware-codec = { version = "0.0.57", path = "codec" }
-commonware-coding = { version = "0.0.57", path = "coding" }
-commonware-collector = { version = "0.0.57", path = "collector" }
-commonware-consensus = { version = "0.0.57", path = "consensus" }
-commonware-cryptography = { version = "0.0.57", path = "cryptography" }
-commonware-deployer = { version = "0.0.57", path = "deployer", default-features = false }
-commonware-macros = { version = "0.0.57", path = "macros" }
-commonware-p2p = { version = "0.0.57", path = "p2p" }
-commonware-resolver = { version = "0.0.57", path = "resolver" }
-commonware-runtime = { version = "0.0.57", path = "runtime" }
-commonware-storage = { version = "0.0.57", path = "storage" }
-commonware-stream = { version = "0.0.57", path = "stream" }
-commonware-utils = { version = "0.0.57", path = "utils" }
+commonware-broadcast = { version = "0.0.58", path = "broadcast" }
+commonware-codec = { version = "0.0.58", path = "codec" }
+commonware-coding = { version = "0.0.58", path = "coding" }
+commonware-collector = { version = "0.0.58", path = "collector" }
+commonware-consensus = { version = "0.0.58", path = "consensus" }
+commonware-cryptography = { version = "0.0.58", path = "cryptography" }
+commonware-deployer = { version = "0.0.58", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.58", path = "macros" }
+commonware-p2p = { version = "0.0.58", path = "p2p" }
+commonware-resolver = { version = "0.0.58", path = "resolver" }
+commonware-runtime = { version = "0.0.58", path = "runtime" }
+commonware-storage = { version = "0.0.58", path = "storage" }
+commonware-stream = { version = "0.0.58", path = "stream" }
+commonware-utils = { version = "0.0.58", path = "utils" }
 thiserror = "2.0.12"
 bytes = "1.7.1"
 sha2 = "0.10.8"

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-broadcast"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Disseminate data over a wide-area network."
 readme = "README.md"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-codec"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Serialize structured data."
 readme = "README.md"

--- a/codec/fuzz/Cargo.toml
+++ b/codec/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-codec-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 publish = false
 edition = "2021"
 

--- a/coding/Cargo.toml
+++ b/coding/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-coding"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Encode data to enable recovery from a subset of fragments."
 readme = "README.md"

--- a/coding/fuzz/Cargo.toml
+++ b/coding/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-coding-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 publish = false
 edition = "2021"
 

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-collector"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Collect responses to committable requests."
 readme = "README.md"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-consensus"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Order opaque messages in a Byzantine environment."
 readme = "README.md"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-cryptography"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Generate keys, sign arbitrary messages, and deterministically verify signatures."
 readme = "README.md"

--- a/cryptography/fuzz/Cargo.toml
+++ b/cryptography/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-cryptography-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 publish = false
 edition = "2021"
 

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-deployer"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Deploy infrastructure across cloud providers."
 readme = "README.md"

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-bridge"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Send succinct consensus certificates between two networks."
 readme = "README.md"

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-chat"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Send encrypted messages to a group of friends using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/examples/estimator/Cargo.toml
+++ b/examples/estimator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-estimator"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Simulate mechanism performance under realistic network conditions."
 readme = "README.md"

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-flood"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Spam peers deployed to AWS EC2 with random messages."
 readme = "README.md"

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-log"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Commit to a secret log and agree to its hash."
 readme = "README.md"

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-sync"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Synchronize state between a server and client."
 readme = "README.md"

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-vrf"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Generate bias-resistant randomness with untrusted contributors using commonware-cryptography and commonware-p2p."
 readme = "README.md"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-macros"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Augment the development of primitives with procedural macros."
 readme = "README.md"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-p2p"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Communicate with authenticated peers over encrypted connections."
 readme = "README.md"

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-resolver"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Resolve data identified by a fixed-length key."
 readme = "README.md"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-runtime"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Execute asynchronous tasks with a configurable scheduler."
 readme = "README.md"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-storage"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Persist and retrieve data from an abstract store."
 readme = "README.md"

--- a/storage/fuzz/Cargo.toml
+++ b/storage/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-storage-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 publish = false
 edition = "2021"
 

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-stream"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Exchange messages over arbitrary transport."
 readme = "README.md"

--- a/stream/fuzz/Cargo.toml
+++ b/stream/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-stream-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 publish = false
 edition = "2021"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "commonware-utils"
 edition = "2021"
 publish = true
-version = "0.0.57"
+version = "0.0.58"
 license = "MIT OR Apache-2.0"
 description = "Leverage common functionality across multiple primitives."
 readme = "README.md"

--- a/utils/fuzz/Cargo.toml
+++ b/utils/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commonware-utils-fuzz"
-version = "0.0.57"
+version = "0.0.58"
 publish = false
 edition = "2021"
 


### PR DESCRIPTION
## Stats

```
 .github/workflows/fast.yml                         |   33 +-
 .github/workflows/publish.yml                      |   10 +-
 .github/workflows/slow.yml                         |   13 +-
 .gitignore                                         |    1 +
 Cargo.lock                                         |   54 +-
 Cargo.toml                                         |   28 +-
 broadcast/Cargo.toml                               |    2 +-
 broadcast/src/buffered/mod.rs                      |    2 +-
 codec/Cargo.toml                                   |    2 +-
 codec/fuzz/Cargo.toml                              |    2 +-
 codec/src/varint.rs                                |    7 +-
 coding/Cargo.toml                                  |    2 +-
 coding/fuzz/Cargo.toml                             |    2 +-
 collector/Cargo.toml                               |    2 +-
 collector/src/p2p/mocks/types.rs                   |   10 +-
 consensus/Cargo.toml                               |    2 +-
 consensus/src/aggregation/config.rs                |    4 +
 consensus/src/aggregation/engine.rs                |   13 +-
 consensus/src/aggregation/mod.rs                   |   17 +-
 consensus/src/marshal/actor.rs                     |  104 +-
 consensus/src/marshal/config.rs                    |   14 +-
 consensus/src/marshal/mod.rs                       |  587 +++--
 consensus/src/ordered_broadcast/config.rs          |   10 +-
 consensus/src/ordered_broadcast/engine.rs          |   11 +-
 consensus/src/ordered_broadcast/mod.rs             |   22 +-
 consensus/src/simplex/actors/voter/actor.rs        |   16 +-
 consensus/src/simplex/actors/voter/mod.rs          |   23 +-
 consensus/src/simplex/config.rs                    |   10 +-
 consensus/src/simplex/engine.rs                    |    1 +
 consensus/src/simplex/mocks/application.rs         |   21 +-
 consensus/src/simplex/mod.rs                       |   73 +-
 .../src/threshold_simplex/actors/voter/actor.rs    |    9 +-
 .../src/threshold_simplex/actors/voter/mod.rs      |   23 +-
 consensus/src/threshold_simplex/config.rs          |   10 +-
 consensus/src/threshold_simplex/engine.rs          |    1 +
 .../src/threshold_simplex/mocks/application.rs     |   13 +-
 consensus/src/threshold_simplex/mod.rs             |   88 +-
 cryptography/Cargo.toml                            |    2 +-
 cryptography/fuzz/Cargo.toml                       |    2 +-
 deployer/Cargo.toml                                |    2 +-
 examples/bridge/Cargo.toml                         |    2 +-
 examples/bridge/src/bin/validator.rs               |    9 +-
 examples/chat/Cargo.toml                           |    2 +-
 examples/estimator/Cargo.toml                      |    2 +-
 examples/flood/Cargo.toml                          |    2 +-
 examples/log/Cargo.toml                            |    2 +-
 examples/log/src/main.rs                           |    9 +-
 examples/sync/Cargo.toml                           |    2 +-
 examples/sync/src/bin/server.rs                    |   18 +-
 examples/sync/src/lib.rs                           |   28 +-
 examples/sync/src/protocol.rs                      |   78 +-
 examples/sync/src/resolver.rs                      |   31 +-
 examples/vrf/Cargo.toml                            |    2 +-
 macros/Cargo.toml                                  |    2 +-
 p2p/Cargo.toml                                     |    2 +-
 pipeline/minimmit/minimmit.md                      |   10 +-
 pipeline/minimmit/quint/README.md                  |    2 +-
 pipeline/minimmit/quint/main_n6f0.qnt              |    3 +-
 pipeline/minimmit/quint/main_n6f1.qnt              |    3 +-
 pipeline/minimmit/quint/main_n6f2.qnt              |    3 +-
 pipeline/minimmit/quint/main_n7f1.qnt              |    3 +-
 pipeline/minimmit/quint/makefile                   |    6 +-
 pipeline/minimmit/quint/replica.qnt                |   80 +-
 pipeline/minimmit/quint/scripts/invariant.sh       |  217 ++
 pipeline/minimmit/quint/tests/tests_n6f0.qnt       |   12 +-
 pipeline/minimmit/quint/tests/tests_n6f1.qnt       |    9 +-
 pipeline/minimmit/quint/tests/tests_n7f1.qnt       |  176 ++
 resolver/Cargo.toml                                |    2 +-
 resolver/src/p2p/wire.rs                           |    4 +-
 runtime/Cargo.toml                                 |    2 +-
 runtime/src/deterministic.rs                       |   44 +-
 runtime/src/lib.rs                                 |  290 ++-
 runtime/src/storage/audited.rs                     |   17 +-
 runtime/src/storage/iouring.rs                     |    5 -
 runtime/src/storage/memory.rs                      |    5 -
 runtime/src/storage/metered.rs                     |  137 +-
 runtime/src/storage/mod.rs                         |    3 +-
 runtime/src/storage/tokio/fallback.rs              |   10 -
 runtime/src/storage/tokio/unix.rs                  |    6 -
 runtime/src/tokio/runtime.rs                       |   38 +-
 runtime/src/utils/buffer/append.rs                 |  146 +-
 runtime/src/utils/buffer/mod.rs                    |  181 +-
 runtime/src/utils/buffer/pool.rs                   |   12 +-
 runtime/src/utils/buffer/read.rs                   |   52 +-
 runtime/src/utils/buffer/tip.rs                    |   13 +-
 runtime/src/utils/buffer/write.rs                  |   16 +-
 runtime/src/utils/mod.rs                           |   97 +-
 runtime/src/utils/signal.rs                        |  228 ++
 storage/Cargo.toml                                 |    7 +-
 storage/fuzz/Cargo.toml                            |    9 +-
 .../fuzz/fuzz_targets/adb_current_operations.rs    |   31 +-
 storage/fuzz/fuzz_targets/adb_operations.rs        |   35 +-
 storage/fuzz/fuzz_targets/adb_sync.rs              |   14 +-
 storage/fuzz/fuzz_targets/archive_operations.rs    |   17 +-
 storage/fuzz/fuzz_targets/freezer_operations.rs    |   14 +-
 storage/fuzz/fuzz_targets/journal_operations.rs    |   15 +-
 storage/fuzz/fuzz_targets/ordinal_operations.rs    |  262 +++
 storage/fuzz/fuzz_targets/rmap_operations.rs       |    4 +-
 storage/src/adb/any/fixed.rs                       | 2360 +++++++++++++++++++
 storage/src/adb/any/mod.rs                         | 2422 +-------------------
 storage/src/adb/any/sync/client.rs                 |  118 +-
 storage/src/adb/any/sync/mod.rs                    |    2 +-
 storage/src/adb/any/sync/resolver.rs               |    6 +-
 storage/src/adb/any/variable.rs                    | 1236 ++++++++++
 storage/src/adb/benches/bench.rs                   |   10 +-
 storage/src/adb/benches/current_init.rs            |  189 ++
 .../src/adb/benches/{any_init.rs => fixed_init.rs} |   19 +-
 storage/src/adb/benches/variable_init.rs           |  158 ++
 storage/src/adb/current.rs                         |   70 +-
 storage/src/adb/immutable.rs                       |   93 +-
 storage/src/adb/mod.rs                             |    7 +-
 storage/src/archive/benches/utils.rs               |   25 +-
 storage/src/archive/immutable/mod.rs               |   34 +-
 storage/src/archive/immutable/storage.rs           |    7 +-
 storage/src/archive/mod.rs                         |   22 +-
 storage/src/archive/prunable/mod.rs                |   90 +-
 storage/src/archive/prunable/storage.rs            |    3 +-
 storage/src/freezer/benches/utils.rs               |   16 +-
 storage/src/freezer/mod.rs                         |   93 +-
 storage/src/freezer/storage.rs                     |   11 +-
 storage/src/index/mod.rs                           |   56 +-
 storage/src/index/storage.rs                       |   43 +-
 storage/src/journal/benches/bench.rs               |   11 +-
 storage/src/journal/benches/fixed_append.rs        |    8 +-
 storage/src/journal/benches/fixed_read_random.rs   |    9 +-
 .../src/journal/benches/fixed_read_sequential.rs   |    9 +-
 storage/src/journal/benches/fixed_replay.rs        |   11 +-
 storage/src/journal/fixed.rs                       |  164 +-
 storage/src/journal/variable.rs                    |  242 +-
 storage/src/lib.rs                                 |    1 +
 storage/src/metadata/mod.rs                        |   10 +-
 storage/src/metadata/storage.rs                    |    8 +-
 storage/src/mmr/bitmap.rs                          |   16 +-
 storage/src/mmr/journaled.rs                       |   45 +-
 storage/src/mmr/mod.rs                             |    2 +-
 storage/src/mmr/verification.rs                    |    2 +-
 storage/src/ordinal/benches/utils.rs               |    8 +-
 storage/src/ordinal/mod.rs                         |  292 ++-
 storage/src/ordinal/storage.rs                     |   36 +-
 storage/src/rmap/mod.rs                            |  238 +-
 storage/src/store/benches/bench.rs                 |    5 +
 storage/src/store/benches/restart.rs               |  133 ++
 storage/src/store/mod.rs                           | 1110 +++++++++
 storage/src/{adb => store}/operation.rs            |  117 +-
 stream/Cargo.toml                                  |    2 +-
 stream/fuzz/Cargo.toml                             |    2 +-
 utils/Cargo.toml                                   |    2 +-
 utils/fuzz/Cargo.toml                              |    2 +-
 utils/fuzz/fuzz_targets/array.rs                   |   12 +-
 utils/src/futures.rs                               |  167 +-
 utils/src/lib.rs                                   |    2 +-
 utils/src/sequence/prefixed_u64.rs                 |   14 +-
 utils/src/sequence/u32.rs                          |   22 +-
 utils/src/sequence/u64.rs                          |   22 +-
 154 files changed, 9311 insertions(+), 4182 deletions(-)
```