### PR TITLE
[docs] Use `font-family: monospace`

### DIFF
--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -155,7 +155,7 @@
 
         function setupBenchmark() {
             // Set Chart.js default font family
-            Chart.defaults.global.defaultFontFamily = 'Consolas, monospace';
+            Chart.defaults.global.defaultFontFamily = 'monospace';
             Chart.defaults.global.defaultFontColor = "#000";
 
             // Build cases

--- a/docs/hiring.css
+++ b/docs/hiring.css
@@ -2,7 +2,7 @@
 
 :root {
     --colorAppBackground: white;
-    --fontFamily: 'Consolas', monospace;
+    --fontFamily: monospace;
     --widthMaxJobBoard: 800px;
     --colorPrimary900: blue;
     --colorPrimary600: lightblue;

--- a/docs/style.css
+++ b/docs/style.css
@@ -15,7 +15,7 @@ body {
     min-height: 100vh;
     background-color: white;
     color: black;
-    font-family: 'Consolas', monospace;
+    font-family: monospace;
     max-width: 800px;
     margin: 0 auto;
     padding: 10px 10px 0 10px;
@@ -78,7 +78,7 @@ button {
     margin-bottom: 5px;
     background-color: -webkit-link;
     color: white;
-    font-family: 'Consolas', monospace;
+    font-family: monospace;
     border-width: 0;
 }
 
@@ -270,7 +270,7 @@ pre {
     padding: 15px;
     overflow-x: auto;
     margin: 15px 0;
-    font-family: 'Consolas', monospace;
+    font-family: monospace;
     font-size: 0.9em;
     line-height: 1.4;
 }
@@ -278,7 +278,7 @@ pre {
 code {
     background-color: #f5f5f5;
     padding: 2px 4px;
-    font-family: 'Consolas', monospace;
+    font-family: monospace;
     font-size: 0.9em;
 }
 


### PR DESCRIPTION
Fixes: #1375 
Alertnative: #1623 

Instead of selecting a specific font, we'll just use the system default. It'll look more familiar to the user 🤷 