### PR TITLE
[p2p] Add backup channel for `Muxer`

### DIFF
--- a/p2p/src/utils/mux.rs
+++ b/p2p/src/utils/mux.rs
@@ -46,6 +46,10 @@ enum Control<R: Receiver> {
 /// Thread-safe routing table mapping each [Channel] to the [mpsc::Sender] for [`Message<P>`].
 type Routes<P> = HashMap<Channel, mpsc::Sender<Message<P>>>;
 
+/// A backup channel response, with a [SubSender] to respond, the [Channel] that wasn't registered,
+/// and the [Message] received.
+type BackupResponse<P> = (Channel, Message<P>);
+
 /// A multiplexer of p2p channels into subchannels.
 pub struct Muxer<E: Spawner, S: Sender, R: Receiver> {
     context: ContextCell<E>,
@@ -54,12 +58,23 @@ pub struct Muxer<E: Spawner, S: Sender, R: Receiver> {
     mailbox_size: usize,
     control_rx: mpsc::UnboundedReceiver<Control<R>>,
     routes: Routes<R::PublicKey>,
+    backup: Option<mpsc::Sender<BackupResponse<R::PublicKey>>>,
 }
 
 impl<E: Spawner, S: Sender, R: Receiver> Muxer<E, S, R> {
     /// Create a multiplexed wrapper around a [Sender] and [Receiver] pair, and return a ([Muxer],
     /// [MuxHandle]) pair that can be used to register routes dynamically.
     pub fn new(context: E, sender: S, receiver: R, mailbox_size: usize) -> (Self, MuxHandle<S, R>) {
+        Self::builder(context, sender, receiver, mailbox_size).build()
+    }
+
+    /// Creates a [MuxerBuilder] that can be used to configure and build a [Muxer].
+    pub fn builder(
+        context: E,
+        sender: S,
+        receiver: R,
+        mailbox_size: usize,
+    ) -> MuxerBuilder<E, S, R> {
         let (control_tx, control_rx) = mpsc::unbounded();
         let mux = Self {
             context: ContextCell::new(context),
@@ -68,14 +83,15 @@ impl<E: Spawner, S: Sender, R: Receiver> Muxer<E, S, R> {
             mailbox_size,
             control_rx,
             routes: HashMap::new(),
+            backup: None,
         };
 
-        let handle = MuxHandle {
+        let mux_handle = MuxHandle {
             sender: mux.sender.clone(),
             control_tx,
         };
 
-        (mux, handle)
+        MuxerBuilder { mux, mux_handle }
     }
 
     /// Start the demuxer using the given spawner.
@@ -131,7 +147,15 @@ impl<E: Spawner, S: Sender, R: Receiver> Muxer<E, S, R> {
 
                     // Get the route for the subchannel.
                     let Some(sender) = self.routes.get_mut(&subchannel) else {
-                        // Drops the message if the subchannel is not found
+                        // Attempt to use the backup channel if available.
+                        if let Some(backup) = &mut self.backup {
+                            if let Err(e) = backup.send((subchannel, (pk, bytes))).await {
+                                debug!(?subchannel, ?e, "failed to send message to backup channel");
+                            }
+                        }
+
+                        // Drops the message if the subchannel is not found or the backup
+                        // channel was not used.
                         continue;
                     };
 
@@ -142,6 +166,9 @@ impl<E: Spawner, S: Sender, R: Receiver> Muxer<E, S, R> {
 
                         // Failure, drop the sender since the receiver is no longer interested.
                         debug!(?subchannel, ?e, "failed to send message to subchannel");
+
+                        // NOTE: The channel is deregistered, but it wasn't when the message was received.
+                        // The backup channel is not used in this case.
                     }
                 }
             }
@@ -178,7 +205,7 @@ impl<S: Sender, R: Receiver> MuxHandle<S, R> {
         Ok((
             SubSender {
                 subchannel,
-                inner: self.sender.clone(),
+                inner: GlobalSender::new(self.sender.clone()),
             },
             SubReceiver {
                 receiver,
@@ -192,7 +219,7 @@ impl<S: Sender, R: Receiver> MuxHandle<S, R> {
 /// Sender that routes messages to the `subchannel`.
 #[derive(Clone, Debug)]
 pub struct SubSender<S: Sender> {
-    inner: S,
+    inner: GlobalSender<S>,
     subchannel: Channel,
 }
 
@@ -206,11 +233,9 @@ impl<S: Sender> Sender for SubSender<S> {
         payload: Bytes,
         priority: bool,
     ) -> Result<Vec<S::PublicKey>, S::Error> {
-        let subchannel = UInt(self.subchannel);
-        let mut buf = BytesMut::with_capacity(subchannel.encode_size() + payload.len());
-        subchannel.write(&mut buf);
-        buf.put_slice(&payload);
-        self.inner.send(recipients, buf.freeze(), priority).await
+        self.inner
+            .send(self.subchannel, recipients, payload, priority)
+            .await
     }
 }
 
@@ -251,6 +276,171 @@ impl<R: Receiver> Drop for SubReceiver<R> {
     }
 }
 
+/// Sender that can send messages over any sub [Channel].
+#[derive(Clone, Debug)]
+pub struct GlobalSender<S: Sender> {
+    inner: S,
+}
+
+impl<S: Sender> GlobalSender<S> {
+    /// Create a new [GlobalSender] wrapping the given [Sender].
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+
+    /// Send a message over the given `subchannel`.
+    pub async fn send(
+        &mut self,
+        subchannel: Channel,
+        recipients: Recipients<S::PublicKey>,
+        payload: Bytes,
+        priority: bool,
+    ) -> Result<Vec<S::PublicKey>, S::Error> {
+        let subchannel = UInt(subchannel);
+        let mut buf = BytesMut::with_capacity(subchannel.encode_size() + payload.len());
+        subchannel.write(&mut buf);
+        buf.put_slice(&payload);
+        self.inner.send(recipients, buf.freeze(), priority).await
+    }
+}
+
+/// A generic builder interface.
+pub trait Builder {
+    /// The output type produced by the builder.
+    type Output;
+
+    /// Builds the output type, consuming `self`.
+    fn build(self) -> Self::Output;
+}
+
+/// A builder that constructs a [Muxer].
+pub struct MuxerBuilder<E: Spawner, S: Sender, R: Receiver> {
+    mux: Muxer<E, S, R>,
+    mux_handle: MuxHandle<S, R>,
+}
+
+impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilder<E, S, R> {
+    type Output = (Muxer<E, S, R>, MuxHandle<S, R>);
+
+    fn build(self) -> Self::Output {
+        (self.mux, self.mux_handle)
+    }
+}
+
+impl<E: Spawner, S: Sender, R: Receiver> MuxerBuilder<E, S, R> {
+    /// Registers a backup channel with the muxer.
+    pub fn with_backup(mut self) -> MuxerBuilderWithBackup<E, S, R> {
+        let (tx, rx) = mpsc::channel(self.mux.mailbox_size);
+        self.mux.backup = Some(tx);
+
+        MuxerBuilderWithBackup {
+            mux: self.mux,
+            mux_handle: self.mux_handle,
+            backup_rx: rx,
+        }
+    }
+
+    /// Registers a global sender with the muxer.
+    pub fn with_global_sender(self) -> MuxerBuilderWithGlobalSender<E, S, R> {
+        let global_sender = GlobalSender::new(self.mux.sender.clone());
+
+        MuxerBuilderWithGlobalSender {
+            mux: self.mux,
+            mux_handle: self.mux_handle,
+            global_sender,
+        }
+    }
+}
+
+/// A builder that constructs a [Muxer] with a backup channel.
+pub struct MuxerBuilderWithBackup<E: Spawner, S: Sender, R: Receiver> {
+    mux: Muxer<E, S, R>,
+    mux_handle: MuxHandle<S, R>,
+    backup_rx: mpsc::Receiver<BackupResponse<R::PublicKey>>,
+}
+
+impl<E: Spawner, S: Sender, R: Receiver> MuxerBuilderWithBackup<E, S, R> {
+    /// Registers a global sender with the muxer.
+    pub fn with_global_sender(self) -> MuxerBuilderAllOpts<E, S, R> {
+        let global_sender = GlobalSender::new(self.mux.sender.clone());
+
+        MuxerBuilderAllOpts {
+            mux: self.mux,
+            mux_handle: self.mux_handle,
+            backup_rx: self.backup_rx,
+            global_sender,
+        }
+    }
+}
+
+impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilderWithBackup<E, S, R> {
+    type Output = (
+        Muxer<E, S, R>,
+        MuxHandle<S, R>,
+        mpsc::Receiver<BackupResponse<R::PublicKey>>,
+    );
+
+    fn build(self) -> Self::Output {
+        (self.mux, self.mux_handle, self.backup_rx)
+    }
+}
+
+/// A builder that constructs a [Muxer] with a [GlobalSender].
+pub struct MuxerBuilderWithGlobalSender<E: Spawner, S: Sender, R: Receiver> {
+    mux: Muxer<E, S, R>,
+    mux_handle: MuxHandle<S, R>,
+    global_sender: GlobalSender<S>,
+}
+
+impl<E: Spawner, S: Sender, R: Receiver> MuxerBuilderWithGlobalSender<E, S, R> {
+    /// Registers a backup channel with the muxer.
+    pub fn with_backup(mut self) -> MuxerBuilderAllOpts<E, S, R> {
+        let (tx, rx) = mpsc::channel(self.mux.mailbox_size);
+        self.mux.backup = Some(tx);
+
+        MuxerBuilderAllOpts {
+            mux: self.mux,
+            mux_handle: self.mux_handle,
+            backup_rx: rx,
+            global_sender: self.global_sender,
+        }
+    }
+}
+
+impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilderWithGlobalSender<E, S, R> {
+    type Output = (Muxer<E, S, R>, MuxHandle<S, R>, GlobalSender<S>);
+
+    fn build(self) -> Self::Output {
+        (self.mux, self.mux_handle, self.global_sender)
+    }
+}
+
+/// A builder that constructs a [Muxer] with a [GlobalSender] and backup channel.
+pub struct MuxerBuilderAllOpts<E: Spawner, S: Sender, R: Receiver> {
+    mux: Muxer<E, S, R>,
+    mux_handle: MuxHandle<S, R>,
+    backup_rx: mpsc::Receiver<BackupResponse<R::PublicKey>>,
+    global_sender: GlobalSender<S>,
+}
+
+impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilderAllOpts<E, S, R> {
+    type Output = (
+        Muxer<E, S, R>,
+        MuxHandle<S, R>,
+        mpsc::Receiver<BackupResponse<R::PublicKey>>,
+        GlobalSender<S>,
+    );
+
+    fn build(self) -> Self::Output {
+        (
+            self.mux,
+            self.mux_handle,
+            self.backup_rx,
+            self.global_sender,
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -261,7 +451,7 @@ mod tests {
     use bytes::Bytes;
     use commonware_cryptography::{ed25519::PrivateKey, PrivateKeyExt, Signer};
     use commonware_macros::{select, test_traced};
-    use commonware_runtime::{deterministic, Clock, Metrics, Runner};
+    use commonware_runtime::{deterministic, Metrics, Runner};
     use std::time::Duration;
 
     type Pk = commonware_cryptography::ed25519::PublicKey;
@@ -313,6 +503,28 @@ mod tests {
         (pubkey, handle)
     }
 
+    /// Create a peer and register it with the oracle.
+    async fn create_peer_with_backup_and_global_sender<E: Spawner + Metrics>(
+        context: &E,
+        oracle: &mut Oracle<Pk>,
+        seed: u64,
+    ) -> (
+        Pk,
+        MuxHandle<impl Sender<PublicKey = Pk>, impl Receiver<PublicKey = Pk>>,
+        mpsc::Receiver<BackupResponse<Pk>>,
+        GlobalSender<simulated::Sender<Pk>>,
+    ) {
+        let pubkey = pk(seed);
+        let (sender, receiver) = oracle.register(pubkey.clone(), 0).await.unwrap();
+        let (mux, handle, backup, global_sender) =
+            Muxer::builder(context.with_label("mux"), sender, receiver, CAPACITY)
+                .with_backup()
+                .with_global_sender()
+                .build();
+        mux.start();
+        (pubkey, handle, backup, global_sender)
+    }
+
     /// Send a burst of messages to a list of senders.
     async fn send_burst<S: Sender>(txs: &mut [SubSender<S>], count: usize) {
         for i in 0..count {
@@ -327,11 +539,7 @@ mod tests {
     }
 
     /// Wait for `n` messages to be received on the receiver.
-    async fn expect_n_messages<E: Spawner + Clock>(
-        rx: &mut SubReceiver<impl Receiver<PublicKey = Pk>>,
-        n: usize,
-        context: &E,
-    ) {
+    async fn expect_n_messages(rx: &mut SubReceiver<impl Receiver<PublicKey = Pk>>, n: usize) {
         let mut count = 0;
         loop {
             select! {
@@ -339,10 +547,42 @@ mod tests {
                     res.expect("should have received message");
                     count += 1;
                 },
-                _ = context.sleep(Duration::from_millis(100)) => { break; },
+            }
+
+            if count >= n {
+                break;
             }
         }
         assert_eq!(n, count);
+    }
+
+    /// Wait for `n` messages to be received on the receiver + backup receiver.
+    async fn expect_n_messages_with_backup(
+        rx: &mut SubReceiver<impl Receiver<PublicKey = Pk>>,
+        backup_rx: &mut mpsc::Receiver<BackupResponse<Pk>>,
+        n: usize,
+        n_backup: usize,
+    ) {
+        let mut count_std = 0;
+        let mut count_backup = 0;
+        loop {
+            select! {
+                res = rx.recv() => {
+                    res.expect("should have received message");
+                    count_std += 1;
+                },
+                res = backup_rx.next() => {
+                    res.expect("should have received message");
+                    count_backup += 1;
+                },
+            }
+
+            if count_std >= n && count_backup >= n_backup {
+                break;
+            }
+        }
+        assert_eq!(n, count_std);
+        assert_eq!(n_backup, count_backup);
     }
 
     #[test]
@@ -430,13 +670,13 @@ mod tests {
             send_burst(&mut [tx1, tx2], CAPACITY * 2).await;
 
             // Try receiving all messages from the second subchannel.
-            expect_n_messages(&mut rx2, CAPACITY, &context).await;
+            expect_n_messages(&mut rx2, CAPACITY).await;
 
             // Try receiving from the first subchannel.
-            expect_n_messages(&mut rx1, CAPACITY * 2, &context).await;
+            expect_n_messages(&mut rx1, CAPACITY * 2).await;
 
             // The second subchannel should be unblocked and receive the rest of the messages.
-            expect_n_messages(&mut rx2, CAPACITY, &context).await;
+            expect_n_messages(&mut rx2, CAPACITY).await;
         });
     }
 
@@ -460,17 +700,14 @@ mod tests {
             // Send 10 messages to each subchannel from pk1 to pk2.
             send_burst(&mut [tx1, tx2], CAPACITY * 2).await;
 
-            // Give the demuxers a moment to process messages.
-            context.sleep(Duration::from_millis(100)).await;
-
             // Try receiving all messages from the second subchannel.
-            expect_n_messages(&mut rx2, CAPACITY, &context).await;
+            expect_n_messages(&mut rx2, CAPACITY).await;
 
             // Drop the first subchannel, erroring the sender and dropping it.
             drop(rx1);
 
             // The second subchannel should be unblocked and receive the rest of the messages.
-            expect_n_messages(&mut rx2, CAPACITY, &context).await;
+            expect_n_messages(&mut rx2, CAPACITY).await;
         });
     }
 
@@ -494,11 +731,148 @@ mod tests {
             // Send 10 messages to each subchannel from pk1 to pk2.
             send_burst(&mut [tx1, tx2], CAPACITY * 2).await;
 
-            // Give the demuxers a moment to process messages.
-            context.sleep(Duration::from_millis(100)).await;
+            // Try receiving all messages from the second subchannel.
+            expect_n_messages(&mut rx2, CAPACITY * 2).await;
+        });
+    }
+
+    #[test]
+    fn test_backup_for_unregistered_subchannel() {
+        // Messages are forwarded to the backup channel if the subchannel they are for
+        // is not registered.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut oracle = start_network(context.clone());
+
+            let (pk1, mut handle1) = create_peer(&context, &mut oracle, 0).await;
+            let (pk2, mut handle2, mut backup2, _) =
+                create_peer_with_backup_and_global_sender(&context, &mut oracle, 1).await;
+            link_bidirectional(&mut oracle, pk1.clone(), pk2.clone()).await;
+
+            // Register the subchannels.
+            let (tx1, _) = handle1.register(1).await.unwrap();
+            let (tx2, _) = handle1.register(2).await.unwrap();
+            // Do not register the first subchannel on the second peer.
+            let (_, mut rx2) = handle2.register(2).await.unwrap();
+
+            // Send 10 messages to each subchannel from pk1 to pk2.
+            send_burst(&mut [tx1, tx2], CAPACITY * 2).await;
+
+            // Try receiving all messages from the second subchannel and backup channel.
+            // All 20 messages sent should be received.
+            expect_n_messages_with_backup(&mut rx2, &mut backup2, CAPACITY * 2, CAPACITY * 2).await;
+        });
+    }
+
+    #[test]
+    fn test_backup_for_unregistered_subchannel_response() {
+        // Messages are forwarded to the backup channel if the subchannel they are for
+        // is not registered.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut oracle = start_network(context.clone());
+
+            let (pk1, mut handle1) = create_peer(&context, &mut oracle, 0).await;
+            let (pk2, _handle2, mut backup2, mut global_sender2) =
+                create_peer_with_backup_and_global_sender(&context, &mut oracle, 1).await;
+            link_bidirectional(&mut oracle, pk1.clone(), pk2.clone()).await;
+
+            // Register the subchannels.
+            let (tx1, mut rx1) = handle1.register(1).await.unwrap();
+            // Do not register any subchannels on the second peer.
+
+            // Send 1 message to each subchannel from pk1 to pk2.
+            send_burst(&mut [tx1], 1).await;
+
+            // Get the message from pk2's backup channel and respond.
+            let (subchannel, (from, _)) = backup2.next().await.unwrap();
+            assert_eq!(subchannel, 1);
+            assert_eq!(from, pk1);
+            global_sender2
+                .send(
+                    subchannel,
+                    Recipients::One(pk1),
+                    b"TEST".to_vec().into(),
+                    true,
+                )
+                .await
+                .unwrap();
+
+            // Receive the response with pk1's receiver.
+            let (from, bytes) = rx1.recv().await.unwrap();
+            assert_eq!(from, pk2);
+            assert_eq!(bytes.as_ref(), b"TEST");
+        });
+    }
+
+    #[test]
+    fn test_message_dropped_for_closed_subchannel() {
+        // Messages are dropped if the subchannel they are for is registered, but has been closed.
+        //
+        // NOTE: This case should be exceedingly rare in practice due to `SubReceiver` deregistering
+        // the subchannel on drop, but is included for completeness.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut oracle = start_network(context.clone());
+
+            let (pk1, mut handle1) = create_peer(&context, &mut oracle, 0).await;
+            let (pk2, mut handle2) = create_peer(&context, &mut oracle, 1).await;
+            link_bidirectional(&mut oracle, pk1.clone(), pk2.clone()).await;
+
+            // Register the subchannels.
+            let (tx1, _) = handle1.register(1).await.unwrap();
+            let (tx2, _) = handle1.register(2).await.unwrap();
+            let (_, mut rx1) = handle2.register(1).await.unwrap();
+            let (_, mut rx2) = handle2.register(2).await.unwrap();
+
+            // Send 10 messages to subchannel 1 from pk1 to pk2.
+            send_burst(&mut [tx1.clone()], CAPACITY * 2).await;
+
+            // Try receiving all messages from the first subchannel.
+            expect_n_messages(&mut rx1, CAPACITY * 2).await;
+
+            // Send 10 messages to subchannel 2 from pk1 to pk2.
+            send_burst(&mut [tx2.clone()], CAPACITY * 2).await;
+
+            // Try receiving all messages from the first subchannel.
+            expect_n_messages(&mut rx2, CAPACITY * 2).await;
+
+            // Explicitly close the underlying receiver for the first subchannel.
+            rx1.receiver.close();
+
+            // Send 10 messages to each subchannel from pk1 to pk2.
+            send_burst(&mut [tx1, tx2], CAPACITY * 2).await;
 
             // Try receiving all messages from the second subchannel.
-            expect_n_messages(&mut rx2, CAPACITY * 2, &context).await;
+            expect_n_messages(&mut rx2, CAPACITY * 2).await;
+        });
+    }
+
+    #[test]
+    fn test_dropped_backup_channel_doesnt_block() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut oracle = start_network(context.clone());
+
+            let (pk1, mut handle1) = create_peer(&context, &mut oracle, 0).await;
+            let (pk2, mut handle2, backup2, _) =
+                create_peer_with_backup_and_global_sender(&context, &mut oracle, 1).await;
+            link_bidirectional(&mut oracle, pk1.clone(), pk2.clone()).await;
+
+            // Explicitly drop the backup receiver.
+            drop(backup2);
+
+            // Register the subchannels.
+            let (tx1, _) = handle1.register(1).await.unwrap();
+            let (tx2, _) = handle1.register(2).await.unwrap();
+            // Do not register the first subchannel on the second peer.
+            let (_, mut rx2) = handle2.register(2).await.unwrap();
+
+            // Send 10 messages to each subchannel from pk1 to pk2.
+            send_burst(&mut [tx1, tx2], CAPACITY * 2).await;
+
+            // Try receiving all messages from the second subchannel.
+            expect_n_messages(&mut rx2, CAPACITY * 2).await;
         });
     }
 


### PR DESCRIPTION
## Overview

Adds an optional backup channel to the `Muxer`, which can be used to handle messages from unregistered sub-channels.

This was suggested by @patrick-ogrady as a means of solving https://github.com/commonwarexyz/monorepo/issues/1920, allowing participants to forward finalization certificates for messages sent by peers in previous epochs' sub-channels.