### PR TITLE
[storage/mmr] faster leaf_pos_to_num implementation plus comparative benchmark

### DIFF
--- a/storage/src/mmr/benches/bench.rs
+++ b/storage/src/mmr/benches/bench.rs
@@ -2,6 +2,7 @@ use criterion::criterion_main;
 
 mod append;
 mod append_additional;
+mod leaf_pos_to_num;
 mod prove_many_elements;
 mod prove_single_element;
 mod update;
@@ -11,5 +12,6 @@ criterion_main!(
     append_additional::benches,
     prove_many_elements::benches,
     prove_single_element::benches,
+    leaf_pos_to_num::benches,
     update::benches,
 );

--- a/storage/src/mmr/benches/leaf_pos_to_num.rs
+++ b/storage/src/mmr/benches/leaf_pos_to_num.rs
@@ -1,0 +1,109 @@
+use commonware_storage::mmr::iterator::{leaf_num_to_pos, leaf_pos_to_num};
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+const ITERATIONS: usize = 1_000_000;
+
+fn bench_leaf_pos_to_num(c: &mut Criterion) {
+    for n in [1_000_000, 1_000_000_000, 1_000_000_000_000] {
+        // Generate random elements
+        let mut rng = StdRng::seed_from_u64(0);
+        for version in [1, 2, 3, 4] {
+            c.bench_function(
+                &format!("{}/n={}/algo={}", module_path!(), n, version),
+                |b| {
+                    b.iter(|| {
+                        for _ in 0..ITERATIONS {
+                            let pos = rng.gen_range(0..n);
+                            match version {
+                                1 => leaf_pos_to_num(pos),
+                                2 => leaf_pos_to_num_3_refinements(pos),
+                                3 => leaf_pos_to_num_binary_search(pos),
+                                4 => leaf_pos_to_num_tree_traversal(pos),
+                                _ => unreachable!(),
+                            };
+                        }
+                    });
+                },
+            );
+        }
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_leaf_pos_to_num
+}
+
+// Apply the refinement function three times in the straightforward way (constant time).
+#[inline]
+pub(crate) const fn leaf_pos_to_num_3_refinements(leaf_pos: u64) -> Option<u64> {
+    let leaf_num = leaf_pos / 2;
+    let leaf_num = (leaf_pos + leaf_num.count_ones() as u64) / 2;
+    let leaf_num = (leaf_pos + leaf_num.count_ones() as u64) / 2;
+    let leaf_num = (leaf_pos + leaf_num.count_ones() as u64) / 2;
+    if leaf_num_to_pos(leaf_num) == leaf_pos {
+        Some(leaf_num)
+    } else if leaf_num_to_pos(leaf_num + 1) == leaf_pos {
+        Some(leaf_num + 1)
+    } else {
+        None
+    }
+}
+
+// Naive tree traversal algorithm (log2(n) time).
+#[inline]
+pub(crate) const fn leaf_pos_to_num_tree_traversal(leaf_pos: u64) -> Option<u64> {
+    if leaf_pos == 0 {
+        return Some(0);
+    }
+
+    let start = u64::MAX >> (leaf_pos + 1).leading_zeros();
+    let height = start.trailing_ones();
+    let mut two_h = 1 << (height - 1);
+    let mut cur_node = start - 1;
+    let mut leaf_num_floor = 0u64;
+
+    while two_h > 1 {
+        if cur_node == leaf_pos {
+            return None;
+        }
+        let left_pos = cur_node - two_h;
+        two_h >>= 1;
+        if leaf_pos > left_pos {
+            // The leaf is in the right subtree, so we must account for the leaves in the left
+            // subtree all of which precede it.
+            leaf_num_floor += two_h;
+            cur_node -= 1; // move to the right child
+        } else {
+            // The node is in the left subtree
+            cur_node = left_pos;
+        }
+    }
+
+    Some(leaf_num_floor)
+}
+
+// Binary search for the n that solves 2*n - n.count_ones() == leaf_pos (log2(n) time).
+#[inline]
+pub(crate) const fn leaf_pos_to_num_binary_search(leaf_pos: u64) -> Option<u64> {
+    let mut lo = 0u64;
+    let mut hi = leaf_pos;
+
+    while lo <= hi {
+        let mid = (lo + hi) / 2;
+        let pos = 2 * mid - (mid.count_ones() as u64);
+        if pos == leaf_pos {
+            return Some(mid);
+        } else if pos < leaf_pos {
+            lo = mid + 1;
+        } else {
+            if mid == 0 {
+                break;
+            }
+            hi = mid - 1;
+        }
+    }
+    None
+}


### PR DESCRIPTION
This is a constant-time implementation of leaf_pos_to_num that improves performance about ~6-13x over the previous implementation. I also added a benchmark that compares various algorithms & implementation strategies.

Benchmark results on my macbook. Algo 1 is the new one, algo 4 is the old.
```
    Running src/mmr/benches/bench.rs (target/release/deps/mmr-37e7c5415768c11c)
Gnuplot not found, using plotters backend
mmr::leaf_pos_to_num/n=1000000/algo=1
                        time:   [7.2045 ms 7.2076 ms 7.2092 ms]
                        change: [-1.1792% -0.9587% -0.7724%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low severe

mmr::leaf_pos_to_num/n=1000000/algo=2
                        time:   [15.985 ms 15.998 ms 16.009 ms]
                        change: [-2.1502% -1.9698% -1.8079%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low severe

mmr::leaf_pos_to_num/n=1000000/algo=3
                        time:   [32.713 ms 33.023 ms 33.510 ms]
                        change: [-2.8902% -1.8354% -0.7542%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild

mmr::leaf_pos_to_num/n=1000000/algo=4
                        time:   [48.283 ms 48.563 ms 48.971 ms]
                        change: [-0.1292% +0.2620% +0.8064%] (p = 0.33 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

mmr::leaf_pos_to_num/n=1000000000/algo=1
                        time:   [7.5432 ms 7.5489 ms 7.5588 ms]
                        change: [-0.2286% -0.0211% +0.2014%] (p = 0.87 > 0.05)
                        No change in performance detected.

mmr::leaf_pos_to_num/n=1000000000/algo=2
                        time:   [16.280 ms 16.336 ms 16.371 ms]
                        change: [-1.7619% -1.2548% -0.8114%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low severe

mmr::leaf_pos_to_num/n=1000000000/algo=3
                        time:   [42.995 ms 43.484 ms 43.827 ms]
                        change: [-5.4367% -3.3511% -1.4468%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

mmr::leaf_pos_to_num/n=1000000000/algo=4
                        time:   [70.073 ms 70.357 ms 70.934 ms]
                        change: [-1.0867% -0.4598% +0.2293%] (p = 0.21 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe

mmr::leaf_pos_to_num/n=1000000000000/algo=1
                        time:   [7.8456 ms 7.8493 ms 7.8545 ms]
                        change: [-0.2712% -0.1115% +0.0581%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

mmr::leaf_pos_to_num/n=1000000000000/algo=2
                        time:   [16.656 ms 16.703 ms 16.742 ms]
                        change: [-1.0531% -0.8685% -0.7016%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild

mmr::leaf_pos_to_num/n=1000000000000/algo=3
                        time:   [52.142 ms 52.792 ms 53.925 ms]
                        change: [-4.5023% -0.8085% +2.5472%] (p = 0.69 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Benchmarking mmr::leaf_pos_to_num/n=1000000000000/algo=4: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.1s or enable flat sampling.
mmr::leaf_pos_to_num/n=1000000000000/algo=4
                        time:   [92.958 ms 93.692 ms 94.480 ms]
                        change: [-0.4751% +0.4194% +1.3165%] (p = 0.40 > 0.05)
                        No change in performance detected.

```
