### PR TITLE
[storage] Introduce `cache`

### DIFF
--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 mod storage;
 pub use storage::Cache;
 
-/// Errors that can occur when interacting with the archive.
+/// Errors that can occur when interacting with the cache.
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("journal error: {0}")]
@@ -40,6 +40,6 @@ pub struct Config<C> {
     /// The buffer size to use when replaying a [commonware_runtime::Blob].
     pub replay_buffer: NonZeroUsize,
 
-    /// The buffer pool to use for the archive's [crate::journal] storage.
+    /// The buffer pool to use for the cache's [crate::journal] storage.
     pub buffer_pool: PoolRef,
 }

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -1,0 +1,38 @@
+use crate::translator::Translator;
+use commonware_runtime::buffer::PoolRef;
+use std::num::{NonZeroU64, NonZeroUsize};
+
+mod storage;
+pub use storage::Archive;
+
+/// Configuration for [Archive] storage.
+#[derive(Clone)]
+pub struct Config<T: Translator, C> {
+    /// Logic to transform keys into their index representation.
+    ///
+    /// [Archive] assumes that all internal keys are spread uniformly across the key space.
+    /// If that is not the case, lookups may be O(n) instead of O(1).
+    pub translator: T,
+
+    /// The partition to use for the archive's [crate::journal] storage.
+    pub partition: String,
+
+    /// The compression level to use for the archive's [crate::journal] storage.
+    pub compression: Option<u8>,
+
+    /// The [commonware_codec::Codec] configuration to use for the value stored in the archive.
+    pub codec_config: C,
+
+    /// The number of items per section (the granularity of pruning).
+    pub items_per_section: NonZeroU64,
+
+    /// The amount of bytes that can be buffered in a section before being written to a
+    /// [commonware_runtime::Blob].
+    pub write_buffer: NonZeroUsize,
+
+    /// The buffer size to use when replaying a [commonware_runtime::Blob].
+    pub replay_buffer: NonZeroUsize,
+
+    /// The buffer pool to use for the archive's [crate::journal] storage.
+    pub buffer_pool: PoolRef,
+}

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -1,26 +1,33 @@
-use crate::translator::Translator;
 use commonware_runtime::buffer::PoolRef;
 use std::num::{NonZeroU64, NonZeroUsize};
+use thiserror::Error;
 
 mod storage;
-pub use storage::Archive;
+pub use storage::Cache;
 
-/// Configuration for [Archive] storage.
+/// Errors that can occur when interacting with the archive.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("journal error: {0}")]
+    Journal(#[from] crate::journal::Error),
+    #[error("record corrupted")]
+    RecordCorrupted,
+    #[error("already pruned to: {0}")]
+    AlreadyPrunedTo(u64),
+    #[error("record too large")]
+    RecordTooLarge,
+}
+
+/// Configuration for [Cache] storage.
 #[derive(Clone)]
-pub struct Config<T: Translator, C> {
-    /// Logic to transform keys into their index representation.
-    ///
-    /// [Archive] assumes that all internal keys are spread uniformly across the key space.
-    /// If that is not the case, lookups may be O(n) instead of O(1).
-    pub translator: T,
-
-    /// The partition to use for the archive's [crate::journal] storage.
+pub struct Config<C> {
+    /// The partition to use for the cache's [crate::journal] storage.
     pub partition: String,
 
-    /// The compression level to use for the archive's [crate::journal] storage.
+    /// The compression level to use for the cache's [crate::journal] storage.
     pub compression: Option<u8>,
 
-    /// The [commonware_codec::Codec] configuration to use for the value stored in the archive.
+    /// The [commonware_codec::Codec] configuration to use for the value stored in the cache.
     pub codec_config: C,
 
     /// The number of items per section (the granularity of pruning).

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -43,3 +43,328 @@ pub struct Config<C> {
     /// The buffer pool to use for the cache's [crate::journal] storage.
     pub buffer_pool: PoolRef,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::journal::Error as JournalError;
+    use commonware_codec::{varint::UInt, EncodeSize};
+    use commonware_macros::test_traced;
+    use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
+    use commonware_utils::{NZUsize, NZU64};
+    use rand::Rng;
+    use std::collections::BTreeMap;
+
+    const DEFAULT_ITEMS_PER_SECTION: u64 = 65536;
+    const DEFAULT_WRITE_BUFFER: usize = 1024;
+    const DEFAULT_REPLAY_BUFFER: usize = 4096;
+    const PAGE_SIZE: NonZeroUsize = NZUsize!(1024);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
+
+    #[test_traced]
+    fn test_cache_compression_then_none() {
+        // Initialize the deterministic context
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Initialize the cache
+            let cfg = Config {
+                partition: "test_partition".into(),
+                codec_config: (),
+                compression: Some(3),
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+                items_per_section: NZU64!(DEFAULT_ITEMS_PER_SECTION),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let mut cache = Cache::init(context.clone(), cfg.clone())
+                .await
+                .expect("Failed to initialize cache");
+
+            // Put the data
+            let index = 1u64;
+            let data = 1;
+            cache
+                .put(index, data)
+                .await
+                .expect("Failed to put data");
+
+            // Close the cache
+            cache.close().await.expect("Failed to close cache");
+
+            // Initialize the cache again without compression
+            let cfg = Config {
+                partition: "test_partition".into(),
+                codec_config: (),
+                compression: None,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+                items_per_section: NZU64!(DEFAULT_ITEMS_PER_SECTION),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let result = Cache::<_, i32>::init(context, cfg.clone()).await;
+            assert!(matches!(
+                result,
+                Err(Error::Journal(JournalError::Codec(_)))
+            ));
+        });
+    }
+
+    #[test_traced]
+    fn test_cache_record_corruption() {
+        // Initialize the deterministic context
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Initialize the cache
+            let cfg = Config {
+                partition: "test_partition".into(),
+                codec_config: (),
+                compression: None,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+                items_per_section: NZU64!(DEFAULT_ITEMS_PER_SECTION),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let mut cache = Cache::init(context.clone(), cfg.clone())
+                .await
+                .expect("Failed to initialize cache");
+
+            let index = 1u64;
+            let data = 1;
+
+            // Put the data
+            cache
+                .put(index, data)
+                .await
+                .expect("Failed to put data");
+
+            // Close the cache
+            cache.close().await.expect("Failed to close cache");
+
+            // Corrupt the value
+            let section = (index / DEFAULT_ITEMS_PER_SECTION) * DEFAULT_ITEMS_PER_SECTION;
+            let (blob, _) = context
+                .open("test_partition", &section.to_be_bytes())
+                .await
+                .unwrap();
+            let value_location = 4 /* journal size */ + UInt(1u64).encode_size() as u64 /* index */ + 4 /* value length */;
+            blob.write_at(b"testdaty".to_vec(), value_location).await.unwrap();
+            blob.sync().await.unwrap();
+
+            // Initialize the cache again
+            let cache = Cache::<_, i32>::init(
+                context,
+                Config {
+                    partition: "test_partition".into(),
+                    codec_config: (),
+                    compression: None,
+                    write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                    replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+                    items_per_section: NZU64!(DEFAULT_ITEMS_PER_SECTION),
+                    buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+                },
+            )
+            .await.expect("Failed to initialize cache");
+
+            // Check that the cache is empty
+            let retrieved: Option<i32> = cache
+                .get(index)
+                .await
+                .expect("Failed to get data");
+            assert!(retrieved.is_none());
+        });
+    }
+
+    #[test_traced]
+    fn test_cache_prune() {
+        // Initialize the deterministic context
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Initialize the cache
+            let cfg = Config {
+                partition: "test_partition".into(),
+                codec_config: (),
+                compression: None,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+                items_per_section: NZU64!(1), // no mask - each item is its own section
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let mut cache = Cache::init(context.clone(), cfg.clone())
+                .await
+                .expect("Failed to initialize cache");
+
+            // Insert multiple items across different sections
+            let items = vec![
+                (1u64, 1),
+                (2u64, 2),
+                (3u64, 3),
+                (4u64, 4),
+                (5u64, 5),
+            ];
+
+            for (index, data) in &items {
+                cache
+                    .put(*index, *data)
+                    .await
+                    .expect("Failed to put data");
+            }
+
+            // Check metrics
+            let buffer = context.encode();
+            assert!(buffer.contains("items_tracked 5"));
+
+            // Prune sections less than 3
+            cache.prune(3).await.expect("Failed to prune");
+
+            // Ensure items 1 and 2 are no longer present
+            for (index, data) in items {
+                let retrieved = cache
+                    .get(index)
+                    .await
+                    .expect("Failed to get data");
+                if index < 3 {
+                    assert!(retrieved.is_none());
+                } else {
+                    assert_eq!(retrieved.expect("Data not found"), data);
+                }
+            }
+
+            // Check metrics
+            let buffer = context.encode();
+            assert!(buffer.contains("items_tracked 3"));
+
+            // Try to prune older section
+            cache.prune(2).await.expect("Failed to prune");
+
+            // Try to prune current section again
+            cache.prune(3).await.expect("Failed to prune");
+
+            // Try to put older index
+            let result = cache.put(1, 1).await;
+            assert!(matches!(result, Err(Error::AlreadyPrunedTo(3))));
+        });
+    }
+
+    fn test_cache_restart(num_items: usize) -> String {
+        // Initialize the deterministic context
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            // Initialize the cache
+            let items_per_section = 256u64;
+            let cfg = Config {
+                partition: "test_partition".into(),
+                codec_config: (),
+                compression: None,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+                items_per_section: NZU64!(items_per_section),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let mut cache = Cache::init(context.clone(), cfg.clone())
+                .await
+                .expect("Failed to initialize cache");
+
+            // Insert multiple items
+            let mut items = BTreeMap::new();
+            while items.len() < num_items {
+                let index = items.len() as u64;
+                let mut data = [0u8; 1024];
+                context.fill(&mut data);
+                items.insert(index, data);
+
+                cache
+                    .put(index, data)
+                    .await
+                    .expect("Failed to put data");
+            }
+
+            // Ensure all items can be retrieved
+            for (index, data) in &items {
+                let retrieved = cache
+                    .get(*index)
+                    .await
+                    .expect("Failed to get data")
+                    .expect("Data not found");
+                assert_eq!(retrieved, *data);
+            }
+
+            // Check metrics
+            let buffer = context.encode();
+            let tracked = format!("items_tracked {num_items:?}");
+            assert!(buffer.contains(&tracked));
+
+            // Close the cache
+            cache.close().await.expect("Failed to close cache");
+
+            // Reinitialize the cache
+            let cfg = Config {
+                partition: "test_partition".into(),
+                codec_config: (),
+                compression: None,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+                items_per_section: NZU64!(items_per_section),
+                buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let mut cache = Cache::<_, [u8; 1024]>::init(context.clone(), cfg.clone())
+                .await
+                .expect("Failed to initialize cache");
+
+            // Ensure all items can be retrieved
+            for (index, data) in &items {
+                let retrieved = cache
+                    .get(*index)
+                    .await
+                    .expect("Failed to get data")
+                    .expect("Data not found");
+                assert_eq!(&retrieved, data);
+            }
+
+            // Prune first half
+            let min = (items.len() / 2) as u64;
+            cache.prune(min).await.expect("Failed to prune");
+
+            // Ensure all items can be retrieved that haven't been pruned
+            let min = (min / items_per_section) * items_per_section;
+            let mut removed = 0;
+            for (index, data) in items {
+                if index >= min {
+                    let retrieved = cache
+                        .get(index)
+                        .await
+                        .expect("Failed to get data")
+                        .expect("Data not found");
+                    assert_eq!(retrieved, data);
+                } else {
+                    let retrieved = cache
+                        .get(index)
+                        .await
+                        .expect("Failed to get data");
+                    assert!(retrieved.is_none());
+                    removed += 1;
+                }
+            }
+
+            // Check metrics
+            let buffer = context.encode();
+            let tracked = format!("items_tracked {:?}", num_items - removed);
+            assert!(buffer.contains(&tracked));
+
+            context.auditor().state()
+        })
+    }
+
+    #[test_traced]
+    #[ignore]
+    fn test_cache_many_items_and_restart() {
+        test_cache_restart(100_000);
+    }
+
+    #[test_traced]
+    #[ignore]
+    fn test_determinism() {
+        let state1 = test_cache_restart(5_000);
+        let state2 = test_cache_restart(5_000);
+        assert_eq!(state1, state2);
+    }
+}

--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -1,89 +1,71 @@
-use super::{Config, Translator};
-use crate::{
-    archive::{Error, Identifier},
-    index::Index,
-    journal::variable::{Config as JConfig, Journal},
-    rmap::RMap,
-};
+use super::{Config, Error};
+use crate::journal::variable::{Config as JConfig, Journal};
 use bytes::{Buf, BufMut};
 use commonware_codec::{varint::UInt, Codec, EncodeSize, Read, ReadExt, Write};
 use commonware_runtime::{Metrics, Storage};
-use commonware_utils::Array;
 use futures::{future::try_join_all, pin_mut, StreamExt};
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::debug;
 
-/// Location of a record in `Journal`.
 struct Location {
     offset: u32,
     len: u32,
 }
 
-/// Record stored in the `Archive`.
-struct Record<K: Array, V: Codec> {
+/// Record stored in the `Cache`.
+struct Record<V: Codec> {
     index: u64,
-    key: K,
     value: V,
 }
 
-impl<K: Array, V: Codec> Record<K, V> {
+impl<V: Codec> Record<V> {
     /// Create a new `Record`.
-    fn new(index: u64, key: K, value: V) -> Self {
-        Self { index, key, value }
+    fn new(index: u64, value: V) -> Self {
+        Self { index, value }
     }
 }
 
-impl<K: Array, V: Codec> Write for Record<K, V> {
+impl<V: Codec> Write for Record<V> {
     fn write(&self, buf: &mut impl BufMut) {
         UInt(self.index).write(buf);
-        self.key.write(buf);
         self.value.write(buf);
     }
 }
 
-impl<K: Array, V: Codec> Read for Record<K, V> {
+impl<V: Codec> Read for Record<V> {
     type Cfg = V::Cfg;
 
     fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, commonware_codec::Error> {
         let index = UInt::read(buf)?.into();
-        let key = K::read(buf)?;
         let value = V::read_cfg(buf, cfg)?;
-        Ok(Self { index, key, value })
+        Ok(Self { index, value })
     }
 }
 
-impl<K: Array, V: Codec> EncodeSize for Record<K, V> {
+impl<V: Codec> EncodeSize for Record<V> {
     fn encode_size(&self) -> usize {
-        UInt(self.index).encode_size() + K::SIZE + self.value.encode_size()
+        UInt(self.index).encode_size() + self.value.encode_size()
     }
 }
 
-/// Implementation of `Archive` storage.
-pub struct Archive<T: Translator, E: Storage + Metrics, K: Array, V: Codec> {
+/// Implementation of `Cache` storage.
+pub struct Cache<E: Storage + Metrics, V: Codec> {
     items_per_section: u64,
-    journal: Journal<E, Record<K, V>>,
+    journal: Journal<E, Record<V>>,
     pending: BTreeSet<u64>,
 
     // Oldest allowed section to read from. This is updated when `prune` is called.
     oldest_allowed: Option<u64>,
-
-    // To efficiently serve `get` and `has` requests, we map a translated representation of each key
-    // to its corresponding index. To avoid iterating over this keys map during pruning, we map said
-    // indexes to their locations in the journal.
-    keys: Index<T, u64>,
     indices: BTreeMap<u64, Location>,
-    intervals: RMap,
 
     items_tracked: Gauge,
-    indices_pruned: Counter,
-    unnecessary_reads: Counter,
     gets: Counter,
     has: Counter,
     syncs: Counter,
 }
 
-impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V> {
+impl<E: Storage + Metrics, V: Codec> Cache<E, V> {
     /// Calculate the section for a given index.
     fn section(&self, index: u64) -> u64 {
         (index / self.items_per_section) * self.items_per_section
@@ -93,9 +75,9 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
     ///
     /// The in-memory index for `Archive` is populated during this call
     /// by replaying the journal.
-    pub async fn init(context: E, cfg: Config<T, V::Cfg>) -> Result<Self, Error> {
+    pub async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
         // Initialize journal
-        let journal = Journal::<E, Record<K, V>>::init(
+        let journal = Journal::<E, Record<V>>::init(
             context.with_label("journal"),
             JConfig {
                 partition: cfg.partition,
@@ -109,10 +91,8 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
 
         // Initialize keys and run corruption check
         let mut indices = BTreeMap::new();
-        let mut keys = Index::init(context.with_label("index"), cfg.translator.clone());
-        let mut intervals = RMap::new();
         {
-            debug!("initializing archive");
+            debug!("initializing cache");
             let stream = journal.replay(cfg.replay_buffer).await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
@@ -121,20 +101,12 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
 
                 // Store index
                 indices.insert(data.index, Location { offset, len });
-
-                // Store index in keys
-                keys.insert(&data.key, data.index);
-
-                // Store index in intervals
-                intervals.insert(data.index);
             }
-            debug!(keys = keys.keys(), "archive initialized");
+            debug!(items = indices.len(), "cache initialized");
         }
 
         // Initialize metrics
         let items_tracked = Gauge::default();
-        let indices_pruned = Counter::default();
-        let unnecessary_reads = Counter::default();
         let gets = Counter::default();
         let has = Counter::default();
         let syncs = Counter::default();
@@ -142,16 +114,6 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
             "items_tracked",
             "Number of items tracked",
             items_tracked.clone(),
-        );
-        context.register(
-            "indices_pruned",
-            "Number of indices pruned",
-            indices_pruned.clone(),
-        );
-        context.register(
-            "unnecessary_reads",
-            "Number of unnecessary reads performed during key lookups",
-            unnecessary_reads.clone(),
         );
         context.register("gets", "Number of gets performed", gets.clone());
         context.register("has", "Number of has performed", has.clone());
@@ -165,18 +127,14 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
             pending: BTreeSet::new(),
             oldest_allowed: None,
             indices,
-            intervals,
-            keys,
             items_tracked,
-            indices_pruned,
-            unnecessary_reads,
             gets,
             has,
             syncs,
         })
     }
 
-    async fn get_index(&self, index: u64) -> Result<Option<V>, Error> {
+    pub async fn get(&self, index: u64) -> Result<Option<V>, Error> {
         // Update metrics
         self.gets.inc();
 
@@ -196,39 +154,10 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
         Ok(Some(record.value))
     }
 
-    async fn get_key(&self, key: &K) -> Result<Option<V>, Error> {
+    pub fn has(&self, index: u64) -> bool {
         // Update metrics
-        self.gets.inc();
+        self.has.inc();
 
-        // Fetch index
-        let iter = self.keys.get(key);
-        let min_allowed = self.oldest_allowed.unwrap_or(0);
-        for index in iter {
-            // Continue if index is no longer allowed due to pruning.
-            if *index < min_allowed {
-                continue;
-            }
-
-            // Fetch item from disk
-            let location = self.indices.get(index).ok_or(Error::RecordCorrupted)?;
-            let section = self.section(*index);
-            let record = self
-                .journal
-                .get_exact(section, location.offset, location.len)
-                .await?
-                .ok_or(Error::RecordCorrupted)?;
-
-            // Get key from item
-            if record.key.as_ref() == key.as_ref() {
-                return Ok(Some(record.value));
-            }
-            self.unnecessary_reads.inc();
-        }
-
-        Ok(None)
-    }
-
-    fn has_index(&self, index: u64) -> bool {
         // Check if index exists
         self.indices.contains_key(&index)
     }
@@ -271,12 +200,6 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
                 _ => break,
             };
             self.indices.remove(&next).unwrap();
-            self.indices_pruned.inc();
-        }
-
-        // Remove all keys from interval tree less than min
-        if min > 0 {
-            self.intervals.remove(0, min - 1);
         }
 
         // Update last pruned (to prevent reads from
@@ -285,15 +208,8 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
         self.items_tracked.set(self.indices.len() as i64);
         Ok(())
     }
-}
 
-impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> crate::archive::Archive
-    for Archive<T, E, K, V>
-{
-    type Key = K;
-    type Value = V;
-
-    async fn put(&mut self, index: u64, key: K, data: V) -> Result<(), Error> {
+    pub async fn put(&mut self, index: u64, value: V) -> Result<(), Error> {
         // Check last pruned
         let oldest_allowed = self.oldest_allowed.unwrap_or(0);
         if index < oldest_allowed {
@@ -306,19 +222,12 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> crate::archive::Ar
         }
 
         // Store item in journal
-        let record = Record::new(index, key.clone(), data);
+        let record = Record::new(index, value);
         let section = self.section(index);
         let (offset, len) = self.journal.append(section, record).await?;
 
         // Store index
         self.indices.insert(index, Location { offset, len });
-
-        // Store interval
-        self.intervals.insert(index);
-
-        // Insert and prune any useless keys
-        self.keys
-            .insert_and_prune(&key, index, |v| *v < oldest_allowed);
 
         // Add section to pending
         self.pending.insert(section);
@@ -328,22 +237,7 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> crate::archive::Ar
         Ok(())
     }
 
-    async fn get(&self, identifier: Identifier<'_, K>) -> Result<Option<V>, Error> {
-        match identifier {
-            Identifier::Index(index) => self.get_index(index).await,
-            Identifier::Key(key) => self.get_key(key).await,
-        }
-    }
-
-    async fn has(&self, identifier: Identifier<'_, K>) -> Result<bool, Error> {
-        self.has.inc();
-        match identifier {
-            Identifier::Index(index) => Ok(self.has_index(index)),
-            Identifier::Key(key) => self.get_key(key).await.map(|result| result.is_some()),
-        }
-    }
-
-    async fn sync(&mut self) -> Result<(), Error> {
+    pub async fn sync(&mut self) -> Result<(), Error> {
         let mut syncs = Vec::with_capacity(self.pending.len());
         for section in self.pending.iter() {
             syncs.push(self.journal.sync(*section));
@@ -354,15 +248,11 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> crate::archive::Ar
         Ok(())
     }
 
-    fn next_gap(&self, index: u64) -> (Option<u64>, Option<u64>) {
-        self.intervals.next_gap(index)
-    }
-
-    async fn close(self) -> Result<(), Error> {
+    pub async fn close(self) -> Result<(), Error> {
         self.journal.close().await.map_err(Error::Journal)
     }
 
-    async fn destroy(self) -> Result<(), Error> {
+    pub async fn destroy(self) -> Result<(), Error> {
         self.journal.destroy().await.map_err(Error::Journal)
     }
 }

--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -1,0 +1,368 @@
+use super::{Config, Translator};
+use crate::{
+    archive::{Error, Identifier},
+    index::Index,
+    journal::variable::{Config as JConfig, Journal},
+    rmap::RMap,
+};
+use bytes::{Buf, BufMut};
+use commonware_codec::{varint::UInt, Codec, EncodeSize, Read, ReadExt, Write};
+use commonware_runtime::{Metrics, Storage};
+use commonware_utils::Array;
+use futures::{future::try_join_all, pin_mut, StreamExt};
+use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
+use std::collections::{BTreeMap, BTreeSet};
+use tracing::debug;
+
+/// Location of a record in `Journal`.
+struct Location {
+    offset: u32,
+    len: u32,
+}
+
+/// Record stored in the `Archive`.
+struct Record<K: Array, V: Codec> {
+    index: u64,
+    key: K,
+    value: V,
+}
+
+impl<K: Array, V: Codec> Record<K, V> {
+    /// Create a new `Record`.
+    fn new(index: u64, key: K, value: V) -> Self {
+        Self { index, key, value }
+    }
+}
+
+impl<K: Array, V: Codec> Write for Record<K, V> {
+    fn write(&self, buf: &mut impl BufMut) {
+        UInt(self.index).write(buf);
+        self.key.write(buf);
+        self.value.write(buf);
+    }
+}
+
+impl<K: Array, V: Codec> Read for Record<K, V> {
+    type Cfg = V::Cfg;
+
+    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, commonware_codec::Error> {
+        let index = UInt::read(buf)?.into();
+        let key = K::read(buf)?;
+        let value = V::read_cfg(buf, cfg)?;
+        Ok(Self { index, key, value })
+    }
+}
+
+impl<K: Array, V: Codec> EncodeSize for Record<K, V> {
+    fn encode_size(&self) -> usize {
+        UInt(self.index).encode_size() + K::SIZE + self.value.encode_size()
+    }
+}
+
+/// Implementation of `Archive` storage.
+pub struct Archive<T: Translator, E: Storage + Metrics, K: Array, V: Codec> {
+    items_per_section: u64,
+    journal: Journal<E, Record<K, V>>,
+    pending: BTreeSet<u64>,
+
+    // Oldest allowed section to read from. This is updated when `prune` is called.
+    oldest_allowed: Option<u64>,
+
+    // To efficiently serve `get` and `has` requests, we map a translated representation of each key
+    // to its corresponding index. To avoid iterating over this keys map during pruning, we map said
+    // indexes to their locations in the journal.
+    keys: Index<T, u64>,
+    indices: BTreeMap<u64, Location>,
+    intervals: RMap,
+
+    items_tracked: Gauge,
+    indices_pruned: Counter,
+    unnecessary_reads: Counter,
+    gets: Counter,
+    has: Counter,
+    syncs: Counter,
+}
+
+impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V> {
+    /// Calculate the section for a given index.
+    fn section(&self, index: u64) -> u64 {
+        (index / self.items_per_section) * self.items_per_section
+    }
+
+    /// Initialize a new `Archive` instance.
+    ///
+    /// The in-memory index for `Archive` is populated during this call
+    /// by replaying the journal.
+    pub async fn init(context: E, cfg: Config<T, V::Cfg>) -> Result<Self, Error> {
+        // Initialize journal
+        let journal = Journal::<E, Record<K, V>>::init(
+            context.with_label("journal"),
+            JConfig {
+                partition: cfg.partition,
+                compression: cfg.compression,
+                codec_config: cfg.codec_config,
+                buffer_pool: cfg.buffer_pool,
+                write_buffer: cfg.write_buffer,
+            },
+        )
+        .await?;
+
+        // Initialize keys and run corruption check
+        let mut indices = BTreeMap::new();
+        let mut keys = Index::init(context.with_label("index"), cfg.translator.clone());
+        let mut intervals = RMap::new();
+        {
+            debug!("initializing archive");
+            let stream = journal.replay(cfg.replay_buffer).await?;
+            pin_mut!(stream);
+            while let Some(result) = stream.next().await {
+                // Extract key from record
+                let (_, offset, len, data) = result?;
+
+                // Store index
+                indices.insert(data.index, Location { offset, len });
+
+                // Store index in keys
+                keys.insert(&data.key, data.index);
+
+                // Store index in intervals
+                intervals.insert(data.index);
+            }
+            debug!(keys = keys.keys(), "archive initialized");
+        }
+
+        // Initialize metrics
+        let items_tracked = Gauge::default();
+        let indices_pruned = Counter::default();
+        let unnecessary_reads = Counter::default();
+        let gets = Counter::default();
+        let has = Counter::default();
+        let syncs = Counter::default();
+        context.register(
+            "items_tracked",
+            "Number of items tracked",
+            items_tracked.clone(),
+        );
+        context.register(
+            "indices_pruned",
+            "Number of indices pruned",
+            indices_pruned.clone(),
+        );
+        context.register(
+            "unnecessary_reads",
+            "Number of unnecessary reads performed during key lookups",
+            unnecessary_reads.clone(),
+        );
+        context.register("gets", "Number of gets performed", gets.clone());
+        context.register("has", "Number of has performed", has.clone());
+        context.register("syncs", "Number of syncs called", syncs.clone());
+        items_tracked.set(indices.len() as i64);
+
+        // Return populated archive
+        Ok(Self {
+            items_per_section: cfg.items_per_section.get(),
+            journal,
+            pending: BTreeSet::new(),
+            oldest_allowed: None,
+            indices,
+            intervals,
+            keys,
+            items_tracked,
+            indices_pruned,
+            unnecessary_reads,
+            gets,
+            has,
+            syncs,
+        })
+    }
+
+    async fn get_index(&self, index: u64) -> Result<Option<V>, Error> {
+        // Update metrics
+        self.gets.inc();
+
+        // Get index location
+        let location = match self.indices.get(&index) {
+            Some(offset) => offset,
+            None => return Ok(None),
+        };
+
+        // Fetch item from disk
+        let section = self.section(index);
+        let record = self
+            .journal
+            .get_exact(section, location.offset, location.len)
+            .await?
+            .ok_or(Error::RecordCorrupted)?;
+        Ok(Some(record.value))
+    }
+
+    async fn get_key(&self, key: &K) -> Result<Option<V>, Error> {
+        // Update metrics
+        self.gets.inc();
+
+        // Fetch index
+        let iter = self.keys.get(key);
+        let min_allowed = self.oldest_allowed.unwrap_or(0);
+        for index in iter {
+            // Continue if index is no longer allowed due to pruning.
+            if *index < min_allowed {
+                continue;
+            }
+
+            // Fetch item from disk
+            let location = self.indices.get(index).ok_or(Error::RecordCorrupted)?;
+            let section = self.section(*index);
+            let record = self
+                .journal
+                .get_exact(section, location.offset, location.len)
+                .await?
+                .ok_or(Error::RecordCorrupted)?;
+
+            // Get key from item
+            if record.key.as_ref() == key.as_ref() {
+                return Ok(Some(record.value));
+            }
+            self.unnecessary_reads.inc();
+        }
+
+        Ok(None)
+    }
+
+    fn has_index(&self, index: u64) -> bool {
+        // Check if index exists
+        self.indices.contains_key(&index)
+    }
+
+    /// Prune `Archive` to the provided `min` (masked by the configured
+    /// section mask).
+    ///
+    /// If this is called with a min lower than the last pruned, nothing
+    /// will happen.
+    pub async fn prune(&mut self, min: u64) -> Result<(), Error> {
+        // Update `min` to reflect section mask
+        let min = self.section(min);
+
+        // Check if min is less than last pruned
+        if let Some(oldest_allowed) = self.oldest_allowed {
+            if min <= oldest_allowed {
+                // We don't return an error in this case because the caller
+                // shouldn't be burdened with converting `min` to some section.
+                return Ok(());
+            }
+        }
+        debug!(min, "pruning archive");
+
+        // Prune journal
+        self.journal.prune(min).await.map_err(Error::Journal)?;
+
+        // Remove pending writes (no need to call `sync` as we are pruning)
+        loop {
+            let next = match self.pending.iter().next() {
+                Some(section) if *section < min => *section,
+                _ => break,
+            };
+            self.pending.remove(&next);
+        }
+
+        // Remove all indices that are less than min
+        loop {
+            let next = match self.indices.first_key_value() {
+                Some((index, _)) if *index < min => *index,
+                _ => break,
+            };
+            self.indices.remove(&next).unwrap();
+            self.indices_pruned.inc();
+        }
+
+        // Remove all keys from interval tree less than min
+        if min > 0 {
+            self.intervals.remove(0, min - 1);
+        }
+
+        // Update last pruned (to prevent reads from
+        // pruned sections)
+        self.oldest_allowed = Some(min);
+        self.items_tracked.set(self.indices.len() as i64);
+        Ok(())
+    }
+}
+
+impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> crate::archive::Archive
+    for Archive<T, E, K, V>
+{
+    type Key = K;
+    type Value = V;
+
+    async fn put(&mut self, index: u64, key: K, data: V) -> Result<(), Error> {
+        // Check last pruned
+        let oldest_allowed = self.oldest_allowed.unwrap_or(0);
+        if index < oldest_allowed {
+            return Err(Error::AlreadyPrunedTo(oldest_allowed));
+        }
+
+        // Check for existing index
+        if self.indices.contains_key(&index) {
+            return Ok(());
+        }
+
+        // Store item in journal
+        let record = Record::new(index, key.clone(), data);
+        let section = self.section(index);
+        let (offset, len) = self.journal.append(section, record).await?;
+
+        // Store index
+        self.indices.insert(index, Location { offset, len });
+
+        // Store interval
+        self.intervals.insert(index);
+
+        // Insert and prune any useless keys
+        self.keys
+            .insert_and_prune(&key, index, |v| *v < oldest_allowed);
+
+        // Add section to pending
+        self.pending.insert(section);
+
+        // Update metrics
+        self.items_tracked.set(self.indices.len() as i64);
+        Ok(())
+    }
+
+    async fn get(&self, identifier: Identifier<'_, K>) -> Result<Option<V>, Error> {
+        match identifier {
+            Identifier::Index(index) => self.get_index(index).await,
+            Identifier::Key(key) => self.get_key(key).await,
+        }
+    }
+
+    async fn has(&self, identifier: Identifier<'_, K>) -> Result<bool, Error> {
+        self.has.inc();
+        match identifier {
+            Identifier::Index(index) => Ok(self.has_index(index)),
+            Identifier::Key(key) => self.get_key(key).await.map(|result| result.is_some()),
+        }
+    }
+
+    async fn sync(&mut self) -> Result<(), Error> {
+        let mut syncs = Vec::with_capacity(self.pending.len());
+        for section in self.pending.iter() {
+            syncs.push(self.journal.sync(*section));
+            self.syncs.inc();
+        }
+        try_join_all(syncs).await?;
+        self.pending.clear();
+        Ok(())
+    }
+
+    fn next_gap(&self, index: u64) -> (Option<u64>, Option<u64>) {
+        self.intervals.next_gap(index)
+    }
+
+    async fn close(self) -> Result<(), Error> {
+        self.journal.close().await.map_err(Error::Journal)
+    }
+
+    async fn destroy(self) -> Result<(), Error> {
+        self.journal.destroy().await.map_err(Error::Journal)
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod adb;
 pub mod archive;
 pub mod bmt;
+pub mod cache;
 pub mod freezer;
 pub mod index;
 pub mod journal;


### PR DESCRIPTION
Sometimes, it is useful to store some intermediate result of computation between actors. This is a more efficient approach than `store` for that task (and allows positional pruning).