### PR TITLE
[storage/journal] improve consistency in journal read/get error handling

### DIFF
--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -380,7 +380,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
 
         let offset = self.locations.read(loc).await?;
         let section = loc / self.log_items_per_section;
-        let op = self.log.get(section, offset).await?.expect("invalid loc");
+        let op = self.log.get(section, offset).await?;
 
         Ok(op.into_value())
     }
@@ -445,7 +445,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
     }
 
     /// Get the operation at location `loc` in the log.
-    async fn get_op(&self, loc: u64) -> Result<Option<Operation<K, V>>, Error> {
+    async fn get_op(&self, loc: u64) -> Result<Operation<K, V>, Error> {
         match self.locations.read(loc).await {
             Ok(offset) => {
                 let section = loc / self.log_items_per_section;
@@ -459,7 +459,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
     /// matches `key`.
     async fn get_from_offset(&self, key: &K, loc: u64, offset: u32) -> Result<Option<V>, Error> {
         let section = loc / self.log_items_per_section;
-        let Some(Operation::Update(k, v)) = self.log.get(section, offset).await? else {
+        let Operation::Update(k, v) = self.log.get(section, offset).await? else {
             panic!("didn't find Update operation at location {loc} and offset {offset}");
         };
 
@@ -615,9 +615,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         for loc in start_loc..=end_index {
             let section = loc / self.log_items_per_section;
             let offset = self.locations.read(loc).await?;
-            let Some(op) = self.log.get(section, offset).await? else {
-                panic!("no log item at location {loc}");
-            };
+            let op = self.log.get(section, offset).await?;
             ops.push(op);
         }
 
@@ -661,7 +659,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         last_commit -= 1;
         let section = last_commit / self.log_items_per_section;
         let offset = self.locations.read(last_commit).await?;
-        let Some(Operation::CommitFloor(metadata, _)) = self.log.get(section, offset).await? else {
+        let Operation::CommitFloor(metadata, _) = self.log.get(section, offset).await? else {
             unreachable!("no commit operation at location of last commit {last_commit}");
         };
 
@@ -732,9 +730,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
             if self.inactivity_floor_loc == self.op_count() {
                 break;
             }
-            let Some(op) = self.get_op(self.inactivity_floor_loc).await? else {
-                panic!("no operation at location {}", self.inactivity_floor_loc);
-            };
+            let op = self.get_op(self.inactivity_floor_loc).await?;
             self.move_op_if_active(op, self.inactivity_floor_loc)
                 .await?;
             self.inactivity_floor_loc += 1;

--- a/storage/src/adb/any/variable/sync.rs
+++ b/storage/src/adb/any/variable/sync.rs
@@ -263,14 +263,11 @@ mod tests {
 
             // Verify the item can be retrieved
             let retrieved = journal.get(lower_section, offset).await.unwrap();
-            assert_eq!(retrieved, Some(42u64));
+            assert_eq!(retrieved, 42u64);
 
             // Append another element
             let (offset2, _) = journal.append(lower_section, 43u64).await.unwrap();
-            assert_eq!(
-                journal.get(lower_section, offset2).await.unwrap(),
-                Some(43u64)
-            );
+            assert_eq!(journal.get(lower_section, offset2).await.unwrap(), 43u64);
 
             journal.destroy().await.unwrap();
         });
@@ -333,18 +330,18 @@ mod tests {
 
             // Verify data integrity: existing data in retained sections is accessible
             let item = journal.get(1, 0).await.unwrap();
-            assert_eq!(item, Some(10u64)); // First item in section 1 (1*10+0)
+            assert_eq!(item, 10u64); // First item in section 1 (1*10+0)
             let item = journal.get(1, 1).await.unwrap();
-            assert_eq!(item, Some(11)); // Second item in section 1 (1*10+1)
+            assert_eq!(item, 11); // Second item in section 1 (1*10+1)
             let item = journal.get(2, 0).await.unwrap();
-            assert_eq!(item, Some(20)); // First item in section 2 (2*10+0)
+            assert_eq!(item, 20); // First item in section 2 (2*10+0)
             let last_element_section = 19 / items_per_section;
             let last_element_offset = (19 % items_per_section.get()) as u32;
             let item = journal
                 .get(last_element_section, last_element_offset)
                 .await
                 .unwrap();
-            assert_eq!(item, Some(34)); // Last item in section 3 (3*10+4)
+            assert_eq!(item, 34); // Last item in section 3 (3*10+4)
             let next_element_section = 20 / items_per_section;
             let next_element_offset = (20 % items_per_section.get()) as u32;
             let result = journal.get(next_element_section, next_element_offset).await;
@@ -354,7 +351,7 @@ mod tests {
             let (offset, _) = journal.append(next_element_section, 999).await.unwrap();
             assert_eq!(
                 journal.get(next_element_section, offset).await.unwrap(),
-                Some(999)
+                999
             );
 
             journal.destroy().await.unwrap();
@@ -440,18 +437,18 @@ mod tests {
 
             // Verify data integrity: existing data in retained sections is accessible
             let item = journal.get(1, 0).await.unwrap();
-            assert_eq!(item, Some(100u64)); // First item in section 1 (1*100+0)
+            assert_eq!(item, 100u64); // First item in section 1 (1*100+0)
             let item = journal.get(1, 1).await.unwrap();
-            assert_eq!(item, Some(101)); // Second item in section 1 (1*100+1)
+            assert_eq!(item, 101); // Second item in section 1 (1*100+1)
             let item = journal.get(2, 0).await.unwrap();
-            assert_eq!(item, Some(200)); // First item in section 2 (2*100+0)
+            assert_eq!(item, 200); // First item in section 2 (2*100+0)
             let last_element_section = 19 / items_per_section;
             let last_element_offset = (19 % items_per_section.get()) as u32;
             let item = journal
                 .get(last_element_section, last_element_offset)
                 .await
                 .unwrap();
-            assert_eq!(item, Some(304)); // Last item in section 3 (3*100+4)
+            assert_eq!(item, 304); // Last item in section 3 (3*100+4)
             let next_element_section = 20 / items_per_section;
             let next_element_offset = (20 % items_per_section.get()) as u32;
             let result = journal.get(next_element_section, next_element_offset).await;
@@ -462,7 +459,7 @@ mod tests {
             let (offset, _) = journal.append(next_element_section, 999).await.unwrap();
             assert_eq!(
                 journal.get(next_element_section, offset).await.unwrap(),
-                Some(999)
+                999
             );
 
             journal.destroy().await.unwrap();
@@ -531,18 +528,18 @@ mod tests {
 
             // Verify data integrity in retained sections
             let item = journal.get(1, 0).await.unwrap();
-            assert_eq!(item, Some(1000u64)); // First item in section 1 (1*1000+0)
+            assert_eq!(item, 1000u64); // First item in section 1 (1*1000+0)
             let item = journal.get(1, 1).await.unwrap();
-            assert_eq!(item, Some(1001)); // Second item in section 1 (1*1000+1)
+            assert_eq!(item, 1001); // Second item in section 1 (1*1000+1)
             let item = journal.get(3, 0).await.unwrap();
-            assert_eq!(item, Some(3000)); // First item in section 3 (3*1000+0)
+            assert_eq!(item, 3000); // First item in section 3 (3*1000+0)
             let last_element_section = 17 / items_per_section;
             let last_element_offset = (17 % items_per_section.get()) as u32;
             let item = journal
                 .get(last_element_section, last_element_offset)
                 .await
                 .unwrap();
-            assert_eq!(item, Some(3002)); // Last item in section 3 (3*1000+2)
+            assert_eq!(item, 3002); // Last item in section 3 (3*1000+2)
 
             // Verify that section 3 was properly truncated
             let section_3_size = journal.size(3).await.unwrap();
@@ -555,7 +552,7 @@ mod tests {
 
             // Assert journal can accept new operations
             let (offset, _) = journal.append(3, 999).await.unwrap();
-            assert_eq!(journal.get(3, offset).await.unwrap(), Some(999));
+            assert_eq!(journal.get(3, offset).await.unwrap(), 999);
 
             journal.destroy().await.unwrap();
         });
@@ -669,9 +666,9 @@ mod tests {
 
             // Verify data integrity in retained sections
             let item = journal.get(2, 0).await.unwrap();
-            assert_eq!(item, Some(200u64)); // First item in section 2
+            assert_eq!(item, 200u64); // First item in section 2
             let item = journal.get(3, 4).await.unwrap();
-            assert_eq!(item, Some(304)); // Last element
+            assert_eq!(item, 304); // Last element
             let next_element_section = 4;
             let result = journal.get(next_element_section, 0).await;
             assert!(matches!(result, Err(Error::SectionOutOfRange(4))));
@@ -680,7 +677,7 @@ mod tests {
             let (offset, _) = journal.append(next_element_section, 999).await.unwrap();
             assert_eq!(
                 journal.get(next_element_section, offset).await.unwrap(),
-                Some(999)
+                999
             );
 
             journal.destroy().await.unwrap();
@@ -740,11 +737,11 @@ mod tests {
 
             // Verify data integrity
             let item = journal.get(1, 0).await.unwrap();
-            assert_eq!(item, Some(100u64)); // First item in section 1
+            assert_eq!(item, 100u64); // First item in section 1
             let item = journal.get(1, 1).await.unwrap();
-            assert_eq!(item, Some(101)); // Second item in section 1 (1*100+1)
+            assert_eq!(item, 101); // Second item in section 1 (1*100+1)
             let item = journal.get(1, 3).await.unwrap();
-            assert_eq!(item, Some(103)); // Item at offset 3 in section 1 (1*100+3)
+            assert_eq!(item, 103); // Item at offset 3 in section 1 (1*100+3)
 
             // Verify that section 1 was properly truncated
             let section_1_size = journal.size(1).await.unwrap();
@@ -760,10 +757,7 @@ mod tests {
             // Assert journal can accept new operations
             let mut journal = journal;
             let (offset, _) = journal.append(target_section, 999).await.unwrap();
-            assert_eq!(
-                journal.get(target_section, offset).await.unwrap(),
-                Some(999)
-            );
+            assert_eq!(journal.get(target_section, offset).await.unwrap(), 999);
 
             journal.destroy().await.unwrap();
         });
@@ -879,13 +873,13 @@ mod tests {
                 assert_eq!(section_1_size, 48);
 
                 // Verify the remaining operations are accessible
-                assert_eq!(journal.get(1, 0).await.unwrap(), Some(100)); // section 1, offset 0 = 1*100+0
-                assert_eq!(journal.get(1, 1).await.unwrap(), Some(101)); // section 1, offset 1 = 1*100+1
-                assert_eq!(journal.get(1, 2).await.unwrap(), Some(102)); // section 1, offset 2 = 1*100+2
+                assert_eq!(journal.get(1, 0).await.unwrap(), 100); // section 1, offset 0 = 1*100+0
+                assert_eq!(journal.get(1, 1).await.unwrap(), 101); // section 1, offset 1 = 1*100+1
+                assert_eq!(journal.get(1, 2).await.unwrap(), 102); // section 1, offset 2 = 1*100+2
 
                 // Verify truncated operations are not accessible
                 let result = journal.get(1, 3).await;
-                assert!(result.is_err()); // op at logical loc 8 should be gone
+                assert!(result.is_err());
                 journal.destroy().await.unwrap();
             }
 
@@ -966,12 +960,12 @@ mod tests {
 
             // Verify section 0 is partially present (only item 2)
             assert!(journal.blobs.contains_key(&0));
-            assert_eq!(journal.get(0, 2).await.unwrap(), Some(2u64));
+            assert_eq!(journal.get(0, 2).await.unwrap(), 2u64);
 
             // Verify section 1 is truncated (items 3, 4 only)
             assert!(journal.blobs.contains_key(&1));
-            assert_eq!(journal.get(1, 0).await.unwrap(), Some(3));
-            assert_eq!(journal.get(1, 1).await.unwrap(), Some(4));
+            assert_eq!(journal.get(1, 0).await.unwrap(), 3);
+            assert_eq!(journal.get(1, 1).await.unwrap(), 4);
 
             // item 5 should be inaccessible (truncated)
             let result = journal.get(1, 2).await;
@@ -982,7 +976,7 @@ mod tests {
 
             // Test that new appends work correctly after truncation
             let (offset, _) = journal.append(1, 999).await.unwrap();
-            assert_eq!(journal.get(1, offset).await.unwrap(), Some(999));
+            assert_eq!(journal.get(1, offset).await.unwrap(), 999);
 
             journal.destroy().await.unwrap();
         });

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -459,7 +459,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
 
         let offset = self.locations.read(loc).await?;
         let section = loc / self.log_items_per_section;
-        let op = self.log.get(section, offset).await?.expect("invalid loc");
+        let op = self.log.get(section, offset).await?;
 
         Ok(op.into_value())
     }
@@ -489,7 +489,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         }
 
         let section = loc / self.log_items_per_section;
-        let Some(Variable::Set(k, v)) = self.log.get(section, offset).await? else {
+        let Variable::Set(k, v) = self.log.get(section, offset).await? else {
             panic!("didn't find Set operation at location {loc} and offset {offset}");
         };
 
@@ -605,9 +605,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         for loc in start_loc..=end_loc {
             let section = loc / self.log_items_per_section;
             let offset = self.locations.read(loc).await?;
-            let Some(op) = self.log.get(section, offset).await? else {
-                panic!("no log item at location {loc}");
-            };
+            let op = self.log.get(section, offset).await?;
             ops.push(op);
         }
 
@@ -659,7 +657,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         };
         let section = last_commit / self.log_items_per_section;
         let offset = self.locations.read(last_commit).await?;
-        let Some(Variable::Commit(metadata)) = self.log.get(section, offset).await? else {
+        let Variable::Commit(metadata) = self.log.get(section, offset).await? else {
             unreachable!("no commit operation at location of last commit {last_commit}");
         };
 

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -191,8 +191,7 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
         let record = self
             .journal
             .get_exact(section, location.offset, location.len)
-            .await?
-            .ok_or(Error::RecordCorrupted)?;
+            .await?;
         Ok(Some(record.value))
     }
 
@@ -215,8 +214,7 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
             let record = self
                 .journal
                 .get_exact(section, location.offset, location.len)
-                .await?
-                .ok_or(Error::RecordCorrupted)?;
+                .await?;
 
             // Get key from item
             if record.key.as_ref() == key.as_ref() {

--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -160,8 +160,7 @@ impl<E: Storage + Metrics, V: Codec> Cache<E, V> {
         let record = self
             .journal
             .get_exact(section, location.offset, location.len)
-            .await?
-            .ok_or(Error::RecordCorrupted)?;
+            .await?;
         Ok(Some(record.value))
     }
 

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -785,10 +785,10 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> Freezer<E, K, V> {
     }
 
     /// Get the value for a given [Cursor].
-    async fn get_cursor(&self, cursor: Cursor) -> Result<Option<V>, Error> {
+    async fn get_cursor(&self, cursor: Cursor) -> Result<V, Error> {
         let entry = self.journal.get(cursor.section(), cursor.offset()).await?;
 
-        Ok(Some(entry.value))
+        Ok(entry.value)
     }
 
     /// Get the first value for a given key.
@@ -832,7 +832,7 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> Freezer<E, K, V> {
     /// is much faster to use it than searching for a `key`.
     pub async fn get<'a>(&'a self, identifier: Identifier<'a, K>) -> Result<Option<V>, Error> {
         match identifier {
-            Identifier::Cursor(cursor) => self.get_cursor(cursor).await,
+            Identifier::Cursor(cursor) => self.get_cursor(cursor).await.map(Some),
             Identifier::Key(key) => self.get_key(key).await,
         }
     }

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -787,9 +787,6 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> Freezer<E, K, V> {
     /// Get the value for a given [Cursor].
     async fn get_cursor(&self, cursor: Cursor) -> Result<Option<V>, Error> {
         let entry = self.journal.get(cursor.section(), cursor.offset()).await?;
-        let Some(entry) = entry else {
-            return Ok(None);
-        };
 
         Ok(Some(entry.value))
     }
@@ -808,10 +805,7 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> Freezer<E, K, V> {
         // Follow the linked list chain to find the first matching key
         loop {
             // Get the entry from the variable journal
-            let entry = match self.journal.get(section, offset).await? {
-                Some(entry) => entry,
-                None => unreachable!("missing entry"),
-            };
+            let entry = self.journal.get(section, offset).await?;
 
             // Check if this key matches
             if entry.key.as_ref() == key.as_ref() {

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -48,6 +48,8 @@ pub enum Error {
     ItemTooLarge(usize),
     #[error("already pruned to section: {0}")]
     AlreadyPrunedToSection(u64),
+    #[error("section out of range: {0}")]
+    SectionOutOfRange(u64),
     #[error("usize too small")]
     UsizeTooSmall,
     #[error("offset overflow")]
@@ -56,10 +58,10 @@ pub enum Error {
     UnexpectedSize(u32, u32),
     #[error("missing blob: {0}")]
     MissingBlob(u64),
+    #[error("item out of range: {0}")]
+    ItemOutOfRange(u64),
     #[error("item pruned: {0}")]
     ItemPruned(u64),
-    #[error("invalid item: {0}")]
-    InvalidItem(u64),
     #[error("invalid rewind: {0}")]
     InvalidRewind(u64),
     #[error("compression failed")]

--- a/storage/src/store/mod.rs
+++ b/storage/src/store/mod.rs
@@ -403,7 +403,7 @@ where
         last_commit -= 1;
         let section = last_commit / self.log_items_per_section;
         let offset = self.locations.read(last_commit).await?;
-        let Some(Operation::CommitFloor(metadata, _)) = self.log.get(section, offset).await? else {
+        let Operation::CommitFloor(metadata, _) = self.log.get(section, offset).await? else {
             unreachable!("no commit operation at location of last commit {last_commit}");
         };
 
@@ -657,11 +657,7 @@ where
         let offset = self.locations.read(loc).await?;
 
         // Get the operation from the log at the specified section and offset.
-        let Some(op) = self.log.get(section, offset).await? else {
-            panic!("invalid location {loc}");
-        };
-
-        Ok(op)
+        self.log.get(section, offset).await.map_err(Error::Journal)
     }
 
     /// Updates the snapshot with the new operation location for the given key.

--- a/storage/src/store/operation.rs
+++ b/storage/src/store/operation.rs
@@ -65,6 +65,16 @@ pub enum Keyless<V: Codec> {
     Commit(Option<V>),
 }
 
+impl<V: Codec> Keyless<V> {
+    /// Returns the value (if any) wrapped by this operation.
+    pub fn into_value(self) -> Option<V> {
+        match self {
+            Keyless::Append(value) => Some(value),
+            Keyless::Commit(value) => value,
+        }
+    }
+}
+
 /// An operation applied to an authenticated database with a variable size value.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum Variable<K: Array, V: Codec> {


### PR DESCRIPTION
Our journals respond rather unpredictably when requesting non-existent items. For example, depending on the specific input values, the variable journal might return either None or one of a variety of error types. The fixed journal might return ItemPruned, or instead simply panic if the requested item is out of range.

This PR makes journal reads of non-existent items consistently return either:

- [Section|Item]Pruned, if the requested item/section has been pruned, or
- [Section|Item]OutOfRange, if the requested item/section does not exist.

The only exception is an invalid variable journal section offset, which we clarify will result in error, but the exact type is undefined.

In no circumstances will a request for a non-existent item return "None".
