### PR TITLE
[p2p/simulated] avoid panic in add_link when jitter == 0 by using MIN_POSITIVE

### DIFF
--- a/p2p/src/simulated/ingress.rs
+++ b/p2p/src/simulated/ingress.rs
@@ -152,9 +152,16 @@ impl<P: PublicKey> Oracle<P> {
 
         // Convert Duration to milliseconds as f64 for the Normal distribution
         let latency_ms = config.latency.as_secs_f64() * 1000.0;
-        let jitter_ms = config.jitter.as_secs_f64() * 1000.0;
+        let base_jitter_ms = config.jitter.as_secs_f64() * 1000.0;
 
-        // Create distribution
+        // Create distribution (Normal requires std dev > 0). If configured jitter is zero,
+        // substitute the smallest positive f64 to emulate deterministic latency without panicking.
+        let jitter_ms = if base_jitter_ms == 0.0 {
+            f64::MIN_POSITIVE
+        } else {
+            base_jitter_ms
+        };
+
         let sampler = Normal::new(latency_ms, jitter_ms).unwrap();
 
         // Wait for update to complete


### PR DESCRIPTION
- rand_distr’s Normal::new(mean, std_dev) requires std_dev > 0; passing 0 returns Err.
- ingress::Oracle::add_link used unwrap() on Normal::new, which panicked for jitter == 0.
- Our tests and expected API allow zero jitter (deterministic latency), so panic is unacceptable.
- Change: when computed jitter_ms == 0.0, substitute f64::MIN_POSITIVE as std dev to emulate deterministic latency while satisfying Normal’s constraint.
- This preserves existing behavior (zero jitter effectively) and prevents runtime panics.
- Note: negative samples already saturate to 0 ms via casting to u64, which remains unchanged.