### PR TITLE
[storage] fix rewind bugs

### DIFF
--- a/storage/fuzz/fuzz_targets/journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/journal_operations.rs
@@ -121,6 +121,7 @@ fn fuzz(input: FuzzInput) {
                 JournalOperation::Rewind { size } => {
                     if *size <= journal_size && *size >= oldest_retained_pos {
                         journal.rewind(*size).await.unwrap();
+                        journal.sync().await.unwrap();
                         journal_size = *size;
                     }
                 }

--- a/storage/src/adb/any/fixed/mod.rs
+++ b/storage/src/adb/any/fixed/mod.rs
@@ -220,6 +220,7 @@ impl<
             let op_count = log_size - rewind_leaf_num;
             warn!(op_count, "rewinding over uncommitted log operations");
             log.rewind(rewind_leaf_num).await?;
+            log.sync().await?;
             log_size = rewind_leaf_num;
         }
 

--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -214,6 +214,7 @@ pub(crate) async fn init_journal<E: Storage + Metrics, A: CodecFixed<Cfg = ()>>(
             );
         journal.prune(lower_bound).await?;
         journal.rewind(upper_bound + 1).await?; // +1 because upper_bound is inclusive
+        journal.sync().await?;
         journal
     };
     let journal_size = journal.size().await?;

--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -225,6 +225,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
                 locations_size, "rewinding misaligned locations map"
             );
             self.locations.rewind(mmr_leaves).await?;
+            self.locations.sync().await?;
         } else if mmr_leaves > locations_size {
             warn!(mmr_leaves, locations_size, "rewinding misaligned mmr");
             self.mmr.pop((mmr_leaves - locations_size) as usize).await?;
@@ -347,6 +348,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         // Pop any MMR elements that are ahead of the last log commit point.
         if mmr_leaves > self.log_size {
             self.locations.rewind(self.log_size).await?;
+            self.locations.sync().await?;
 
             let op_count = mmr_leaves - self.log_size;
             warn!(op_count, "popping uncommitted MMR operations");

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -297,6 +297,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
                 locations_size, "rewinding misaligned locations map"
             );
             locations.rewind(mmr_leaves).await?;
+            locations.sync().await?;
         }
         if mmr_leaves > locations_size {
             warn!(mmr_leaves, locations_size, "rewinding misaligned mmr");
@@ -391,6 +392,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         // Pop any MMR elements that are ahead of the last log commit point.
         if mmr_leaves > log_size {
             locations.rewind(log_size).await?;
+            locations.sync().await?;
 
             let op_count = mmr_leaves - log_size;
             warn!(op_count, "popping uncommitted MMR operations");

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -578,6 +578,7 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> Freezer<E, K, V> {
 
                 // Rewind the journal to the committed section and offset
                 journal.rewind(checkpoint.section, checkpoint.size).await?;
+                journal.sync(checkpoint.section).await?;
 
                 // Resize table if needed
                 let expected_table_len = Self::table_offset(checkpoint.table_size);

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -366,9 +366,10 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> Journal<E, A> {
     /// precedes the oldest retained element point. The journal is not synced after rewinding.
     ///
     /// # Warnings
-    ///   - This operation is not guaranteed to survive restarts until sync is called.
-    ///   - This operation is not atomic, but it will always leave the journal in a consistent state
-    ///     in the event of failure since blobs are always removed from newest to oldest.
+    ///
+    /// * This operation is not guaranteed to survive restarts until sync is called.
+    /// * This operation is not atomic, but it will always leave the journal in a consistent state
+    ///   in the event of failure since blobs are always removed from newest to oldest.
     pub async fn rewind(&mut self, size: u64) -> Result<(), Error> {
         match size.cmp(&self.size().await?) {
             std::cmp::Ordering::Greater => return Err(Error::InvalidRewind(size)),

--- a/storage/src/journal/fixed.rs
+++ b/storage/src/journal/fixed.rs
@@ -362,11 +362,13 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> Journal<E, A> {
         Ok(item_pos)
     }
 
-    /// Rewind the journal to the given `size`. Returns [Error::MissingBlob] if the rewind
-    /// point precedes the oldest retained element point. The journal is not synced after rewinding.
+    /// Rewind the journal to the given `size`. Returns [Error::MissingBlob] if the rewind point
+    /// precedes the oldest retained element point. The journal is not synced after rewinding.
     ///
-    /// Note that this operation is not atomic, but it will always leave the journal in a consistent
-    /// state in the event of failure since blobs are always removed from newest to oldest.
+    /// # Warnings
+    ///   - This operation is not guaranteed to survive restarts until sync is called.
+    ///   - This operation is not atomic, but it will always leave the journal in a consistent state
+    ///     in the event of failure since blobs are always removed from newest to oldest.
     pub async fn rewind(&mut self, size: u64) -> Result<(), Error> {
         match size.cmp(&self.size().await?) {
             std::cmp::Ordering::Greater => return Err(Error::InvalidRewind(size)),

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -654,9 +654,10 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     /// Rewinds the journal to the given `section` and `offset`, removing any data beyond it.
     ///
     /// # Warnings
-    ///   - This operation is not guaranteed to survive restarts until sync is called.
-    ///   - This operation is not atomic, but it will always leave the journal in a consistent state
-    ///     in the event of failure since blobs are always removed in reverse order of section.
+    ///
+    /// * This operation is not guaranteed to survive restarts until sync is called.
+    /// * This operation is not atomic, but it will always leave the journal in a consistent state
+    ///   in the event of failure since blobs are always removed in reverse order of section.
     pub async fn rewind_to_offset(&mut self, section: u64, offset: u32) -> Result<(), Error> {
         self.rewind(section, offset as u64 * ITEM_ALIGNMENT).await
     }
@@ -666,9 +667,10 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     /// This removes any data beyond the specified `section` and `size`.
     ///
     /// # Warnings
-    ///   - This operation is not guaranteed to survive restarts until sync is called.
-    ///   - This operation is not atomic, but it will always leave the journal in a consistent state
-    ///     in the event of failure since blobs are always removed in reverse order of section.
+    ///
+    /// * This operation is not guaranteed to survive restarts until sync is called.
+    /// * This operation is not atomic, but it will always leave the journal in a consistent state
+    ///   in the event of failure since blobs are always removed in reverse order of section.
     pub async fn rewind(&mut self, section: u64, size: u64) -> Result<(), Error> {
         self.prune_guard(section, false)?;
 

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -652,6 +652,11 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     }
 
     /// Rewinds the journal to the given `section` and `offset`, removing any data beyond it.
+    ///
+    /// # Warnings
+    ///   - This operation is not guaranteed to survive restarts until sync is called.
+    ///   - This operation is not atomic, but it will always leave the journal in a consistent state
+    ///     in the event of failure since blobs are always removed in reverse order of section.
     pub async fn rewind_to_offset(&mut self, section: u64, offset: u32) -> Result<(), Error> {
         self.rewind(section, offset as u64 * ITEM_ALIGNMENT).await
     }
@@ -659,6 +664,11 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     /// Rewinds the journal to the given `section` and `size`.
     ///
     /// This removes any data beyond the specified `section` and `size`.
+    ///
+    /// # Warnings
+    ///   - This operation is not guaranteed to survive restarts until sync is called.
+    ///   - This operation is not atomic, but it will always leave the journal in a consistent state
+    ///     in the event of failure since blobs are always removed in reverse order of section.
     pub async fn rewind(&mut self, section: u64, size: u64) -> Result<(), Error> {
         self.prune_guard(section, false)?;
 
@@ -707,6 +717,10 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     /// Rewinds the `section` to the given `size`.
     ///
     /// Unlike [Self::rewind], this method does not modify anything other than the given `section`.
+    ///
+    /// # Warning
+    ///
+    /// This operation is not guaranteed to survive restarts until sync is called.
     pub async fn rewind_section(&mut self, section: u64, size: u64) -> Result<(), Error> {
         self.prune_guard(section, false)?;
 

--- a/storage/src/store/mod.rs
+++ b/storage/src/store/mod.rs
@@ -531,6 +531,7 @@ where
                 "rewinding uncommitted locations"
             );
             self.locations.rewind(self.log_size).await?;
+            self.locations.sync().await?;
         }
 
         // Confirm post-conditions hold.


### PR DESCRIPTION
(1) We were incorrectly assuming journal rewind() and mmr.pop() were "sticky" operations, but in fact they aren't sticky until sync is called. This PR makes pop() sticky, and calls sync() where appropriate after rewinding.

(2) The journaled MMR's sync() operation was returning immediately when size == 0, which was preventing the syncing of a rewind to offset 0. Removed the size == 0 check, and added a regression test for this scenario.

Rewind documentation is updated to clearly state its properties.