### PR TITLE
[cryptography] Use CryptoRng consistently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,7 +506,7 @@ pub trait PublicKey: Verifier + Sized + ReadExt + Encode + PartialEq + Array {}
 
 // Extension traits for additional functionality
 pub trait PrivateKeyExt: PrivateKey {
-    fn from_rng<R: Rng + CryptoRng>(rng: &mut R) -> Self;
+    fn from_rng<R: CryptoRngCore>(rng: &mut R) -> Self;
 }
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,6 +1492,7 @@ dependencies = [
  "governor",
  "prometheus-client",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "tracing",
  "tracing-subscriber",
 ]

--- a/cryptography/src/blake3/mod.rs
+++ b/cryptography/src/blake3/mod.rs
@@ -29,7 +29,7 @@ use core::{
     fmt::{Debug, Display},
     ops::Deref,
 };
-use rand::{CryptoRng, Rng};
+use rand_core::CryptoRngCore;
 use zeroize::Zeroize;
 
 /// Re-export [blake3::Hasher] as `CoreBlake3` for external use if needed.
@@ -173,7 +173,7 @@ impl Display for Digest {
 }
 
 impl crate::Digest for Digest {
-    fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+    fn random<R: CryptoRngCore>(rng: &mut R) -> Self {
         let mut array = [0u8; DIGEST_LENGTH];
         rng.fill_bytes(&mut array);
         Self(array)

--- a/cryptography/src/bls12381/dkg/dealer.rs
+++ b/cryptography/src/bls12381/dkg/dealer.rs
@@ -9,7 +9,7 @@ use crate::{
     PublicKey,
 };
 use commonware_utils::quorum;
-use rand::RngCore;
+use rand_core::CryptoRngCore;
 use std::{
     collections::{HashMap, HashSet},
     marker::PhantomData,
@@ -38,7 +38,7 @@ pub struct Dealer<P: PublicKey, V: Variant> {
 
 impl<P: PublicKey, V: Variant> Dealer<P, V> {
     /// Create a new dealer for a DKG/Resharing procedure.
-    pub fn new<R: RngCore>(
+    pub fn new<R: CryptoRngCore>(
         rng: &mut R,
         share: Option<Share>,
         mut players: Vec<P>,

--- a/cryptography/src/bls12381/dkg/ops.rs
+++ b/cryptography/src/bls12381/dkg/ops.rs
@@ -9,12 +9,12 @@ use crate::bls12381::{
         variant::Variant,
     },
 };
-use rand::RngCore;
+use rand_core::CryptoRngCore;
 use rayon::{prelude::*, ThreadPoolBuilder};
 use std::collections::BTreeMap;
 
 /// Generate shares and a commitment.
-pub fn generate_shares<R: RngCore, V: Variant>(
+pub fn generate_shares<R: CryptoRngCore, V: Variant>(
     rng: &mut R,
     share: Option<Share>,
     n: u32,

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -40,7 +40,7 @@ use core::{
     mem::MaybeUninit,
     ptr,
 };
-use rand::RngCore;
+use rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Domain separation tag used when hashing a message to a curve (G1 or G2).
@@ -200,7 +200,7 @@ pub const PRIVATE_KEY_LENGTH: usize = SCALAR_LENGTH;
 
 impl Scalar {
     /// Generates a random scalar using the provided RNG.
-    pub fn from_rand<R: RngCore>(rng: &mut R) -> Self {
+    pub fn from_rand<R: CryptoRngCore>(rng: &mut R) -> Self {
         // Generate a random 64 byte buffer
         let mut ikm = [0u8; 64];
         rng.fill_bytes(&mut ikm);

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -18,7 +18,7 @@ use crate::bls12381::primitives::poly::{compute_weights, prepare_evaluations};
 use alloc::{borrow::Cow, collections::BTreeMap, vec, vec::Vec};
 use commonware_codec::Encode;
 use commonware_utils::union_unique;
-use rand::RngCore;
+use rand_core::CryptoRngCore;
 #[cfg(feature = "std")]
 use rayon::{prelude::*, ThreadPoolBuilder};
 #[cfg(feature = "std")]
@@ -32,7 +32,7 @@ pub fn compute_public<V: Variant>(private: &Scalar) -> V::Public {
 }
 
 /// Returns a new keypair derived from the provided randomness.
-pub fn keypair<R: RngCore, V: Variant>(rng: &mut R) -> (group::Private, V::Public) {
+pub fn keypair<R: CryptoRngCore, V: Variant>(rng: &mut R) -> (group::Private, V::Public) {
     let private = group::Private::from_rand(rng);
     let public = compute_public::<V>(&private);
     (private, public)

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -20,7 +20,7 @@ use commonware_codec::{varint::UInt, EncodeSize, Error as CodecError, Read, Read
 use core::hash::Hash;
 #[cfg(feature = "std")]
 use rand::rngs::OsRng;
-use rand::RngCore;
+use rand_core::CryptoRngCore;
 #[cfg(feature = "std")]
 use std::collections::BTreeMap;
 
@@ -90,7 +90,7 @@ pub fn new(degree: u32) -> Poly<Scalar> {
 // sampled at random from the provided RNG.
 ///
 /// In the context of secret sharing, the threshold is the degree + 1.
-pub fn new_from<R: RngCore>(degree: u32, rng: &mut R) -> Poly<Scalar> {
+pub fn new_from<R: CryptoRngCore>(degree: u32, rng: &mut R) -> Poly<Scalar> {
     // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/a714310be76620e10e8797d6637df64011926430/crates/threshold-bls/src/poly.rs#L46-L52
     let coeffs = (0..=degree)
         .map(|_| Scalar::from_rand(rng))

--- a/cryptography/src/bls12381/primitives/variant.rs
+++ b/cryptography/src/bls12381/primitives/variant.rs
@@ -19,7 +19,7 @@ use core::{
     fmt::{Debug, Formatter},
     hash::Hash,
 };
-use rand::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 /// A specific instance of a signature scheme.
 pub trait Variant: Clone + Send + Sync + Hash + Eq + Debug + 'static {
@@ -43,7 +43,7 @@ pub trait Variant: Clone + Send + Sync + Hash + Eq + Debug + 'static {
     ) -> Result<(), Error>;
 
     /// Verify a batch of signatures from the provided public keys and pre-hashed messages.
-    fn batch_verify<R: RngCore + CryptoRng>(
+    fn batch_verify<R: CryptoRngCore>(
         rng: &mut R,
         publics: &[Self::Public],
         hms: &[Self::Signature],
@@ -127,7 +127,7 @@ impl Variant for MinPk {
     /// the batch verification succeeds.
     ///
     /// Source: <https://ethresear.ch/t/security-of-bls-batch-verification/10748>
-    fn batch_verify<R: RngCore + CryptoRng>(
+    fn batch_verify<R: CryptoRngCore>(
         rng: &mut R,
         publics: &[Self::Public],
         hms: &[Self::Signature],
@@ -273,7 +273,7 @@ impl Variant for MinSig {
     /// the batch verification succeeds.
     ///
     /// Source: <https://ethresear.ch/t/security-of-bls-batch-verification/10748>
-    fn batch_verify<R: RngCore + CryptoRng>(
+    fn batch_verify<R: CryptoRngCore>(
         rng: &mut R,
         publics: &[Self::Public],
         hms: &[Self::Signature],

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -44,7 +44,7 @@ use core::{
     hash::{Hash, Hasher},
     ops::Deref,
 };
-use rand::{CryptoRng, Rng, RngCore};
+use rand_core::CryptoRngCore;
 #[cfg(feature = "std")]
 use std::borrow::Cow;
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -150,7 +150,7 @@ impl crate::Signer for PrivateKey {
 }
 
 impl PrivateKeyExt for PrivateKey {
-    fn from_rng<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+    fn from_rng<R: CryptoRngCore>(rng: &mut R) -> Self {
         let (private, _) = ops::keypair::<_, MinPk>(rng);
         let raw = private.encode_fixed();
         Self { raw, key: private }
@@ -385,7 +385,7 @@ impl BatchVerifier<PublicKey> for Batch {
         true
     }
 
-    fn verify<R: RngCore + CryptoRng>(self, rng: &mut R) -> bool {
+    fn verify<R: CryptoRngCore>(self, rng: &mut R) -> bool {
         MinPk::batch_verify(rng, &self.publics, &self.hms, &self.signatures).is_ok()
     }
 }

--- a/cryptography/src/bls12381/tle.rs
+++ b/cryptography/src/bls12381/tle.rs
@@ -92,7 +92,7 @@ use alloc::vec::Vec;
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, FixedSize, Read, ReadExt, Write};
 use commonware_utils::sequence::FixedBytes;
-use rand::{CryptoRng, Rng};
+use rand_core::CryptoRngCore;
 
 /// Domain separation tag for hashing the `h3` message to a scalar.
 const DST: DST = b"TLE_BLS12381_XMD:SHA-256_SSWU_RO_H3_";
@@ -249,7 +249,7 @@ fn xor(a: &Block, b: &Block) -> Block {
 ///
 /// # Returns
 /// * `Ciphertext<V>` - The encrypted ciphertext
-pub fn encrypt<R: Rng + CryptoRng, V: Variant>(
+pub fn encrypt<R: CryptoRngCore, V: Variant>(
     rng: &mut R,
     public: V::Public,
     target: (Option<&[u8]>, &[u8]),

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -3,7 +3,6 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         use crate::BatchVerifier;
         use std::borrow::{Cow, ToOwned};
-        use rand::RngCore;
     } else {
         use alloc::borrow::ToOwned;
     }
@@ -17,7 +16,7 @@ use core::{
     ops::Deref,
 };
 use ed25519_consensus::{self, VerificationKey};
-use rand::{CryptoRng, Rng};
+use rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const CURVE_NAME: &str = "ed25519";
@@ -56,7 +55,7 @@ impl crate::Signer for PrivateKey {
 }
 
 impl PrivateKeyExt for PrivateKey {
-    fn from_rng<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+    fn from_rng<R: CryptoRngCore>(rng: &mut R) -> Self {
         let key = ed25519_consensus::SigningKey::new(rng);
         let raw = key.to_bytes();
         Self { raw, key }
@@ -360,7 +359,7 @@ impl BatchVerifier<PublicKey> for Batch {
         true
     }
 
-    fn verify<R: RngCore + CryptoRng>(self, rng: &mut R) -> bool {
+    fn verify<R: CryptoRngCore>(self, rng: &mut R) -> bool {
         self.verifier.verify(rng).is_ok()
     }
 }

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -16,12 +16,13 @@ extern crate alloc;
 
 use commonware_codec::{Encode, ReadExt};
 use commonware_utils::Array;
-use rand::{CryptoRng, Rng, RngCore, SeedableRng as _};
+use rand::SeedableRng as _;
 use rand_chacha::ChaCha20Rng;
 
 pub mod bls12381;
 pub mod ed25519;
 pub mod sha256;
+use rand_core::CryptoRngCore;
 pub use sha256::{CoreSha256, Sha256};
 pub mod blake3;
 pub use blake3::{Blake3, CoreBlake3};
@@ -73,7 +74,7 @@ pub trait PrivateKeyExt: PrivateKey {
     }
 
     /// Create a fresh [PrivateKey] using the supplied RNG.
-    fn from_rng<R: Rng + CryptoRng>(rng: &mut R) -> Self;
+    fn from_rng<R: CryptoRngCore>(rng: &mut R) -> Self;
 }
 
 /// Verifies [Signature]s over messages.
@@ -132,7 +133,7 @@ pub trait BatchVerifier<K: PublicKey> {
     /// (`c_1 + d` and `c_2 - d`).
     ///
     /// You can read more about this [here](https://ethresear.ch/t/security-of-bls-batch-verification/10748#the-importance-of-randomness-4).
-    fn verify<R: RngCore + CryptoRng>(self, rng: &mut R) -> bool;
+    fn verify<R: CryptoRngCore>(self, rng: &mut R) -> bool;
 }
 
 /// Specializes the [commonware_utils::Array] trait with the Copy trait for cryptographic digests
@@ -144,7 +145,7 @@ pub trait Digest: Array + Copy {
     ///
     /// This function is typically used for testing and is not recommended
     /// for production use.
-    fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self;
+    fn random<R: CryptoRngCore>(rng: &mut R) -> Self;
 }
 
 /// An object that can be uniquely represented as a [Digest].

--- a/cryptography/src/secp256r1/scheme.rs
+++ b/cryptography/src/secp256r1/scheme.rs
@@ -21,7 +21,7 @@ use p256::{
     },
     elliptic_curve::scalar::IsHigh,
 };
-use rand::{CryptoRng, Rng};
+use rand_core::CryptoRngCore;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const CURVE_NAME: &str = "secp256r1";
@@ -69,7 +69,7 @@ impl crate::Signer for PrivateKey {
 }
 
 impl PrivateKeyExt for PrivateKey {
-    fn from_rng<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+    fn from_rng<R: CryptoRngCore>(rng: &mut R) -> Self {
         let key = SigningKey::random(rng);
         let raw = key.to_bytes().into();
         Self { raw, key }

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -30,7 +30,7 @@ use core::{
     fmt::{Debug, Display},
     ops::Deref,
 };
-use rand::{CryptoRng, Rng};
+use rand_core::CryptoRngCore;
 use sha2::{Digest as _, Sha256 as ISha256};
 use zeroize::Zeroize;
 
@@ -156,7 +156,7 @@ impl Display for Digest {
 }
 
 impl crate::Digest for Digest {
-    fn random<R: Rng + CryptoRng>(rng: &mut R) -> Self {
+    fn random<R: CryptoRngCore>(rng: &mut R) -> Self {
         let mut array = [0u8; DIGEST_LENGTH];
         rng.fill_bytes(&mut array);
         Self(array)

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -19,6 +19,7 @@ commonware-runtime = { workspace = true }
 commonware-utils = { workspace = true }
 bytes = { workspace = true }
 rand = { workspace = true }
+rand_core = { workspace = true }
 tracing = { workspace = true }
 futures = { workspace = true }
 clap = { workspace = true }

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -15,13 +15,13 @@ use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{Clock, Spawner};
 use commonware_utils::quorum;
 use futures::{channel::mpsc, SinkExt};
-use rand::Rng;
+use rand_core::CryptoRngCore;
 use std::{collections::HashMap, time::Duration};
 use tracing::{debug, info, warn};
 
 /// A DKG/Resharing contributor that can be configured to behave honestly
 /// or deviate as a rogue, lazy, or forger.
-pub struct Contributor<E: Clock + Rng + Spawner, C: Signer> {
+pub struct Contributor<E: Clock + CryptoRngCore + Spawner, C: Signer> {
     context: E,
     crypto: C,
     dkg_phase_timeout: Duration,
@@ -37,7 +37,7 @@ pub struct Contributor<E: Clock + Rng + Spawner, C: Signer> {
     signatures: mpsc::Sender<(u64, Output<MinSig>)>,
 }
 
-impl<E: Clock + Rng + Spawner, C: Signer> Contributor<E, C> {
+impl<E: Clock + CryptoRngCore + Spawner, C: Signer> Contributor<E, C> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         context: E,


### PR DESCRIPTION
Closes #1088.

This also modifies things to avoid the use of `Rng`, preferring `RngCore` instead (just within this crate), and the use of `RngCore + CryptoRng` to instead use `CryptoRngCore`.