### PR TITLE
[mmr] Add `init_from_pinned_nodes`

### DIFF
--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -245,7 +245,7 @@ pub(crate) async fn init_journal<E: Storage + Metrics, A: CodecFixed<Cfg = ()>>(
 /// - Reading from positions 0-19 will return `ItemPruned` since those blobs don't exist
 /// - This represents a journal that had operations 0-24, with operations 0-19 pruned,
 ///   leaving operations 20-24 in tail blob 2.
-async fn init_journal_at_size<E: Storage + Metrics, A: CodecFixed<Cfg = ()>>(
+pub(crate) async fn init_journal_at_size<E: Storage + Metrics, A: CodecFixed<Cfg = ()>>(
     context: E,
     cfg: fixed::Config,
     size: u64,

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -129,7 +129,8 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
     /// * `context` - Storage context
     /// * `pinned_nodes` - Digest values in the order returned by `Proof::nodes_to_pin(mmr_size)`
     /// * `mmr_size` - The logical size of the MMR (all elements before this are considered pruned)
-    /// * `config` - Journaled MMR configuration
+    /// * `config` - Journaled MMR configuration. Any data in the given journal and metadata
+    ///   partitions will be overwritten.
     pub async fn init_from_pinned_nodes(
         context: E,
         pinned_nodes: Vec<H::Digest>,

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -136,19 +136,17 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         mmr_size: u64,
         config: Config,
     ) -> Result<Self, Error> {
-        // Destroy existing data to ensure clean state
+        // Destroy any existing journal data
+        context.remove(&config.journal_partition, None).await.ok();
+        context.remove(&config.metadata_partition, None).await.ok();
+
+        // Create the journal with the desired size
         let journal_cfg = JConfig {
             partition: config.journal_partition.clone(),
             items_per_blob: config.items_per_blob,
             buffer_pool: config.buffer_pool.clone(),
             write_buffer: config.write_buffer,
         };
-
-        // Destroy any existing journal data
-        context.remove(&config.journal_partition, None).await.ok();
-        context.remove(&config.metadata_partition, None).await.ok();
-
-        // Create the journal with the desired size
         let journal =
             init_journal_at_size(context.with_label("mmr_journal"), journal_cfg, mmr_size).await?;
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -116,11 +116,14 @@ const NODE_PREFIX: u8 = 0;
 const PRUNE_TO_POS_PREFIX: u8 = 1;
 
 impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
-    /// Initialize a new journaled MMR from a set of pinned nodes.
+    /// Initialize a new journaled MMR from an MMR's size and set of pinned nodes.
     ///
     /// This creates a journaled MMR that appears to have `mmr_size` elements, all of which
-    /// are considered pruned away, leaving only the minimal set of `pinned_nodes` required
-    /// for proof generation. The next element added will be at position `mmr_size`.
+    /// are pruned, leaving only the minimal set of `pinned_nodes` required for proof generation.
+    /// The next element added will be at position `mmr_size`.
+    ///
+    /// The returned MMR is functionally equivalent to a journaled MMR that was created,
+    /// populated, and then pruned up to its size.
     ///
     /// # Arguments
     /// * `context` - Storage context

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -125,4 +125,6 @@ pub enum Error {
     RootMismatch,
     #[error("invalid proof")]
     InvalidProof,
+    #[error("runtime error: {0}")]
+    Runtime(#[from] commonware_runtime::Error),
 }


### PR DESCRIPTION
Implements a new method `init_from_pinned_nodes` that allows for creation of a new journaled MMR from the pinned nodes corresponding to a given MMR, along with the size of that MMR.

Resolves #1421 