### PR TITLE
chore(utils): specify msrv of 1.87

### DIFF
--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -3,6 +3,8 @@ name = "commonware-utils"
 edition.workspace = true
 publish = true
 version.workspace = true
+# We use https://doc.rust-lang.org/stable/std/primitive.usize.html#method.unbounded_shr
+rust-version = "1.87"
 license.workspace = true
 description = "Leverage common functionality across multiple primitives."
 readme = "README.md"


### PR DESCRIPTION
(Partially) Closes #1580 

This is needed by the unbounded_shr function that was introduced in https://github.com/commonwarexyz/monorepo/pull/1454

When trying to build `examples/sync`:
```
$ cargo +1.86 build
...
error[E0658]: use of unstable library feature `unbounded_shifts`
   --> utils/src/bitvec.rs:322:51
    |
322 |             n if n < BITS_PER_BLOCK => FULL_BLOCK.unbounded_shr((BITS_PER_BLOCK - n) as u32),
    |                                                   ^^^^^^^^^^^^^
    |
    = note: see issue #129375 <https://github.com/rust-lang/rust/issues/129375> for more information
```

With the msrv mentioned in utils:
```
$ cargo +1.86 build
error: rustc 1.86.0 is not supported by the following package:
  commonware-utils@0.0.62 requires rustc 1.87
```