### PR TITLE
[runtime] Fix spawn_ref child tracking and adopt it across long-lived actors

### DIFF
--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -104,7 +104,7 @@ impl<
     ///
     /// This will also rebuild the state of the engine from provided `Journal`.
     pub fn start(
-        self,
+        mut self,
         voter_network: (
             impl Sender<PublicKey = C::PublicKey>,
             impl Receiver<PublicKey = C::PublicKey>,
@@ -114,9 +114,7 @@ impl<
             impl Receiver<PublicKey = C::PublicKey>,
         ),
     ) -> Handle<()> {
-        self.context
-            .clone()
-            .spawn(|_| self.run(voter_network, resolver_network))
+        self.context.spawn_ref()(self.run(voter_network, resolver_network))
     }
 
     async fn run(

--- a/consensus/src/threshold_simplex/engine.rs
+++ b/consensus/src/threshold_simplex/engine.rs
@@ -146,7 +146,7 @@ impl<
     ///
     /// This will also rebuild the state of the engine from provided `Journal`.
     pub fn start(
-        self,
+        mut self,
         pending_network: (
             impl Sender<PublicKey = C::PublicKey>,
             impl Receiver<PublicKey = C::PublicKey>,
@@ -160,9 +160,7 @@ impl<
             impl Receiver<PublicKey = C::PublicKey>,
         ),
     ) -> Handle<()> {
-        self.context
-            .clone()
-            .spawn(|_| self.run(pending_network, recovered_network, resolver_network))
+        self.context.spawn_ref()(self.run(pending_network, recovered_network, resolver_network))
     }
 
     async fn run(

--- a/p2p/src/authenticated/discovery/actors/dialer.rs
+++ b/p2p/src/authenticated/discovery/actors/dialer.rs
@@ -126,13 +126,11 @@ impl<E: Spawner + Clock + GClock + Network + Rng + CryptoRng + Metrics, C: Signe
     /// Start the dialer actor.
     #[allow(clippy::type_complexity)]
     pub fn start(
-        self,
+        mut self,
         tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
         supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
-        self.context
-            .clone()
-            .spawn(|_| self.run(tracker, supervisor))
+        self.context.spawn_ref()(self.run(tracker, supervisor))
     }
 
     #[allow(clippy::type_complexity)]

--- a/p2p/src/authenticated/discovery/actors/listener.rs
+++ b/p2p/src/authenticated/discovery/actors/listener.rs
@@ -104,13 +104,11 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
 
     #[allow(clippy::type_complexity)]
     pub fn start(
-        self,
+        mut self,
         tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
         supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
-        self.context
-            .clone()
-            .spawn(|_| self.run(tracker, supervisor))
+        self.context.spawn_ref()(self.run(tracker, supervisor))
     }
 
     #[allow(clippy::type_complexity)]

--- a/p2p/src/authenticated/lookup/actors/dialer.rs
+++ b/p2p/src/authenticated/lookup/actors/dialer.rs
@@ -126,13 +126,11 @@ impl<E: Spawner + Clock + GClock + Network + Rng + CryptoRng + Metrics, C: Signe
     /// Start the dialer actor.
     #[allow(clippy::type_complexity)]
     pub fn start(
-        self,
+        mut self,
         tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
         supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
-        self.context
-            .clone()
-            .spawn(|_| self.run(tracker, supervisor))
+        self.context.spawn_ref()(self.run(tracker, supervisor))
     }
 
     #[allow(clippy::type_complexity)]

--- a/p2p/src/authenticated/lookup/actors/listener.rs
+++ b/p2p/src/authenticated/lookup/actors/listener.rs
@@ -105,13 +105,11 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Network + Rng + CryptoRng + Metri
 
     #[allow(clippy::type_complexity)]
     pub fn start(
-        self,
+        mut self,
         tracker: Mailbox<tracker::Message<E, C::PublicKey>>,
         supervisor: Mailbox<spawner::Message<E, SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
-        self.context
-            .clone()
-            .spawn(|_| self.run(tracker, supervisor))
+        self.context.spawn_ref()(self.run(tracker, supervisor))
     }
 
     #[allow(clippy::type_complexity)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -143,6 +143,17 @@ pub trait Spawner: Clone + Send + Sync + 'static {
     ///
     /// If this function is used to spawn multiple tasks from the same context (including child
     /// tasks), the runtime will panic to prevent accidental misuse.
+    ///
+    /// `spawn_ref` installs a fresh child list for the new task. Clones created before the call keep
+    /// pointing at the previous list, so children spawned from those clones run independently (they
+    /// are not aborted when the parent finishes). If you want child supervision to apply, obtain the
+    /// `spawn_ref` closure first and then clone/label inside the task:
+    ///
+    /// ```ignore
+    /// context.spawn_ref()(async move {
+    ///     context.clone().spawn_child(|_| async move { /* ... */ });
+    /// });
+    /// ```
     fn spawn_ref<F, T>(&mut self) -> impl FnOnce(F) -> Handle<T> + 'static
     where
         F: Future<Output = T> + Send + 'static,

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -435,17 +435,15 @@ impl crate::Spawner for Context {
         // Get metrics
         let (_, metric) = spawn_metrics!(self, future);
 
+        // Give spawned task its own empty children list
+        let children = Arc::new(Mutex::new(Vec::new()));
+        self.children = children.clone();
+
         // Set up the task
         let executor = self.executor.clone();
 
         move |f: F| {
-            let (f, handle) = Handle::init_future(
-                f,
-                metric,
-                executor.cfg.catch_panics,
-                // Give spawned task its own empty children list
-                Arc::new(Mutex::new(Vec::new())),
-            );
+            let (f, handle) = Handle::init_future(f, metric, executor.cfg.catch_panics, children);
 
             // Spawn the task
             executor.runtime.spawn(f);


### PR DESCRIPTION
1. Fix `spawn_ref` implementations to set the child list before returning the closure (same as is done on `spawn`).
2. Extend runtime child-task tests to exercise both `spawn` and `spawn_ref` (these changes catch the issue fixed above).
3. Update all actors that were doing `context.clone().spawn()` on start, to use `spawn_ref` instead.