### PR TITLE
fix clippy warnings on println formatting

### DIFF
--- a/coding/src/benches/bench.rs
+++ b/coding/src/benches/bench.rs
@@ -17,7 +17,7 @@ pub(crate) fn benchmark_encode_generic<S: Scheme>(name: &str, c: &mut Criterion)
                 extra_shards: (chunks - min) as u16,
             };
             c.bench_function(
-                &format!("{}/msg_len={} chunks={}", name, data_length, chunks),
+                &format!("{name}/msg_len={data_length} chunks={chunks}"),
                 |b| {
                     b.iter_batched(
                         || {
@@ -46,7 +46,7 @@ pub(crate) fn benchmark_decode_generic<S: Scheme>(name: &str, c: &mut Criterion)
                 extra_shards: (chunks - min) as u16,
             };
             c.bench_function(
-                &format!("{}/msg_len={} chunks={}", name, data_length, chunks),
+                &format!("{name}/msg_len={data_length} chunks={chunks}"),
                 |b| {
                     b.iter_batched(
                         || {

--- a/stream/fuzz/fuzz_targets/e2e.rs
+++ b/stream/fuzz/fuzz_targets/e2e.rs
@@ -186,13 +186,13 @@ fn fuzz(input: FuzzInput) {
         // for it to send a message it never will.
         let (d_res, l_res) = match select(dialer_handle, listener_handle).await {
             Either::Left((d_res, l_handle)) => {
-                match d_res.inspect_err(|e| println!("A: {:?}", e)).unwrap().ok() {
+                match d_res.inspect_err(|e| println!("A: {e:?}")).unwrap().ok() {
                     Some(d_res) => (Some(d_res), l_handle.await.unwrap().ok()),
                     None => (None, None),
                 }
             }
             Either::Right((l_res, d_handle)) => {
-                match l_res.inspect_err(|e| println!("B: {:?}", e)).unwrap().ok() {
+                match l_res.inspect_err(|e| println!("B: {e:?}")).unwrap().ok() {
                     Some(l_res) => (d_handle.await.unwrap().ok(), Some(l_res)),
                     None => (None, None),
                 }


### PR DESCRIPTION
`clippy 0.1.88` complains about not putting values inside the `{}`.

More [recent](https://github.com/rust-lang/rust-clippy/issues/15516) clippy versions don't complain about this by default, so I'm not sure if we care to enforce this or not. At the least, this PR makes the code more similar to other `println!` usages.