### PR TITLE
[storage/adb+mmr] Recovery bug fixes

### DIFF
--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -231,11 +231,8 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
             mmr_leaves = locations_size;
         }
 
-        // The size of the log at the last commit point (including the commit operation), or 0 if
-        // none.
-        let mut end_loc = 0;
-        // The offset into the log of the operation following the last-known commit (if any).
-        let mut end_offset: Option<u32> = None;
+        // The location and blob-offset of the first operation to follow the last known commit point.
+        let mut after_last_commit = None;
         // The set of operations that have not yet been committed.
         let mut uncommitted_ops = HashMap::new();
         let mut oldest_retained_loc_found = false;
@@ -256,12 +253,13 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
                             self.oldest_retained_loc = self.log_size;
                             oldest_retained_loc_found = true;
                         }
-                        let loc = self.log_size; // location of the current operation.
-                        self.log_size += 1;
 
-                        if end_offset.is_none() {
-                            end_offset = Some(offset);
+                        let loc = self.log_size; // location of the current operation.
+                        if after_last_commit.is_none() {
+                            after_last_commit = Some((loc, offset));
                         }
+
+                        self.log_size += 1;
 
                         // Consistency check: confirm the provided section matches what we expect from this operation's
                         // index.
@@ -318,8 +316,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
                                     }
                                 }
                                 uncommitted_ops.clear();
-                                end_loc = self.log_size;
-                                end_offset = None;
+                                after_last_commit = None;
                             }
                             _ => unreachable!(
                                 "unexpected operation type at offset {offset} of section {section}"
@@ -329,27 +326,21 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
                 }
             }
         }
-        if end_loc < self.log_size {
+
+        // Rewind the operations log if necessary.
+        if let Some((end_loc, end_offset)) = after_last_commit {
+            assert!(!uncommitted_ops.is_empty());
             warn!(
                 op_count = uncommitted_ops.len(),
                 log_size = end_loc,
+                end_offset,
                 "rewinding over uncommitted operations at end of log"
             );
-            if end_loc == 0 {
-                self.log.rewind_to_offset(0, 0).await?;
-            } else {
-                assert!(end_offset.is_some());
-                let end_offset = end_offset.unwrap();
-                let mut prune_to_section = (end_loc - 1) / self.log_items_per_section;
-                if end_offset == 0 {
-                    prune_to_section += 1;
-                }
-                self.log
-                    .rewind_to_offset(prune_to_section, end_offset)
-                    .await?;
-                self.log.sync(prune_to_section).await?;
-            }
-
+            let prune_to_section = end_loc / self.log_items_per_section;
+            self.log
+                .rewind_to_offset(prune_to_section, end_offset)
+                .await?;
+            self.log.sync(prune_to_section).await?;
             self.log_size = end_loc;
         }
 

--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -1316,6 +1316,7 @@ pub(super) mod test {
                 db.update(k, v).await.unwrap();
             }
             db.commit().await.unwrap();
+            let root = db.root(&mut hasher);
 
             // Add more elements but crash after writing only the locations
             for i in 0u64..ELEMENTS {
@@ -1335,6 +1336,7 @@ pub(super) mod test {
                 db.update(k, v).await.unwrap();
             }
             db.commit().await.unwrap();
+            let root = db.root(&mut hasher);
 
             // Add more elements but crash after writing only the oldest_retained_loc
             for i in 0u64..ELEMENTS {

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -77,7 +77,9 @@ pub struct SyncConfig<D: Digest> {
 
 /// A MMR backed by a fixed-item-length journal.
 pub struct Mmr<E: RStorage + Clock + Metrics, H: CHasher> {
-    /// A memory resident MMR used to build the MMR structure and cache updates.
+    /// A memory resident MMR used to build the MMR structure and cache updates. It caches all
+    /// un-synced nodes, and the pinned node set as derived from both its own pruning boundary and
+    /// the journaled MMR's pruning boundary.
     mem_mmr: MemMmr<H>,
 
     /// Stores all unpruned MMR nodes.
@@ -208,16 +210,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             pinned_nodes,
             pool: cfg.thread_pool,
         });
-
-        // Compute the additional pinned nodes needed to prove all journal elements at the current
-        // pruning boundary.
-        let mut pinned_nodes = HashMap::new();
-        for pos in Proof::<H::Digest>::nodes_to_pin(metadata_prune_pos) {
-            let digest =
-                Mmr::<E, H>::get_from_metadata_or_journal(&metadata, &journal, pos).await?;
-            pinned_nodes.insert(pos, digest);
-        }
-        mem_mmr.add_pinned_nodes(pinned_nodes);
+        Self::add_extra_pinned_nodes(&mut mem_mmr, &metadata, &journal, metadata_prune_pos).await?;
 
         let mut s = Self {
             mem_mmr,
@@ -238,6 +231,23 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         }
 
         Ok(s)
+    }
+
+    /// Adds the pinned nodes based on `prune_pos` to `mem_mmr`.
+    async fn add_extra_pinned_nodes(
+        mem_mmr: &mut MemMmr<H>,
+        metadata: &Metadata<E, U64, Vec<u8>>,
+        journal: &Journal<E, H::Digest>,
+        prune_pos: u64,
+    ) -> Result<(), Error> {
+        let mut pinned_nodes = HashMap::new();
+        for pos in Proof::<H::Digest>::nodes_to_pin(prune_pos) {
+            let digest = Mmr::<E, H>::get_from_metadata_or_journal(metadata, journal, pos).await?;
+            pinned_nodes.insert(pos, digest);
+        }
+        mem_mmr.add_pinned_nodes(pinned_nodes);
+
+        Ok(())
     }
 
     /// Initialize an MMR for synchronization, reusing existing data if possible.
@@ -308,13 +318,8 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
 
         // Add the additional pinned nodes required for the pruning boundary, if applicable.
         if cfg.lower_bound < journal_size {
-            let mut pinned_nodes_pruning_boundary = HashMap::new();
-            for pos in Proof::<H::Digest>::nodes_to_pin(cfg.lower_bound) {
-                let digest =
-                    Mmr::<E, H>::get_from_metadata_or_journal(&metadata, &journal, pos).await?;
-                pinned_nodes_pruning_boundary.insert(pos, digest);
-            }
-            mem_mmr.add_pinned_nodes(pinned_nodes_pruning_boundary);
+            Self::add_extra_pinned_nodes(&mut mem_mmr, &metadata, &journal, cfg.lower_bound)
+                .await?;
         }
 
         Ok(Self {
@@ -461,6 +466,13 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             pinned_nodes,
             pool: self.mem_mmr.thread_pool.take(),
         });
+        Self::add_extra_pinned_nodes(
+            &mut self.mem_mmr,
+            &self.metadata,
+            &self.journal,
+            self.pruned_to_pos,
+        )
+        .await?;
 
         Ok(())
     }

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -169,7 +169,10 @@ impl<H: CHasher> Mmr<H> {
     /// pinned_nodes map.
     pub fn get_node_unchecked(&self, pos: u64) -> &H::Digest {
         if pos < self.pruned_to_pos {
-            return self.pinned_nodes.get(&pos).unwrap();
+            return self
+                .pinned_nodes
+                .get(&pos)
+                .expect("requested node is pruned and not pinned");
         }
 
         &self.nodes[self.pos_to_index(pos)]

--- a/storage/src/store/mod.rs
+++ b/storage/src/store/mod.rs
@@ -1091,6 +1091,11 @@ mod test {
 
             // Simulate a failed commit and test that we rollback to the previous root.
             db.simulate_failure(false, false).await.unwrap();
+            let db = create_test_store(context.with_label("store")).await;
+            assert_eq!(db.op_count(), op_count);
+
+            // Close and reopen the store to ensure the final commit is preserved.
+            db.close().await.unwrap();
             let mut db = create_test_store(context.with_label("store")).await;
             assert_eq!(db.op_count(), op_count);
 

--- a/storage/src/store/mod.rs
+++ b/storage/src/store/mod.rs
@@ -388,11 +388,8 @@ where
     async fn build_snapshot_from_log(mut self) -> Result<Self, Error> {
         let mut locations_size = self.locations.size().await?;
 
-        // The size of the log at the last commit point (including the commit operation), or 0 if
-        // none.
-        let mut end_loc = 0;
-        // The offset into the log at the end_loc.
-        let mut end_offset = 0;
+        // The location and blob-offset of the first operation to follow the last known commit point.
+        let mut after_last_commit = None;
         // The set of operations that have not yet been committed.
         let mut uncommitted_ops = HashMap::new();
         let mut oldest_retained_loc_found = false;
@@ -404,13 +401,18 @@ where
                     Err(e) => {
                         return Err(Error::Journal(e));
                     }
-                    Ok((section, offset, size, op)) => {
+                    Ok((section, offset, _, op)) => {
                         if !oldest_retained_loc_found {
                             self.log_size = section * self.log_items_per_section;
                             self.oldest_retained_loc = self.log_size;
                             oldest_retained_loc_found = true;
                         }
+
                         let loc = self.log_size; // location of the current operation.
+                        if after_last_commit.is_none() {
+                            after_last_commit = Some((loc, offset));
+                        }
+
                         self.log_size += 1;
 
                         // Consistency check: confirm the provided section matches what we expect from this operation's
@@ -464,8 +466,7 @@ where
                                     }
                                 }
                                 uncommitted_ops.clear();
-                                end_loc = self.log_size;
-                                end_offset = offset + size;
+                                after_last_commit = None;
                             }
                             _ => unreachable!(
                                 "unexpected operation type at offset {offset} of section {section}"
@@ -475,13 +476,17 @@ where
                 }
             }
         }
-        if end_loc < self.log_size {
+
+        // Rewind the operations log if necessary.
+        if let Some((end_loc, end_offset)) = after_last_commit {
+            assert!(!uncommitted_ops.is_empty());
             warn!(
                 op_count = uncommitted_ops.len(),
                 log_size = end_loc,
+                end_offset,
                 "rewinding over uncommitted operations at end of log"
             );
-            let prune_to_section = end_loc.saturating_sub(1) / self.log_items_per_section;
+            let prune_to_section = end_loc / self.log_items_per_section;
             self.log
                 .rewind_to_offset(prune_to_section, end_offset)
                 .await?;


### PR DESCRIPTION
Fixes 2 bugs:

1. All variable length stores were computing the wrong variable log rewind point during recovery in various cases.
2. Journaled MMR pop() wasn't re-adding the "extra" pinned nodes to the mem-mmr after resetting it, causing recovery to fail in some cases where the MMR had to be rewinded (since rewinding used pop()).

Improves the journal pop() test case to prevent regressions for (2), and immutable adb recery + non-adb store test cases to prevent regressions from (1) in those 2 stores.  Dan's new recovery test case(s) should prevent (1) from regressing in variable adb.