### PR TITLE
feat: add external tokio runtime support

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2232,6 +2232,91 @@ mod tests {
     }
 
     #[test]
+    fn test_external_tokio_basic_functionality() {
+        let rt = ::tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            // Create config with external tokio enabled
+            let config = tokio::Config::default().with_external_tokio(true);
+            let executor = tokio::Runner::new(config);
+
+            // We need to run this in spawn_blocking since Runner::start uses block_on
+            let result = ::tokio::task::spawn_blocking(move || {
+                executor.start(|context| async move {
+                    // Test basic spawning
+                    let handle = context.spawn(|_| async move { 42 });
+                    handle.await.unwrap()
+                })
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(result, 42);
+        });
+    }
+
+    #[test]
+    fn test_external_tokio_clock_operations() {
+        let rt = ::tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let config = tokio::Config::default().with_external_tokio(true);
+            let executor = tokio::Runner::new(config);
+
+            ::tokio::task::spawn_blocking(move || {
+                executor.start(|context| async move {
+                    // Test clock operations
+                    let start = context.current();
+                    context.sleep(Duration::from_millis(10)).await;
+                    let end = context.current();
+
+                    assert!(end.duration_since(start).unwrap() >= Duration::from_millis(10));
+                })
+            })
+            .await
+            .unwrap();
+        });
+    }
+
+    #[test]
+    fn test_external_tokio_metrics() {
+        let rt = ::tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let config = tokio::Config::default().with_external_tokio(true);
+            let executor = tokio::Runner::new(config);
+
+            ::tokio::task::spawn_blocking(move || {
+                executor.start(|context| async move {
+                    // Test metrics functionality
+                    assert_eq!(context.label(), "");
+
+                    let counter = Counter::<u64>::default();
+                    context.register("test", "test", counter.clone());
+                    counter.inc();
+
+                    let buffer = context.encode();
+                    assert!(buffer.contains("test_total 1"));
+                })
+            })
+            .await
+            .unwrap();
+        });
+    }
+
+    #[test]
+    fn test_external_tokio_config_default() {
+        // Test that default config has use_external_tokio = false
+        let config = tokio::Config::default();
+        assert_eq!(config.use_external_tokio(), false);
+        
+        // Test that with_external_tokio works
+        let config = config.with_external_tokio(true);
+        assert_eq!(config.use_external_tokio(), true);
+        
+        // Test that it can be turned back off
+        let config = config.with_external_tokio(false);
+        assert_eq!(config.use_external_tokio(), false);
+    }
+
+    #[test]
     fn test_tokio_process_rss_metric() {
         let executor = tokio::Runner::default();
         executor.start(|context| async move {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2305,15 +2305,15 @@ mod tests {
     fn test_external_tokio_config_default() {
         // Test that default config has use_external_tokio = false
         let config = tokio::Config::default();
-        assert_eq!(config.use_external_tokio(), false);
+        assert!(!config.use_external_tokio());
         
         // Test that with_external_tokio works
         let config = config.with_external_tokio(true);
-        assert_eq!(config.use_external_tokio(), true);
+        assert!(config.use_external_tokio());
         
         // Test that it can be turned back off
         let config = config.with_external_tokio(false);
-        assert_eq!(config.use_external_tokio(), false);
+        assert!(!config.use_external_tokio());
     }
 
     #[test]

--- a/runtime/src/tokio/mod.rs
+++ b/runtime/src/tokio/mod.rs
@@ -6,7 +6,14 @@
 //! By default, the runtime will catch any panic and log the error. It is
 //! possible to override this behavior in the configuration.
 //!
-//! # Example
+//! # Variants
+//!
+//! This module provides two main ways to use tokio:
+//!
+//! - [`Runner`]: Creates and manages its own tokio runtime instance (default behavior)
+//! - [`Config::with_external_tokio`]: Configures the runtime to use an existing tokio instance
+//!
+//! # Example with Runner (creates own runtime)
 //!
 //! ```rust
 //! use commonware_runtime::{Spawner, Runner, tokio, Metrics};
@@ -21,6 +28,31 @@
 //!     println!("Child result: {:?}", result.await);
 //!     println!("Parent exited");
 //! });
+//! ```
+//!
+//! # Example with external tokio runtime
+//!
+//! ```rust
+//! use commonware_runtime::{Spawner, Runner, tokio, Metrics};
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     // Configure to use external tokio runtime
+//!     let config = tokio::Config::default().with_external_tokio(true);
+//!     let executor = tokio::Runner::new(config);
+//!     
+//!     tokio::task::spawn_blocking(move || {
+//!         executor.start(|context| async move {
+//!             println!("Parent started");
+//!             let result = context.with_label("child").spawn(|_| async move {
+//!                 println!("Child started");
+//!                 "hello"
+//!             });
+//!             println!("Child result: {:?}", result.await);
+//!             println!("Parent exited");
+//!         })
+//!     }).await.unwrap();
+//! }
 //! ```
 
 mod runtime;

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -274,7 +274,11 @@ impl crate::Runner for Runner {
         // We prefer to collect process metrics outside of `Context` because
         // we are using `runtime_registry` rather than the one provided by `Context`.
         let process = MeteredProcess::init(runtime_registry);
-        runtime.spawn(process.collect(tokio::time::sleep));
+        if self.cfg.use_external_tokio {
+            tokio::spawn(process.collect(tokio::time::sleep));
+        } else {
+            runtime.spawn(process.collect(tokio::time::sleep));
+        }
 
         // Initialize storage
         cfg_if::cfg_if! {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -49,7 +49,7 @@ pub fn hex(bytes: &[u8]) -> String {
 /// Converts a hexadecimal string to bytes.
 pub fn from_hex(hex: &str) -> Option<Vec<u8>> {
     let bytes = hex.as_bytes();
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         return None;
     }
 


### PR DESCRIPTION
Adds ability to use existing tokio runtime instead of creating new one.

When `use_current_tokio_runtime()` is called, Context uses `tokio::spawn` instead of `executor.runtime.spawn`.

Fixes #1652