### PR TITLE
[storage/mmr] update comment for 'size' field of Proof

### DIFF
--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -524,6 +524,11 @@ impl<H: CHasher, const N: usize> Bitmap<H, N> {
     /// Return an inclusion proof for the specified bit, along with the chunk of the bitmap
     /// containing that bit. The proof can be used to prove any bit in the chunk.
     ///
+    /// The bitmap proof stores the number of bits in the bitmap within the `size` field of the
+    /// proof instead of MMR size since the underlying MMR's size does not reflect the number of
+    /// bits in any partial chunk. The underlying MMR size can be derived from the number of
+    /// bits as `leaf_num_to_pos(proof.size / Bitmap<_, N>::CHUNK_SIZE_BITS)`.
+    ///
     /// # Warning
     ///
     /// Panics if there are unprocessed updates.

--- a/storage/src/mmr/proof.rs
+++ b/storage/src/mmr/proof.rs
@@ -47,7 +47,9 @@ pub enum ReconstructionError {
 /// elements within the range, ordered by the position of their parent.
 #[derive(Clone, Debug, Eq)]
 pub struct Proof<D: Digest> {
-    /// The total number of nodes in the MMR.
+    /// The total number of nodes in the MMR for MMR proofs, though other authenticated data
+    /// structures may override the meaning of this field. For example the authenticated bitmap
+    /// stores the number of bits in the bitmap within this field.
     pub size: u64,
     /// The digests necessary for proving the inclusion of an element, or range of elements, in the
     /// MMR.

--- a/storage/src/mmr/proof.rs
+++ b/storage/src/mmr/proof.rs
@@ -48,8 +48,8 @@ pub enum ReconstructionError {
 #[derive(Clone, Debug, Eq)]
 pub struct Proof<D: Digest> {
     /// The total number of nodes in the MMR for MMR proofs, though other authenticated data
-    /// structures may override the meaning of this field. For example the authenticated bitmap
-    /// stores the number of bits in the bitmap within this field.
+    /// structures may override the meaning of this field. For example the authenticated
+    /// [crate::mmr::bitmap::Bitmap] stores the number of bits in the bitmap within this field.
     pub size: u64,
     /// The digests necessary for proving the inclusion of an element, or range of elements, in the
     /// MMR.


### PR DESCRIPTION
Small update of the size field documentation to clarify that authenticated data structures other than a pure MMR may override its precise meaning.