### PR TITLE
[codec] Add impl for ()

### DIFF
--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -140,6 +140,24 @@ impl<const N: usize> FixedSize for [u8; N] {
     const SIZE: usize = N;
 }
 
+impl Write for () {
+    #[inline]
+    fn write(&self, _buf: &mut impl BufMut) {}
+}
+
+impl Read for () {
+    type Cfg = ();
+
+    #[inline]
+    fn read_cfg(_buf: &mut impl Buf, _cfg: &Self::Cfg) -> Result<Self, Error> {
+        Ok(())
+    }
+}
+
+impl FixedSize for () {
+    const SIZE: usize = 0;
+}
+
 // Option implementation
 impl<T: Write> Write for Option<T> {
     #[inline]
@@ -299,6 +317,12 @@ mod tests {
         let none: Option<u32> = None;
         assert_eq!(none.encode_size(), 1);
         assert_eq!(none.encode().len(), 1);
+    }
+
+    #[test]
+    fn test_unit() {
+        let x = ();
+        assert_eq!(<()>::decode(x.encode()).unwrap(), x)
     }
 
     #[test]


### PR DESCRIPTION
This might seem a bit pointless, but this can show up if you have some kind of generic abstraction requiring codec, but want to use () for that type.

For example, in the coding abstraction work, I want a type in the abstraction to implement Codec, but in some impls, that type is (), so this impl is useful.