### PR TITLE
[storage/mmr] binary search in to_nearest_size

### DIFF
--- a/storage/src/mmr/iterator.rs
+++ b/storage/src/mmr/iterator.rs
@@ -69,7 +69,10 @@ impl PeakIterator {
     ///
     /// Panics if `size` exceeds [crate::mmr::MAX_POSITION].
     pub fn to_nearest_size(size: Position) -> Position {
-        assert!(size <= crate::mmr::MAX_POSITION, "size exceeds MAX_POSITION");
+        assert!(
+            size <= crate::mmr::MAX_POSITION,
+            "size exceeds MAX_POSITION"
+        );
 
         // Algorithm: A valid MMR size corresponds to a specific number of leaves N, where:
         // mmr_size(N) = 2*N - popcount(N)


### PR DESCRIPTION
Binary search on leaf count instead of iterating backwards. Drops complexity from O(log²n) to O(log n).

Fixes #820