### PR TITLE
[cryptography] Error on reading invalid bloom filter

### DIFF
--- a/cryptography/fuzz/fuzz_targets/bloomfilter.rs
+++ b/cryptography/fuzz/fuzz_targets/bloomfilter.rs
@@ -25,11 +25,9 @@ struct FuzzInput {
 }
 
 fn fuzz(input: FuzzInput) {
-    let hashers = input.hashers.get();
-    let mut bf = BloomFilter::new(NonZeroU8::new(hashers).unwrap(), input.bits.into());
+    let cfg = (input.hashers, input.bits.into());
+    let mut bf = BloomFilter::new(input.hashers, input.bits.into());
     let mut model: HashSet<Vec<u8>> = HashSet::new();
-
-    let cfg = (hashers, input.bits.into());
 
     for op in input.ops.into_iter().take(64) {
         match op {


### PR DESCRIPTION
`BloomFilter` expects `BloomFilter.bits.len() > 0` always holds. However, it's possible to call `read_cfg` with invalid value 0, resulting in a `BloomFilter` that violates this invariant.

This PR makes the config type `NonZeroU64` to prevent reading an invalid `BloomFilter`.

Resolves #1747