### PR TITLE
[storage] add get_loc to all stores

### DIFF
--- a/storage/src/adb/any/fixed/mod.rs
+++ b/storage/src/adb/any/fixed/mod.rs
@@ -366,6 +366,17 @@ impl<
         Ok(self.get_with_loc(key).await?.map(|(v, _)| v))
     }
 
+    /// Get the value of the operation with location `loc` in the db. Returns [Error::OperationPruned]
+    /// if the location precedes the oldest retained location. The location is otherwise assumed
+    /// valid.
+    pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+        if loc < self.inactivity_floor_loc {
+            return Err(Error::OperationPruned(loc));
+        }
+
+        Ok(self.log.read(loc).await?.into_value())
+    }
+
     /// Get the value & location of the active operation for `key` in the db, or None if it has no
     /// value.
     pub(crate) async fn get_with_loc(&self, key: &K) -> Result<Option<(V, u64)>, Error> {
@@ -574,9 +585,8 @@ impl<
         old_loc: u64,
     ) -> Result<Option<u64>, Error> {
         // If the translated key is not in the snapshot, get a cursor to look for the key.
-        let Some(key) = op.to_key() else {
-            // `op` is a commit
-            return Ok(None);
+        let Some(key) = op.key() else {
+            return Ok(None); // operations without keys cannot be active
         };
         let new_loc = self.op_count();
         let Some(mut cursor) = self.snapshot.get_mut(key) else {
@@ -1316,7 +1326,7 @@ pub(super) mod test {
             // This loop checks that the expected true bits are true in the bitmap.
             for pos in db.inactivity_floor_loc..items {
                 let item = db.log.read(pos).await.unwrap();
-                let Some(item_key) = item.to_key() else {
+                let Some(item_key) = item.key() else {
                     // `item` is a commit
                     continue;
                 };
@@ -1488,64 +1498,6 @@ pub(super) mod test {
                 ),);
 
                 ref_db.destroy().await.unwrap();
-            }
-
-            db.destroy().await.unwrap();
-        });
-    }
-
-    #[test]
-    fn test_any_db_historical_proof_size_too_large() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            let mut db = create_test_db(context.clone()).await;
-            let ops = create_test_ops(10);
-            apply_ops(&mut db, ops).await;
-            db.commit().await.unwrap();
-            let op_count = db.op_count();
-
-            // Historical size > current database size is invalid
-            let result = db.historical_proof(op_count + 1, op_count, 5).await;
-            match result {
-                Err(Error::Mmr(crate::mmr::Error::HistoricalSizeTooLarge(requested, actual))) => {
-                    assert_eq!(requested, leaf_num_to_pos(op_count + 1));
-                    assert_eq!(actual, leaf_num_to_pos(op_count));
-                }
-                _ => panic!("expected HistoricalSizeTooLarge error"),
-            }
-
-            db.destroy().await.unwrap();
-        });
-    }
-
-    #[test]
-    fn test_any_db_historical_proof_size_too_small() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            let mut db = create_test_db(context.clone()).await;
-            let ops = create_test_ops(10);
-            apply_ops(&mut db, ops).await;
-            db.commit().await.unwrap();
-            let op_count = db.op_count();
-
-            // Historical size == start location is invalid
-            let result = db.historical_proof(op_count, op_count, 5).await;
-            match result {
-                Err(Error::Mmr(crate::mmr::Error::HistoricalSizeTooSmall(size, start_loc))) => {
-                    assert_eq!(size, leaf_num_to_pos(op_count));
-                    assert_eq!(start_loc, leaf_num_to_pos(op_count));
-                }
-                _ => panic!("expected HistoricalSizeTooSmall error"),
-            }
-
-            // Historical size < start location is invalid
-            let result = db.historical_proof(op_count, op_count + 1, 5).await;
-            match result {
-                Err(Error::Mmr(crate::mmr::Error::HistoricalSizeTooSmall(size, start_loc))) => {
-                    assert_eq!(size, leaf_num_to_pos(op_count));
-                    assert_eq!(start_loc, leaf_num_to_pos(op_count + 1));
-                }
-                _ => panic!("expected HistoricalSizeTooSmall error"),
             }
 
             db.destroy().await.unwrap();

--- a/storage/src/adb/any/fixed/mod.rs
+++ b/storage/src/adb/any/fixed/mod.rs
@@ -363,13 +363,13 @@ impl<
 
     /// Get the value of `key` in the db, or None if it has no value.
     pub async fn get(&self, key: &K) -> Result<Option<V>, Error> {
-        Ok(self.get_with_loc(key).await?.map(|(v, _)| v))
+        Ok(self.get_key_loc(key).await?.map(|(v, _)| v))
     }
 
     /// Get the value of the operation with location `loc` in the db. Returns [Error::OperationPruned]
     /// if the location precedes the oldest retained location. The location is otherwise assumed
     /// valid.
-    pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+    pub async fn get_loc(&self, loc: u64) -> Result<Option<V>, Error> {
         assert!(loc < self.op_count());
         if loc < self.inactivity_floor_loc {
             return Err(Error::OperationPruned(loc));
@@ -380,7 +380,7 @@ impl<
 
     /// Get the value & location of the active operation for `key` in the db, or None if it has no
     /// value.
-    pub(crate) async fn get_with_loc(&self, key: &K) -> Result<Option<(V, u64)>, Error> {
+    pub(crate) async fn get_key_loc(&self, key: &K) -> Result<Option<(V, u64)>, Error> {
         for &loc in self.snapshot.get(key) {
             let (k, v) = Self::get_update_op(&self.log, loc).await?;
             if k == *key {

--- a/storage/src/adb/any/fixed/mod.rs
+++ b/storage/src/adb/any/fixed/mod.rs
@@ -370,6 +370,7 @@ impl<
     /// if the location precedes the oldest retained location. The location is otherwise assumed
     /// valid.
     pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+        assert!(loc < self.op_count());
         if loc < self.inactivity_floor_loc {
             return Err(Error::OperationPruned(loc));
         }

--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -611,10 +611,7 @@ mod tests {
             assert_eq!(synced_db.root(&mut hasher), root);
 
             // Verify the synced database doesn't have any operations beyond the sync range.
-            assert_eq!(
-                synced_db.get(final_op.to_key().unwrap()).await.unwrap(),
-                None
-            );
+            assert_eq!(synced_db.get(final_op.key().unwrap()).await.unwrap(), None);
 
             synced_db.destroy().await.unwrap();
         });
@@ -701,15 +698,15 @@ mod tests {
             }
 
             for target_op in &original_ops {
-                if let Some(key) = target_op.to_key() {
+                if let Some(key) = target_op.key() {
                     let target_value = target_db.read().await.get(key).await.unwrap();
                     let synced_value = sync_db.get(key).await.unwrap();
                     assert_eq!(target_value, synced_value);
                 }
             }
             // Verify the last operation is present
-            let last_key = last_op[0].to_key().unwrap();
-            let last_value = *last_op[0].to_value().unwrap();
+            let last_key = last_op[0].key().unwrap();
+            let last_value = *last_op[0].value().unwrap();
             assert_eq!(sync_db.get(last_key).await.unwrap(), Some(last_value));
 
             sync_db.destroy().await.unwrap();
@@ -795,7 +792,7 @@ mod tests {
 
             // Verify state matches for sample operations
             for target_op in &target_ops {
-                if let Some(key) = target_op.to_key() {
+                if let Some(key) = target_op.key() {
                     let target_value = target_db.get(key).await.unwrap();
                     let synced_value = sync_db.get(key).await.unwrap();
                     assert_eq!(target_value, synced_value);

--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -384,7 +384,7 @@ mod tests {
             for op in &target_db_ops {
                 match op {
                     Fixed::Update(key, _) => {
-                        if let Some((value, loc)) = target_db.get_with_loc(key).await.unwrap() {
+                        if let Some((value, loc)) = target_db.get_key_loc(key).await.unwrap() {
                             expected_kvs.insert(*key, (value, loc));
                             deleted_keys.remove(key);
                         }
@@ -433,12 +433,12 @@ mod tests {
 
             // Verify that the synced database matches the target state
             for (key, &(value, loc)) in &expected_kvs {
-                let synced_opt = got_db.get_with_loc(key).await.unwrap();
+                let synced_opt = got_db.get_key_loc(key).await.unwrap();
                 assert_eq!(synced_opt, Some((value, loc)));
             }
             // Verify that deleted keys are absent
             for key in &deleted_keys {
-                assert!(got_db.get_with_loc(key).await.unwrap().is_none(),);
+                assert!(got_db.get_key_loc(key).await.unwrap().is_none(),);
             }
 
             // Put more key-value pairs into both databases

--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -377,6 +377,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
     /// Get the value of the operation with location `loc` in the db. Returns [Error::OperationPruned]
     /// if loc precedes the oldest retained location. The location is otherwise assumed valid.
     pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+        assert!(loc < self.op_count());
         if loc < self.oldest_retained_loc {
             return Err(Error::OperationPruned(loc));
         }

--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -624,7 +624,8 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         Ok(())
     }
 
-    /// Get the metadata associated with the last commit, or None if no commit has been made.
+    /// Get the location and metadata associated with the last commit, or None if no commit has been
+    /// made.
     pub async fn get_metadata(&self) -> Result<Option<(u64, Option<V>)>, Error> {
         let mut last_commit = self.op_count() - self.uncommitted_ops;
         if last_commit == 0 {

--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -374,6 +374,20 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         Ok(None)
     }
 
+    /// Get the value of the operation with location `loc` in the db. Returns [Error::OperationPruned]
+    /// if loc precedes the oldest retained location. The location is otherwise assumed valid.
+    pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+        if loc < self.oldest_retained_loc {
+            return Err(Error::OperationPruned(loc));
+        }
+
+        let offset = self.locations.read(loc).await?.into();
+        let section = loc / self.log_items_per_section;
+        let op = self.log.get(section, offset).await?.expect("invalid loc");
+
+        Ok(op.into_value())
+    }
+
     /// Returns the location of the operation that set the key's current value, or None if the key isn't currently assigned any value.
     pub async fn get_loc(&self, key: &K) -> Result<Option<u64>, Error> {
         let iter = self.snapshot.get(key);
@@ -609,7 +623,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
     }
 
     /// Get the metadata associated with the last commit, or None if no commit has been made.
-    pub async fn get_metadata(&self) -> Result<Option<V>, Error> {
+    pub async fn get_metadata(&self) -> Result<Option<(u64, Option<V>)>, Error> {
         let mut last_commit = self.op_count() - self.uncommitted_ops;
         if last_commit == 0 {
             return Ok(None);
@@ -621,7 +635,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
             unreachable!("no commit operation at location of last commit {last_commit}");
         };
 
-        Ok(metadata)
+        Ok(Some((last_commit, metadata)))
     }
 
     /// Sync the db to disk ensuring the current state is persisted. Batch operations will be
@@ -646,7 +660,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         old_loc: u64,
     ) -> Result<Option<u64>, Error> {
         // If the translated key is not in the snapshot, get a cursor to look for the key.
-        let Some(key) = op.to_key() else {
+        let Some(key) = op.key() else {
             // `op` is not a key-related operation, so it is not active.
             return Ok(None);
         };
@@ -952,7 +966,7 @@ pub(super) mod test {
             assert_eq!(db.inactivity_floor_loc, db.op_count() - 1);
 
             // Make sure we can still get the metadata.
-            assert_eq!(db.get_metadata().await.unwrap(), metadata);
+            assert_eq!(db.get_metadata().await.unwrap(), Some((8, metadata)));
 
             // Re-activate the keys by updating them.
             db.update(d1, v1.clone()).await.unwrap();
@@ -964,12 +978,14 @@ pub(super) mod test {
 
             // Confirm close/reopen gets us back to the same state.
             db.commit(None).await.unwrap();
+            assert_eq!(db.op_count(), 19);
             let root = db.root(&mut hasher);
             db.close().await.unwrap();
-            let mut db = open_db(context).await;
+            let mut db = open_db(context.clone()).await;
             assert_eq!(db.root(&mut hasher), root);
             assert_eq!(db.snapshot.keys(), 2);
-            assert_eq!(db.get_metadata().await.unwrap(), None);
+            assert_eq!(db.op_count(), 19);
+            assert_eq!(db.get_metadata().await.unwrap(), Some((18, None)));
 
             // Commit will raise the inactivity floor, which won't affect state but will affect the
             // root.

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -262,6 +262,13 @@ impl<
         self.any.get(key).await
     }
 
+    /// Get the value of the operation with location `loc` in the db. Returns
+    /// [Error::OperationPruned] if loc precedes the oldest retained location. The location is
+    /// otherwise assumed valid.
+    pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+        self.any.keyless_get(loc).await
+    }
+
     /// Get the level of the base MMR into which we are grafting.
     ///
     /// This value is log2 of the chunk size in bits. Since we assume the chunk size is a power of
@@ -1048,9 +1055,9 @@ pub mod test {
                 }
                 // Found an active operation! Create a proof for its active current key/value.
                 let op = db.any.log.read(i).await.unwrap();
-                let key = op.to_key().unwrap();
+                let key = op.key().unwrap();
                 let (proof, info) = db.key_value_proof(hasher.inner(), *key).await.unwrap();
-                assert_eq!(info.value, *op.to_value().unwrap());
+                assert_eq!(info.value, *op.value().unwrap());
                 // Proof should validate against the current value and correct root.
                 assert!(CurrentTest::verify_key_value_proof(
                     hasher.inner(),

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -456,6 +456,20 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         Ok(None)
     }
 
+    /// Get the value of the operation with location `loc` in the db. Returns [Error::OperationPruned]
+    /// if loc precedes the oldest retained location. The location is otherwise assumed valid.
+    pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+        if loc < self.oldest_retained_loc {
+            return Err(Error::OperationPruned(loc));
+        }
+
+        let offset = self.locations.read(loc).await?.into();
+        let section = loc / self.log_items_per_section;
+        let op = self.log.get(section, offset).await?.expect("invalid loc");
+
+        Ok(op.into_value())
+    }
+
     /// Get the value of the operation with location `loc` in the db if it matches `key`. Returns
     /// [Error::OperationPruned] if loc precedes the oldest retained location. The location is
     /// otherwise assumed valid.
@@ -602,7 +616,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
 
     /// Get the metadata associated with the last commit, or None if no commit has been made or if
     /// there is no metadata associated with the last commit.
-    pub async fn get_metadata(&self) -> Result<Option<V>, Error> {
+    pub async fn get_metadata(&self) -> Result<Option<(u64, Option<V>)>, Error> {
         let Some(last_commit) = self.last_commit else {
             return Ok(None);
         };
@@ -612,7 +626,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
             unreachable!("no commit operation at location of last commit {last_commit}");
         };
 
-        Ok(metadata)
+        Ok(Some((last_commit, metadata)))
     }
 
     /// Sync the db to disk ensuring the current state is persisted. Batch operations will be
@@ -819,7 +833,10 @@ pub(super) mod test {
             assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
             assert!(db.get(&k2).await.unwrap().is_none());
             assert_eq!(db.op_count(), 2);
-            assert_eq!(db.get_metadata().await.unwrap(), metadata.clone());
+            assert_eq!(
+                db.get_metadata().await.unwrap(),
+                Some((1, metadata.clone()))
+            );
             // Set the second key.
             db.set(k2, v2.clone()).await.unwrap();
             assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
@@ -827,12 +844,12 @@ pub(super) mod test {
             assert_eq!(db.op_count(), 3);
 
             // Make sure we can still get metadata.
-            assert_eq!(db.get_metadata().await.unwrap(), metadata);
+            assert_eq!(db.get_metadata().await.unwrap(), Some((1, metadata)));
 
             // Commit the second key.
             db.commit(None).await.unwrap();
             assert_eq!(db.op_count(), 4);
-            assert_eq!(db.get_metadata().await.unwrap(), None);
+            assert_eq!(db.get_metadata().await.unwrap(), Some((3, None)));
 
             // Capture state.
             let root = db.root(&mut hasher);
@@ -850,7 +867,7 @@ pub(super) mod test {
             assert!(db.get(&k3).await.unwrap().is_none());
             assert_eq!(db.op_count(), 4);
             assert_eq!(db.root(&mut hasher), root);
-            assert_eq!(db.get_metadata().await.unwrap(), None);
+            assert_eq!(db.get_metadata().await.unwrap(), Some((3, None)));
 
             // Cleanup.
             db.destroy().await.unwrap();

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -615,8 +615,8 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         self.sync().await
     }
 
-    /// Get the metadata associated with the last commit, or None if no commit has been made or if
-    /// there is no metadata associated with the last commit.
+    /// Get the location and metadata associated with the last commit, or None if no commit has been
+    /// made.
     pub async fn get_metadata(&self) -> Result<Option<(u64, Option<V>)>, Error> {
         let Some(last_commit) = self.last_commit else {
             return Ok(None);

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -458,7 +458,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
 
     /// Get the value of the operation with location `loc` in the db. Returns [Error::OperationPruned]
     /// if loc precedes the oldest retained location. The location is otherwise assumed valid.
-    pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+    pub async fn get_loc(&self, loc: u64) -> Result<Option<V>, Error> {
         assert!(loc < self.op_count());
         if loc < self.oldest_retained_loc {
             return Err(Error::OperationPruned(loc));

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -459,6 +459,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
     /// Get the value of the operation with location `loc` in the db. Returns [Error::OperationPruned]
     /// if loc precedes the oldest retained location. The location is otherwise assumed valid.
     pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+        assert!(loc < self.op_count());
         if loc < self.oldest_retained_loc {
             return Err(Error::OperationPruned(loc));
         }

--- a/storage/src/adb/immutable/sync/mod.rs
+++ b/storage/src/adb/immutable/sync/mod.rs
@@ -479,7 +479,10 @@ mod tests {
             assert_eq!(got_db.op_count(), target_op_count);
             assert_eq!(got_db.oldest_retained_loc, target_oldest_retained_loc);
             assert_eq!(got_db.root(&mut hasher), target_root);
-            assert_eq!(got_db.get_metadata().await.unwrap(), Some(Sha256::fill(1)));
+            assert_eq!(
+                got_db.get_metadata().await.unwrap(),
+                Some((0, Some(Sha256::fill(1))))
+            );
 
             got_db.destroy().await.unwrap();
             let target_db = match Arc::try_unwrap(target_db) {

--- a/storage/src/adb/keyless.rs
+++ b/storage/src/adb/keyless.rs
@@ -241,8 +241,9 @@ impl<E: Storage + Clock + Metrics, V: Codec, H: CHasher> Keyless<E, V, H> {
         }
     }
 
-    /// Get the number of appends + commits that have been applied to the db.
-    pub fn size(&self) -> u64 {
+    /// Get the number of operations (appends + commits) that have been applied to the db since
+    /// inception.
+    pub fn op_count(&self) -> u64 {
         self.size
     }
 
@@ -522,7 +523,7 @@ mod test {
         executor.start(|context| async move {
             let mut db = open_db(context.clone()).await;
             let mut hasher = Standard::<Sha256>::new();
-            assert_eq!(db.size(), 0);
+            assert_eq!(db.op_count(), 0);
             assert_eq!(db.oldest_retained_loc().await.unwrap(), None);
             assert_eq!(db.root(&mut hasher), MemMmr::default().root(&mut hasher));
             assert_eq!(db.get_metadata().await.unwrap(), None);
@@ -534,13 +535,13 @@ mod test {
             db.close().await.unwrap();
             let mut db = open_db(context.clone()).await;
             assert_eq!(db.root(&mut hasher), root);
-            assert_eq!(db.size(), 0);
+            assert_eq!(db.op_count(), 0);
             assert_eq!(db.get_metadata().await.unwrap(), None);
 
             // Test calling commit on an empty db which should make it (durably) non-empty.
             let metadata = Some(vec![3u8; 10]);
             db.commit(metadata.clone()).await.unwrap();
-            assert_eq!(db.size(), 1); // floor op added
+            assert_eq!(db.op_count(), 1); // floor op added
             assert_eq!(
                 db.get_metadata().await.unwrap(),
                 Some((0, metadata.clone()))
@@ -574,13 +575,13 @@ mod test {
 
             // Make sure closing/reopening gets us back to the same state.
             db.commit(None).await.unwrap();
-            assert_eq!(db.size(), 3); // 2 appends, 1 commit
+            assert_eq!(db.op_count(), 3); // 2 appends, 1 commit
             assert_eq!(db.get_metadata().await.unwrap(), Some((2, None)));
             assert_eq!(db.get(2).await.unwrap(), None); // the commit op
             let root = db.root(&mut hasher);
             db.close().await.unwrap();
             let mut db = open_db(context.clone()).await;
-            assert_eq!(db.size(), 3);
+            assert_eq!(db.op_count(), 3);
             assert_eq!(db.root(&mut hasher), root);
 
             assert_eq!(db.get(loc1).await.unwrap().unwrap(), v1);
@@ -597,7 +598,7 @@ mod test {
             // Make sure commit operation remains after close/reopen.
             db.close().await.unwrap();
             let db = open_db(context.clone()).await;
-            assert_eq!(db.size(), 3);
+            assert_eq!(db.op_count(), 3);
             assert_eq!(db.root(&mut hasher), root);
 
             db.destroy().await.unwrap();
@@ -680,7 +681,7 @@ mod test {
             // Make sure we can close/reopen and get back to the same state.
             db.close().await.unwrap();
             let db = open_db(context.clone()).await;
-            assert_eq!(db.size(), 2 * ELEMENTS + 2);
+            assert_eq!(db.op_count(), 2 * ELEMENTS + 2);
             assert_eq!(db.root(&mut hasher), root);
 
             db.destroy().await.unwrap();
@@ -726,7 +727,7 @@ mod test {
                 );
 
                 // Check that we got the expected number of operations
-                let expected_ops = std::cmp::min(max_ops, db.size() - start_loc);
+                let expected_ops = std::cmp::min(max_ops, db.op_count() - start_loc);
                 assert_eq!(
                     ops.len() as u64,
                     expected_ops,
@@ -819,7 +820,7 @@ mod test {
             db.close().await.unwrap();
             let mut db = open_db(context.clone()).await;
             assert_eq!(db.root(&mut hasher), root);
-            assert_eq!(db.size(), 2 * ELEMENTS + 2);
+            assert_eq!(db.op_count(), 2 * ELEMENTS + 2);
             assert!(db.oldest_retained_loc().await.unwrap().unwrap() <= PRUNE_LOC);
 
             // Test that we can't get pruned values
@@ -858,7 +859,7 @@ mod test {
                 );
 
                 // Check that we got operations
-                let expected_ops = std::cmp::min(max_ops, db.size() - start_loc);
+                let expected_ops = std::cmp::min(max_ops, db.op_count() - start_loc);
                 assert_eq!(
                     ops.len() as u64,
                     expected_ops,
@@ -882,13 +883,13 @@ mod test {
             );
 
             // Test edge case: prune everything except the last few operations
-            let almost_all = db.size() - 5;
+            let almost_all = db.op_count() - 5;
             db.prune(almost_all).await.unwrap();
 
             let final_oldest = db.oldest_retained_loc().await.unwrap().unwrap();
 
             // Should still be able to prove the remaining operations
-            if final_oldest < db.size() {
+            if final_oldest < db.op_count() {
                 let (final_proof, final_ops) = db.proof(final_oldest, 10).await.unwrap();
                 assert!(
                     verify_proof(&mut hasher, &final_proof, final_oldest, &final_ops, &root),

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -115,10 +115,6 @@ pub enum Error {
     InvalidProofLength,
     #[error("proof missing digest at position: {0}")]
     MissingDigest(u64),
-    #[error("given historical size >= database size: ({0}) >= ({1})")]
-    HistoricalSizeTooLarge(u64, u64),
-    #[error("given historical size <= start location: ({0}) <= ({1})")]
-    HistoricalSizeTooSmall(u64, u64),
     #[error("invalid size: {0}")]
     InvalidSize(u64),
     #[error("root mismatch")]

--- a/storage/src/store/mod.rs
+++ b/storage/src/store/mod.rs
@@ -280,6 +280,7 @@ where
     /// [Error::OperationPruned] if loc precedes the oldest retained location. The location is
     /// otherwise assumed valid.
     pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+        assert!(loc < self.log_size);
         let op = self.get_op(loc).await?;
 
         Ok(op.into_value())
@@ -590,6 +591,7 @@ where
     /// if the location precedes the oldest retained location. The location is otherwise assumed
     /// valid.
     async fn get_op(&self, loc: u64) -> Result<Operation<K, V>, Error> {
+        assert!(loc < self.log_size);
         if loc < self.oldest_retained_loc {
             return Err(Error::OperationPruned(loc));
         }

--- a/storage/src/store/mod.rs
+++ b/storage/src/store/mod.rs
@@ -265,7 +265,7 @@ where
     pub async fn get(&self, key: &K) -> Result<Option<V>, Error> {
         for &loc in self.snapshot.get(key) {
             let Operation::Update(k, v) = self.get_op(loc).await? else {
-                panic!("location ({loc}) does not reference update operation");
+                unreachable!("location ({loc}) does not reference update operation");
             };
 
             if &k == key {
@@ -576,8 +576,10 @@ where
                         return Ok(Some(*loc));
                     }
                 }
-                Err(Error::OperationPruned(_)) => panic!("invalid location in snapshot: loc={loc}"),
-                _ => panic!("non-update operation referenced by snapshot: loc={loc}"),
+                Err(Error::OperationPruned(_)) => {
+                    unreachable!("invalid location in snapshot: loc={loc}")
+                }
+                _ => unreachable!("non-update operation referenced by snapshot: loc={loc}"),
             }
         }
 

--- a/storage/src/store/mod.rs
+++ b/storage/src/store/mod.rs
@@ -128,9 +128,9 @@ pub enum Error {
     #[error(transparent)]
     Journal(#[from] crate::journal::Error),
 
-    /// The requested key was not found in the snapshot.
-    #[error("key not found")]
-    KeyNotFound,
+    /// The requested operation has been pruned.
+    #[error("operation pruned")]
+    OperationPruned(u64),
 }
 
 /// Configuration for initializing a [Store] database.
@@ -263,9 +263,9 @@ where
     ///
     /// If the key does not exist, returns `Ok(None)`.
     pub async fn get(&self, key: &K) -> Result<Option<V>, Error> {
-        for location in self.snapshot.get(key) {
-            let Operation::Update(k, v) = self.get_op(*location).await? else {
-                panic!("location ({location}) does not reference set operation",);
+        for &loc in self.snapshot.get(key) {
+            let Operation::Update(k, v) = self.get_op(loc).await? else {
+                panic!("location ({loc}) does not reference update operation");
             };
 
             if &k == key {
@@ -276,17 +276,26 @@ where
         Ok(None)
     }
 
+    /// Get the value of the operation with location `loc` in the db. Returns
+    /// [Error::OperationPruned] if loc precedes the oldest retained location. The location is
+    /// otherwise assumed valid.
+    pub async fn keyless_get(&self, loc: u64) -> Result<Option<V>, Error> {
+        let op = self.get_op(loc).await?;
+
+        Ok(op.into_value())
+    }
+
     /// Updates the value associated with the given key in the store.
     ///
     /// The operation is immediately visible in the snapshot for subsequent queries, but remains
     /// uncommitted until [Store::commit] is called. Uncommitted operations will be rolled back
     /// if the store is closed without committing.
     pub async fn update(&mut self, key: K, value: V) -> Result<(), Error> {
-        let new_location = self.log_size;
-        if let Some(old_location) = self.get_loc(&key).await? {
-            Self::update_loc(&mut self.snapshot, &key, old_location, new_location);
+        let new_loc = self.log_size;
+        if let Some(old_loc) = self.get_loc(&key).await? {
+            Self::update_loc(&mut self.snapshot, &key, old_loc, new_loc);
         } else {
-            self.snapshot.insert(&key, new_location);
+            self.snapshot.insert(&key, new_loc);
         };
 
         self.apply_op(Operation::Update(key, value))
@@ -320,7 +329,7 @@ where
 
     /// Get the metadata associated with the last commit, or None if no commit has been made or
     /// there is no metadata associated with the last commit.
-    pub async fn get_metadata(&self) -> Result<Option<V>, Error> {
+    pub async fn get_metadata(&self) -> Result<Option<(u64, Option<V>)>, Error> {
         let mut last_commit = self.op_count() - self.uncommitted_ops;
         if last_commit == 0 {
             return Ok(None);
@@ -332,7 +341,7 @@ where
             unreachable!("no commit operation at location of last commit {last_commit}");
         };
 
-        Ok(metadata)
+        Ok(Some((last_commit, metadata)))
     }
 
     /// Closes the store. Any uncommitted operations will be lost if they have not been committed
@@ -557,8 +566,8 @@ where
         Ok(offset)
     }
 
-    /// Gets the location of the most recent [Operation::Update] for the key, or [None] if
-    /// the key does not have a value.
+    /// Gets the location of the most recent [Operation::Update] for the key, or [None] if the key
+    /// does not have a value.
     async fn get_loc(&self, key: &K) -> Result<Option<u64>, Error> {
         for loc in self.snapshot.get(key) {
             match self.get_op(*loc).await {
@@ -567,52 +576,58 @@ where
                         return Ok(Some(*loc));
                     }
                 }
-                Err(Error::KeyNotFound) => return Ok(None),
-                _ => continue,
+                Err(Error::OperationPruned(_)) => panic!("invalid location in snapshot: loc={loc}"),
+                _ => panic!("non-update operation referenced by snapshot: loc={loc}"),
             }
         }
 
         Ok(None)
     }
 
-    /// Gets a [Operation] from the log at the given location.
-    async fn get_op(&self, location: u64) -> Result<Operation<K, V>, Error> {
-        let section = location / self.log_items_per_section;
-        let offset = self.locations.read(location).await?.into();
+    /// Gets a [Operation] from the log at the given location. Returns [Error::OperationPruned]
+    /// if the location precedes the oldest retained location. The location is otherwise assumed
+    /// valid.
+    async fn get_op(&self, loc: u64) -> Result<Operation<K, V>, Error> {
+        if loc < self.oldest_retained_loc {
+            return Err(Error::OperationPruned(loc));
+        }
+
+        let section = loc / self.log_items_per_section;
+        let offset = self.locations.read(loc).await?.into();
 
         // Get the operation from the log at the specified section and offset.
         let Some(op) = self.log.get(section, offset).await? else {
-            return Err(Error::KeyNotFound);
+            panic!("invalid location {loc}");
         };
 
         Ok(op)
     }
 
     /// Updates the snapshot with the new operation location for the given key.
-    fn update_loc(snapshot: &mut Index<T, u64>, key: &K, old_location: u64, new_location: u64) {
+    fn update_loc(snapshot: &mut Index<T, u64>, key: &K, old_loc: u64, new_loc: u64) {
         let Some(mut cursor) = snapshot.get_mut(key) else {
             return;
         };
 
         // Iterate over conflicts in the snapshot.
-        while let Some(location) = cursor.next() {
-            if *location == old_location {
+        while let Some(loc) = cursor.next() {
+            if *loc == old_loc {
                 // Update the cursor with the new location for this key.
-                cursor.update(new_location);
+                cursor.update(new_loc);
                 return;
             }
         }
     }
 
     /// Deletes items in the snapshot that point to the given location.
-    fn delete_loc(snapshot: &mut Index<T, u64>, key: &K, old_location: u64) {
+    fn delete_loc(snapshot: &mut Index<T, u64>, key: &K, old_loc: u64) {
         let Some(mut cursor) = snapshot.get_mut(key) else {
             return;
         };
 
         // Iterate over conflicts in the snapshot.
-        while let Some(location) = cursor.next() {
-            if *location == old_location {
+        while let Some(loc) = cursor.next() {
+            if *loc == old_loc {
                 // Delete the element from the cursor.
                 cursor.delete();
                 return;
@@ -626,10 +641,10 @@ where
     async fn move_op_if_active(
         &mut self,
         op: Operation<K, V>,
-        old_location: u64,
+        old_loc: u64,
     ) -> Result<Option<u64>, Error> {
         // If the translated key is not in the snapshot, get a cursor to look for the key.
-        let Some(key) = op.to_key() else {
+        let Some(key) = op.key() else {
             // `op` is not a key-related operation, so it is not active.
             return Ok(None);
         };
@@ -638,17 +653,17 @@ where
             return Ok(None);
         };
 
-        let new_location = self.log_size;
+        let new_loc = self.log_size;
 
         // Iterate over all conflicting keys in the snapshot.
-        while let Some(&location) = cursor.next() {
-            if location == old_location {
+        while let Some(&loc) = cursor.next() {
+            if loc == old_loc {
                 // Update the location of the operation in the snapshot.
-                cursor.update(new_location);
+                cursor.update(new_loc);
                 drop(cursor);
 
                 self.apply_op(op).await?;
-                return Ok(Some(old_location));
+                return Ok(Some(old_loc));
             }
         }
 
@@ -831,7 +846,10 @@ mod test {
             // Persist the changes
             let metadata = Some(vec![99, 100]);
             store.commit(metadata.clone()).await.unwrap();
-            assert_eq!(store.get_metadata().await.unwrap(), metadata);
+            assert_eq!(
+                store.get_metadata().await.unwrap(),
+                Some((3, metadata.clone()))
+            );
 
             // Even though the store was pruned, the inactivity floor was raised by 2, and
             // the old operations remain in the same blob as an active operation, so they're
@@ -863,10 +881,10 @@ mod test {
             assert_eq!(store.inactivity_floor_loc, 2);
 
             // Make sure we can still get metadata.
-            assert_eq!(store.get_metadata().await.unwrap(), metadata);
+            assert_eq!(store.get_metadata().await.unwrap(), Some((3, metadata)));
 
             store.commit(None).await.unwrap();
-            assert_eq!(store.get_metadata().await.unwrap(), None);
+            assert_eq!(store.get_metadata().await.unwrap(), Some((8, None)));
 
             assert_eq!(store.log_size, 9);
             assert_eq!(store.uncommitted_ops, 0);

--- a/storage/src/store/mod.rs
+++ b/storage/src/store/mod.rs
@@ -328,8 +328,8 @@ where
         self.prune_inactive().await
     }
 
-    /// Get the metadata associated with the last commit, or None if no commit has been made or
-    /// there is no metadata associated with the last commit.
+    /// Get the location and metadata associated with the last commit, or None if no commit has been
+    /// made.
     pub async fn get_metadata(&self) -> Result<Option<(u64, Option<V>)>, Error> {
         let mut last_commit = self.op_count() - self.uncommitted_ops;
         if last_commit == 0 {


### PR DESCRIPTION
- Adds "keyless get" (get_loc) to all stores, and makes get_metadata across all behave the same (returning commit position).

- More idiomatic naming in Operation for the key/value accessors/conversions.

- Improve behavioral and naming consistency between non-adb store and the others.

- Remove HistoricalProofSize errors and use precondition assertions instead (to be more consistent with other MMR code, which panics on incorrect usage rather than returning errors.)