### PR TITLE
[stream] link listener response to dialer hello

### DIFF
--- a/broadcast/src/buffered/mocks.rs
+++ b/broadcast/src/buffered/mocks.rs
@@ -2,7 +2,7 @@
 
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Error as CodecError, RangeCfg, Read, ReadRangeExt, Write};
-use commonware_cryptography::{hash, sha256::Digest, Committable, Digestible};
+use commonware_cryptography::{sha256::Digest, Committable, Digestible, Hasher, Sha256};
 
 /// A simple test message.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,14 +31,14 @@ impl TestMessage {
 impl Digestible for TestMessage {
     type Digest = Digest;
     fn digest(&self) -> Digest {
-        hash(&self.content)
+        Sha256::hash(&self.content)
     }
 }
 
 impl Committable for TestMessage {
     type Commitment = Digest;
     fn commitment(&self) -> Digest {
-        hash(&self.commitment)
+        Sha256::hash(&self.commitment)
     }
 }
 

--- a/collector/src/p2p/mocks/types.rs
+++ b/collector/src/p2p/mocks/types.rs
@@ -1,10 +1,6 @@
 use bytes::{Buf, BufMut};
 use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
-use commonware_cryptography::{
-    hash,
-    sha256::{Digest, Sha256},
-    Committable, Digestible, Hasher,
-};
+use commonware_cryptography::{sha256::Digest, Committable, Digestible, Hasher, Sha256};
 
 /// A mock request for testing
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -37,7 +33,7 @@ impl Committable for Request {
     type Commitment = Digest;
 
     fn commitment(&self) -> Self::Commitment {
-        hash(&self.id.to_be_bytes())
+        Sha256::hash(&self.id.to_be_bytes())
     }
 }
 
@@ -83,7 +79,7 @@ impl FixedSize for Response {
 impl Committable for Response {
     type Commitment = Digest;
     fn commitment(&self) -> Self::Commitment {
-        hash(&self.id.to_be_bytes())
+        Sha256::hash(&self.id.to_be_bytes())
     }
 }
 

--- a/consensus/src/aggregation/mocks/application.rs
+++ b/consensus/src/aggregation/mocks/application.rs
@@ -1,5 +1,5 @@
 use crate::{aggregation::types::Index, Automaton as A};
-use commonware_cryptography::{hash, sha256, Hasher, Sha256};
+use commonware_cryptography::{Hasher, Sha256};
 use futures::channel::oneshot;
 use tracing::trace;
 
@@ -22,7 +22,7 @@ impl Application {
 
 impl A for Application {
     type Context = Index;
-    type Digest = sha256::Digest;
+    type Digest = <Sha256 as Hasher>::Digest;
 
     async fn genesis(&mut self) -> Self::Digest {
         let mut hasher = Sha256::default();
@@ -36,11 +36,11 @@ impl A for Application {
         let digest = match self.strategy {
             Strategy::Correct => {
                 let payload = format!("data for index {context}");
-                hash(payload.as_bytes())
+                Sha256::hash(payload.as_bytes())
             }
             Strategy::Incorrect => {
                 let conflicting_payload = format!("conflicting_data for index {context}");
-                hash(conflicting_payload.as_bytes())
+                Sha256::hash(conflicting_payload.as_bytes())
             }
         };
 

--- a/consensus/src/aggregation/types.rs
+++ b/consensus/src/aggregation/types.rs
@@ -358,8 +358,7 @@ mod tests {
             dkg::ops::{self, evaluate_all},
             primitives::{ops::sign_message, variant::MinSig},
         },
-        sha256::Sha256,
-        Hasher,
+        Hasher, Sha256,
     };
     use commonware_runtime::deterministic;
 

--- a/consensus/src/marshal/ingress/handler.rs
+++ b/consensus/src/marshal/ingress/handler.rs
@@ -242,14 +242,17 @@ mod tests {
     use super::*;
     use crate::marshal::mocks::block::Block as TestBlock;
     use commonware_codec::{Encode, ReadExt};
-    use commonware_cryptography::sha256::{self, Digest as Sha256Digest};
+    use commonware_cryptography::{
+        sha256::{Digest as Sha256Digest, Sha256},
+        Hasher as _,
+    };
     use std::collections::BTreeSet;
 
     type B = TestBlock<Sha256Digest>;
 
     #[test]
     fn test_subject_block_encoding() {
-        let commitment = sha256::hash(b"test");
+        let commitment = Sha256::hash(b"test");
         let request = Request::<B>::Block(commitment);
 
         // Test encoding
@@ -326,7 +329,7 @@ mod tests {
 
     #[test]
     fn test_encode_size() {
-        let commitment = sha256::hash(&[0u8; 32]);
+        let commitment = Sha256::hash(&[0u8; 32]);
         let r1 = Request::<B>::Block(commitment);
         let r2 = Request::<B>::Finalized { height: u64::MAX };
         let r3 = Request::<B>::Notarized { view: 0 };
@@ -340,8 +343,8 @@ mod tests {
     #[test]
     fn test_request_ord_same_variant() {
         // Test ordering within the same variant
-        let commitment1 = sha256::hash(b"test1");
-        let commitment2 = sha256::hash(b"test2");
+        let commitment1 = Sha256::hash(b"test1");
+        let commitment2 = Sha256::hash(b"test2");
         let block1 = Request::<B>::Block(commitment1);
         let block2 = Request::<B>::Block(commitment2);
 
@@ -375,7 +378,7 @@ mod tests {
 
     #[test]
     fn test_request_ord_cross_variant() {
-        let commitment = sha256::hash(b"test");
+        let commitment = Sha256::hash(b"test");
         let block = Request::<B>::Block(commitment);
         let finalized = Request::<B>::Finalized { height: 100 };
         let notarized = Request::<B>::Notarized { view: 200 };
@@ -400,8 +403,8 @@ mod tests {
 
     #[test]
     fn test_request_partial_ord() {
-        let commitment1 = sha256::hash(b"test1");
-        let commitment2 = sha256::hash(b"test2");
+        let commitment1 = Sha256::hash(b"test1");
+        let commitment2 = Sha256::hash(b"test2");
         let block1 = Request::<B>::Block(commitment1);
         let block2 = Request::<B>::Block(commitment2);
         let finalized = Request::<B>::Finalized { height: 100 };
@@ -429,9 +432,9 @@ mod tests {
 
     #[test]
     fn test_request_ord_sorting() {
-        let commitment1 = sha256::hash(b"a");
-        let commitment2 = sha256::hash(b"b");
-        let commitment3 = sha256::hash(b"c");
+        let commitment1 = Sha256::hash(b"a");
+        let commitment2 = Sha256::hash(b"b");
+        let commitment3 = Sha256::hash(b"c");
 
         let requests = vec![
             Request::<B>::Notarized { view: 300 },
@@ -480,7 +483,7 @@ mod tests {
         assert!(max_finalized < min_notarized);
 
         // Test self-comparison
-        let commitment = sha256::hash(b"self");
+        let commitment = Sha256::hash(b"self");
         let block = Request::<B>::Block(commitment);
         assert_eq!(block.cmp(&block), std::cmp::Ordering::Equal);
         assert_eq!(min_finalized.cmp(&min_finalized), std::cmp::Ordering::Equal);

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -94,8 +94,8 @@ mod tests {
             },
         },
         ed25519::{PrivateKey, PublicKey},
-        sha256::{self, Digest as Sha256Digest},
-        Digestible, PrivateKeyExt as _, Signer as _,
+        sha256::{Digest as Sha256Digest, Sha256},
+        Digestible, Hasher as _, PrivateKeyExt as _, Signer as _,
     };
     use commonware_macros::test_traced;
     use commonware_p2p::simulated::{self, Link, Network, Oracle};
@@ -345,9 +345,9 @@ mod tests {
 
             // Generate blocks, skipping the genesis block.
             let mut blocks = Vec::<B>::new();
-            let mut parent = sha256::hash(b"");
+            let mut parent = Sha256::hash(b"");
             for i in 1..=NUM_BLOCKS {
-                let block = B::new::<sha256::Sha256>(parent, i, i);
+                let block = B::new::<Sha256>(parent, i, i);
                 parent = block.digest();
                 blocks.push(block);
             }
@@ -445,8 +445,8 @@ mod tests {
             };
             setup_network_links(&mut oracle, &peers, link).await;
 
-            let parent = sha256::hash(b"");
-            let block = B::new::<sha256::Sha256>(parent, 1, 1);
+            let parent = Sha256::hash(b"");
+            let block = B::new::<Sha256>(parent, 1, 1);
             let commitment = block.digest();
 
             let subscription_rx = actor.subscribe(Some(1), commitment).await;
@@ -499,9 +499,9 @@ mod tests {
             };
             setup_network_links(&mut oracle, &peers, link).await;
 
-            let parent = sha256::hash(b"");
-            let block1 = B::new::<sha256::Sha256>(parent, 1, 1);
-            let block2 = B::new::<sha256::Sha256>(block1.digest(), 2, 2);
+            let parent = Sha256::hash(b"");
+            let block1 = B::new::<Sha256>(parent, 1, 1);
+            let block2 = B::new::<Sha256>(block1.digest(), 2, 2);
             let commitment1 = block1.digest();
             let commitment2 = block2.digest();
 
@@ -567,9 +567,9 @@ mod tests {
             };
             setup_network_links(&mut oracle, &peers, link).await;
 
-            let parent = sha256::hash(b"");
-            let block1 = B::new::<sha256::Sha256>(parent, 1, 1);
-            let block2 = B::new::<sha256::Sha256>(block1.digest(), 2, 2);
+            let parent = Sha256::hash(b"");
+            let block1 = B::new::<Sha256>(parent, 1, 1);
+            let block2 = B::new::<Sha256>(block1.digest(), 2, 2);
             let commitment1 = block1.digest();
             let commitment2 = block2.digest();
 
@@ -629,12 +629,12 @@ mod tests {
             };
             setup_network_links(&mut oracle, &peers, link).await;
 
-            let parent = sha256::hash(b"");
-            let block1 = B::new::<sha256::Sha256>(parent, 1, 1);
-            let block2 = B::new::<sha256::Sha256>(block1.digest(), 2, 2);
-            let block3 = B::new::<sha256::Sha256>(block2.digest(), 3, 3);
-            let block4 = B::new::<sha256::Sha256>(block3.digest(), 4, 4);
-            let block5 = B::new::<sha256::Sha256>(block4.digest(), 5, 5);
+            let parent = Sha256::hash(b"");
+            let block1 = B::new::<Sha256>(parent, 1, 1);
+            let block2 = B::new::<Sha256>(block1.digest(), 2, 2);
+            let block3 = B::new::<Sha256>(block2.digest(), 3, 3);
+            let block4 = B::new::<Sha256>(block3.digest(), 4, 4);
+            let block5 = B::new::<Sha256>(block4.digest(), 5, 5);
 
             let sub1_rx = actor.subscribe(Some(1), block1.digest()).await;
             let sub2_rx = actor.subscribe(Some(2), block2.digest()).await;

--- a/consensus/src/ordered_broadcast/ack_manager.rs
+++ b/consensus/src/ordered_broadcast/ack_manager.rs
@@ -159,7 +159,8 @@ mod tests {
             primitives::variant::{MinPk, MinSig},
         },
         ed25519::PublicKey,
-        sha256,
+        sha256::Sha256,
+        Hasher,
     };
 
     /// Aggregated helper functions to reduce duplication in tests.
@@ -167,7 +168,7 @@ mod tests {
         use super::*;
         use crate::ordered_broadcast::types::Chunk;
         use commonware_codec::{DecodeExt, FixedSize};
-        use commonware_cryptography::bls12381::primitives::group::Share;
+        use commonware_cryptography::{bls12381::primitives::group::Share, Hasher};
         use rand::{rngs::StdRng, SeedableRng as _};
 
         const NAMESPACE: &[u8] = b"1234";
@@ -187,9 +188,9 @@ mod tests {
         /// Create an Ack by signing a partial with the provided share.
         pub fn create_ack<V: Variant>(
             share: &Share,
-            chunk: Chunk<PublicKey, sha256::Digest>,
+            chunk: Chunk<PublicKey, <Sha256 as Hasher>::Digest>,
             epoch: Epoch,
-        ) -> Ack<PublicKey, V, sha256::Digest> {
+        ) -> Ack<PublicKey, V, <Sha256 as Hasher>::Digest> {
             Ack::sign(NAMESPACE, share, chunk, epoch)
         }
 
@@ -204,7 +205,7 @@ mod tests {
         /// Generate a threshold signature directly from the shares specified by `indices`.
         pub fn generate_threshold_from_indices<V: Variant>(
             shares: &[Share],
-            chunk: &Chunk<PublicKey, sha256::Digest>,
+            chunk: &Chunk<PublicKey, <Sha256 as Hasher>::Digest>,
             epoch: &Epoch,
             quorum: u32,
             indices: &[usize],
@@ -219,10 +220,10 @@ mod tests {
         /// Create a vector of acks for the given share indices.
         pub fn create_acks_for_indices<V: Variant>(
             shares: &[Share],
-            chunk: Chunk<PublicKey, sha256::Digest>,
+            chunk: Chunk<PublicKey, <Sha256 as Hasher>::Digest>,
             epoch: Epoch,
             indices: &[usize],
-        ) -> Vec<Ack<PublicKey, V, sha256::Digest>> {
+        ) -> Vec<Ack<PublicKey, V, <Sha256 as Hasher>::Digest>> {
             indices
                 .iter()
                 .map(|&i| create_ack(&shares[i], chunk.clone(), epoch))
@@ -232,9 +233,9 @@ mod tests {
         /// Add acks (generated from the provided share indices) to the manager.
         /// Returns the threshold signature if produced.
         pub fn add_acks_for_indices<V: Variant>(
-            manager: &mut AckManager<PublicKey, V, sha256::Digest>,
+            manager: &mut AckManager<PublicKey, V, <Sha256 as Hasher>::Digest>,
             shares: &[Share],
-            chunk: Chunk<PublicKey, sha256::Digest>,
+            chunk: Chunk<PublicKey, <Sha256 as Hasher>::Digest>,
             epoch: Epoch,
             quorum: u32,
             indices: &[usize],
@@ -255,13 +256,13 @@ mod tests {
         let num_validators = 6;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
         let sequencer = helpers::gen_public_key(1);
         let height = 10;
         let epoch = 5;
 
-        let chunk1 = Chunk::new(sequencer.clone(), height, sha256::hash(b"payload1"));
-        let chunk2 = Chunk::new(sequencer, height, sha256::hash(b"payload2"));
+        let chunk1 = Chunk::new(sequencer.clone(), height, Sha256::hash(b"payload1"));
+        let chunk2 = Chunk::new(sequencer, height, Sha256::hash(b"payload2"));
 
         let threshold1 =
             helpers::add_acks_for_indices(&mut acks, &shares, chunk1, epoch, quorum, &[0, 1, 2]);
@@ -284,13 +285,13 @@ mod tests {
         let num_validators = 4;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
         let sequencer = helpers::gen_public_key(1);
         let epoch = 10;
         let height1 = 10;
         let height2 = 20;
 
-        let chunk1 = Chunk::new(sequencer.clone(), height1, sha256::hash(b"chunk1"));
+        let chunk1 = Chunk::new(sequencer.clone(), height1, Sha256::hash(b"chunk1"));
         let threshold1 = helpers::generate_threshold_from_indices::<V>(
             &shares,
             &chunk1,
@@ -304,7 +305,7 @@ mod tests {
             Some((epoch, threshold1))
         );
 
-        let chunk2 = Chunk::new(sequencer.clone(), height2, sha256::hash(b"chunk2"));
+        let chunk2 = Chunk::new(sequencer.clone(), height2, Sha256::hash(b"chunk2"));
         let threshold2 = helpers::generate_threshold_from_indices::<V>(
             &shares,
             &chunk2,
@@ -332,11 +333,11 @@ mod tests {
         let num_validators = 4;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
         let sequencer = helpers::gen_public_key(1);
         let epoch = 10;
 
-        let chunk1 = Chunk::new(sequencer.clone(), 10, sha256::hash(b"chunk1"));
+        let chunk1 = Chunk::new(sequencer.clone(), 10, Sha256::hash(b"chunk1"));
         let threshold1 = helpers::generate_threshold_from_indices::<V>(
             &shares,
             &chunk1,
@@ -350,7 +351,7 @@ mod tests {
             Some((epoch, threshold1))
         );
 
-        let chunk2 = Chunk::new(sequencer.clone(), 11, sha256::hash(b"chunk2"));
+        let chunk2 = Chunk::new(sequencer.clone(), 11, Sha256::hash(b"chunk2"));
         let threshold2 = helpers::generate_threshold_from_indices::<V>(
             &shares,
             &chunk2,
@@ -369,7 +370,7 @@ mod tests {
             Some((epoch, threshold2))
         );
 
-        let chunk3 = Chunk::new(sequencer.clone(), 12, sha256::hash(b"chunk3"));
+        let chunk3 = Chunk::new(sequencer.clone(), 12, Sha256::hash(b"chunk3"));
         let threshold3 = helpers::generate_threshold_from_indices::<V>(
             &shares,
             &chunk3,
@@ -401,13 +402,13 @@ mod tests {
         let num_validators = 4;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
         let sequencer = helpers::gen_public_key(1);
         let height = 30;
         let epoch1 = 1;
         let epoch2 = 2;
 
-        let chunk = Chunk::new(sequencer.clone(), height, sha256::hash(b"chunk"));
+        let chunk = Chunk::new(sequencer.clone(), height, Sha256::hash(b"chunk"));
 
         let threshold1 = helpers::generate_threshold_from_indices::<V>(
             &shares,
@@ -444,11 +445,11 @@ mod tests {
         let num_validators = 4;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
         let epoch = 99;
         let sequencer = helpers::gen_public_key(1);
         let height = 42;
-        let chunk = Chunk::new(sequencer.clone(), height, sha256::hash(&sequencer));
+        let chunk = Chunk::new(sequencer.clone(), height, Sha256::hash(&sequencer));
 
         let threshold = helpers::generate_threshold_from_indices::<V>(
             &shares,
@@ -482,11 +483,11 @@ mod tests {
         let num_validators = 4;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
         let sequencer = helpers::gen_public_key(1);
         let epoch = 1;
         let height = 10;
-        let chunk = Chunk::new(sequencer, height, sha256::hash(b"payload"));
+        let chunk = Chunk::new(sequencer, height, Sha256::hash(b"payload"));
 
         let ack = helpers::create_ack(&shares[0], chunk, epoch);
         assert!(acks.add_ack(&ack, quorum).is_none());
@@ -504,11 +505,11 @@ mod tests {
         let num_validators = 4;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
         let sequencer = helpers::gen_public_key(1);
         let epoch = 1;
         let height = 10;
-        let chunk = Chunk::new(sequencer, height, sha256::hash(b"payload"));
+        let chunk = Chunk::new(sequencer, height, Sha256::hash(b"payload"));
 
         let acks_vec = helpers::create_acks_for_indices(&shares, chunk.clone(), epoch, &[0, 1, 2]);
         let mut produced = None;
@@ -534,15 +535,15 @@ mod tests {
         let num_validators = 4;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
 
         let sequencer1 = helpers::gen_public_key(1);
         let sequencer2 = helpers::gen_public_key(3);
         let epoch = 1;
         let height = 10;
 
-        let chunk1 = Chunk::new(sequencer1.clone(), height, sha256::hash(b"payload1"));
-        let chunk2 = Chunk::new(sequencer2.clone(), height, sha256::hash(b"payload2"));
+        let chunk1 = Chunk::new(sequencer1.clone(), height, Sha256::hash(b"payload1"));
+        let chunk2 = Chunk::new(sequencer2.clone(), height, Sha256::hash(b"payload2"));
 
         let threshold1 =
             helpers::add_acks_for_indices(&mut acks, &shares, chunk1, epoch, quorum, &[0, 1, 2])
@@ -567,11 +568,11 @@ mod tests {
         let num_validators = 4;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
         let sequencer = helpers::gen_public_key(1);
         let epoch = 1;
         let height = 10;
-        let chunk = Chunk::new(sequencer.clone(), height, sha256::hash(b"payload"));
+        let chunk = Chunk::new(sequencer.clone(), height, Sha256::hash(b"payload"));
 
         let acks_vec = helpers::create_acks_for_indices(&shares, chunk, epoch, &[0, 1]);
         for ack in acks_vec {
@@ -591,13 +592,13 @@ mod tests {
         let num_validators = 6;
         let quorum = 3;
         let shares = helpers::setup_shares::<V>(num_validators, quorum);
-        let mut acks = AckManager::<PublicKey, V, sha256::Digest>::new();
+        let mut acks = AckManager::<PublicKey, V, <Sha256 as Hasher>::Digest>::new();
         let sequencer = helpers::gen_public_key(1);
         let epoch = 1;
         let height = 10;
 
-        let payload1 = sha256::hash(b"payload1");
-        let payload2 = sha256::hash(b"payload2");
+        let payload1 = Sha256::hash(b"payload1");
+        let payload2 = Sha256::hash(b"payload2");
 
         let chunk1 = Chunk::new(sequencer.clone(), height, payload1);
         let chunk2 = Chunk::new(sequencer, height, payload2);

--- a/consensus/src/ordered_broadcast/ack_manager.rs
+++ b/consensus/src/ordered_broadcast/ack_manager.rs
@@ -159,8 +159,7 @@ mod tests {
             primitives::variant::{MinPk, MinSig},
         },
         ed25519::PublicKey,
-        sha256::Sha256,
-        Hasher,
+        Hasher, Sha256,
     };
 
     /// Aggregated helper functions to reduce duplication in tests.

--- a/consensus/src/ordered_broadcast/tip_manager.rs
+++ b/consensus/src/ordered_broadcast/tip_manager.rs
@@ -60,7 +60,7 @@ mod tests {
     use commonware_cryptography::{
         bls12381::primitives::variant::{MinPk, MinSig},
         ed25519::{PrivateKey, PublicKey, Signature},
-        sha256::{self, Digest},
+        sha256::{Digest, Sha256},
     };
     use rand::SeedableRng;
 
@@ -69,7 +69,7 @@ mod tests {
         use super::*;
         use crate::ordered_broadcast::types::Chunk;
         use commonware_codec::{DecodeExt, FixedSize};
-        use commonware_cryptography::{PrivateKeyExt as _, Signer as _};
+        use commonware_cryptography::{Hasher as _, PrivateKeyExt as _, Signer as _};
 
         /// Creates a dummy link for testing.
         pub fn create_dummy_node<V: Variant>(
@@ -82,7 +82,7 @@ mod tests {
                 Signature::decode(&mut data).unwrap()
             };
             Node::new(
-                Chunk::new(sequencer, height, sha256::hash(payload.as_bytes())),
+                Chunk::new(sequencer, height, Sha256::hash(payload.as_bytes())),
                 signature,
                 None,
             )

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -52,7 +52,7 @@ mod tests {
         Viewable,
     };
     use commonware_codec::Encode;
-    use commonware_cryptography::{ed25519, hash, PrivateKeyExt as _, Sha256};
+    use commonware_cryptography::{ed25519, Hasher as _, PrivateKeyExt as _, Sha256};
     use commonware_macros::test_traced;
     use commonware_p2p::{
         simulated::{Config as NConfig, Link, Network},
@@ -191,7 +191,7 @@ mod tests {
             actor.start(backfiller, voter_sender, voter_receiver);
 
             // Send finalization over network (view 100)
-            let payload = hash(b"test");
+            let payload = Sha256::hash(b"test");
             let proposal = Proposal::new(100, 50, payload);
             let mut signatures = Vec::new();
             for i in 0..threshold {
@@ -219,7 +219,7 @@ mod tests {
             }
 
             // Send old notarization from backfiller that should be ignored (view 50)
-            let payload = hash(b"test2");
+            let payload = Sha256::hash(b"test2");
             let proposal = Proposal::new(50, 49, payload);
             let mut signatures = Vec::new();
             for i in 0..threshold {
@@ -231,7 +231,7 @@ mod tests {
             mailbox.notarization(notarization).await;
 
             // Send new finalization (view 300)
-            let payload = hash(b"test3");
+            let payload = Sha256::hash(b"test3");
             let proposal = Proposal::new(300, 100, payload);
             let mut signatures = Vec::new();
             for i in 0..threshold {
@@ -395,7 +395,7 @@ mod tests {
             let journal_floor_target: View = lf_target - activity_timeout + 5;
 
             // Send finalization over network (view 100)
-            let proposal = Proposal::new(lf_target, lf_target - 1, hash(b"test"));
+            let proposal = Proposal::new(lf_target, lf_target - 1, Sha256::hash(b"test"));
             let mut signatures = Vec::new();
             for i in 0..threshold {
                 let finalization = Finalize::sign(
@@ -429,7 +429,7 @@ mod tests {
             let proposal = Proposal::new(
                 journal_floor_target,
                 journal_floor_target - 1,
-                hash(b"test2"),
+                Sha256::hash(b"test2"),
             );
             let mut signatures = Vec::new();
             for i in 0..threshold {
@@ -465,7 +465,11 @@ mod tests {
             // problematic_view (42) < journal_floor_target (45)
             // interesting(42, false) -> 42 + AT(10) >= LF(50) -> 52 >= 50
             let problematic_view: View = journal_floor_target - 3;
-            let proposal = Proposal::new(problematic_view, problematic_view - 1, hash(b"test3"));
+            let proposal = Proposal::new(
+                problematic_view,
+                problematic_view - 1,
+                Sha256::hash(b"test3"),
+            );
             let mut signatures = Vec::new();
             for i in 0..threshold {
                 let notarize = Notarize::sign(
@@ -496,7 +500,7 @@ mod tests {
             }
 
             // Send finalization over network (view 100)
-            let proposal = Proposal::new(100, 99, hash(b"test"));
+            let proposal = Proposal::new(100, 99, Sha256::hash(b"test"));
             let mut signatures = Vec::new();
             for i in 0..threshold {
                 let finalization = Finalize::sign(

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -62,7 +62,7 @@ mod tests {
             dkg::ops,
             primitives::{ops::threshold_signature_recover, variant::MinSig},
         },
-        ed25519, hash, PrivateKeyExt as _, Sha256,
+        ed25519, Hasher as _, PrivateKeyExt as _, Sha256,
     };
     use commonware_macros::test_traced;
     use commonware_p2p::{
@@ -240,7 +240,7 @@ mod tests {
                 });
 
             // Send finalization over network (view 100)
-            let payload = hash(b"test");
+            let payload = Sha256::hash(b"test");
             let proposal = Proposal::new(100, 50, payload);
             let partials: Vec<_> = shares
                 .iter()
@@ -300,7 +300,7 @@ mod tests {
             }
 
             // Send old notarization from resolver that should be ignored (view 50)
-            let payload = hash(b"test2");
+            let payload = Sha256::hash(b"test2");
             let proposal = Proposal::new(50, 49, payload);
             let partials: Vec<_> = shares
                 .iter()
@@ -324,7 +324,7 @@ mod tests {
                 .await;
 
             // Send new finalization (view 300)
-            let payload = hash(b"test3");
+            let payload = Sha256::hash(b"test3");
             let proposal = Proposal::new(300, 100, payload);
             let partials: Vec<_> = shares
                 .iter()
@@ -556,7 +556,7 @@ mod tests {
             let journal_floor_target: View = lf_target - activity_timeout + 5;
 
             // Send Finalization to advance last_finalized
-            let proposal_lf = Proposal::new(lf_target, lf_target - 1, hash(b"test"));
+            let proposal_lf = Proposal::new(lf_target, lf_target - 1, Sha256::hash(b"test"));
             let finalization_lf_sigs = shares
                 .iter()
                 .take(threshold as usize)
@@ -625,7 +625,7 @@ mod tests {
             let proposal_jft = Proposal::new(
                 journal_floor_target,
                 journal_floor_target - 1,
-                hash(b"test2"),
+                Sha256::hash(b"test2"),
             );
             let notarization_jft_sigs = shares
                 .iter()
@@ -667,8 +667,11 @@ mod tests {
             // problematic_view (42) < journal_floor_target (45)
             // interesting(42, false) -> 42 + AT(10) >= LF(50) -> 52 >= 50
             let problematic_view: View = journal_floor_target - 3;
-            let proposal_bft =
-                Proposal::new(problematic_view, problematic_view - 1, hash(b"test3"));
+            let proposal_bft = Proposal::new(
+                problematic_view,
+                problematic_view - 1,
+                Sha256::hash(b"test3"),
+            );
             let notarization_bft_sigs = shares
                 .iter()
                 .take(threshold as usize)
@@ -705,7 +708,7 @@ mod tests {
             }
 
             // Send Finalization to new view (100)
-            let proposal_lf = Proposal::new(100, 99, hash(b"test4"));
+            let proposal_lf = Proposal::new(100, 99, Sha256::hash(b"test4"));
             let finalization_lf_sigs = shares
                 .iter()
                 .take(threshold as usize)

--- a/cryptography/fuzz/fuzz_targets/sha256_hasher.rs
+++ b/cryptography/fuzz/fuzz_targets/sha256_hasher.rs
@@ -2,10 +2,7 @@
 
 use arbitrary::Arbitrary;
 use commonware_codec::{DecodeExt, Encode};
-use commonware_cryptography::{
-    sha256::{hash as our_hash, Digest, Sha256 as OurSha256},
-    Hasher,
-};
+use commonware_cryptography::{sha256::Digest, Hasher, Sha256 as OurSha256};
 use libfuzzer_sys::fuzz_target;
 use sha2::{Digest as RefSha2Digest, Sha256 as RefSha256};
 
@@ -80,7 +77,7 @@ fn fuzz_chunked_vs_whole(chunks: &[Vec<u8>]) {
 
 // Differential fuzzing
 fn fuzz_diff_hash(data: &[u8]) {
-    let our_hash_result = our_hash(data);
+    let our_hash_result = OurSha256::hash(data);
     let ref_hash_result = RefSha256::digest(data);
     assert_eq!(our_hash_result.as_ref(), ref_hash_result.as_slice());
 }

--- a/cryptography/src/blake3/mod.rs
+++ b/cryptography/src/blake3/mod.rs
@@ -70,7 +70,7 @@ impl Hasher for Blake3 {
         }
     }
 
-    fn update(&mut self, message: &[u8]) {
+    fn update(&mut self, message: &[u8]) -> &mut Self {
         #[cfg(not(feature = "parallel-blake3"))]
         self.hasher.update(message);
 
@@ -86,6 +86,8 @@ impl Hasher for Blake3 {
                 self.hasher.update(message);
             }
         }
+
+        self
     }
 
     fn finalize(&mut self) -> Self::Digest {
@@ -95,8 +97,9 @@ impl Hasher for Blake3 {
         Self::Digest::from(array)
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self) -> &mut Self {
         self.hasher = CoreBlake3::new();
+        self
     }
 
     fn empty() -> Self::Digest {

--- a/cryptography/src/bloomfilter.rs
+++ b/cryptography/src/bloomfilter.rs
@@ -1,6 +1,9 @@
 //! An implementation of a [Bloom Filter](https://en.wikipedia.org/wiki/Bloom_filter).
 
-use crate::{hash, sha256::Digest};
+use crate::{
+    sha256::{Digest, Sha256},
+    Hasher,
+};
 use bytes::{Buf, BufMut};
 use commonware_codec::{
     codec::{Read, Write},
@@ -40,7 +43,7 @@ impl BloomFilter {
     /// Generate `num_hashers` bit indices for a given item.
     fn indices(&self, item: &[u8], bits: usize) -> impl Iterator<Item = usize> {
         // Extract two 128-bit hash values from the SHA256 digest of the item
-        let digest = hash(item);
+        let digest = Sha256::hash(item);
         let mut h1_bytes = [0u8; HALF_DIGEST_LEN];
         h1_bytes.copy_from_slice(&digest[0..HALF_DIGEST_LEN]);
         let h1 = u128::from_be_bytes(h1_bytes);

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -17,7 +17,7 @@ use rand::{CryptoRng, Rng, RngCore, SeedableRng};
 pub mod bls12381;
 pub mod ed25519;
 pub mod sha256;
-pub use sha256::{hash, CoreSha256, Sha256};
+pub use sha256::{CoreSha256, Sha256};
 pub mod blake3;
 pub use blake3::{Blake3, CoreBlake3};
 pub mod bloomfilter;

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -193,7 +193,7 @@ pub trait Hasher: Clone + Send + Sync + 'static {
     fn new() -> Self;
 
     /// Append message to previously recorded data.
-    fn update(&mut self, message: &[u8]);
+    fn update(&mut self, message: &[u8]) -> &mut Self;
 
     /// Hash all recorded data and reset the hasher
     /// to the initial state.
@@ -202,7 +202,7 @@ pub trait Hasher: Clone + Send + Sync + 'static {
     /// Reset the hasher without generating a hash.
     ///
     /// This function does not need to be called after `finalize`.
-    fn reset(&mut self);
+    fn reset(&mut self) -> &mut Self;
 
     /// Return result of hashing nothing.
     fn empty() -> Self::Digest;

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -207,16 +207,7 @@ pub trait Hasher: Clone + Send + Sync + 'static {
     /// Return result of hashing nothing.
     fn empty() -> Self::Digest;
 
-    /// A convenience method for hashing a single message.
-    ///
-    /// This should have the same behavior as:
-    /// ```no_run
-    /// # use commonware_cryptography::Hasher;
-    /// # fn harness<ThisHasher: Hasher>(message: &[u8]) {
-    /// ThisHasher::new().update(message).finalize();
-    /// # }
-    ///
-    /// ```
+    /// Hash a single message with a one-time-use hasher.
     fn hash(message: &[u8]) -> Self::Digest {
         Self::new().update(message).finalize()
     }

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -206,6 +206,20 @@ pub trait Hasher: Clone + Send + Sync + 'static {
 
     /// Return result of hashing nothing.
     fn empty() -> Self::Digest;
+
+    /// A convenience method for hashing a single message.
+    ///
+    /// This should have the same behavior as:
+    /// ```no_run
+    /// # use commonware_cryptography::Hasher;
+    /// # fn harness<ThisHasher: Hasher>(message: &[u8]) {
+    /// ThisHasher::new().update(message).finalize();
+    /// # }
+    ///
+    /// ```
+    fn hash(message: &[u8]) -> Self::Digest {
+        Self::new().update(message).finalize()
+    }
 }
 
 #[cfg(test)]

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -37,11 +37,6 @@ pub type CoreSha256 = ISha256;
 
 const DIGEST_LENGTH: usize = 32;
 
-/// Generate a SHA-256 digest from a message.
-pub fn hash(message: &[u8]) -> Digest {
-    Sha256::hash(message)
-}
-
 /// SHA-256 hasher.
 #[derive(Debug)]
 pub struct Sha256 {
@@ -198,7 +193,7 @@ mod tests {
         assert_eq!(hex(digest.as_ref()), HELLO_DIGEST);
 
         // Test simple hasher
-        let hash = hash(msg);
+        let hash = Sha256::hash(msg);
         assert_eq!(hex(hash.as_ref()), HELLO_DIGEST);
     }
 

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -79,8 +79,9 @@ impl Hasher for Sha256 {
         }
     }
 
-    fn update(&mut self, message: &[u8]) {
+    fn update(&mut self, message: &[u8]) -> &mut Self {
         self.hasher.update(message);
+        self
     }
 
     fn finalize(&mut self) -> Self::Digest {
@@ -89,8 +90,9 @@ impl Hasher for Sha256 {
         Self::Digest::from(array)
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self) -> &mut Self {
         self.hasher = ISha256::new();
+        self
     }
 
     fn empty() -> Self::Digest {

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -39,8 +39,7 @@ const DIGEST_LENGTH: usize = 32;
 
 /// Generate a SHA-256 digest from a message.
 pub fn hash(message: &[u8]) -> Digest {
-    let array: [u8; DIGEST_LENGTH] = ISha256::digest(message).into();
-    Digest::from(array)
+    Sha256::hash(message)
 }
 
 /// SHA-256 hasher.

--- a/storage/fuzz/fuzz_targets/journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/journal_operations.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use arbitrary::{Arbitrary, Result, Unstructured};
-use commonware_cryptography::hash;
+use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
 use commonware_storage::journal::{
     fixed::{
@@ -98,7 +98,7 @@ fn fuzz(input: FuzzInput) {
         for op in input.operations.iter() {
             match op {
                 JournalOperation::Append { value } => {
-                    let digest = hash(&value.to_be_bytes());
+                    let digest = Sha256::hash(&value.to_be_bytes());
                     let _pos = journal.append(digest).await.unwrap();
                     journal_size += 1;
                 }
@@ -171,7 +171,7 @@ fn fuzz(input: FuzzInput) {
 
                 JournalOperation::AppendMany { count } => {
                     for _ in 0..*count {
-                        let digest = hash(&next_value.to_be_bytes());
+                        let digest = Sha256::hash(&next_value.to_be_bytes());
                         journal.append(digest).await.unwrap();
                         next_value += 1;
                         journal_size += 1;

--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -325,9 +325,8 @@ mod tests {
         translator::TwoCap,
     };
     use commonware_cryptography::{
-        hash,
         sha256::{self, Digest},
-        Digest as _, Sha256,
+        Digest as _, Hasher, Sha256,
     };
     use commonware_macros::test_traced;
     use commonware_runtime::{
@@ -350,7 +349,7 @@ mod tests {
     }
 
     fn test_digest(value: u64) -> Digest {
-        hash(&value.to_be_bytes())
+        Sha256::hash(&value.to_be_bytes())
     }
 
     #[test_case(1, NZU64!(1); "singleton db with batch size == 1")]
@@ -1514,10 +1513,10 @@ mod tests {
             assert_eq!(synced_db.mmr.size(), 0);
 
             // Test that we can perform operations on the synced database
-            let key1 = hash(&1u64.to_be_bytes());
-            let value1 = hash(&10u64.to_be_bytes());
-            let key2 = hash(&2u64.to_be_bytes());
-            let value2 = hash(&20u64.to_be_bytes());
+            let key1 = Sha256::hash(&1u64.to_be_bytes());
+            let value1 = Sha256::hash(&10u64.to_be_bytes());
+            let key2 = Sha256::hash(&2u64.to_be_bytes());
+            let value2 = Sha256::hash(&20u64.to_be_bytes());
 
             synced_db.update(key1, value1).await.unwrap();
             synced_db.update(key2, value2).await.unwrap();

--- a/storage/src/adb/benches/current_init.rs
+++ b/storage/src/adb/benches/current_init.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{hash, Hasher, Sha256};
+use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{
     benchmarks::{context, tokio},
     buffer::PoolRef,
@@ -81,19 +81,19 @@ fn gen_random_current(cfg: Config, num_elements: u64, num_operations: u64, threa
         // Insert a random value for every possible element into the db.
         let mut rng = StdRng::seed_from_u64(42);
         for i in 0u64..num_elements {
-            let k = hash(&i.to_be_bytes());
-            let v = hash(&rng.next_u32().to_be_bytes());
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&rng.next_u32().to_be_bytes());
             db.update(k, v).await.unwrap();
         }
 
         // Randomly update / delete them.
         for _ in 0u64..num_operations {
-            let rand_key = hash(&(rng.next_u64() % num_elements).to_be_bytes());
+            let rand_key = Sha256::hash(&(rng.next_u64() % num_elements).to_be_bytes());
             if rng.next_u32() % DELETE_FREQUENCY == 0 {
                 db.delete(rand_key).await.unwrap();
                 continue;
             }
-            let v = hash(&rng.next_u32().to_be_bytes());
+            let v = Sha256::hash(&rng.next_u32().to_be_bytes());
             db.update(rand_key, v).await.unwrap();
             if rng.next_u32() % COMMIT_FREQUENCY == 0 {
                 db.commit().await.unwrap();

--- a/storage/src/adb/benches/fixed_init.rs
+++ b/storage/src/adb/benches/fixed_init.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{hash, Hasher, Sha256};
+use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{
     benchmarks::{context, tokio},
     buffer::PoolRef,
@@ -68,19 +68,19 @@ fn gen_random_any(cfg: Config, num_elements: u64, num_operations: u64) {
         // Insert a random value for every possible element into the db.
         let mut rng = StdRng::seed_from_u64(42);
         for i in 0u64..num_elements {
-            let k = hash(&i.to_be_bytes());
-            let v = hash(&rng.next_u32().to_be_bytes());
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&rng.next_u32().to_be_bytes());
             db.update(k, v).await.unwrap();
         }
 
         // Randomly update / delete them.
         for _ in 0u64..num_operations {
-            let rand_key = hash(&(rng.next_u64() % num_elements).to_be_bytes());
+            let rand_key = Sha256::hash(&(rng.next_u64() % num_elements).to_be_bytes());
             if rng.next_u32() % DELETE_FREQUENCY == 0 {
                 db.delete(rand_key).await.unwrap();
                 continue;
             }
-            let v = hash(&rng.next_u32().to_be_bytes());
+            let v = Sha256::hash(&rng.next_u32().to_be_bytes());
             db.update(rand_key, v).await.unwrap();
             if rng.next_u32() % COMMIT_FREQUENCY == 0 {
                 db.commit().await.unwrap();

--- a/storage/src/adb/benches/variable_init.rs
+++ b/storage/src/adb/benches/variable_init.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{hash, Hasher, Sha256};
+use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{
     benchmarks::{context, tokio},
     buffer::PoolRef,
@@ -72,7 +72,7 @@ fn gen_random_any(cfg: Config, num_elements: u64, num_operations: u64) {
         // Insert a random value for every possible element into the db.
         let mut rng = StdRng::seed_from_u64(42);
         for i in 0u64..num_elements {
-            let k = hash(&i.to_be_bytes());
+            let k = Sha256::hash(&i.to_be_bytes());
             // Generate a random value with a length between 24 and 40 bytes (avg = 32).
             let v = vec![(rng.next_u32() % 255) as u8; ((rng.next_u32() % 16) + 24) as usize];
             db.update(k, v).await.unwrap();
@@ -80,7 +80,7 @@ fn gen_random_any(cfg: Config, num_elements: u64, num_operations: u64) {
 
         // Randomly update / delete them.
         for _ in 0u64..num_operations {
-            let rand_key = hash(&(rng.next_u64() % num_elements).to_be_bytes());
+            let rand_key = Sha256::hash(&(rng.next_u64() % num_elements).to_be_bytes());
             if rng.next_u32() % DELETE_FREQUENCY == 0 {
                 db.delete(rand_key).await.unwrap();
                 continue;

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -751,7 +751,7 @@ impl<
 pub mod test {
     use super::*;
     use crate::translator::TwoCap;
-    use commonware_cryptography::{hash, sha256::Digest, Sha256};
+    use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Runner as _};
     use commonware_utils::{NZUsize, NZU64};
@@ -804,8 +804,8 @@ pub mod test {
             assert_eq!(db.root(&mut hasher).await.unwrap(), root0);
 
             // Add one key.
-            let k1 = hash(&0u64.to_be_bytes());
-            let v1 = hash(&10u64.to_be_bytes());
+            let k1 = Sha256::hash(&0u64.to_be_bytes());
+            let v1 = Sha256::hash(&10u64.to_be_bytes());
             db.update(k1, v1).await.unwrap();
             assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
             db.commit().await.unwrap();
@@ -972,20 +972,20 @@ pub mod test {
         let mut rng = StdRng::seed_from_u64(rng_seed);
 
         for i in 0u64..num_elements {
-            let k = hash(&i.to_be_bytes());
-            let v = hash(&rng.next_u32().to_be_bytes());
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&rng.next_u32().to_be_bytes());
             db.update(k, v).await.unwrap();
         }
 
         // Randomly update / delete them. We use a delete frequency that is 1/7th of the update
         // frequency.
         for _ in 0u64..num_elements * 10 {
-            let rand_key = hash(&(rng.next_u64() % num_elements).to_be_bytes());
+            let rand_key = Sha256::hash(&(rng.next_u64() % num_elements).to_be_bytes());
             if rng.next_u32() % 7 == 0 {
                 db.delete(rand_key).await.unwrap();
                 continue;
             }
-            let v = hash(&rng.next_u32().to_be_bytes());
+            let v = Sha256::hash(&rng.next_u32().to_be_bytes());
             db.update(rand_key, v).await.unwrap();
             if commit_changes && rng.next_u32() % 20 == 0 {
                 // Commit every ~20 updates.
@@ -1311,8 +1311,8 @@ pub mod test {
 
             const NUM_OPERATIONS: u64 = 500;
             for i in 0..NUM_OPERATIONS {
-                let key = hash(&i.to_be_bytes());
-                let value = hash(&(i * 1000).to_be_bytes());
+                let key = Sha256::hash(&i.to_be_bytes());
+                let value = Sha256::hash(&(i * 1000).to_be_bytes());
                 db.update(key, value).await.unwrap();
 
                 // Commit periodically to advance the inactivity floor
@@ -1412,8 +1412,8 @@ pub mod test {
             // Apply identical operations to both databases
             const NUM_OPERATIONS: u64 = 1000;
             for i in 0..NUM_OPERATIONS {
-                let key = hash(&i.to_be_bytes());
-                let value = hash(&(i * 1000).to_be_bytes());
+                let key = Sha256::hash(&i.to_be_bytes());
+                let value = Sha256::hash(&(i * 1000).to_be_bytes());
 
                 db_no_delay.update(key, value).await.unwrap();
                 db_max_delay.update(key, value).await.unwrap();

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -732,7 +732,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
 pub(super) mod test {
     use super::*;
     use crate::{adb::verify_proof, mmr::mem::Mmr as MemMmr, translator::TwoCap};
-    use commonware_cryptography::{hash, sha256::Digest, Sha256};
+    use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{
         deterministic::{self},
@@ -885,7 +885,7 @@ pub(super) mod test {
             let mut db = open_db(context.clone()).await;
 
             for i in 0u64..ELEMENTS {
-                let k = hash(&i.to_be_bytes());
+                let k = Sha256::hash(&i.to_be_bytes());
                 let v = vec![i as u8; 100];
                 db.set(k, v).await.unwrap();
             }
@@ -902,7 +902,7 @@ pub(super) mod test {
             assert_eq!(root, db.root(&mut hasher));
             assert_eq!(db.op_count(), ELEMENTS + 1);
             for i in 0u64..ELEMENTS {
-                let k = hash(&i.to_be_bytes());
+                let k = Sha256::hash(&i.to_be_bytes());
                 let v = vec![i as u8; 100];
                 assert_eq!(db.get(&k).await.unwrap().unwrap(), v);
             }
@@ -929,7 +929,7 @@ pub(super) mod test {
             let mut db = open_db(context.clone()).await;
 
             for i in 0u64..ELEMENTS {
-                let k = hash(&i.to_be_bytes());
+                let k = Sha256::hash(&i.to_be_bytes());
                 let v = vec![i as u8; 100];
                 db.set(k, v).await.unwrap();
             }
@@ -940,7 +940,7 @@ pub(super) mod test {
 
             // Insert another 1000 keys then simulate a failed close and test recovery.
             for i in 0u64..ELEMENTS {
-                let k = hash(&i.to_be_bytes());
+                let k = Sha256::hash(&i.to_be_bytes());
                 let v = vec![i as u8; 100];
                 db.set(k, v).await.unwrap();
             }
@@ -974,7 +974,7 @@ pub(super) mod test {
             let mut db = open_db(context.clone()).await;
 
             for i in 0u64..ELEMENTS {
-                let k = hash(&i.to_be_bytes());
+                let k = Sha256::hash(&i.to_be_bytes());
                 let v = vec![i as u8; 100];
                 db.set(k, v).await.unwrap();
             }
@@ -985,7 +985,7 @@ pub(super) mod test {
 
             // Insert another 1000 keys then simulate a failed close and test recovery.
             for i in 0u64..ELEMENTS {
-                let k = hash(&i.to_be_bytes());
+                let k = Sha256::hash(&i.to_be_bytes());
                 let v = vec![i as u8; 100];
                 db.set(k, v).await.unwrap();
             }
@@ -1021,7 +1021,7 @@ pub(super) mod test {
             const ELEMENTS: u64 = 1000;
 
             for i in 0u64..ELEMENTS {
-                let k = hash(&i.to_be_bytes());
+                let k = Sha256::hash(&i.to_be_bytes());
                 let v = vec![i as u8; 100];
                 db.set(k, v).await.unwrap();
             }
@@ -1031,7 +1031,7 @@ pub(super) mod test {
 
             // Insert another 1000 keys then simulate a failed close and test recovery.
             for i in 0u64..ELEMENTS {
-                let k = hash(&i.to_be_bytes());
+                let k = Sha256::hash(&i.to_be_bytes());
                 let v = vec![i as u8; 100];
                 db.set(k, v).await.unwrap();
             }
@@ -1059,7 +1059,7 @@ pub(super) mod test {
             let mut db = open_db(context.clone()).await;
 
             for i in 0u64..ELEMENTS {
-                let k = hash(&i.to_be_bytes());
+                let k = Sha256::hash(&i.to_be_bytes());
                 let v = vec![i as u8; 100];
                 db.set(k, v).await.unwrap();
             }
@@ -1080,11 +1080,11 @@ pub(super) mod test {
 
             // Try to fetch a pruned key.
             let pruned_loc = oldest_retained_loc - 1;
-            let pruned_key = hash(&pruned_loc.to_be_bytes());
+            let pruned_key = Sha256::hash(&pruned_loc.to_be_bytes());
             assert!(db.get(&pruned_key).await.unwrap().is_none());
 
             // Try to fetch unpruned key.
-            let unpruned_key = hash(&oldest_retained_loc.to_be_bytes());
+            let unpruned_key = Sha256::hash(&oldest_retained_loc.to_be_bytes());
             assert!(db.get(&unpruned_key).await.unwrap().is_some());
 
             // Close & reopen the db, making sure the re-opened db has exactly the same state.
@@ -1112,11 +1112,11 @@ pub(super) mod test {
 
             // Try to fetch a pruned key.
             let pruned_loc = oldest_retained_loc - 3;
-            let pruned_key = hash(&pruned_loc.to_be_bytes());
+            let pruned_key = Sha256::hash(&pruned_loc.to_be_bytes());
             assert!(db.get(&pruned_key).await.unwrap().is_none());
 
             // Try to fetch unpruned key.
-            let unpruned_key = hash(&oldest_retained_loc.to_be_bytes());
+            let unpruned_key = Sha256::hash(&oldest_retained_loc.to_be_bytes());
             assert!(db.get(&unpruned_key).await.unwrap().is_some());
 
             // Confirm behavior of trying to create a proof of pruned items is as expected.

--- a/storage/src/adb/keyless.rs
+++ b/storage/src/adb/keyless.rs
@@ -481,7 +481,7 @@ mod test {
         adb::verify_proof,
         mmr::{hasher::Standard, mem::Mmr as MemMmr},
     };
-    use commonware_cryptography::{hash, Sha256};
+    use commonware_cryptography::Sha256;
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Runner as _};
     use commonware_utils::{NZUsize, NZU64};
@@ -754,7 +754,7 @@ mod test {
                 }
 
                 // Verify that proof fails with wrong root
-                let wrong_root = hash(&[0xFF; 32]);
+                let wrong_root = Sha256::hash(&[0xFF; 32]);
                 assert!(
                     !verify_proof(&mut hasher, &proof, start_loc, &ops, &wrong_root),
                     "Proof should fail with wrong root"

--- a/storage/src/archive/immutable/mod.rs
+++ b/storage/src/archive/immutable/mod.rs
@@ -25,7 +25,7 @@
 //!
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, deterministic, buffer::PoolRef};
-//! use commonware_cryptography::hash;
+//! use commonware_cryptography::{Hasher as _, Sha256};
 //! use commonware_storage::{
 //!     archive::{
 //!         Archive as _,
@@ -56,7 +56,7 @@
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
 //!
 //!     // Put a key
-//!     archive.put(1, hash(b"data"), 10).await.unwrap();
+//!     archive.put(1, Sha256::hash(b"data"), 10).await.unwrap();
 //!
 //!     // Close the archive (also closes the freezer and ordinal)
 //!     archive.close().await.unwrap();
@@ -118,9 +118,11 @@ pub struct Config<C> {
 mod tests {
     use super::*;
     use crate::archive::Archive as ArchiveTrait;
-    use commonware_cryptography::{hash, sha256::Digest};
+    use commonware_cryptography::{Hasher, Sha256};
     use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
     use commonware_utils::{NZUsize, NZU64};
+
+    type Digest = <Sha256 as Hasher>::Digest;
 
     const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
@@ -155,8 +157,8 @@ mod tests {
             let mut archive = Archive::init(context.clone(), cfg.clone()).await.unwrap();
 
             // Add some data
-            let key1 = hash(b"key1");
-            let key2 = hash(b"key2");
+            let key1 = Sha256::hash(b"key1");
+            let key2 = Sha256::hash(b"key2");
             archive.put(1, key1, 2000).await.unwrap();
             archive.put(2, key2, 2001).await.unwrap();
 

--- a/storage/src/archive/immutable/mod.rs
+++ b/storage/src/archive/immutable/mod.rs
@@ -118,11 +118,9 @@ pub struct Config<C> {
 mod tests {
     use super::*;
     use crate::archive::Archive as ArchiveTrait;
-    use commonware_cryptography::{Hasher, Sha256};
+    use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
     use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
     use commonware_utils::{NZUsize, NZU64};
-
-    type Digest = <Sha256 as Hasher>::Digest;
 
     const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -103,7 +103,7 @@
 //!
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, deterministic, buffer::PoolRef};
-//! use commonware_cryptography::hash;
+//! use commonware_cryptography::{Hasher as _, Sha256};
 //! use commonware_storage::{
 //!     translator::FourCap,
 //!     archive::{
@@ -129,7 +129,7 @@
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
 //!
 //!     // Put a key
-//!     archive.put(1, hash(b"data"), 10).await.unwrap();
+//!     archive.put(1, Sha256::hash(b"data"), 10).await.unwrap();
 //!
 //!     // Close the archive (also closes the journal)
 //!     archive.close().await.unwrap();

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -134,7 +134,7 @@ impl<H: Hasher> Tree<H> {
 
                 // Hash the right child
                 if chunk.len() == 2 {
-                    hasher.update(&chunk[1])
+                    hasher.update(&chunk[1]);
                 } else {
                     // If no right child exists, duplicate left child.
                     hasher.update(&chunk[0]);

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -20,11 +20,11 @@
 //!
 //! ```rust
 //! use commonware_storage::bmt::{Builder, Tree};
-//! use commonware_cryptography::{hash, Sha256, sha256::Digest};
+//! use commonware_cryptography::{Sha256, sha256::Digest, Hasher as _};
 //!
 //! // Create transactions and compute their digests
 //! let txs = [b"tx1", b"tx2", b"tx3", b"tx4"];
-//! let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+//! let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
 //!
 //! // Build a Merkle Tree from the digests
 //! let mut builder = Builder::<Sha256>::new(digests.len());
@@ -553,10 +553,7 @@ impl<H: Hasher> EncodeSize for RangeProof<H> {
 mod tests {
     use super::*;
     use commonware_codec::{DecodeExt, Encode};
-    use commonware_cryptography::{
-        hash,
-        sha256::{Digest, Sha256},
-    };
+    use commonware_cryptography::sha256::{Digest, Sha256};
     use commonware_utils::hex;
 
     fn test_merkle_tree(n: usize) -> Digest {
@@ -564,7 +561,7 @@ mod tests {
         let mut digests = Vec::with_capacity(n);
         let mut builder = Builder::new(n);
         for i in 0..n {
-            let digest = hash(&i.to_be_bytes());
+            let digest = Sha256::hash(&i.to_be_bytes());
             builder.add(&digest);
             digests.push(digest);
         }
@@ -594,7 +591,7 @@ mod tests {
             // Modify a sibling hash and ensure the proof fails
             if !proof.siblings.is_empty() {
                 let mut update_tamper = proof.clone();
-                update_tamper.siblings[0] = hash(b"tampered");
+                update_tamper.siblings[0] = Sha256::hash(b"tampered");
                 assert!(
                     update_tamper
                         .verify(&mut hasher, leaf, i as u32, &root)
@@ -605,7 +602,7 @@ mod tests {
 
             // Add a sibling hash and ensure the proof fails
             let mut add_tamper = proof.clone();
-            add_tamper.siblings.push(hash(b"tampered"));
+            add_tamper.siblings.push(Sha256::hash(b"tampered"));
             assert!(
                 add_tamper
                     .verify(&mut hasher, leaf, i as u32, &root)
@@ -852,7 +849,7 @@ mod tests {
     fn test_tampered_proof_no_siblings() {
         // Create transactions and digests
         let txs = [b"tx1", b"tx2", b"tx3", b"tx4"];
-        let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+        let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
         let element = &digests[0];
 
         // Build tree
@@ -878,7 +875,7 @@ mod tests {
     fn test_tampered_proof_extra_sibling() {
         // Create transactions and digests
         let txs = [b"tx1", b"tx2", b"tx3", b"tx4"];
-        let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+        let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
         let element = &digests[0];
 
         // Build tree
@@ -904,7 +901,7 @@ mod tests {
     fn test_invalid_proof_wrong_element() {
         // Create transactions and digests
         let txs = [b"tx1", b"tx2", b"tx3", b"tx4"];
-        let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+        let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
 
         // Build tree
         let mut builder = Builder::new(txs.len());
@@ -919,7 +916,7 @@ mod tests {
 
         // Use a wrong element (e.g. hash of a different transaction).
         let mut hasher = Sha256::default();
-        let wrong_leaf = hash(b"wrong_tx");
+        let wrong_leaf = Sha256::hash(b"wrong_tx");
         assert!(proof.verify(&mut hasher, &wrong_leaf, 2, &root).is_err());
     }
 
@@ -927,7 +924,7 @@ mod tests {
     fn test_invalid_proof_wrong_index() {
         // Create transactions and digests
         let txs = [b"tx1", b"tx2", b"tx3", b"tx4"];
-        let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+        let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
 
         // Build tree
         let mut builder = Builder::new(txs.len());
@@ -949,7 +946,7 @@ mod tests {
     fn test_invalid_proof_wrong_root() {
         // Create transactions and digests
         let txs = [b"tx1", b"tx2", b"tx3", b"tx4"];
-        let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+        let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
 
         // Build tree
         let mut builder = Builder::new(txs.len());
@@ -963,7 +960,7 @@ mod tests {
 
         // Use a wrong root (hash of a different input).
         let mut hasher = Sha256::default();
-        let wrong_root = hash(b"wrong_root");
+        let wrong_root = Sha256::hash(b"wrong_root");
         assert!(proof
             .verify(&mut hasher, &digests[0], 0, &wrong_root)
             .is_err());
@@ -973,7 +970,7 @@ mod tests {
     fn test_invalid_proof_serialization_truncated() {
         // Create transactions and digests
         let txs = [b"tx1", b"tx2", b"tx3"];
-        let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+        let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(txs.len());
@@ -995,7 +992,7 @@ mod tests {
     fn test_invalid_proof_serialization_extra() {
         // Create transactions and digests
         let txs = [b"tx1", b"tx2", b"tx3"];
-        let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+        let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(txs.len());
@@ -1017,7 +1014,7 @@ mod tests {
     fn test_invalid_proof_modified_hash() {
         // Create transactions and digests
         let txs = [b"tx1", b"tx2", b"tx3", b"tx4"];
-        let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+        let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
 
         // Build tree
         let mut builder = Builder::new(txs.len());
@@ -1032,7 +1029,7 @@ mod tests {
 
         // Modify the first hash in the proof.
         let mut hasher = Sha256::default();
-        proof.siblings[0] = hash(b"modified");
+        proof.siblings[0] = Sha256::hash(b"modified");
         assert!(proof.verify(&mut hasher, &digests[2], 2, &root).is_err());
     }
 
@@ -1040,7 +1037,7 @@ mod tests {
     fn test_odd_tree_duplicate_index_proof() {
         // Create transactions and digests
         let txs = [b"tx1", b"tx2", b"tx3"];
-        let digests: Vec<Digest> = txs.iter().map(|tx| hash(*tx)).collect();
+        let digests: Vec<Digest> = txs.iter().map(|tx| Sha256::hash(*tx)).collect();
 
         // Build tree
         let mut builder = Builder::new(txs.len());
@@ -1068,7 +1065,7 @@ mod tests {
     #[test]
     fn test_range_proof_basic() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1098,7 +1095,7 @@ mod tests {
     #[test]
     fn test_range_proof_single_element() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1121,7 +1118,7 @@ mod tests {
     #[test]
     fn test_range_proof_full_tree() {
         // Create test data
-        let digests: Vec<Digest> = (0..7u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..7u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1140,7 +1137,7 @@ mod tests {
     #[test]
     fn test_range_proof_edge_cases() {
         // Create test data
-        let digests: Vec<Digest> = (0..15u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..15u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1173,7 +1170,7 @@ mod tests {
     #[test]
     fn test_range_proof_invalid_range() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1192,7 +1189,7 @@ mod tests {
     #[test]
     fn test_range_proof_tampering() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1208,7 +1205,11 @@ mod tests {
         let range_leaves = &digests[2..5];
 
         // Test with wrong leaves
-        let wrong_leaves = vec![hash(b"wrong1"), hash(b"wrong2"), hash(b"wrong3")];
+        let wrong_leaves = vec![
+            Sha256::hash(b"wrong1"),
+            Sha256::hash(b"wrong2"),
+            Sha256::hash(b"wrong3"),
+        ];
         assert!(range_proof
             .verify(&mut hasher, 2, &wrong_leaves, &root)
             .is_err());
@@ -1223,16 +1224,16 @@ mod tests {
         assert!(!tampered_proof.siblings.is_empty());
         // Tamper with the first level's left sibling if it exists
         if let Some(ref mut left) = tampered_proof.siblings[0].left {
-            *left = hash(b"tampered");
+            *left = Sha256::hash(b"tampered");
         } else if let Some(ref mut right) = tampered_proof.siblings[0].right {
-            *right = hash(b"tampered");
+            *right = Sha256::hash(b"tampered");
         }
         assert!(tampered_proof
             .verify(&mut hasher, 2, range_leaves, &root)
             .is_err());
 
         // Test with wrong root
-        let wrong_root = hash(b"wrong_root");
+        let wrong_root = Sha256::hash(b"wrong_root");
         assert!(range_proof
             .verify(&mut hasher, 2, range_leaves, &wrong_root)
             .is_err());
@@ -1243,7 +1244,7 @@ mod tests {
         // Test range proofs for trees of various sizes
         for tree_size in [1, 2, 3, 4, 5, 7, 8, 15, 16, 31, 32, 63, 64] {
             let digests: Vec<Digest> = (0..tree_size as u32)
-                .map(|i| hash(&i.to_be_bytes()))
+                .map(|i| Sha256::hash(&i.to_be_bytes()))
                 .collect();
 
             // Build tree
@@ -1276,7 +1277,7 @@ mod tests {
     #[test]
     fn test_range_proof_malicious_wrong_position() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1303,7 +1304,7 @@ mod tests {
     #[test]
     fn test_range_proof_malicious_reordered_leaves() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1327,7 +1328,7 @@ mod tests {
     #[test]
     fn test_range_proof_malicious_extra_siblings() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1346,9 +1347,9 @@ mod tests {
         assert!(!range_proof.siblings.is_empty());
         // Force an invalid state by modifying the siblings
         if range_proof.siblings[0].left.is_none() {
-            range_proof.siblings[0].left = Some(hash(b"extra"));
+            range_proof.siblings[0].left = Some(Sha256::hash(b"extra"));
         } else if range_proof.siblings[0].right.is_none() {
-            range_proof.siblings[0].right = Some(hash(b"extra"));
+            range_proof.siblings[0].right = Some(Sha256::hash(b"extra"));
         }
         assert!(range_proof
             .verify(&mut hasher, 2, range_leaves, &root)
@@ -1358,7 +1359,7 @@ mod tests {
     #[test]
     fn test_range_proof_malicious_missing_siblings() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1388,7 +1389,7 @@ mod tests {
     #[test]
     fn test_range_proof_integer_overflow_protection() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1406,7 +1407,7 @@ mod tests {
     #[test]
     fn test_range_proof_malicious_wrong_tree_structure() {
         // Create test data
-        let digests: Vec<Digest> = (0..8u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..8u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1423,7 +1424,7 @@ mod tests {
 
         // Add extra level (simulating proof from different tree structure)
         range_proof.siblings.push(Bounds {
-            left: Some(hash(b"fake_level")),
+            left: Some(Sha256::hash(b"fake_level")),
             right: None,
         });
         assert!(range_proof
@@ -1444,7 +1445,7 @@ mod tests {
         // Test various power-of-2 boundary conditions
         for tree_size in [1, 2, 4, 8, 16, 32] {
             let digests: Vec<Digest> = (0..tree_size as u32)
-                .map(|i| hash(&i.to_be_bytes()))
+                .map(|i| Sha256::hash(&i.to_be_bytes()))
                 .collect();
 
             // Build tree
@@ -1526,13 +1527,13 @@ mod tests {
             .is_ok());
 
         // Should fail with non-empty leaves
-        let non_empty_leaves = vec![hash(b"leaf")];
+        let non_empty_leaves = vec![Sha256::hash(b"leaf")];
         assert!(range_proof
             .verify(&mut hasher, 0, &non_empty_leaves, &root)
             .is_err());
 
         // Should fail with wrong root
-        let wrong_root = hash(b"wrong");
+        let wrong_root = Sha256::hash(b"wrong");
         assert!(range_proof
             .verify(&mut hasher, 0, empty_leaves, &wrong_root)
             .is_err());
@@ -1576,7 +1577,7 @@ mod tests {
     fn test_range_proof_bounds_usage() {
         // This test ensures that all bounds in a range proof are actually used during verification
         // and that we don't have unnecessary siblings
-        let digests: Vec<Digest> = (0..16u32).map(|i| hash(&i.to_be_bytes())).collect();
+        let digests: Vec<Digest> = (0..16u32).map(|i| Sha256::hash(&i.to_be_bytes())).collect();
 
         // Build tree
         let mut builder = Builder::<Sha256>::new(digests.len());
@@ -1629,7 +1630,7 @@ mod tests {
                 // If there's no left sibling, adding one should make the proof fail
                 if bounds.left.is_none() {
                     let mut tampered_proof = range_proof.clone();
-                    tampered_proof.siblings[level_idx].left = Some(hash(b"fake_left"));
+                    tampered_proof.siblings[level_idx].left = Some(Sha256::hash(b"fake_left"));
                     assert!(tampered_proof
                         .verify(&mut hasher, start, &digests[start as usize..end], &root)
                         .is_err());
@@ -1638,7 +1639,7 @@ mod tests {
                 // If there's no right sibling, adding one should make the proof fail
                 if bounds.right.is_none() {
                     let mut tampered_proof = range_proof.clone();
-                    tampered_proof.siblings[level_idx].right = Some(hash(b"fake_right"));
+                    tampered_proof.siblings[level_idx].right = Some(Sha256::hash(b"fake_right"));
                     assert!(tampered_proof
                         .verify(&mut hasher, start, &digests[start as usize..end], &root)
                         .is_err());
@@ -1652,7 +1653,7 @@ mod tests {
         // Test trees with odd sizes that require duplicate nodes
         for tree_size in [3, 5, 7, 9, 11, 13, 15] {
             let digests: Vec<Digest> = (0..tree_size as u32)
-                .map(|i| hash(&i.to_be_bytes()))
+                .map(|i| Sha256::hash(&i.to_be_bytes()))
                 .collect();
 
             // Build tree

--- a/storage/src/index/benches/insert.rs
+++ b/storage/src/index/benches/insert.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::hash;
+use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_runtime::Metrics;
 use commonware_storage::{index::Index, translator::TwoCap};
 use criterion::{criterion_group, Criterion};
@@ -34,7 +34,7 @@ fn bench_insert(c: &mut Criterion) {
                 let mut rng = StdRng::seed_from_u64(0);
                 let mut kvs = Vec::with_capacity(items);
                 for i in 0..items {
-                    kvs.push((hash(&i.to_be_bytes()), i as u64));
+                    kvs.push((Sha256::hash(&i.to_be_bytes()), i as u64));
                 }
 
                 let mut total = Duration::ZERO;

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -605,7 +605,7 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> Journal<E, A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use commonware_cryptography::{hash, sha256::Digest};
+    use commonware_cryptography::{sha256::Digest, Hasher as _, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{
         deterministic::{self, Context},
@@ -619,7 +619,7 @@ mod tests {
 
     /// Generate a SHA-256 digest for the given value.
     fn test_digest(value: u64) -> Digest {
-        hash(&value.to_be_bytes())
+        Sha256::hash(&value.to_be_bytes())
     }
 
     fn test_cfg(items_per_blob: NonZeroU64) -> Config {
@@ -1434,7 +1434,7 @@ mod tests {
                 .read_at(vec![0u8; size as usize], 0)
                 .await
                 .expect("Failed to read blob");
-            let digest = hash(buf.as_ref());
+            let digest = Sha256::hash(buf.as_ref());
             assert_eq!(
                 hex(&digest),
                 "ed2ea67208cde2ee8c16cca5aa4f369f55b1402258c6b7760e5baf134e38944a",
@@ -1449,7 +1449,7 @@ mod tests {
                 .read_at(vec![0u8; size as usize], 0)
                 .await
                 .expect("Failed to read blob");
-            let digest = hash(buf.as_ref());
+            let digest = Sha256::hash(buf.as_ref());
             assert_eq!(
                 hex(&digest),
                 "cc7efd4fc999aff36b9fd4213ba8da5810dc1849f92ae2ddf7c6dc40545f9aff",

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -802,7 +802,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
 mod tests {
     use super::*;
     use bytes::BufMut;
-    use commonware_cryptography::hash;
+    use commonware_cryptography::{Hasher, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Error as RError, Runner, Storage};
     use commonware_utils::{NZUsize, StableBuf};
@@ -1995,7 +1995,7 @@ mod tests {
                 .read_at(vec![0u8; size as usize], 0)
                 .await
                 .expect("Failed to read blob");
-            let digest = hash(buf.as_ref());
+            let digest = Sha256::hash(buf.as_ref());
             assert_eq!(
                 hex(&digest),
                 "ca3845fa7fabd4d2855ab72ed21226d1d6eb30cb895ea9ec5e5a14201f3f25d8",

--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -658,7 +658,7 @@ mod tests {
     use super::*;
     use crate::mmr::hasher::Standard;
     use commonware_codec::FixedSize;
-    use commonware_cryptography::{hash, Sha256};
+    use commonware_cryptography::Sha256;
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Runner as _};
 
@@ -668,7 +668,7 @@ mod tests {
         assert_eq!(N % 32, 0);
         let mut vec: Vec<u8> = Vec::new();
         for _ in 0..N / 32 {
-            vec.extend(hash(s).iter());
+            vec.extend(Sha256::hash(s).iter());
         }
 
         vec.try_into().unwrap()

--- a/storage/src/mmr/iterator.rs
+++ b/storage/src/mmr/iterator.rs
@@ -258,18 +258,18 @@ impl Iterator for PathIterator {
 mod tests {
     use super::*;
     use crate::mmr::{hasher::Standard, mem::Mmr};
-    use commonware_cryptography::{sha256::hash, Sha256};
+    use commonware_cryptography::{sha256::Sha256, Hasher, Sha256 as Sha256Hasher};
     use commonware_runtime::{deterministic, Runner};
 
     #[test]
     fn test_leaf_num_calculation() {
-        let digest = hash(b"testing");
+        let digest = Sha256::hash(b"testing");
 
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             // Build MMR with 1000 leaves and make sure we can correctly convert each leaf position to
             // its number and back again.
-            let mut mmr: Mmr<Sha256> = Mmr::new();
+            let mut mmr: Mmr<Sha256Hasher> = Mmr::new();
             let mut hasher = Standard::new();
             let mut num_to_pos = Vec::new();
             for _ in 0u64..1000 {

--- a/storage/src/mmr/iterator.rs
+++ b/storage/src/mmr/iterator.rs
@@ -258,7 +258,7 @@ impl Iterator for PathIterator {
 mod tests {
     use super::*;
     use crate::mmr::{hasher::Standard, mem::Mmr};
-    use commonware_cryptography::{sha256::Sha256, Hasher, Sha256 as Sha256Hasher};
+    use commonware_cryptography::{sha256::Sha256, Hasher};
     use commonware_runtime::{deterministic, Runner};
 
     #[test]
@@ -269,7 +269,7 @@ mod tests {
         executor.start(|_| async move {
             // Build MMR with 1000 leaves and make sure we can correctly convert each leaf position to
             // its number and back again.
-            let mut mmr: Mmr<Sha256Hasher> = Mmr::new();
+            let mut mmr: Mmr<Sha256> = Mmr::new();
             let mut hasher = Standard::new();
             let mut num_to_pos = Vec::new();
             for _ in 0u64..1000 {

--- a/storage/src/mmr/iterator.rs
+++ b/storage/src/mmr/iterator.rs
@@ -258,7 +258,7 @@ impl Iterator for PathIterator {
 mod tests {
     use super::*;
     use crate::mmr::{hasher::Standard, mem::Mmr};
-    use commonware_cryptography::{sha256::Sha256, Hasher};
+    use commonware_cryptography::{Hasher, Sha256};
     use commonware_runtime::{deterministic, Runner};
 
     #[test]

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -785,13 +785,13 @@ mod tests {
             build_and_check_test_roots_mmr, build_batched_and_check_test_roots_journaled, ROOTS,
         },
     };
-    use commonware_cryptography::{hash, sha256::Digest, Hasher, Sha256};
+    use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{buffer::PoolRef, deterministic, Blob as _, Runner};
     use commonware_utils::{hex, NZUsize, NZU64};
 
     fn test_digest(v: usize) -> Digest {
-        hash(&v.to_be_bytes())
+        Sha256::hash(&v.to_be_bytes())
     }
 
     const PAGE_SIZE: usize = 111;

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -732,12 +732,12 @@ mod tests {
     use crate::mmr::{hasher::Standard, mem::Mmr};
     use bytes::Bytes;
     use commonware_codec::{Decode, Encode};
-    use commonware_cryptography::{hash, sha256::Digest, Sha256};
+    use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Runner};
 
     fn test_digest(v: u8) -> Digest {
-        hash(&[v])
+        Sha256::hash(&[v])
     }
 
     #[test_traced]

--- a/storage/src/store/benches/restart.rs
+++ b/storage/src/store/benches/restart.rs
@@ -1,4 +1,4 @@
-use commonware_cryptography::{hash, Hasher, Sha256};
+use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{
     benchmarks::{context, tokio},
     buffer::PoolRef,
@@ -61,19 +61,19 @@ fn gen_random_store(cfg: Config, num_elements: u64, num_operations: u64) {
         // Insert a random value for every possible element into the db.
         let mut rng = StdRng::seed_from_u64(42);
         for i in 0u64..num_elements {
-            let k = hash(&i.to_be_bytes());
-            let v = hash(&rng.next_u32().to_be_bytes());
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&rng.next_u32().to_be_bytes());
             db.update(k, v).await.unwrap();
         }
 
         // Randomly update / delete them.
         for _ in 0u64..num_operations {
-            let rand_key = hash(&(rng.next_u64() % num_elements).to_be_bytes());
+            let rand_key = Sha256::hash(&(rng.next_u64() % num_elements).to_be_bytes());
             if rng.next_u32() % DELETE_FREQUENCY == 0 {
                 db.delete(rand_key).await.unwrap();
                 continue;
             }
-            let v = hash(&rng.next_u32().to_be_bytes());
+            let v = Sha256::hash(&rng.next_u32().to_be_bytes());
             db.update(rand_key, v).await.unwrap();
             if rng.next_u32() % COMMIT_FREQUENCY == 0 {
                 db.commit(Some(metadata)).await.unwrap();

--- a/stream/fuzz/fuzz_targets/connection.rs
+++ b/stream/fuzz/fuzz_targets/connection.rs
@@ -40,7 +40,7 @@ impl<'a> arbitrary::Arbitrary<'a> for FuzzInput {
             .collect::<Result<Vec<_>, _>>()?;
 
         // Generate constrained parameters
-        let max_message_size = u.int_in_range(177..=1024 * 1023)?;
+        let max_message_size = u.int_in_range(210..=1024 * 1023)?;
         let synchrony_bound_secs = u.int_in_range(1..=12)?;
         let max_handshake_age_secs = u.int_in_range(1..=12)?;
         let handshake_timeout_secs = u.int_in_range(1..=12)?;

--- a/stream/fuzz/fuzz_targets/connection.rs
+++ b/stream/fuzz/fuzz_targets/connection.rs
@@ -40,6 +40,7 @@ impl<'a> arbitrary::Arbitrary<'a> for FuzzInput {
             .collect::<Result<Vec<_>, _>>()?;
 
         // Generate constrained parameters
+        // 210 is the max size of an Info message using an Ed25519 key.
         let max_message_size = u.int_in_range(210..=1024 * 1023)?;
         let synchrony_bound_secs = u.int_in_range(1..=12)?;
         let max_handshake_age_secs = u.int_in_range(1..=12)?;

--- a/stream/fuzz/fuzz_targets/e2e.rs
+++ b/stream/fuzz/fuzz_targets/e2e.rs
@@ -360,6 +360,7 @@ fn fuzz(input: FuzzInput) {
                                             &dialer_state.config.namespace,
                                             dialer_state.config.synchrony_bound,
                                             dialer_state.config.max_handshake_age,
+                                            None,
                                         );
 
                                         match verify_result {
@@ -525,6 +526,7 @@ fn fuzz(input: FuzzInput) {
                                             &listener_state.config.namespace,
                                             listener_state.config.synchrony_bound,
                                             listener_state.config.max_handshake_age,
+                                            None,
                                         );
 
                                         match verify_result {

--- a/stream/src/lib.rs
+++ b/stream/src/lib.rs
@@ -32,6 +32,8 @@ pub enum Error {
     InvalidTimestampOld(u64),
     #[error("timestamp too future: {0}")]
     InvalidTimestampFuture(u64),
+    #[error("info continuation tag was invalid")]
+    InvalidInfoContinuationTag,
 
     // Confirmation errors
     #[error("shared secret was not contributory")]

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -55,6 +55,7 @@ impl<C: Signer, Si: Sink, St: Stream> IncomingConnection<C, Si, St> {
             &config.namespace,
             config.synchrony_bound,
             config.max_handshake_age,
+            None,
         )?;
         Ok(Self {
             config,
@@ -179,6 +180,7 @@ impl<Si: Sink, St: Stream> Connection<Si, St> {
             &config.namespace,
             config.synchrony_bound,
             config.max_handshake_age,
+            Some(&hello_msg),
         )?;
 
         // Ensure we connected to the right peer
@@ -261,7 +263,8 @@ impl<Si: Sink, St: Stream> Connection<Si, St> {
         let hello = handshake::Hello::sign(
             &mut crypto,
             &namespace,
-            handshake::Info::new(incoming.peer_public_key, listener_ephemeral, timestamp),
+            handshake::Info::new(incoming.peer_public_key, listener_ephemeral, timestamp)
+                .with_tag_over(&incoming.dialer_hello_msg),
         );
 
         // Derive shared secret and ensure it is contributory
@@ -661,7 +664,6 @@ mod tests {
 
                     // Read the hello from dialer
                     let msg = recv_frame(&mut peer_stream, 1024).await.unwrap();
-                    let _ = handshake::Hello::<PublicKey>::decode(msg).unwrap();
 
                     // Create mock shared secret and cipher for `confirmation`
                     let mock_secret = [1u8; 32];
@@ -674,7 +676,11 @@ mod tests {
                         peer_config.crypto.public_key(),
                         x25519::PublicKey::from_secret(&secret),
                         timestamp,
-                    );
+                    )
+                    .with_tag_over(&msg);
+
+                    let _ = handshake::Hello::<PublicKey>::decode(msg).unwrap();
+
                     let hello =
                         handshake::Hello::sign(&mut actual_peer, &peer_config.namespace, info);
 
@@ -735,19 +741,19 @@ mod tests {
 
                     // Read the hello from dialer
                     let msg = recv_frame(&mut peer_stream, 1024).await.unwrap();
-                    let _ = handshake::Hello::<PublicKey>::decode(msg).unwrap();
-
-                    // Create mock cipher for `confirmation`
-                    let mock_secret = [1u8; 32];
-                    let mock_cipher = ChaCha20Poly1305::new(&mock_secret.into());
-
                     // Create a custom hello info bytes with zero ephemeral key
                     let timestamp = context.current().epoch_millis();
                     let info = handshake::Info::new(
                         recipient_pk,
                         x25519::PublicKey::from_bytes([0u8; 32]),
                         timestamp,
-                    );
+                    )
+                    .with_tag_over(&msg);
+                    let _ = handshake::Hello::<PublicKey>::decode(msg).unwrap();
+
+                    // Create mock cipher for `confirmation`
+                    let mock_secret = [1u8; 32];
+                    let mock_cipher = ChaCha20Poly1305::new(&mock_secret.into());
 
                     // Create the signed `hello`
                     let hello = handshake::Hello::sign(&mut listener_crypto, &namespace, info);
@@ -775,6 +781,80 @@ mod tests {
 
             // Verify the error
             assert!(matches!(result, Err(Error::SharedSecretNotContributory)));
+        });
+    }
+
+    #[test]
+    fn test_upgrade_dialer_invalid_continuation_tag() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Create cryptographic identities
+            let dialer_crypto = PrivateKey::from_seed(0);
+            let mut listener_crypto = PrivateKey::from_seed(1);
+            let listener_public_key = listener_crypto.public_key();
+
+            // Set up mock channels
+            let (dialer_sink, mut peer_stream) = mocks::Channel::init();
+            let (mut peer_sink, dialer_stream) = mocks::Channel::init();
+
+            // Dialer configuration
+            let dialer_config = Config {
+                crypto: dialer_crypto,
+                namespace: b"test_namespace".to_vec(),
+                max_message_size: 1024,
+                synchrony_bound: Duration::from_secs(5),
+                max_handshake_age: Duration::from_secs(5),
+                handshake_timeout: Duration::from_secs(5),
+            };
+
+            // Spawn a mock peer that responds with a listener response containing an all-zero ephemeral key
+            context.with_label("mock_peer").spawn({
+                let namespace = dialer_config.namespace.clone();
+                let recipient_pk = dialer_config.crypto.public_key();
+                move |mut context| async move {
+                    use chacha20poly1305::KeyInit;
+
+                    // Read the hello from dialer
+                    let msg = recv_frame(&mut peer_stream, 1024).await.unwrap();
+                    let _ = handshake::Hello::<PublicKey>::decode(msg).unwrap();
+
+                    // Create mock cipher for `confirmation`
+                    let mock_secret = [1u8; 32];
+                    let mock_cipher = ChaCha20Poly1305::new(&mock_secret.into());
+
+                    let secret = x25519::new(&mut context);
+                    let listener_ephemeral = x25519::PublicKey::from_secret(&secret);
+                    // Create a custom hello info bytes with zero ephemeral key
+                    let timestamp = context.current().epoch_millis();
+                    let info = handshake::Info::new(recipient_pk, listener_ephemeral, timestamp)
+                        .with_tag_over(b"not the right message");
+
+                    // Create the signed `hello`
+                    let hello = handshake::Hello::sign(&mut listener_crypto, &namespace, info);
+
+                    // Create fake listener response (using fake transcript)
+                    let fake_transcript = b"fake_transcript_for_non_contributory_test";
+                    let confirmation = Confirmation::create(mock_cipher, fake_transcript).unwrap();
+
+                    // Send the listener response
+                    send_frame(&mut peer_sink, &(hello, confirmation).encode(), 1024)
+                        .await
+                        .unwrap();
+                }
+            });
+
+            // Attempt connection - should fail due to non-contributory shared secret
+            let result = Connection::upgrade_dialer(
+                context,
+                dialer_config,
+                dialer_sink,
+                dialer_stream,
+                listener_public_key,
+            )
+            .await;
+
+            // Verify the error
+            assert!(matches!(result, Err(Error::InvalidInfoContinuationTag)));
         });
     }
 

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -664,10 +664,9 @@ mod tests {
             // Spawn a mock peer that responds with a listener response from wrong peer
             context.with_label("mock_peer").spawn({
                 move |mut context| async move {
-                    use chacha20poly1305::KeyInit;
-
                     // Read the hello from dialer
                     let msg = recv_frame(&mut peer_stream, 1024).await.unwrap();
+                    let _ = handshake::Hello::<PublicKey>::decode(msg.clone()).unwrap();
 
                     // Create mock shared secret and cipher for `confirmation`
                     let mock_secret = [1u8; 32];
@@ -682,8 +681,6 @@ mod tests {
                         timestamp,
                         &msg,
                     );
-
-                    let _ = handshake::Hello::<PublicKey>::decode(msg).unwrap();
 
                     let hello =
                         handshake::Hello::sign(&mut actual_peer, &peer_config.namespace, info);
@@ -741,10 +738,9 @@ mod tests {
                 let namespace = dialer_config.namespace.clone();
                 let recipient_pk = dialer_config.crypto.public_key();
                 move |context| async move {
-                    use chacha20poly1305::KeyInit;
-
                     // Read the hello from dialer
                     let msg = recv_frame(&mut peer_stream, 1024).await.unwrap();
+                    let _ = handshake::Hello::<PublicKey>::decode(msg.clone()).unwrap();
 
                     // Create a custom hello info bytes with zero ephemeral key
                     let timestamp = context.current().epoch_millis();
@@ -754,7 +750,6 @@ mod tests {
                         timestamp,
                         &msg,
                     );
-                    let _ = handshake::Hello::<PublicKey>::decode(msg).unwrap();
 
                     // Create mock cipher for `confirmation`
                     let mock_secret = [1u8; 32];

--- a/stream/src/public_key/connection.rs
+++ b/stream/src/public_key/connection.rs
@@ -681,7 +681,6 @@ mod tests {
                         timestamp,
                         &msg,
                     );
-
                     let hello =
                         handshake::Hello::sign(&mut actual_peer, &peer_config.namespace, info);
 

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -10,7 +10,7 @@ use chacha20poly1305::{
 use commonware_codec::{
     varint::UInt, Encode, EncodeSize, Error as CodecError, FixedSize, Read, ReadExt, Write,
 };
-use commonware_cryptography::{PublicKey, Signer};
+use commonware_cryptography::{Hasher, PublicKey, Sha256, Signer};
 use commonware_runtime::Clock;
 use commonware_utils::SystemTimeExt;
 use std::time::Duration;
@@ -27,6 +27,8 @@ pub struct Info<P: PublicKey> {
 
     /// Timestamp of the handshake (in epoch milliseconds).
     timestamp: u64,
+    /// c.f. [`Self::with_tag_over`]
+    continuation_tag: Option<<Sha256 as Hasher>::Digest>,
 }
 
 impl<P: PublicKey> Info<P> {
@@ -36,6 +38,33 @@ impl<P: PublicKey> Info<P> {
             recipient,
             ephemeral_public_key,
             timestamp,
+            continuation_tag: None,
+        }
+    }
+
+    /// Augment this message by computing a tag over some data.
+    ///
+    /// For example, to allow for the info to also be linked to the hello message sent by the other peer,
+    /// or having this information attest to a MAC using a previous shared session key.
+    pub fn with_tag_over(self, data: &[u8]) -> Self {
+        let mut sha = Sha256::new();
+        sha.update(data);
+        Self {
+            continuation_tag: Some(sha.finalize()),
+            ..self
+        }
+    }
+
+    /// Check that the tag in this message matches a piece of information.
+    pub fn check_tag_over(&self, data: &[u8]) -> Result<(), Error> {
+        let ok = |tag| {
+            let mut sha = Sha256::new();
+            sha.update(data);
+            sha.finalize() == tag
+        };
+        match self.continuation_tag {
+            Some(x) if ok(x) => Ok(()),
+            _ => Err(Error::InvalidInfoContinuationTag),
         }
     }
 }
@@ -45,6 +74,7 @@ impl<P: PublicKey> Write for Info<P> {
         self.recipient.write(buf);
         self.ephemeral_public_key.write(buf);
         UInt(self.timestamp).write(buf);
+        self.continuation_tag.write(buf);
     }
 }
 
@@ -55,10 +85,12 @@ impl<P: PublicKey> Read for Info<P> {
         let recipient = P::read(buf)?;
         let ephemeral_public_key = x25519::PublicKey::read(buf)?;
         let timestamp = UInt::read(buf)?.into();
-        Ok(Info {
+        let continuation_tag = Option::read(buf)?;
+        Ok(Self {
             recipient,
             ephemeral_public_key,
             timestamp,
+            continuation_tag,
         })
     }
 }
@@ -68,6 +100,7 @@ impl<P: PublicKey> EncodeSize for Info<P> {
         self.recipient.encode_size()
             + self.ephemeral_public_key.encode_size()
             + UInt(self.timestamp).encode_size()
+            + self.continuation_tag.encode_size()
     }
 }
 
@@ -127,6 +160,7 @@ impl<P: PublicKey> Hello<P> {
         namespace: &[u8],
         synchrony_bound: Duration,
         max_handshake_age: Duration,
+        tag_data: Option<&[u8]>,
     ) -> Result<(), Error> {
         // Verify that the signature is for us
         //
@@ -168,6 +202,10 @@ impl<P: PublicKey> Hello<P> {
             .verify(Some(namespace), &self.info.encode(), &self.signature)
         {
             return Err(Error::InvalidSignature);
+        }
+
+        if let Some(d) = tag_data {
+            self.info.check_tag_over(d)?;
         }
         Ok(())
     }
@@ -298,11 +336,7 @@ mod tests {
             let hello = Hello::sign(
                 &mut sender,
                 TEST_NAMESPACE,
-                Info {
-                    timestamp,
-                    recipient: recipient.clone(),
-                    ephemeral_public_key,
-                },
+                Info::new(recipient.clone(), ephemeral_public_key, timestamp),
             );
 
             // Decode the hello message
@@ -336,6 +370,7 @@ mod tests {
                     TEST_NAMESPACE,
                     synchrony_bound,
                     max_handshake_age,
+                    None,
                 )
                 .unwrap();
             assert_eq!(hello.signer, sender.public_key());
@@ -357,11 +392,7 @@ mod tests {
             let hello = Hello::sign(
                 &mut sender,
                 TEST_NAMESPACE,
-                Info {
-                    timestamp: 0,
-                    recipient: recipient.public_key(),
-                    ephemeral_public_key,
-                },
+                Info::new(recipient.public_key(), ephemeral_public_key, 0),
             );
 
             // Setup a mock sink and stream
@@ -407,11 +438,11 @@ mod tests {
             let hello = Hello::sign(
                 &mut sender,
                 TEST_NAMESPACE,
-                Info {
-                    timestamp: 0,
-                    recipient: PrivateKey::from_seed(1).public_key(),
+                Info::new(
+                    PrivateKey::from_seed(1).public_key(),
                     ephemeral_public_key,
-                },
+                    0,
+                ),
             );
 
             // Setup a mock sink and stream
@@ -509,11 +540,7 @@ mod tests {
             let hello = Hello::sign(
                 &mut sender,
                 TEST_NAMESPACE,
-                Info {
-                    timestamp: 0,
-                    recipient: recipient.public_key(),
-                    ephemeral_public_key,
-                },
+                Info::new(recipient.public_key(), ephemeral_public_key, 0),
             );
 
             // Tamper with the hello to make the signature invalid
@@ -528,6 +555,7 @@ mod tests {
                 TEST_NAMESPACE,
                 Duration::from_secs(5),
                 Duration::from_secs(5),
+                None,
             );
             assert!(matches!(result, Err(Error::InvalidSignature)));
         });
@@ -548,11 +576,7 @@ mod tests {
             let hello = Hello::sign(
                 &mut signer,
                 TEST_NAMESPACE,
-                Info {
-                    timestamp: 0,
-                    recipient: recipient.clone(),
-                    ephemeral_public_key,
-                },
+                Info::new(recipient.clone(), ephemeral_public_key, 0),
             );
 
             // Time starts at 0 in deterministic executor.
@@ -567,6 +591,7 @@ mod tests {
                     TEST_NAMESPACE,
                     synchrony_bound,
                     timeout_duration,
+                    None,
                 )
                 .unwrap();
 
@@ -580,6 +605,7 @@ mod tests {
                 TEST_NAMESPACE,
                 synchrony_bound,
                 timeout_duration,
+                None,
             );
             assert!(matches!(result, Err(Error::InvalidTimestampOld(t)) if t == 0));
         });
@@ -648,22 +674,14 @@ mod tests {
             let hello_ok = Hello::sign(
                 &mut signer,
                 TEST_NAMESPACE,
-                Info{
-                    timestamp: SYNCHRONY_BOUND_MILLIS,
-                    recipient: recipient.clone(),
-                    ephemeral_public_key,
-                },
+                Info::new(recipient.clone(), ephemeral_public_key, SYNCHRONY_BOUND_MILLIS)
             );
 
             // Create a hello 1ms too far into the future.
             let hello_late = Hello::sign(
                 &mut signer,
                 TEST_NAMESPACE,
-                Info{
-                    timestamp:SYNCHRONY_BOUND_MILLIS + 1,
-                    recipient: recipient.clone(),
-                    ephemeral_public_key,
-                },
+                Info::new(recipient.clone(), ephemeral_public_key, SYNCHRONY_BOUND_MILLIS + 1)
             );
 
             // Verify the okay hello.
@@ -673,6 +691,7 @@ mod tests {
                 TEST_NAMESPACE,
                 synchrony_bound,
                 timeout_duration,
+                None,
             ).unwrap(); // no error
 
             // Hello too far into the future fails.
@@ -682,8 +701,41 @@ mod tests {
                 TEST_NAMESPACE,
                 synchrony_bound,
                 timeout_duration,
+                None
             );
             assert!(matches!(result, Err(Error::InvalidTimestampFuture(t)) if t == SYNCHRONY_BOUND_MILLIS + 1));
         });
+    }
+
+    #[test]
+    fn test_info_tag_confirmation_happy_path() {
+        let info = Info::new(
+            PrivateKey::from_seed(1).public_key(),
+            PublicKey::from_bytes([1u8; 32]),
+            0,
+        )
+        .with_tag_over(b"ABC");
+        assert!(info.check_tag_over(b"ABC").is_ok())
+    }
+
+    #[test]
+    fn test_info_no_tag_but_check_with_data_fails() {
+        let info = Info::new(
+            PrivateKey::from_seed(1).public_key(),
+            PublicKey::from_bytes([1u8; 32]),
+            0,
+        );
+        assert!(info.check_tag_over(b"ABC").is_err())
+    }
+
+    #[test]
+    fn test_info_tag_but_check_with_different_data_fails() {
+        let info = Info::new(
+            PrivateKey::from_seed(1).public_key(),
+            PublicKey::from_bytes([1u8; 32]),
+            0,
+        )
+        .with_tag_over(b"ABC");
+        assert!(info.check_tag_over(b"not ABC").is_err())
     }
 }

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -56,14 +56,14 @@ impl<P: PublicKey> Info<P> {
             recipient,
             ephemeral_public_key,
             timestamp,
-            continuation_tag: Some(Sha256::new().update(data).finalize()),
+            continuation_tag: Some(Sha256::hash(data)),
         }
     }
 
     pub fn check_tag(&self, data: &[u8]) -> Result<(), Error> {
         if self
             .continuation_tag
-            .is_some_and(|tag| tag == Sha256::new().update(data).finalize())
+            .is_some_and(|tag| tag == Sha256::hash(data))
         {
             Ok(())
         } else {

--- a/stream/src/public_key/handshake.rs
+++ b/stream/src/public_key/handshake.rs
@@ -27,6 +27,7 @@ pub struct Info<P: PublicKey> {
 
     /// Timestamp of the handshake (in epoch milliseconds).
     timestamp: u64,
+
     /// c.f. [`Self::new_with_tag`]
     continuation_tag: Option<<Sha256 as Hasher>::Digest>,
 }
@@ -207,6 +208,7 @@ impl<P: PublicKey> Hello<P> {
             return Err(Error::InvalidSignature);
         }
 
+        // Verify the continuation tag (if provided)
         if let Some(d) = tag_data {
             self.info.check_tag(d)?;
         }

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -29,8 +29,11 @@
 //!
 //! Thus:
 //! - Message 1 is a `Hello` message from the dialer to the listener
-//! - Message 2 is a `Hello` and `Confirmation` message from the listener to the dialer
+//! - Message 2 is a `Hello` (with a continuation tag) and `Confirmation` message from the listener to the dialer
 //! - Message 3 is a `Confirmation` message from the dialer to the listener
+//!
+//! _The continuation tag binds the a response to a particular dialer's hello message, preventing
+//! exfiltration to a different session._
 //!
 //! ## Encryption
 //!
@@ -64,8 +67,9 @@
 //!   signatures.
 //! - **Forward Secrecy**: Ephemeral encryption keys ensure that any compromise of long-term static keys
 //!   doesn't expose the contents of previous sessions.
-//! - **Session Uniqueness**: Confirmations are bound to the complete handshake transcript (including
-//!   the randomly generated session key), preventing replay attacks and ensuring message integrity.
+//! - **Session Uniqueness**: A listener's [handshake::Hello] is bound to the dialer's [handshake::Hello] message and
+//!   [handshake::Confirmation]s are bound to the complete handshake transcript, preventing replay attacks and ensuring
+//!   message integrity.
 //! - **Handshake Timeout**: A configurable deadline is enforced for handshake completion to protect
 //!   against malicious peers that create connections but abandon handshakes.
 //!

--- a/stream/src/public_key/mod.rs
+++ b/stream/src/public_key/mod.rs
@@ -32,8 +32,8 @@
 //! - Message 2 is a `Hello` (with a continuation tag) and `Confirmation` message from the listener to the dialer
 //! - Message 3 is a `Confirmation` message from the dialer to the listener
 //!
-//! _The continuation tag binds the a response to a particular dialer's hello message, preventing
-//! exfiltration to a different session._
+//! _The continuation tag binds the listener's [handshake::Hello] response to a particular dialer's
+//! [handshake::Hello] message, preventing exfiltration to a different session._
 //!
 //! ## Encryption
 //!


### PR DESCRIPTION
Closes #1481.

This binds the signed response from the listener to the hello message received from the dialer.

This is implemented by augmenting the Info message with a "continuation tag". Info has a new method to add a tag, computed as a hash over some data. This tag, if present, will then get included in the signature in the hello message.

This could be made even more fool proof by integrating the proposed transcript construction (https://github.com/commonwarexyz/monorepo/issues/1483), but I expect that will be better done with a refactor of the stream crate to separate out the cryptographic AKE into a proper abstraction.