### PR TITLE
[consensus, p2p, storage] remove superfluous context cloning

### DIFF
--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -662,9 +662,7 @@ mod tests {
                 let mut engine_handlers = Vec::new();
                 for scheme in schemes.into_iter() {
                     // Create scheme context
-                    let context = context
-                        .clone()
-                        .with_label(&format!("validator-{}", scheme.public_key()));
+                    let context = context.with_label(&format!("validator-{}", scheme.public_key()));
 
                     // Start engine
                     let validator = scheme.public_key();

--- a/consensus/src/threshold_simplex/mod.rs
+++ b/consensus/src/threshold_simplex/mod.rs
@@ -817,9 +817,7 @@ mod tests {
                 let mut engine_handlers = Vec::new();
                 for (idx, scheme) in schemes.into_iter().enumerate() {
                     // Create scheme context
-                    let context = context
-                        .clone()
-                        .with_label(&format!("validator-{}", scheme.public_key()));
+                    let context = context.with_label(&format!("validator-{}", scheme.public_key()));
 
                     // Configure engine
                     let validator = scheme.public_key();

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -703,35 +703,32 @@ impl Link {
         // Spawn a task that will wait for messages to be sent to the link and then send them
         // over the network.
         let (inbox, mut outbox) = mpsc::unbounded::<(Channel, Bytes, SystemTime)>();
-        context
-            .clone()
-            .with_label("link")
-            .spawn(move |context| async move {
-                // Dial the peer and handshake by sending it the dialer's public key
-                let (mut sink, _) = context.dial(socket).await.unwrap();
-                if let Err(err) = send_frame(&mut sink, &dialer, max_size).await {
-                    error!(?err, "failed to send public key to listener");
-                    return;
-                }
+        context.with_label("link").spawn(move |context| async move {
+            // Dial the peer and handshake by sending it the dialer's public key
+            let (mut sink, _) = context.dial(socket).await.unwrap();
+            if let Err(err) = send_frame(&mut sink, &dialer, max_size).await {
+                error!(?err, "failed to send public key to listener");
+                return;
+            }
 
-                // Process messages in order, waiting for their receive time
-                while let Some((channel, message, receive_complete_at)) = outbox.next().await {
-                    // Wait until the message should arrive at receiver
-                    context.sleep_until(receive_complete_at).await;
+            // Process messages in order, waiting for their receive time
+            while let Some((channel, message, receive_complete_at)) = outbox.next().await {
+                // Wait until the message should arrive at receiver
+                context.sleep_until(receive_complete_at).await;
 
-                    // Send the message
-                    let mut data = bytes::BytesMut::with_capacity(Channel::SIZE + message.len());
-                    data.extend_from_slice(&channel.to_be_bytes());
-                    data.extend_from_slice(&message);
-                    let data = data.freeze();
-                    send_frame(&mut sink, &data, max_size).await.unwrap();
+                // Send the message
+                let mut data = bytes::BytesMut::with_capacity(Channel::SIZE + message.len());
+                data.extend_from_slice(&channel.to_be_bytes());
+                data.extend_from_slice(&message);
+                let data = data.freeze();
+                send_frame(&mut sink, &data, max_size).await.unwrap();
 
-                    // Bump received messages metric
-                    received_messages
-                        .get_or_create(&metrics::Message::new(&dialer, &receiver, channel))
-                        .inc();
-                }
-            });
+                // Bump received messages metric
+                received_messages
+                    .get_or_create(&metrics::Message::new(&dialer, &receiver, channel))
+                    .inc();
+            }
+        });
 
         Self {
             sampler,

--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -1428,7 +1428,7 @@ mod tests {
 
             // Create log with operations
             let mut log = init_journal(
-                context.clone().with_label("ops_log"),
+                context.with_label("ops_log"),
                 fixed::Config {
                     partition: format!("ops_log_{}", context.next_u64()),
                     items_per_blob: NZU64!(1024),


### PR DESCRIPTION
Drop all instances of `context.clone().with_label()`.