### PR TITLE
[cryptography] finish renaming scheme -> signer

### DIFF
--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -1,4 +1,4 @@
-//! BLS12-381 implementation of the `Scheme` trait.
+//! BLS12-381 implementation of the [crate::Verifier] and [crate::Signer] traits.
 //!
 //! This implementation uses the `blst` crate for BLS12-381 operations. This
 //! crate implements serialization according to the "ZCash BLS12-381" specification

--- a/cryptography/src/ed25519/mod.rs
+++ b/cryptography/src/ed25519/mod.rs
@@ -1,4 +1,4 @@
-//! Ed25519 implementation of the `Scheme` trait.
+//! Ed25519 implementation of the [crate::Verifier] and [crate::Signer] traits.
 //!
 //! This implementation uses the `ed25519-consensus` crate to adhere to a strict
 //! set of validation rules for Ed25519 signatures (which is necessary for

--- a/cryptography/src/secp256r1/mod.rs
+++ b/cryptography/src/secp256r1/mod.rs
@@ -1,4 +1,4 @@
-//! Secp256r1 implementation of the `Scheme` trait.
+//! Secp256r1 implementation of the [crate::Verifier] and [crate::Signer] traits.
 //!
 //! This implementation operates over public keys in compressed form (SEC 1, Version 2.0, Section 2.3.3), generates
 //! deterministic signatures as specified in [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979), and enforces


### PR DESCRIPTION
- Update docs to hard link to the trait (now `Signer`).
- Rename internal `scheme` modules to `signer`, matching the trait they impl.