### PR TITLE
[ci] Run all benchmarks in `benchmarks` job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Compile benchmarks
         run: cargo bench ${{ matrix.cargo_flags }} --no-run
       - name: Run benchmarks
+        env:
+          RUSTFLAGS: "--cfg full_bench"
         run: |
           cargo bench ${{ matrix.cargo_flags }} \
             --benches -p ${{ matrix.package }} \

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace = true
 repository = "https://github.com/commonwarexyz/monorepo/tree/main/cryptography"
 documentation = "https://docs.rs/commonware-cryptography"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(full_bench)'] }
+
 [dependencies]
 commonware-codec = { workspace = true }
 commonware-utils = { workspace = true }

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -14,9 +14,9 @@ use std::{collections::HashMap, hint::black_box};
 const CONCURRENCY: usize = 1;
 
 // Configure contributors based on context
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const CONTRIBUTORS: &[u32] = &[5, 10, 20, 50];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const CONTRIBUTORS: &[u32] = &[5, 10, 20, 50, 100, 250, 500];
 
 fn benchmark_dkg_recovery(c: &mut Criterion) {

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -11,9 +11,9 @@ use rand::{rngs::StdRng, SeedableRng};
 use std::{collections::HashMap, hint::black_box};
 
 // Configure contributors based on context
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const CONTRIBUTORS: &[usize] = &[5, 10, 20, 50];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const CONTRIBUTORS: &[usize] = &[5, 10, 20, 50, 100, 250, 500];
 
 fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace = true
 repository = "https://github.com/commonwarexyz/monorepo/tree/main/storage"
 documentation = "https://docs.rs/commonware-storage"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(full_bench)'] }
+
 [dependencies]
 commonware-codec = {workspace = true, default-features = false }
 commonware-cryptography = {workspace = true, default-features = false }

--- a/storage/src/index/benches/hashmap_insert.rs
+++ b/storage/src/index/benches/hashmap_insert.rs
@@ -2,9 +2,9 @@ use criterion::{criterion_group, BatchSize, Criterion};
 use rand::Rng;
 use std::collections::HashMap;
 
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const N_ITEMS: [usize; 1] = [100_000];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const N_ITEMS: [usize; 3] = [100_000, 1_000_000, 10_000_000];
 
 struct MockIndex {

--- a/storage/src/index/benches/hashmap_insert_fixed.rs
+++ b/storage/src/index/benches/hashmap_insert_fixed.rs
@@ -2,9 +2,9 @@ use criterion::{criterion_group, BatchSize, Criterion};
 use rand::Rng;
 use std::collections::HashMap;
 
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const N_ITEMS: [usize; 1] = [100_000];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const N_ITEMS: [usize; 3] = [100_000, 1_000_000, 10_000_000];
 
 struct MockIndex {

--- a/storage/src/index/benches/hashmap_iteration.rs
+++ b/storage/src/index/benches/hashmap_iteration.rs
@@ -2,9 +2,9 @@ use criterion::{black_box, criterion_group, BatchSize, Criterion};
 use rand::Rng;
 use std::collections::HashMap;
 
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const N_ITEMS: [usize; 1] = [100_000];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const N_ITEMS: [usize; 3] = [100_000, 1_000_000, 10_000_000];
 
 struct MockIndex {

--- a/storage/src/index/benches/insert.rs
+++ b/storage/src/index/benches/insert.rs
@@ -9,9 +9,9 @@ use prometheus_client::registry::Metric;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 use std::time::{Duration, Instant};
 
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const N_ITEMS: [usize; 2] = [10_000, 50_000];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const N_ITEMS: [usize; 5] = [10_000, 50_000, 100_000, 500_000, 1_000_000];
 
 #[derive(Clone)]

--- a/storage/src/mmr/benches/append.rs
+++ b/storage/src/mmr/benches/append.rs
@@ -4,9 +4,9 @@ use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, SeedableRng};
 
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const N_LEAVES: [usize; 2] = [10_000, 100_000];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000];
 
 fn bench_append(c: &mut Criterion) {

--- a/storage/src/mmr/benches/append_additional.rs
+++ b/storage/src/mmr/benches/append_additional.rs
@@ -4,9 +4,9 @@ use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, SeedableRng};
 
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const N_LEAVES: [usize; 2] = [10_000, 100_000];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000];
 
 fn bench_append_additional(c: &mut Criterion) {

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -8,9 +8,9 @@ use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
 const SAMPLE_SIZE: usize = 100;
 
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const N_LEAVES: [usize; 2] = [10_000, 100_000];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000];
 
 fn bench_prove_many_elements(c: &mut Criterion) {

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -6,9 +6,9 @@ use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
 const SAMPLE_SIZE: usize = 100;
 
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const N_LEAVES: [usize; 2] = [10_000, 100_000];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000];
 
 fn bench_prove_single_element(c: &mut Criterion) {

--- a/storage/src/mmr/benches/update.rs
+++ b/storage/src/mmr/benches/update.rs
@@ -23,9 +23,9 @@ enum Strategy {
 /// returns start diminishing.
 const THREADS: usize = 8;
 
-#[cfg(test)]
+#[cfg(not(full_bench))]
 const N_LEAVES: [usize; 1] = [100_000];
-#[cfg(not(test))]
+#[cfg(full_bench)]
 const N_LEAVES: [usize; 4] = [100_000, 1_000_000, 5_000_000, 10_000_000];
 
 /// Benchmark the performance of randomly updating leaves in an MMR.


### PR DESCRIPTION
## Overview

Some benchmarks are currently parameterized to run less iterations in "test mode." Because commonware doesn't use [integration benchmarks](https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests), rustc still links `libtest` even without the presence of a harness, enabling `cfg(test)`.

This changes adds a new `cfg` flag to `commonware-cryptography` and `commonware-storage`, making this toggle explicit.

fixes https://github.com/commonwarexyz/monorepo/issues/1807