### PR TITLE
fix(chat): add missing CLI parameter descriptions

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -79,20 +79,27 @@ fn main() {
     // Parse arguments
     let matches = Command::new("commonware-chat")
         .about("send encrypted messages to a group of friends")
-        .arg(Arg::new("me").long("me").required(true))
+        .arg(
+            Arg::new("me")
+                .long("me")
+                .required(true)
+                .help("Your identity in format <key>@<port> (e.g., 1@3001)")
+        )
         .arg(
             Arg::new("friends")
                 .long("friends")
                 .required(true)
                 .value_delimiter(',')
-                .value_parser(value_parser!(u64)),
+                .value_parser(value_parser!(u64))
+                .help("Comma-separated list of friend keys (e.g., 1,2,3,4)")
         )
         .arg(
             Arg::new("bootstrappers")
                 .long("bootstrappers")
                 .required(false)
                 .value_delimiter(',')
-                .value_parser(value_parser!(String)),
+                .value_parser(value_parser!(String))
+                .help("Comma-separated list of bootstrap peers in format <key>@<ip>:<port>")
         )
         .get_matches();
 


### PR DESCRIPTION
The chat example was missing help text for CLI arguments, making it unclear how to use the tool.

Added descriptions for:
- `--me`: identity format and example
- `--friends`: comma-separated friend keys  
- `--bootstrappers`: bootstrap peer format

Before:
```
      --me <me>                        
      --friends <friends>              
      --bootstrappers <bootstrappers>
```

After:
```
      --me <me>                        Your identity in format <key>@<port> (e.g., 1@3001)
      --friends <friends>              Comma-separated list of friend keys (e.g., 1,2,3,4)
      --bootstrappers <bootstrappers>  Comma-separated list of bootstrap peers in format <key>@<ip>:<port>
```
