### PR TITLE
[runtime] Clarifying documentation for the `Signal` future

### DIFF
--- a/runtime/src/utils/signal.rs
+++ b/runtime/src/utils/signal.rs
@@ -43,6 +43,10 @@ use std::{
 /// a performance regression from introducing `Signaler`, it is recommended
 /// to wait on a reference to `Signal` (i.e. `&mut signal`).
 ///
+/// _Note: Polling the same `Signal` after it has resolved will always panic.
+/// When waiting on a reference to a `Signal`, ensure it is either fused
+/// or not polled again after it has yielded a result._
+///
 /// ```rust
 /// use commonware_macros::select;
 /// use commonware_runtime::{Clock, Spawner, Runner, deterministic, Metrics, signal::Signaler};


### PR DESCRIPTION
## Overview

Adds clarifying documentation for the `Signal` future's example.

As an example, failing to break out of a `select!` after a reference to a `Signal` future resolves will cause the program to panic:

```rs
#[test]
fn repoll_cancellation_token() {
    use crate::{
        signal::Signal, tokio::Runner as TokioRunner, Clock, Metrics, Runner, Spawner,
    };
    use std::time::Duration;

    let runner = TokioRunner::default();
    runner.start(|ctx| async move {
        let child = ctx.with_label("task_b").spawn(|ctx| async move {
            let stopped = &mut ctx.stopped();
            assert!(matches!(stopped, Signal::Open(_)));

            loop {
                commonware_macros::select! {
                    _ = futures::future::pending::<()>() => {
                        dbg!("Pending future impossibly resolved");
                    },
                    _ = stopped => {
                        dbg!("task b stopped successfully");
                        // Deliberately continue loop - `stopped` will be re-polled.
                    },
                }
            }
        });

        ctx.sleep(Duration::from_millis(100)).await;
        ctx.stop(0, None).await.unwrap();
        child.await.unwrap();
    });
}
```