### PR TITLE
[workspace] make justfile nix friendly

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         tool: just@1.43.0
     - name: Fmt
-      run: just check-fmt ${{ env.NIGHTLY_VERSION }}
+      run: just check-fmt +${{ env.NIGHTLY_VERSION }}
     - name: Lint
       run: just clippy ${{ matrix.flags }}
     - name: Check docs
@@ -123,7 +123,7 @@ jobs:
       with:
         tool: just@1.43.0,cargo-udeps@${{ env.UDEPS_VERSION }}
     - name: Check for unused dependencies
-      run: just udeps ${{ env.NIGHTLY_VERSION }}
+      run: just udeps +${{ env.NIGHTLY_VERSION }}
 
   Lock:
     runs-on: ubuntu-latest

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -130,4 +130,4 @@ jobs:
       with:
         tool: just@1.43.0
     - name: Test all targets
-      run: just fuzz ${{ matrix.fuzz_dir }} 60 ${{ env.NIGHTLY_VERSION }}
+      run: just fuzz ${{ matrix.fuzz_dir }} 60 +${{ env.NIGHTLY_VERSION }}

--- a/justfile
+++ b/justfile
@@ -18,12 +18,12 @@ build *args='':
 pre-pr: lint test-docs test
 
 # Fixes the formatting of the workspace
-fix-fmt nightly_version='nightly':
-  cargo +{{nightly_version}} fmt --all
+fix-fmt nightly_version='+nightly':
+  cargo {{nightly_version}} fmt --all
 
 # Check the formatting of the workspace
-check-fmt nightly_version='nightly':
-  cargo +{{nightly_version}} fmt --all -- --check
+check-fmt nightly_version='+nightly':
+  cargo {{nightly_version}} fmt --all -- --check
 
 # Run clippy lints
 clippy *args='':
@@ -49,15 +49,15 @@ check-docs *args='':
   RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items $@
 
 # Run all fuzz tests in a given directory
-fuzz fuzz_dir max_time='60' nightly_version='nightly':
+fuzz fuzz_dir max_time='60' nightly_version='+nightly':
   #!/usr/bin/env bash
-  for target in $(cargo +{{nightly_version}} fuzz list --fuzz-dir {{fuzz_dir}}); do
-    cargo +{{nightly_version}} fuzz run $target --fuzz-dir {{fuzz_dir}} -- -max_total_time={{max_time}}
+  for target in $(cargo {{nightly_version}} fuzz list --fuzz-dir {{fuzz_dir}}); do
+    cargo {{nightly_version}} fuzz run $target --fuzz-dir {{fuzz_dir}} -- -max_total_time={{max_time}}
   done
 
 # Check for unused dependencies
-udeps nightly_version='nightly':
-  cargo +{{nightly_version}} udeps --all-targets
+udeps nightly_version='+nightly':
+  cargo {{nightly_version}} udeps --all-targets
 
 # Run miri tests on a given module
 miri module:


### PR DESCRIPTION
I use nix shell and not rustup, so commands like `cargo +nightly` don't work for me (instead my nix shell just uses a nightly rustfmt). Also there is no `/bin/bash` on nixos. This allows me to use the justfile like this: `just fix-fmt ""`. Either way I think the changes in this PR are still general enough to be acceptable.