### PR TITLE
[storage] Add `Location`/`Position` documentation; prevent panics

### DIFF
--- a/storage/src/adb/any/fixed/mod.rs
+++ b/storage/src/adb/any/fixed/mod.rs
@@ -538,7 +538,7 @@ impl<
         max_ops: NonZeroU64,
     ) -> Result<(Proof<H::Digest>, Vec<Operation<K, V>>), Error> {
         let op_count = Location::new(op_count);
-        let end_loc = std::cmp::min(op_count, start_loc.checked_add(max_ops.get()).unwrap());
+        let end_loc = std::cmp::min(op_count, start_loc.saturating_add(max_ops.get()));
 
         let mmr_size = Position::from(op_count).as_u64();
         let proof = self

--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -609,7 +609,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         assert!(start_loc < op_count);
 
         let op_count = Location::new(op_count);
-        let end_loc = std::cmp::min(op_count, start_loc.checked_add(max_ops.get()).unwrap());
+        let end_loc = std::cmp::min(op_count, start_loc.saturating_add(max_ops.get()));
         let mmr_size = Position::from(op_count).as_u64();
 
         let proof = self

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -423,7 +423,7 @@ impl<
         let mmr = &self.any.mmr;
         let leaves = mmr.leaves();
         assert!(start_loc < leaves, "start_loc is invalid");
-        let max_loc = start_loc.checked_add(max_ops.get()).unwrap();
+        let max_loc = start_loc.saturating_add(max_ops.get());
         let end_loc = core::cmp::min(max_loc, Location::new(leaves));
 
         // Generate the proof from the grafted MMR.

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -607,7 +607,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         }
 
         let op_count = Location::new(op_count);
-        let end_loc = std::cmp::min(op_count, start_loc.checked_add(max_ops.get()).unwrap());
+        let end_loc = std::cmp::min(op_count, start_loc.saturating_add(max_ops.get()));
         let mmr_size = Position::from(op_count);
 
         let proof = self

--- a/storage/src/mmr/location.rs
+++ b/storage/src/mmr/location.rs
@@ -82,6 +82,11 @@ impl From<Location> for u64 {
     }
 }
 
+/// Add two locations together.
+///
+/// # Panics
+///
+/// Panics if the result overflows.
 impl Add for Location {
     type Output = Self;
 
@@ -91,6 +96,11 @@ impl Add for Location {
     }
 }
 
+/// Add a location and a `u64`.
+///
+/// # Panics
+///
+/// Panics if the result overflows.
 impl Add<u64> for Location {
     type Output = Self;
 
@@ -100,6 +110,11 @@ impl Add<u64> for Location {
     }
 }
 
+/// Subtract two locations.
+///
+/// # Panics
+///
+/// Panics if the result underflows.
 impl Sub for Location {
     type Output = Self;
 
@@ -109,6 +124,11 @@ impl Sub for Location {
     }
 }
 
+/// Subtract a `u64` from a location.
+///
+/// # Panics
+///
+/// Panics if the result underflows.
 impl Sub<u64> for Location {
     type Output = Self;
 
@@ -147,6 +167,11 @@ impl PartialOrd<Location> for u64 {
     }
 }
 
+/// Add a `u64` to a location.
+///
+/// # Panics
+///
+/// Panics if the result overflows.
 impl AddAssign<u64> for Location {
     #[inline]
     fn add_assign(&mut self, rhs: u64) {
@@ -154,6 +179,11 @@ impl AddAssign<u64> for Location {
     }
 }
 
+/// Subtract a `u64` from a location.
+///
+/// # Panics
+///
+/// Panics if the result underflows.
 impl SubAssign<u64> for Location {
     #[inline]
     fn sub_assign(&mut self, rhs: u64) {

--- a/storage/src/mmr/position.rs
+++ b/storage/src/mmr/position.rs
@@ -107,6 +107,11 @@ impl From<Location> for Position {
     }
 }
 
+/// Add two positions together.
+///
+/// # Panics
+///
+/// Panics if the result overflows.
 impl Add for Position {
     type Output = Self;
 
@@ -116,6 +121,11 @@ impl Add for Position {
     }
 }
 
+/// Add a position and a `u64`.
+///
+/// # Panics
+///
+/// Panics if the result overflows.
 impl Add<u64> for Position {
     type Output = Self;
 
@@ -125,6 +135,11 @@ impl Add<u64> for Position {
     }
 }
 
+/// Subtract two positions.
+///
+/// # Panics
+///
+/// Panics if the result underflows.
 impl Sub for Position {
     type Output = Self;
 
@@ -134,6 +149,11 @@ impl Sub for Position {
     }
 }
 
+/// Subtract a `u64` from a position.
+///
+/// # Panics
+///
+/// Panics if the result underflows.
 impl Sub<u64> for Position {
     type Output = Self;
 
@@ -172,6 +192,11 @@ impl PartialOrd<Position> for u64 {
     }
 }
 
+/// Add a `u64` to a position.
+///
+/// # Panics
+///
+/// Panics if the result overflows.
 impl AddAssign<u64> for Position {
     #[inline]
     fn add_assign(&mut self, rhs: u64) {
@@ -179,6 +204,11 @@ impl AddAssign<u64> for Position {
     }
 }
 
+/// Subtract a `u64` from a position.
+///
+/// # Panics
+///
+/// Panics if the result underflows.
 impl SubAssign<u64> for Position {
     #[inline]
     fn sub_assign(&mut self, rhs: u64) {


### PR DESCRIPTION
* Use `saturating_add` instead of `checked_add` to prevent panics on too-large input
* Add documentation to clarify that `Location` and `Position` operations panic on underflow/overflow

Resolves #1749