### PR TITLE
[bitvec] Remove possible panic in debug mode for `BitVec::mask_over_first_n_bits`

### DIFF
--- a/utils/src/bitvec.rs
+++ b/utils/src/bitvec.rs
@@ -315,11 +315,10 @@ impl BitVec {
     /// Creates a mask with the first `num_bits` bits set to 1.
     #[inline(always)]
     fn mask_over_first_n_bits(num_bits: usize) -> Block {
-        assert!(num_bits <= BITS_PER_BLOCK, "num_bits exceeds block size");
-        // Special-case for `BITS_PER_BLOCK` bits to avoid shl overflow
         match num_bits {
             BITS_PER_BLOCK => FULL_BLOCK,
-            _ => (1 << num_bits) - 1,
+            n if n < BITS_PER_BLOCK => FULL_BLOCK.unbounded_shr((BITS_PER_BLOCK - n) as u32),
+            _ => panic!("num_bits exceeds block size: {}", num_bits),
         }
     }
 
@@ -948,8 +947,10 @@ mod tests {
         // Test with various sizes
         for i in 0..=BITS_PER_BLOCK {
             let mask = BitVec::mask_over_first_n_bits(i);
-            assert_eq!(mask.count_ones() as usize, i);
-            assert_eq!(mask.count_zeros() as usize, BITS_PER_BLOCK - i);
+            let ones = mask.trailing_ones() as usize;
+            let zeroes = mask.leading_zeros() as usize;
+            assert_eq!(ones, i);
+            assert_eq!(ones.checked_add(zeroes).unwrap(), BITS_PER_BLOCK);
             assert_eq!(
                 mask,
                 ((1 as Block)


### PR DESCRIPTION
Prevent possible panics in `mask_over_first_n_bits` when compiled for debug due to an underflow when `N

We don't catch these errors in tests or production since both are compiled for production