### PR TITLE
Fix Typos in Comment

### DIFF
--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -849,7 +849,7 @@ mod tests {
             );
             network.start();
 
-            // Both sender and receiver have the same bandiwdth (1000 B/s)
+            // Both sender and receiver have the same bandwidth (1000 B/s)
             // 500 bytes at 1000 B/s = 0.5 seconds
             test_bandwidth_between_peers(
                 &mut context,

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -11,7 +11,7 @@ use tokio::{
 pub struct Blob {
     partition: String,
     name: Vec<u8>,
-    // Files must be seeked prior to any read or write operation and are thus
+    // Files must be sought prior to any read or write operation and are thus
     // not safe to concurrently interact with. If we switched to mapping files
     // we could remove this lock.
     file: Arc<Mutex<fs::File>>,

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! # Format
 //!
-//! The [Freezer] uses a two-level architecture: an extendible hash table (written in a single [commonware_runtime::Blob])
+//! The [Freezer] uses a two-level architecture: an extendable hash table (written in a single [commonware_runtime::Blob])
 //! that maps keys to locations and a [crate::journal::variable::Journal] that stores key-value data.
 //!
 //! ```text


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `bandiwdth` → `bandwidth`
  - `seeked` → `sought`
  - `extendible` → `extendable`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.