### PR TITLE
`[commonware-resolver]` enable `mocks` feature for unit tests

### DIFF
--- a/resolver/src/p2p/fetcher.rs
+++ b/resolver/src/p2p/fetcher.rs
@@ -270,7 +270,7 @@ impl<E: Clock + GClock + Rng + Metrics, P: PublicKey, Key: Span, NetS: Sender<Pu
     }
 }
 
-#[cfg(all(test, feature = "mocks"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::p2p::mocks::Key as MockKey;

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -74,7 +74,7 @@ pub trait Coordinator: Clone + Send + Sync + 'static {
     fn peer_set_id(&self) -> u64;
 }
 
-#[cfg(all(test, feature = "mocks"))]
+#[cfg(test)]
 mod tests {
     use super::{
         mocks::{Consumer, Coordinator, CoordinatorMsg, Event, Key, Producer},

--- a/resolver/src/p2p/wire.rs
+++ b/resolver/src/p2p/wire.rs
@@ -104,7 +104,7 @@ impl<Key: Span> Read for Payload<Key> {
     }
 }
 
-#[cfg(all(test, feature = "mocks"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::p2p::mocks::Key as MockKey;


### PR DESCRIPTION
On `main` when I run `cargo test -p commonware-resolver` I get this compilation error:

```
➜  monorepo git:(main) ✗ cargo test -p commonware-resolver                      
   Compiling commonware-resolver v0.0.60 (/Users/XYZ/monorepo/resolver)
error[E0432]: unresolved import `crate::p2p::mocks`
   --> resolver/src/p2p/fetcher.rs:276:21
    |
276 |     use crate::p2p::mocks::Key as MockKey;
    |                     ^^^^^ could not find `mocks` in `p2p`
    |
note: found an item that was configured out
   --> resolver/src/p2p/mod.rs:48:9
    |
48  | pub mod mocks;
    |         ^^^^^
note: the item is gated behind the `mocks` feature
   --> resolver/src/p2p/mod.rs:47:7
    |
47  | #[cfg(feature = "mocks")]
    |       ^^^^^^^^^^^^^^^^^
error[E0432]: unresolved import `crate::p2p::mocks`
   --> resolver/src/p2p/wire.rs:110:21
 ...
 ```
 
 The issue is that the `commonware-resolver` unit tests relies on the `mocks` feature, which is not enabled by default. 
 
 This PR enables the `mocks` feature for dev targets (i.e. unit tests) so `cargo test -p commonware-resolver` compiles and runs.