### PR TITLE
[runtime] remove `Spawner::spawn_ref`

### DIFF
--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -159,7 +159,7 @@ fn fuzz(input: FuzzInput) {
                 disconnect_on_block: false,
             },
         );
-        network.start();
+        network.start(context.with_label("network"));
 
         // Create peers
         let mut peers = Vec::new();
@@ -185,9 +185,9 @@ fn fuzz(input: FuzzInput) {
             // Create engine
             let engine_context = context.with_label(&format!("peer_{i}"));
             let (engine, mailbox) =
-                Engine::<_, PublicKey, FuzzMessage>::new(engine_context, config);
+                Engine::<PublicKey, FuzzMessage>::new(engine_context.clone(), config);
             mailboxes.insert(public_key.clone(), mailbox);
-            engine.start((sender, receiver));
+            engine.start(engine_context, (sender, receiver));
         }
 
         // Add links between peers

--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -152,14 +152,15 @@ fn fuzz(input: FuzzInput) {
     let executor = deterministic::Runner::default();
     executor.start(|context| async move {
         // Create network
+        let network_context = context.with_label("network");
         let (network, mut oracle) = Network::<deterministic::Context, PublicKey>::new(
-            context.with_label("network"),
+            network_context.clone(),
             commonware_p2p::simulated::Config {
                 max_size: 1024 * 1024,
                 disconnect_on_block: false,
             },
         );
-        network.start(context.with_label("network"));
+        network.start(network_context);
 
         // Create peers
         let mut peers = Vec::new();

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -75,7 +75,7 @@ mod tests {
                 disconnect_on_block: true,
             },
         );
-        network.start();
+        network.start(context.with_label("network"));
 
         let mut schemes = (0..num_peers)
             .map(|i| PrivateKey::from_seed(i as u64))
@@ -125,9 +125,9 @@ mod tests {
                 codec_config: RangeCfg::from(..),
             };
             let (engine, engine_mailbox) =
-                Engine::<_, PublicKey, TestMessage>::new(context.clone(), config);
+                Engine::<PublicKey, TestMessage>::new(context.clone(), config);
             mailboxes.insert(peer.clone(), engine_mailbox);
-            engine.start(network);
+            engine.start(context, network);
         }
         mailboxes
     }

--- a/collector/fuzz/fuzz_targets/collector.rs
+++ b/collector/fuzz/fuzz_targets/collector.rs
@@ -416,6 +416,7 @@ fn fuzz(input: FuzzInput) {
                     let (_tx, _rx) = mpsc::unbounded();
                     let mock_receiver = MockReceiver { rx: _rx };
                     engine.start(
+                        context.clone(),
                         (MockSender, mock_receiver),
                         (
                             MockSender,

--- a/collector/src/p2p/engine.rs
+++ b/collector/src/p2p/engine.rs
@@ -64,7 +64,7 @@ where
     ///
     /// Returns a tuple of the engine and the mailbox for sending messages.
     pub fn new(
-        context: impl Metrics,
+        metrics: impl Metrics,
         cfg: Config<B, M, H, Rq::Cfg, Rs::Cfg>,
     ) -> (Self, Mailbox<P, Rq>) {
         // Create mailbox
@@ -75,13 +75,13 @@ where
         let outstanding = Gauge::default();
         let requests = Counter::default();
         let responses = Counter::default();
-        context.register(
+        metrics.register(
             "outstanding",
             "outstanding commitments",
             outstanding.clone(),
         );
-        context.register("requests", "processed requests", requests.clone());
-        context.register("responses", "sent responses", responses.clone());
+        metrics.register("requests", "processed requests", requests.clone());
+        metrics.register("responses", "sent responses", responses.clone());
 
         (
             Self {
@@ -102,16 +102,16 @@ where
         )
     }
 
-    /// Starts the engine with the given network channels.
+    /// Starts the engine with the given spawner and network channels.
     ///
     /// Returns a handle that can be used to wait for the engine to complete.
     pub fn start(
         self,
-        context: impl Spawner,
+        spawner: impl Spawner,
         requests: (impl Sender<PublicKey = P>, impl Receiver<PublicKey = P>),
         responses: (impl Sender<PublicKey = P>, impl Receiver<PublicKey = P>),
     ) -> Handle<()> {
-        context.spawn(|_| self.run(requests, responses))
+        spawner.spawn(|_| self.run(requests, responses))
     }
 
     async fn run(

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -249,7 +249,7 @@ impl<
             buffer_pool: self.journal_buffer_pool.clone(),
             write_buffer: self.journal_write_buffer,
         };
-        let journal = Journal::init(context.clone().with_label("journal"), journal_cfg)
+        let journal = Journal::init(context.with_label("journal"), journal_cfg)
             .await
             .expect("init failed");
         let unverified_indices = self.replay(&context, &journal).await;

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -337,9 +337,7 @@ impl<
                             self.metrics.digest.inc(Status::Dropped);
                         }
                         Ok(digest) => {
-                            if let Err(err) =
-                                self.handle_digest(index, digest, &mut sender).await
-                            {
+                            if let Err(err) = self.handle_digest(index, digest, &mut sender).await {
                                 debug!(?err, ?index, "handle_digest failed");
                                 continue;
                             }

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -163,7 +163,7 @@ mod tests {
                 disconnect_on_block: true,
             },
         );
-        network.start();
+        network.start(context.with_label("network"));
 
         let mut schemes = (0..num_validators)
             .map(|i| PrivateKey::from_seed(i as u64))
@@ -258,7 +258,7 @@ mod tests {
             );
 
             let (sender, receiver) = registrations.remove(validator).unwrap();
-            engine.start((sender, receiver));
+            engine.start(context.with_label("engine"), (sender, receiver));
         }
         monitors
     }
@@ -508,7 +508,7 @@ mod tests {
                         );
 
                         let (sender, receiver) = registrations.remove(validator).unwrap();
-                        engine.start((sender, receiver));
+                        engine.start(validator_context.with_label("engine"), (sender, receiver));
                     }
 
                     // Create a single completion watcher for the shared reporter
@@ -660,7 +660,7 @@ mod tests {
                     );
 
                     let (sender, receiver) = registrations.remove(validator).unwrap();
-                    engine.start((sender, receiver));
+                    engine.start(validator_context.with_label("engine"), (sender, receiver));
                 }
 
                 // Wait for validators to reach target_index (past skip_index)
@@ -745,7 +745,7 @@ mod tests {
                     );
 
                     let (sender, receiver) = registrations.remove(validator).unwrap();
-                    engine.start((sender, receiver));
+                    engine.start(validator_context.with_label("engine"), (sender, receiver));
                 }
 
                 // Wait for skip_index to be confirmed (should happen on replay)
@@ -1041,7 +1041,7 @@ mod tests {
                 );
 
                 let (sender, receiver) = registrations.remove(validator).unwrap();
-                engine.start((sender, receiver));
+                engine.start(context.with_label("engine"), (sender, receiver));
             }
 
             // With insufficient validators, consensus should not be achievable

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -156,14 +156,15 @@ mod tests {
         Vec<PublicKey>,
         Registrations<PublicKey>,
     ) {
+        let network_context = context.with_label("network");
         let (network, mut oracle) = Network::new(
-            context.with_label("network"),
+            network_context.clone(),
             commonware_p2p::simulated::Config {
                 max_size: 1024 * 1024,
                 disconnect_on_block: true,
             },
         );
-        network.start(context.with_label("network"));
+        network.start(network_context);
 
         let mut schemes = (0..num_validators)
             .map(|i| PrivateKey::from_seed(i as u64))
@@ -234,8 +235,9 @@ mod tests {
             context.with_label("reporter").spawn(|_| reporter.run());
             reporters.insert(validator.clone(), reporter_mailbox);
 
+            let engine_context = context.with_label("engine");
             let engine = Engine::new(
-                context.with_label("engine"),
+                engine_context.clone(),
                 Config {
                     monitor,
                     validators: supervisor,
@@ -258,7 +260,7 @@ mod tests {
             );
 
             let (sender, receiver) = registrations.remove(validator).unwrap();
-            engine.start(context.with_label("engine"), (sender, receiver));
+            engine.start(engine_context, (sender, receiver));
         }
         monitors
     }
@@ -484,8 +486,9 @@ mod tests {
                             .unwrap()
                             .insert(validator.clone(), automaton.clone());
 
+                        let engine_context = validator_context.with_label("engine");
                         let engine = Engine::new(
-                            validator_context.with_label("engine"),
+                            engine_context.clone(),
                             Config {
                                 monitor,
                                 validators: supervisor,
@@ -508,7 +511,7 @@ mod tests {
                         );
 
                         let (sender, receiver) = registrations.remove(validator).unwrap();
-                        engine.start(validator_context.with_label("engine"), (sender, receiver));
+                        engine.start(engine_context, (sender, receiver));
                     }
 
                     // Create a single completion watcher for the shared reporter
@@ -634,8 +637,9 @@ mod tests {
                         .unwrap()
                         .insert(validator.clone(), automaton.clone());
 
+                    let engine_context = validator_context.with_label("engine");
                     let engine = Engine::new(
-                        validator_context.with_label("engine"),
+                        engine_context.clone(),
                         Config {
                             monitor,
                             validators: supervisor,
@@ -660,7 +664,7 @@ mod tests {
                     );
 
                     let (sender, receiver) = registrations.remove(validator).unwrap();
-                    engine.start(validator_context.with_label("engine"), (sender, receiver));
+                    engine.start(engine_context, (sender, receiver));
                 }
 
                 // Wait for validators to reach target_index (past skip_index)
@@ -719,8 +723,9 @@ mod tests {
                         .unwrap()
                         .insert(validator.clone(), automaton.clone());
 
+                    let engine_context = validator_context.with_label("engine");
                     let engine = Engine::new(
-                        validator_context.with_label("engine"),
+                        engine_context.clone(),
                         Config {
                             monitor,
                             validators: supervisor,
@@ -745,7 +750,7 @@ mod tests {
                     );
 
                     let (sender, receiver) = registrations.remove(validator).unwrap();
-                    engine.start(validator_context.with_label("engine"), (sender, receiver));
+                    engine.start(engine_context, (sender, receiver));
                 }
 
                 // Wait for skip_index to be confirmed (should happen on replay)
@@ -1017,8 +1022,9 @@ mod tests {
                 context.with_label("reporter").spawn(|_| reporter.run());
                 reporters.insert(validator.clone(), reporter_mailbox);
 
+                let engine_context = context.with_label("engine");
                 let engine = Engine::new(
-                    context.with_label("engine"),
+                    engine_context.clone(),
                     Config {
                         monitor,
                         validators: supervisor,
@@ -1041,7 +1047,7 @@ mod tests {
                 );
 
                 let (sender, receiver) = registrations.remove(validator).unwrap();
-                engine.start(context.with_label("engine"), (sender, receiver));
+                engine.start(engine_context, (sender, receiver));
             }
 
             // With insufficient validators, consensus should not be achievable

--- a/consensus/src/marshal/cache.rs
+++ b/consensus/src/marshal/cache.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use commonware_codec::Codec;
 use commonware_cryptography::bls12381::primitives::variant::Variant;
-use commonware_runtime::{buffer::PoolRef, Clock, Metrics, Spawner, Storage};
+use commonware_runtime::{buffer::PoolRef, Clock, Metrics, Storage};
 use commonware_storage::{
     archive::{self, prunable, Archive as _, Identifier},
     metadata::{self, Metadata},
@@ -35,7 +35,7 @@ pub(crate) struct Config {
 }
 
 /// Prunable archives for a single epoch.
-struct Cache<R: Rng + Spawner + Metrics + Clock + GClock + Storage, B: Block, V: Variant> {
+struct Cache<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> {
     /// Verified blocks stored by view
     verified_blocks: prunable::Archive<TwoCap, R, B::Commitment, B>,
     /// Notarized blocks stored by view
@@ -46,7 +46,7 @@ struct Cache<R: Rng + Spawner + Metrics + Clock + GClock + Storage, B: Block, V:
     finalizations: prunable::Archive<TwoCap, R, B::Commitment, Finalization<V, B::Commitment>>,
 }
 
-impl<R: Rng + Spawner + Metrics + Clock + GClock + Storage, B: Block, V: Variant> Cache<R, B, V> {
+impl<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> Cache<R, B, V> {
     /// Prune the archives to the given view.
     async fn prune(&mut self, min_view: View) {
         match futures::try_join!(
@@ -62,11 +62,7 @@ impl<R: Rng + Spawner + Metrics + Clock + GClock + Storage, B: Block, V: Variant
 }
 
 /// Manages prunable caches and their metadata.
-pub(crate) struct Manager<
-    R: Rng + Spawner + Metrics + Clock + GClock + Storage,
-    B: Block,
-    V: Variant,
-> {
+pub(crate) struct Manager<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> {
     /// Context
     context: R,
 
@@ -84,7 +80,7 @@ pub(crate) struct Manager<
     caches: BTreeMap<Epoch, Cache<R, B, V>>,
 }
 
-impl<R: Rng + Spawner + Metrics + Clock + GClock + Storage, B: Block, V: Variant> Manager<R, B, V> {
+impl<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> Manager<R, B, V> {
     /// Initialize the cache manager and its metadata store.
     pub(crate) async fn init(context: R, cfg: Config, codec_config: B::Cfg) -> Self {
         // Initialize metadata

--- a/consensus/src/marshal/cache.rs
+++ b/consensus/src/marshal/cache.rs
@@ -13,7 +13,6 @@ use commonware_storage::{
 };
 use commonware_utils::sequence::FixedBytes;
 use governor::clock::Clock as GClock;
-use rand::Rng;
 use std::{
     cmp::max,
     collections::BTreeMap,
@@ -35,7 +34,7 @@ pub(crate) struct Config {
 }
 
 /// Prunable archives for a single epoch.
-struct Cache<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> {
+struct Cache<R: Metrics + Clock + GClock + Storage, B: Block, V: Variant> {
     /// Verified blocks stored by view
     verified_blocks: prunable::Archive<TwoCap, R, B::Commitment, B>,
     /// Notarized blocks stored by view
@@ -46,7 +45,7 @@ struct Cache<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> 
     finalizations: prunable::Archive<TwoCap, R, B::Commitment, Finalization<V, B::Commitment>>,
 }
 
-impl<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> Cache<R, B, V> {
+impl<R: Metrics + Clock + GClock + Storage, B: Block, V: Variant> Cache<R, B, V> {
     /// Prune the archives to the given view.
     async fn prune(&mut self, min_view: View) {
         match futures::try_join!(
@@ -62,7 +61,7 @@ impl<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> Cache<R,
 }
 
 /// Manages prunable caches and their metadata.
-pub(crate) struct Manager<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> {
+pub(crate) struct Manager<R: Metrics + Clock + GClock + Storage, B: Block, V: Variant> {
     /// Context
     context: R,
 
@@ -80,7 +79,7 @@ pub(crate) struct Manager<R: Rng + Metrics + Clock + GClock + Storage, B: Block,
     caches: BTreeMap<Epoch, Cache<R, B, V>>,
 }
 
-impl<R: Rng + Metrics + Clock + GClock + Storage, B: Block, V: Variant> Manager<R, B, V> {
+impl<R: Metrics + Clock + GClock + Storage, B: Block, V: Variant> Manager<R, B, V> {
     /// Initialize the cache manager and its metadata store.
     pub(crate) async fn init(context: R, cfg: Config, codec_config: B::Cfg) -> Self {
         // Initialize metadata

--- a/consensus/src/marshal/finalizer.rs
+++ b/consensus/src/marshal/finalizer.rs
@@ -1,5 +1,5 @@
 use crate::{marshal::ingress::orchestrator::Orchestrator, Block, Reporter};
-use commonware_runtime::{Clock, Metrics, Spawner, Storage};
+use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_storage::metadata::{self, Metadata};
 use commonware_utils::sequence::FixedBytes;
 use futures::{channel::mpsc, StreamExt};
@@ -13,7 +13,7 @@ const LATEST_KEY: FixedBytes<1> = FixedBytes::new([0u8]);
 ///
 /// Stores the highest height for which the application has processed. This allows resuming
 /// processing from the last processed height after a restart.
-pub struct Finalizer<B: Block, R: Spawner + Clock + Metrics + Storage, Z: Reporter<Activity = B>> {
+pub struct Finalizer<B: Block, R: Clock + Metrics + Storage, Z: Reporter<Activity = B>> {
     // Application that processes the finalized blocks.
     application: Z,
 
@@ -27,9 +27,7 @@ pub struct Finalizer<B: Block, R: Spawner + Clock + Metrics + Storage, Z: Report
     metadata: Metadata<R, FixedBytes<1>, u64>,
 }
 
-impl<B: Block, R: Spawner + Clock + Metrics + Storage, Z: Reporter<Activity = B>>
-    Finalizer<B, R, Z>
-{
+impl<B: Block, R: Clock + Metrics + Storage, Z: Reporter<Activity = B>> Finalizer<B, R, Z> {
     /// Initialize the finalizer.
     pub async fn new(
         context: R,

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -198,13 +198,13 @@ mod tests {
         };
         let (broadcast_engine, buffer) = buffered::Engine::new(context.clone(), broadcast_config);
         let network = oracle.register(secret.public_key(), 2).await.unwrap();
-        broadcast_engine.start(network);
+        broadcast_engine.start(context.clone(), network);
 
         let (actor, mailbox) = actor::Actor::init(context.clone(), config).await;
         let application = Application::<B>::default();
 
         // Start the application
-        actor.start(application.clone(), buffer, resolver);
+        actor.start(context.clone(), application.clone(), buffer, resolver);
 
         (application, mailbox)
     }
@@ -277,7 +277,7 @@ mod tests {
                 disconnect_on_block: true,
             },
         );
-        network.start();
+        network.start(context.with_label("network"));
         oracle
     }
 

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -205,7 +205,7 @@ mod tests {
         let application = Application::<B>::default();
 
         // Start the application
-        actor.start(context.clone(), application.clone(), buffer, resolver);
+        actor.start(context, application.clone(), buffer, resolver);
 
         (application, mailbox)
     }
@@ -271,14 +271,15 @@ mod tests {
     }
 
     fn setup_network(context: deterministic::Context) -> Oracle<P> {
+        let network_context = context.with_label("network");
         let (network, oracle) = Network::new(
-            context.with_label("network"),
+            network_context.clone(),
             simulated::Config {
                 max_size: 1024 * 1024,
                 disconnect_on_block: true,
             },
         );
-        network.start(context.with_label("network"));
+        network.start(network_context);
         oracle
     }
 

--- a/consensus/src/marshal/resolver/p2p.rs
+++ b/consensus/src/marshal/resolver/p2p.rs
@@ -69,6 +69,6 @@ where
             priority_responses: config.priority_responses,
         },
     );
-    resolver_engine.start(backfill);
+    resolver_engine.start(ctx.with_label("resolver"), backfill);
     (receiver, resolver)
 }

--- a/consensus/src/marshal/resolver/p2p.rs
+++ b/consensus/src/marshal/resolver/p2p.rs
@@ -56,8 +56,9 @@ where
 {
     let (handler, receiver) = mpsc::channel(config.mailbox_size);
     let handler = Handler::new(handler);
+    let resolver_context = ctx.with_label("resolver");
     let (resolver_engine, resolver) = p2p::Engine::new(
-        ctx.with_label("resolver"),
+        resolver_context.clone(),
         p2p::Config {
             coordinator: config.coordinator,
             consumer: handler.clone(),
@@ -69,6 +70,6 @@ where
             priority_responses: config.priority_responses,
         },
     );
-    resolver_engine.start(ctx.with_label("resolver"), backfill);
+    resolver_engine.start(resolver_context, backfill);
     (receiver, resolver)
 }

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -371,9 +371,7 @@ impl<
                     };
 
                     // Propose the chunk
-                    if let Err(err) =
-                        self.propose(context.clone(), payload, &mut node_sender).await
-                    {
+                    if let Err(err) = self.propose(context.clone(), payload, &mut node_sender).await {
                         warn!(?err, ?context, "propose new failed");
                         continue;
                     }

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -981,12 +981,10 @@ impl<
             buffer_pool: self.journal_buffer_pool.clone(),
             write_buffer: self.journal_write_buffer,
         };
-        let journal = Journal::<_, Node<C::PublicKey, V, D>>::init(
-            runtime.clone().with_label("journal"),
-            cfg,
-        )
-        .await
-        .expect("unable to init journal");
+        let journal =
+            Journal::<_, Node<C::PublicKey, V, D>>::init(runtime.with_label("journal"), cfg)
+                .await
+                .expect("unable to init journal");
 
         // Replay journal
         {

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -222,8 +222,9 @@ mod tests {
             context.with_label("reporter").spawn(|_| reporter.run());
             reporters.insert(validator.clone(), reporter_mailbox);
 
+            let engine_context = context.with_label("engine");
             let engine = Engine::new(
-                context.with_label("engine"),
+                engine_context.clone(),
                 Config {
                     crypto: scheme.clone(),
                     relay: automaton.clone(),
@@ -248,7 +249,7 @@ mod tests {
             );
 
             let ((a1, a2), (b1, b2)) = registrations.remove(validator).unwrap();
-            engine.start(context.with_label("engine"), (a1, a2), (b1, b2));
+            engine.start(engine_context, (a1, a2), (b1, b2));
         }
         monitors
     }
@@ -799,14 +800,15 @@ mod tests {
             participants.push(sequencer.public_key()); // as long as external participants are in same position for all, it is safe
 
             // Create network
+            let network_context = context.with_label("network");
             let (network, mut oracle) = Network::new(
-                context.with_label("network"),
+                network_context.clone(),
                 commonware_p2p::simulated::Config {
                     max_size: 1024 * 1024,
                     disconnect_on_block: true,
                 },
             );
-            network.start(context.with_label("network"));
+            network.start(network_context);
 
             // Register all participants
             let mut registrations = register_participants(&mut oracle, &participants).await;
@@ -853,8 +855,9 @@ mod tests {
                 context.with_label("reporter").spawn(|_| reporter.run());
                 reporters.insert(validator.clone(), reporter_mailbox);
 
+                let engine_context = context.with_label("engine");
                 let engine = Engine::new(
-                    context.with_label("engine"),
+                    engine_context.clone(),
                     Config {
                         crypto: scheme.clone(),
                         relay: automaton.clone(),
@@ -879,7 +882,7 @@ mod tests {
                 );
 
                 let ((a1, a2), (b1, b2)) = registrations.remove(validator).unwrap();
-                engine.start(context.with_label("engine"), (a1, a2), (b1, b2));
+                engine.start(engine_context, (a1, a2), (b1, b2));
             }
 
             // Spawn sequencer engine
@@ -898,8 +901,9 @@ mod tests {
                     );
                 context.with_label("reporter").spawn(|_| reporter.run());
                 reporters.insert(sequencer.public_key(), reporter_mailbox);
+                let engine_context = context.with_label("engine");
                 let engine = Engine::new(
-                    context.with_label("engine"),
+                    engine_context.clone(),
                     Config {
                         crypto: sequencer.clone(),
                         relay: automaton.clone(),
@@ -933,7 +937,7 @@ mod tests {
                 );
 
                 let ((a1, a2), (b1, b2)) = registrations.remove(&sequencer.public_key()).unwrap();
-                engine.start(context.with_label("engine"), (a1, a2), (b1, b2));
+                engine.start(engine_context, (a1, a2), (b1, b2));
             }
 
             // Await reporters

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -158,7 +158,7 @@ mod tests {
                 disconnect_on_block: true,
             },
         );
-        network.start();
+        network.start(context.with_label("network"));
 
         let mut schemes = (0..num_validators)
             .map(|i| PrivateKey::from_seed(i as u64))
@@ -248,7 +248,7 @@ mod tests {
             );
 
             let ((a1, a2), (b1, b2)) = registrations.remove(validator).unwrap();
-            engine.start((a1, a2), (b1, b2));
+            engine.start(context.with_label("engine"), (a1, a2), (b1, b2));
         }
         monitors
     }
@@ -392,7 +392,7 @@ mod tests {
                         disconnect_on_block: true,
                     },
                 );
-                network.start();
+                network.start(context.with_label("network"));
 
                 let mut schemes = (0..num_validators)
                     .map(|i| PrivateKey::from_seed(i as u64))
@@ -806,7 +806,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register all participants
             let mut registrations = register_participants(&mut oracle, &participants).await;
@@ -879,7 +879,7 @@ mod tests {
                 );
 
                 let ((a1, a2), (b1, b2)) = registrations.remove(validator).unwrap();
-                engine.start((a1, a2), (b1, b2));
+                engine.start(context.with_label("engine"), (a1, a2), (b1, b2));
             }
 
             // Spawn sequencer engine
@@ -933,7 +933,7 @@ mod tests {
                 );
 
                 let ((a1, a2), (b1, b2)) = registrations.remove(&sequencer.public_key()).unwrap();
-                engine.start((a1, a2), (b1, b2));
+                engine.start(context.with_label("engine"), (a1, a2), (b1, b2));
             }
 
             // Await reporters

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -99,12 +99,12 @@ impl Inflight {
 
 /// Requests are made concurrently to multiple peers.
 pub struct Actor<
-    E: Clock + GClock + Rng + Metrics + Spawner,
+    E: Clock + GClock + Rng + Metrics,
     C: PublicKey,
     D: Digest,
     S: Supervisor<Index = View, PublicKey = C>,
 > {
-    context: Option<E>,
+    context: E,
     supervisor: S,
 
     epoch: Epoch,
@@ -132,7 +132,7 @@ pub struct Actor<
 }
 
 impl<
-        E: Clock + GClock + Rng + Metrics + Spawner,
+        E: Clock + GClock + Rng + Metrics,
         C: PublicKey,
         D: Digest,
         S: Supervisor<Index = View, PublicKey = C>,
@@ -168,7 +168,7 @@ impl<
         let (sender, receiver) = mpsc::channel(cfg.mailbox_size);
         (
             Self {
-                context: Some(context),
+                context,
                 supervisor: cfg.supervisor,
 
                 epoch: cfg.epoch,
@@ -201,7 +201,6 @@ impl<
     /// Concurrent indicates whether we should send a new request (only if we see a request for the first time)
     async fn send<Sr: Sender<PublicKey = C>>(
         &mut self,
-        context: &mut E,
         shuffle: bool,
         sender: &mut WrappedSender<Sr, Backfiller<C::Signature, D>>,
     ) {
@@ -221,7 +220,7 @@ impl<
                 .required
                 .iter()
                 .filter(|entry| !self.inflight.contains(entry))
-                .choose_multiple(context, self.max_fetch_count);
+                .choose_multiple(&mut self.context, self.max_fetch_count);
             if entries.is_empty() {
                 return;
             }
@@ -257,7 +256,8 @@ impl<
                     // We return instead of waiting to continue serving requests and in case we
                     // learn of new notarizations or nullifications in the meantime.
                     warn!("failed to send request to any validator");
-                    let deadline = context
+                    let deadline = self
+                        .context
                         .current()
                         .checked_add(self.fetch_timeout)
                         .expect("time overflowed");
@@ -297,20 +297,17 @@ impl<
     }
 
     pub fn start(
-        mut self,
+        self,
+        spawner: impl Spawner,
         voter: voter::Mailbox<C::Signature, D>,
         sender: impl Sender<PublicKey = C>,
         receiver: impl Receiver<PublicKey = C>,
     ) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|context| self.run(context, voter, sender, receiver))
+        spawner.spawn(|_| self.run(voter, sender, receiver))
     }
 
     async fn run(
         mut self,
-        mut context: E,
         mut voter: voter::Mailbox<C::Signature, D>,
         sender: impl Sender<PublicKey = C>,
         receiver: impl Receiver<PublicKey = C>,
@@ -332,13 +329,13 @@ impl<
 
             // Set timeout for retry
             let retry = match self.retry {
-                Some(retry) => Either::Left(context.sleep_until(retry)),
+                Some(retry) => Either::Left(self.context.sleep_until(retry)),
                 None => Either::Right(futures::future::pending()),
             };
 
             // Set timeout for next request
             let (request, timeout) = if let Some((request, timeout)) = self.requester.next() {
-                (request, Either::Left(context.sleep_until(timeout)))
+                (request, Either::Left(self.context.sleep_until(timeout)))
             } else {
                 (0, Either::Right(futures::future::pending()))
             };
@@ -347,7 +344,7 @@ impl<
             select! {
                 _ = retry => {
                     // Retry sending after rate limiting
-                    self.send(&mut context, false, &mut sender).await;
+                    self.send(false, &mut sender).await;
                 },
                 _ = timeout => {
                     // Penalize peer for timeout
@@ -356,7 +353,7 @@ impl<
                     self.requester.timeout(request);
 
                     // Send message
-                    self.send(&mut context, true, &mut sender).await;
+                    self.send(true, &mut sender).await;
                 },
                 mailbox = self.mailbox_receiver.next() => {
                     let msg = match mailbox {
@@ -374,7 +371,7 @@ impl<
                             }
 
                             // Trigger fetch of new notarizations and nullifications as soon as possible
-                            self.send(&mut context, false, &mut sender).await;
+                            self.send(false, &mut sender).await;
                         }
                         Message::Notarized { notarization } => {
                             // Update current view
@@ -586,7 +583,7 @@ impl<
                             }
 
                             // If still work to do, send another request
-                            self.send(&mut context, shuffle, &mut sender).await;
+                            self.send(shuffle, &mut sender).await;
                         },
                     }
                 },

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -324,7 +324,7 @@ pub struct Actor<
     F: Reporter<Activity = Activity<C::Signature, D>>,
     S: Supervisor<Index = View, PublicKey = C::PublicKey>,
 > {
-    context: E,
+    context: Option<E>,
     crypto: C,
     automaton: A,
     relay: R,
@@ -417,7 +417,7 @@ impl<
         let mailbox = Mailbox::new(mailbox_sender);
         (
             Self {
-                context,
+                context: Some(context),
                 crypto: cfg.crypto,
                 automaton: cfg.automaton,
                 relay: cfg.relay,
@@ -589,7 +589,7 @@ impl<
         Some((context.clone(), self.automaton.propose(context).await))
     }
 
-    fn timeout_deadline(&mut self) -> SystemTime {
+    fn timeout_deadline(&mut self, context: &E) -> SystemTime {
         // Return the earliest deadline
         let view = self.views.get_mut(&self.view).unwrap();
         if let Some(deadline) = view.leader_deadline {
@@ -606,13 +606,14 @@ impl<
         }
 
         // Set nullify retry, if none already set
-        let null_retry = self.context.current() + self.nullify_retry;
+        let null_retry = context.current() + self.nullify_retry;
         view.nullify_retry = Some(null_retry);
         null_retry
     }
 
     async fn timeout<Sr: Sender>(
         &mut self,
+        context: &E,
         sender: &mut WrappedSender<Sr, Voter<C::Signature, D>>,
     ) {
         // Set timeout fired
@@ -677,7 +678,7 @@ impl<
         );
 
         // Handle the nullify
-        self.handle_nullify(nullify.clone()).await;
+        self.handle_nullify(context, nullify.clone()).await;
 
         // Sync the journal
         self.journal
@@ -696,7 +697,7 @@ impl<
         debug!(view = self.view, "broadcasted nullify");
     }
 
-    async fn nullify(&mut self, nullify: Nullify<C::Signature>) -> bool {
+    async fn nullify(&mut self, context: &E, nullify: Nullify<C::Signature>) -> bool {
         // Ensure we are in the right view to process this message
         if !self.interesting(nullify.view(), false) {
             return false;
@@ -716,16 +717,16 @@ impl<
         }
 
         // Handle nullify
-        self.handle_nullify(nullify).await;
+        self.handle_nullify(context, nullify).await;
         true
     }
 
-    async fn handle_nullify(&mut self, nullify: Nullify<C::Signature>) {
+    async fn handle_nullify(&mut self, context: &E, nullify: Nullify<C::Signature>) {
         // Check to see if nullify is for proposal in view
         let view = nullify.view();
         let round = self.views.entry(view).or_insert_with(|| {
             Round::new(
-                self.context.current(),
+                context.current(),
                 self.reporter.clone(),
                 self.supervisor.clone(),
                 Rnd::new(self.epoch, view),
@@ -889,16 +890,16 @@ impl<
         true
     }
 
-    fn since_view_start(&self, view: u64) -> Option<(bool, f64)> {
+    fn since_view_start(&self, context: &E, view: u64) -> Option<(bool, f64)> {
         let round = self.views.get(&view)?;
         let leader = &round.leader;
-        let Ok(elapsed) = self.context.current().duration_since(round.start) else {
+        let Ok(elapsed) = context.current().duration_since(round.start) else {
             return None;
         };
         Some((*leader == self.crypto.public_key(), elapsed.as_secs_f64()))
     }
 
-    fn enter_view(&mut self, view: u64) {
+    fn enter_view(&mut self, context: &E, view: u64) {
         // Ensure view is valid
         if view <= self.view {
             trace!(
@@ -912,14 +913,14 @@ impl<
         // Setup new view
         let round = self.views.entry(view).or_insert_with(|| {
             Round::new(
-                self.context.current(),
+                context.current(),
                 self.reporter.clone(),
                 self.supervisor.clone(),
                 Rnd::new(self.epoch, view),
             )
         });
-        round.leader_deadline = Some(self.context.current() + self.leader_timeout);
-        round.advance_deadline = Some(self.context.current() + self.notarization_timeout);
+        round.leader_deadline = Some(context.current() + self.leader_timeout);
+        round.advance_deadline = Some(context.current() + self.notarization_timeout);
         self.view = view;
 
         // Update metrics
@@ -958,7 +959,7 @@ impl<
         // Reduce leader deadline to now
         debug!(view, ?leader, "skipping leader timeout due to inactivity");
         self.skipped_views.inc();
-        self.views.get_mut(&view).unwrap().leader_deadline = Some(self.context.current());
+        self.views.get_mut(&view).unwrap().leader_deadline = Some(context.current());
     }
 
     /// The minimum view we are tracking both in-memory and on-disk.
@@ -1017,7 +1018,7 @@ impl<
         self.tracked_views.set(self.views.len() as i64);
     }
 
-    async fn notarize(&mut self, notarize: Notarize<C::Signature, D>) -> bool {
+    async fn notarize(&mut self, context: &E, notarize: Notarize<C::Signature, D>) -> bool {
         // Ensure we are in the right view to process this message
         let view = notarize.view();
         if !self.interesting(view, false) {
@@ -1038,16 +1039,16 @@ impl<
         }
 
         // Handle notarize
-        self.handle_notarize(notarize).await;
+        self.handle_notarize(context, notarize).await;
         true
     }
 
-    async fn handle_notarize(&mut self, notarize: Notarize<C::Signature, D>) {
+    async fn handle_notarize(&mut self, context: &E, notarize: Notarize<C::Signature, D>) {
         // Check to see if notarize is for proposal in view
         let view = notarize.view();
         let round = self.views.entry(view).or_insert_with(|| {
             Round::new(
-                self.context.current(),
+                context.current(),
                 self.reporter.clone(),
                 self.supervisor.clone(),
                 Rnd::new(self.epoch, view),
@@ -1066,7 +1067,11 @@ impl<
         }
     }
 
-    async fn notarization(&mut self, notarization: Notarization<C::Signature, D>) -> bool {
+    async fn notarization(
+        &mut self,
+        context: &E,
+        notarization: Notarization<C::Signature, D>,
+    ) -> bool {
         // Check if we are still in a view where this notarization could help
         let view = notarization.view();
         if !self.interesting(view, true) {
@@ -1090,16 +1095,20 @@ impl<
         }
 
         // Handle notarization
-        self.handle_notarization(&notarization).await;
+        self.handle_notarization(context, &notarization).await;
         true
     }
 
-    async fn handle_notarization(&mut self, notarization: &Notarization<C::Signature, D>) {
+    async fn handle_notarization(
+        &mut self,
+        context: &E,
+        notarization: &Notarization<C::Signature, D>,
+    ) {
         // Add signatures to view (needed to broadcast notarization if we get proposal)
         let view = notarization.view();
         let round = self.views.entry(view).or_insert_with(|| {
             Round::new(
-                self.context.current(),
+                context.current(),
                 self.reporter.clone(),
                 self.supervisor.clone(),
                 Rnd::new(self.epoch, view),
@@ -1133,10 +1142,14 @@ impl<
         }
 
         // Enter next view
-        self.enter_view(view + 1);
+        self.enter_view(context, view + 1);
     }
 
-    async fn nullification(&mut self, nullification: Nullification<C::Signature>) -> bool {
+    async fn nullification(
+        &mut self,
+        context: &E,
+        nullification: Nullification<C::Signature>,
+    ) -> bool {
         // Check if we are still in a view where this notarization could help
         if !self.interesting(nullification.view(), true) {
             return false;
@@ -1159,17 +1172,21 @@ impl<
         }
 
         // Handle notarization
-        self.handle_nullification(&nullification).await;
+        self.handle_nullification(context, &nullification).await;
         true
     }
 
-    async fn handle_nullification(&mut self, nullification: &Nullification<C::Signature>) {
+    async fn handle_nullification(
+        &mut self,
+        context: &E,
+        nullification: &Nullification<C::Signature>,
+    ) {
         // Add signatures to view (needed to broadcast notarization if we get proposal)
         let view = nullification.view();
         let rnd = Rnd::new(self.epoch, view);
         let round = self.views.entry(view).or_insert_with(|| {
             Round::new(
-                self.context.current(),
+                context.current(),
                 self.reporter.clone(),
                 self.supervisor.clone(),
                 rnd,
@@ -1193,10 +1210,10 @@ impl<
         round.advance_deadline = None;
 
         // Enter next view
-        self.enter_view(nullification.view() + 1);
+        self.enter_view(context, nullification.view() + 1);
     }
 
-    async fn finalize(&mut self, finalize: Finalize<C::Signature, D>) -> bool {
+    async fn finalize(&mut self, context: &E, finalize: Finalize<C::Signature, D>) -> bool {
         // Ensure we are in the right view to process this message
         let view = finalize.view();
         if !self.interesting(view, false) {
@@ -1217,16 +1234,16 @@ impl<
         }
 
         // Handle finalize
-        self.handle_finalize(finalize).await;
+        self.handle_finalize(context, finalize).await;
         true
     }
 
-    async fn handle_finalize(&mut self, finalize: Finalize<C::Signature, D>) {
+    async fn handle_finalize(&mut self, context: &E, finalize: Finalize<C::Signature, D>) {
         // Get view for finalize
         let view = finalize.view();
         let round = self.views.entry(view).or_insert_with(|| {
             Round::new(
-                self.context.current(),
+                context.current(),
                 self.reporter.clone(),
                 self.supervisor.clone(),
                 Rnd::new(self.epoch, view),
@@ -1245,7 +1262,11 @@ impl<
         }
     }
 
-    async fn finalization(&mut self, finalization: Finalization<C::Signature, D>) -> bool {
+    async fn finalization(
+        &mut self,
+        context: &E,
+        finalization: Finalization<C::Signature, D>,
+    ) -> bool {
         // Check if we are still in a view where this finalization could help
         let view = finalization.view();
         if !self.interesting(view, true) {
@@ -1269,16 +1290,20 @@ impl<
         }
 
         // Process finalization
-        self.handle_finalization(&finalization).await;
+        self.handle_finalization(context, &finalization).await;
         true
     }
 
-    async fn handle_finalization(&mut self, finalization: &Finalization<C::Signature, D>) {
+    async fn handle_finalization(
+        &mut self,
+        context: &E,
+        finalization: &Finalization<C::Signature, D>,
+    ) {
         // Add signatures to view (needed to broadcast finalization if we get proposal)
         let view = finalization.view();
         let round = self.views.entry(view).or_insert_with(|| {
             Round::new(
-                self.context.current(),
+                context.current(),
                 self.reporter.clone(),
                 self.supervisor.clone(),
                 Rnd::new(self.epoch, view),
@@ -1313,7 +1338,7 @@ impl<
         }
 
         // Enter next view
-        self.enter_view(view + 1);
+        self.enter_view(context, view + 1);
     }
 
     fn construct_notarize(&mut self, view: u64) -> Option<Notarize<C::Signature, D>> {
@@ -1483,6 +1508,7 @@ impl<
 
     async fn notify<Sr: Sender>(
         &mut self,
+        context: &E,
         backfiller: &mut resolver::Mailbox<C::Signature, D>,
         sender: &mut WrappedSender<Sr, Voter<C::Signature, D>>,
         view: u64,
@@ -1490,7 +1516,7 @@ impl<
         // Attempt to notarize
         if let Some(notarize) = self.construct_notarize(view) {
             // Handle the notarize
-            self.handle_notarize(notarize.clone()).await;
+            self.handle_notarize(context, notarize.clone()).await;
 
             // Sync the journal
             self.journal
@@ -1511,7 +1537,7 @@ impl<
         // Attempt to notarization
         if let Some(notarization) = self.construct_notarization(view, false) {
             // Record latency if we are the leader (only way to get unbiased observation)
-            if let Some((leader, elapsed)) = self.since_view_start(view) {
+            if let Some((leader, elapsed)) = self.since_view_start(context, view) {
                 if leader {
                     self.notarization_latency.observe(elapsed);
                 }
@@ -1521,7 +1547,7 @@ impl<
             backfiller.notarized(notarization.clone()).await;
 
             // Handle the notarization
-            self.handle_notarization(&notarization).await;
+            self.handle_notarization(context, &notarization).await;
 
             // Sync the journal
             self.journal
@@ -1552,7 +1578,7 @@ impl<
             backfiller.nullified(nullification.clone()).await;
 
             // Handle the nullification
-            self.handle_nullification(&nullification).await;
+            self.handle_nullification(context, &nullification).await;
 
             // Sync the journal
             self.journal
@@ -1629,7 +1655,7 @@ impl<
         // Attempt to finalize
         if let Some(finalize) = self.construct_finalize(view) {
             // Handle the finalize
-            self.handle_finalize(finalize.clone()).await;
+            self.handle_finalize(context, finalize.clone()).await;
 
             // Sync the journal
             self.journal
@@ -1650,7 +1676,7 @@ impl<
         // Attempt to finalization
         if let Some(finalization) = self.construct_finalization(view, false) {
             // Record latency if we are the leader (only way to get unbiased observation)
-            if let Some((leader, elapsed)) = self.since_view_start(view) {
+            if let Some((leader, elapsed)) = self.since_view_start(context, view) {
                 if leader {
                     self.finalization_latency.observe(elapsed);
                 }
@@ -1660,7 +1686,7 @@ impl<
             backfiller.finalized(view).await;
 
             // Handle the finalization
-            self.handle_finalization(&finalization).await;
+            self.handle_finalization(context, &finalization).await;
 
             // Sync the journal
             self.journal
@@ -1690,11 +1716,15 @@ impl<
         sender: impl Sender,
         receiver: impl Receiver,
     ) -> Handle<()> {
-        self.context.spawn_ref()(self.run(backfiller, sender, receiver))
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|context| self.run(context, backfiller, sender, receiver))
     }
 
     async fn run(
         mut self,
+        context: E,
         mut backfiller: resolver::Mailbox<C::Signature, D>,
         sender: impl Sender,
         receiver: impl Receiver,
@@ -1709,11 +1739,11 @@ impl<
         // Add initial view
         //
         // We start on view 1 because the genesis container occupies view 0/height 0.
-        self.enter_view(1);
+        self.enter_view(&context, 1);
 
         // Initialize journal
         let journal = Journal::<_, Voter<C::Signature, D>>::init(
-            self.context.with_label("journal"),
+            context.with_label("journal"),
             JConfig {
                 partition: self.partition.clone(),
                 compression: None,        // most of the data is not compressible
@@ -1727,7 +1757,7 @@ impl<
 
         // Rebuild from journal
         let mut observed_view = 1;
-        let start = self.context.current();
+        let start = context.current();
         {
             let stream = journal
                 .replay(0, 0, self.replay_buffer)
@@ -1743,7 +1773,7 @@ impl<
                 match msg {
                     Voter::Notarize(notarize) => {
                         // Handle notarize
-                        self.handle_notarize(notarize.clone()).await;
+                        self.handle_notarize(&context, notarize.clone()).await;
 
                         // Update round info
                         let Some(public_key_index) = public_key_index else {
@@ -1759,7 +1789,7 @@ impl<
                     }
                     Voter::Nullify(nullify) => {
                         // Handle nullify
-                        self.handle_nullify(nullify.clone()).await;
+                        self.handle_nullify(&context, nullify.clone()).await;
 
                         // Update round info
                         let Some(public_key_index) = public_key_index else {
@@ -1773,7 +1803,7 @@ impl<
                     }
                     Voter::Finalize(finalize) => {
                         // Handle finalize
-                        self.handle_finalize(finalize.clone()).await;
+                        self.handle_finalize(&context, finalize.clone()).await;
 
                         // Update round info
                         //
@@ -1795,24 +1825,24 @@ impl<
         self.journal = Some(journal);
 
         // Update current view and immediately move to timeout (very unlikely we restarted and still within timeout)
-        let end = self.context.current();
+        let end = context.current();
         let elapsed = end.duration_since(start).unwrap_or_default();
         debug!(
             current_view = observed_view,
             ?elapsed,
             "consensus initialized"
         );
-        self.enter_view(observed_view);
+        self.enter_view(&context, observed_view);
         {
             let round = self.views.get_mut(&observed_view).expect("missing round");
-            round.leader_deadline = Some(self.context.current());
-            round.advance_deadline = Some(self.context.current());
+            round.leader_deadline = Some(context.current());
+            round.advance_deadline = Some(context.current());
         }
         self.current_view.set(observed_view as i64);
         self.tracked_views.set(self.views.len() as i64);
 
         // Create shutdown tracker
-        let mut shutdown = self.context.stopped();
+        let mut shutdown = context.stopped();
 
         // Process messages
         let mut pending_set = None;
@@ -1855,7 +1885,7 @@ impl<
             };
 
             // Wait for a timeout to fire or for a message to arrive
-            let timeout = self.timeout_deadline();
+            let timeout = self.timeout_deadline(&context);
             let view;
             select! {
                 _ = &mut shutdown => {
@@ -1868,9 +1898,9 @@ impl<
                         .expect("unable to close journal");
                     return;
                 },
-                _ = self.context.sleep_until(timeout) => {
+                _ = context.sleep_until(timeout) => {
                     // Trigger the timeout
-                    self.timeout(&mut sender).await;
+                    self.timeout(&context, &mut sender).await;
                     view = self.view;
                 },
                 proposed = propose_wait => {
@@ -1945,11 +1975,11 @@ impl<
                     match msg {
                         Message::Notarization(notarization)  => {
                             debug!(view, "received notarization from backfiller");
-                            self.handle_notarization(&notarization).await;
+                            self.handle_notarization(&context, &notarization).await;
                         },
                         Message::Nullification(nullification) => {
                             debug!(view, "received nullification from backfiller");
-                            self.handle_nullification(&nullification).await;
+                            self.handle_nullification(&context, &nullification).await;
                         },
                     }
                 },
@@ -1974,27 +2004,27 @@ impl<
                     let interesting = match msg {
                         Voter::Notarize(notarize) => {
                             self.received_messages.get_or_create(&metrics::PeerMessage::notarize(&s)).inc();
-                            self.notarize(notarize).await
+                            self.notarize(&context, notarize).await
                         }
                         Voter::Notarization(notarization) => {
                             self.received_messages.get_or_create(&metrics::PeerMessage::notarization(&s)).inc();
-                            self.notarization(notarization).await
+                            self.notarization(&context, notarization).await
                         }
                         Voter::Nullify(nullify) => {
                             self.received_messages.get_or_create(&metrics::PeerMessage::nullify(&s)).inc();
-                            self.nullify(nullify).await
+                            self.nullify(&context, nullify).await
                         }
                         Voter::Nullification(nullification) => {
                             self.received_messages.get_or_create(&metrics::PeerMessage::nullification(&s)).inc();
-                            self.nullification(nullification).await
+                            self.nullification(&context, nullification).await
                         }
                         Voter::Finalize(finalize) => {
                             self.received_messages.get_or_create(&metrics::PeerMessage::finalize(&s)).inc();
-                            self.finalize(finalize).await
+                            self.finalize(&context, finalize).await
                         }
                         Voter::Finalization(finalization) => {
                             self.received_messages.get_or_create(&metrics::PeerMessage::finalization(&s)).inc();
-                            self.finalization(finalization).await
+                            self.finalization(&context, finalization).await
                         }
                     };
                     if !interesting {
@@ -2005,7 +2035,8 @@ impl<
             };
 
             // Attempt to send any new view messages
-            self.notify(&mut backfiller, &mut sender, view).await;
+            self.notify(&context, &mut backfiller, &mut sender, view)
+                .await;
 
             // After sending all required messages, prune any views
             // we no longer need

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -90,7 +90,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.with_label("network"));
 
             // Get participants
             let mut schemes = Vec::new();
@@ -126,7 +126,7 @@ mod tests {
                 context.with_label("application"),
                 application_cfg,
             );
-            actor.start();
+            actor.start(context.with_label("application"));
             let cfg = Config {
                 crypto: scheme,
                 automaton: application.clone(),
@@ -192,7 +192,7 @@ mod tests {
             });
 
             // Run the actor
-            actor.start(backfiller, voter_sender, voter_receiver);
+            actor.start(context.clone(), backfiller, voter_sender, voter_receiver);
 
             // Send finalization over network (view 100)
             let payload = Sha256::hash(b"test");
@@ -290,7 +290,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.with_label("network"));
 
             // Get participants
             let mut private_keys = Vec::new();
@@ -325,7 +325,7 @@ mod tests {
                 context.with_label("application"),
                 application_cfg,
             );
-            actor.start();
+            actor.start(context.with_label("application"));
             let cfg = Config {
                 crypto: private_key,
                 automaton: application.clone(),
@@ -391,7 +391,7 @@ mod tests {
             });
 
             // Run the actor
-            actor.start(backfiller, voter_sender, voter_receiver);
+            actor.start(context.clone(), backfiller, voter_sender, voter_receiver);
 
             // Establish Prune Floor (50 - 10 + 5 = 45)
             //

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -121,7 +121,7 @@ pub struct Config<H: Hasher, P: PublicKey> {
     pub verify_latency: Latency,
 }
 
-pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
+pub struct Application<E: Clock + RngCore, H: Hasher, P: PublicKey> {
     context: E,
     hasher: H,
     participant: P,
@@ -139,7 +139,7 @@ pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
     verified: HashSet<H::Digest>,
 }
 
-impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P> {
+impl<E: Clock + RngCore, H: Hasher, P: PublicKey> Application<E, H, P> {
     pub fn new(context: E, cfg: Config<H, P>) -> (Self, Mailbox<H::Digest>) {
         // Register self on relay
         let broadcast = cfg.relay.register(cfg.participant.clone());
@@ -152,7 +152,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
         let (sender, receiver) = mpsc::channel(1024);
         (
             Self {
-                context: Some(context),
+                context,
                 hasher: cfg.hasher,
                 participant: cfg.participant,
 
@@ -186,14 +186,16 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
 
     /// When proposing a block, we do not care if the parent is verified (or even in our possession).
     /// Backfilling verification dependencies is considered out-of-scope for consensus.
-    async fn propose(&mut self, runtime: &mut E, context: Context<H::Digest>) -> H::Digest {
+    async fn propose(&mut self, context: Context<H::Digest>) -> H::Digest {
         // Simulate the propose latency
-        let duration = self.propose_latency.sample(runtime);
-        runtime.sleep(Duration::from_millis(duration as u64)).await;
+        let duration = self.propose_latency.sample(&mut self.context);
+        self.context
+            .sleep(Duration::from_millis(duration as u64))
+            .await;
 
         // Generate the payload
         let parent = context.parent.1;
-        let random = runtime.gen::<u64>(); // Ensures we always have a unique payload
+        let random = self.context.gen::<u64>(); // Ensures we always have a unique payload
         let payload = (context.round, parent, random).encode();
         self.hasher.update(&payload);
         let digest = self.hasher.finalize();
@@ -208,14 +210,15 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
 
     async fn verify(
         &mut self,
-        runtime: &mut E,
         context: Context<H::Digest>,
         payload: H::Digest,
         mut contents: Bytes,
     ) -> bool {
         // Simulate the verify latency
-        let duration = self.verify_latency.sample(runtime);
-        runtime.sleep(Duration::from_millis(duration as u64)).await;
+        let duration = self.verify_latency.sample(&mut self.context);
+        self.context
+            .sleep(Duration::from_millis(duration as u64))
+            .await;
 
         // Verify contents
         let (parsed_round, parent, _) =
@@ -244,14 +247,11 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
             .await;
     }
 
-    pub fn start(mut self) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|runtime| self.run(runtime))
+    pub fn start(self, spawner: impl Spawner) -> Handle<()> {
+        spawner.spawn(|_| self.run())
     }
 
-    async fn run(mut self, mut runtime: E) {
+    async fn run(mut self) {
         // Setup digest tracking
         #[allow(clippy::type_complexity)]
         let mut waiters: HashMap<
@@ -274,13 +274,13 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                             let _ = response.send(digest);
                         }
                         Message::Propose { context, response } => {
-                            let digest = self.propose(&mut runtime, context).await;
+                            let digest = self.propose(context).await;
                             let _ = response.send(digest);
                         }
                         Message::Verify { context, payload, response } => {
                             if let Some(contents) = seen.get(&payload) {
                                 let verified =
-                                    self.verify(&mut runtime, context, payload, contents.clone()).await;
+                                    self.verify(context, payload, contents.clone()).await;
                                 let _ = response.send(verified);
                             } else {
                                 waiters
@@ -304,7 +304,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                     if let Some(waiters) = waiters.remove(&digest) {
                         for (context, sender) in waiters {
                             let verified =
-                                self.verify(&mut runtime, context, digest, contents.clone()).await;
+                                self.verify(context, digest, contents.clone()).await;
                             sender.send(verified).expect("Failed to send verification");
                         }
                     }

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -122,7 +122,7 @@ pub struct Config<H: Hasher, P: PublicKey> {
 }
 
 pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
-    context: E,
+    context: Option<E>,
     hasher: H,
     participant: P,
 
@@ -152,7 +152,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
         let (sender, receiver) = mpsc::channel(1024);
         (
             Self {
-                context,
+                context: Some(context),
                 hasher: cfg.hasher,
                 participant: cfg.participant,
 
@@ -186,16 +186,14 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
 
     /// When proposing a block, we do not care if the parent is verified (or even in our possession).
     /// Backfilling verification dependencies is considered out-of-scope for consensus.
-    async fn propose(&mut self, context: Context<H::Digest>) -> H::Digest {
+    async fn propose(&mut self, runtime: &mut E, context: Context<H::Digest>) -> H::Digest {
         // Simulate the propose latency
-        let duration = self.propose_latency.sample(&mut self.context);
-        self.context
-            .sleep(Duration::from_millis(duration as u64))
-            .await;
+        let duration = self.propose_latency.sample(runtime);
+        runtime.sleep(Duration::from_millis(duration as u64)).await;
 
         // Generate the payload
         let parent = context.parent.1;
-        let random = self.context.gen::<u64>(); // Ensures we always have a unique payload
+        let random = runtime.gen::<u64>(); // Ensures we always have a unique payload
         let payload = (context.round, parent, random).encode();
         self.hasher.update(&payload);
         let digest = self.hasher.finalize();
@@ -210,15 +208,14 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
 
     async fn verify(
         &mut self,
+        runtime: &mut E,
         context: Context<H::Digest>,
         payload: H::Digest,
         mut contents: Bytes,
     ) -> bool {
         // Simulate the verify latency
-        let duration = self.verify_latency.sample(&mut self.context);
-        self.context
-            .sleep(Duration::from_millis(duration as u64))
-            .await;
+        let duration = self.verify_latency.sample(runtime);
+        runtime.sleep(Duration::from_millis(duration as u64)).await;
 
         // Verify contents
         let (parsed_round, parent, _) =
@@ -248,10 +245,13 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
     }
 
     pub fn start(mut self) -> Handle<()> {
-        self.context.spawn_ref()(self.run())
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|runtime| self.run(runtime))
     }
 
-    async fn run(mut self) {
+    async fn run(mut self, mut runtime: E) {
         // Setup digest tracking
         #[allow(clippy::type_complexity)]
         let mut waiters: HashMap<
@@ -274,12 +274,13 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                             let _ = response.send(digest);
                         }
                         Message::Propose { context, response } => {
-                            let digest = self.propose(context).await;
+                            let digest = self.propose(&mut runtime, context).await;
                             let _ = response.send(digest);
                         }
                         Message::Verify { context, payload, response } => {
                             if let Some(contents) = seen.get(&payload) {
-                                let verified = self.verify(context, payload, contents.clone()).await;
+                                let verified =
+                                    self.verify(&mut runtime, context, payload, contents.clone()).await;
                                 let _ = response.send(verified);
                             } else {
                                 waiters
@@ -302,7 +303,8 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                     // Check if we have a waiter
                     if let Some(waiters) = waiters.remove(&digest) {
                         for (context, sender) in waiters {
-                            let verified = self.verify(context, digest, contents.clone()).await;
+                            let verified =
+                                self.verify(&mut runtime, context, digest, contents.clone()).await;
                             sender.send(verified).expect("Failed to send verification");
                         }
                     }

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -122,7 +122,7 @@ pub struct Config<H: Hasher, P: PublicKey> {
 }
 
 pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
-    context: Option<E>,
+    context: E,
     hasher: H,
     participant: P,
 

--- a/consensus/src/simplex/mocks/outdated.rs
+++ b/consensus/src/simplex/mocks/outdated.rs
@@ -8,8 +8,7 @@ use crate::{
 use commonware_codec::{Decode, Encode};
 use commonware_cryptography::{Hasher, Signer};
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Clock, Handle, Spawner};
-use rand::{CryptoRng, Rng};
+use commonware_runtime::{Handle, Spawner};
 use std::collections::HashMap;
 use tracing::debug;
 
@@ -20,13 +19,7 @@ pub struct Config<C: Signer, S: Supervisor<Index = View>> {
     pub view_delta: u64,
 }
 
-pub struct Outdated<
-    E: Clock + Rng + CryptoRng + Spawner,
-    C: Signer,
-    H: Hasher,
-    S: Supervisor<Index = View, PublicKey = C::PublicKey>,
-> {
-    context: Option<E>,
+pub struct Outdated<C: Signer, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>> {
     crypto: C,
     supervisor: S,
 
@@ -36,16 +29,11 @@ pub struct Outdated<
     view_delta: u64,
 }
 
-impl<
-        E: Clock + Rng + CryptoRng + Spawner,
-        C: Signer,
-        H: Hasher,
-        S: Supervisor<Index = View, PublicKey = C::PublicKey>,
-    > Outdated<E, C, H, S>
+impl<C: Signer, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>>
+    Outdated<C, H, S>
 {
-    pub fn new(context: E, cfg: Config<C, S>) -> Self {
+    pub fn new(cfg: Config<C, S>) -> Self {
         Self {
-            context: Some(context),
             crypto: cfg.crypto,
             supervisor: cfg.supervisor,
 
@@ -56,11 +44,12 @@ impl<
         }
     }
 
-    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|_| self.run(voter_network))
+    pub fn start(
+        self,
+        spawner: impl Spawner,
+        voter_network: (impl Sender, impl Receiver),
+    ) -> Handle<()> {
+        spawner.spawn(|_| self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/reconfigurer.rs
+++ b/consensus/src/simplex/mocks/reconfigurer.rs
@@ -20,25 +20,19 @@ pub struct Config<C: Signer, S: Supervisor<Index = View, PublicKey = C::PublicKe
     pub namespace: Vec<u8>,
 }
 
-pub struct Reconfigurer<
-    E: Spawner,
-    C: Signer,
-    H: Hasher,
-    S: Supervisor<Index = View, PublicKey = C::PublicKey>,
-> {
-    context: Option<E>,
+pub struct Reconfigurer<C: Signer, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>>
+{
     crypto: C,
     supervisor: S,
     namespace: Vec<u8>,
     _hasher: PhantomData<H>,
 }
 
-impl<E: Spawner, C: Signer, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>>
-    Reconfigurer<E, C, H, S>
+impl<C: Signer, H: Hasher, S: Supervisor<Index = View, PublicKey = C::PublicKey>>
+    Reconfigurer<C, H, S>
 {
-    pub fn new(context: E, cfg: Config<C, S>) -> Self {
+    pub fn new(cfg: Config<C, S>) -> Self {
         Self {
-            context: Some(context),
             crypto: cfg.crypto,
             supervisor: cfg.supervisor,
             namespace: cfg.namespace,
@@ -46,11 +40,12 @@ impl<E: Spawner, C: Signer, H: Hasher, S: Supervisor<Index = View, PublicKey = C
         }
     }
 
-    pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|_| self.run(voter_network))
+    pub fn start(
+        self,
+        spawner: impl Spawner,
+        voter_network: (impl Sender, impl Receiver),
+    ) -> Handle<()> {
+        spawner.spawn(|_| self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/reconfigurer.rs
+++ b/consensus/src/simplex/mocks/reconfigurer.rs
@@ -26,7 +26,7 @@ pub struct Reconfigurer<
     H: Hasher,
     S: Supervisor<Index = View, PublicKey = C::PublicKey>,
 > {
-    context: E,
+    context: Option<E>,
     crypto: C,
     supervisor: S,
     namespace: Vec<u8>,
@@ -38,7 +38,7 @@ impl<E: Spawner, C: Signer, H: Hasher, S: Supervisor<Index = View, PublicKey = C
 {
     pub fn new(context: E, cfg: Config<C, S>) -> Self {
         Self {
-            context,
+            context: Some(context),
             crypto: cfg.crypto,
             supervisor: cfg.supervisor,
             namespace: cfg.namespace,
@@ -47,7 +47,10 @@ impl<E: Spawner, C: Signer, H: Hasher, S: Supervisor<Index = View, PublicKey = C
     }
 
     pub fn start(mut self, voter_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.spawn_ref()(self.run(voter_network))
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|_| self.run(voter_network))
     }
 
     async fn run(mut self, voter_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -662,9 +662,7 @@ mod tests {
                 let mut engine_handlers = Vec::new();
                 for scheme in schemes.into_iter() {
                     // Create scheme context
-                    let context = context
-                        .clone()
-                        .with_label(&format!("validator-{}", scheme.public_key()));
+                    let context = context.with_label(&format!("validator-{}", scheme.public_key()));
 
                     // Start engine
                     let validator = scheme.public_key();

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -257,7 +257,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -310,7 +310,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let cfg = config::Config {
                     crypto: scheme,
                     automaton: application.clone(),
@@ -339,7 +339,7 @@ mod tests {
                 let (voter, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(voter, resolver));
+                engine_handlers.push(engine.start(context.with_label("engine"), voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -491,7 +491,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -554,7 +554,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
 
                 // Configure engine
                 let cfg = config::Config {
@@ -585,7 +585,7 @@ mod tests {
                 let (voter, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine.start(voter, resolver);
+                engine.start(context.with_label("engine"), voter, resolver);
             }
 
             // Wait for all engines (including the observer) to finish
@@ -632,7 +632,7 @@ mod tests {
                 );
 
                 // Start network
-                network.start();
+                network.start(context.with_label("network"));
 
                 // Register participants
                 let mut schemes = Vec::new();
@@ -685,7 +685,8 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
+
                     let cfg = config::Config {
                         crypto: scheme,
                         automaton: application.clone(),
@@ -714,7 +715,11 @@ mod tests {
                     let (voter_network, resolver_network) = registrations
                         .remove(&validator)
                         .expect("validator should be registered");
-                    engine_handlers.push(engine.start(voter_network, resolver_network));
+                    engine_handlers.push(engine.start(
+                        context.with_label("engine"),
+                        voter_network,
+                        resolver_network,
+                    ));
                 }
 
                 // Store all finalizer handles
@@ -792,7 +797,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -856,7 +861,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let cfg = config::Config {
                     crypto: scheme.clone(),
                     automaton: application.clone(),
@@ -885,7 +890,7 @@ mod tests {
                     .remove(&validator)
                     .expect("validator should be registered");
                 let engine = Engine::new(context.with_label("engine"), cfg);
-                engine_handlers.push(engine.start(voter, resolver));
+                engine_handlers.push(engine.start(context.with_label("engine"), voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -975,7 +980,7 @@ mod tests {
                 context.with_label("application"),
                 application_cfg,
             );
-            actor.start();
+            actor.start(context.with_label("application"));
             let cfg = config::Config {
                 crypto: scheme,
                 automaton: application.clone(),
@@ -1004,7 +1009,7 @@ mod tests {
                 .remove(&validator)
                 .expect("validator should be registered");
             let engine = Engine::new(context.with_label("engine"), cfg);
-            engine_handlers.push(engine.start(voter, resolver));
+            engine_handlers.push(engine.start(context.with_label("engine"), voter, resolver));
 
             // Wait for new engine to finalize required
             let (mut latest, mut monitor) = supervisor.subscribe().await;
@@ -1035,7 +1040,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1099,7 +1104,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let cfg = config::Config {
                     crypto: scheme,
                     automaton: application.clone(),
@@ -1128,7 +1133,7 @@ mod tests {
                     .remove(&validator)
                     .expect("validator should be registered");
                 let engine = Engine::new(context.with_label("engine"), cfg);
-                engine_handlers.push(engine.start(voter, resolver));
+                engine_handlers.push(engine.start(context.with_label("engine"), voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -1264,7 +1269,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1327,7 +1332,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let cfg = config::Config {
                     crypto: scheme,
                     automaton: application.clone(),
@@ -1356,7 +1361,7 @@ mod tests {
                     .remove(&validator)
                     .expect("validator should be registered");
                 let engine = Engine::new(context.with_label("engine"), cfg);
-                engine_handlers.push(engine.start(voter, resolver));
+                engine_handlers.push(engine.start(context.with_label("engine"), voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -1434,7 +1439,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1487,7 +1492,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let cfg = config::Config {
                     crypto: scheme.clone(),
                     automaton: application.clone(),
@@ -1516,7 +1521,7 @@ mod tests {
                     .remove(&validator)
                     .expect("validator should be registered");
                 let engine = Engine::new(context.with_label("engine"), cfg);
-                engine_handlers.push(engine.start(voter, resolver));
+                engine_handlers.push(engine.start(context.with_label("engine"), voter, resolver));
             }
 
             // Wait for a few virtual minutes (shouldn't finalize anything)
@@ -1622,7 +1627,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1672,7 +1677,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let cfg = config::Config {
                     crypto: scheme.clone(),
                     automaton: application.clone(),
@@ -1701,7 +1706,7 @@ mod tests {
                     .remove(&validator)
                     .expect("validator should be registered");
                 let engine = Engine::new(context.with_label("engine"), cfg);
-                engine_handlers.push(engine.start(voter, resolver));
+                engine_handlers.push(engine.start(context.with_label("engine"), voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -1800,7 +1805,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1853,7 +1858,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let cfg = config::Config {
                     crypto: scheme,
                     automaton: application.clone(),
@@ -1882,7 +1887,7 @@ mod tests {
                     .remove(&validator)
                     .expect("validator should be registered");
                 let engine = Engine::new(context.with_label("engine"), cfg);
-                engine_handlers.push(engine.start(voter, resolver));
+                engine_handlers.push(engine.start(context.with_label("engine"), voter, resolver));
             }
 
             // Wait for all engines to finish
@@ -1954,7 +1959,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2008,7 +2013,7 @@ mod tests {
                             context.with_label("byzantine_engine"),
                             cfg,
                         );
-                    engine.start(voter);
+                    engine.start(context.with_label("byzantine_engine"), voter);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2022,7 +2027,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let cfg = config::Config {
                         crypto: scheme,
                         automaton: application.clone(),
@@ -2051,7 +2056,7 @@ mod tests {
                         .remove(&validator)
                         .expect("validator should be registered");
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(voter, resolver);
+                    engine.start(context.with_label("engine"), voter, resolver);
                 }
             }
 
@@ -2127,7 +2132,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2176,9 +2181,9 @@ mod tests {
                     let (voter, _) = registrations
                         .remove(&validator)
                         .expect("validator should be registered");
-                    let engine: mocks::nuller::Nuller<_, _, Sha256, _> =
-                        mocks::nuller::Nuller::new(context.with_label("byzantine_engine"), cfg);
-                    engine.start(voter);
+                    let engine: mocks::nuller::Nuller<_, Sha256, _> =
+                        mocks::nuller::Nuller::new(cfg);
+                    engine.start(context.with_label("byzantine_engine"), voter);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2192,7 +2197,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let cfg = config::Config {
                         crypto: scheme,
                         automaton: application.clone(),
@@ -2221,7 +2226,7 @@ mod tests {
                         .remove(&validator)
                         .expect("validator should be registered");
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(voter, resolver);
+                    engine.start(context.with_label("engine"), voter, resolver);
                 }
             }
 
@@ -2284,7 +2289,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2333,12 +2338,9 @@ mod tests {
                     let (voter, _) = registrations
                         .remove(&validator)
                         .expect("validator should be registered");
-                    let engine: mocks::reconfigurer::Reconfigurer<_, _, Sha256, _> =
-                        mocks::reconfigurer::Reconfigurer::new(
-                            context.with_label("byzantine_engine"),
-                            cfg,
-                        );
-                    engine.start(voter);
+                    let engine: mocks::reconfigurer::Reconfigurer<_, Sha256, _> =
+                        mocks::reconfigurer::Reconfigurer::new(cfg);
+                    engine.start(context.with_label("byzantine_engine"), voter);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2352,7 +2354,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let cfg = config::Config {
                         crypto: scheme,
                         automaton: application.clone(),
@@ -2381,7 +2383,7 @@ mod tests {
                         .remove(&validator)
                         .expect("validator should be registered");
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(voter, resolver);
+                    engine.start(context.with_label("engine"), voter, resolver);
                 }
             }
 
@@ -2446,7 +2448,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2496,9 +2498,9 @@ mod tests {
                     let (voter, _) = registrations
                         .remove(&validator)
                         .expect("validator should be registered");
-                    let engine: mocks::outdated::Outdated<_, _, Sha256, _> =
-                        mocks::outdated::Outdated::new(context.with_label("byzantine_engine"), cfg);
-                    engine.start(voter);
+                    let engine: mocks::outdated::Outdated<_, Sha256, _> =
+                        mocks::outdated::Outdated::new(cfg);
+                    engine.start(context.with_label("byzantine_engine"), voter);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2512,7 +2514,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let cfg = config::Config {
                         crypto: scheme,
                         automaton: application.clone(),
@@ -2541,7 +2543,7 @@ mod tests {
                         .remove(&validator)
                         .expect("validator should be registered");
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(voter, resolver);
+                    engine.start(context.with_label("engine"), voter, resolver);
                 }
             }
 
@@ -2597,7 +2599,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2650,7 +2652,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let cfg = config::Config {
                     crypto: scheme,
                     automaton: application.clone(),
@@ -2679,7 +2681,7 @@ mod tests {
                     .remove(&validator)
                     .expect("validator should be registered");
                 let engine = Engine::new(context.with_label("engine"), cfg);
-                engine_handlers.push(engine.start(voter, resolver));
+                engine_handlers.push(engine.start(context.with_label("engine"), voter, resolver));
             }
 
             // Wait for all engines to finish

--- a/consensus/src/threshold_simplex/actors/batcher/actor.rs
+++ b/consensus/src/threshold_simplex/actors/batcher/actor.rs
@@ -330,7 +330,7 @@ pub struct Actor<
         Polynomial = Vec<V::Public>,
     >,
 > {
-    context: E,
+    context: Option<E>,
     blocker: B,
     reporter: R,
     supervisor: S,
@@ -397,7 +397,7 @@ impl<
         let (sender, receiver) = mpsc::channel(cfg.mailbox_size);
         (
             Self {
-                context: context.clone(),
+                context: Some(context.clone()),
                 blocker: cfg.blocker,
                 reporter: cfg.reporter,
                 supervisor: cfg.supervisor,
@@ -425,7 +425,10 @@ impl<
         consensus: voter::Mailbox<V, D>,
         receiver: impl Receiver<PublicKey = C>,
     ) -> Handle<()> {
-        self.context.spawn_ref()(self.run(consensus, receiver))
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|_| self.run(consensus, receiver))
     }
 
     pub async fn run(

--- a/consensus/src/threshold_simplex/actors/resolver/actor.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/actor.rs
@@ -111,7 +111,7 @@ pub struct Actor<
         Polynomial = Vec<V::Public>,
     >,
 > {
-    context: E,
+    context: Option<E>,
     blocker: B,
     supervisor: S,
 
@@ -182,7 +182,7 @@ impl<
         let (sender, receiver) = mpsc::channel(cfg.mailbox_size);
         (
             Self {
-                context,
+                context: Some(context),
                 blocker: cfg.blocker,
                 supervisor: cfg.supervisor,
 
@@ -215,6 +215,7 @@ impl<
     /// Concurrent indicates whether we should send a new request (only if we see a request for the first time)
     async fn send<Sr: Sender<PublicKey = C>>(
         &mut self,
+        context: &mut E,
         shuffle: bool,
         sender: &mut WrappedSender<Sr, Backfiller<V, D>>,
     ) {
@@ -234,7 +235,7 @@ impl<
                 .required
                 .iter()
                 .filter(|entry| !self.inflight.contains(entry))
-                .choose_multiple(&mut self.context, self.max_fetch_count);
+                .choose_multiple(context, self.max_fetch_count);
             if entries.is_empty() {
                 return;
             }
@@ -270,8 +271,7 @@ impl<
                     // We return instead of waiting to continue serving requests and in case we
                     // learn of new notarizations or nullifications in the meantime.
                     warn!("failed to send request to any validator");
-                    let deadline = self
-                        .context
+                    let deadline = context
                         .current()
                         .checked_add(self.fetch_timeout)
                         .expect("time overflowed");
@@ -316,11 +316,15 @@ impl<
         sender: impl Sender<PublicKey = C>,
         receiver: impl Receiver<PublicKey = C>,
     ) -> Handle<()> {
-        self.context.spawn_ref()(self.run(voter, sender, receiver))
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|context| self.run(context, voter, sender, receiver))
     }
 
     async fn run(
         mut self,
+        mut context: E,
         mut voter: voter::Mailbox<V, D>,
         sender: impl Sender<PublicKey = C>,
         receiver: impl Receiver<PublicKey = C>,
@@ -339,13 +343,13 @@ impl<
 
             // Set timeout for retry
             let retry = match self.retry {
-                Some(retry) => Either::Left(self.context.sleep_until(retry)),
+                Some(retry) => Either::Left(context.sleep_until(retry)),
                 None => Either::Right(futures::future::pending()),
             };
 
             // Set timeout for next request
             let (request, timeout) = if let Some((request, timeout)) = self.requester.next() {
-                (request, Either::Left(self.context.sleep_until(timeout)))
+                (request, Either::Left(context.sleep_until(timeout)))
             } else {
                 (0, Either::Right(futures::future::pending()))
             };
@@ -354,7 +358,7 @@ impl<
             select! {
                 _ = retry => {
                     // Retry sending after rate limiting
-                    self.send(false, &mut sender).await;
+                    self.send(&mut context, false, &mut sender).await;
                 },
                 _ = timeout => {
                     // Penalize peer for timeout
@@ -363,7 +367,7 @@ impl<
                     self.requester.timeout(request);
 
                     // Send message
-                    self.send(true, &mut sender).await;
+                    self.send(&mut context, true, &mut sender).await;
                 },
                 mailbox = self.mailbox_receiver.next() => {
                     let msg = match mailbox {
@@ -383,7 +387,7 @@ impl<
                             }
 
                             // Trigger fetch of new notarizations and nullifications as soon as possible
-                            self.send(false, &mut sender).await;
+                            self.send(&mut context, false, &mut sender).await;
                         }
                         Message::Notarized { notarization } => {
                             // Update current view
@@ -580,7 +584,7 @@ impl<
                             }
 
                             // If still work to do, send another request
-                            self.send(shuffle, &mut sender).await;
+                            self.send(&mut context, shuffle, &mut sender).await;
                         },
                     }
                 },

--- a/consensus/src/threshold_simplex/actors/resolver/actor.rs
+++ b/consensus/src/threshold_simplex/actors/resolver/actor.rs
@@ -99,7 +99,7 @@ impl Inflight {
 
 /// Requests are made concurrently to multiple peers.
 pub struct Actor<
-    E: Clock + GClock + Rng + Metrics + Spawner,
+    E: Clock + GClock + Rng + Metrics,
     C: PublicKey,
     B: Blocker<PublicKey = C>,
     V: Variant,
@@ -111,7 +111,7 @@ pub struct Actor<
         Polynomial = Vec<V::Public>,
     >,
 > {
-    context: Option<E>,
+    context: E,
     blocker: B,
     supervisor: S,
 
@@ -139,7 +139,7 @@ pub struct Actor<
 }
 
 impl<
-        E: Clock + GClock + Rng + Metrics + Spawner,
+        E: Clock + GClock + Rng + Metrics,
         C: PublicKey,
         B: Blocker<PublicKey = C>,
         V: Variant,
@@ -182,7 +182,7 @@ impl<
         let (sender, receiver) = mpsc::channel(cfg.mailbox_size);
         (
             Self {
-                context: Some(context),
+                context,
                 blocker: cfg.blocker,
                 supervisor: cfg.supervisor,
 
@@ -215,7 +215,6 @@ impl<
     /// Concurrent indicates whether we should send a new request (only if we see a request for the first time)
     async fn send<Sr: Sender<PublicKey = C>>(
         &mut self,
-        context: &mut E,
         shuffle: bool,
         sender: &mut WrappedSender<Sr, Backfiller<V, D>>,
     ) {
@@ -235,7 +234,7 @@ impl<
                 .required
                 .iter()
                 .filter(|entry| !self.inflight.contains(entry))
-                .choose_multiple(context, self.max_fetch_count);
+                .choose_multiple(&mut self.context, self.max_fetch_count);
             if entries.is_empty() {
                 return;
             }
@@ -271,7 +270,8 @@ impl<
                     // We return instead of waiting to continue serving requests and in case we
                     // learn of new notarizations or nullifications in the meantime.
                     warn!("failed to send request to any validator");
-                    let deadline = context
+                    let deadline = self
+                        .context
                         .current()
                         .checked_add(self.fetch_timeout)
                         .expect("time overflowed");
@@ -311,20 +311,17 @@ impl<
     }
 
     pub fn start(
-        mut self,
+        self,
+        spawner: impl Spawner,
         voter: voter::Mailbox<V, D>,
         sender: impl Sender<PublicKey = C>,
         receiver: impl Receiver<PublicKey = C>,
     ) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|context| self.run(context, voter, sender, receiver))
+        spawner.spawn(|_| self.run(voter, sender, receiver))
     }
 
     async fn run(
         mut self,
-        mut context: E,
         mut voter: voter::Mailbox<V, D>,
         sender: impl Sender<PublicKey = C>,
         receiver: impl Receiver<PublicKey = C>,
@@ -343,13 +340,13 @@ impl<
 
             // Set timeout for retry
             let retry = match self.retry {
-                Some(retry) => Either::Left(context.sleep_until(retry)),
+                Some(retry) => Either::Left(self.context.sleep_until(retry)),
                 None => Either::Right(futures::future::pending()),
             };
 
             // Set timeout for next request
             let (request, timeout) = if let Some((request, timeout)) = self.requester.next() {
-                (request, Either::Left(context.sleep_until(timeout)))
+                (request, Either::Left(self.context.sleep_until(timeout)))
             } else {
                 (0, Either::Right(futures::future::pending()))
             };
@@ -358,7 +355,7 @@ impl<
             select! {
                 _ = retry => {
                     // Retry sending after rate limiting
-                    self.send(&mut context, false, &mut sender).await;
+                    self.send(false, &mut sender).await;
                 },
                 _ = timeout => {
                     // Penalize peer for timeout
@@ -367,7 +364,7 @@ impl<
                     self.requester.timeout(request);
 
                     // Send message
-                    self.send(&mut context, true, &mut sender).await;
+                    self.send(true, &mut sender).await;
                 },
                 mailbox = self.mailbox_receiver.next() => {
                     let msg = match mailbox {
@@ -387,7 +384,7 @@ impl<
                             }
 
                             // Trigger fetch of new notarizations and nullifications as soon as possible
-                            self.send(&mut context, false, &mut sender).await;
+                            self.send(false, &mut sender).await;
                         }
                         Message::Notarized { notarization } => {
                             // Update current view
@@ -584,7 +581,7 @@ impl<
                             }
 
                             // If still work to do, send another request
-                            self.send(&mut context, shuffle, &mut sender).await;
+                            self.send(shuffle, &mut sender).await;
                         },
                     }
                 },

--- a/consensus/src/threshold_simplex/actors/voter/mod.rs
+++ b/consensus/src/threshold_simplex/actors/voter/mod.rs
@@ -100,7 +100,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.with_label("network"));
 
             // Get participants
             let mut schemes = Vec::new();
@@ -147,7 +147,7 @@ mod tests {
                 context.with_label("application"),
                 application_cfg,
             );
-            actor.start();
+            actor.start(context.with_label("application"));
             let cfg = Config {
                 crypto: scheme,
                 blocker: oracle.control(validator.clone()),
@@ -214,6 +214,7 @@ mod tests {
 
             // Run the actor
             actor.start(
+                context.clone(),
                 batcher,
                 resolver,
                 pending_sender,
@@ -417,7 +418,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.with_label("network"));
 
             // Get participants
             let mut private_keys = Vec::new();
@@ -461,7 +462,7 @@ mod tests {
             };
             let (actor, application) =
                 mocks::application::Application::new(context.with_label("app"), app_config);
-            actor.start();
+            actor.start(context.with_label("app"));
             let voter_config = Config {
                 crypto: private_key.clone(),
                 blocker: oracle.control(validator.clone()),
@@ -528,6 +529,7 @@ mod tests {
 
             // Start the actor
             actor.start(
+                context.clone(),
                 batcher_mailbox,
                 resolver_mailbox,
                 pending_sender,

--- a/consensus/src/threshold_simplex/mocks/application.rs
+++ b/consensus/src/threshold_simplex/mocks/application.rs
@@ -125,7 +125,7 @@ pub struct Config<H: Hasher, P: PublicKey> {
 }
 
 pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
-    context: E,
+    context: Option<E>,
     hasher: H,
     participant: P,
 
@@ -155,7 +155,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
         let (sender, receiver) = mpsc::channel(1024);
         (
             Self {
-                context,
+                context: Some(context),
                 hasher: cfg.hasher,
                 participant: cfg.participant,
 
@@ -189,15 +189,13 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
 
     /// When proposing a block, we do not care if the parent is verified (or even in our possession).
     /// Backfilling verification dependencies is considered out-of-scope for consensus.
-    async fn propose(&mut self, context: Context<H::Digest>) -> H::Digest {
+    async fn propose(&mut self, runtime: &mut E, context: Context<H::Digest>) -> H::Digest {
         // Simulate the propose latency
-        let duration = self.propose_latency.sample(&mut self.context);
-        self.context
-            .sleep(Duration::from_millis(duration as u64))
-            .await;
+        let duration = self.propose_latency.sample(runtime);
+        runtime.sleep(Duration::from_millis(duration as u64)).await;
 
         // Generate the payload
-        let rand = self.context.gen::<u64>();
+        let rand = runtime.gen::<u64>();
         let payload = (context.round, context.parent.1, rand).encode();
         self.hasher.update(&payload);
         let digest = self.hasher.finalize();
@@ -212,15 +210,14 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
 
     async fn verify(
         &mut self,
+        runtime: &mut E,
         context: Context<H::Digest>,
         payload: H::Digest,
         mut contents: Bytes,
     ) -> bool {
         // Simulate the verify latency
-        let duration = self.verify_latency.sample(&mut self.context);
-        self.context
-            .sleep(Duration::from_millis(duration as u64))
-            .await;
+        let duration = self.verify_latency.sample(runtime);
+        runtime.sleep(Duration::from_millis(duration as u64)).await;
 
         // Verify contents
         let (parsed_round, parent, _) =
@@ -250,10 +247,13 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
     }
 
     pub fn start(mut self) -> Handle<()> {
-        self.context.spawn_ref()(self.run())
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|context| self.run(context))
     }
 
-    async fn run(mut self) {
+    async fn run(mut self, mut runtime: E) {
         // Setup digest tracking
         #[allow(clippy::type_complexity)]
         let mut waiters: HashMap<
@@ -266,7 +266,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
         loop {
             select! {
                 message = self.mailbox.next() => {
-                    let message =match message {
+                    let message = match message {
                         Some(message) => message,
                         None => break,
                     };
@@ -276,12 +276,12 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                             let _ = response.send(digest);
                         }
                         Message::Propose { context, response } => {
-                            let digest = self.propose(context).await;
+                            let digest = self.propose(&mut runtime, context).await;
                             let _ = response.send(digest);
                         }
                         Message::Verify { context, payload, response } => {
                             if let Some(contents) = seen.get(&payload) {
-                                let verified = self.verify(context, payload, contents.clone()).await;
+                                let verified = self.verify(&mut runtime, context, payload, contents.clone()).await;
                                 let _ = response.send(verified);
                             } else {
                                 waiters
@@ -304,7 +304,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                     // Check if we have a waiter
                     if let Some(waiters) = waiters.remove(&digest) {
                         for (context, sender) in waiters {
-                            let verified = self.verify(context, digest, contents.clone()).await;
+                            let verified = self.verify(&mut runtime, context, digest, contents.clone()).await;
                             sender.send(verified).expect("Failed to send verification");
                         }
                     }

--- a/consensus/src/threshold_simplex/mocks/conflicter.rs
+++ b/consensus/src/threshold_simplex/mocks/conflicter.rs
@@ -11,7 +11,7 @@ use commonware_cryptography::{
     Digest, Hasher,
 };
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Clock, Handle, Spawner};
+use commonware_runtime::{Handle, Spawner};
 use rand::{CryptoRng, Rng};
 use std::marker::PhantomData;
 use tracing::debug;
@@ -22,12 +22,12 @@ pub struct Config<S: ThresholdSupervisor<Index = View, Share = group::Share>> {
 }
 
 pub struct Conflicter<
-    E: Clock + Rng + CryptoRng + Spawner,
+    E: Rng + CryptoRng + Send + 'static,
     V: Variant,
     H: Hasher,
     S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
 > {
-    context: Option<E>,
+    context: E,
     supervisor: S,
     namespace: Vec<u8>,
     _hasher: PhantomData<H>,
@@ -35,7 +35,7 @@ pub struct Conflicter<
 }
 
 impl<
-        E: Clock + Rng + CryptoRng + Spawner,
+        E: Rng + CryptoRng + Send + 'static,
         V: Variant,
         H: Hasher,
         S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
@@ -43,7 +43,7 @@ impl<
 {
     pub fn new(context: E, cfg: Config<S>) -> Self {
         Self {
-            context: Some(context),
+            context,
             supervisor: cfg.supervisor,
             namespace: cfg.namespace,
             _hasher: PhantomData,
@@ -51,14 +51,15 @@ impl<
         }
     }
 
-    pub fn start(mut self, pending_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|context| self.run(context, pending_network))
+    pub fn start(
+        self,
+        spawner: impl Spawner,
+        pending_network: (impl Sender, impl Receiver),
+    ) -> Handle<()> {
+        spawner.spawn(|_| self.run(pending_network))
     }
 
-    async fn run(self, mut context: E, pending_network: (impl Sender, impl Receiver)) {
+    async fn run(mut self, pending_network: (impl Sender, impl Receiver)) {
         let (mut sender, mut receiver) = pending_network;
         while let Ok((s, msg)) = receiver.recv().await {
             // Parse message
@@ -76,7 +77,7 @@ impl<
                     // Notarize random digest
                     let view = notarize.view();
                     let share = self.supervisor.share(view).unwrap();
-                    let payload = H::Digest::random(&mut context);
+                    let payload = H::Digest::random(&mut self.context);
                     let proposal =
                         Proposal::new(notarize.proposal.round, notarize.proposal.parent, payload);
                     let n = Notarize::<V, _>::sign(&self.namespace, share, proposal);
@@ -92,7 +93,7 @@ impl<
                     // Finalize random digest
                     let view = finalize.view();
                     let share = self.supervisor.share(view).unwrap();
-                    let payload = H::Digest::random(&mut context);
+                    let payload = H::Digest::random(&mut self.context);
                     let proposal =
                         Proposal::new(finalize.proposal.round, finalize.proposal.parent, payload);
                     let f = Finalize::<V, _>::sign(&self.namespace, share, proposal);

--- a/consensus/src/threshold_simplex/mocks/impersonator.rs
+++ b/consensus/src/threshold_simplex/mocks/impersonator.rs
@@ -27,7 +27,7 @@ pub struct Impersonator<
     H: Hasher,
     S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
 > {
-    context: E,
+    context: Option<E>,
     supervisor: S,
 
     namespace: Vec<u8>,
@@ -45,7 +45,7 @@ impl<
 {
     pub fn new(context: E, cfg: Config<S>) -> Self {
         Self {
-            context,
+            context: Some(context),
             supervisor: cfg.supervisor,
 
             namespace: cfg.namespace,
@@ -56,7 +56,10 @@ impl<
     }
 
     pub fn start(mut self, pending_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.spawn_ref()(self.run(pending_network))
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|_| self.run(pending_network))
     }
 
     async fn run(self, pending_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/invalid.rs
+++ b/consensus/src/threshold_simplex/mocks/invalid.rs
@@ -14,8 +14,7 @@ use commonware_cryptography::{
     Hasher,
 };
 use commonware_p2p::{Receiver, Recipients, Sender};
-use commonware_runtime::{Clock, Handle, Spawner};
-use rand::{CryptoRng, Rng};
+use commonware_runtime::{Handle, Spawner};
 use std::marker::PhantomData;
 use tracing::debug;
 
@@ -25,12 +24,10 @@ pub struct Config<S: ThresholdSupervisor<Index = View, Share = group::Share>> {
 }
 
 pub struct Invalid<
-    E: Clock + Rng + CryptoRng + Spawner,
     V: Variant,
     H: Hasher,
     S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
 > {
-    context: Option<E>,
     supervisor: S,
 
     namespace: Vec<u8>,
@@ -40,15 +37,13 @@ pub struct Invalid<
 }
 
 impl<
-        E: Clock + Rng + CryptoRng + Spawner,
         V: Variant,
         H: Hasher,
         S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
-    > Invalid<E, V, H, S>
+    > Invalid<V, H, S>
 {
-    pub fn new(context: E, cfg: Config<S>) -> Self {
+    pub fn new(cfg: Config<S>) -> Self {
         Self {
-            context: Some(context),
             supervisor: cfg.supervisor,
 
             namespace: cfg.namespace,
@@ -58,11 +53,12 @@ impl<
         }
     }
 
-    pub fn start(mut self, pending_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|_| self.run(pending_network))
+    pub fn start(
+        self,
+        spawner: impl Spawner,
+        pending_network: (impl Sender, impl Receiver),
+    ) -> Handle<()> {
+        spawner.spawn(|_| self.run(pending_network))
     }
 
     async fn run(self, pending_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/nuller.rs
+++ b/consensus/src/threshold_simplex/mocks/nuller.rs
@@ -21,12 +21,10 @@ pub struct Config<S: ThresholdSupervisor<Index = View, Share = group::Share>> {
 }
 
 pub struct Nuller<
-    E: Spawner,
     V: Variant,
     H: Hasher,
     S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
 > {
-    context: Option<E>,
     supervisor: S,
     namespace: Vec<u8>,
     _hasher: PhantomData<H>,
@@ -34,15 +32,13 @@ pub struct Nuller<
 }
 
 impl<
-        E: Spawner,
         V: Variant,
         H: Hasher,
         S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
-    > Nuller<E, V, H, S>
+    > Nuller<V, H, S>
 {
-    pub fn new(context: E, cfg: Config<S>) -> Self {
+    pub fn new(cfg: Config<S>) -> Self {
         Self {
-            context: Some(context),
             supervisor: cfg.supervisor,
             namespace: cfg.namespace,
             _hasher: PhantomData,
@@ -50,11 +46,12 @@ impl<
         }
     }
 
-    pub fn start(mut self, pending_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|_| self.run(pending_network))
+    pub fn start(
+        self,
+        spawner: impl Spawner,
+        pending_network: (impl Sender, impl Receiver),
+    ) -> Handle<()> {
+        spawner.spawn(|_| self.run(pending_network))
     }
 
     async fn run(self, pending_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/outdated.rs
+++ b/consensus/src/threshold_simplex/mocks/outdated.rs
@@ -28,7 +28,7 @@ pub struct Outdated<
     H: Hasher,
     S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
 > {
-    context: E,
+    context: Option<E>,
     supervisor: S,
 
     namespace: Vec<u8>,
@@ -49,7 +49,7 @@ impl<
 {
     pub fn new(context: E, cfg: Config<S>) -> Self {
         Self {
-            context,
+            context: Some(context),
             supervisor: cfg.supervisor,
 
             namespace: cfg.namespace,
@@ -63,7 +63,10 @@ impl<
     }
 
     pub fn start(mut self, pending_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.spawn_ref()(self.run(pending_network))
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|_| self.run(pending_network))
     }
 
     async fn run(mut self, pending_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/reconfigurer.rs
+++ b/consensus/src/threshold_simplex/mocks/reconfigurer.rs
@@ -23,12 +23,10 @@ pub struct Config<S: ThresholdSupervisor<Index = View, Share = group::Share>> {
 }
 
 pub struct Reconfigurer<
-    E: Spawner,
     V: Variant,
     H: Hasher,
     S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
 > {
-    context: Option<E>,
     supervisor: S,
     namespace: Vec<u8>,
     _hasher: PhantomData<H>,
@@ -36,15 +34,13 @@ pub struct Reconfigurer<
 }
 
 impl<
-        E: Spawner,
         V: Variant,
         H: Hasher,
         S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
-    > Reconfigurer<E, V, H, S>
+    > Reconfigurer<V, H, S>
 {
-    pub fn new(context: E, cfg: Config<S>) -> Self {
+    pub fn new(cfg: Config<S>) -> Self {
         Self {
-            context: Some(context),
             supervisor: cfg.supervisor,
             namespace: cfg.namespace,
             _hasher: PhantomData,
@@ -52,11 +48,12 @@ impl<
         }
     }
 
-    pub fn start(mut self, pending_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|_| self.run(pending_network))
+    pub fn start(
+        self,
+        spawner: impl Spawner,
+        pending_network: (impl Sender, impl Receiver),
+    ) -> Handle<()> {
+        spawner.spawn(|_| self.run(pending_network))
     }
 
     async fn run(self, pending_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mocks/reconfigurer.rs
+++ b/consensus/src/threshold_simplex/mocks/reconfigurer.rs
@@ -28,7 +28,7 @@ pub struct Reconfigurer<
     H: Hasher,
     S: ThresholdSupervisor<Seed = V::Signature, Index = View, Share = group::Share>,
 > {
-    context: E,
+    context: Option<E>,
     supervisor: S,
     namespace: Vec<u8>,
     _hasher: PhantomData<H>,
@@ -44,7 +44,7 @@ impl<
 {
     pub fn new(context: E, cfg: Config<S>) -> Self {
         Self {
-            context,
+            context: Some(context),
             supervisor: cfg.supervisor,
             namespace: cfg.namespace,
             _hasher: PhantomData,
@@ -53,7 +53,10 @@ impl<
     }
 
     pub fn start(mut self, pending_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        self.context.spawn_ref()(self.run(pending_network))
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|_| self.run(pending_network))
     }
 
     async fn run(self, pending_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -817,9 +817,7 @@ mod tests {
                 let mut engine_handlers = Vec::new();
                 for (idx, scheme) in schemes.into_iter().enumerate() {
                     // Create scheme context
-                    let context = context
-                        .clone()
-                        .with_label(&format!("validator-{}", scheme.public_key()));
+                    let context = context.with_label(&format!("validator-{}", scheme.public_key()));
 
                     // Configure engine
                     let validator = scheme.public_key();

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -349,7 +349,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -412,7 +412,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(scheme.public_key());
                 let cfg = config::Config {
                     crypto: scheme,
@@ -444,7 +444,12 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(pending, recovered, resolver));
+                engine_handlers.push(engine.start(
+                    context.with_label("engine"),
+                    pending,
+                    recovered,
+                    resolver,
+                ));
             }
 
             // Wait for all engines to finish
@@ -607,7 +612,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants (active)
             let mut schemes = Vec::new();
@@ -680,7 +685,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(validator.clone());
                 let cfg = config::Config {
                     crypto: scheme,
@@ -712,7 +717,7 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine.start(pending, recovered, resolver);
+                engine.start(context.with_label("engine"), pending, recovered, resolver);
             }
 
             // Wait for all  engines to finish
@@ -788,7 +793,7 @@ mod tests {
                 );
 
                 // Start network
-                network.start();
+                network.start(context.with_label("network"));
 
                 // Register participants
                 let mut schemes = Vec::new();
@@ -847,7 +852,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let blocker = oracle.control(scheme.public_key());
                     let cfg = config::Config {
                         crypto: scheme,
@@ -879,7 +884,12 @@ mod tests {
                     let (pending, recovered, resolver) = registrations
                         .remove(&validator)
                         .expect("validator should be registered");
-                    engine_handlers.push(engine.start(pending, recovered, resolver));
+                    engine_handlers.push(engine.start(
+                        context.with_label("engine"),
+                        pending,
+                        recovered,
+                        resolver,
+                    ));
                 }
 
                 // Store all finalizer handles
@@ -969,7 +979,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1043,7 +1053,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(scheme.public_key());
                 let cfg = config::Config {
                     crypto: scheme.clone(),
@@ -1075,7 +1085,12 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(pending, recovered, resolver));
+                engine_handlers.push(engine.start(
+                    context.with_label("engine"),
+                    pending,
+                    recovered,
+                    resolver,
+                ));
             }
 
             // Wait for all engines to finish
@@ -1171,7 +1186,7 @@ mod tests {
                 context.with_label("application"),
                 application_cfg,
             );
-            actor.start();
+            actor.start(context.with_label("application"));
             let blocker = oracle.control(scheme.public_key());
             let cfg = config::Config {
                 crypto: scheme,
@@ -1203,7 +1218,12 @@ mod tests {
             let (pending, recovered, resolver) = registrations
                 .remove(&validator)
                 .expect("validator should be registered");
-            engine_handlers.push(engine.start(pending, recovered, resolver));
+            engine_handlers.push(engine.start(
+                context.with_label("engine"),
+                pending,
+                recovered,
+                resolver,
+            ));
 
             // Wait for new engine to finalize required
             let (mut latest, mut monitor) = supervisor.subscribe().await;
@@ -1244,7 +1264,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1318,7 +1338,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(scheme.public_key());
                 let cfg = config::Config {
                     crypto: scheme,
@@ -1350,7 +1370,12 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(pending, recovered, resolver));
+                engine_handlers.push(engine.start(
+                    context.with_label("engine"),
+                    pending,
+                    recovered,
+                    resolver,
+                ));
             }
 
             // Wait for all engines to finish
@@ -1512,7 +1537,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1585,7 +1610,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(scheme.public_key());
                 let cfg = config::Config {
                     crypto: scheme,
@@ -1617,7 +1642,12 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(pending, recovered, resolver));
+                engine_handlers.push(engine.start(
+                    context.with_label("engine"),
+                    pending,
+                    recovered,
+                    resolver,
+                ));
             }
 
             // Wait for all engines to finish
@@ -1702,7 +1732,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1765,7 +1795,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(scheme.public_key());
                 let cfg = config::Config {
                     crypto: scheme.clone(),
@@ -1797,7 +1827,12 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(pending, recovered, resolver));
+                engine_handlers.push(engine.start(
+                    context.with_label("engine"),
+                    pending,
+                    recovered,
+                    resolver,
+                ));
             }
 
             // Wait for a few virtual minutes (shouldn't finalize anything)
@@ -1918,7 +1953,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -1981,7 +2016,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(scheme.public_key());
                 let cfg = config::Config {
                     crypto: scheme.clone(),
@@ -2013,7 +2048,12 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(pending, recovered, resolver));
+                engine_handlers.push(engine.start(
+                    context.with_label("engine"),
+                    pending,
+                    recovered,
+                    resolver,
+                ));
             }
 
             // Wait for all engines to finish
@@ -2130,7 +2170,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2193,7 +2233,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(scheme.public_key());
                 let cfg = config::Config {
                     crypto: scheme,
@@ -2225,7 +2265,12 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(pending, recovered, resolver));
+                engine_handlers.push(engine.start(
+                    context.with_label("engine"),
+                    pending,
+                    recovered,
+                    resolver,
+                ));
             }
 
             // Wait for all engines to finish
@@ -2311,7 +2356,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2375,7 +2420,7 @@ mod tests {
                             context.with_label("byzantine_engine"),
                             cfg,
                         );
-                    engine.start(pending);
+                    engine.start(context.with_label("byzantine_engine"), pending);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2389,7 +2434,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let blocker = oracle.control(scheme.public_key());
                     let cfg = config::Config {
                         crypto: scheme,
@@ -2416,7 +2461,7 @@ mod tests {
                         buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(pending, recovered, resolver);
+                    engine.start(context.with_label("engine"), pending, recovered, resolver);
                 }
             }
 
@@ -2506,7 +2551,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2565,9 +2610,9 @@ mod tests {
                         namespace: namespace.clone(),
                     };
 
-                    let engine: mocks::invalid::Invalid<_, V, Sha256, _> =
-                        mocks::invalid::Invalid::new(context.with_label("byzantine_engine"), cfg);
-                    engine.start(pending);
+                    let engine: mocks::invalid::Invalid<V, Sha256, _> =
+                        mocks::invalid::Invalid::new(cfg);
+                    engine.start(context.with_label("byzantine_engine"), pending);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2581,7 +2626,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let blocker = oracle.control(scheme.public_key());
                     let cfg = config::Config {
                         crypto: scheme,
@@ -2608,7 +2653,7 @@ mod tests {
                         buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(pending, recovered, resolver);
+                    engine.start(context.with_label("engine"), pending, recovered, resolver);
                 }
             }
 
@@ -2686,7 +2731,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2745,12 +2790,9 @@ mod tests {
                         namespace: namespace.clone(),
                     };
 
-                    let engine: mocks::impersonator::Impersonator<_, V, Sha256, _> =
-                        mocks::impersonator::Impersonator::new(
-                            context.with_label("byzantine_engine"),
-                            cfg,
-                        );
-                    engine.start(pending);
+                    let engine: mocks::impersonator::Impersonator<V, Sha256, _> =
+                        mocks::impersonator::Impersonator::new(cfg);
+                    engine.start(context.with_label("byzantine_engine"), pending);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2764,7 +2806,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let blocker = oracle.control(scheme.public_key());
                     let cfg = config::Config {
                         crypto: scheme,
@@ -2791,7 +2833,7 @@ mod tests {
                         buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(pending, recovered, resolver);
+                    engine.start(context.with_label("engine"), pending, recovered, resolver);
                 }
             }
 
@@ -2865,7 +2907,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -2923,12 +2965,9 @@ mod tests {
                         supervisor,
                         namespace: namespace.clone(),
                     };
-                    let engine: mocks::reconfigurer::Reconfigurer<_, V, Sha256, _> =
-                        mocks::reconfigurer::Reconfigurer::new(
-                            context.with_label("byzantine_engine"),
-                            cfg,
-                        );
-                    engine.start(pending);
+                    let engine: mocks::reconfigurer::Reconfigurer<V, Sha256, _> =
+                        mocks::reconfigurer::Reconfigurer::new(cfg);
+                    engine.start(context.with_label("byzantine_engine"), pending);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -2942,7 +2981,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let blocker = oracle.control(scheme.public_key());
                     let cfg = config::Config {
                         crypto: scheme,
@@ -2969,7 +3008,7 @@ mod tests {
                         buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(pending, recovered, resolver);
+                    engine.start(context.with_label("engine"), pending, recovered, resolver);
                 }
             }
 
@@ -3043,7 +3082,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -3101,9 +3140,9 @@ mod tests {
                         supervisor,
                         namespace: namespace.clone(),
                     };
-                    let engine: mocks::nuller::Nuller<_, V, Sha256, _> =
-                        mocks::nuller::Nuller::new(context.with_label("byzantine_engine"), cfg);
-                    engine.start(pending);
+                    let engine: mocks::nuller::Nuller<V, Sha256, _> =
+                        mocks::nuller::Nuller::new(cfg);
+                    engine.start(context.with_label("byzantine_engine"), pending);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -3117,7 +3156,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let blocker = oracle.control(scheme.public_key());
                     let cfg = config::Config {
                         crypto: scheme,
@@ -3144,7 +3183,7 @@ mod tests {
                         buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(pending, recovered, resolver);
+                    engine.start(context.with_label("engine"), pending, recovered, resolver);
                 }
             }
 
@@ -3231,7 +3270,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -3290,9 +3329,9 @@ mod tests {
                         namespace: namespace.clone(),
                         view_delta: activity_timeout * 4,
                     };
-                    let engine: mocks::outdated::Outdated<_, V, Sha256, _> =
-                        mocks::outdated::Outdated::new(context.with_label("byzantine_engine"), cfg);
-                    engine.start(pending);
+                    let engine: mocks::outdated::Outdated<V, Sha256, _> =
+                        mocks::outdated::Outdated::new(cfg);
+                    engine.start(context.with_label("byzantine_engine"), pending);
                 } else {
                     supervisors.push(supervisor.clone());
                     let application_cfg = mocks::application::Config {
@@ -3306,7 +3345,7 @@ mod tests {
                         context.with_label("application"),
                         application_cfg,
                     );
-                    actor.start();
+                    actor.start(context.with_label("application"));
                     let blocker = oracle.control(scheme.public_key());
                     let cfg = config::Config {
                         crypto: scheme,
@@ -3333,7 +3372,7 @@ mod tests {
                         buffer_pool: PoolRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                     };
                     let engine = Engine::new(context.with_label("engine"), cfg);
-                    engine.start(pending, recovered, resolver);
+                    engine.start(context.with_label("engine"), pending, recovered, resolver);
                 }
             }
 
@@ -3400,7 +3439,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -3463,7 +3502,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(scheme.public_key());
                 let cfg = config::Config {
                     crypto: scheme,
@@ -3495,7 +3534,12 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(pending, recovered, resolver));
+                engine_handlers.push(engine.start(
+                    context.with_label("engine"),
+                    pending,
+                    recovered,
+                    resolver,
+                ));
             }
 
             // Wait for all engines to finish
@@ -3557,7 +3601,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.with_label("network"));
 
             // Register participants
             let mut schemes = Vec::new();
@@ -3629,7 +3673,7 @@ mod tests {
                     context.with_label("application"),
                     application_cfg,
                 );
-                actor.start();
+                actor.start(context.with_label("application"));
                 let blocker = oracle.control(scheme.public_key());
                 let cfg = config::Config {
                     crypto: scheme,
@@ -3661,7 +3705,12 @@ mod tests {
                 let (pending, recovered, resolver) = registrations
                     .remove(&validator)
                     .expect("validator should be registered");
-                engine_handlers.push(engine.start(pending, recovered, resolver));
+                engine_handlers.push(engine.start(
+                    context.with_label("engine"),
+                    pending,
+                    recovered,
+                    resolver,
+                ));
             }
 
             // Prepare TLE test data

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -251,8 +251,9 @@ fn main() {
         );
 
         // Start consensus
-        network.start();
+        network.start(context.with_label("network"));
         engine.start(
+            context.with_label("engine"),
             (pending_sender, pending_receiver),
             (recovered_sender, recovered_receiver),
             (resolver_sender, resolver_receiver),

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -181,7 +181,7 @@ fn main() {
         );
 
         // Start network
-        let network_handler = network.start();
+        let network_handler = network.start(context.with_label("network"));
 
         // Block on GUI
         handler::run(

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -299,7 +299,7 @@ async fn run_simulation_logic<C: Spawner + Clock + Clone + Metrics + RNetwork + 
             disconnect_on_block: true,
         },
     );
-    network.start();
+    network.start(context.with_label("network"));
 
     let identities = setup_network_identities(&mut oracle, distribution).await;
     setup_network_links(&mut oracle, &identities, latencies).await;

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -134,7 +134,7 @@ fn main() {
         );
 
         // Create network
-        let p2p = network.start();
+        let p2p = network.start(context.with_label("network"));
 
         // Create flood
         let flood_sender = context

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -219,9 +219,10 @@ fn main() {
         let engine = simplex::Engine::new(context.with_label("engine"), cfg);
 
         // Start consensus
-        application.start();
-        network.start();
+        application.start(context.clone());
+        network.start(context.with_label("network"));
         engine.start(
+            context.clone(),
             (voter_sender, voter_receiver),
             (resolver_sender, resolver_receiver),
         );

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -274,7 +274,7 @@ fn main() {
                 lazy,
                 forger,
             );
-            contributor.start(contributor_sender, contributor_receiver);
+            contributor.start(context.clone(), contributor_sender, contributor_receiver);
 
             // Create vrf
             let (vrf_sender, vrf_receiver) = network.register(
@@ -289,7 +289,7 @@ fn main() {
                 contributors,
                 requests,
             );
-            signer.start(vrf_sender, vrf_receiver);
+            signer.start(context.clone(), vrf_sender, vrf_receiver);
         } else {
             let (arbiter_sender, arbiter_receiver) = network.register(
                 handlers::DKG_CHANNEL,
@@ -302,8 +302,11 @@ fn main() {
                 DKG_PHASE_TIMEOUT,
                 contributors,
             );
-            arbiter.start(arbiter_sender, arbiter_receiver);
+            arbiter.start(context.clone(), arbiter_sender, arbiter_receiver);
         }
-        network.start().await.expect("Network failed");
+        network
+            .start(context.with_label("network"))
+            .await
+            .expect("Network failed");
     });
 }

--- a/p2p/src/authenticated/discovery/actors/dialer.rs
+++ b/p2p/src/authenticated/discovery/actors/dialer.rs
@@ -77,8 +77,8 @@ impl<C: Signer> Actor<C> {
     async fn dial_peer<E: Spawner + Clock + GClock + Network + Rng + CryptoRng + Metrics>(
         &mut self,
         context: &E,
-        reservation: Reservation<E, C::PublicKey>,
-        supervisor: &mut Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        reservation: Reservation<C::PublicKey>,
+        supervisor: &mut Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) {
         // Extract metadata from the reservation
         let Metadata::Dialer(peer, address) = reservation.metadata().clone() else {
@@ -126,8 +126,8 @@ impl<C: Signer> Actor<C> {
     pub fn start<E: Spawner + Clock + GClock + Network + Rng + CryptoRng + Metrics>(
         self,
         context: E,
-        tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
         context.spawn(|context| self.run(context, tracker, supervisor))
     }
@@ -136,8 +136,8 @@ impl<C: Signer> Actor<C> {
     async fn run<E: Spawner + Clock + GClock + Network + Rng + CryptoRng + Metrics>(
         mut self,
         mut context: E,
-        mut tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        mut supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        mut tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        mut supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) {
         let mut dial_deadline = context.current();
         let mut query_deadline = context.current();

--- a/p2p/src/authenticated/discovery/actors/listener.rs
+++ b/p2p/src/authenticated/discovery/actors/listener.rs
@@ -25,10 +25,7 @@ pub struct Config<C: Signer> {
     pub allowed_incoming_connection_rate: Quota,
 }
 
-pub struct Actor<
-    E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metrics,
-    C: Signer,
-> {
+pub struct Actor<E: Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metrics, C: Signer> {
     address: SocketAddr,
     stream_cfg: StreamConfig<C>,
     rate_limiter: RateLimiter<NotKeyed, InMemoryState, E, NoOpMiddleware<E::Instant>>,
@@ -67,8 +64,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
         stream_cfg: StreamConfig<C>,
         sink: SinkOf<E>,
         stream: StreamOf<E>,
-        mut tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        mut supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        mut tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        mut supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) {
         let (peer, send, recv) = match listen(
             context,
@@ -102,8 +99,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
     pub fn start(
         self,
         context: E,
-        tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
         context.spawn(|context| self.run(context, tracker, supervisor))
     }
@@ -112,8 +109,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
     async fn run(
         self,
         context: E,
-        tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) {
         // Start listening for incoming connections
         let mut listener = context

--- a/p2p/src/authenticated/discovery/actors/listener.rs
+++ b/p2p/src/authenticated/discovery/actors/listener.rs
@@ -29,8 +29,6 @@ pub struct Actor<
     E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metrics,
     C: Signer,
 > {
-    context: E,
-
     address: SocketAddr,
     stream_cfg: StreamConfig<C>,
     rate_limiter: RateLimiter<NotKeyed, InMemoryState, E, NoOpMiddleware<E::Instant>>,
@@ -51,8 +49,6 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
         );
 
         Self {
-            context: context.clone(),
-
             address: cfg.address,
             stream_cfg: cfg.stream_cfg,
             rate_limiter: RateLimiter::direct_with_clock(
@@ -105,23 +101,22 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
     #[allow(clippy::type_complexity)]
     pub fn start(
         self,
+        context: E,
         tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
         supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
-        self.context
-            .clone()
-            .spawn(|_| self.run(tracker, supervisor))
+        context.spawn(|context| self.run(context, tracker, supervisor))
     }
 
     #[allow(clippy::type_complexity)]
     async fn run(
         self,
+        context: E,
         tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
         supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) {
         // Start listening for incoming connections
-        let mut listener = self
-            .context
+        let mut listener = context
             .bind(self.address)
             .await
             .expect("failed to bind listener");
@@ -131,8 +126,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
             // Ensure we don't attempt to perform too many handshakes at once
             if let Err(wait_until) = self.rate_limiter.check() {
                 self.handshakes_rate_limited.inc();
-                let wait = wait_until.wait_time_from(self.context.now());
-                self.context.sleep(wait).await;
+                let wait = wait_until.wait_time_from(context.now());
+                context.sleep(wait).await;
             }
 
             // Accept a new connection
@@ -146,7 +141,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
             debug!(ip = ?address.ip(), port = ?address.port(), "accepted incoming connection");
 
             // Spawn a new handshaker to upgrade connection
-            self.context.with_label("handshaker").spawn({
+            context.with_label("handshaker").spawn({
                 let stream_cfg = self.stream_cfg.clone();
                 let tracker = tracker.clone();
                 let supervisor = supervisor.clone();

--- a/p2p/src/authenticated/discovery/actors/peer/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/actor.rs
@@ -100,7 +100,7 @@ impl<C: PublicKey> Actor<C> {
         context: E,
         peer: C,
         (mut conn_sender, mut conn_receiver): (Sender<O>, Receiver<I>),
-        mut tracker: Mailbox<tracker::Message<E, C>>,
+        mut tracker: Mailbox<tracker::Message<C>>,
         channels: Channels<C>,
     ) -> Error {
         // Instantiate rate limiters for each message type

--- a/p2p/src/authenticated/discovery/actors/router/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/router/actor.rs
@@ -20,19 +20,17 @@ use std::collections::BTreeMap;
 use tracing::debug;
 
 /// Router actor that manages peer connections and routing messages.
-pub struct Actor<E: Spawner + Metrics, P: PublicKey> {
-    context: Option<E>,
-
+pub struct Actor<P: PublicKey> {
     control: mpsc::Receiver<Message<P>>,
     connections: BTreeMap<P, Relay<Data>>,
 
     messages_dropped: Family<metrics::Message, Counter>,
 }
 
-impl<E: Spawner + Metrics, P: PublicKey> Actor<E, P> {
+impl<P: PublicKey> Actor<P> {
     /// Returns a new [Actor] along with a [Mailbox] and [Messenger]
     /// that can be used to send messages to the router.
-    pub fn new(context: E, cfg: Config) -> (Self, Mailbox<Message<P>>, Messenger<P>) {
+    pub fn new(context: impl Metrics, cfg: Config) -> (Self, Mailbox<Message<P>>, Messenger<P>) {
         // Create mailbox
         let (control_sender, control_receiver) = mpsc::channel(cfg.mailbox_size);
 
@@ -47,7 +45,6 @@ impl<E: Spawner + Metrics, P: PublicKey> Actor<E, P> {
         // Create actor
         (
             Self {
-                context: Some(context),
                 control: control_receiver,
                 connections: BTreeMap::new(),
                 messages_dropped,
@@ -88,11 +85,8 @@ impl<E: Spawner + Metrics, P: PublicKey> Actor<E, P> {
     /// Starts a new task that runs the router [Actor].
     /// Returns a [Handle] that can be used to await the completion of the task,
     /// which will run until its `control` receiver is closed.
-    pub fn start(mut self, routing: Channels<P>) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|_| self.run(routing))
+    pub fn start(self, spawner: impl Spawner, routing: Channels<P>) -> Handle<()> {
+        spawner.spawn(|_| self.run(routing))
     }
 
     /// Runs the [Actor] event loop, processing incoming messages control messages

--- a/p2p/src/authenticated/discovery/actors/router/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/router/actor.rs
@@ -21,7 +21,7 @@ use tracing::debug;
 
 /// Router actor that manages peer connections and routing messages.
 pub struct Actor<E: Spawner + Metrics, P: PublicKey> {
-    context: E,
+    context: Option<E>,
 
     control: mpsc::Receiver<Message<P>>,
     connections: BTreeMap<P, Relay<Data>>,
@@ -47,7 +47,7 @@ impl<E: Spawner + Metrics, P: PublicKey> Actor<E, P> {
         // Create actor
         (
             Self {
-                context,
+                context: Some(context),
                 control: control_receiver,
                 connections: BTreeMap::new(),
                 messages_dropped,
@@ -89,7 +89,10 @@ impl<E: Spawner + Metrics, P: PublicKey> Actor<E, P> {
     /// Returns a [Handle] that can be used to await the completion of the task,
     /// which will run until its `control` receiver is closed.
     pub fn start(mut self, routing: Channels<P>) -> Handle<()> {
-        self.context.spawn_ref()(self.run(routing))
+        self.context
+            .take()
+            .expect("context is only consumed on start")
+            .spawn(|_| self.run(routing))
     }
 
     /// Runs the [Actor] event loop, processing incoming messages control messages

--- a/p2p/src/authenticated/discovery/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/spawner/ingress.rs
@@ -1,10 +1,10 @@
 use crate::authenticated::{discovery::actors::tracker::Reservation, Mailbox};
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Clock, Metrics, Network, Sink, Spawner, Stream};
+use commonware_runtime::{Sink, Stream};
 use commonware_stream::{Receiver, Sender};
 
 /// Messages that can be processed by the spawner actor.
-pub enum Message<E: Spawner + Clock + Metrics, O: Sink, I: Stream, P: PublicKey> {
+pub enum Message<O: Sink, I: Stream, P: PublicKey> {
     /// Notify the spawner to create a new task for the given peer.
     Spawn {
         /// The peer's public key.
@@ -12,18 +12,16 @@ pub enum Message<E: Spawner + Clock + Metrics, O: Sink, I: Stream, P: PublicKey>
         /// The connection to the peer.
         connection: (Sender<O>, Receiver<I>),
         /// The reservation for the peer.
-        reservation: Reservation<E, P>,
+        reservation: Reservation<P>,
     },
 }
 
-impl<E: Spawner + Clock + Metrics + Network, P: PublicKey, O: Sink, I: Stream>
-    Mailbox<Message<E, O, I, P>>
-{
+impl<P: PublicKey, O: Sink, I: Stream> Mailbox<Message<O, I, P>> {
     /// Send a message to the actor to spawn a new task for the given peer.
     pub async fn spawn(
         &mut self,
         connection: (Sender<O>, Receiver<I>),
-        reservation: Reservation<E, P>,
+        reservation: Reservation<P>,
     ) {
         self.send(Message::Spawn {
             peer: reservation.metadata().public_key().clone(),

--- a/p2p/src/authenticated/discovery/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/actor.rs
@@ -285,7 +285,7 @@ mod tests {
         PrivateKeyExt as _, Signer,
     };
     use commonware_runtime::{
-        deterministic::{self, Context},
+        deterministic::{self},
         Clock, Runner,
     };
     use commonware_utils::{BitVec as UtilsBitVec, NZU32};
@@ -355,11 +355,11 @@ mod tests {
     // Mock a connection to a peer by reserving it as if it had dialed us and the `peer` actor had
     // sent an initialization.
     async fn connect_to_peer(
-        mailbox: &mut Mailbox<Message<Context, PublicKey>>,
+        mailbox: &mut Mailbox<Message<PublicKey>>,
         peer: &PublicKey,
         peer_mailbox: &Mailbox<peer::Message<PublicKey>>,
         peer_receiver: &mut mpsc::Receiver<peer::Message<PublicKey>>,
-    ) -> tracker::Reservation<Context, PublicKey> {
+    ) -> tracker::Reservation<PublicKey> {
         let res = mailbox
             .listen(peer.clone())
             .await
@@ -378,8 +378,8 @@ mod tests {
 
     // Test Harness
     struct TestHarness {
-        mailbox: Mailbox<Message<deterministic::Context, PublicKey>>,
-        oracle: Oracle<deterministic::Context, PublicKey>,
+        mailbox: Mailbox<Message<PublicKey>>,
+        oracle: Oracle<PublicKey>,
         ip_namespace: Vec<u8>,
         tracker_pk: PublicKey,
         tracker_signer: PrivateKey,
@@ -970,7 +970,7 @@ mod tests {
                         addr,
                     ) => {
                         assert_eq!(pk, &boot_pk);
-                        assert_eq!(*addr, boot_addr);
+                        assert_eq!(addr, &boot_addr);
                     }
                     _ => panic!("Expected Dialer metadata"),
                 }

--- a/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
@@ -7,14 +7,14 @@ use crate::authenticated::{
     Mailbox,
 };
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Metrics, Spawner};
+use commonware_runtime::Spawner;
 use futures::{
     channel::{mpsc, oneshot},
     SinkExt,
 };
 
 /// Messages that can be sent to the tracker actor.
-pub enum Message<E: Spawner + Metrics, C: PublicKey> {
+pub enum Message<E: Spawner, C: PublicKey> {
     // ---------- Used by oracle ----------
     /// Register a peer set at a given index.
     ///
@@ -124,7 +124,7 @@ pub enum Message<E: Spawner + Metrics, C: PublicKey> {
     },
 }
 
-impl<E: Spawner + Metrics, C: PublicKey> Mailbox<Message<E, C>> {
+impl<E: Spawner, C: PublicKey> Mailbox<Message<E, C>> {
     /// Send a `Connect` message to the tracker.
     pub async fn connect(&mut self, public_key: C, dialer: bool, peer: Mailbox<peer::Message<C>>) {
         self.send(Message::Connect {
@@ -201,11 +201,11 @@ impl<E: Spawner + Metrics, C: PublicKey> Mailbox<Message<E, C>> {
 
 /// Allows releasing reservations
 #[derive(Clone)]
-pub struct Releaser<E: Spawner + Metrics, C: PublicKey> {
+pub struct Releaser<E: Spawner, C: PublicKey> {
     sender: mpsc::Sender<Message<E, C>>,
 }
 
-impl<E: Spawner + Metrics, C: PublicKey> Releaser<E, C> {
+impl<E: Spawner, C: PublicKey> Releaser<E, C> {
     /// Create a new releaser.
     pub(super) fn new(sender: mpsc::Sender<Message<E, C>>) -> Self {
         Self { sender }
@@ -236,11 +236,11 @@ impl<E: Spawner + Metrics, C: PublicKey> Releaser<E, C> {
 /// Peers that are not explicitly authorized
 /// will be blocked by commonware-p2p.
 #[derive(Clone)]
-pub struct Oracle<E: Spawner + Metrics, C: PublicKey> {
+pub struct Oracle<E: Spawner, C: PublicKey> {
     sender: mpsc::Sender<Message<E, C>>,
 }
 
-impl<E: Spawner + Metrics, C: PublicKey> Oracle<E, C> {
+impl<E: Spawner, C: PublicKey> Oracle<E, C> {
     pub(super) fn new(sender: mpsc::Sender<Message<E, C>>) -> Self {
         Self { sender }
     }
@@ -261,7 +261,7 @@ impl<E: Spawner + Metrics, C: PublicKey> Oracle<E, C> {
     }
 }
 
-impl<E: Spawner + Metrics, C: PublicKey> crate::Blocker for Oracle<E, C> {
+impl<E: Spawner, C: PublicKey> crate::Blocker for Oracle<E, C> {
     type PublicKey = C;
 
     async fn block(&mut self, public_key: Self::PublicKey) {

--- a/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
@@ -82,7 +82,7 @@ pub enum Message<C: PublicKey> {
 
     /// Request a reservation for a particular peer to dial.
     ///
-    /// The tracker will respond with an [Option<Reservation<C>>], which will be `None` if the
+    /// The tracker will respond with an [`Option<Reservation<C>>`], which will be `None` if the
     /// reservation cannot be granted (e.g., if the peer is already connected, blocked or already
     /// has an active reservation).
     Dial {
@@ -105,7 +105,7 @@ pub enum Message<C: PublicKey> {
 
     /// Request a reservation for a particular peer.
     ///
-    /// The tracker will respond with an [Option<Reservation<C>>], which will be `None` if  the
+    /// The tracker will respond with an [`Option<Reservation<C>>`], which will be `None` if  the
     /// reservation cannot be granted (e.g., if the peer is already connected, blocked or already
     /// has an active reservation).
     Listen {

--- a/p2p/src/authenticated/discovery/actors/tracker/reservation.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/reservation.rs
@@ -1,65 +1,33 @@
 use super::Metadata;
-use crate::authenticated::discovery::actors::tracker::ingress::Releaser;
+use crate::authenticated::discovery::actors::tracker::ingress::ReleaserHandle;
 use commonware_cryptography::PublicKey;
-use commonware_runtime::Spawner;
 
 /// Reservation for a peer in the network. This is used to ensure that the peer is reserved only
 /// once, and that the reservation is released when the peer connection fails or is closed.
-pub struct Reservation<E: Spawner, P: PublicKey> {
-    /// Context needed to spawn tasks if needed.
-    ///
-    /// Stored as an `Option` to avoid unnecessary cloning by `take`ing the value.
-    spawner: Option<E>,
-
+pub struct Reservation<P: PublicKey> {
     /// Metadata about the reservation.
     metadata: Metadata<P>,
 
     /// Used to automatically notify the completion of the reservation when it is dropped.
-    ///
-    /// Stored as an `Option` to avoid unnecessary cloning by `take`ing the value.
-    releaser: Option<Releaser<E, P>>,
+    releaser: ReleaserHandle<P>,
 }
 
-impl<E: Spawner, P: PublicKey> Reservation<E, P> {
+impl<P: PublicKey> Reservation<P> {
     /// Create a new reservation for a peer.
-    pub fn new(spawner: E, metadata: Metadata<P>, releaser: Releaser<E, P>) -> Self {
-        Self {
-            spawner: Some(spawner),
-            metadata,
-            releaser: Some(releaser),
-        }
+    pub fn new(metadata: Metadata<P>, releaser: ReleaserHandle<P>) -> Self {
+        Self { metadata, releaser }
     }
 }
 
-impl<E: Spawner, P: PublicKey> Reservation<E, P> {
+impl<P: PublicKey> Reservation<P> {
     /// Returns the metadata associated with this reservation.
     pub fn metadata(&self) -> &Metadata<P> {
         &self.metadata
     }
 }
 
-impl<E: Spawner, P: PublicKey> Drop for Reservation<E, P> {
+impl<P: PublicKey> Drop for Reservation<P> {
     fn drop(&mut self) {
-        let mut releaser = self
-            .releaser
-            .take()
-            .expect("Reservation::drop called twice");
-
-        // If the mailbox is not full, release the reservation immediately without spawning a task.
-        if releaser.try_release(self.metadata.clone()) {
-            // Sent successfully, nothing to do.
-            return;
-        };
-
-        // If the mailbox is full, we avoid blocking by spawning a task to handle the release.
-        // While it may not be immediately obvious how a deadlock could occur, we take the
-        // conservative approach of avoiding it.
-        let metadata = self.metadata.clone();
-        self.spawner
-            .take()
-            .expect("spawner is only consumed on drop")
-            .spawn(move |_| async move {
-                releaser.release(metadata).await;
-            });
+        self.releaser.release(self.metadata.clone());
     }
 }

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -176,7 +176,7 @@
 //!     );
 //!
 //!     // Run network
-//!     let network_handler = network.start();
+//!     let network_handler = network.start(context.with_label("network"));
 //!
 //!     // Example: Use sender
 //!     let _ = sender.send(Recipients::All, bytes::Bytes::from_static(b"hello"), false).await;
@@ -297,7 +297,8 @@ mod tests {
                 bootstrappers,
                 max_message_size,
             );
-            let (mut network, mut oracle) = Network::new(context.with_label("network"), config);
+            let network_context = context.with_label("network");
+            let (mut network, mut oracle) = Network::new(network_context.clone(), config);
 
             // Register peers
             oracle.register(0, addresses.clone()).await;
@@ -307,7 +308,7 @@ mod tests {
                 network.register(0, Quota::per_second(NZU32!(100)), DEFAULT_MESSAGE_BACKLOG);
 
             // Wait to connect to all peers, and then send messages to everyone
-            network.start();
+            network.start(network_context.clone());
 
             // Send/Receive messages
             context.with_label("agent").spawn({
@@ -551,7 +552,8 @@ mod tests {
                     bootstrappers,
                     1_024 * 1_024, // 1MB
                 );
-                let (mut network, mut oracle) = Network::new(context.with_label("network"), config);
+                let network_context = context.with_label("network");
+                let (mut network, mut oracle) = Network::new(network_context.clone(), config);
 
                 // Register peers at separate indices
                 oracle.register(0, vec![addresses[0].clone()]).await;
@@ -567,7 +569,7 @@ mod tests {
                     network.register(0, Quota::per_second(NZU32!(10)), DEFAULT_MESSAGE_BACKLOG);
 
                 // Wait to connect to all peers, and then send messages to everyone
-                network.start();
+                network.start(network_context.clone());
 
                 // Send/Receive messages
                 let handler = context
@@ -635,7 +637,8 @@ mod tests {
                 Vec::new(),
                 1_024 * 1_024, // 1MB
             );
-            let (mut network, mut oracle) = Network::new(context.with_label("network"), config);
+            let network_context = context.with_label("network");
+            let (mut network, mut oracle) = Network::new(network_context.clone(), config);
 
             // Register peers
             oracle.register(0, addresses.clone()).await;
@@ -645,7 +648,7 @@ mod tests {
                 network.register(0, Quota::per_second(NZU32!(10)), DEFAULT_MESSAGE_BACKLOG);
 
             // Wait to connect to all peers, and then send messages to everyone
-            network.start();
+            network.start(network_context.clone());
 
             // Crate random message
             let mut msg = vec![0u8; 10 * 1024 * 1024]; // 10MB (greater than frame capacity)
@@ -685,11 +688,12 @@ mod tests {
                 vec![(peers[1].public_key(), socket1)],
                 1_024 * 1_024, // 1MB
             );
-            let (mut network0, mut oracle0) = Network::new(context.with_label("peer-0"), config0);
+            let peer0_ctx = context.with_label("peer-0");
+            let (mut network0, mut oracle0) = Network::new(peer0_ctx.clone(), config0);
             oracle0.register(0, addresses.clone()).await;
             let (mut sender0, _receiver0) =
                 network0.register(0, Quota::per_hour(NZU32!(1)), DEFAULT_MESSAGE_BACKLOG);
-            network0.start();
+            network0.start(peer0_ctx.clone());
 
             // Create network for peer 1
             let signer1 = peers[1].clone();
@@ -699,11 +703,12 @@ mod tests {
                 vec![(peers[0].public_key(), socket0)],
                 1_024 * 1_024, // 1MB
             );
-            let (mut network1, mut oracle1) = Network::new(context.with_label("peer-1"), config1);
+            let peer1_ctx = context.with_label("peer-1");
+            let (mut network1, mut oracle1) = Network::new(peer1_ctx.clone(), config1);
             oracle1.register(0, addresses.clone()).await;
             let (_sender1, _receiver1) =
                 network1.register(0, Quota::per_hour(NZU32!(1)), DEFAULT_MESSAGE_BACKLOG);
-            network1.start();
+            network1.start(peer1_ctx.clone());
 
             // Send first message, which should be allowed and consume the quota.
             let msg = vec![0u8; 1024]; // 1KB

--- a/p2p/src/authenticated/discovery/network.rs
+++ b/p2p/src/authenticated/discovery/network.rs
@@ -31,7 +31,7 @@ pub struct Network<
 
     channels: Channels<C::PublicKey>,
     tracker: tracker::Actor<E, C>,
-    tracker_mailbox: Mailbox<tracker::Message<E, C::PublicKey>>,
+    tracker_mailbox: Mailbox<tracker::Message<C::PublicKey>>,
     router: router::Actor<C::PublicKey>,
     router_mailbox: Mailbox<router::Message<C::PublicKey>>,
 }
@@ -49,7 +49,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metr
     ///
     /// * A tuple containing the network instance and the oracle that
     ///   can be used by a developer to configure which peers are authorized.
-    pub fn new(context: E, cfg: Config<C>) -> (Self, tracker::Oracle<E, C::PublicKey>) {
+    pub fn new(context: E, cfg: Config<C>) -> (Self, tracker::Oracle<C::PublicKey>) {
         let (tracker, tracker_mailbox, oracle) = tracker::Actor::new(
             context.with_label("tracker"),
             tracker::Config {

--- a/p2p/src/authenticated/discovery/network.rs
+++ b/p2p/src/authenticated/discovery/network.rs
@@ -27,13 +27,12 @@ pub struct Network<
     E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metrics,
     C: Signer,
 > {
-    context: Option<E>,
     cfg: Config<C>,
 
     channels: Channels<C::PublicKey>,
     tracker: tracker::Actor<E, C>,
     tracker_mailbox: Mailbox<tracker::Message<E, C::PublicKey>>,
-    router: router::Actor<E, C::PublicKey>,
+    router: router::Actor<C::PublicKey>,
     router_mailbox: Mailbox<router::Message<C::PublicKey>>,
 }
 
@@ -78,7 +77,6 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metr
 
         (
             Self {
-                context: Some(context),
                 cfg,
 
                 channels,
@@ -119,19 +117,16 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metr
     /// Starts the network.
     ///
     /// After the network is started, it is not possible to add more channels.
-    pub fn start(mut self) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|context| self.run(context))
+    pub fn start(self, context: E) -> Handle<()> {
+        context.spawn(|context| self.run(context))
     }
 
     async fn run(self, context: E) {
         // Start tracker
-        let mut tracker_task = self.tracker.start();
+        let mut tracker_task = self.tracker.start(context.clone());
 
         // Start router
-        let mut router_task = self.router.start(self.channels);
+        let mut router_task = self.router.start(context.clone(), self.channels);
 
         // Start spawner
         let (spawner, spawner_mailbox) = spawner::Actor::new(
@@ -145,8 +140,11 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metr
                 peer_gossip_max_count: self.cfg.peer_gossip_max_count,
             },
         );
-        let mut spawner_task =
-            spawner.start(self.tracker_mailbox.clone(), self.router_mailbox.clone());
+        let mut spawner_task = spawner.start(
+            context.with_label("spawner"),
+            self.tracker_mailbox.clone(),
+            self.router_mailbox.clone(),
+        );
 
         // Start listener
         let stream_cfg = StreamConfig {
@@ -165,8 +163,11 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metr
                 allowed_incoming_connection_rate: self.cfg.allowed_incoming_connection_rate,
             },
         );
-        let mut listener_task =
-            listener.start(self.tracker_mailbox.clone(), spawner_mailbox.clone());
+        let mut listener_task = listener.start(
+            context.with_label("listener"),
+            self.tracker_mailbox.clone(),
+            spawner_mailbox.clone(),
+        );
 
         // Start dialer
         let dialer = dialer::Actor::new(
@@ -177,7 +178,11 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metr
                 query_frequency: self.cfg.query_frequency,
             },
         );
-        let mut dialer_task = dialer.start(self.tracker_mailbox, spawner_mailbox);
+        let mut dialer_task = dialer.start(
+            context.with_label("dialer"),
+            self.tracker_mailbox,
+            spawner_mailbox,
+        );
 
         // Wait for first actor to exit
         info!("network started");

--- a/p2p/src/authenticated/lookup/actors/dialer.rs
+++ b/p2p/src/authenticated/lookup/actors/dialer.rs
@@ -77,8 +77,8 @@ impl<C: Signer> Actor<C> {
     async fn dial_peer<E: Spawner + Clock + GClock + Network + Rng + CryptoRng + Metrics>(
         &mut self,
         context: &E,
-        reservation: Reservation<E, C::PublicKey>,
-        supervisor: &mut Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        reservation: Reservation<C::PublicKey>,
+        supervisor: &mut Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) {
         // Extract metadata from the reservation
         let Metadata::Dialer(peer, address) = reservation.metadata().clone() else {
@@ -126,8 +126,8 @@ impl<C: Signer> Actor<C> {
     pub fn start<E: Spawner + Clock + GClock + Network + Rng + CryptoRng + Metrics>(
         self,
         context: E,
-        tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
         context.spawn(|context| self.run(context, tracker, supervisor))
     }
@@ -136,8 +136,8 @@ impl<C: Signer> Actor<C> {
     async fn run<E: Spawner + Clock + GClock + Network + Rng + CryptoRng + Metrics>(
         mut self,
         mut context: E,
-        mut tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        mut supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        mut tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        mut supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) {
         let mut dial_deadline = context.current();
         let mut query_deadline = context.current();

--- a/p2p/src/authenticated/lookup/actors/listener.rs
+++ b/p2p/src/authenticated/lookup/actors/listener.rs
@@ -25,10 +25,7 @@ pub struct Config<C: Signer> {
     pub allowed_incoming_connection_rate: Quota,
 }
 
-pub struct Actor<
-    E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metrics,
-    C: Signer,
-> {
+pub struct Actor<E: ReasonablyRealtime, C: Signer> {
     address: SocketAddr,
     stream_cfg: StreamConfig<C>,
     rate_limiter: RateLimiter<NotKeyed, InMemoryState, E, NoOpMiddleware<E::Instant>>,
@@ -67,8 +64,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
         stream_cfg: StreamConfig<C>,
         sink: SinkOf<E>,
         stream: StreamOf<E>,
-        mut tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        mut supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        mut tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        mut supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) {
         // Perform handshake
         let (peer, send, recv) = match listen(
@@ -103,8 +100,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
     pub fn start(
         self,
         context: E,
-        tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
         context.spawn(|context| self.run(context, tracker, supervisor))
     }
@@ -113,8 +110,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
     async fn run(
         self,
         context: E,
-        tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
-        supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
+        tracker: Mailbox<tracker::Message<C::PublicKey>>,
+        supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) {
         // Start listening for incoming connections
         let mut listener = context

--- a/p2p/src/authenticated/lookup/actors/router/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/router/actor.rs
@@ -20,25 +20,23 @@ use std::collections::BTreeMap;
 use tracing::debug;
 
 /// Router actor that manages peer connections and routing messages.
-pub struct Actor<E: Spawner + Metrics, P: PublicKey> {
-    context: Option<E>,
-
+pub struct Actor<P: PublicKey> {
     control: mpsc::Receiver<Message<P>>,
     connections: BTreeMap<P, Relay<Data>>,
 
     messages_dropped: Family<metrics::Message, Counter>,
 }
 
-impl<E: Spawner + Metrics, P: PublicKey> Actor<E, P> {
+impl<P: PublicKey> Actor<P> {
     /// Returns a new [Actor] along with a [Mailbox] and [Messenger]
     /// that can be used to send messages to the router.
-    pub fn new(context: E, cfg: Config) -> (Self, Mailbox<Message<P>>, Messenger<P>) {
+    pub fn new(metrics: impl Metrics, cfg: Config) -> (Self, Mailbox<Message<P>>, Messenger<P>) {
         // Create mailbox
         let (control_sender, control_receiver) = mpsc::channel(cfg.mailbox_size);
 
         // Create metrics
         let messages_dropped = Family::<metrics::Message, Counter>::default();
-        context.register(
+        metrics.register(
             "messages_dropped",
             "messages dropped",
             messages_dropped.clone(),
@@ -47,7 +45,6 @@ impl<E: Spawner + Metrics, P: PublicKey> Actor<E, P> {
         // Create actor
         (
             Self {
-                context: Some(context),
                 control: control_receiver,
                 connections: BTreeMap::new(),
                 messages_dropped,
@@ -94,11 +91,8 @@ impl<E: Spawner + Metrics, P: PublicKey> Actor<E, P> {
     /// Starts a new task that runs the router [Actor].
     /// Returns a [Handle] that can be used to await the completion of the task,
     /// which will run until its `control` receiver is closed.
-    pub fn start(mut self, routing: Channels<P>) -> Handle<()> {
-        self.context
-            .take()
-            .expect("context is only consumed on start")
-            .spawn(|_| self.run(routing))
+    pub fn start(self, spawner: impl Spawner, routing: Channels<P>) -> Handle<()> {
+        spawner.spawn(|_| self.run(routing))
     }
 
     /// Runs the [Actor] event loop, processing incoming messages control messages

--- a/p2p/src/authenticated/lookup/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/actor.rs
@@ -86,8 +86,7 @@ impl<Si: Sink, St: Stream, C: PublicKey> Actor<Si, St, C> {
         context: E,
         tracker: Mailbox<tracker::Message<C>>,
         router: Mailbox<router::Message<C>>,
-    )
-    where
+    ) where
         E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics,
     {
         while let Some(msg) = self.receiver.next().await {

--- a/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
@@ -1,10 +1,10 @@
 use crate::authenticated::{lookup::actors::tracker::Reservation, Mailbox};
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Sink, Spawner, Stream};
+use commonware_runtime::{Sink, Stream};
 use commonware_stream::{Receiver, Sender};
 
 /// Messages that can be processed by the spawner actor.
-pub enum Message<E: Spawner, Si: Sink, St: Stream, P: PublicKey> {
+pub enum Message<Si: Sink, St: Stream, P: PublicKey> {
     /// Notify the spawner to create a new task for the given peer.
     Spawn {
         /// The peer's public key.
@@ -12,16 +12,16 @@ pub enum Message<E: Spawner, Si: Sink, St: Stream, P: PublicKey> {
         /// The connection to the peer.
         connection: (Sender<Si>, Receiver<St>),
         /// The reservation for the peer.
-        reservation: Reservation<E, P>,
+        reservation: Reservation<P>,
     },
 }
 
-impl<E: Spawner, Si: Sink, St: Stream, P: PublicKey> Mailbox<Message<E, Si, St, P>> {
+impl<Si: Sink, St: Stream, P: PublicKey> Mailbox<Message<Si, St, P>> {
     /// Send a message to the actor to spawn a new task for the given peer.
     pub async fn spawn(
         &mut self,
         connection: (Sender<Si>, Receiver<St>),
-        reservation: Reservation<E, P>,
+        reservation: Reservation<P>,
     ) {
         self.send(Message::Spawn {
             peer: reservation.metadata().public_key().clone(),

--- a/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
@@ -1,10 +1,10 @@
 use crate::authenticated::{lookup::actors::tracker::Reservation, Mailbox};
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Clock, Metrics, Sink, Spawner, Stream};
+use commonware_runtime::{Sink, Spawner, Stream};
 use commonware_stream::{Receiver, Sender};
 
 /// Messages that can be processed by the spawner actor.
-pub enum Message<E: Spawner + Clock + Metrics, Si: Sink, St: Stream, P: PublicKey> {
+pub enum Message<E: Spawner, Si: Sink, St: Stream, P: PublicKey> {
     /// Notify the spawner to create a new task for the given peer.
     Spawn {
         /// The peer's public key.
@@ -16,9 +16,7 @@ pub enum Message<E: Spawner + Clock + Metrics, Si: Sink, St: Stream, P: PublicKe
     },
 }
 
-impl<E: Spawner + Clock + Metrics, Si: Sink, St: Stream, P: PublicKey>
-    Mailbox<Message<E, Si, St, P>>
-{
+impl<E: Spawner, Si: Sink, St: Stream, P: PublicKey> Mailbox<Message<E, Si, St, P>> {
     /// Send a message to the actor to spawn a new task for the given peer.
     pub async fn spawn(
         &mut self,

--- a/p2p/src/authenticated/lookup/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/actor.rs
@@ -38,11 +38,7 @@ impl<E: GClock + RuntimeMetrics + Clone, C: Signer> Actor<E, C> {
     pub fn new(
         context: E,
         cfg: Config<C>,
-    ) -> (
-        Self,
-        Mailbox<Message<C::PublicKey>>,
-        Oracle<C::PublicKey>,
-    ) {
+    ) -> (Self, Mailbox<Message<C::PublicKey>>, Oracle<C::PublicKey>) {
         // General initialization
         let directory_cfg = directory::Config {
             max_sets: cfg.tracked_peer_sets,
@@ -193,8 +189,8 @@ mod tests {
 
     // Test Harness
     struct TestHarness {
-        mailbox: Mailbox<Message<deterministic::Context, PublicKey>>,
-        oracle: Oracle<deterministic::Context, PublicKey>,
+        mailbox: Mailbox<Message<PublicKey>>,
+        oracle: Oracle<PublicKey>,
     }
 
     fn setup_actor(
@@ -203,7 +199,7 @@ mod tests {
     ) -> TestHarness {
         // Actor::new takes ownership, so clone again if cfg_to_clone is needed later
         let (actor, mailbox, oracle) = Actor::new(runner_context.clone(), cfg_to_clone);
-        runner_context.spawn(|_| actor.run());
+        runner_context.spawn(|context| actor.run(context));
 
         TestHarness { mailbox, oracle }
     }
@@ -416,7 +412,7 @@ mod tests {
                 match res.metadata() {
                     crate::authenticated::lookup::actors::tracker::Metadata::Dialer(pk, addr) => {
                         assert_eq!(pk, &boot_pk);
-                        assert_eq!(*addr, boot_addr);
+                        assert_eq!(addr, &boot_addr);
                     }
                     _ => panic!("Expected Dialer metadata"),
                 }

--- a/p2p/src/authenticated/lookup/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/directory.rs
@@ -1,12 +1,11 @@
 use super::{metrics::Metrics, record::Record, Metadata, Reservation};
 use crate::authenticated::lookup::{actors::tracker::ingress::Releaser, metrics};
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Clock, Metrics as RuntimeMetrics, Spawner};
+use commonware_runtime::{Metrics as RuntimeMetrics, Spawner};
 use governor::{
     clock::Clock as GClock, middleware::NoOpMiddleware, state::keyed::HashMapStateStore, Quota,
     RateLimiter,
 };
-use rand::Rng;
 use std::{
     collections::{BTreeMap, HashMap},
     net::SocketAddr,
@@ -26,7 +25,7 @@ pub struct Config {
 }
 
 /// Represents a collection of records for all peers.
-pub struct Directory<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: PublicKey> {
+pub struct Directory<E: Spawner + GClock + RuntimeMetrics, C: PublicKey> {
     context: E,
 
     // ---------- Configuration ----------
@@ -56,7 +55,7 @@ pub struct Directory<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Publ
     metrics: Metrics,
 }
 
-impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
+impl<E: Spawner + GClock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
     /// Create a new set of records using the given local node information.
     pub fn init(
         context: E,

--- a/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
@@ -6,13 +6,16 @@ use crate::authenticated::{
 use commonware_cryptography::PublicKey;
 use commonware_runtime::Spawner;
 use futures::{
-    channel::{mpsc, oneshot},
-    SinkExt,
+    channel::{
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
+        oneshot,
+    },
+    SinkExt, StreamExt,
 };
 use std::net::SocketAddr;
 
 /// Messages that can be sent to the tracker actor.
-pub enum Message<E: Spawner, C: PublicKey> {
+pub enum Message<C: PublicKey> {
     // ---------- Used by oracle ----------
     /// Register a peer set at a given index.
     Register {
@@ -44,7 +47,7 @@ pub enum Message<E: Spawner, C: PublicKey> {
 
     /// Request a reservation for a particular peer to dial.
     ///
-    /// The tracker will respond with an [Option<Reservation<E, C>>], which will be `None` if the
+    /// The tracker will respond with an [Option<Reservation<C>>], which will be `None` if the
     /// reservation cannot be granted (e.g., if the peer is already connected, blocked or already
     /// has an active reservation).
     Dial {
@@ -52,7 +55,7 @@ pub enum Message<E: Spawner, C: PublicKey> {
         public_key: C,
 
         /// sender to respond with the reservation.
-        reservation: oneshot::Sender<Option<Reservation<E, C>>>,
+        reservation: oneshot::Sender<Option<Reservation<C>>>,
     },
 
     // ---------- Used by listener ----------
@@ -67,7 +70,7 @@ pub enum Message<E: Spawner, C: PublicKey> {
 
     /// Request a reservation for a particular peer.
     ///
-    /// The tracker will respond with an [Option<Reservation<E, C>>], which will be `None` if  the
+    /// The tracker will respond with an [Option<Reservation<C>>], which will be `None` if  the
     /// reservation cannot be granted (e.g., if the peer is already connected, blocked or already
     /// has an active reservation).
     Listen {
@@ -75,7 +78,7 @@ pub enum Message<E: Spawner, C: PublicKey> {
         public_key: C,
 
         /// The sender to respond with the reservation.
-        reservation: oneshot::Sender<Option<Reservation<E, C>>>,
+        reservation: oneshot::Sender<Option<Reservation<C>>>,
     },
 
     // ---------- Used by reservation ----------
@@ -86,7 +89,7 @@ pub enum Message<E: Spawner, C: PublicKey> {
     },
 }
 
-impl<E: Spawner, C: PublicKey> Mailbox<Message<E, C>> {
+impl<C: PublicKey> Mailbox<Message<C>> {
     /// Send a `Connect` message to the tracker.
     pub async fn connect(&mut self, public_key: C, peer: Mailbox<peer::Message>) {
         self.send(Message::Connect { public_key, peer })
@@ -104,7 +107,7 @@ impl<E: Spawner, C: PublicKey> Mailbox<Message<E, C>> {
     }
 
     /// Send a `Dial` message to the tracker.
-    pub async fn dial(&mut self, public_key: C) -> Option<Reservation<E, C>> {
+    pub async fn dial(&mut self, public_key: C) -> Option<Reservation<C>> {
         let (tx, rx) = oneshot::channel();
         self.send(Message::Dial {
             public_key,
@@ -128,7 +131,7 @@ impl<E: Spawner, C: PublicKey> Mailbox<Message<E, C>> {
     }
 
     /// Send a `Listen` message to the tracker.
-    pub async fn listen(&mut self, public_key: C) -> Option<Reservation<E, C>> {
+    pub async fn listen(&mut self, public_key: C) -> Option<Reservation<C>> {
         let (tx, rx) = oneshot::channel();
         self.send(Message::Listen {
             public_key,
@@ -140,35 +143,65 @@ impl<E: Spawner, C: PublicKey> Mailbox<Message<E, C>> {
     }
 }
 
-/// Allows releasing reservations
-#[derive(Clone)]
-pub struct Releaser<E: Spawner, C: PublicKey> {
-    sender: mpsc::Sender<Message<E, C>>,
+/// Owns the release worker for reservations.
+pub struct Releaser<C: PublicKey> {
+    sender: mpsc::Sender<Message<C>>,
+    backlog: UnboundedReceiver<Metadata<C>>,
 }
 
-impl<E: Spawner, C: PublicKey> Releaser<E, C> {
-    /// Create a new releaser.
-    pub(super) fn new(sender: mpsc::Sender<Message<E, C>>) -> Self {
-        Self { sender }
+impl<C: PublicKey> Releaser<C> {
+    /// Creates a new releaser and associated handle for issuing release requests.
+    pub(super) fn new(sender: mpsc::Sender<Message<C>>) -> (Self, ReleaserHandle<C>) {
+        let (backlog_tx, backlog_rx) = mpsc::unbounded();
+        (
+            Self {
+                sender: sender.clone(),
+                backlog: backlog_rx,
+            },
+            ReleaserHandle {
+                sender,
+                backlog: backlog_tx,
+            },
+        )
     }
 
-    /// Try to release a reservation.
-    ///
-    /// Returns `true` if the reservation was released, `false` if the mailbox is full.
-    pub fn try_release(&mut self, metadata: Metadata<C>) -> bool {
-        match self.sender.try_send(Message::Release { metadata }) {
-            Ok(()) => true,
-            Err(e) if e.is_full() => false,
-            Err(e) if e.is_disconnected() => true,
-            Err(_) => false,
+    /// Spawns the worker that drains the backlog and forwards releases to the tracker mailbox.
+    pub(super) fn start(mut self, spawner: impl Spawner) {
+        spawner.spawn(move |_| async move {
+            while let Some(metadata) = self.backlog.next().await {
+                if self
+                    .sender
+                    .send(Message::Release { metadata })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+    }
+}
+
+/// Handle used by reservations to request releases.
+#[derive(Clone)]
+pub struct ReleaserHandle<C: PublicKey> {
+    sender: mpsc::Sender<Message<C>>,
+    backlog: UnboundedSender<Metadata<C>>,
+}
+
+impl<C: PublicKey> ReleaserHandle<C> {
+    /// Releases a reservation, queueing it if the tracker mailbox is currently full.
+    pub fn release(&mut self, metadata: Metadata<C>) {
+        match self.sender.try_send(Message::Release {
+            metadata: metadata.clone(),
+        }) {
+            Ok(()) => {}
+            Err(e) if e.is_disconnected() => {}
+            Err(e) if e.is_full() => {
+                let _ = self.backlog.unbounded_send(metadata);
+            }
+            Err(_) => {}
         }
-    }
-
-    /// Release a reservation.
-    ///
-    /// This method will block if the mailbox is full.
-    pub async fn release(&mut self, metadata: Metadata<C>) {
-        let _ = self.sender.send(Message::Release { metadata }).await;
     }
 }
 
@@ -177,29 +210,22 @@ impl<E: Spawner, C: PublicKey> Releaser<E, C> {
 /// Peers that are not explicitly authorized
 /// will be blocked by commonware-p2p.
 #[derive(Clone)]
-pub struct Oracle<E: Spawner, C: PublicKey> {
-    sender: mpsc::Sender<Message<E, C>>,
+pub struct Oracle<C: PublicKey> {
+    sender: mpsc::Sender<Message<C>>,
 }
 
-impl<E: Spawner, C: PublicKey> Oracle<E, C> {
-    pub(super) fn new(sender: mpsc::Sender<Message<E, C>>) -> Self {
+impl<C: PublicKey> Oracle<C> {
+    pub(super) fn new(sender: mpsc::Sender<Message<C>>) -> Self {
         Self { sender }
     }
 
     /// Register a set of authorized peers at a given index.
-    ///
-    /// # Parameters
-    ///
-    /// * `index` - Index of the set of authorized peers (like a blockchain height).
-    ///   Should be monotonically increasing.
-    /// * `peers` - Vector of authorized peers at an `index` (does not need to be sorted).
-    ///   Each element is a tuple containing the public key and the socket address of the peer.
     pub async fn register(&mut self, index: u64, peers: Vec<(C, SocketAddr)>) {
         let _ = self.sender.send(Message::Register { index, peers }).await;
     }
 }
 
-impl<E: Spawner, C: PublicKey> crate::Blocker for Oracle<E, C> {
+impl<C: PublicKey> crate::Blocker for Oracle<C> {
     type PublicKey = C;
 
     async fn block(&mut self, public_key: Self::PublicKey) {

--- a/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
@@ -47,7 +47,7 @@ pub enum Message<C: PublicKey> {
 
     /// Request a reservation for a particular peer to dial.
     ///
-    /// The tracker will respond with an [Option<Reservation<C>>], which will be `None` if the
+    /// The tracker will respond with an [`Option<Reservation<C>>`], which will be `None` if the
     /// reservation cannot be granted (e.g., if the peer is already connected, blocked or already
     /// has an active reservation).
     Dial {
@@ -70,7 +70,7 @@ pub enum Message<C: PublicKey> {
 
     /// Request a reservation for a particular peer.
     ///
-    /// The tracker will respond with an [Option<Reservation<C>>], which will be `None` if  the
+    /// The tracker will respond with an [`Option<Reservation<C>>`], which will be `None` if  the
     /// reservation cannot be granted (e.g., if the peer is already connected, blocked or already
     /// has an active reservation).
     Listen {

--- a/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
@@ -4,7 +4,7 @@ use crate::authenticated::{
     Mailbox,
 };
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Metrics, Spawner};
+use commonware_runtime::Spawner;
 use futures::{
     channel::{mpsc, oneshot},
     SinkExt,
@@ -12,7 +12,7 @@ use futures::{
 use std::net::SocketAddr;
 
 /// Messages that can be sent to the tracker actor.
-pub enum Message<E: Spawner + Metrics, C: PublicKey> {
+pub enum Message<E: Spawner, C: PublicKey> {
     // ---------- Used by oracle ----------
     /// Register a peer set at a given index.
     Register {
@@ -86,7 +86,7 @@ pub enum Message<E: Spawner + Metrics, C: PublicKey> {
     },
 }
 
-impl<E: Spawner + Metrics, C: PublicKey> Mailbox<Message<E, C>> {
+impl<E: Spawner, C: PublicKey> Mailbox<Message<E, C>> {
     /// Send a `Connect` message to the tracker.
     pub async fn connect(&mut self, public_key: C, peer: Mailbox<peer::Message>) {
         self.send(Message::Connect { public_key, peer })
@@ -142,11 +142,11 @@ impl<E: Spawner + Metrics, C: PublicKey> Mailbox<Message<E, C>> {
 
 /// Allows releasing reservations
 #[derive(Clone)]
-pub struct Releaser<E: Spawner + Metrics, C: PublicKey> {
+pub struct Releaser<E: Spawner, C: PublicKey> {
     sender: mpsc::Sender<Message<E, C>>,
 }
 
-impl<E: Spawner + Metrics, C: PublicKey> Releaser<E, C> {
+impl<E: Spawner, C: PublicKey> Releaser<E, C> {
     /// Create a new releaser.
     pub(super) fn new(sender: mpsc::Sender<Message<E, C>>) -> Self {
         Self { sender }
@@ -177,11 +177,11 @@ impl<E: Spawner + Metrics, C: PublicKey> Releaser<E, C> {
 /// Peers that are not explicitly authorized
 /// will be blocked by commonware-p2p.
 #[derive(Clone)]
-pub struct Oracle<E: Spawner + Metrics, C: PublicKey> {
+pub struct Oracle<E: Spawner, C: PublicKey> {
     sender: mpsc::Sender<Message<E, C>>,
 }
 
-impl<E: Spawner + Metrics, C: PublicKey> Oracle<E, C> {
+impl<E: Spawner, C: PublicKey> Oracle<E, C> {
     pub(super) fn new(sender: mpsc::Sender<Message<E, C>>) -> Self {
         Self { sender }
     }
@@ -199,7 +199,7 @@ impl<E: Spawner + Metrics, C: PublicKey> Oracle<E, C> {
     }
 }
 
-impl<E: Spawner + Metrics, C: PublicKey> crate::Blocker for Oracle<E, C> {
+impl<E: Spawner, C: PublicKey> crate::Blocker for Oracle<E, C> {
     type PublicKey = C;
 
     async fn block(&mut self, public_key: Self::PublicKey) {

--- a/p2p/src/authenticated/lookup/actors/tracker/reservation.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/reservation.rs
@@ -1,65 +1,33 @@
 use super::Metadata;
-use crate::authenticated::lookup::actors::tracker::ingress::Releaser;
+use crate::authenticated::lookup::actors::tracker::ingress::ReleaserHandle;
 use commonware_cryptography::PublicKey;
-use commonware_runtime::Spawner;
 
 /// Reservation for a peer in the network. This is used to ensure that the peer is reserved only
 /// once, and that the reservation is released when the peer connection fails or is closed.
-pub struct Reservation<E: Spawner, P: PublicKey> {
-    /// Context needed to spawn tasks if needed.
-    ///
-    /// Stored as an `Option` to avoid unnecessary cloning by `take`ing the value.
-    spawner: Option<E>,
-
+pub struct Reservation<P: PublicKey> {
     /// Metadata about the reservation.
     metadata: Metadata<P>,
 
     /// Used to automatically notify the completion of the reservation when it is dropped.
-    ///
-    /// Stored as an `Option` to avoid unnecessary cloning by `take`ing the value.
-    releaser: Option<Releaser<E, P>>,
+    releaser: ReleaserHandle<P>,
 }
 
-impl<E: Spawner, P: PublicKey> Reservation<E, P> {
+impl<P: PublicKey> Reservation<P> {
     /// Create a new reservation for a peer.
-    pub fn new(spawner: E, metadata: Metadata<P>, releaser: Releaser<E, P>) -> Self {
-        Self {
-            spawner: Some(spawner),
-            metadata,
-            releaser: Some(releaser),
-        }
+    pub fn new(metadata: Metadata<P>, releaser: ReleaserHandle<P>) -> Self {
+        Self { metadata, releaser }
     }
 }
 
-impl<E: Spawner, P: PublicKey> Reservation<E, P> {
+impl<P: PublicKey> Reservation<P> {
     /// Returns the metadata associated with this reservation.
     pub fn metadata(&self) -> &Metadata<P> {
         &self.metadata
     }
 }
 
-impl<E: Spawner, P: PublicKey> Drop for Reservation<E, P> {
+impl<P: PublicKey> Drop for Reservation<P> {
     fn drop(&mut self) {
-        let mut releaser = self
-            .releaser
-            .take()
-            .expect("Reservation::drop called twice");
-
-        // If the mailbox is not full, release the reservation immediately without spawning a task.
-        if releaser.try_release(self.metadata.clone()) {
-            // Sent successfully, nothing to do.
-            return;
-        };
-
-        // If the mailbox is full, we avoid blocking by spawning a task to handle the release.
-        // While it may not be immediately obvious how a deadlock could occur, we take the
-        // conservative approach of avoiding it.
-        let metadata = self.metadata.clone();
-        self.spawner
-            .take()
-            .expect("spawner is only consumed on drop")
-            .spawn(move |_| async move {
-                releaser.release(metadata).await;
-            });
+        self.releaser.release(self.metadata.clone());
     }
 }

--- a/p2p/src/authenticated/lookup/actors/tracker/reservation.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/reservation.rs
@@ -1,13 +1,15 @@
 use super::Metadata;
 use crate::authenticated::lookup::actors::tracker::ingress::Releaser;
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Metrics, Spawner};
+use commonware_runtime::Spawner;
 
 /// Reservation for a peer in the network. This is used to ensure that the peer is reserved only
 /// once, and that the reservation is released when the peer connection fails or is closed.
-pub struct Reservation<E: Spawner + Metrics, P: PublicKey> {
+pub struct Reservation<E: Spawner, P: PublicKey> {
     /// Context needed to spawn tasks if needed.
-    context: Option<E>,
+    ///
+    /// Stored as an `Option` to avoid unnecessary cloning by `take`ing the value.
+    spawner: Option<E>,
 
     /// Metadata about the reservation.
     metadata: Metadata<P>,
@@ -18,25 +20,25 @@ pub struct Reservation<E: Spawner + Metrics, P: PublicKey> {
     releaser: Option<Releaser<E, P>>,
 }
 
-impl<E: Spawner + Metrics, P: PublicKey> Reservation<E, P> {
+impl<E: Spawner, P: PublicKey> Reservation<E, P> {
     /// Create a new reservation for a peer.
-    pub fn new(context: E, metadata: Metadata<P>, releaser: Releaser<E, P>) -> Self {
+    pub fn new(spawner: E, metadata: Metadata<P>, releaser: Releaser<E, P>) -> Self {
         Self {
-            context: Some(context),
+            spawner: Some(spawner),
             metadata,
             releaser: Some(releaser),
         }
     }
 }
 
-impl<E: Spawner + Metrics, P: PublicKey> Reservation<E, P> {
+impl<E: Spawner, P: PublicKey> Reservation<E, P> {
     /// Returns the metadata associated with this reservation.
     pub fn metadata(&self) -> &Metadata<P> {
         &self.metadata
     }
 }
 
-impl<E: Spawner + Metrics, P: PublicKey> Drop for Reservation<E, P> {
+impl<E: Spawner, P: PublicKey> Drop for Reservation<E, P> {
     fn drop(&mut self) {
         let mut releaser = self
             .releaser
@@ -53,9 +55,9 @@ impl<E: Spawner + Metrics, P: PublicKey> Drop for Reservation<E, P> {
         // While it may not be immediately obvious how a deadlock could occur, we take the
         // conservative approach of avoiding it.
         let metadata = self.metadata.clone();
-        self.context
+        self.spawner
             .take()
-            .expect("context is only consumed on drop")
+            .expect("spawner is only consumed on drop")
             .spawn(move |_| async move {
                 releaser.release(metadata).await;
             });

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -113,7 +113,7 @@
 //!     );
 //!
 //!     // Run network
-//!     let network_handler = network.start();
+//!     let network_handler = network.start(context.with_label("network"));
 //!
 //!     // Example: Use sender
 //!     let _ = sender.send(Recipients::All, bytes::Bytes::from_static(b"hello"), false).await;
@@ -224,7 +224,8 @@ mod tests {
 
             // Create network
             let config = Config::test(private_key.clone(), *address, max_message_size);
-            let (mut network, mut oracle) = Network::new(context.with_label("network"), config);
+            let network_context = context.with_label("network");
+            let (mut network, mut oracle) = Network::new(network_context.clone(), config);
 
             // Register peers
             oracle.register(0, peers.clone()).await;
@@ -234,7 +235,7 @@ mod tests {
                 network.register(0, Quota::per_second(NZU32!(100)), DEFAULT_MESSAGE_BACKLOG);
 
             // Wait to connect to all peers, and then send messages to everyone
-            network.start();
+            network.start(network_context.clone());
 
             // Send/Receive messages
             let peers = peers.clone();
@@ -485,7 +486,8 @@ mod tests {
                     *peer_addr,
                     1_024 * 1_024, // 1MB
                 );
-                let (mut network, mut oracle) = Network::new(context.with_label("network"), config);
+                let network_context = context.with_label("network");
+                let (mut network, mut oracle) = Network::new(network_context.clone(), config);
 
                 // Register peers at separate indices
                 oracle.register(0, vec![peers[0].clone()]).await;
@@ -501,7 +503,7 @@ mod tests {
                     network.register(0, Quota::per_second(NZU32!(10)), DEFAULT_MESSAGE_BACKLOG);
 
                 // Wait to connect to all peers, and then send messages to everyone
-                network.start();
+                network.start(network_context.clone());
 
                 // Send/Receive messages
                 let msg = peer_pk.clone();
@@ -575,7 +577,8 @@ mod tests {
                 addr,
                 1_024 * 1_024, // 1MB
             );
-            let (mut network, mut oracle) = Network::new(context.with_label("network"), config);
+            let network_context = context.with_label("network");
+            let (mut network, mut oracle) = Network::new(network_context.clone(), config);
 
             // Register peers
             oracle.register(0, peers.clone()).await;
@@ -585,7 +588,7 @@ mod tests {
                 network.register(0, Quota::per_second(NZU32!(10)), DEFAULT_MESSAGE_BACKLOG);
 
             // Wait to connect to all peers, and then send messages to everyone
-            network.start();
+            network.start(network_context.clone());
 
             // Crate random message
             let mut msg = vec![0u8; 10 * 1024 * 1024]; // 10MB (greater than frame capacity)
@@ -625,19 +628,21 @@ mod tests {
 
             // Create network for peer 0
             let config0 = Config::test(sk0, addr0, 1_024 * 1_024); // 1MB
-            let (mut network0, mut oracle0) = Network::new(context.with_label("peer-0"), config0);
+            let peer0_ctx = context.with_label("peer-0");
+            let (mut network0, mut oracle0) = Network::new(peer0_ctx.clone(), config0);
             oracle0.register(0, peers.clone()).await;
             let (mut sender0, _receiver0) =
                 network0.register(0, Quota::per_hour(NZU32!(1)), DEFAULT_MESSAGE_BACKLOG);
-            network0.start();
+            network0.start(peer0_ctx.clone());
 
             // Create network for peer 1
             let config1 = Config::test(sk1, addr1, 1_024 * 1_024); // 1MB
-            let (mut network1, mut oracle1) = Network::new(context.with_label("peer-1"), config1);
+            let peer1_ctx = context.with_label("peer-1");
+            let (mut network1, mut oracle1) = Network::new(peer1_ctx.clone(), config1);
             oracle1.register(0, peers.clone()).await;
             let (_sender1, _receiver1) =
                 network1.register(0, Quota::per_hour(NZU32!(1)), DEFAULT_MESSAGE_BACKLOG);
-            network1.start();
+            network1.start(peer1_ctx.clone());
 
             // Send first message, which should be allowed and consume the quota.
             let msg = vec![0u8; 1024]; // 1KB

--- a/p2p/src/authenticated/lookup/network.rs
+++ b/p2p/src/authenticated/lookup/network.rs
@@ -28,7 +28,7 @@ pub struct Network<
 
     channels: Channels<C::PublicKey>,
     tracker: tracker::Actor<E, C>,
-    tracker_mailbox: Mailbox<tracker::Message<E, C::PublicKey>>,
+    tracker_mailbox: Mailbox<tracker::Message<C::PublicKey>>,
     router: router::Actor<C::PublicKey>,
     router_mailbox: Mailbox<router::Message<C::PublicKey>>,
 }
@@ -46,7 +46,7 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metr
     ///
     /// * A tuple containing the network instance and the oracle that
     ///   can be used by a developer to configure which peers are authorized.
-    pub fn new(context: E, cfg: Config<C>) -> (Self, tracker::Oracle<E, C::PublicKey>) {
+    pub fn new(context: E, cfg: Config<C>) -> (Self, tracker::Oracle<C::PublicKey>) {
         let (tracker, tracker_mailbox, oracle) = tracker::Actor::new(
             context.with_label("tracker"),
             tracker::Config {

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -85,7 +85,7 @@
 //!     let (network, mut oracle) = Network::new(context.with_label("network"), p2p_cfg);
 //!
 //!     // Start network
-//!     let network_handler = network.start();
+//!     let network_handler = network.start(context.clone());
 //!
 //!     // Register peers
 //!     let (sender1, receiver1) = oracle.register(peers[0].clone(), 0).await.unwrap();
@@ -205,7 +205,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.clone());
 
             // Register agents
             let mut agents = BTreeMap::new();
@@ -322,7 +322,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.clone());
 
             // Register agents
             let mut agents = HashMap::new();
@@ -363,7 +363,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.clone());
 
             // Register agents
             let pk = PrivateKey::from_seed(0).public_key();
@@ -401,7 +401,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.clone());
 
             // Register agents
             let pk = PrivateKey::from_seed(0).public_key();
@@ -427,7 +427,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.clone());
 
             // Register agents
             let pk1 = PrivateKey::from_seed(0).public_key();
@@ -467,7 +467,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.clone());
 
             // Register agents
             let pk1 = PrivateKey::from_seed(0).public_key();
@@ -541,7 +541,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.clone());
 
             // Register agents
             let pk1 = PrivateKey::from_seed(0).public_key();
@@ -594,7 +594,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.clone());
 
             // Define agents
             let pk1 = PrivateKey::from_seed(0).public_key();
@@ -664,7 +664,7 @@ mod tests {
             );
 
             // Start network
-            network.start();
+            network.start(context.clone());
 
             // Register agents
             let pk1 = PrivateKey::from_seed(0).public_key();
@@ -848,7 +848,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             // Both sender and receiver have the same bandiwdth (1000 B/s)
             // 500 bytes at 1000 B/s = 0.5 seconds
@@ -940,7 +940,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             // Configuration
             const NUM_PEERS: usize = 100;
@@ -1090,7 +1090,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             // Register agents
             let pk1 = PrivateKey::from_seed(1).public_key();
@@ -1148,7 +1148,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             let pk1 = PrivateKey::from_seed(1).public_key();
             let pk2 = PrivateKey::from_seed(2).public_key();
@@ -1254,7 +1254,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             // Create 10 senders and 1 receiver
             let mut senders = Vec::new();
@@ -1337,7 +1337,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             // Create fast sender
             let sender = ed25519::PrivateKey::from_seed(0).public_key();
@@ -1421,7 +1421,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             // Create 10 slow senders
             let mut senders = Vec::new();
@@ -1511,7 +1511,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             // Create 3 senders
             let mut senders = Vec::new();
@@ -1651,7 +1651,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             // Create 3 senders
             let mut senders = Vec::new();
@@ -1746,7 +1746,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             // Create two peers
             let sender = PrivateKey::from_seed(1).public_key();
@@ -1843,7 +1843,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             let pk_sender = PrivateKey::from_seed(1).public_key();
             let pk_receiver = PrivateKey::from_seed(2).public_key();
@@ -1929,7 +1929,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             let pk_sender = PrivateKey::from_seed(1).public_key();
             let pk_receiver = PrivateKey::from_seed(2).public_key();
@@ -2000,7 +2000,7 @@ mod tests {
                     disconnect_on_block: true,
                 },
             );
-            network.start();
+            network.start(context.clone());
 
             let pk_sender = PrivateKey::from_seed(1).public_key();
             let pk_receiver = PrivateKey::from_seed(2).public_key();

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -771,7 +771,7 @@ mod tests {
             };
             let network_context = context.with_label("network");
             let (network, mut oracle) = Network::new(network_context.clone(), cfg);
-            network_context.spawn(|context| network.run(context));
+            let _handle = network.start(network_context.clone());
 
             // Create two public keys
             let pk1 = ed25519::PrivateKey::from_seed(1).public_key();
@@ -851,8 +851,9 @@ mod tests {
         let runner = deterministic::Runner::default();
 
         runner.start(|context| async move {
-            let (network, mut oracle) = Network::new(context.with_label("network"), cfg);
-            let network_handle = network.start();
+            let network_context = context.with_label("network");
+            let (network, mut oracle) = Network::new(network_context.clone(), cfg);
+            let network_handle = network.start(network_context.clone());
 
             let sender_pk = ed25519::PrivateKey::from_seed(10).public_key();
             let recipient_pk = ed25519::PrivateKey::from_seed(11).public_key();
@@ -913,8 +914,9 @@ mod tests {
         let runner = deterministic::Runner::default();
 
         runner.start(|context| async move {
-            let (network, mut oracle) = Network::new(context.with_label("network"), cfg);
-            let network_handle = network.start();
+            let network_context = context.with_label("network");
+            let (network, mut oracle) = Network::new(network_context.clone(), cfg);
+            let network_handle = network.start(network_context.clone());
 
             let sender_pk = ed25519::PrivateKey::from_seed(42).public_key();
             let recipient_a = ed25519::PrivateKey::from_seed(43).public_key();

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -125,7 +125,7 @@ mod tests {
                 disconnect_on_block: true,
             },
         );
-        network.start();
+        network.start(context.with_label("network"));
 
         let schemes: Vec<PrivateKey> = peer_seeds
             .iter()
@@ -168,8 +168,9 @@ mod tests {
         producer: Producer<Key, Bytes>,
     ) -> Mailbox<Key> {
         let public_key = signer.public_key();
+        let context = context.with_label(&format!("actor_{public_key}"));
         let (engine, mailbox) = Engine::new(
-            context.with_label(&format!("actor_{public_key}")),
+            context.clone(),
             Config {
                 coordinator: coordinator.clone(),
                 consumer,
@@ -186,7 +187,7 @@ mod tests {
                 priority_responses: false,
             },
         );
-        engine.start(connection);
+        engine.start(context, connection);
 
         mailbox
     }

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -332,9 +332,7 @@ mod tests {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let context = context.with_label(LABEL);
-            let spawn_blocking = context.clone().spawn_blocking_ref(false);
-
-            let blocking_handle = spawn_blocking(|| {
+            let blocking_handle = context.clone().spawn_blocking(false, |_| {
                 // Simulate some blocking work
                 42
             });

--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -1434,7 +1434,7 @@ mod tests {
 
             // Create log with operations
             let mut log = init_journal(
-                context.clone().with_label("ops_log"),
+                context.with_label("ops_log"),
                 fixed::Config {
                     partition: format!("ops_log_{}", context.next_u64()),
                     items_per_blob: NZU64!(1024),
@@ -1524,7 +1524,7 @@ mod tests {
 
                 // Create log with operations
                 let mut log = init_journal(
-                    context.clone().with_label("boundary_log"),
+                    context.with_label("boundary_log"),
                     fixed::Config {
                         partition: format!("boundary_log_{}_{}", lower_bound, context.next_u64()),
                         items_per_blob: NZU64!(1024),


### PR DESCRIPTION
This PR removes `Spawner::spawn_ref` and `Spawner::spawn_blocking_ref`. Every actor now owns its runtime handle as an `Option`, consumes it when `start` is called, and spawns work using the context received from spawn. Any actor method now receives that context explicitly, so they no longer reach back into `self.context`. Removing the `spawn*_ref` methods also allows removing the check for duplicate spawns, since now any spawn consumes `self`, hence it's impossible to spawn multiple times with the same context.

Opening this PR as a preparation for an upcoming refactoring of the `Spawner` API (#1692). I'm not entirely sure whether these changes are worth it or whether we could just instead do `self.context.clone().spawn(|_| self.run())` in the `start` method of actors. Cloning a context is mainly cloning a bunch of `Arc`s and this is done once at startup.