### PR TITLE
[ci] Improve `no_std` check

### DIFF
--- a/.github/scripts/check_no_std.sh
+++ b/.github/scripts/check_no_std.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+no_std_packages=(
+  commonware-codec
+  commonware-utils
+  commonware-cryptography
+  commonware-storage
+)
+
+for package in "${no_std_packages[@]}"; do
+  build_cmd="cargo build -p $package --no-default-features --target thumbv7em-none-eabihf --release"
+  if [ -n "$CI" ]; then
+    echo "::group::$build_cmd"
+  else
+    printf "\n%s:\n  %s\n" "$package" "$build_cmd"
+  fi
+
+  $build_cmd && du -h "target/thumbv7em-none-eabihf/release/lib${package//-/_}.rlib"
+
+  if [ -n "$CI" ]; then
+    echo "::endgroup::"
+  fi
+done

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -57,6 +57,8 @@ jobs:
           - os: ubuntu-latest
             flags: "--features commonware-runtime/iouring-network"
           - os: ubuntu-latest
+            flags: "--no-default-features"
+          - os: ubuntu-latest
             flags: ""
           - os: windows-latest
             flags: ""
@@ -152,14 +154,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-arm-none-eabi
-    - name: Build and test codec
-      run: cargo build -p commonware-codec --no-default-features --target thumbv7em-none-eabihf --release && du -h target/thumbv7em-none-eabihf/release/libcommonware_codec.rlib && cargo test -p commonware-codec --no-default-features --verbose
-    - name: Build utils
-      run: cargo build -p commonware-utils --no-default-features --target thumbv7em-none-eabihf --release && du -h target/thumbv7em-none-eabihf/release/libcommonware_utils.rlib
-    - name: Build cryptography
-      run: cargo build -p commonware-cryptography --no-default-features --target thumbv7em-none-eabihf --release && du -h target/thumbv7em-none-eabihf/release/libcommonware_cryptography.rlib
-    - name: Build storage
-      run: cargo build -p commonware-storage --no-default-features --target thumbv7em-none-eabihf --release && du -h target/thumbv7em-none-eabihf/release/libcommonware_storage.rlib
+    - name: Check no_std compatibility
+      run: ./.github/scripts/check_no_std.sh
 
   Unsafe:
     runs-on: ubuntu-latest

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -29,6 +29,8 @@ jobs:
           - os: ubuntu-latest
             flags: "--features commonware-runtime/iouring-network"
           - os: ubuntu-latest
+            flags: "--no-default-features"
+          - os: ubuntu-latest
             flags: ""
           - os: windows-latest
             flags: ""


### PR DESCRIPTION
## Overview

Improves the `no_std` check in CI. Adding more `no_std` packages to be tested in CI is now a 1-line change, and contributors can run the comprehensive `no_std` build check locally by invoking the script.

Also extends the `tests` job to test _all_ crates with `--no-default-features`. Previously, only `commonware-codec` was tested without default features enabled.