### PR TITLE
[storage] Fix `full_bench` gate for `cfg_if`-gated benches

### DIFF
--- a/storage/src/adb/benches/current_init.rs
+++ b/storage/src/adb/benches/current_init.rs
@@ -42,7 +42,7 @@ const MULTI_THREADED: usize = 8;
 const CHUNK_SIZE: usize = 32;
 
 cfg_if::cfg_if! {
-    if #[cfg(test)] {
+    if #[cfg(not(full_bench))] {
         const ELEMENTS: [u64; 1] = [NUM_ELEMENTS];
         const OPERATIONS: [u64; 1] = [NUM_OPERATIONS];
     } else {

--- a/storage/src/adb/benches/fixed_init.rs
+++ b/storage/src/adb/benches/fixed_init.rs
@@ -34,7 +34,7 @@ const PAGE_CACHE_SIZE: usize = 10_000;
 const THREADS: usize = 8;
 
 cfg_if::cfg_if! {
-    if #[cfg(test)] {
+    if #[cfg(not(full_bench))] {
         const ELEMENTS: [u64; 1] = [NUM_ELEMENTS];
         const OPERATIONS: [u64; 1] = [NUM_OPERATIONS];
     } else {

--- a/storage/src/adb/benches/variable_init.rs
+++ b/storage/src/adb/benches/variable_init.rs
@@ -37,7 +37,7 @@ const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10_000);
 const THREADS: usize = 8;
 
 cfg_if::cfg_if! {
-    if #[cfg(test)] {
+    if #[cfg(not(full_bench))] {
         const ELEMENTS: [u64; 1] = [NUM_ELEMENTS];
         const OPERATIONS: [u64; 1] = [NUM_OPERATIONS];
     } else {

--- a/storage/src/store/benches/restart.rs
+++ b/storage/src/store/benches/restart.rs
@@ -31,7 +31,7 @@ const PAGE_SIZE: NonZeroUsize = NZUsize!(16_384);
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10_000);
 
 cfg_if::cfg_if! {
-    if #[cfg(test)] {
+    if #[cfg(not(full_bench))] {
         const ELEMENTS: [u64; 1] = [NUM_ELEMENTS];
         const OPERATIONS: [u64; 1] = [NUM_OPERATIONS];
     } else {


### PR DESCRIPTION
## Overview

https://github.com/commonwarexyz/monorepo/pull/1810 missed a few of the `commonware-storage` benchmarks that had their "test-mode" iterations gated by `cfg_if`.