### PR TITLE
[runtime] update spawn api with extended task semantics

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -972,7 +972,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let (label, metric) = spawn_metrics!(self, blocking, self.spawn_config.is_dedicated());
+        let (label, metric) = spawn_metrics!(self, blocking);
 
         // Initialize the blocking task
         let executor = self.executor();
@@ -994,7 +994,7 @@ impl crate::Spawner for Context {
         self.spawned = true;
 
         // Get metrics
-        let (label, metric) = spawn_metrics!(self, blocking, self.spawn_config.is_dedicated());
+        let (label, metric) = spawn_metrics!(self, blocking);
 
         // Set up the task
         let executor = self.executor();

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -952,17 +952,6 @@ impl crate::Spawner for Context {
         }
     }
 
-    fn spawn_child<F, Fut, T>(self, f: F) -> Handle<T>
-    where
-        F: FnOnce(Self) -> Fut + Send + 'static,
-        Fut: Future<Output = T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let mut context = self;
-        context.spawn_config = context.spawn_config.supervised();
-        context.spawn(f)
-    }
-
     fn spawn_blocking<F, T>(self, f: F) -> Handle<T>
     where
         F: FnOnce(Self) -> T + Send + 'static,

--- a/runtime/src/macros.rs
+++ b/runtime/src/macros.rs
@@ -13,19 +13,22 @@ macro_rules! spawn_metrics {
     // Handle future tasks
     ($ctx:ident, future) => {
         $crate::spawn_metrics!(
-            $crate::telemetry::metrics::task::Label::future($ctx.name.clone()),
+            $crate::telemetry::metrics::task::Label::future(
+                $ctx.name.clone(),
+                $ctx.spawn_config.is_supervised(),
+                $ctx.spawn_config.is_dedicated(),
+            ),
             @make $ctx
         )
     };
 
     // Handle blocking tasks
-    ($ctx:ident, blocking, $dedicated:expr) => {
+    ($ctx:ident, blocking) => {
         $crate::spawn_metrics!(
-            if $dedicated {
-                $crate::telemetry::metrics::task::Label::blocking_dedicated($ctx.name.clone())
-            } else {
-                $crate::telemetry::metrics::task::Label::blocking_shared($ctx.name.clone())
-            },
+            $crate::telemetry::metrics::task::Label::blocking(
+                $ctx.name.clone(),
+                $ctx.spawn_config.is_dedicated(),
+            ),
             @make $ctx
         )
     };

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -526,17 +526,6 @@ impl crate::Spawner for Context {
         }
     }
 
-    fn spawn_child<F, Fut, T>(self, f: F) -> Handle<T>
-    where
-        F: FnOnce(Self) -> Fut + Send + 'static,
-        Fut: Future<Output = T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let mut context = self;
-        context.spawn_config = context.spawn_config.supervised();
-        context.spawn(f)
-    }
-
     fn spawn_blocking<F, T>(self, f: F) -> Handle<T>
     where
         F: FnOnce(Self) -> T + Send + 'static,

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -546,7 +546,7 @@ impl crate::Spawner for Context {
         assert!(!self.spawned, "already spawned");
 
         // Get metrics
-        let (_, metric) = spawn_metrics!(self, blocking, dedicated);
+        let (_, metric) = spawn_metrics!(self, blocking);
 
         // Set up the task
         let executor = self.executor.clone();
@@ -574,7 +574,7 @@ impl crate::Spawner for Context {
         let dedicated = self.spawn_config.is_dedicated();
 
         // Get metrics
-        let (_, metric) = spawn_metrics!(self, blocking, dedicated);
+        let (_, metric) = spawn_metrics!(self, blocking);
 
         // Set up the task
         let executor = self.executor.clone();

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -410,7 +410,7 @@ mod tests {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let context = context.with_label(LABEL);
-            let spawn_blocking = context.clone().spawn_blocking_ref(false);
+            let spawn_blocking = context.clone().spawn_blocking_ref();
 
             let blocking_handle = spawn_blocking(|| {
                 // Simulate some blocking work

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -76,7 +76,8 @@ pub fn create_pool<S: Spawner + Metrics>(
             // task and thus should be provisioned as a dedicated thread.
             context
                 .with_label("rayon-thread")
-                .spawn_blocking(true, move |_| thread.run());
+                .dedicated()
+                .spawn_blocking(move |_| thread.run());
             Ok(())
         })
         .build()?;


### PR DESCRIPTION
Introduce builder-style semantics to the `Spawner` trait so callers express supervision and scheduling directly on the context: `supervised()`, `detached()`, `dedicated()` and `shared()`.

Dropped the `spawn_child` method as its behavior is now achieved with `context.supervised().spawn(...)` and updated blocking APIs `spawn_blocking` / `spawn_blocking_ref` to no longer take the `dedicated` boolean parameter,
instead that can be achieved with `context.dedicated().spawn_blocking(...)`.

`spawn_metrics!` was updated to track the precise task configuration.

Fixes #1692.