### PR TITLE
[runtime::utils] `AbortToken` wraps `AbortHandle` to decrement the `running` metric on `abort()`

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -33,12 +33,11 @@ use crate::{
     },
     telemetry::metrics::task::Label,
     utils::signal::{Signal, Stopper},
-    Clock, Error, Handle, ListenerOf, METRICS_PREFIX,
+    AbortToken, Clock, Error, Handle, ListenerOf, METRICS_PREFIX,
 };
 use commonware_macros::select;
 use commonware_utils::{hex, SystemTimeExt};
 use futures::{
-    stream::AbortHandle,
     task::{waker, ArcWake},
     Future,
 };
@@ -680,7 +679,7 @@ pub struct Context {
     executor: Weak<Executor>,
     network: Arc<Network>,
     storage: Arc<Storage>,
-    children: Arc<Mutex<Vec<AbortHandle>>>,
+    children: Arc<Mutex<Vec<AbortToken>>>,
 }
 
 impl Context {

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -10,12 +10,15 @@ use crate::{
     network::iouring::{Config as IoUringNetworkConfig, Network as IoUringNetwork},
 };
 use crate::{
-    network::metered::Network as MeteredNetwork, process::metered::Metrics as MeteredProcess,
-    signal::Signal, storage::metered::Storage as MeteredStorage, telemetry::metrics::task::Label,
-    utils::signal::Stopper, Clock, Error, Handle, SinkOf, StreamOf, METRICS_PREFIX,
+    network::metered::Network as MeteredNetwork,
+    process::metered::Metrics as MeteredProcess,
+    signal::Signal,
+    storage::metered::Storage as MeteredStorage,
+    telemetry::metrics::task::Label,
+    utils::{signal::Stopper, AbortToken},
+    Clock, Error, Handle, SinkOf, StreamOf, METRICS_PREFIX,
 };
 use commonware_macros::select;
-use futures::stream::AbortHandle;
 use governor::clock::{Clock as GClock, ReasonablyRealtime};
 use prometheus_client::{
     encoding::text::encode,
@@ -368,7 +371,7 @@ pub struct Context {
     executor: Arc<Executor>,
     storage: Storage,
     network: Network,
-    children: Arc<Mutex<Vec<AbortHandle>>>,
+    children: Arc<Mutex<Vec<AbortToken>>>,
 }
 
 impl Context {

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -18,6 +18,7 @@ pub mod buffer;
 pub mod signal;
 
 mod handle;
+pub(crate) use handle::AbortToken;
 pub use handle::Handle;
 
 /// Yield control back to the runtime.


### PR DESCRIPTION
Fixes #1670 

If you await the original `Handle`, then the `poll` function will decrement the `running` metric, which is why this was not caught in the original tests