### PR TITLE
[cryptography] Reduce shared work between Arbiter and Player

### DIFF
--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::{
     bls12381::{
-        dkg::{Dealer, Player},
+        dkg::{player::FinalizeInput, Dealer, Player},
         primitives::variant::MinSig,
     },
     ed25519, PrivateKeyExt as _, Signer as _,
@@ -54,7 +54,11 @@ fn benchmark_dkg_recovery(c: &mut Criterion) {
                     (player, commitments)
                 },
                 |(player, commitments)| {
-                    black_box(player.finalize(commitments, BTreeMap::new()).unwrap());
+                    black_box(
+                        player
+                            .finalize(FinalizeInput::new(commitments, BTreeMap::new()))
+                            .unwrap(),
+                    );
                 },
                 BatchSize::SmallInput,
             );

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::{
     bls12381::{
-        dkg::{Dealer, Player},
+        dkg::{player::FinalizeInput, Dealer, Player},
         primitives::variant::MinSig,
     },
     ed25519, PrivateKeyExt as _, Signer as _,
@@ -65,7 +65,7 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
         for player in players {
             outputs.push(
                 player
-                    .finalize(commitments.clone(), BTreeMap::new())
+                    .finalize(FinalizeInput::new(commitments.clone(), BTreeMap::new()))
                     .unwrap(),
             );
         }
@@ -102,7 +102,11 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
                             (player, commitments)
                         },
                         |(player, commitments)| {
-                            black_box(player.finalize(commitments, BTreeMap::new()).unwrap());
+                            black_box(
+                                player
+                                    .finalize(FinalizeInput::new(commitments, BTreeMap::new()))
+                                    .unwrap(),
+                            );
                         },
                         BatchSize::SmallInput,
                     );

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -111,6 +111,7 @@ pub fn new_with_constant(
 }
 
 /// A Barycentric Weight for interpolation at x=0.
+#[derive(Clone)]
 pub struct Weight(Scalar);
 
 impl Weight {

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -3,7 +3,7 @@ use commonware_codec::{Decode, Encode};
 use commonware_cryptography::{
     bls12381::{
         dkg::{
-            player::Output,
+            player::{FinalizeInput, Output},
             types::{Ack, Share},
             Dealer, Player,
         },
@@ -424,7 +424,8 @@ impl<E: Clock + CryptoRngCore + Spawner, C: Signer> Contributor<E, C> {
                     if should_deal && !commitments.contains_key(&me_idx) {
                         warn!(round, "commitment not included");
                     }
-                    let Ok(output) = player_obj.finalize(commitments, reveals) else {
+                    let Ok(output) = player_obj.finalize(FinalizeInput::new(commitments, reveals))
+                    else {
                         warn!(round, "failed to finalize round");
                         return (round, None);
                     };


### PR DESCRIPTION
When calling `.finalize()`, the `Arbiter` performs heavily computations which can be reused by `Player` during its finalization,  if both are running locally (as recommended)

- [X] Computation of Group Polynomial 
- [X] Compute weights in case of resharing


Closes #1840 