### PR TITLE
Remove unnecessary clone() in wire message test

### DIFF
--- a/resolver/src/p2p/wire.rs
+++ b/resolver/src/p2p/wire.rs
@@ -125,7 +125,7 @@ mod tests {
         let payload = Payload::<MockKey>::Response(Bytes::from("Hello, world!"));
         let original = Message { id: 4321, payload };
         let encoded = original.encode();
-        let decoded = Message::decode(encoded.clone()).unwrap();
+        let decoded = Message::decode(encoded).unwrap();
         assert_eq!(original, decoded);
     }
 


### PR DESCRIPTION
Eliminates redundant clone() call in test_codec_response() since the  encoded variable is not used after Message::decode().