### PR TITLE
[storage/adb] Implement new floor raising policy in adb::fixed::any

### DIFF
--- a/storage/src/adb/any/fixed/mod.rs
+++ b/storage/src/adb/any/fixed/mod.rs
@@ -584,7 +584,7 @@ impl<
     /// since it applies at least one operation.
     async fn raise_inactivity_floor(&mut self, max_steps: u64) -> Result<(), Error> {
         // special case for empty db, allowing us to raise the floor to the tip.
-        if self.op_count() == 0 {
+        if self.snapshot.keys() == 0 {
             self.inactivity_floor_loc = self.op_count();
         } else {
             for _ in 0..max_steps {

--- a/storage/src/adb/any/fixed/mod.rs
+++ b/storage/src/adb/any/fixed/mod.rs
@@ -601,6 +601,8 @@ impl<
     /// Panics if there is not at least one active operation above the inactivity floor.
     async fn raise_floor(&mut self) -> Result<(), Error> {
         // Search for the first active operation above the inactivity floor and move it to tip.
+        //
+        // TODO(https://github.com/commonwarexyz/monorepo/issues/1829): optimize this w/ a bitmap.
         let mut op = self.log.read(*self.inactivity_floor_loc).await?;
         while self
             .move_op_if_active(op, self.inactivity_floor_loc)

--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -108,7 +108,7 @@ where
             log,
             inactivity_floor_loc: range.start,
             snapshot,
-            uncommitted_ops: 0,
+            steps: 0,
             hasher: StandardHasher::<H>::new(),
         };
         db.sync().await?;

--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -95,11 +95,11 @@ where
         // Build the snapshot from the log.
         let mut snapshot =
             Index::init(context.with_label("snapshot"), db_config.translator.clone());
-        any::fixed::Any::<E, K, V, H, T>::build_snapshot_from_log::<0 /* UNUSED_N */>(
+        any::fixed::Any::<E, K, V, H, T>::build_snapshot_from_log(
             range.start,
             &log,
             &mut snapshot,
-            None,
+            |_, _| {},
         )
         .await?;
 

--- a/storage/src/adb/current.rs
+++ b/storage/src/adb/current.rs
@@ -9,7 +9,7 @@ use crate::{
         any::fixed::{Any, Config as AConfig},
         Error,
     },
-    index::Unordered as Index,
+    index::{Index as _, Unordered as Index},
     mmr::{
         bitmap::Bitmap,
         grafting::{
@@ -18,16 +18,16 @@ use crate::{
         hasher::Hasher,
         verification, Location, Proof, StandardHasher as Standard,
     },
-    store::operation::Fixed,
+    store::operation::Fixed as Operation,
     translator::Translator,
 };
 use commonware_codec::{CodecFixed, Encode as _, FixedSize};
 use commonware_cryptography::Hasher as CHasher;
 use commonware_runtime::{buffer::PoolRef, Clock, Metrics, Storage as RStorage, ThreadPool};
 use commonware_utils::Array;
-use futures::{future::try_join_all, try_join};
+use futures::{future::try_join_all, try_join, TryFutureExt as _};
 use std::num::{NonZeroU64, NonZeroUsize};
-use tracing::debug;
+use tracing::{debug, info};
 
 /// Configuration for a [Current] authenticated db.
 #[derive(Clone)]
@@ -88,7 +88,8 @@ pub struct Current<
     /// order to further prove whether a key _currently_ has a specific value.
     pub status: Bitmap<H, N>,
 
-    last_commit_loc: Option<Location>,
+    /// The location of the last commit operation.
+    pub last_commit_loc: Option<Location>,
 
     context: E,
 
@@ -201,16 +202,16 @@ impl<
             .load_grafted_digests(&status.dirty_chunks(), &mmr)
             .await?;
         status.sync(&mut grafter).await?;
-        let last_commit_loc = log.size().await?.checked_sub(1).map(Location::new);
 
         let any = Any {
             mmr,
             log,
             snapshot,
             inactivity_floor_loc,
-            uncommitted_ops: 0,
+            steps: 0,
             hasher: Standard::<H>::new(),
         };
+        let last_commit_loc = status.bit_count().checked_sub(1).map(Location::new);
 
         Ok(Self {
             any,
@@ -279,59 +280,68 @@ impl<
         Ok(())
     }
 
-    /// Commit pending operations to the adb::any and sync it to disk. Leverages parallel
-    /// Merkleization of the any-db if a thread pool is provided.
+    /// Commit pending operations to the adb::any ensuring their durability upon return from this
+    /// function. Leverages parallel Merkleization of the any-db if a thread pool is provided.
     async fn commit_ops(&mut self) -> Result<(), Error> {
-        // Raise the inactivity floor by the # of uncommitted operations, plus 1 to account for the
-        // commit op that will be appended.
-        self.raise_inactivity_floor(self.any.uncommitted_ops + 1)
+        // Inactivate the current commit operation.
+        let bit_count = self.status.bit_count();
+        if let Some(last_commit_loc) = self.last_commit_loc {
+            self.status.set_bit(*last_commit_loc, false);
+        }
+
+        // Raise the inactivity floor by taking `self.steps` steps.
+        let steps_to_take = self.any.steps + 1; // account for the previous commit becoming inactive.
+        for _ in 0..steps_to_take {
+            if self.any.snapshot.keys() == 0 {
+                self.any.inactivity_floor_loc = Location::new(bit_count);
+                info!(tip = ?self.any.inactivity_floor_loc, "db is empty, raising floor to tip");
+                break;
+            }
+            self.raise_floor().await?;
+        }
+        self.any.steps = 0;
+
+        // Apply the commit operation with the new inactivity floor.
+        self.any
+            .apply_op(Operation::CommitFloor(self.any.inactivity_floor_loc))
             .await?;
+        self.last_commit_loc = Some(Location::new(self.status.bit_count()));
+        self.status.append(true); // Always treat most recent commit op as active.
 
         // Sync the log and process the updates to the MMR in parallel.
-        let log_fut = async { self.any.log.sync().await.map_err(Error::Journal) };
         let mmr_fut = async {
             self.any.mmr.process_updates(&mut self.any.hasher);
             Ok::<(), Error>(())
         };
-        try_join!(log_fut, mmr_fut)?;
-        self.any.uncommitted_ops = 0;
+        try_join!(self.any.log.sync().map_err(Error::Journal), mmr_fut)?;
 
-        self.any.sync().await
+        Ok(())
     }
 
-    /// Raise the inactivity floor by exactly `max_steps` steps, followed by applying a commit
-    /// operation. Each step either advances over an inactive operation, or re-applies an active
-    /// operation to the tip and then advances over it. An active bit will be added to the status
-    /// bitmap for any moved operation, with its old location in the bitmap flipped to false.
+    /// Raise the inactivity floor by taking one _step_, which involves searching for the first
+    /// active operation above the inactivity floor, moving it to tip, and then setting the
+    /// inactivity floor to the location following the moved operation. This method is therefore
+    /// guaranteed to raise the floor by at least one.
     ///
-    /// This method does not change the state of the db's snapshot, but it always changes the root
-    /// since it applies at least one operation.
-    async fn raise_inactivity_floor(&mut self, max_steps: u64) -> Result<(), Error> {
-        for _ in 0..max_steps {
-            if self.any.inactivity_floor_loc == self.op_count() {
-                break;
-            }
-            let op = self.any.log.read(*self.any.inactivity_floor_loc).await?;
-            let old_loc = self
-                .any
-                .move_op_if_active(op, self.any.inactivity_floor_loc)
-                .await?;
-            if let Some(old_loc) = old_loc {
-                self.status.set_bit(*old_loc, false);
-                self.status.append(true);
-            }
+    /// # Panics if there is not at least one active operation above the inactivity floor.
+    async fn raise_floor(&mut self) -> Result<(), Error> {
+        // Use the status bitmap to find the first active operation above the inactivity floor.
+        while !self.status.get_bit(*self.any.inactivity_floor_loc) {
             self.any.inactivity_floor_loc += 1;
         }
 
-        self.any
-            .apply_op(Fixed::CommitFloor(self.any.inactivity_floor_loc))
-            .await?;
-        // Most recent commit operation should be the only one "active".
+        // Move the active operation to tip.
+        let op = self.any.log.read(*self.any.inactivity_floor_loc).await?;
+        let loc = self
+            .any
+            .move_op_if_active(op, self.any.inactivity_floor_loc)
+            .await?
+            .expect("op should be active based on status bitmap");
+        self.status.set_bit(*loc, false);
         self.status.append(true);
-        if let Some(last_commit_loc) = self.last_commit_loc {
-            self.status.set_bit(*last_commit_loc, false);
-        }
-        self.last_commit_loc = Some(Location::new(self.status.bit_count() - 1));
+
+        // Advance inactivity floor above the moved operation since we know it's inactive.
+        self.any.inactivity_floor_loc += 1;
 
         Ok(())
     }
@@ -427,7 +437,7 @@ impl<
         hasher: &mut H,
         start_loc: Location,
         max_ops: NonZeroU64,
-    ) -> Result<(Proof<H::Digest>, Vec<Fixed<K, V>>, Vec<[u8; N]>), Error> {
+    ) -> Result<(Proof<H::Digest>, Vec<Operation<K, V>>, Vec<[u8; N]>), Error> {
         assert!(
             !self.status.is_dirty(),
             "must process updates before computing proofs"
@@ -483,7 +493,7 @@ impl<
         hasher: &mut Standard<H>,
         proof: &Proof<H::Digest>,
         start_loc: Location,
-        ops: &[Fixed<K, V>],
+        ops: &[Operation<K, V>],
         chunks: &[[u8; N]],
         root: &H::Digest,
     ) -> bool {
@@ -614,7 +624,7 @@ impl<
             Location::new(num),
             vec![&info.chunk],
         );
-        let element = Fixed::Update(info.key.clone(), info.value.clone()).encode();
+        let element = Operation::Update(info.key.clone(), info.value.clone()).encode();
 
         let next_bit = *op_count % Bitmap::<H, N>::CHUNK_SIZE_BITS;
         if next_bit == 0 {
@@ -678,7 +688,7 @@ impl<
         &self,
         hasher: &mut H,
         loc: Location,
-    ) -> Result<(Proof<H::Digest>, Fixed<K, V>, Location, [u8; N]), Error> {
+    ) -> Result<(Proof<H::Digest>, Operation<K, V>, Location, [u8; N]), Error> {
         let op = self.any.log.read(*loc).await?;
 
         let height = Self::grafting_height();
@@ -798,22 +808,24 @@ pub mod test {
             db.update(k1, v1).await.unwrap();
             assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
             db.commit().await.unwrap();
-            assert_eq!(db.op_count(), 4); // 1 update, 1 commit, 2 moves.
+            assert_eq!(db.op_count(), 3); // 1 update, 1 commit, 1 move.
             let root1 = db.root(&mut hasher).await.unwrap();
             assert!(root1 != root0);
             db.close().await.unwrap();
             db = open_db(context.clone(), partition).await;
-            assert_eq!(db.op_count(), 4); // 1 update, 1 commit, 2 moves.
+            assert_eq!(db.op_count(), 3); // 1 update, 1 commit, 1 moves.
             assert_eq!(db.root(&mut hasher).await.unwrap(), root1);
 
             // Delete that one key.
             db.delete(k1).await.unwrap();
             db.commit().await.unwrap();
-            assert_eq!(db.op_count(), 6); // 1 update, 2 commits, 2 moves, 1 delete.
+            assert_eq!(db.op_count(), 5); // 1 update, 2 commits, 1 move, 1 delete.
             let root2 = db.root(&mut hasher).await.unwrap();
+
+            // Confirm close/re-open preserves state.
             db.close().await.unwrap();
             db = open_db(context.clone(), partition).await;
-            assert_eq!(db.op_count(), 6); // 1 update, 2 commits, 2 moves, 1 delete.
+            assert_eq!(db.op_count(), 5);
             assert_eq!(db.root(&mut hasher).await.unwrap(), root2);
 
             // Confirm all activity bits are false except for the last commit.


### PR DESCRIPTION
- Implement floor raising policy described in https://github.com/commonwarexyz/monorepo/issues/1805 for adb::fixed::any and adb::current.
- Makes adb::current treat the last commit operation only as "active". This allows proving an adb::current is empty, which is important for exclusion proofs.
- Changes how the status bitmap is updated during replay. Instead of passing into adb::any (requiring the adb::any understand how bitmaps work), the adb::current instead passes in a closure that is invoked for each replayed operation.

Porting the policy to the remaining stores will be done in a separate PR.