### PR TITLE
[cryptography] poly: add from_iter and new_with_constant fns

### DIFF
--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -408,6 +408,8 @@ pub mod tests {
     use super::*;
     use crate::bls12381::primitives::group::{Scalar, G2};
     use commonware_codec::{Decode, Encode};
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
 
     #[test]
     fn poly_degree() {
@@ -562,5 +564,13 @@ pub mod tests {
         let encoded = original.encode();
         let decoded = Poly::<Scalar>::decode_cfg(encoded, &(original.required() as usize)).unwrap();
         assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_new_with_constant() {
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let constant = Scalar::from_rand(&mut rng);
+        let poly = new_with_constant(5, &mut rng, constant.clone());
+        assert_eq!(poly.constant(), &constant);
     }
 }


### PR DESCRIPTION
`from_iter` is useful to avoid needing to call collect yourself, and enables a useful function, which sets the 0 value of the polynomial to a particular element, which is needed in a DKG reshare.

I think there's enough value in the simple change to merit inclusion, even without propagating the change. (I'm working on a refactor of the DKG code which will use this method).