### PR TITLE
[ci] Use `cargo-nextest` for `Fast`/`Slow` Tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  All:
+  Coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -47,6 +47,7 @@ jobs:
         RUSTDOCFLAGS: "-D warnings"
 
   Tests:
+    name: "Tests (os: ${{ matrix.os }}, flags: \"${{ matrix.flags }}\") (partition: ${{ matrix.partition }}/2)"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -54,23 +55,49 @@ jobs:
         include:
           - os: ubuntu-latest
             flags: "--features commonware-runtime/iouring-storage"
+            partition: 1
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-storage"
+            partition: 2
           - os: ubuntu-latest
             flags: "--features commonware-runtime/iouring-network"
+            partition: 1
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-network"
+            partition: 2
           - os: ubuntu-latest
             flags: "--no-default-features"
+            partition: 1
+          - os: ubuntu-latest
+            flags: "--no-default-features"
+            partition: 2
           - os: ubuntu-latest
             flags: ""
+            partition: 1
+          - os: ubuntu-latest
+            flags: ""
+            partition: 2
           - os: windows-latest
             flags: ""
+            partition: 1
+          - os: windows-latest
+            flags: ""
+            partition: 2
           - os: macos-latest
             flags: ""
+            partition: 1
+          - os: macos-latest
+            flags: ""
+            partition: 2
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Run setup
       uses: ./.github/actions/setup
+    - name: Install nextest
+      uses: taiki-e/install-action@cargo-nextest
     - name: Run tests
-      run: cargo test ${{ matrix.flags }} --verbose
+      run: cargo nextest run ${{ matrix.flags }} --partition hash:${{matrix.partition}}/2 --verbose
 
   Dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -52,43 +52,28 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-storage"
-            partition: 1
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-storage"
-            partition: 2
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-network"
-            partition: 1
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-network"
-            partition: 2
-          - os: ubuntu-latest
-            flags: "--no-default-features"
-            partition: 1
-          - os: ubuntu-latest
-            flags: "--no-default-features"
-            partition: 2
-          - os: ubuntu-latest
-            flags: ""
-            partition: 1
-          - os: ubuntu-latest
-            flags: ""
-            partition: 2
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        partition: [1, 2]
+        flags:
+          - "--features commonware-runtime/iouring-storage"
+          - "--features commonware-runtime/iouring-network"
+          - "--no-default-features"
+          - ""
+        exclude:
+          # Only run io_uring features on Ubuntu
           - os: windows-latest
-            flags: ""
-            partition: 1
+            flags: "--features commonware-runtime/iouring-storage"
+          - os: macos-latest
+            flags: "--features commonware-runtime/iouring-storage"
           - os: windows-latest
-            flags: ""
-            partition: 2
+            flags: "--features commonware-runtime/iouring-network"
           - os: macos-latest
-            flags: ""
-            partition: 1
+            flags: "--features commonware-runtime/iouring-network"
+          # Only run --no-default-features on Ubuntu
+          - os: windows-latest
+            flags: "--no-default-features"
           - os: macos-latest
-            flags: ""
-            partition: 2
+            flags: "--no-default-features"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -98,6 +83,20 @@ jobs:
       uses: taiki-e/install-action@cargo-nextest
     - name: Run tests
       run: cargo nextest run ${{ matrix.flags }} --partition hash:${{matrix.partition}}/2 --verbose
+
+  Tests-Gate:
+    name: "Fast-Tests"
+    runs-on: ubuntu-latest
+    needs: Tests
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.Tests.result }}" != "success" ]; then
+            echo "Tests failed or were cancelled"
+            exit 1
+          fi
+          echo "All tests passed successfully!"
 
   Dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -24,79 +24,28 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-storage"
-            partition: 1
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-storage"
-            partition: 2
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-storage"
-            partition: 3
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-storage"
-            partition: 4
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-network"
-            partition: 1
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-network"
-            partition: 2
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-network"
-            partition: 3
-          - os: ubuntu-latest
-            flags: "--features commonware-runtime/iouring-network"
-            partition: 4
-          - os: ubuntu-latest
-            flags: "--no-default-features"
-            partition: 1
-          - os: ubuntu-latest
-            flags: "--no-default-features"
-            partition: 2
-          - os: ubuntu-latest
-            flags: "--no-default-features"
-            partition: 3
-          - os: ubuntu-latest
-            flags: "--no-default-features"
-            partition: 4
-          - os: ubuntu-latest
-            flags: ""
-            partition: 1
-          - os: ubuntu-latest
-            flags: ""
-            partition: 2
-          - os: ubuntu-latest
-            flags: ""
-            partition: 3
-          - os: ubuntu-latest
-            flags: ""
-            partition: 4
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        partition: [1, 2, 3, 4]
+        flags:
+          - "--features commonware-runtime/iouring-storage"
+          - "--features commonware-runtime/iouring-network"
+          - "--no-default-features"
+          - ""
+        exclude:
+          # Only run io_uring features on Ubuntu
           - os: windows-latest
-            flags: ""
-            partition: 1
+            flags: "--features commonware-runtime/iouring-storage"
+          - os: macos-latest
+            flags: "--features commonware-runtime/iouring-storage"
           - os: windows-latest
-            flags: ""
-            partition: 2
+            flags: "--features commonware-runtime/iouring-network"
+          - os: macos-latest
+            flags: "--features commonware-runtime/iouring-network"
+          # Only run --no-default-features on Ubuntu
           - os: windows-latest
-            flags: ""
-            partition: 3
-          - os: windows-latest
-            flags: ""
-            partition: 4
+            flags: "--no-default-features"
           - os: macos-latest
-            flags: ""
-            partition: 1
-          - os: macos-latest
-            flags: ""
-            partition: 2
-          - os: macos-latest
-            flags: ""
-            partition: 3
-          - os: macos-latest
-            flags: ""
-            partition: 4
+            flags: "--no-default-features"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -106,6 +55,20 @@ jobs:
       uses: taiki-e/install-action@cargo-nextest
     - name: Run ignored tests
       run: cargo nextest run ${{ matrix.flags }} --partition hash:${{matrix.partition}}/4 --verbose -- --ignored
+
+  Tests-Gate:
+    name: "Slow-Tests"
+    runs-on: ubuntu-latest
+    needs: Tests
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.Tests.result }}" != "success" ]; then
+            echo "Tests failed or were cancelled"
+            exit 1
+          fi
+          echo "All tests passed successfully!"
 
   Benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   Tests:
+    name: "Tests (os: ${{ matrix.os }}, flags: \"${{ matrix.flags }}\") (partition: ${{ matrix.partition }}/4)"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
     strategy:
@@ -26,23 +27,85 @@ jobs:
         include:
           - os: ubuntu-latest
             flags: "--features commonware-runtime/iouring-storage"
+            partition: 1
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-storage"
+            partition: 2
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-storage"
+            partition: 3
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-storage"
+            partition: 4
           - os: ubuntu-latest
             flags: "--features commonware-runtime/iouring-network"
+            partition: 1
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-network"
+            partition: 2
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-network"
+            partition: 3
+          - os: ubuntu-latest
+            flags: "--features commonware-runtime/iouring-network"
+            partition: 4
           - os: ubuntu-latest
             flags: "--no-default-features"
+            partition: 1
+          - os: ubuntu-latest
+            flags: "--no-default-features"
+            partition: 2
+          - os: ubuntu-latest
+            flags: "--no-default-features"
+            partition: 3
+          - os: ubuntu-latest
+            flags: "--no-default-features"
+            partition: 4
           - os: ubuntu-latest
             flags: ""
+            partition: 1
+          - os: ubuntu-latest
+            flags: ""
+            partition: 2
+          - os: ubuntu-latest
+            flags: ""
+            partition: 3
+          - os: ubuntu-latest
+            flags: ""
+            partition: 4
           - os: windows-latest
             flags: ""
+            partition: 1
+          - os: windows-latest
+            flags: ""
+            partition: 2
+          - os: windows-latest
+            flags: ""
+            partition: 3
+          - os: windows-latest
+            flags: ""
+            partition: 4
           - os: macos-latest
             flags: ""
+            partition: 1
+          - os: macos-latest
+            flags: ""
+            partition: 2
+          - os: macos-latest
+            flags: ""
+            partition: 3
+          - os: macos-latest
+            flags: ""
+            partition: 4
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Run setup
       uses: ./.github/actions/setup
+    - name: Install nextest
+      uses: taiki-e/install-action@cargo-nextest
     - name: Run ignored tests
-      run: cargo test ${{ matrix.flags }} --verbose -- --ignored
+      run: cargo nextest run ${{ matrix.flags }} --partition hash:${{matrix.partition}}/4 --verbose -- --ignored
 
   Benchmarks:
     runs-on: ubuntu-latest
@@ -51,24 +114,14 @@ jobs:
         include:
           - package: commonware-cryptography
             cargo_flags: ""
-            file_suffix: ""
-            benchmark_name: "commonware-cryptography"
           - package: commonware-storage
             cargo_flags: ""
-            file_suffix: ""
-            benchmark_name: "commonware-storage"
           - package: commonware-storage
             cargo_flags: "--features commonware-runtime/iouring-storage" # Additional features can be added here
-            file_suffix: "-features"
-            benchmark_name: "commonware-storage --features"
           - package: commonware-stream
             cargo_flags: ""
-            file_suffix: ""
-            benchmark_name: "commonware-stream"
           - package: commonware-coding
             cargo_flags: ""
-            file_suffix: ""
-            benchmark_name: "commonware-coding"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -8,7 +8,6 @@ use commonware_cryptography::{
 use commonware_utils::quorum;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use std::{collections::HashMap, hint::black_box};
 
 // Configure contributors based on context
@@ -50,18 +49,15 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
         for (dealer_idx, dealer) in contributors.iter().take(t as usize).enumerate() {
             let (_, commitment, shares) =
                 Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
-            players
-                .par_iter_mut()
-                .enumerate()
-                .for_each(|(player_idx, player)| {
-                    player
-                        .share(
-                            dealer.clone(),
-                            commitment.clone(),
-                            shares[player_idx].clone(),
-                        )
-                        .unwrap();
-                });
+            for (player_idx, player) in players.iter_mut().enumerate() {
+                player
+                    .share(
+                        dealer.clone(),
+                        commitment.clone(),
+                        shares[player_idx].clone(),
+                    )
+                    .unwrap();
+            }
             commitments.insert(dealer_idx as u32, commitment);
         }
 

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -8,6 +8,7 @@ use commonware_cryptography::{
 use commonware_utils::quorum;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use std::{collections::HashMap, hint::black_box};
 
 // Configure contributors based on context
@@ -49,15 +50,18 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
         for (dealer_idx, dealer) in contributors.iter().take(t as usize).enumerate() {
             let (_, commitment, shares) =
                 Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
-            for (player_idx, player) in players.iter_mut().enumerate() {
-                player
-                    .share(
-                        dealer.clone(),
-                        commitment.clone(),
-                        shares[player_idx].clone(),
-                    )
-                    .unwrap();
-            }
+            players
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(player_idx, player)| {
+                    player
+                        .share(
+                            dealer.clone(),
+                            commitment.clone(),
+                            shares[player_idx].clone(),
+                        )
+                        .unwrap();
+                });
             commitments.insert(dealer_idx as u32, commitment);
         }
 

--- a/storage/src/adb/benches/fixed_generate.rs
+++ b/storage/src/adb/benches/fixed_generate.rs
@@ -92,7 +92,6 @@ type AnyDb = Any<Context, <Sha256 as Hasher>::Digest, <Sha256 as Hasher>::Digest
 
 /// Benchmark the generation of a large randomly generated any db.
 fn bench_fixed_generate(c: &mut Criterion) {
-    tracing_subscriber::fmt().try_init().ok();
     let cfg = Config::default();
     let runner = tokio::Runner::new(cfg.clone());
     for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 2] {

--- a/storage/src/adb/benches/keyless_generate.rs
+++ b/storage/src/adb/benches/keyless_generate.rs
@@ -77,7 +77,6 @@ type KeylessDb = Keyless<Context, Vec<u8>, Sha256>;
 
 /// Benchmark the generation of a large randomly generated keyless db.
 fn bench_keyless_generate(c: &mut Criterion) {
-    tracing_subscriber::fmt().try_init().ok();
     let cfg = Config::default();
     let runner = tokio::Runner::new(cfg.clone());
     for operations in [NUM_OPERATIONS, NUM_OPERATIONS * 2] {

--- a/storage/src/adb/benches/variable_generate.rs
+++ b/storage/src/adb/benches/variable_generate.rs
@@ -98,7 +98,6 @@ type AnyDb = Any<Context, <Sha256 as Hasher>::Digest, Vec<u8>, Sha256, EightCap>
 
 /// Benchmark the generation of a large randomly generated any db.
 fn bench_variable_generate(c: &mut Criterion) {
-    tracing_subscriber::fmt().try_init().ok();
     let cfg = Config::default();
     let runner = tokio::Runner::new(cfg.clone());
     for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 2] {


### PR DESCRIPTION
## Overview

Switches CI's test runner over to `cargo-nextest`.

### Performance

For the `Fast` tests ([`nextest` w/ 2 partitions](https://github.com/commonwarexyz/monorepo/actions/runs/17742610001/job/50420087520) vs. [`cargo test`](https://github.com/commonwarexyz/monorepo/actions/runs/17742291236/job/50419045877)), shaves:
*  `3m47s` off of the `ubuntu-latest` tests
* `6m35s` off of the `windows-latest` tests
* `3m31s` off of the `macos-latest` tests 

For the `Slow` tests ([`nextest` w/ 4 partitions](https://github.com/commonwarexyz/monorepo/actions/runs/17742610001/job/50420087520) vs. [`cargo test`](https://github.com/commonwarexyz/monorepo/actions/runs/17722980678/job/50358490051)), shaves:
* `31m49s` off of the `ubuntu-latest` tests
* `31m56s` off of the `windows-latest` tests
* `36m5s` off of the `macos-latest` tests
