### PR TITLE
[consensus/marshal] Allow generic `Resolver`

### DIFF
--- a/consensus/src/marshal/config.rs
+++ b/consensus/src/marshal/config.rs
@@ -1,29 +1,18 @@
 use crate::Block;
-use commonware_cryptography::{bls12381::primitives::variant::Variant, PublicKey};
-use commonware_resolver::p2p::Coordinator;
+use commonware_cryptography::bls12381::primitives::variant::Variant;
 use commonware_runtime::buffer::PoolRef;
-use governor::Quota;
 use std::num::{NonZeroU64, NonZeroUsize};
 
 /// Marshal configuration.
-pub struct Config<V: Variant, P: PublicKey, Z: Coordinator<PublicKey = P>, B: Block> {
-    /// The public key of the validator.
-    pub public_key: P,
-
+pub struct Config<V: Variant, B: Block> {
     /// The identity of the network.
     pub identity: V::Public,
-
-    /// The coordinator for the resolvers.
-    pub coordinator: Z,
 
     /// The prefix to use for all partitions.
     pub partition_prefix: String,
 
     /// Size of backfill request/response mailbox.
     pub mailbox_size: usize,
-
-    /// Backfill rate limit.
-    pub backfill_quota: Quota,
 
     /// Minimum number of views to retain temporary data after the application processes a block.
     ///

--- a/consensus/src/marshal/ingress/mod.rs
+++ b/consensus/src/marshal/ingress/mod.rs
@@ -1,3 +1,3 @@
-pub(crate) mod handler;
+pub mod handler;
 pub mod mailbox;
 pub(crate) mod orchestrator;

--- a/consensus/src/marshal/resolver/mod.rs
+++ b/consensus/src/marshal/resolver/mod.rs
@@ -1,0 +1,3 @@
+//! Default resolvers available for the [Actor](super::actor::Actor).
+
+pub mod p2p;

--- a/consensus/src/marshal/resolver/p2p.rs
+++ b/consensus/src/marshal/resolver/p2p.rs
@@ -1,0 +1,62 @@
+//! P2P resolver initialization and config.
+
+use crate::{
+    marshal::ingress::handler::{self, Handler},
+    Block,
+};
+use commonware_cryptography::PublicKey;
+use commonware_p2p::{utils::requester, Receiver, Sender};
+use commonware_resolver::p2p::{self, Coordinator};
+use commonware_runtime::{Clock, Metrics, Spawner};
+use futures::channel::mpsc;
+use governor::{clock::Clock as GClock, Quota};
+use rand::Rng;
+use std::{num::NonZeroU32, time::Duration};
+
+/// Configuration for the P2P [Resolver](commonware_resolver::Resolver).
+pub struct Config<P: PublicKey, C: Coordinator<PublicKey = P>> {
+    pub public_key: P,
+    pub coordinator: C,
+    pub mailbox_size: usize,
+}
+
+/// Initialize a P2P resolver.
+pub fn init_p2p_resolver<E, C, B, S, R, P>(
+    ctx: &E,
+    config: Config<P, C>,
+    backfill: (S, R),
+) -> (
+    mpsc::Receiver<handler::Message<B>>,
+    p2p::Mailbox<handler::Request<B>>,
+)
+where
+    E: Rng + Spawner + Clock + GClock + Metrics,
+    C: Coordinator<PublicKey = P>,
+    B: Block,
+    S: Sender<PublicKey = P>,
+    R: Receiver<PublicKey = P>,
+    P: PublicKey,
+{
+    let (handler, receiver) = mpsc::channel(config.mailbox_size);
+    let handler = Handler::new(handler);
+    let (resolver_engine, resolver) = p2p::Engine::new(
+        ctx.with_label("resolver"),
+        p2p::Config {
+            coordinator: config.coordinator,
+            consumer: handler.clone(),
+            producer: handler,
+            mailbox_size: config.mailbox_size,
+            requester_config: requester::Config {
+                public_key: config.public_key,
+                rate_limit: Quota::per_second(NonZeroU32::new(5).unwrap()),
+                initial: Duration::from_secs(1),
+                timeout: Duration::from_secs(2),
+            },
+            fetch_retry_timeout: Duration::from_millis(100),
+            priority_requests: false,
+            priority_responses: false,
+        },
+    );
+    resolver_engine.start(backfill);
+    (receiver, resolver)
+}


### PR DESCRIPTION
## Overview

Allows for a generic [`Resolver`](https://docs.rs/commonware-resolver/latest/commonware_resolver/trait.Resolver.html) to be used in [`marshal::Actor`](https://docs.rs/commonware-consensus/latest/commonware_consensus/marshal/actor/struct.Actor.html), rather than requiring the use of the `p2p` variant.

Fixes #1329 