### PR TITLE
[p2p/simulated, estimator] simulate bandwidth and message size constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,7 @@ dependencies = [
  "bytes",
  "clap",
  "colored",
+ "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
  "commonware-p2p",

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -84,14 +84,14 @@ mod tests {
 
         let mut registrations: Registrations = BTreeMap::new();
         for peer in peers.iter() {
-            let (sender, receiver) = oracle.register(peer.clone(), 0).await.unwrap();
+            let (sender, receiver) = oracle.register(peer.clone(), 0, None, None).await.unwrap();
             registrations.insert(peer.clone(), (sender, receiver));
         }
 
         // Add links between all peers
         let link = Link {
-            latency: NETWORK_SPEED.as_millis() as f64,
-            jitter: 0.0,
+            latency: NETWORK_SPEED,
+            jitter: Duration::ZERO,
             success_rate,
         };
         for p1 in peers.iter() {

--- a/collector/src/p2p/mod.rs
+++ b/collector/src/p2p/mod.rs
@@ -66,13 +66,13 @@ mod tests {
 
     const MAILBOX_SIZE: usize = 1024;
     const LINK: Link = Link {
-        latency: 10.0,
-        jitter: 1.0,
+        latency: Duration::from_millis(10),
+        jitter: Duration::from_millis(1),
         success_rate: 1.0,
     };
     const LINK_SLOW: Link = Link {
-        latency: 1_000.0,
-        jitter: 1.0,
+        latency: Duration::from_millis(1_000),
+        jitter: Duration::from_millis(1),
         success_rate: 1.0,
     };
 
@@ -104,8 +104,8 @@ mod tests {
 
         let mut connections = Vec::new();
         for peer in &peers {
-            let (sender1, receiver1) = oracle.register(peer.clone(), 0).await.unwrap();
-            let (sender2, receiver2) = oracle.register(peer.clone(), 1).await.unwrap();
+            let (sender1, receiver1) = oracle.register(peer.clone(), 0, None, None).await.unwrap();
+            let (sender2, receiver2) = oracle.register(peer.clone(), 1, None, None).await.unwrap();
             connections.push(((sender1, receiver1), (sender2, receiver2)));
         }
 

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -107,8 +107,8 @@ mod tests {
 
     /// Reliable network link configuration for testing.
     const RELIABLE_LINK: Link = Link {
-        latency: 10.0,
-        jitter: 1.0,
+        latency: Duration::from_millis(10),
+        jitter: Duration::from_millis(1),
         success_rate: 1.0,
     };
 
@@ -119,7 +119,10 @@ mod tests {
     ) -> Registrations<PublicKey> {
         let mut registrations = BTreeMap::new();
         for participant in participants.iter() {
-            let (sender, receiver) = oracle.register(participant.clone(), 0).await.unwrap();
+            let (sender, receiver) = oracle
+                .register(participant.clone(), 0, None, None)
+                .await
+                .unwrap();
             registrations.insert(participant.clone(), (sender, receiver));
         }
         registrations
@@ -581,8 +584,8 @@ mod tests {
 
             // Use degraded network links with realistic conditions
             let degraded_link = Link {
-                latency: 200.0,
-                jitter: 150.0,
+                latency: Duration::from_millis(200),
+                jitter: Duration::from_millis(150),
                 success_rate: 0.5,
             };
 
@@ -733,8 +736,8 @@ mod tests {
             context.sleep(Duration::from_secs(20)).await;
 
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             for v1 in pks.iter() {

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -170,11 +170,17 @@ mod tests {
             codec_config: (),
         };
         let (broadcast_engine, buffer) = buffered::Engine::new(context.clone(), broadcast_config);
-        let network = oracle.register(secret.public_key(), 1).await.unwrap();
+        let network = oracle
+            .register(secret.public_key(), 1, None, None)
+            .await
+            .unwrap();
         broadcast_engine.start(network);
 
         // Start the actor
-        let backfill = oracle.register(secret.public_key(), 2).await.unwrap();
+        let backfill = oracle
+            .register(secret.public_key(), 2, None, None)
+            .await
+            .unwrap();
         actor.start(application.clone(), buffer, backfill);
 
         (application, mailbox)
@@ -283,8 +289,8 @@ mod tests {
     #[test_traced("WARN")]
     fn test_finalize_good_links() {
         let link = Link {
-            latency: 100.0,
-            jitter: 1.0,
+            latency: Duration::from_millis(100),
+            jitter: Duration::from_millis(1),
             success_rate: 1.0,
         };
         for seed in 0..5 {
@@ -299,8 +305,8 @@ mod tests {
     #[test_traced("WARN")]
     fn test_finalize_bad_links() {
         let link = Link {
-            latency: 200.0,
-            jitter: 50.0,
+            latency: Duration::from_millis(200),
+            jitter: Duration::from_millis(50),
             success_rate: 0.7,
         };
         for seed in 0..5 {
@@ -367,9 +373,7 @@ mod tests {
 
                 // Wait for the block to be broadcast, but due to jitter, we may or may not receive
                 // the block before continuing.
-                context
-                    .sleep(Duration::from_millis(link.latency as u64))
-                    .await;
+                context.sleep(link.latency).await;
 
                 // Notarize block by the validator that broadcasted it
                 let proposal = Proposal {
@@ -439,8 +443,8 @@ mod tests {
             let mut actor = actors[0].clone();
 
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             setup_network_links(&mut oracle, &peers, link).await;
@@ -493,8 +497,8 @@ mod tests {
             let mut actor = actors[0].clone();
 
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             setup_network_links(&mut oracle, &peers, link).await;
@@ -561,8 +565,8 @@ mod tests {
             let mut actor = actors[0].clone();
 
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             setup_network_links(&mut oracle, &peers, link).await;
@@ -623,8 +627,8 @@ mod tests {
             let mut actor = actors[0].clone();
 
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             setup_network_links(&mut oracle, &peers, link).await;

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -97,8 +97,14 @@ mod tests {
     ) -> Registrations<PublicKey> {
         let mut registrations = BTreeMap::new();
         for participant in participants.iter() {
-            let (a1, a2) = oracle.register(participant.clone(), 0).await.unwrap();
-            let (b1, b2) = oracle.register(participant.clone(), 1).await.unwrap();
+            let (a1, a2) = oracle
+                .register(participant.clone(), 0, None, None)
+                .await
+                .unwrap();
+            let (b1, b2) = oracle
+                .register(participant.clone(), 1, None, None)
+                .await
+                .unwrap();
             registrations.insert(participant.clone(), ((a1, a2), (b1, b2)));
         }
         registrations
@@ -174,8 +180,8 @@ mod tests {
 
         let registrations = register_participants(&mut oracle, &pks).await;
         let link = Link {
-            latency: 10.0,
-            jitter: 1.0,
+            latency: Duration::from_millis(10),
+            jitter: Duration::from_millis(1),
             success_rate: 1.0,
         };
         link_participants(&mut oracle, &pks, Action::Link(link), None).await;
@@ -407,8 +413,8 @@ mod tests {
 
                 let mut registrations = register_participants(&mut oracle, &pks).await;
                 let link = commonware_p2p::simulated::Link {
-                    latency: 10.0,
-                    jitter: 1.0,
+                    latency: Duration::from_millis(10),
+                    jitter: Duration::from_millis(1),
                     success_rate: 1.0,
                 };
                 link_participants(&mut oracle, &pks, Action::Link(link), None).await;
@@ -525,8 +531,8 @@ mod tests {
 
             // Heal the partition by re-adding links.
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_participants(&mut oracle, &pks, Action::Link(link), None).await;
@@ -567,8 +573,8 @@ mod tests {
             )
             .await;
             let delayed_link = Link {
-                latency: 50.0,
-                jitter: 40.0,
+                latency: Duration::from_millis(50),
+                jitter: Duration::from_millis(40),
                 success_rate: 0.5,
             };
             let mut oracle_clone = oracle.clone();
@@ -740,8 +746,8 @@ mod tests {
 
             // Heal the partition by re-adding links.
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_participants(&mut oracle, &pks, Action::Link(link), None).await;
@@ -809,8 +815,8 @@ mod tests {
             // Register all participants
             let mut registrations = register_participants(&mut oracle, &participants).await;
             let link = commonware_p2p::simulated::Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_participants(&mut oracle, &participants, Action::Link(link), None).await;
@@ -969,8 +975,8 @@ mod tests {
             )
             .await;
             let delayed_link = Link {
-                latency: 80.0,
-                jitter: 10.0,
+                latency: Duration::from_millis(80),
+                jitter: Duration::from_millis(10),
                 success_rate: 0.98,
             };
             let mut oracle_clone = oracle.clone();

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -151,17 +151,19 @@ mod tests {
 
             // Create a dummy network mailbox
             let peer = schemes[1].public_key();
-            let (voter_sender, voter_receiver) =
-                oracle.register(validator.clone(), 0).await.unwrap();
+            let (voter_sender, voter_receiver) = oracle
+                .register(validator.clone(), 0, None, None)
+                .await
+                .unwrap();
             let (mut peer_sender, mut peer_receiver) =
-                oracle.register(peer.clone(), 0).await.unwrap();
+                oracle.register(peer.clone(), 0, None, None).await.unwrap();
             oracle
                 .add_link(
                     validator.clone(),
                     peer.clone(),
                     Link {
-                        latency: 0.0,
-                        jitter: 0.0,
+                        latency: Duration::from_millis(0),
+                        jitter: Duration::from_millis(0),
                         success_rate: 1.0,
                     },
                 )
@@ -172,8 +174,8 @@ mod tests {
                     peer,
                     validator,
                     Link {
-                        latency: 0.0,
-                        jitter: 0.0,
+                        latency: Duration::from_millis(0),
+                        jitter: Duration::from_millis(0),
                         success_rate: 1.0,
                     },
                 )
@@ -348,17 +350,19 @@ mod tests {
 
             // Create a dummy network mailbox
             let peer = private_keys[1].public_key();
-            let (voter_sender, voter_receiver) =
-                oracle.register(validator.clone(), 0).await.unwrap();
+            let (voter_sender, voter_receiver) = oracle
+                .register(validator.clone(), 0, None, None)
+                .await
+                .unwrap();
             let (mut peer_sender, mut peer_receiver) =
-                oracle.register(peer.clone(), 0).await.unwrap();
+                oracle.register(peer.clone(), 0, None, None).await.unwrap();
             oracle
                 .add_link(
                     validator.clone(),
                     peer.clone(),
                     Link {
-                        latency: 0.0,
-                        jitter: 0.0,
+                        latency: Duration::from_millis(0),
+                        jitter: Duration::from_millis(0),
                         success_rate: 1.0,
                     },
                 )
@@ -369,8 +373,8 @@ mod tests {
                     peer,
                     validator,
                     Link {
-                        latency: 0.0,
-                        jitter: 0.0,
+                        latency: Duration::from_millis(0),
+                        jitter: Duration::from_millis(0),
                         success_rate: 1.0,
                     },
                 )

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -166,10 +166,14 @@ mod tests {
     ) -> HashMap<P, ((Sender<P>, Receiver<P>), (Sender<P>, Receiver<P>))> {
         let mut registrations = HashMap::new();
         for validator in validators.iter() {
-            let (voter_sender, voter_receiver) =
-                oracle.register(validator.clone(), 0).await.unwrap();
-            let (resolver_sender, resolver_receiver) =
-                oracle.register(validator.clone(), 1).await.unwrap();
+            let (voter_sender, voter_receiver) = oracle
+                .register(validator.clone(), 0, None, None)
+                .await
+                .unwrap();
+            let (resolver_sender, resolver_receiver) = oracle
+                .register(validator.clone(), 1, None, None)
+                .await
+                .unwrap();
             registrations.insert(
                 validator.clone(),
                 (
@@ -274,8 +278,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -517,8 +521,8 @@ mod tests {
 
                 // Link all validators
                 let link = Link {
-                    latency: 50.0,
-                    jitter: 50.0,
+                    latency: Duration::from_millis(50),
+                    jitter: Duration::from_millis(50),
                     success_rate: 1.0,
                 };
                 link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -678,8 +682,8 @@ mod tests {
 
             // Link all validators except first
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(
@@ -770,8 +774,8 @@ mod tests {
 
             // Degrade network connections for online peers
             let link = Link {
-                latency: 3_000.0,
-                jitter: 0.0,
+                latency: Duration::from_millis(3_000),
+                jitter: Duration::from_millis(0),
                 success_rate: 1.0,
             };
             link_validators(
@@ -812,8 +816,8 @@ mod tests {
 
             // Restore network connections for all online peers
             let link = Link {
-                latency: 10.0,
-                jitter: 2.5,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(3),
                 success_rate: 1.0,
             };
             link_validators(
@@ -920,8 +924,8 @@ mod tests {
 
             // Link all validators except first
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(
@@ -1148,8 +1152,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -1286,7 +1290,7 @@ mod tests {
         let n = 5;
         let required_containers = 100;
         let activity_timeout = 10;
-        let skip_timeout = 2;
+        let skip_timeout = 3;
         let namespace = b"consensus".to_vec();
         let executor = deterministic::Runner::timed(Duration::from_secs(180));
         executor.start(|context| async move {
@@ -1317,8 +1321,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 3_000.0,
-                jitter: 0.0,
+                latency: Duration::from_millis(3_000),
+                jitter: Duration::from_millis(0),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -1421,8 +1425,8 @@ mod tests {
 
             // Update links
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -1504,8 +1508,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link.clone()), None).await;
@@ -1681,8 +1685,8 @@ mod tests {
 
             // Link all validators
             let degraded_link = Link {
-                latency: 200.0,
-                jitter: 150.0,
+                latency: Duration::from_millis(200),
+                jitter: Duration::from_millis(150),
                 success_rate: 0.5,
             };
             link_validators(&mut oracle, &validators, Action::Link(degraded_link), None).await;
@@ -1834,8 +1838,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -2006,8 +2010,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -2170,8 +2174,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -2320,8 +2324,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 80.0,
-                jitter: 10.0,
+                latency: Duration::from_millis(80),
+                jitter: Duration::from_millis(10),
                 success_rate: 0.98,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -172,21 +172,25 @@ mod tests {
 
             // Create a dummy network mailbox
             let peer = schemes[1].public_key();
-            let (pending_sender, _pending_receiver) =
-                oracle.register(validator.clone(), 0).await.unwrap();
-            let (recovered_sender, recovered_receiver) =
-                oracle.register(validator.clone(), 1).await.unwrap();
+            let (pending_sender, _pending_receiver) = oracle
+                .register(validator.clone(), 0, None, None)
+                .await
+                .unwrap();
+            let (recovered_sender, recovered_receiver) = oracle
+                .register(validator.clone(), 1, None, None)
+                .await
+                .unwrap();
             let (mut _peer_pending_sender, mut _peer_pending_receiver) =
-                oracle.register(peer.clone(), 0).await.unwrap();
+                oracle.register(peer.clone(), 0, None, None).await.unwrap();
             let (mut peer_recovered_sender, mut peer_recovered_receiver) =
-                oracle.register(peer.clone(), 1).await.unwrap();
+                oracle.register(peer.clone(), 1, None, None).await.unwrap();
             oracle
                 .add_link(
                     validator.clone(),
                     peer.clone(),
                     Link {
-                        latency: 0.0,
-                        jitter: 0.0,
+                        latency: Duration::from_millis(0),
+                        jitter: Duration::from_millis(0),
                         success_rate: 1.0,
                     },
                 )
@@ -197,8 +201,8 @@ mod tests {
                     peer,
                     validator,
                     Link {
-                        latency: 0.0,
-                        jitter: 0.0,
+                        latency: Duration::from_millis(0),
+                        jitter: Duration::from_millis(0),
                         success_rate: 1.0,
                     },
                 )
@@ -481,21 +485,25 @@ mod tests {
 
             // Create a dummy network mailbox
             let peer = private_keys[1].public_key();
-            let (pending_sender, _pending_receiver) =
-                oracle.register(validator.clone(), 0).await.unwrap();
-            let (recovered_sender, recovered_receiver) =
-                oracle.register(validator.clone(), 1).await.unwrap();
+            let (pending_sender, _pending_receiver) = oracle
+                .register(validator.clone(), 0, None, None)
+                .await
+                .unwrap();
+            let (recovered_sender, recovered_receiver) = oracle
+                .register(validator.clone(), 1, None, None)
+                .await
+                .unwrap();
             let (mut _peer_pending_sender, mut _peer_pending_receiver) =
-                oracle.register(peer.clone(), 0).await.unwrap();
+                oracle.register(peer.clone(), 0, None, None).await.unwrap();
             let (mut peer_recovered_sender, mut peer_recovered_receiver) =
-                oracle.register(peer.clone(), 1).await.unwrap();
+                oracle.register(peer.clone(), 1, None, None).await.unwrap();
             oracle
                 .add_link(
                     validator.clone(),
                     peer.clone(),
                     Link {
-                        latency: 0.0,
-                        jitter: 0.0,
+                        latency: Duration::from_millis(0),
+                        jitter: Duration::from_millis(0),
                         success_rate: 1.0,
                     },
                 )
@@ -506,8 +514,8 @@ mod tests {
                     peer,
                     validator,
                     Link {
-                        latency: 0.0,
-                        jitter: 0.0,
+                        latency: Duration::from_millis(0),
+                        jitter: Duration::from_millis(0),
                         success_rate: 1.0,
                     },
                 )

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -256,12 +256,18 @@ mod tests {
     > {
         let mut registrations = HashMap::new();
         for validator in validators.iter() {
-            let (pending_sender, pending_receiver) =
-                oracle.register(validator.clone(), 0).await.unwrap();
-            let (recovered_sender, recovered_receiver) =
-                oracle.register(validator.clone(), 1).await.unwrap();
-            let (resolver_sender, resolver_receiver) =
-                oracle.register(validator.clone(), 2).await.unwrap();
+            let (pending_sender, pending_receiver) = oracle
+                .register(validator.clone(), 0, None, None)
+                .await
+                .unwrap();
+            let (recovered_sender, recovered_receiver) = oracle
+                .register(validator.clone(), 1, None, None)
+                .await
+                .unwrap();
+            let (resolver_sender, resolver_receiver) = oracle
+                .register(validator.clone(), 2, None, None)
+                .await
+                .unwrap();
             registrations.insert(
                 validator.clone(),
                 (
@@ -364,8 +370,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -633,8 +639,8 @@ mod tests {
 
                 // Link all validators
                 let link = Link {
-                    latency: 50.0,
-                    jitter: 50.0,
+                    latency: Duration::from_millis(50),
+                    jitter: Duration::from_millis(50),
                     success_rate: 1.0,
                 };
                 link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -811,8 +817,8 @@ mod tests {
 
             // Link all validators except first
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(
@@ -917,8 +923,8 @@ mod tests {
 
             // Degrade network connections for online peers
             let link = Link {
-                latency: 3_000.0,
-                jitter: 0.0,
+                latency: Duration::from_millis(3_000),
+                jitter: Duration::from_millis(0),
                 success_rate: 1.0,
             };
             link_validators(
@@ -957,8 +963,8 @@ mod tests {
 
             // Restore network connections for all online peers
             let link = Link {
-                latency: 10.0,
-                jitter: 2.5,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(3),
                 success_rate: 1.0,
             };
             link_validators(
@@ -1081,8 +1087,8 @@ mod tests {
 
             // Link all validators except first
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(
@@ -1348,8 +1354,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -1537,8 +1543,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 3_000.0,
-                jitter: 0.0,
+                latency: Duration::from_millis(3_000),
+                jitter: Duration::from_millis(0),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -1651,8 +1657,8 @@ mod tests {
 
             // Update links
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -1748,8 +1754,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link.clone()), None).await;
@@ -1955,8 +1961,8 @@ mod tests {
 
             // Link all validators
             let degraded_link = Link {
-                latency: 200.0,
-                jitter: 150.0,
+                latency: Duration::from_millis(200),
+                jitter: Duration::from_millis(150),
                 success_rate: 0.5,
             };
             link_validators(&mut oracle, &validators, Action::Link(degraded_link), None).await;
@@ -2131,8 +2137,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -2325,8 +2331,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -2504,8 +2510,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -2682,8 +2688,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -2869,8 +2875,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -3037,8 +3043,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 80.0,
-                jitter: 10.0,
+                latency: Duration::from_millis(80),
+                jitter: Duration::from_millis(10),
                 success_rate: 0.98,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;
@@ -3189,8 +3195,8 @@ mod tests {
 
             // Link all validators
             let link = Link {
-                latency: 10.0,
-                jitter: 5.0,
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(5),
                 success_rate: 1.0,
             };
             link_validators(&mut oracle, &validators, Action::Link(link), None).await;

--- a/examples/estimator/Cargo.toml
+++ b/examples/estimator/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/estim
 documentation = "https://docs.rs/commonware-estimator"
 
 [dependencies]
+commonware-codec = { workspace = true }
 commonware-cryptography = { workspace = true }
 commonware-macros = { workspace = true }
 commonware-p2p = { workspace = true }

--- a/examples/estimator/simplex_with_sizes.lazy
+++ b/examples/estimator/simplex_with_sizes.lazy
@@ -1,0 +1,15 @@
+# Simplex (with message sizes)
+
+## Propose a block (1KB proposal)
+propose{0, size=100024}
+
+## Multicast notarize (small 100-byte notarizations)
+wait{0, threshold=1, delay=(0.1,1)}
+broadcast{1, size=100}
+
+## Multicast finalize after observing 2f+1 notarize (200-byte finalize messages)
+wait{1, threshold=67%, delay=(0.1,1)}
+broadcast{2, size=200}
+
+## Wait for 2f+1 finalize
+wait{2, threshold=67%, delay=(0.1,1)}

--- a/examples/estimator/src/lib.rs
+++ b/examples/estimator/src/lib.rs
@@ -1289,4 +1289,49 @@ broadcast{1}
         let content = "wait{1, threshold=1} && wait{2, threshold=1})";
         parse_task(content);
     }
+
+    #[test]
+    fn test_parse_task_commands_with_message_sizes() {
+        let content = r#"
+propose{1, size=1024}
+broadcast{2, size=100}
+reply{3, size=64}
+reply{4}
+"#;
+
+        let commands = parse_task(content);
+        assert_eq!(commands.len(), 4);
+
+        match &commands[0].1 {
+            Command::Propose(id, size) => {
+                assert_eq!(*id, 1);
+                assert_eq!(*size, Some(1024));
+            }
+            _ => panic!("Expected Propose command with size"),
+        }
+
+        match &commands[1].1 {
+            Command::Broadcast(id, size) => {
+                assert_eq!(*id, 2);
+                assert_eq!(*size, Some(100));
+            }
+            _ => panic!("Expected Broadcast command with size"),
+        }
+
+        match &commands[2].1 {
+            Command::Reply(id, size) => {
+                assert_eq!(*id, 3);
+                assert_eq!(*size, Some(64));
+            }
+            _ => panic!("Expected Reply command with size"),
+        }
+
+        match &commands[3].1 {
+            Command::Reply(id, size) => {
+                assert_eq!(*id, 4);
+                assert_eq!(*size, None);
+            }
+            _ => panic!("Expected Reply command without size"),
+        }
+    }
 }

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -272,7 +272,7 @@ async fn setup_network_identities(
         for _ in 0..*count {
             let identity = ed25519::PrivateKey::from_seed(peer_idx as u64).public_key();
             let (sender, receiver) = oracle
-                .register(identity.clone(), DEFAULT_CHANNEL)
+                .register(identity.clone(), DEFAULT_CHANNEL, None, None)
                 .await
                 .unwrap();
             let (sender, receiver) = wrap::<_, _, u32>((), sender, receiver);
@@ -297,8 +297,8 @@ async fn setup_network_links(
             }
             let latency = latencies[region][other_region];
             let link = Link {
-                latency: latency.0,
-                jitter: latency.1,
+                latency: Duration::from_micros((latency.0 * 1000.0) as u64),
+                jitter: Duration::from_micros((latency.1 * 1000.0) as u64),
                 success_rate: DEFAULT_SUCCESS_RATE,
             };
             oracle

--- a/p2p/src/simulated/ingress.rs
+++ b/p2p/src/simulated/ingress.rs
@@ -11,6 +11,8 @@ pub enum Message<P: PublicKey> {
     Register {
         public_key: P,
         channel: Channel,
+        egress_bps: Option<usize>,
+        ingress_bps: Option<usize>,
         #[allow(clippy::type_complexity)]
         result: oneshot::Sender<Result<(Sender<P>, Receiver<P>), Error>>,
     },
@@ -90,16 +92,23 @@ impl<P: PublicKey> Oracle<P> {
     ///
     /// By default, the peer will not be linked to any other peers. If a peer is already
     /// registered on a given channel, it will return an error.
+    ///
+    /// Bandwidth can be specified for the peer's egress (upload) and ingress (download)
+    /// rates in bytes per second. `None` means unlimited bandwidth.
     pub async fn register(
         &mut self,
         public_key: P,
         channel: Channel,
+        egress_bps: Option<usize>,
+        ingress_bps: Option<usize>,
     ) -> Result<(Sender<P>, Receiver<P>), Error> {
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(Message::Register {
                 public_key,
                 channel,
+                egress_bps,
+                ingress_bps,
                 result: sender,
             })
             .await

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -39,8 +39,8 @@
 //!     let network_handler = network.start();
 //!
 //!     // Register some peers
-//!     let (sender, receiver) = oracle.register(peers[0].clone(), 0).await.unwrap();
-//!     let (sender, receiver) = oracle.register(peers[1].clone(), 0).await.unwrap();
+//!     let (sender, receiver) = oracle.register(peers[0].clone(), 0, None, None).await.unwrap();
+//!     let (sender, receiver) = oracle.register(peers[1].clone(), 0, None, None).await.unwrap();
 //!
 //!     // Link 2 peers
 //!     oracle.add_link(
@@ -153,7 +153,8 @@ mod tests {
             let (seen_sender, mut seen_receiver) = mpsc::channel(1024);
             for i in 0..size {
                 let pk = PrivateKey::from_seed(i as u64).public_key();
-                let (sender, mut receiver) = oracle.register(pk.clone(), 0).await.unwrap();
+                let (sender, mut receiver) =
+                    oracle.register(pk.clone(), 0, None, None).await.unwrap();
                 agents.insert(pk, sender);
                 let mut agent_sender = seen_sender.clone();
                 context
@@ -268,7 +269,7 @@ mod tests {
             let mut agents = HashMap::new();
             for i in 0..10 {
                 let pk = PrivateKey::from_seed(i as u64).public_key();
-                let (sender, _) = oracle.register(pk.clone(), 0).await.unwrap();
+                let (sender, _) = oracle.register(pk.clone(), 0, None, None).await.unwrap();
                 agents.insert(pk, sender);
             }
 
@@ -306,7 +307,7 @@ mod tests {
 
             // Register agents
             let pk = PrivateKey::from_seed(0).public_key();
-            oracle.register(pk.clone(), 0).await.unwrap();
+            oracle.register(pk.clone(), 0, None, None).await.unwrap();
 
             // Attempt to link self
             let result = oracle
@@ -343,8 +344,8 @@ mod tests {
 
             // Register agents
             let pk = PrivateKey::from_seed(0).public_key();
-            oracle.register(pk.clone(), 0).await.unwrap();
-            let result = oracle.register(pk, 0).await;
+            oracle.register(pk.clone(), 0, None, None).await.unwrap();
+            let result = oracle.register(pk, 0, None, None).await;
 
             // Confirm error is correct
             assert!(matches!(result, Err(Error::ChannelAlreadyRegistered(0))));
@@ -369,8 +370,8 @@ mod tests {
             // Register agents
             let pk1 = PrivateKey::from_seed(0).public_key();
             let pk2 = PrivateKey::from_seed(1).public_key();
-            oracle.register(pk1.clone(), 0).await.unwrap();
-            oracle.register(pk2.clone(), 0).await.unwrap();
+            oracle.register(pk1.clone(), 0, None, None).await.unwrap();
+            oracle.register(pk2.clone(), 0, None, None).await.unwrap();
 
             // Attempt to link with invalid success rate
             let result = oracle
@@ -408,8 +409,8 @@ mod tests {
             // Register agents
             let pk1 = PrivateKey::from_seed(0).public_key();
             let pk2 = PrivateKey::from_seed(1).public_key();
-            oracle.register(pk1.clone(), 0).await.unwrap();
-            oracle.register(pk2.clone(), 0).await.unwrap();
+            oracle.register(pk1.clone(), 0, None, None).await.unwrap();
+            oracle.register(pk2.clone(), 0, None, None).await.unwrap();
 
             // Attempt to link with invalid jitter
             let result = oracle
@@ -463,12 +464,14 @@ mod tests {
             // Register agents
             let pk1 = PrivateKey::from_seed(0).public_key();
             let pk2 = PrivateKey::from_seed(1).public_key();
-            let (mut sender1, mut receiver1) = oracle.register(pk1.clone(), 0).await.unwrap();
-            let (mut sender2, mut receiver2) = oracle.register(pk2.clone(), 0).await.unwrap();
+            let (mut sender1, mut receiver1) =
+                oracle.register(pk1.clone(), 0, None, None).await.unwrap();
+            let (mut sender2, mut receiver2) =
+                oracle.register(pk2.clone(), 0, None, None).await.unwrap();
 
             // Register unused channels
-            let _ = oracle.register(pk1.clone(), 1).await.unwrap();
-            let _ = oracle.register(pk2.clone(), 2).await.unwrap();
+            let _ = oracle.register(pk1.clone(), 1, None, None).await.unwrap();
+            let _ = oracle.register(pk2.clone(), 2, None, None).await.unwrap();
 
             // Link agents
             oracle
@@ -536,8 +539,8 @@ mod tests {
             // Register agents
             let pk1 = PrivateKey::from_seed(0).public_key();
             let pk2 = PrivateKey::from_seed(1).public_key();
-            let (mut sender1, _) = oracle.register(pk1.clone(), 0).await.unwrap();
-            let (_, mut receiver2) = oracle.register(pk2.clone(), 1).await.unwrap();
+            let (mut sender1, _) = oracle.register(pk1.clone(), 0, None, None).await.unwrap();
+            let (_, mut receiver2) = oracle.register(pk2.clone(), 1, None, None).await.unwrap();
 
             // Link agents
             oracle
@@ -588,8 +591,10 @@ mod tests {
             // Define agents
             let pk1 = PrivateKey::from_seed(0).public_key();
             let pk2 = PrivateKey::from_seed(1).public_key();
-            let (mut sender1, mut receiver1) = oracle.register(pk1.clone(), 0).await.unwrap();
-            let (mut sender2, mut receiver2) = oracle.register(pk2.clone(), 0).await.unwrap();
+            let (mut sender1, mut receiver1) =
+                oracle.register(pk1.clone(), 0, None, None).await.unwrap();
+            let (mut sender2, mut receiver2) =
+                oracle.register(pk2.clone(), 0, None, None).await.unwrap();
 
             // Link agents
             oracle
@@ -657,8 +662,10 @@ mod tests {
             // Register agents
             let pk1 = PrivateKey::from_seed(0).public_key();
             let pk2 = PrivateKey::from_seed(1).public_key();
-            let (mut sender1, mut receiver1) = oracle.register(pk1.clone(), 0).await.unwrap();
-            let (mut sender2, mut receiver2) = oracle.register(pk2.clone(), 0).await.unwrap();
+            let (mut sender1, mut receiver1) =
+                oracle.register(pk1.clone(), 0, None, None).await.unwrap();
+            let (mut sender2, mut receiver2) =
+                oracle.register(pk2.clone(), 0, None, None).await.unwrap();
 
             // Send messages
             let msg1 = Bytes::from("attempt 1: hello from pk1");

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -15,6 +15,7 @@
 //! use commonware_p2p::simulated::{Config, Link, Network};
 //! use commonware_cryptography::{ed25519, PrivateKey, Signer as _, PublicKey as _, PrivateKeyExt as _};
 //! use commonware_runtime::{deterministic, Spawner, Runner, Metrics};
+//! use std::time::Duration;
 //!
 //! // Generate peers
 //! let peers = vec![
@@ -47,8 +48,8 @@
 //!         peers[0].clone(),
 //!         peers[1].clone(),
 //!         Link {
-//!             latency: 5.0,
-//!             jitter: 2.5,
+//!             latency: Duration::from_millis(5),
+//!             jitter: Duration::from_millis(2),
 //!             success_rate: 0.75,
 //!         },
 //!     ).await.unwrap();
@@ -64,8 +65,8 @@
 //!         peers[0].clone(),
 //!         peers[1].clone(),
 //!         Link {
-//!             latency: 100.0,
-//!             jitter: 25.0,
+//!             latency: Duration::from_millis(100),
+//!             jitter: Duration::from_millis(25),
 //!             success_rate: 0.8,
 //!         },
 //!     ).await.unwrap();
@@ -112,8 +113,6 @@ pub enum Error {
     DialFailed,
     #[error("peer missing")]
     PeerMissing,
-    #[error("invalid connection definition: latency={0}, jitter={1}")]
-    InvalidBehavior(f64, f64),
 }
 
 pub use ingress::{Link, Oracle};
@@ -182,8 +181,8 @@ mod tests {
                             agent.clone(),
                             other.clone(),
                             Link {
-                                latency: 5.0,
-                                jitter: 2.5,
+                                latency: Duration::from_millis(5),
+                                jitter: Duration::from_millis(2),
                                 success_rate: 0.75,
                             },
                         )
@@ -315,8 +314,8 @@ mod tests {
                     pk.clone(),
                     pk,
                     Link {
-                        latency: 5.0,
-                        jitter: 2.5,
+                        latency: Duration::from_millis(5),
+                        jitter: Duration::from_millis(2),
                         success_rate: 0.75,
                     },
                 )
@@ -379,8 +378,8 @@ mod tests {
                     pk1,
                     pk2,
                     Link {
-                        latency: 5.0,
-                        jitter: 2.5,
+                        latency: Duration::from_millis(5),
+                        jitter: Duration::from_millis(2),
                         success_rate: 1.5,
                     },
                 )
@@ -391,60 +390,6 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_invalid_behavior() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            // Create simulated network
-            let (network, mut oracle) = Network::new(
-                context.with_label("network"),
-                Config {
-                    max_size: 1024 * 1024,
-                },
-            );
-
-            // Start network
-            network.start();
-
-            // Register agents
-            let pk1 = PrivateKey::from_seed(0).public_key();
-            let pk2 = PrivateKey::from_seed(1).public_key();
-            oracle.register(pk1.clone(), 0, None, None).await.unwrap();
-            oracle.register(pk2.clone(), 0, None, None).await.unwrap();
-
-            // Attempt to link with invalid jitter
-            let result = oracle
-                .add_link(
-                    pk1.clone(),
-                    pk2.clone(),
-                    Link {
-                        latency: -5.0,
-                        jitter: 2.5,
-                        success_rate: 1.0,
-                    },
-                )
-                .await;
-
-            // Confirm error is correct
-            assert!(matches!(result, Err(Error::InvalidBehavior(-5.0, 2.5))));
-
-            // Attempt to link with invalid jitter
-            let result = oracle
-                .add_link(
-                    pk1,
-                    pk2,
-                    Link {
-                        latency: 5.0,
-                        jitter: -2.5,
-                        success_rate: 1.0,
-                    },
-                )
-                .await;
-
-            // Confirm error is correct
-            assert!(matches!(result, Err(Error::InvalidBehavior(5.0, -2.5))));
-        });
-    }
 
     #[test]
     fn test_simple_message_delivery() {
@@ -479,8 +424,8 @@ mod tests {
                     pk1.clone(),
                     pk2.clone(),
                     Link {
-                        latency: 5.0,
-                        jitter: 2.5,
+                        latency: Duration::from_millis(5),
+                        jitter: Duration::from_millis(2),
                         success_rate: 1.0,
                     },
                 )
@@ -491,8 +436,8 @@ mod tests {
                     pk2.clone(),
                     pk1.clone(),
                     Link {
-                        latency: 5.0,
-                        jitter: 2.5,
+                        latency: Duration::from_millis(5),
+                        jitter: Duration::from_millis(2),
                         success_rate: 1.0,
                     },
                 )
@@ -548,8 +493,8 @@ mod tests {
                     pk1,
                     pk2.clone(),
                     Link {
-                        latency: 5.0,
-                        jitter: 0.0,
+                        latency: Duration::from_millis(5),
+                        jitter: Duration::ZERO,
                         success_rate: 1.0,
                     },
                 )
@@ -602,8 +547,8 @@ mod tests {
                     pk1.clone(),
                     pk2.clone(),
                     Link {
-                        latency: 5.0,
-                        jitter: 2.5,
+                        latency: Duration::from_millis(5),
+                        jitter: Duration::from_millis(2),
                         success_rate: 1.0,
                     },
                 )
@@ -614,8 +559,8 @@ mod tests {
                     pk2.clone(),
                     pk1.clone(),
                     Link {
-                        latency: 5.0,
-                        jitter: 2.5,
+                        latency: Duration::from_millis(5),
+                        jitter: Duration::from_millis(2),
                         success_rate: 1.0,
                     },
                 )
@@ -696,8 +641,8 @@ mod tests {
                     pk1.clone(),
                     pk2.clone(),
                     Link {
-                        latency: 5.0,
-                        jitter: 2.5,
+                        latency: Duration::from_millis(5),
+                        jitter: Duration::from_millis(2),
                         success_rate: 1.0,
                     },
                 )
@@ -708,8 +653,8 @@ mod tests {
                     pk2.clone(),
                     pk1.clone(),
                     Link {
-                        latency: 5.0,
-                        jitter: 2.5,
+                        latency: Duration::from_millis(5),
+                        jitter: Duration::from_millis(2),
                         success_rate: 1.0,
                     },
                 )

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! Both peer and link modification can be performed dynamically over the lifetime of the simulated network. This
 //! can be used to mimic transient network partitions, offline nodes (that later connect), and/or degrading link
-//! quality.
+//! quality. Messages on a link are delivered in order, and optional per-peer bandwidth limits account for
+//! transmission delay and queueing.
 //!
 //! # Determinism
 //!
@@ -39,9 +40,11 @@
 //!     // Start network
 //!     let network_handler = network.start();
 //!
-//!     // Register some peers
-//!     let (sender, receiver) = oracle.register(peers[0].clone(), 0, None, None).await.unwrap();
-//!     let (sender, receiver) = oracle.register(peers[1].clone(), 0, None, None).await.unwrap();
+//!     // Register some peers with bandwidth limits
+//!     // peer[0]: 10KB/s egress, unlimited ingress
+//!     let (sender, receiver) = oracle.register(peers[0].clone(), 0, Some(10_000), None).await.unwrap();
+//!     // peer[1]: unlimited egress, 5KB/s ingress
+//!     let (sender, receiver) = oracle.register(peers[1].clone(), 0, None, Some(5_000)).await.unwrap();
 //!
 //!     // Link 2 peers
 //!     oracle.add_link(

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -821,8 +821,8 @@ mod tests {
 
             // Add link
             let link = ingress::Link {
-                latency: 2.0,
-                jitter: 1.0,
+                latency: Duration::from_millis(2),
+                jitter: Duration::from_millis(1),
                 success_rate: 0.9,
             };
             oracle

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -99,13 +99,13 @@ mod tests {
     const TIMEOUT: Duration = Duration::from_millis(400);
     const FETCH_RETRY_TIMEOUT: Duration = Duration::from_millis(100);
     const LINK: Link = Link {
-        latency: 10.0,
-        jitter: 1.0,
+        latency: Duration::from_millis(10),
+        jitter: Duration::from_millis(1),
         success_rate: 1.0,
     };
     const LINK_UNRELIABLE: Link = Link {
-        latency: 10.0,
-        jitter: 1.0,
+        latency: Duration::from_millis(10),
+        jitter: Duration::from_millis(1),
         success_rate: 0.5,
     };
 
@@ -134,7 +134,7 @@ mod tests {
 
         let mut connections = Vec::new();
         for peer in &peers {
-            let (sender, receiver) = oracle.register(peer.clone(), 0).await.unwrap();
+            let (sender, receiver) = oracle.register(peer.clone(), 0, None, None).await.unwrap();
             connections.push((sender, receiver));
         }
 


### PR DESCRIPTION
This PR implements bandwidth-aware network simulation in two parts: p2p/simulated network now supports realistic bandwidth constraints with proper message transmission delays and queueing, and estimator CLI/DSL extensions that expose this functionality to users.

Closes #1407
