### PR TITLE
[storage/adb] Support Multi-Proofs

### DIFF
--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -1586,7 +1586,7 @@ mod tests {
 
             // Test 2: Verify with wrong elements should fail
             // Use completely different byte arrays
-            let wrong_elements = vec![
+            let wrong_elements = [
                 vec![255u8, 254u8, 253u8],
                 vec![252u8, 251u8, 250u8],
                 vec![249u8, 248u8, 247u8],
@@ -1750,7 +1750,7 @@ mod tests {
             let root = mmr.root(&mut hasher);
 
             // Test generating proof for many single elements
-            let indices = vec![3, 7, 15, 31, 63, 95];
+            let indices = [3, 7, 15, 31, 63, 95];
             let selected_positions: Vec<u64> = indices.iter().map(|&idx| positions[idx]).collect();
 
             let multi_proof = Proof::multi_proof(&mmr, &selected_positions).await.unwrap();

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -133,7 +133,9 @@ impl<D: Digest> PartialEq for Proof<D> {
 
 impl<D: Digest> PartialEq for MultiProof<D> {
     fn eq(&self, other: &Self) -> bool {
-        self.size == other.size && self.positions == other.positions && self.digests == other.digests
+        self.size == other.size
+            && self.positions == other.positions
+            && self.digests == other.digests
     }
 }
 
@@ -201,19 +203,20 @@ impl<D: Digest> Read for MultiProof<D> {
 
         // Read the digests
         let digests = Vec::<D>::read_range(buf, range)?;
-        Ok(MultiProof { size, positions, digests })
+        Ok(MultiProof {
+            size,
+            positions,
+            digests,
+        })
     }
 }
 
 impl<D: Digest> MultiProof<D> {
-    /// Combine multiple independent proofs for the same MMR state into a single proof
+    /// Combine multiple single-element proofs for the same MMR state into a single proof
     /// that avoids duplicating digests.
     ///
-    /// Each proof is paired with the positions it proves. For range proofs, provide
-    /// the start and end positions. For single element proofs, provide just one position.
-    ///
     /// All proofs must be for the same MMR size, otherwise returns an error.
-    pub fn combine(proofs: Vec<(Proof<D>, Vec<u64>)>) -> Result<Self, Error> {
+    pub fn combine(proofs: Vec<(Proof<D>, u64)>) -> Result<Self, Error> {
         if proofs.is_empty() {
             return Ok(MultiProof {
                 size: 0,
@@ -230,31 +233,15 @@ impl<D: Digest> MultiProof<D> {
             }
         }
 
-        // Collect all positions being proven (just the actual element positions)
-        let mut all_positions = Vec::new();
-        for (_, positions) in &proofs {
-            all_positions.extend(positions);
-        }
+        // Collect all positions being proven
+        let mut all_positions: Vec<u64> = proofs.iter().map(|(_, pos)| *pos).collect();
         all_positions.sort_unstable();
         all_positions.dedup();
 
         // Collect all required node positions for all proofs
         let mut all_required_positions = Vec::new();
-        for (_, positions) in &proofs {
-            let required = match positions.len() {
-                1 => {
-                    // Single element proof
-                    Proof::<D>::nodes_required_for_range_proof(size, positions[0], positions[0])
-                }
-                2 => {
-                    // Range proof from positions[0] to positions[1]
-                    Proof::<D>::nodes_required_for_range_proof(size, positions[0], positions[1])
-                }
-                _ => {
-                    // For simplicity, we only support single elements or ranges
-                    return Err(Error::InvalidProof);
-                }
-            };
+        for (_, position) in &proofs {
+            let required = Proof::<D>::nodes_required_for_range_proof(size, *position, *position);
             all_required_positions.extend(required);
         }
 
@@ -269,13 +256,8 @@ impl<D: Digest> MultiProof<D> {
 
         // Map positions to digests from the original proofs
         let mut position_to_digest = HashMap::new();
-        for (proof, positions) in &proofs {
-            let required = match positions.len() {
-                1 => Proof::<D>::nodes_required_for_range_proof(size, positions[0], positions[0]),
-                2 => Proof::<D>::nodes_required_for_range_proof(size, positions[0], positions[1]),
-                _ => return Err(Error::InvalidProof),
-            };
-            
+        for (proof, position) in &proofs {
+            let required = Proof::<D>::nodes_required_for_range_proof(size, *position, *position);
             for (pos, digest) in required.iter().zip(proof.digests.iter()) {
                 position_to_digest.insert(*pos, *digest);
             }
@@ -303,12 +285,7 @@ impl<D: Digest> MultiProof<D> {
     ///
     /// The elements vector must contain elements in the same order as the positions
     /// in the MultiProof.
-    pub fn verify<I, H, E>(
-        &self,
-        hasher: &mut H,
-        elements: &[E],
-        root: &D,
-    ) -> bool
+    pub fn verify<I, H, E>(&self, hasher: &mut H, elements: &[E], root: &D) -> bool
     where
         I: CHasher<Digest = D>,
         H: Hasher<I>,
@@ -341,7 +318,7 @@ impl<D: Digest> MultiProof<D> {
         // Map the deduplicated positions to digests from our proof
         let mut position_to_digest = HashMap::new();
         let mut digest_iter = self.digests.iter();
-        
+
         for pos in &deduplicated_positions {
             if let Some(digest) = digest_iter.next() {
                 position_to_digest.insert(*pos, *digest);
@@ -359,7 +336,7 @@ impl<D: Digest> MultiProof<D> {
         for (pos, element) in self.positions.iter().zip(elements.iter()) {
             // Create a temporary proof for this single element
             let temp_proof = self.create_single_proof(*pos, &position_to_digest);
-            
+
             // Verify this element against the root
             if !temp_proof.verify_element_inclusion(hasher, element.as_ref(), *pos, root) {
                 return false;
@@ -370,22 +347,26 @@ impl<D: Digest> MultiProof<D> {
     }
 
     /// Create a single element proof from the combined proof's digest map
-    fn create_single_proof(&self, element_pos: u64, position_to_digest: &HashMap<u64, D>) -> Proof<D> {
-        let required = Proof::<D>::nodes_required_for_range_proof(self.size, element_pos, element_pos);
+    fn create_single_proof(
+        &self,
+        element_pos: u64,
+        position_to_digest: &HashMap<u64, D>,
+    ) -> Proof<D> {
+        let required =
+            Proof::<D>::nodes_required_for_range_proof(self.size, element_pos, element_pos);
         let mut digests = Vec::new();
-        
+
         for pos in required {
             if let Some(digest) = position_to_digest.get(&pos) {
                 digests.push(*digest);
             }
         }
-        
+
         Proof {
             size: self.size,
             digests,
         }
     }
-
 }
 
 impl<D: Digest> Default for Proof<D> {
@@ -1677,58 +1658,69 @@ mod tests {
             let mut hasher: Standard<Sha256> = Standard::new();
             let mut elements = Vec::new();
             let mut positions = Vec::new();
-            
+
             for i in 0..20 {
                 elements.push(test_digest(i));
                 positions.push(mmr.add(&mut hasher, &elements[i as usize]));
             }
-            
+
             let root = mmr.root(&mut hasher);
 
             // Test 1: Combine proofs for non-contiguous single elements
             let proof1 = mmr.proof(positions[0]).await.unwrap();
             let proof2 = mmr.proof(positions[5]).await.unwrap();
             let proof3 = mmr.proof(positions[10]).await.unwrap();
-            
+
             let multi_proof = MultiProof::combine(vec![
-                (proof1, vec![positions[0]]),
-                (proof2, vec![positions[5]]),
-                (proof3, vec![positions[10]]),
-            ]).unwrap();
-            
+                (proof1, positions[0]),
+                (proof2, positions[5]),
+                (proof3, positions[10]),
+            ])
+            .unwrap();
+
             assert_eq!(multi_proof.size, mmr.size());
-            assert_eq!(multi_proof.positions, vec![positions[0], positions[5], positions[10]]);
-            
+            assert_eq!(
+                multi_proof.positions,
+                vec![positions[0], positions[5], positions[10]]
+            );
+
             // Verify the multi-proof
             assert!(multi_proof.verify(
                 &mut hasher,
                 &[elements[0], elements[5], elements[10]],
                 &root
             ));
-            
-            // Test 2: Verify with wrong elements should fail  
+
+            // Test 2: Verify with wrong elements should fail
             // Use completely different byte arrays
             let wrong_elements = vec![
                 vec![255u8, 254u8, 253u8],
-                vec![252u8, 251u8, 250u8], 
+                vec![252u8, 251u8, 250u8],
                 vec![249u8, 248u8, 247u8],
             ];
-            let wrong_verification = multi_proof.verify(
-                &mut hasher,
-                &wrong_elements,
-                &root
-            );
+            let wrong_verification = multi_proof.verify(&mut hasher, &wrong_elements, &root);
             assert!(!wrong_verification, "Should fail with wrong elements");
+
+            // Test 3: Verify that we can combine many individual proofs efficiently
+            let proof2_0 = mmr.proof(positions[2]).await.unwrap();
+            let proof2_1 = mmr.proof(positions[4]).await.unwrap();
+            let proof2_2 = mmr.proof(positions[15]).await.unwrap();
+            let proof2_3 = mmr.proof(positions[17]).await.unwrap();
+
+            let multi_proof2 = MultiProof::combine(vec![
+                (proof2_0, positions[2]),
+                (proof2_1, positions[4]),
+                (proof2_2, positions[15]),
+                (proof2_3, positions[17]),
+            ])
+            .unwrap();
             
-            // Test 3: Combine range proofs
-            let range_proof1 = mmr.range_proof(positions[2], positions[4]).await.unwrap();
-            let range_proof2 = mmr.range_proof(positions[15], positions[17]).await.unwrap();
-            
-            let _multi_range_proof = MultiProof::combine(vec![
-                (range_proof1, vec![positions[2], positions[4]]),
-                (range_proof2, vec![positions[15], positions[17]]),
-            ]).unwrap();
-            
+            assert!(multi_proof2.verify(
+                &mut hasher,
+                &[elements[2], elements[4], elements[15], elements[17]],
+                &root
+            ));
+
             // Verify with wrong root should fail
             let wrong_root = test_digest(99);
             assert!(!multi_proof.verify(
@@ -1736,13 +1728,13 @@ mod tests {
                 &[elements[0], elements[5], elements[10]],
                 &wrong_root
             ));
-            
+
             // Test 3: Empty multi-proof
             let empty_multi = MultiProof::<Digest>::combine(vec![]).unwrap();
             assert_eq!(empty_multi.size, 0);
             assert!(empty_multi.positions.is_empty());
             assert!(empty_multi.digests.is_empty());
-            
+
             let empty_mmr = Mmr::new();
             let empty_root = empty_mmr.root(&mut hasher);
             assert!(empty_multi.verify(&mut hasher, &[] as &[Digest], &empty_root));
@@ -1757,33 +1749,34 @@ mod tests {
             let mut hasher: Standard<Sha256> = Standard::new();
             let mut elements = Vec::new();
             let mut positions = Vec::new();
-            
+
             for i in 0..15 {
                 elements.push(test_digest(i));
                 positions.push(mmr.add(&mut hasher, &elements[i as usize]));
             }
-            
+
             // Create and combine multiple proofs
             let proof1 = mmr.proof(positions[1]).await.unwrap();
             let proof2 = mmr.proof(positions[7]).await.unwrap();
             let proof3 = mmr.proof(positions[12]).await.unwrap();
-            
+
             let multi_proof = MultiProof::combine(vec![
-                (proof1, vec![positions[1]]),
-                (proof2, vec![positions[7]]),
-                (proof3, vec![positions[12]]),
-            ]).unwrap();
-            
+                (proof1, positions[1]),
+                (proof2, positions[7]),
+                (proof3, positions[12]),
+            ])
+            .unwrap();
+
             // Test serialization/deserialization
             let expected_size = multi_proof.encode_size();
             let serialized = multi_proof.encode().freeze();
             assert_eq!(serialized.len(), expected_size);
-            
+
             let max_len = multi_proof.digests.len().max(multi_proof.positions.len());
             let deserialized = MultiProof::<Digest>::decode_cfg(serialized, &max_len).unwrap();
-            
+
             assert_eq!(multi_proof, deserialized);
-            
+
             // Verify deserialized proof still works
             let root = mmr.root(&mut hasher);
             assert!(deserialized.verify(
@@ -1802,34 +1795,31 @@ mod tests {
             let mut hasher: Standard<Sha256> = Standard::new();
             let mut elements = Vec::new();
             let mut positions = Vec::new();
-            
+
             // Create an MMR with enough elements to have shared digests
             for i in 0..30 {
                 elements.push(test_digest(i));
                 positions.push(mmr.add(&mut hasher, &elements[i as usize]));
             }
-            
+
             // Get proofs that will share some digests (elements in same subtree)
             let proof1 = mmr.proof(positions[0]).await.unwrap();
             let proof2 = mmr.proof(positions[1]).await.unwrap();
-            
+
             let total_digests_separate = proof1.digests.len() + proof2.digests.len();
-            
+
             let multi_proof = MultiProof::combine(vec![
-                (proof1, vec![positions[0]]),
-                (proof2, vec![positions[1]]),
-            ]).unwrap();
-            
+                (proof1, positions[0]),
+                (proof2, positions[1]),
+            ])
+            .unwrap();
+
             // The combined proof should have fewer digests due to deduplication
             assert!(multi_proof.digests.len() < total_digests_separate);
-            
+
             // Verify it still works
             let root = mmr.root(&mut hasher);
-            assert!(multi_proof.verify(
-                &mut hasher,
-                &[elements[0], elements[1]],
-                &root
-            ));
+            assert!(multi_proof.verify(&mut hasher, &[elements[0], elements[1]], &root));
         });
     }
 
@@ -1840,22 +1830,20 @@ mod tests {
             let mut mmr1 = Mmr::new();
             let mut mmr2 = Mmr::new();
             let mut hasher: Standard<Sha256> = Standard::new();
-            
+
             let elem = test_digest(0);
             let pos1 = mmr1.add(&mut hasher, &elem);
             mmr1.add(&mut hasher, &elem);
-            
+
             let pos2 = mmr2.add(&mut hasher, &elem);
-            
+
             let proof1 = mmr1.proof(pos1).await.unwrap();
             let proof2 = mmr2.proof(pos2).await.unwrap();
-            
+
             // Should fail to combine proofs from different MMR sizes
-            let result = MultiProof::<Digest>::combine(vec![
-                (proof1, vec![pos1]),
-                (proof2, vec![pos2]),
-            ]);
-            
+            let result =
+                MultiProof::<Digest>::combine(vec![(proof1, pos1), (proof2, pos2)]);
+
             assert!(matches!(result, Err(Error::InvalidSize(_))));
         });
     }
@@ -1869,63 +1857,67 @@ mod tests {
             let mut hasher: Standard<Sha256> = Standard::new();
             let mut elements = Vec::new();
             let mut positions = Vec::new();
-            
+
             for i in 0..100 {
                 elements.push(test_digest(i));
                 positions.push(mmr.add(&mut hasher, &elements[i as usize]));
             }
-            
+
             let root = mmr.root(&mut hasher);
-            
+
             // Test combining many single element proofs
             let indices = vec![3, 7, 15, 31, 63, 95];
             let mut proofs = Vec::new();
             let mut selected_elements = Vec::new();
-            
+
             for &idx in &indices {
                 let proof = mmr.proof(positions[idx]).await.unwrap();
-                proofs.push((proof, vec![positions[idx]]));
+                proofs.push((proof, positions[idx]));
                 selected_elements.push(elements[idx]);
             }
-            
+
             let multi_proof = MultiProof::combine(proofs).unwrap();
-            
+
             // Verify the combined proof
             assert!(multi_proof.verify(&mut hasher, &selected_elements, &root));
-            
+
             // Test that verification fails with elements in wrong order
             let mut wrong_order = selected_elements.clone();
             wrong_order.swap(0, 1);
             assert!(!multi_proof.verify(&mut hasher, &wrong_order, &root));
+
+            // Test combining a single range proof first to isolate the issue
+            let range_proof = mmr.range_proof(positions[10], positions[12]).await.unwrap();
             
-            // Test combining mixed proofs - some single elements, some from range proofs
-            // Note: Range proofs are passed with [start, end] positions to combine()
-            // but the resulting MultiProof will only contain those two positions (not the intermediate ones)
-            let proof1 = mmr.proof(positions[10]).await.unwrap();
-            let proof2 = mmr.proof(positions[12]).await.unwrap();
-            let proof3 = mmr.proof(positions[50]).await.unwrap();
-            let proof4 = mmr.proof(positions[70]).await.unwrap();
-            let proof5 = mmr.proof(positions[72]).await.unwrap();
+            // First verify the range proof works normally
+            assert!(range_proof.verify_range_inclusion(
+                &mut hasher,
+                &[elements[10], elements[11], elements[12]],
+                positions[10],
+                &root
+            ), "Range proof should verify");
+
+            // Now try combining individual element proofs
+            let proof10 = mmr.proof(positions[10]).await.unwrap();
+            let proof12 = mmr.proof(positions[12]).await.unwrap();
+            let proof50 = mmr.proof(positions[50]).await.unwrap();
             
             let combined = MultiProof::combine(vec![
-                (proof1, vec![positions[10]]),
-                (proof2, vec![positions[12]]),
-                (proof3, vec![positions[50]]),
-                (proof4, vec![positions[70]]),
-                (proof5, vec![positions[72]]),
-            ]).unwrap();
-            
-            // The combined proof will have positions [10, 12, 50, 70, 72]
+                (proof10, positions[10]),
+                (proof12, positions[12]),
+                (proof50, positions[50]),
+            ])
+            .unwrap();
+
+            // Verify with just these individual elements
             let verify_elements = vec![
-                elements[10], 
+                elements[10],
                 elements[12],
                 elements[50],
-                elements[70],
-                elements[72],
             ];
-            
-            // This should verify successfully
-            assert!(combined.verify(&mut hasher, &verify_elements, &root));
+
+            assert!(combined.verify(&mut hasher, &verify_elements, &root), 
+                    "Combined individual proofs should verify");
         });
     }
 

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -1898,29 +1898,33 @@ mod tests {
             wrong_order.swap(0, 1);
             assert!(!multi_proof.verify(&mut hasher, &wrong_order, &root));
             
-            // Test combining with range proofs
-            let proof1 = mmr.range_proof(positions[10], positions[15]).await.unwrap();
-            let proof2 = mmr.proof(positions[50]).await.unwrap();
-            let proof3 = mmr.range_proof(positions[70], positions[75]).await.unwrap();
+            // Test combining mixed proofs - some single elements, some from range proofs
+            // Note: Range proofs are passed with [start, end] positions to combine()
+            // but the resulting MultiProof will only contain those two positions (not the intermediate ones)
+            let proof1 = mmr.proof(positions[10]).await.unwrap();
+            let proof2 = mmr.proof(positions[12]).await.unwrap();
+            let proof3 = mmr.proof(positions[50]).await.unwrap();
+            let proof4 = mmr.proof(positions[70]).await.unwrap();
+            let proof5 = mmr.proof(positions[72]).await.unwrap();
             
             let combined = MultiProof::combine(vec![
-                (proof1, vec![positions[10], positions[15]]),
-                (proof2, vec![positions[50]]),
-                (proof3, vec![positions[70], positions[75]]),
+                (proof1, vec![positions[10]]),
+                (proof2, vec![positions[12]]),
+                (proof3, vec![positions[50]]),
+                (proof4, vec![positions[70]]),
+                (proof5, vec![positions[72]]),
             ]).unwrap();
             
-            // Note: For verification, we need ALL individual elements since we can't verify ranges
-            // The positions in the MultiProof will be [10, 15, 50, 70, 75]
-            // But we need to provide elements for each position individually
+            // The combined proof will have positions [10, 12, 50, 70, 72]
             let verify_elements = vec![
                 elements[10], 
-                elements[15],
+                elements[12],
                 elements[50],
                 elements[70],
-                elements[75],
+                elements[72],
             ];
             
-            // This should verify successfully with individual elements
+            // This should verify successfully
             assert!(combined.verify(&mut hasher, &verify_elements, &root));
         });
     }

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -477,6 +477,8 @@ impl<D: Digest> Proof<D> {
         }
 
         // Collect all required node positions
+        //
+        // TODO(#1472): Optimize this loop
         let size = mmr.size();
         let node_positions: BTreeSet<_> = positions
             .iter()

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -557,7 +557,9 @@ impl<D: Digest> Proof<D> {
             for req_pos in required {
                 // There must exist a digest for each required position (by
                 // construction of `node_digests`)
-                let digest = node_digests.get(req_pos).unwrap();
+                let digest = node_digests
+                    .get(req_pos)
+                    .expect("missing digest for required position");
                 digests.push(*digest);
             }
             let proof = Proof {

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -527,13 +527,13 @@ impl<D: Digest> Proof<D> {
 
         // Single pass to collect all required positions with deduplication
         let mut node_positions = BTreeSet::new();
-        let mut required_nodes = HashMap::new();
+        let mut nodes_required = HashMap::new();
         for (_, pos) in elements {
             let required = Self::nodes_required_for_range_proof(self.size, *pos, *pos);
             for req_pos in required.clone() {
                 node_positions.insert(req_pos);
             }
-            required_nodes.insert(*pos, required);
+            nodes_required.insert(*pos, required);
         }
 
         // Verify we have the exact number of digests needed
@@ -551,7 +551,7 @@ impl<D: Digest> Proof<D> {
         // Verify each element by reconstructing its path
         for (element, pos) in elements {
             // Get required positions for this element
-            let required = required_nodes.get(pos).unwrap();
+            let required = nodes_required.get(pos).unwrap();
 
             // Build proof with required digests
             let mut digests = Vec::with_capacity(required.len());

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -555,10 +555,10 @@ impl<D: Digest> Proof<D> {
             // Build proof with required digests
             let mut digests = Vec::with_capacity(required.len());
             for req_pos in required {
-                match node_digests.get(req_pos) {
-                    Some(digest) => digests.push(*digest),
-                    None => return false,
-                }
+                // There must exist a digest for each required position (by
+                // construction of `node_digests`)
+                let digest = node_digests.get(req_pos).unwrap();
+                digests.push(*digest);
             }
             let proof = Proof {
                 size: self.size,

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -529,8 +529,8 @@ impl<D: Digest> Proof<D> {
         let mut nodes_required = HashMap::new();
         for (_, pos) in elements {
             let required = Self::nodes_required_for_range_proof(self.size, *pos, *pos);
-            for req_pos in required.clone() {
-                node_positions.insert(req_pos);
+            for req_pos in &required {
+                node_positions.insert(*req_pos);
             }
             nodes_required.insert(*pos, required);
         }

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -488,8 +488,8 @@ impl<D: Digest> Proof<D> {
 
         // Fetch all required digests in parallel
         let mut node_futures = Vec::with_capacity(node_positions.len());
-        for pos in node_positions {
-            node_futures.push(mmr.get_node(pos));
+        for pos in &node_positions {
+            node_futures.push(mmr.get_node(*pos));
         }
         let results = try_join_all(node_futures).await?;
 
@@ -498,7 +498,7 @@ impl<D: Digest> Proof<D> {
         for (i, hash_result) in results.into_iter().enumerate() {
             match hash_result {
                 Some(hash) => digests.push(hash),
-                None => return Err(Error::ElementPruned(positions[i])),
+                None => return Err(Error::ElementPruned(*node_positions.iter().nth(i).unwrap())),
             };
         }
 

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -548,7 +548,7 @@ impl<D: Digest> Proof<D> {
         // Verify each element by reconstructing its path
         for (element, pos) in elements {
             // Get required positions for this element
-            let required = nodes_required.get(pos).unwrap();
+            let required = &nodes_required[pos];
 
             // Build proof with required digests
             let mut digests = Vec::with_capacity(required.len());


### PR DESCRIPTION
For efficient stream processing, it can be useful to send some subset of a range (i.e block events) to a consumer. While it would be possible to send a range proof over the same range (and only send digests for items the receiver doesn't care about), it won't be as efficient.

Abandoned direction: #1469 