### PR TITLE
[runtime/deterministic] Cleanup `.clear()`

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -649,7 +649,7 @@ impl Tasks {
 
     /// Drop all active tasks.
     fn clear(&self) {
-        // Drop pending tasks
+        // Clear pending tasks
         let pending: BTreeMap<u128, Weak<Task>> = {
             let mut pending = self.pending.lock().unwrap();
             take(&mut *pending)
@@ -664,7 +664,7 @@ impl Tasks {
             *future.lock().unwrap() = None;
         }
 
-        // Clear the pending queue (already dropped any future it may contain
+        // Clear queue (already dropped any future it may contain
         // when iterating over pending)
         self.queue.lock().unwrap().clear();
     }

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -649,13 +649,11 @@ impl Tasks {
 
     /// Drop all active tasks.
     fn clear(&self) {
-        // Snapshot pending tasks
+        // Drop pending tasks
         let pending: BTreeMap<u128, Weak<Task>> = {
             let mut pending = self.pending.lock().unwrap();
             take(&mut *pending)
         };
-
-        // Drop their futures to release captured resources
         for (_, task) in pending {
             let Some(task) = task.upgrade() else {
                 continue;
@@ -666,7 +664,8 @@ impl Tasks {
             *future.lock().unwrap() = None;
         }
 
-        // Clear the run queue
+        // Clear the pending queue (already dropped any future it may contain
+        // when iterating over pending)
         self.queue.lock().unwrap().clear();
     }
 }


### PR DESCRIPTION
Iterate over pending tasks once (rather than twice)