### PR TITLE
[ci] Use `taiki-e/install-action`

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -111,15 +111,10 @@ jobs:
       run: echo "rust_version=$(rustc +${{ env.NIGHTLY_VERSION }} --version)" >> "$GITHUB_OUTPUT"
     - name: Run setup
       uses: ./.github/actions/setup
-    - name: Cache cargo-udeps
-      id: cargo-udeps-cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/bin/cargo-udeps
-        key: ${{ runner.os }}-${{ env.UDEPS_VERSION }}-cargo-udeps-${{ steps.rust-version.outputs.rust_version }}
     - name: Install cargo-udeps
-      if: steps.cargo-udeps-cache.outputs.cache-hit != 'true'
-      run: cargo +${{ env.NIGHTLY_VERSION }} install cargo-udeps --version ${{ env.UDEPS_VERSION }}
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-udeps@${{ env.UDEPS_VERSION }}
     - name: Check for unused dependencies
       run: cargo +${{ env.NIGHTLY_VERSION }} udeps --all-targets
 


### PR DESCRIPTION
## Overview

Small cleanup to CI - uses `taiki-e/install-action` rather than manually installing and caching binaries from the `crates.io` registry.

_note_: `cargo-fuzz` is still built manually + cached, since it only distributes an `x86_64-unknown-linux-musl` binary (https://github.com/rust-fuzz/cargo-fuzz/releases/tag/0.12.0). We could use this with the existing runner, but would need to adjust the fuzz tests to also run with `musl` rather than `libc`; doesn't seem very desirable imo.

closes #1612 