### PR TITLE
[coding] Add an extra check step before decoding

### DIFF
--- a/coding/src/benches/bench_size.rs
+++ b/coding/src/benches/bench_size.rs
@@ -24,7 +24,7 @@ fn benchmark_size<S: Scheme>(name: &str) {
 
             let (commitment, shard_proofs) = S::encode(&config, data.as_slice()).unwrap();
             let (shard, proof) = shard_proofs.first().unwrap();
-            let reshard = S::check(&commitment, proof, shard).unwrap();
+            let reshard = S::reshard(&commitment, proof, shard).unwrap();
 
             println!(
                 "{} (shard)/msg_len={} chunks={}: {} B",

--- a/coding/src/no_coding.rs
+++ b/coding/src/no_coding.rs
@@ -25,6 +25,8 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
 
     type ReShard = ();
 
+    type CheckedShard = ();
+
     type Proof = ();
 
     type Error = NoCodingError;
@@ -41,7 +43,7 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
         Ok((commitment, shards))
     }
 
-    fn check(
+    fn reshard(
         commitment: &Self::Commitment,
         _proof: &Self::Proof,
         shard: &Self::Shard,
@@ -53,11 +55,18 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
         Ok(())
     }
 
+    fn check(
+        _commitment: &Self::Commitment,
+        _reshard: Self::ReShard,
+    ) -> Result<Self::CheckedShard, Self::Error> {
+        Ok(())
+    }
+
     fn decode(
         _config: &crate::Config,
         _commitment: &Self::Commitment,
         my_shard: Self::Shard,
-        _shards: &[Self::ReShard],
+        _shards: &[Self::CheckedShard],
     ) -> Result<Vec<u8>, Self::Error> {
         Ok(my_shard)
     }


### PR DESCRIPTION
Closes #1686

This implements an extra step, wherein after receiving the reshards from other participants, you're forced to check them individually, before passing them to decode. The intention is that if you receive a reshard, and it fails this check, then you don't even consider it as progress towards the minimum number of shards you need to reconstruct the data.

This avoids issues where someone can cause reconstruction to fail by sending an invalid shard.