### PR TITLE
[adb::variable::*] Fix Miscellaneous Recovery Issues

### DIFF
--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -1212,7 +1212,20 @@ pub(super) mod test {
             }
             db.commit().await.unwrap();
 
+            let root = db.root(&mut hasher);
             assert_eq!(db.op_count(), 2787);
+            assert_eq!(leaf_pos_to_num(db.mmr.size()), Some(2787));
+            assert_eq!(db.locations.size().await.unwrap(), 2787);
+            assert_eq!(db.inactivity_floor_loc, 1480);
+            assert_eq!(db.oldest_retained_loc().unwrap(), 1477);
+            assert_eq!(db.snapshot.items(), 857);
+            db.close().await.unwrap();
+
+            let db = open_db(context.clone()).await;
+            assert_eq!(root, db.root(&mut hasher));
+            assert_eq!(db.op_count(), 2787);
+            assert_eq!(leaf_pos_to_num(db.mmr.size()), Some(2787));
+            assert_eq!(db.locations.size().await.unwrap(), 2787);
             assert_eq!(db.inactivity_floor_loc, 1480);
             assert_eq!(db.oldest_retained_loc().unwrap(), 1477);
             assert_eq!(db.snapshot.items(), 857);

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -169,7 +169,10 @@ impl<H: CHasher> Mmr<H> {
     /// pinned_nodes map.
     pub fn get_node_unchecked(&self, pos: u64) -> &H::Digest {
         if pos < self.pruned_to_pos {
-            return self.pinned_nodes.get(&pos).unwrap();
+            return self
+                .pinned_nodes
+                .get(&pos)
+                .expect("requested node is pruned and not pinned");
         }
 
         &self.nodes[self.pos_to_index(pos)]


### PR DESCRIPTION
This pull request refactors the recovery logic for operation logs in both variable and immutable database implementations, improving consistency and reliability after partial writes or crashes. It also enhances the Merkle Mountain Range (MMR) journaled implementation to better manage pinned nodes, ensuring proof validity and handling edge cases. Comprehensive new tests are added to verify correct recovery under various failure scenarios.

**Recovery logic improvements (most important):**

* Refactored the operation log recovery in `variable/mod.rs`, `immutable/mod.rs`, and `store/mod.rs` to track the first operation after the last commit point (`after_last_commit`) instead of relying on `end_loc` and `end_offset`, ensuring more precise rollback and pruning of uncommitted operations. [[1]](diffhunk://#diff-e44539305483fd3a60600e85eac47c6e1f8c3b1cc11bd916842c5c40c89fd73eL234-R235) [[2]](diffhunk://#diff-02bfcef8922851d41f3c0d81b1543cb05c2cb301afe26400f8db81043577bf2cL300-R301) [[3]](diffhunk://#diff-57f5cc405b5013aab3253d69dae20d45b9a4cf6d287b7f90115c66e8b3b2b2fdL391-R392)
* Updated the recovery process to use `after_last_commit` for rewinding logs, including improved assertions and logging, and removed the old logic based on `end_loc` and `end_offset`. [[1]](diffhunk://#diff-e44539305483fd3a60600e85eac47c6e1f8c3b1cc11bd916842c5c40c89fd73eL328-R339) [[2]](diffhunk://#diff-02bfcef8922851d41f3c0d81b1543cb05c2cb301afe26400f8db81043577bf2cL365-R379)

**MMR journaled implementation enhancements:**

* Extracted pinned node management into a new async helper method `add_extra_pinned_nodes`, called at key points in the MMR lifecycle to ensure all required nodes are pinned for proof generation and pruning boundaries. [[1]](diffhunk://#diff-ca38ae003e49e1b46c9947e0642d951f1b4c4d85f9dba679c2ee920757a6d328L211-R213) [[2]](diffhunk://#diff-ca38ae003e49e1b46c9947e0642d951f1b4c4d85f9dba679c2ee920757a6d328R236-R252) [[3]](diffhunk://#diff-ca38ae003e49e1b46c9947e0642d951f1b4c4d85f9dba679c2ee920757a6d328L311-R322) [[4]](diffhunk://#diff-ca38ae003e49e1b46c9947e0642d951f1b4c4d85f9dba679c2ee920757a6d328R469-R475)
* Improved error handling when accessing pruned nodes in `mem.rs` by making the panic message more informative.

**Testing and validation:**

* Added extensive tests for partial sync recovery in `variable/mod.rs` and for MMR pruning and proof validity in `journaled.rs`, including scenarios with simulated failures and reopening databases to verify state consistency. [[1]](diffhunk://#diff-e44539305483fd3a60600e85eac47c6e1f8c3b1cc11bd916842c5c40c89fd73eR1218-R1352) [[2]](diffhunk://#diff-ca38ae003e49e1b46c9947e0642d951f1b4c4d85f9dba679c2ee920757a6d328R840-R855) [[3]](diffhunk://#diff-02bfcef8922851d41f3c0d81b1543cb05c2cb301afe26400f8db81043577bf2cR908-R913)

**Consistency fixes:**

* Applied similar recovery logic changes to `store/mod.rs` for consistency across database backends. [[1]](diffhunk://#diff-57f5cc405b5013aab3253d69dae20d45b9a4cf6d287b7f90115c66e8b3b2b2fdL391-R392) [[2]](diffhunk://#diff-57f5cc405b5013aab3253d69dae20d45b9a4cf6d287b7f90115c66e8b3b2b2fdL407-R415)