### PR TITLE
[storage] Tune benchmarks down in CI tests

### DIFF
--- a/storage/src/adb/benches/current_init.rs
+++ b/storage/src/adb/benches/current_init.rs
@@ -41,6 +41,16 @@ const MULTI_THREADED: usize = 8;
 /// current::grafting_height()) and a multiple of digest size.
 const CHUNK_SIZE: usize = 32;
 
+cfg_if::cfg_if! {
+    if #[cfg(test)] {
+        const ELEMENTS: [u64; 1] = [NUM_ELEMENTS];
+        const OPERATIONS: [u64; 1] = [NUM_OPERATIONS];
+    } else {
+        const ELEMENTS: [u64; 2] = [NUM_ELEMENTS, NUM_ELEMENTS * 2];
+        const OPERATIONS: [u64; 2] = [NUM_OPERATIONS, NUM_OPERATIONS * 2];
+    }
+}
+
 fn current_cfg(pool: Option<ThreadPool>) -> CConfig<EightCap> {
     CConfig::<EightCap> {
         mmr_journal_partition: format!("journal_{PARTITION_SUFFIX}"),
@@ -115,9 +125,8 @@ type CurrentDb = Current<
 fn bench_current_init(c: &mut Criterion) {
     let cfg = Config::default();
     let runner = tokio::Runner::new(cfg.clone());
-
-    for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 2] {
-        for operations in [NUM_OPERATIONS, NUM_OPERATIONS * 2] {
+    for elements in ELEMENTS {
+        for operations in OPERATIONS {
             for (multithreaded_name, threads) in [("off", SINGLE_THREADED), ("on", MULTI_THREADED)]
             {
                 gen_random_current(cfg.clone(), elements, operations, threads);

--- a/storage/src/adb/benches/fixed_init.rs
+++ b/storage/src/adb/benches/fixed_init.rs
@@ -33,6 +33,16 @@ const PAGE_CACHE_SIZE: usize = 10_000;
 /// timing itself since any::init is single threaded.
 const THREADS: usize = 8;
 
+cfg_if::cfg_if! {
+    if #[cfg(test)] {
+        const ELEMENTS: [u64; 1] = [NUM_ELEMENTS];
+        const OPERATIONS: [u64; 1] = [NUM_OPERATIONS];
+    } else {
+        const ELEMENTS: [u64; 2] = [NUM_ELEMENTS, NUM_ELEMENTS * 2];
+        const OPERATIONS: [u64; 2] = [NUM_OPERATIONS, NUM_OPERATIONS * 2];
+    }
+}
+
 fn any_cfg(pool: ThreadPool) -> AConfig<EightCap> {
     AConfig::<EightCap> {
         mmr_journal_partition: format!("journal_{PARTITION_SUFFIX}"),
@@ -95,8 +105,8 @@ type AnyDb = Any<Context, <Sha256 as Hasher>::Digest, <Sha256 as Hasher>::Digest
 fn bench_fixed_init(c: &mut Criterion) {
     let cfg = Config::default();
     let runner = tokio::Runner::new(cfg.clone());
-    for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 2] {
-        for operations in [NUM_OPERATIONS, NUM_OPERATIONS * 2] {
+    for elements in ELEMENTS {
+        for operations in OPERATIONS {
             gen_random_any(cfg.clone(), elements, operations);
 
             c.bench_function(

--- a/storage/src/adb/benches/variable_init.rs
+++ b/storage/src/adb/benches/variable_init.rs
@@ -36,6 +36,16 @@ const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10_000);
 /// timing itself since any::init is single threaded.
 const THREADS: usize = 8;
 
+cfg_if::cfg_if! {
+    if #[cfg(test)] {
+        const ELEMENTS: [u64; 1] = [NUM_ELEMENTS];
+        const OPERATIONS: [u64; 1] = [NUM_OPERATIONS];
+    } else {
+        const ELEMENTS: [u64; 2] = [NUM_ELEMENTS, NUM_ELEMENTS * 2];
+        const OPERATIONS: [u64; 2] = [NUM_OPERATIONS, NUM_OPERATIONS * 2];
+    }
+}
+
 fn any_cfg(pool: ThreadPool) -> AConfig<EightCap, (commonware_codec::RangeCfg, ())> {
     AConfig::<EightCap, (commonware_codec::RangeCfg, ())> {
         mmr_journal_partition: format!("journal_{PARTITION_SUFFIX}"),
@@ -102,8 +112,8 @@ type AnyDb = Any<Context, <Sha256 as Hasher>::Digest, Vec<u8>, Sha256, EightCap>
 fn bench_variable_init(c: &mut Criterion) {
     let cfg = Config::default();
     let runner = tokio::Runner::new(cfg.clone());
-    for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 2] {
-        for operations in [NUM_OPERATIONS, NUM_OPERATIONS * 2] {
+    for elements in ELEMENTS {
+        for operations in OPERATIONS {
             gen_random_any(cfg.clone(), elements, operations);
 
             c.bench_function(

--- a/storage/src/index/benches/hashmap_insert.rs
+++ b/storage/src/index/benches/hashmap_insert.rs
@@ -2,6 +2,11 @@ use criterion::{criterion_group, BatchSize, Criterion};
 use rand::Rng;
 use std::collections::HashMap;
 
+#[cfg(test)]
+const N_ITEMS: [usize; 1] = [100_000];
+#[cfg(not(test))]
+const N_ITEMS: [usize; 3] = [100_000, 1_000_000, 10_000_000];
+
 struct MockIndex {
     _section: u64,
     _offset: u32,
@@ -10,7 +15,7 @@ struct MockIndex {
 }
 
 fn benchmark_hashmap_insert(c: &mut Criterion) {
-    for n in [100_000, 1_000_000, 10_000_000] {
+    for n in N_ITEMS {
         for k in [4, 8, 16, 32] {
             c.bench_function(&format!("{}/n={} k={}", module_path!(), n, k), |b| {
                 b.iter_batched(

--- a/storage/src/index/benches/hashmap_insert_fixed.rs
+++ b/storage/src/index/benches/hashmap_insert_fixed.rs
@@ -2,6 +2,11 @@ use criterion::{criterion_group, BatchSize, Criterion};
 use rand::Rng;
 use std::collections::HashMap;
 
+#[cfg(test)]
+const N_ITEMS: [usize; 1] = [100_000];
+#[cfg(not(test))]
+const N_ITEMS: [usize; 3] = [100_000, 1_000_000, 10_000_000];
+
 struct MockIndex {
     _section: u64,
     _offset: u32,
@@ -10,7 +15,7 @@ struct MockIndex {
 }
 
 fn benchmark_hashmap_insert_fixed(c: &mut Criterion) {
-    for n in [100_000, 1_000_000, 10_000_000] {
+    for n in N_ITEMS {
         c.bench_function(&format!("{}/n={} k={}", module_path!(), n, 4), |b| {
             b.iter_batched(
                 || {

--- a/storage/src/index/benches/hashmap_iteration.rs
+++ b/storage/src/index/benches/hashmap_iteration.rs
@@ -2,6 +2,11 @@ use criterion::{black_box, criterion_group, BatchSize, Criterion};
 use rand::Rng;
 use std::collections::HashMap;
 
+#[cfg(test)]
+const N_ITEMS: [usize; 1] = [100_000];
+#[cfg(not(test))]
+const N_ITEMS: [usize; 3] = [100_000, 1_000_000, 10_000_000];
+
 struct MockIndex {
     section: u64,
     _offset: u32,
@@ -10,7 +15,7 @@ struct MockIndex {
 }
 
 fn benchmark_hashmap_iteration(c: &mut Criterion) {
-    for n in [100_000, 1_000_000, 10_000_000] {
+    for n in N_ITEMS {
         for k in [4, 8, 16, 32] {
             c.bench_function(&format!("{}/n={} k={}", module_path!(), n, k), |b| {
                 b.iter_batched(

--- a/storage/src/index/benches/insert.rs
+++ b/storage/src/index/benches/insert.rs
@@ -6,6 +6,11 @@ use prometheus_client::registry::Metric;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
+const N_ITEMS: [usize; 2] = [10_000, 50_000];
+#[cfg(not(test))]
+const N_ITEMS: [usize; 5] = [10_000, 50_000, 100_000, 500_000, 1_000_000];
+
 #[derive(Clone)]
 struct DummyMetrics;
 
@@ -26,7 +31,7 @@ impl Metrics for DummyMetrics {
 }
 
 fn bench_insert(c: &mut Criterion) {
-    for items in [10_000, 50_000, 100_000, 500_000, 1_000_000] {
+    for items in N_ITEMS {
         let label = format!("{}/items={}", module_path!(), items,);
         c.bench_function(&label, |b| {
             b.iter_custom(move |iters| {

--- a/storage/src/mmr/benches/append.rs
+++ b/storage/src/mmr/benches/append.rs
@@ -4,8 +4,13 @@ use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, SeedableRng};
 
+#[cfg(test)]
+const N_LEAVES: [usize; 2] = [10_000, 100_000];
+#[cfg(not(test))]
+const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000];
+
 fn bench_append(c: &mut Criterion) {
-    for n in [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000] {
+    for n in N_LEAVES {
         // Generate random elements
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);

--- a/storage/src/mmr/benches/append_additional.rs
+++ b/storage/src/mmr/benches/append_additional.rs
@@ -4,8 +4,13 @@ use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, SeedableRng};
 
+#[cfg(test)]
+const N_LEAVES: [usize; 2] = [10_000, 100_000];
+#[cfg(not(test))]
+const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000];
+
 fn bench_append_additional(c: &mut Criterion) {
-    for n in [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000] {
+    for n in N_LEAVES {
         // Generate random elements
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -6,8 +6,13 @@ use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
 const SAMPLE_SIZE: usize = 100;
 
+#[cfg(test)]
+const N_LEAVES: [usize; 2] = [10_000, 100_000];
+#[cfg(not(test))]
+const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000];
+
 fn bench_prove_many_elements(c: &mut Criterion) {
-    for n in [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000] {
+    for n in N_LEAVES {
         // Populate MMR
         let mut mmr = Mmr::<Sha256>::new();
         let mut positions = Vec::with_capacity(n);

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -6,8 +6,13 @@ use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
 const SAMPLE_SIZE: usize = 100;
 
+#[cfg(test)]
+const N_LEAVES: [usize; 2] = [10_000, 100_000];
+#[cfg(not(test))]
+const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000];
+
 fn bench_prove_single_element(c: &mut Criterion) {
-    for n in [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000] {
+    for n in N_LEAVES {
         // Populate MMR
         let mut mmr = Mmr::<Sha256>::new();
         let mut elements = Vec::with_capacity(n);

--- a/storage/src/mmr/benches/update.rs
+++ b/storage/src/mmr/benches/update.rs
@@ -23,12 +23,17 @@ enum Strategy {
 /// returns start diminishing.
 const THREADS: usize = 8;
 
+#[cfg(test)]
+const N_LEAVES: [usize; 1] = [100_000];
+#[cfg(not(test))]
+const N_LEAVES: [usize; 4] = [100_000, 1_000_000, 5_000_000, 10_000_000];
+
 /// Benchmark the performance of randomly updating leaves in an MMR.
 fn bench_update(c: &mut Criterion) {
     let cfg = Config::default();
     let runner = tokio::Runner::new(cfg);
     for updates in [1_000_000, 100_000] {
-        for leaves in [100_000, 1_000_000, 5_000_000, 10_000_000] {
+        for leaves in N_LEAVES {
             for strategy in [
                 Strategy::NoBatching,
                 Strategy::BatchedSerial,
@@ -59,9 +64,9 @@ fn bench_update(c: &mut Criterion) {
                                 }
                                 _ => Mmr::<Sha256>::new(),
                             };
-                            let mut elements = Vec::with_capacity(leaves as usize);
+                            let mut elements = Vec::with_capacity(leaves);
                             let mut sampler = StdRng::seed_from_u64(0);
-                            let mut leaf_positions = Vec::with_capacity(leaves as usize);
+                            let mut leaf_positions = Vec::with_capacity(leaves);
                             let mut h = StandardHasher::new();
 
                             // Append random elements to MMR
@@ -79,7 +84,7 @@ fn bench_update(c: &mut Criterion) {
                             let mut leaf_map = HashMap::new();
                             for _ in 0..updates {
                                 let rand_leaf_num = sampler.gen_range(0..leaves);
-                                let rand_leaf_pos = leaf_positions[rand_leaf_num as usize];
+                                let rand_leaf_pos = leaf_positions[rand_leaf_num];
                                 let rand_leaf_swap = sampler.gen_range(0..elements.len());
                                 let new_element = &elements[rand_leaf_swap];
                                 leaf_map.insert(rand_leaf_pos, *new_element);

--- a/storage/src/store/benches/restart.rs
+++ b/storage/src/store/benches/restart.rs
@@ -30,6 +30,16 @@ const PAGE_SIZE: NonZeroUsize = NZUsize!(16_384);
 /// The number of pages to cache in the buffer pool.
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10_000);
 
+cfg_if::cfg_if! {
+    if #[cfg(test)] {
+        const ELEMENTS: [u64; 1] = [NUM_ELEMENTS];
+        const OPERATIONS: [u64; 1] = [NUM_OPERATIONS];
+    } else {
+        const ELEMENTS: [u64; 2] = [NUM_ELEMENTS, NUM_ELEMENTS * 2];
+        const OPERATIONS: [u64; 2] = [NUM_OPERATIONS, NUM_OPERATIONS * 2];
+    }
+}
+
 fn store_cfg() -> SConfig<EightCap, ()> {
     SConfig::<EightCap, ()> {
         log_journal_partition: format!("log_{PARTITION_SUFFIX}"),
@@ -91,8 +101,8 @@ type StoreDb = Store<Context, <Sha256 as Hasher>::Digest, <Sha256 as Hasher>::Di
 fn bench_restart(c: &mut Criterion) {
     let cfg = Config::default();
     let runner = tokio::Runner::new(cfg.clone());
-    for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 2] {
-        for operations in [NUM_OPERATIONS, NUM_OPERATIONS * 2] {
+    for elements in ELEMENTS {
+        for operations in OPERATIONS {
             // Create a large store db.
             gen_random_store(cfg.clone(), elements, operations);
 


### PR DESCRIPTION
## Overview

Requested by @patrick-ogrady, tunes down the `commonware-storage` benchmarks when running in test mode.