### PR TITLE
[consensus/aggregation] Migrate to Fixed-Length Types

### DIFF
--- a/consensus/src/aggregation/types.rs
+++ b/consensus/src/aggregation/types.rs
@@ -331,9 +331,9 @@ impl<V: Variant, D: Digest> Read for Activity<V, D> {
 impl<V: Variant, D: Digest> EncodeSize for Activity<V, D> {
     fn encode_size(&self) -> usize {
         1 + match self {
-            Activity::Ack(ack) => ack.encode_size(),
-            Activity::Certified(certificate) => certificate.encode_size(),
-            Activity::Tip(index) => index.encode_size(),
+            Activity::Ack(_) => Ack::<V, D>::SIZE,
+            Activity::Certified(_) => Certificate::<V, D>::SIZE,
+            Activity::Tip(_) => Index::SIZE,
         }
     }
 }

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -12,7 +12,7 @@ use crate::bls12381::primitives::{
     Error,
 };
 use bytes::{Buf, BufMut};
-use commonware_codec::{varint::UInt, EncodeSize, Error as CodecError, Read, ReadExt, Write};
+use commonware_codec::{EncodeSize, Error as CodecError, FixedSize, Read, ReadExt, Write};
 use rand::{rngs::OsRng, RngCore};
 use std::{collections::BTreeMap, hash::Hash};
 
@@ -38,7 +38,7 @@ pub struct Eval<C: Element> {
 
 impl<C: Element> Write for Eval<C> {
     fn write(&self, buf: &mut impl BufMut) {
-        UInt(self.index).write(buf);
+        self.index.write(buf);
         self.value.write(buf);
     }
 }
@@ -47,16 +47,14 @@ impl<C: Element> Read for Eval<C> {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
-        let index = UInt::read(buf)?.into();
+        let index = u32::read(buf)?;
         let value = C::read(buf)?;
         Ok(Self { index, value })
     }
 }
 
-impl<C: Element> EncodeSize for Eval<C> {
-    fn encode_size(&self) -> usize {
-        UInt(self.index).encode_size() + C::SIZE
-    }
+impl<C: Element> FixedSize for Eval<C> {
+    const SIZE: usize = u32::SIZE + C::SIZE;
 }
 
 /// A polynomial that is using a scalar for the variable x and a generic


### PR DESCRIPTION
Related: #1417

For better compatibility with downstream storage (like `ordinal`), migrate to using `FixedSize` types. I considered adding multiple encoding paths (minimal and fixed for things like `Item`) but that seemed to be a lot of complexity for a pretty modest savings. We can revisit if it becomes an issue (and/or investigate ways to support a conditional fixed/variable encoding in `codec`)?