### PR TITLE
Add more adjustments to the generic coding API

### DIFF
--- a/coding/fuzz/src/lib.rs
+++ b/coding/fuzz/src/lib.rs
@@ -68,8 +68,8 @@ pub fn fuzz<S: Scheme>(input: FuzzInput) {
     let mut checked_shards = shards
         .iter()
         .map(|(shard, proof)| {
-            let reshard = S::reshard(&commitment, proof, shard).unwrap();
-            S::check(&commitment, reshard).unwrap()
+            let reshard = S::reshard(&config, &commitment, proof, shard).unwrap();
+            S::check(&config, &commitment, reshard).unwrap()
         })
         .collect::<Vec<_>>();
     // The last shard is "ours"

--- a/coding/fuzz/src/lib.rs
+++ b/coding/fuzz/src/lib.rs
@@ -82,7 +82,7 @@ pub fn fuzz<S: Scheme>(input: FuzzInput) {
         &config,
         &commitment,
         checking_data.pop().unwrap(),
-        &checked_shards[..to_use as usize],
+        &checked_shards[..(to_use as usize).min(checked_shards.len())],
     )
     .unwrap();
     assert_eq!(&decoded, &data);

--- a/coding/fuzz/src/lib.rs
+++ b/coding/fuzz/src/lib.rs
@@ -67,9 +67,10 @@ pub fn fuzz<S: Scheme>(input: FuzzInput) {
     // Each participant checks their shard
     let (mut checking_data, mut checked_shards): (Vec<_>, Vec<_>) = shards
         .into_iter()
-        .map(|shard| {
+        .enumerate()
+        .map(|(i, shard)| {
             let (checking_data, checked_shard, _) =
-                S::reshard(&config, &commitment, shard).unwrap();
+                S::reshard(&config, &commitment, i as u16, shard).unwrap();
             (checking_data, checked_shard)
         })
         .collect();

--- a/coding/src/benches/bench.rs
+++ b/coding/src/benches/bench.rs
@@ -1,6 +1,6 @@
 use commonware_coding::{Config, Scheme};
 use criterion::{criterion_main, BatchSize, Criterion};
-use rand::{seq::SliceRandom, RngCore, SeedableRng as _};
+use rand::{RngCore, SeedableRng as _};
 use rand_chacha::ChaCha8Rng;
 
 mod no_coding;

--- a/coding/src/benches/bench.rs
+++ b/coding/src/benches/bench.rs
@@ -64,8 +64,9 @@ pub(crate) fn benchmark_decode_generic<S: Scheme>(name: &str, c: &mut Criterion)
                                 .iter()
                                 .take(min)
                                 .map(|(shard, proof)| {
-                                    let reshard = S::reshard(&commitment, proof, shard).unwrap();
-                                    S::check(&commitment, reshard).unwrap()
+                                    let reshard =
+                                        S::reshard(&config, &commitment, proof, shard).unwrap();
+                                    S::check(&config, &commitment, reshard).unwrap()
                                 })
                                 .collect::<Vec<_>>();
 
@@ -73,7 +74,7 @@ pub(crate) fn benchmark_decode_generic<S: Scheme>(name: &str, c: &mut Criterion)
                         },
                         // We include the cost of checking your shard as part of decoding
                         |(commitment, (my_shard, my_proof), reshards)| {
-                            S::reshard(&commitment, &my_proof, &my_shard).unwrap();
+                            S::reshard(&config, &commitment, &my_proof, &my_shard).unwrap();
                             S::decode(&config, &commitment, my_shard, &reshards).unwrap();
                         },
                         BatchSize::SmallInput,

--- a/coding/src/benches/bench.rs
+++ b/coding/src/benches/bench.rs
@@ -77,8 +77,16 @@ pub(crate) fn benchmark_decode_generic<S: Scheme>(name: &str, c: &mut Criterion)
                                 S::reshard(&config, &commitment, my_shard).unwrap();
                             let checked_shards = reshards
                                 .into_iter()
-                                .map(|reshard| {
-                                    S::check(&config, &commitment, &checking_data, reshard).unwrap()
+                                .enumerate()
+                                .map(|(i, reshard)| {
+                                    S::check(
+                                        &config,
+                                        &commitment,
+                                        &checking_data,
+                                        i as u16,
+                                        reshard,
+                                    )
+                                    .unwrap()
                                 })
                                 .collect::<Vec<_>>();
                             S::decode(&config, &commitment, checking_data, &checked_shards)

--- a/coding/src/benches/bench_size.rs
+++ b/coding/src/benches/bench_size.rs
@@ -22,10 +22,8 @@ fn benchmark_size<S: Scheme>(name: &str) {
                 data
             };
 
-            let (commitment, shard_proofs) = S::encode(&config, data.as_slice()).unwrap();
-            let (shard, proof) = shard_proofs.first().unwrap();
-            let reshard = S::reshard(&config, &commitment, proof, shard).unwrap();
-
+            let (commitment, mut shards) = S::encode(&config, data.as_slice()).unwrap();
+            let shard = shards.pop().unwrap();
             println!(
                 "{} (shard)/msg_len={} chunks={}: {} B",
                 name,
@@ -33,13 +31,8 @@ fn benchmark_size<S: Scheme>(name: &str) {
                 chunks,
                 shard.encode_size()
             );
-            println!(
-                "{} (proof)/msg_len={} chunks={}: {} B",
-                name,
-                data_length,
-                chunks,
-                proof.encode_size()
-            );
+
+            let (_, _, reshard) = S::reshard(&config, &commitment, shard).unwrap();
             println!(
                 "{} (reshard)/msg_len={} chunks={}: {} B",
                 name,

--- a/coding/src/benches/bench_size.rs
+++ b/coding/src/benches/bench_size.rs
@@ -24,7 +24,7 @@ fn benchmark_size<S: Scheme>(name: &str) {
 
             let (commitment, shard_proofs) = S::encode(&config, data.as_slice()).unwrap();
             let (shard, proof) = shard_proofs.first().unwrap();
-            let reshard = S::reshard(&commitment, proof, shard).unwrap();
+            let reshard = S::reshard(&config, &commitment, proof, shard).unwrap();
 
             println!(
                 "{} (shard)/msg_len={} chunks={}: {} B",

--- a/coding/src/benches/bench_size.rs
+++ b/coding/src/benches/bench_size.rs
@@ -32,7 +32,13 @@ fn benchmark_size<S: Scheme>(name: &str) {
                 shard.encode_size()
             );
 
-            let (_, _, reshard) = S::reshard(&config, &commitment, shard).unwrap();
+            let (_, _, reshard) = S::reshard(
+                &config,
+                &commitment,
+                config.minimum_shards + config.extra_shards - 1,
+                shard,
+            )
+            .unwrap();
             println!(
                 "{} (reshard)/msg_len={} chunks={}: {} B",
                 name,

--- a/coding/src/benches/bench_size.rs
+++ b/coding/src/benches/bench_size.rs
@@ -24,7 +24,7 @@ fn benchmark_size<S: Scheme>(name: &str) {
 
             let (commitment, shard_proofs) = S::encode(&config, data.as_slice()).unwrap();
             let (shard, proof) = shard_proofs.first().unwrap();
-            let reshard = S::check(&commitment, proof, shard).unwrap();
+            let reshard = S::reshard(&commitment, proof, shard).unwrap();
 
             println!(
                 "{} (shard)/msg_len={} chunks={}: {} B",

--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -98,13 +98,13 @@ pub trait Scheme {
     /// A commitment attesting to the shards of data.
     type Commitment: Digest;
     /// A shard of data, to be received by a participant.
-    type Shard: Codec;
+    type Shard: Codec + Send + Sync + 'static;
     /// A shard shared with other participants, to aid them in reconstruction.
     ///
     /// In most cases, this will be the same as `Shard`, but some schemes might
     /// have extra information in `Shard` that may not be necessary to reconstruct
     /// the data.
-    type ReShard: Codec;
+    type ReShard: Codec + Send + Sync + 'static;
     /// Data which can assist in checking shards.
     type CheckingData;
     /// A shard that has been checked for inclusion in the commitment.

--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -83,8 +83,8 @@ impl Read for Config {
 /// // We can use this checking_data to check the other shards.
 /// let mut checked_shards = Vec::new();
 /// checked_shards.push(checked_shard);
-/// for reshard in reshards.into_iter().skip(1) {
-///   checked_shards.push(RS::check(&config, &commitment, &checking_data, reshard).unwrap())
+/// for (i, reshard) in reshards.into_iter().enumerate().skip(1) {
+///   checked_shards.push(RS::check(&config, &commitment, &checking_data, i as u16, reshard).unwrap())
 /// }
 ///
 /// let data2 = RS::decode(&config, &commitment, checking_data, &checked_shards[..2]).unwrap();
@@ -145,6 +145,7 @@ pub trait Scheme {
         config: &Config,
         commitment: &Self::Commitment,
         checking_data: &Self::CheckingData,
+        index: u16,
         reshard: Self::ReShard,
     ) -> Result<Self::CheckedShard, Self::Error>;
 

--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -74,8 +74,8 @@ impl Read for Config {
 /// let (shards, checked_shards): (Vec<_>, Vec<_>) = shards
 ///         .into_iter()
 ///         .map(|(shard, proof)| {
-///             let reshard = RS::reshard(&commitment, &proof, &shard).unwrap();
-///             let checked_shard = RS::check(&commitment, reshard).unwrap();
+///             let reshard = RS::reshard(&config, &commitment, &proof, &shard).unwrap();
+///             let checked_shard = RS::check(&config, &commitment, reshard).unwrap();
 ///             (shard, checked_shard)
 ///         })
 ///         .collect();
@@ -124,6 +124,7 @@ pub trait Scheme {
     ///
     /// This might have a stronger guarantee, in the case of [ValidatingScheme].
     fn reshard(
+        config: &Config,
         commitment: &Self::Commitment,
         proof: &Self::Proof,
         shard: &Self::Shard,
@@ -131,6 +132,7 @@ pub trait Scheme {
 
     /// Check the integrity of a reshard, producing a checked shard.
     fn check(
+        config: &Config,
         commitment: &Self::Commitment,
         reshard: Self::ReShard,
     ) -> Result<Self::CheckedShard, Self::Error>;
@@ -179,8 +181,8 @@ mod test {
         let (shards, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
             .map(|(shard, proof)| {
-                let reshard = S::reshard(&commitment, &proof, &shard).unwrap();
-                let checked_shard = S::check(&commitment, reshard).unwrap();
+                let reshard = S::reshard(&config, &commitment, &proof, &shard).unwrap();
+                let checked_shard = S::check(&config, &commitment, reshard).unwrap();
                 (shard, checked_shard)
             })
             .collect();
@@ -209,8 +211,8 @@ mod test {
         let (shards, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
             .map(|(shard, proof)| {
-                let reshard = S::reshard(&commitment, &proof, &shard).unwrap();
-                let checked_shard = S::check(&commitment, reshard).unwrap();
+                let reshard = S::reshard(&config, &commitment, &proof, &shard).unwrap();
+                let checked_shard = S::check(&config, &commitment, reshard).unwrap();
                 (shard, checked_shard)
             })
             .collect();
@@ -239,8 +241,8 @@ mod test {
         let (shards, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
             .map(|(shard, proof)| {
-                let reshard = S::reshard(&commitment, &proof, &shard).unwrap();
-                let checked_shard = S::check(&commitment, reshard).unwrap();
+                let reshard = S::reshard(&config, &commitment, &proof, &shard).unwrap();
+                let checked_shard = S::check(&config, &commitment, reshard).unwrap();
                 (shard, checked_shard)
             })
             .collect();
@@ -269,8 +271,8 @@ mod test {
         let (shards, checked_shard): (Vec<_>, Vec<_>) = shards
             .into_iter()
             .map(|(shard, proof)| {
-                let reshard = S::reshard(&commitment, &proof, &shard).unwrap();
-                let checked_shard = S::check(&commitment, reshard).unwrap();
+                let reshard = S::reshard(&config, &commitment, &proof, &shard).unwrap();
+                let checked_shard = S::check(&config, &commitment, reshard).unwrap();
                 (shard, checked_shard)
             })
             .collect();
@@ -299,8 +301,8 @@ mod test {
         let (shards, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
             .map(|(shard, proof)| {
-                let reshard = S::reshard(&commitment, &proof, &shard).unwrap();
-                let checked_shard = S::check(&commitment, reshard).unwrap();
+                let reshard = S::reshard(&config, &commitment, &proof, &shard).unwrap();
+                let checked_shard = S::check(&config, &commitment, reshard).unwrap();
                 (shard, checked_shard)
             })
             .collect();
@@ -329,8 +331,8 @@ mod test {
         let (shards, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
             .map(|(shard, proof)| {
-                let reshard = S::reshard(&commitment, &proof, &shard).unwrap();
-                let checked_shard = S::check(&commitment, reshard).unwrap();
+                let reshard = S::reshard(&config, &commitment, &proof, &shard).unwrap();
+                let checked_shard = S::check(&config, &commitment, reshard).unwrap();
                 (shard, checked_shard)
             })
             .collect();

--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -73,8 +73,9 @@ impl Read for Config {
 /// // to check other peoples reshards.
 /// let (mut checking_data_w_shard, reshards): (Vec<_>, Vec<_>) = shards
 ///         .into_iter()
-///         .map(|shard| {
-///             let (checking_data, checked_shard, reshard) = RS::reshard(&config, &commitment, shard).unwrap();
+///         .enumerate()
+///         .map(|(i, shard)| {
+///             let (checking_data, checked_shard, reshard) = RS::reshard(&config, &commitment, i as u16, shard).unwrap();
 ///             ((checking_data, checked_shard), reshard)
 ///         })
 ///         .collect();
@@ -134,6 +135,7 @@ pub trait Scheme {
     fn reshard(
         config: &Config,
         commitment: &Self::Commitment,
+        index: u16,
         shard: Self::Shard,
     ) -> Result<(Self::CheckingData, Self::CheckedShard, Self::ReShard), Self::Error>;
 
@@ -192,9 +194,10 @@ mod test {
 
         let (mut checking_data, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
-            .map(|shard| {
+            .enumerate()
+            .map(|(i, shard)| {
                 let (checking_data, checked_shard, _) =
-                    S::reshard(&config, &commitment, shard).unwrap();
+                    S::reshard(&config, &commitment, i as u16, shard).unwrap();
                 (checking_data, checked_shard)
             })
             .collect();
@@ -221,9 +224,10 @@ mod test {
 
         let (mut checking_data, mut checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
-            .map(|shard| {
+            .enumerate()
+            .map(|(i, shard)| {
                 let (checking_data, checked_shard, _) =
-                    S::reshard(&config, &commitment, shard).unwrap();
+                    S::reshard(&config, &commitment, i as u16, shard).unwrap();
                 (checking_data, checked_shard)
             })
             .collect();
@@ -255,9 +259,10 @@ mod test {
 
         let (mut checking_data, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
-            .map(|shard| {
+            .enumerate()
+            .map(|(i, shard)| {
                 let (checking_data, checked_shard, _) =
-                    S::reshard(&config, &commitment, shard).unwrap();
+                    S::reshard(&config, &commitment, i as u16, shard).unwrap();
                 (checking_data, checked_shard)
             })
             .collect();
@@ -284,9 +289,10 @@ mod test {
 
         let (mut checking_data, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
-            .map(|shard| {
+            .enumerate()
+            .map(|(i, shard)| {
                 let (checking_data, checked_shard, _) =
-                    S::reshard(&config, &commitment, shard).unwrap();
+                    S::reshard(&config, &commitment, i as u16, shard).unwrap();
                 (checking_data, checked_shard)
             })
             .collect();
@@ -313,9 +319,10 @@ mod test {
 
         let (mut checking_data, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
-            .map(|shard| {
+            .enumerate()
+            .map(|(i, shard)| {
                 let (checking_data, checked_shard, _) =
-                    S::reshard(&config, &commitment, shard).unwrap();
+                    S::reshard(&config, &commitment, i as u16, shard).unwrap();
                 (checking_data, checked_shard)
             })
             .collect();
@@ -342,9 +349,10 @@ mod test {
 
         let (mut checking_data, checked_shards): (Vec<_>, Vec<_>) = shards
             .into_iter()
-            .map(|shard| {
+            .enumerate()
+            .map(|(i, shard)| {
                 let (checking_data, checked_shard, _) =
-                    S::reshard(&config, &commitment, shard).unwrap();
+                    S::reshard(&config, &commitment, i as u16, shard).unwrap();
                 (checking_data, checked_shard)
             })
             .collect();

--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -125,12 +125,15 @@ pub trait Scheme {
         data: impl Buf,
     ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error>;
 
-    /// Check the integrity of a shard, producing a reshard to sent to others.
+    /// Take your own shard, check it, and produce a [Scheme::ReShard] to forward to others.
     ///
-    /// At a minimum, this checks that the shard is included in the data attested
-    /// to by the commitment.
+    /// This takes in an index, which is the index you expect the shard to be.
     ///
-    /// This might have a stronger guarantee, in the case of [ValidatingScheme].
+    /// This will produce a [Scheme::CheckedShard] which counts towards the minimum
+    /// number of shards you need to reconstruct the data, in [Scheme::decode].
+    ///
+    /// You also get [Scheme::CheckingData], which has information you can use to check
+    /// the shards you receive from others.
     #[allow(clippy::type_complexity)]
     fn reshard(
         config: &Config,
@@ -141,8 +144,10 @@ pub trait Scheme {
 
     /// Check the integrity of a reshard, producing a checked shard.
     ///
-    /// This requires the checking data produced from your own shard, in the
-    /// [Scheme::reshard] function.
+    /// This requires the [Scheme::CheckingData] produced by [Scheme::reshard].
+    ///
+    /// This takes in an index, to make sure that the reshard you're checking
+    /// is associated with the participant you expect it to be.
     fn check(
         config: &Config,
         commitment: &Self::Commitment,

--- a/coding/src/no_coding.rs
+++ b/coding/src/no_coding.rs
@@ -15,8 +15,15 @@ pub enum NoCodingError {
 ///
 /// The commitment is simply a hash of that data. This struct is generic
 /// over the choice of [commonware_cryptography::Hasher].
+#[derive(Clone, Copy)]
 pub struct NoCoding<H> {
     _marker: PhantomData<H>,
+}
+
+impl<H> std::fmt::Debug for NoCoding<H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NoCoding").finish()
+    }
 }
 
 impl<H: Hasher> crate::Scheme for NoCoding<H> {

--- a/coding/src/no_coding.rs
+++ b/coding/src/no_coding.rs
@@ -1,3 +1,4 @@
+use crate::Config;
 use commonware_cryptography::Hasher;
 use std::marker::PhantomData;
 use thiserror::Error;
@@ -44,6 +45,7 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
     }
 
     fn reshard(
+        _config: &Config,
         commitment: &Self::Commitment,
         _proof: &Self::Proof,
         shard: &Self::Shard,
@@ -56,6 +58,7 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
     }
 
     fn check(
+        _config: &Config,
         _commitment: &Self::Commitment,
         _reshard: Self::ReShard,
     ) -> Result<Self::CheckedShard, Self::Error> {

--- a/coding/src/no_coding.rs
+++ b/coding/src/no_coding.rs
@@ -47,6 +47,7 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
     fn reshard(
         _config: &Config,
         commitment: &Self::Commitment,
+        _index: u16,
         shard: Self::Shard,
     ) -> Result<(Self::CheckingData, Self::CheckedShard, Self::ReShard), Self::Error> {
         let my_commitment = H::new().update(shard.as_slice()).finalize();

--- a/coding/src/no_coding.rs
+++ b/coding/src/no_coding.rs
@@ -60,6 +60,7 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
         _config: &Config,
         _commitment: &Self::Commitment,
         _checking_data: &Self::CheckingData,
+        _index: u16,
         _reshard: Self::ReShard,
     ) -> Result<Self::CheckedShard, Self::Error> {
         Ok(())

--- a/coding/src/no_coding.rs
+++ b/coding/src/no_coding.rs
@@ -25,6 +25,8 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
 
     type ReShard = ();
 
+    type CheckedShard = ();
+
     type Proof = ();
 
     type Error = NoCodingError;
@@ -41,7 +43,7 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
         Ok((commitment, shards))
     }
 
-    fn check(
+    fn reshard(
         commitment: &Self::Commitment,
         _proof: &Self::Proof,
         shard: &Self::Shard,
@@ -53,11 +55,18 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
         Ok(())
     }
 
+    fn check(
+        _commitment: &Self::Commitment,
+        _reshard: Self::ReShard,
+    ) -> Result<Self::CheckedShard, Self::Error> {
+        Ok(())
+    }
+
     fn decode(
         _config: &crate::Config,
         _commitment: &Self::Commitment,
         my_shard: Self::Shard,
-        _shards: &[Self::ReShard],
+        _shards: &[Self::CheckedShard],
     ) -> Result<Vec<u8>, Self::Error> {
         Ok(my_shard)
     }

--- a/coding/src/reed_solomon/mod.rs
+++ b/coding/src/reed_solomon/mod.rs
@@ -448,6 +448,7 @@ impl<H: Hasher> Scheme for ReedSolomon<H> {
     }
 
     fn reshard(
+        _config: &Config,
         commitment: &Self::Commitment,
         _proof: &Self::Proof,
         shard: &Self::Shard,
@@ -460,6 +461,7 @@ impl<H: Hasher> Scheme for ReedSolomon<H> {
     }
 
     fn check(
+        _config: &Config,
         commitment: &Self::Commitment,
         reshard: Self::ReShard,
     ) -> Result<Self::CheckedShard, Self::Error> {

--- a/coding/src/reed_solomon/mod.rs
+++ b/coding/src/reed_solomon/mod.rs
@@ -450,8 +450,12 @@ impl<H: Hasher> Scheme for ReedSolomon<H> {
     fn reshard(
         _config: &Config,
         commitment: &Self::Commitment,
+        index: u16,
         shard: Self::Shard,
     ) -> Result<(Self::CheckingData, Self::CheckedShard, Self::ReShard), Self::Error> {
+        if shard.index != index {
+            return Err(Error::WrongIndex(index));
+        }
         if shard.verify(shard.index, commitment) {
             Ok(((), shard.clone(), shard))
         } else {

--- a/coding/src/reed_solomon/mod.rs
+++ b/coding/src/reed_solomon/mod.rs
@@ -24,6 +24,8 @@ pub enum Error {
     InvalidDataLength(usize),
     #[error("invalid index: {0}")]
     InvalidIndex(u16),
+    #[error("wrong index: {0}")]
+    WrongIndex(u16),
 }
 
 /// A piece of data from a Reed-Solomon encoded object.
@@ -461,8 +463,12 @@ impl<H: Hasher> Scheme for ReedSolomon<H> {
         _config: &Config,
         commitment: &Self::Commitment,
         _checking_data: &Self::CheckingData,
+        index: u16,
         reshard: Self::ReShard,
     ) -> Result<Self::CheckedShard, Self::Error> {
+        if reshard.index != index {
+            return Err(Error::WrongIndex(reshard.index));
+        }
         if !reshard.verify(reshard.index, commitment) {
             return Err(Error::InvalidProof);
         }

--- a/coding/src/reed_solomon/mod.rs
+++ b/coding/src/reed_solomon/mod.rs
@@ -29,7 +29,7 @@ pub enum Error {
 }
 
 /// A piece of data from a Reed-Solomon encoded object.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Chunk<H: Hasher> {
     /// The shard of encoded data.
     shard: Vec<u8>,
@@ -99,6 +99,14 @@ impl<H: Hasher> EncodeSize for Chunk<H> {
         self.shard.encode_size() + self.index.encode_size() + self.proof.encode_size()
     }
 }
+
+impl<H: Hasher> PartialEq for Chunk<H> {
+    fn eq(&self, other: &Self) -> bool {
+        self.shard == other.shard && self.index == other.index && self.proof == other.proof
+    }
+}
+
+impl<H: Hasher> Eq for Chunk<H> {}
 
 /// Prepare data for encoding.
 fn prepare_data(data: Vec<u8>, k: usize, m: usize) -> Vec<Vec<u8>> {
@@ -421,8 +429,15 @@ fn decode<H: Hasher>(
 ///    generated. This new root MUST match the original [bmt] root. This prevents attacks where
 ///    an adversary provides a valid set of chunks that decode to different data.
 /// 4. If the roots match, the original data is extracted from the reconstructed data shards.
+#[derive(Clone, Copy)]
 pub struct ReedSolomon<H> {
     _marker: PhantomData<H>,
+}
+
+impl<H> std::fmt::Debug for ReedSolomon<H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReedSolomon").finish()
+    }
 }
 
 impl<H: Hasher> Scheme for ReedSolomon<H> {


### PR DESCRIPTION
- Adds in the affordances for ZODA
- An index is always passed, making sure that verifiers are in control of this information
- A `check` step is added, producing one checked shard (your own), checking data for future reshards, and the reshard you need to send to others.