### PR TITLE
feat: add skip_application_wait config to make finalizer stream optional

### DIFF
--- a/consensus/src/marshal/config.rs
+++ b/consensus/src/marshal/config.rs
@@ -69,4 +69,11 @@ pub struct Config<V: Variant, P: PublicKey, Z: Coordinator<PublicKey = P>, B: Bl
 
     /// Maximum number of blocks to repair at once
     pub max_repair: u64,
+
+    /// Whether to skip waiting for application processing in the finalizer.
+    /// 
+    /// When true, the finalizer won't wait for the application to process blocks,
+    /// allowing it to run ahead as fast as possible. This is useful for teams that
+    /// prefer to poll consensus state at their own pace.
+    pub skip_application_wait: bool,
 }

--- a/consensus/src/marshal/finalizer.rs
+++ b/consensus/src/marshal/finalizer.rs
@@ -15,7 +15,8 @@ const LATEST_KEY: FixedBytes<1> = FixedBytes::new([0u8]);
 /// processing from the last processed height after a restart.
 pub struct Finalizer<B: Block, R: Spawner + Clock + Metrics + Storage, Z: Reporter<Activity = B>> {
     // Application that processes the finalized blocks.
-    application: Z,
+    // When None, the finalizer won't wait for application processing.
+    application: Option<Z>,
 
     // Orchestrator that stores the finalized blocks.
     orchestrator: Orchestrator<B>,
@@ -34,7 +35,7 @@ impl<B: Block, R: Spawner + Clock + Metrics + Storage, Z: Reporter<Activity = B>
     pub async fn new(
         context: R,
         partition_prefix: String,
-        application: Z,
+        application: Option<Z>,
         orchestrator: Orchestrator<B>,
         notifier_rx: mpsc::Receiver<()>,
     ) -> Self {

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -168,6 +168,7 @@ mod tests {
             freezer_journal_compression: None,
             freezer_journal_buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
             immutable_items_per_section: NZU64!(10),
+            skip_application_wait: false,  // Default to waiting for application
         };
 
         let (actor, mailbox) = actor::Actor::init(context.clone(), config).await;


### PR DESCRIPTION
Implements #1661 - adds `skip_application_wait` config to make finalizer stream optional.

Realized we can just use the existing `Option<Reporter>` implementation. When it's `None`, the report call becomes a no-op.

Changed finalizer to accept `Option<Reporter>` instead of `Reporter`. If `skip_application_wait` is true, we pass `None`, otherwise `Some(application)`.
