### PR TITLE
[broadcast] Exit on shutdown signal in `buffered::Engine`

### DIFF
--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -160,6 +160,7 @@ impl<E: Clock + Spawner + Metrics, P: PublicKey, M: Committable + Digestible + C
                 // Handle shutdown signal
                 _ = &mut shutdown => {
                     debug!("shutdown");
+                    break;
                 },
 
                 // Handle mailbox messages


### PR DESCRIPTION
## Overview

Ran into this while working on the DKG over simplex example - `buffered::Engine` will re-poll the shared future after completion due to not exiting its event loop on a shutdown signal, causing a panic during an otherwise graceful shutdown.