### PR TITLE
[adb::sync] Add `sync::Target::read_cfg` validation

### DIFF
--- a/storage/src/adb/sync/target.rs
+++ b/storage/src/adb/sync/target.rs
@@ -35,7 +35,7 @@ impl<D: Digest> Read for Target<D> {
         let upper_bound_ops = u64::read(buf)?;
         if lower_bound_ops > upper_bound_ops {
             return Err(CodecError::Invalid(
-                "storage::adb::sync::target",
+                "storage::adb::sync::Target",
                 "lower_bound_ops > upper_bound_ops",
             ));
         }


### PR DESCRIPTION
Error on deserializing an invalid target where lower bound > upper bound