### PR TITLE
[ci] Unpin `nightly` in CI workflows

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -11,7 +11,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   UDEPS_VERSION: 0.1.57
-  NIGHTLY_VERSION: nightly-2025-08-10
+  NIGHTLY_VERSION: nightly
 
 jobs:
   Lint:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   FUZZ_VERSION: 0.12.0
-  NIGHTLY_VERSION: nightly-2025-08-10
+  NIGHTLY_VERSION: nightly
 
 jobs:
   Tests:

--- a/runtime/fuzz/fuzz_targets/buffer.rs
+++ b/runtime/fuzz/fuzz_targets/buffer.rs
@@ -89,7 +89,7 @@ fn fuzz(input: FuzzInput) {
 
         let prefill = (input.seed as usize) & 0x0FFF;
         if prefill > 0 && initial_size == 0 {
-            let initial_data: Vec<u8> = (0..prefill).map(|i| (i as u8)).collect();
+            let initial_data: Vec<u8> = (0..prefill).map(|i| i as u8).collect();
             let _ = blob.write_at(initial_data, 0).await;
         }
 


### PR DESCRIPTION
## Overview

Unpins the version of the `nightly` toolchain in CI; The issue with `cargo-udeps` has since been fixed.

Tested w/ `cargo 1.92.0-nightly (24bb93c38 2025-09-10)` + `cargo-udeps 0.1.57`

closes #1392