### PR TITLE
[chore] `&Vec<T>` -> `&[T]`

### DIFF
--- a/consensus/src/aggregation/mocks/supervisor.rs
+++ b/consensus/src/aggregation/mocks/supervisor.rs
@@ -65,8 +65,8 @@ impl<P: PublicKey, V: Variant> S for Supervisor<P, V> {
         unimplemented!()
     }
 
-    fn participants(&self, epoch: Self::Index) -> Option<&Vec<Self::PublicKey>> {
-        self.validators.get(&epoch)
+    fn participants(&self, epoch: Self::Index) -> Option<&[Self::PublicKey]> {
+        self.validators.get(&epoch).map(|v| v.as_slice())
     }
 
     fn is_participant(&self, epoch: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {

--- a/consensus/src/aggregation/safe_tip.rs
+++ b/consensus/src/aggregation/safe_tip.rs
@@ -37,7 +37,7 @@ impl<P: Array> SafeTip<P> {
     /// # Panics
     ///
     /// Panics if the validator set is empty or if the validators are not unique.
-    pub fn init(&mut self, validators: &Vec<P>) {
+    pub fn init(&mut self, validators: &[P]) {
         // Ensure the validator set is not empty and all validators are unique
         assert!(!validators.is_empty());
 
@@ -70,7 +70,7 @@ impl<P: Array> SafeTip<P> {
     /// # Panics
     ///
     /// Panics if the new validator set is not unique and the same size as the existing set.
-    pub fn reconcile(&mut self, validators: &Vec<P>) {
+    pub fn reconcile(&mut self, validators: &[P]) {
         // Verify the new validators and collect them into a set.
         assert!(
             validators.len() == self.tips.len(),
@@ -287,7 +287,7 @@ mod tests {
         // Test init with empty validator set
         let mut safe_tip = SafeTip::<PublicKey>::default();
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            safe_tip.init(&vec![]);
+            safe_tip.init(&[]);
         }));
         assert!(result.is_err());
 

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -158,7 +158,7 @@ cfg_if::cfg_if! {
 
             /// Get the **sorted** participants for the given view. This is called when entering a new view before
             /// listening for proposals or votes. If nothing is returned, the view will not be entered.
-            fn participants(&self, index: Self::Index) -> Option<&Vec<Self::PublicKey>>;
+            fn participants(&self, index: Self::Index) -> Option<&[Self::PublicKey]>;
 
             // Indicate whether some candidate is a participant at the given view.
             fn is_participant(&self, index: Self::Index, candidate: &Self::PublicKey) -> Option<u32>;

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -529,7 +529,7 @@ impl<
             let Some(validators) = self.validators.participants(self.epoch) else {
                 return Err(Error::UnknownValidators(self.epoch));
             };
-            let mut recipients = validators.clone();
+            let mut recipients = validators.to_vec();
             if self
                 .validators
                 .is_participant(self.epoch, &tip.chunk.sequencer)
@@ -803,7 +803,7 @@ impl<
         // Send the node to all validators
         node_sender
             .send(
-                Recipients::Some(validators.clone()),
+                Recipients::Some(validators.to_vec()),
                 node,
                 self.priority_proposals,
             )

--- a/consensus/src/ordered_broadcast/mocks/sequencers.rs
+++ b/consensus/src/ordered_broadcast/mocks/sequencers.rs
@@ -32,7 +32,7 @@ impl<P: PublicKey> Supervisor for Sequencers<P> {
         unimplemented!()
     }
 
-    fn participants(&self, _: Self::Index) -> Option<&Vec<Self::PublicKey>> {
+    fn participants(&self, _: Self::Index) -> Option<&[Self::PublicKey]> {
         Some(&self.participants)
     }
 

--- a/consensus/src/ordered_broadcast/mocks/validators.rs
+++ b/consensus/src/ordered_broadcast/mocks/validators.rs
@@ -47,7 +47,7 @@ impl<P: PublicKey, V: Variant> Supervisor for Validators<P, V> {
         unimplemented!()
     }
 
-    fn participants(&self, _: Self::Index) -> Option<&Vec<Self::PublicKey>> {
+    fn participants(&self, _: Self::Index) -> Option<&[Self::PublicKey]> {
         Some(&self.validators)
     }
 

--- a/consensus/src/simplex/mocks/supervisor.rs
+++ b/consensus/src/simplex/mocks/supervisor.rs
@@ -94,7 +94,7 @@ impl<C: PublicKey, D: Digest> Su for Supervisor<C, D> {
         Some(leader)
     }
 
-    fn participants(&self, index: Self::Index) -> Option<&Vec<Self::PublicKey>> {
+    fn participants(&self, index: Self::Index) -> Option<&[Self::PublicKey]> {
         let closest = match self.participants.range(..=index).next_back() {
             Some((_, p)) => p,
             None => {

--- a/consensus/src/threshold_simplex/mocks/supervisor.rs
+++ b/consensus/src/threshold_simplex/mocks/supervisor.rs
@@ -106,7 +106,7 @@ impl<P: PublicKey, V: Variant, D: Digest> Su for Supervisor<P, V, D> {
         unimplemented!("only defined in supertrait")
     }
 
-    fn participants(&self, index: Self::Index) -> Option<&Vec<Self::PublicKey>> {
+    fn participants(&self, index: Self::Index) -> Option<&[Self::PublicKey]> {
         let closest = match self.participants.range(..=index).next_back() {
             Some((_, (_, _, p, _))) => p,
             None => {

--- a/examples/bridge/src/application/supervisor.rs
+++ b/examples/bridge/src/application/supervisor.rs
@@ -55,8 +55,8 @@ impl<P: PublicKey> Su for Supervisor<P> {
         unimplemented!("only defined in supertrait")
     }
 
-    fn participants(&self, _: Self::Index) -> Option<&Vec<Self::PublicKey>> {
-        Some(&self.participants)
+    fn participants(&self, _: Self::Index) -> Option<&[Self::PublicKey]> {
+        Some(self.participants.as_ref())
     }
 
     fn is_participant(&self, _: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {

--- a/examples/log/src/application/supervisor.rs
+++ b/examples/log/src/application/supervisor.rs
@@ -44,7 +44,7 @@ impl<P: PublicKey, S: Signature, D: Digest> Su for Supervisor<P, S, D> {
         Some(self.participants[index as usize % self.participants.len()].clone())
     }
 
-    fn participants(&self, _: Self::Index) -> Option<&Vec<Self::PublicKey>> {
+    fn participants(&self, _: Self::Index) -> Option<&[Self::PublicKey]> {
         Some(&self.participants)
     }
 

--- a/resolver/src/p2p/mocks/coordinator.rs
+++ b/resolver/src/p2p/mocks/coordinator.rs
@@ -73,7 +73,7 @@ impl<P: PublicKey> Coordinator<P> {
 impl<P: PublicKey> crate::p2p::Coordinator for Coordinator<P> {
     type PublicKey = P;
 
-    fn peers(&self) -> &Vec<Self::PublicKey> {
+    fn peers(&self) -> &[Self::PublicKey] {
         // Still using the hack for testing purposes
         let peers = self.get_peers();
         Box::leak(Box::new(peers))

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -64,7 +64,7 @@ pub trait Coordinator: Clone + Send + Sync + 'static {
     /// Returns the current list of peers that can be used to fetch data.
     ///
     /// This is also used to filter requests from peers.
-    fn peers(&self) -> &Vec<Self::PublicKey>;
+    fn peers(&self) -> &[Self::PublicKey];
 
     /// Returns an identifier for the peer set.
     ///

--- a/storage/src/index/benches/insert.rs
+++ b/storage/src/index/benches/insert.rs
@@ -67,10 +67,7 @@ fn bench_insert(c: &mut Criterion) {
     }
 }
 
-fn run_benchmark<I: Index<Value = u64>>(
-    index: &mut I,
-    kvs: &Vec<(<Sha256 as Hasher>::Digest, u64)>,
-) {
+fn run_benchmark<I: Index<Value = u64>>(index: &mut I, kvs: &[(<Sha256 as Hasher>::Digest, u64)]) {
     for (k, v) in kvs {
         index.insert(k, *v);
     }


### PR DESCRIPTION
## Overview

Updates APIs throughout the codebase that accept/return `&Vec<T>` to use `&[T]`. 