### PR TITLE
[storage] Add `put_sync` to `Cache`

### DIFF
--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -285,6 +285,14 @@ impl<E: Storage + Metrics, V: Codec> Cache<E, V> {
         Ok(())
     }
 
+    /// Stores an item in the [Cache] and syncs it, plus any other pending writes, to disk.
+    ///
+    /// If the index already exists, the cache is just synced.
+    pub async fn put_sync(&mut self, index: u64, value: V) -> Result<(), Error> {
+        self.put(index, value).await?;
+        self.sync().await
+    }
+
     /// Close the [Cache].
     ///
     /// Any pending writes will be synced prior to closing.


### PR DESCRIPTION
## Overview

Adds a `put_sync` function to `Cache` to align it with the API of `Metadata` / `Archive`.

closes #1555 