### PR TITLE
[codec] allow accessing error source chain

### DIFF
--- a/codec/src/error.rs
+++ b/codec/src/error.rs
@@ -69,6 +69,9 @@ pub enum Error {
     /// - The boxed [std::error::Error] is the original source error.
     ///
     /// Allows propagating custom errors through the codec reading process.
-    #[error("Wrapped Error: Context({0}), Source({1})")]
-    Wrapped(&'static str, Box<dyn std::error::Error + Send + Sync>),
+    #[error("Wrapped Error: Context({0})")]
+    Wrapped(
+        &'static str,
+        #[source] Box<dyn std::error::Error + Send + Sync>,
+    ),
 }


### PR DESCRIPTION
`codex::Error` in its current form does not allow the `thiserror::Error` proc macro to establish a source-chain. The `Display` impl generated by it will only emit the top level error and drop all underlying errors.

To allow it to establish a source chain the field needs to be either tagged `#[source]` or the field named `source: UnderlyingError`. (or tag it `[#from]`, but the very desirable `context` info does not allow for that)

I have opted to tag the field `#[source]` to mimimize churn. The `Source({1})` was also removed because the intended way to access the underlying information is via `std::error::Error::source`. And because having `Source({1})` would yield to duplicate messages both at error levels 0 and 1.