### PR TITLE
[runtime] Standardize Panic Handling

### DIFF
--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -512,8 +512,7 @@ mod tests {
 
     #[test_traced]
     fn test_tokio_connectivity() {
-        let cfg = tokio::Config::default();
-        let executor = tokio::Runner::new(cfg.clone());
+        let executor = tokio::Runner::default();
         executor.start(|context| async move {
             const MAX_MESSAGE_SIZE: usize = 1_024 * 1_024; // 1MB
             let base_port = 3000;

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -457,8 +457,7 @@ mod tests {
 
     #[test_traced]
     fn test_tokio_connectivity() {
-        let cfg = tokio::Config::default();
-        let executor = tokio::Runner::new(cfg.clone());
+        let executor = tokio::Runner::default();
         executor.start(|context| async move {
             const MAX_MESSAGE_SIZE: usize = 1_024 * 1_024; // 1MB
             let base_port = 4000;

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -334,7 +334,7 @@ impl Runner {
 
         // Pin root task to the heap
         let storage = context.storage.clone();
-        let mut root = Box::pin(Panicker::handle(panicked, f(context)));
+        let mut root = Box::pin(Panicker::interrupt(panicked, f(context)));
 
         // Register the root task
         Tasks::register_root(&executor.tasks);

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -36,12 +36,11 @@ use crate::{
         signal::{Signal, Stopper},
         Aborter, Panicker,
     },
-    Clock, Error, Handle, ListenerOf, Panic, METRICS_PREFIX,
+    Clock, Error, Handle, ListenerOf, Panicked, METRICS_PREFIX,
 };
 use commonware_macros::select;
 use commonware_utils::{hex, time::SYSTEM_TIME_PRECISION, SystemTimeExt};
 use futures::{
-    channel::oneshot,
     task::{waker, ArcWake},
     Future,
 };
@@ -248,7 +247,7 @@ pub struct Executor {
     tasks: Arc<Tasks>,
     sleeping: Mutex<BinaryHeap<Alarm>>,
     shutdown: Mutex<Stopper>,
-    panicker: Option<Panicker>,
+    panicker: Panicker,
 }
 
 /// An artifact that can be used to recover the state of the runtime.
@@ -334,7 +333,7 @@ impl Runner {
 
         // Pin root task to the heap
         let storage = context.storage.clone();
-        let mut root = Box::pin(Panicker::interrupt(panicked, f(context)));
+        let mut root = Box::pin(panicked.interrupt(f(context)));
 
         // Register the root task
         Tasks::register_root(&executor.tasks);
@@ -521,7 +520,7 @@ impl Runner {
             rng: executor.rng,
             time: executor.time,
             storage,
-            catch_panics: executor.panicker.is_none(),
+            catch_panics: executor.panicker.catch(),
         };
 
         (output, checkpoint)
@@ -707,7 +706,7 @@ pub struct Context {
 }
 
 impl Context {
-    fn new(cfg: Config) -> (Self, Arc<Executor>, Option<oneshot::Receiver<Panic>>) {
+    fn new(cfg: Config) -> (Self, Arc<Executor>, Panicked) {
         // Create a new registry
         let mut registry = Registry::default();
         let runtime_registry = registry.sub_registry_with_prefix(METRICS_PREFIX);
@@ -727,12 +726,7 @@ impl Context {
         let network = MeteredNetwork::new(network, runtime_registry);
 
         // Initialize panicker
-        let (panicker, panicked) = if cfg.catch_panics {
-            (None, None)
-        } else {
-            let (panic_tx, panic_rx) = oneshot::channel();
-            (Some(Panicker::new(panic_tx)), Some(panic_rx))
-        };
+        let (panicker, panicked) = Panicker::new(cfg.catch_panics);
 
         let executor = Arc::new(Executor {
             registry: Mutex::new(registry),
@@ -773,7 +767,7 @@ impl Context {
     /// It is only permitted to call this method after the runtime has finished (i.e. once `start` returns)
     /// and only permitted to do once (otherwise multiple recovered runtimes will share the same inner state).
     /// If either one of these conditions is violated, this method will panic.
-    fn recover(checkpoint: Checkpoint) -> (Self, Arc<Executor>, Option<oneshot::Receiver<Panic>>) {
+    fn recover(checkpoint: Checkpoint) -> (Self, Arc<Executor>, Panicked) {
         // Rebuild metrics
         let mut registry = Registry::default();
         let runtime_registry = registry.sub_registry_with_prefix(METRICS_PREFIX);
@@ -785,12 +779,7 @@ impl Context {
         let network = MeteredNetwork::new(network, runtime_registry);
 
         // Initialize panicker
-        let (panicker, panicked) = if checkpoint.catch_panics {
-            (None, None)
-        } else {
-            let (panic_tx, panic_rx) = oneshot::channel();
-            (Some(Panicker::new(panic_tx)), Some(panic_rx))
-        };
+        let (panicker, panicked) = Panicker::new(checkpoint.catch_panics);
 
         let executor = Arc::new(Executor {
             // Copied from the checkpoint
@@ -872,7 +861,7 @@ impl crate::Spawner for Context {
         self.children = children.clone();
 
         let future = f(self);
-        let (f, handle) = Handle::init_future(future, metric, children, executor.panicker.clone());
+        let (f, handle) = Handle::init_future(future, metric, executor.panicker.clone(), children);
 
         // Spawn the task
         Tasks::register_work(&executor.tasks, label, Box::pin(f));
@@ -899,7 +888,7 @@ impl crate::Spawner for Context {
         let executor = self.executor();
 
         move |f: F| {
-            let (f, handle) = Handle::init_future(f, metric, children, executor.panicker.clone());
+            let (f, handle) = Handle::init_future(f, metric, executor.panicker.clone(), children);
 
             // Spawn the task
             Tasks::register_work(&executor.tasks, label, Box::pin(f));

--- a/runtime/src/tokio/mod.rs
+++ b/runtime/src/tokio/mod.rs
@@ -3,8 +3,7 @@
 //!
 //! # Panics
 //!
-//! By default, the runtime will catch any panic and log the error. It is
-//! possible to override this behavior in the configuration.
+//! Unless configured otherwise, any task panic will lead to a runtime panic.
 //!
 //! # Example
 //!

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -19,7 +19,6 @@ use crate::{
     Clock, Error, Handle, SinkOf, StreamOf, METRICS_PREFIX,
 };
 use commonware_macros::select;
-use futures::channel::oneshot;
 use governor::clock::{Clock as GClock, ReasonablyRealtime};
 use prometheus_client::{
     encoding::text::encode,
@@ -216,7 +215,7 @@ pub struct Executor {
     metrics: Arc<Metrics>,
     runtime: Runtime,
     shutdown: Mutex<Stopper>,
-    panicker: Option<Panicker>,
+    panicker: Panicker,
 }
 
 /// Implementation of [crate::Runner] for the `tokio` runtime.
@@ -259,12 +258,7 @@ impl crate::Runner for Runner {
             .expect("failed to create Tokio runtime");
 
         // Initialize panicker
-        let (panicker, panicked) = if self.cfg.catch_panics {
-            (None, None)
-        } else {
-            let (panic_tx, panic_rx) = oneshot::channel();
-            (Some(Panicker::new(panic_tx)), Some(panic_rx))
-        };
+        let (panicker, panicked) = Panicker::new(self.cfg.catch_panics);
 
         // Collect process metrics.
         //
@@ -348,9 +342,7 @@ impl crate::Runner for Runner {
             network,
             children: Arc::new(Mutex::new(Vec::new())),
         };
-        let output = executor
-            .runtime
-            .block_on(Panicker::interrupt(panicked, f(context)));
+        let output = executor.runtime.block_on(panicked.interrupt(f(context)));
         gauge.dec();
 
         output
@@ -426,7 +418,7 @@ impl crate::Spawner for Context {
         self.children = children.clone();
 
         let future = f(self);
-        let (f, handle) = Handle::init_future(future, metric, children, executor.panicker.clone());
+        let (f, handle) = Handle::init_future(future, metric, executor.panicker.clone(), children);
 
         // Spawn the task
         executor.runtime.spawn(f);
@@ -454,7 +446,7 @@ impl crate::Spawner for Context {
 
         move |f: F| {
             let (f, handle) =
-                Handle::init_future(f, metric, children.clone(), executor.panicker.clone());
+                Handle::init_future(f, metric, executor.panicker.clone(), children.clone());
 
             // Spawn the task
             executor.runtime.spawn(f);

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -350,7 +350,7 @@ impl crate::Runner for Runner {
         };
         let output = executor
             .runtime
-            .block_on(Panicker::handle(panicked, f(context)));
+            .block_on(Panicker::interrupt(panicked, f(context)));
         gauge.dec();
 
         output

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -214,19 +214,22 @@ pub(crate) struct Panicker {
 }
 
 impl Panicker {
+    /// Creates a new [Panicker] with the provided sender.
     pub(crate) fn new(sender: oneshot::Sender<Panic>) -> Self {
         Self {
             sender: Arc::new(Mutex::new(Some(sender))),
         }
     }
 
+    /// Notifies the [Panicker] that a panic has occurred.
     pub(crate) fn notify(&self, panic: Panic) {
         if let Some(sender) = self.sender.lock().unwrap().take() {
             let _ = sender.send(panic);
         }
     }
 
-    pub(crate) async fn handle<Fut>(
+    /// Polls a task that should be interrupted by a panic.
+    pub(crate) async fn interrupt<Fut>(
         panicked: Option<oneshot::Receiver<Panic>>,
         task: Fut,
     ) -> Fut::Output

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -242,9 +242,10 @@ impl Panicker {
             return;
         }
 
-        // If there is already a panic, ignore the new one
+        // If we've already sent a panic, ignore the new one (we check sender
+        // here because we take panic when handling it)
         let mut inner = self.inner.lock().unwrap();
-        if inner.panic.is_some() {
+        if inner.sender.is_none() {
             return;
         }
 

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -282,7 +282,6 @@ impl Panicked {
                 // and return the output
                 Err(_) => task.await,
             },
-            // If the task completes, return the output
             Either::Right((output, _)) => {
                 // Check if there is a panic we haven't processed (will always be registered before a task completes)
                 if let Some(panic) = self.inner.lock().unwrap().panic.take() {

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -246,9 +246,10 @@ impl Panicker {
         pin_mut!(task);
         match select(panicked, task).await {
             Either::Left((panic, task)) => match panic {
-                // If the oneshot completes, resume the unwind
+                // If there is a panic, resume the unwind
                 Ok(panic) => resume_unwind(panic),
-                // If the oneshot closes, wait for the task to complete
+                // If there can never be a panic (oneshot is closed), wait for the task to complete
+                // and return the output
                 Err(_) => task.await,
             },
             // If the task completes, return the output

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -19,7 +19,7 @@ pub mod signal;
 
 mod handle;
 pub use handle::Handle;
-pub(crate) use handle::{Aborter, MetricHandle, Panic, Panicker};
+pub(crate) use handle::{Aborter, MetricHandle, Panicked, Panicker};
 
 /// Yield control back to the runtime.
 pub async fn reschedule() {

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -19,7 +19,7 @@ pub mod signal;
 
 mod handle;
 pub use handle::Handle;
-pub(crate) use handle::{Aborter, MetricHandle};
+pub(crate) use handle::{Aborter, MetricHandle, Panic, Panicker};
 
 /// Yield control back to the runtime.
 pub async fn reschedule() {


### PR DESCRIPTION
Precursor: #1784 

It turns out that `catch_panic` on `tokio` was ~useless. This change standardizes panic handling between tokio/deterministic and adds tests to ensure a panic in some observed task bubbles up.

This is often the intended behavior for a blockchain node (where a panic internally can cause a halt) but isn't necessarily intended for all applications (and thus the setting to catch_panics is retained).