### PR TITLE
[storage/mmr] improve panic error messages

### DIFF
--- a/storage/src/mmr/iterator.rs
+++ b/storage/src/mmr/iterator.rs
@@ -44,7 +44,9 @@ impl PeakIterator {
             return 0;
         }
 
-        let last_peak = PeakIterator::new(size).last().unwrap();
+        let last_peak = PeakIterator::new(size)
+            .last()
+            .expect("PeakIterator has at least one peak when size > 0");
         last_peak.0 - last_peak.1 as u64
     }
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -445,7 +445,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             let Ok(digest) = digest else {
                 error!(
                     pos,
-                    err = %digest.err().unwrap(),
+                    err = %digest.expect_err("digest is Err in else branch"),
                     "could not convert node from metadata bytes to digest"
                 );
                 return Err(Error::MissingNode(pos));

--- a/storage/src/mmr/proof.rs
+++ b/storage/src/mmr/proof.rs
@@ -584,14 +584,20 @@ where
     }
 
     if let Some(ref mut collected_digests) = collected_digests {
-        collected_digests.push((left_pos, left_digest.unwrap()));
-        collected_digests.push((right_pos, right_digest.unwrap()));
+        collected_digests.push((
+            left_pos,
+            left_digest.expect("left_digest guaranteed to be Some after checks above"),
+        ));
+        collected_digests.push((
+            right_pos,
+            right_digest.expect("right_digest guaranteed to be Some after checks above"),
+        ));
     }
 
     Ok(hasher.node_digest(
         range_info.pos,
-        &left_digest.unwrap(),
-        &right_digest.unwrap(),
+        &left_digest.expect("left_digest guaranteed to be Some after checks above"),
+        &right_digest.expect("right_digest guaranteed to be Some after checks above"),
     ))
 }
 


### PR DESCRIPTION
Changes various unwraps() to expect() with appropriate error messages should they ever trigger.

Also adds assertion to clarify overflow condition in destination_pos.

related: https://github.com/commonwarexyz/monorepo/issues/1604
