### PR TITLE
[consensus] Add `Automaton::certify` check to be carried out after notarization

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -99,6 +99,26 @@ cfg_if::cfg_if! {
                 context: Self::Context,
                 payload: Self::Digest,
             ) -> impl Future<Output = oneshot::Receiver<bool>> + Send;
+
+            /// Determine whether a notarized payload is safe to finalize. If not, the payload will
+            /// be excluded from the block chain and will not be finalized. Therefore, the return
+            /// value must be deterministic and consistent across all participants.
+            ///
+            /// Applications that employ erasure-coding can override this to delay or prevent
+            /// finalization until they have reconstructed and validated the full block (e.g., after
+            /// receiving enough shards).
+            fn certify(
+                &mut self,
+                _context: Self::Context,
+                _payload: Self::Digest,
+            ) -> impl Future<Output = oneshot::Receiver<bool>> + Send {
+                #[allow(clippy::async_yields_async)]
+                async move {
+                    let (sender, receiver) = oneshot::channel();
+                    let _ = sender.send(true);
+                    receiver
+                }
+            }
         }
 
         /// Application is a minimal interface for standard implementations that operate over a stream

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -101,7 +101,7 @@ cfg_if::cfg_if! {
             ) -> impl Future<Output = oneshot::Receiver<bool>> + Send;
 
             /// Determine whether a notarized payload is safe to finalize. If not, the payload will
-            /// be excluded from the block chain and will not be finalized. Therefore, the return
+            /// be excluded from the blockchain and will not be finalized. Therefore, the return
             /// value must be deterministic and consistent across all participants.
             ///
             /// Applications that employ erasure-coding can override this to delay or prevent

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -226,7 +226,10 @@ impl<
                     }
                 }
             }
-            Voter::Notarization(_) | Voter::Finalization(_) | Voter::Nullification(_) => {
+            Voter::Notarization(_)
+            | Voter::Finalization(_)
+            | Voter::Nullification(_)
+            | Voter::Certification(_, _) => {
                 warn!(?sender, "blocking peer");
                 self.blocker.block(sender).await;
                 false
@@ -254,7 +257,10 @@ impl<
                     .await;
                 self.finalizes.insert(finalize.clone());
             }
-            Voter::Notarization(_) | Voter::Finalization(_) | Voter::Nullification(_) => {
+            Voter::Notarization(_)
+            | Voter::Finalization(_)
+            | Voter::Nullification(_)
+            | Voter::Certification(_, _) => {
                 unreachable!("recovered messages should be sent to batcher");
             }
         }

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -804,16 +804,6 @@ impl<
                     )
                     .await;
                 }
-
-                // If we have a latest finalization, broadcast it
-                if let Some(finalization) = self
-                    .views
-                    .get(&self.last_finalized)
-                    .and_then(|r| r.finalization.as_ref().cloned())
-                {
-                    self.broadcast_cert(recovered_sender, Voter::Finalization(finalization), true)
-                        .await;
-                }
             }
         }
 

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -737,7 +737,11 @@ impl<
         };
 
         // Request proposal from application
-        debug!(view = self.view, "requested proposal from automaton");
+        debug!(
+            view = self.view,
+            me = self.scheme.me(),
+            "requested proposal from automaton"
+        );
         let context = Context {
             round: Rnd::new(self.epoch, self.view),
             leader: self
@@ -774,6 +778,35 @@ impl<
         null_retry
     }
 
+    /// Sends a certificate to all validators.
+    async fn send_certificate<Sr: Sender>(
+        &mut self,
+        sender: &mut WrappedSender<Sr, Voter<S, D>>,
+        certificate: Voter<S, D>,
+        is_rebroadcast: bool,
+    ) {
+        // Log the broadcast and record metrics
+        let (metric, name) = match &certificate {
+            Voter::Notarization(_) => (metrics::Outbound::notarization(), "notarization"),
+            Voter::Nullification(_) => (metrics::Outbound::nullification(), "nullification"),
+            Voter::Finalization(_) => (metrics::Outbound::finalization(), "finalization"),
+            _ => unreachable!(),
+        };
+        self.outbound_messages.get_or_create(metric).inc();
+        let debug_msg = match is_rebroadcast {
+            true => format!("rebroadcast {}", name),
+            false => format!("broadcast {}", name),
+        };
+        let view = certificate.view();
+        debug!(view = view, debug_msg);
+
+        // Send the certificate
+        sender
+            .send(Recipients::All, certificate, true)
+            .await
+            .unwrap();
+    }
+
     async fn timeout<Sp: Sender, Sr: Sender>(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,
@@ -799,15 +832,8 @@ impl<
             let mut did_broadcast = false;
             // If we have a previous finalization, broadcast it
             if let Some(finalization) = self.construct_finalization(past_view, true).await {
-                self.outbound_messages
-                    .get_or_create(metrics::Outbound::finalization())
-                    .inc();
-                let msg = Voter::Finalization(finalization);
-                recovered_sender
-                    .send(Recipients::All, msg, true)
-                    .await
-                    .unwrap();
-                debug!(view = past_view, "rebroadcast entry finalization");
+                self.send_certificate(recovered_sender, Voter::Finalization(finalization), true)
+                    .await;
                 did_broadcast = true;
             }
 
@@ -817,29 +843,38 @@ impl<
                 // If we have a previous notarization, broadcast it.
                 // The payload may not be certified.
                 if let Some(notarization) = self.construct_notarization(past_view, true).await {
-                    self.outbound_messages
-                        .get_or_create(metrics::Outbound::notarization())
-                        .inc();
-                    let msg = Voter::Notarization(notarization);
-                    recovered_sender
-                        .send(Recipients::All, msg, true)
-                        .await
-                        .unwrap();
-                    debug!(view = past_view, "rebroadcast entry notarization");
+                    self.send_certificate(
+                        recovered_sender,
+                        Voter::Notarization(notarization),
+                        true,
+                    )
+                    .await;
                     did_broadcast = true;
                 }
 
                 // If we have a previous nullification, broadcast it
                 if let Some(nullification) = self.construct_nullification(past_view, true).await {
-                    self.outbound_messages
-                        .get_or_create(metrics::Outbound::nullification())
-                        .inc();
-                    let msg = Voter::Nullification(nullification);
-                    recovered_sender
-                        .send(Recipients::All, msg, true)
-                        .await
-                        .unwrap();
-                    debug!(view = past_view, "rebroadcast entry nullification");
+                    self.send_certificate(
+                        recovered_sender,
+                        Voter::Nullification(nullification),
+                        true,
+                    )
+                    .await;
+                    did_broadcast = true;
+                }
+
+                // If we have a latest finalization, broadcast it
+                if let Some(finalization) = self
+                    .views
+                    .get(&self.last_finalized)
+                    .and_then(|r| r.finalization.as_ref().cloned())
+                {
+                    self.send_certificate(
+                        recovered_sender,
+                        Voter::Finalization(finalization),
+                        true,
+                    )
+                    .await;
                     did_broadcast = true;
                 }
             }
@@ -876,7 +911,7 @@ impl<
         self.outbound_messages
             .get_or_create(metrics::Outbound::nullify())
             .inc();
-        debug!(round=?nullify.round(), "broadcasting nullify");
+        debug!(round=?nullify.round(), me = self.scheme.me(), "broadcasting nullify");
         let msg = Voter::Nullify(nullify);
         pending_sender
             .send(Recipients::All, msg, true)
@@ -987,7 +1022,7 @@ impl<
                 let parent_proposal = match self.is_certified(cursor) {
                     Some(parent) => parent,
                     None => {
-                        debug!(view = cursor, "parent proposal is not certified");
+                        debug!(view = cursor, me = self.scheme.me(), views = ?self.views.keys().collect::<Vec<_>>(), "parent proposal is not certified");
                         return None;
                     }
                 };
@@ -1051,32 +1086,40 @@ impl<
         // Get the context for the proposal.
         let parent_view = proposal.parent;
 
-        // Get the leader
-        let Some(leader) = round.leader else {
-            // If the leader is not set, then we may need the seed for this round.
-            // We should attempt to fetch a notarization or nullification for the previous round.
-            let last_view = view - 1;
-            let (missing_notarizations, missing_nullifications) = if parent_view == last_view {
-                (vec![last_view], vec![])
-            } else {
-                (vec![parent_view], vec![last_view])
-            };
-            resolver
-                .fetch(missing_notarizations, missing_nullifications)
-                .await;
-            self.certification_candidates.insert(view);
-            return None;
-        };
+        let mut missing_notarizations = None;
+        let mut missing_nullifications = None;
 
-        // Since we have a notarization, the parent does not need to be certified by us. It is
-        // implicitly certified by the fact that participants notarized the current proposal.
-        let Some(parent_payload) = self.is_notarized(parent_view) else {
-            // However, if the parent is not notarized, then we cannot be sure what the parent is.
-            // We should attempt to fetch its notarization and to certify this view later.
-            resolver.fetch(vec![parent_view], vec![]).await;
-            self.certification_candidates.insert(view);
+        // If the leader is not set, we need the seed for this round. If the parent view is not
+        // the previous view, then a nullification is missing.
+        let leader_opt = round.leader;
+        if leader_opt.is_none() {
+            let prev_view = view - 1;
+            if parent_view != prev_view {
+                missing_nullifications = Some(prev_view);
+            }
+        }
+
+        // Fetch the parent notarization if we don't have it. We need to guarantee the parent
+        // payload in order to certify this view.
+        let parent_payload_opt = self.is_notarized(parent_view).copied();
+        if parent_payload_opt.is_none() {
+            missing_notarizations = Some(parent_view);
+        }
+
+        // If any missing certificates are needed to certify this view, then we should fetch them.
+        if missing_notarizations.is_some() || missing_nullifications.is_some() {
+            resolver
+                .fetch(
+                    missing_notarizations.map_or_else(Vec::new, |v| vec![v]),
+                    missing_nullifications.map_or_else(Vec::new, |v| vec![v]),
+                )
+                .await;
             return None;
-        };
+        }
+
+        // At this point, the context is able to be constructed—the leader and parent payload exist
+        let leader = leader_opt.unwrap();
+        let parent_payload = parent_payload_opt.unwrap();
         let context = Context {
             round: proposal.round,
             leader: self
@@ -1085,7 +1128,7 @@ impl<
                 .key(leader)
                 .expect("leader not found")
                 .clone(),
-            parent: (parent_view, *parent_payload),
+            parent: (parent_view, parent_payload),
         };
 
         // Request certification.
@@ -1150,20 +1193,19 @@ impl<
 
         // Log the result and exit early if certification failed since we should not move to the
         // next view until a nullification is formed.
-        if !success {
-            return;
+        if success {
+            // Enter next view. We should have a notarization for this view,
+            // otherwise we would not have asked for certification in the first place.
+            let notarization = round.notarization.as_ref().unwrap();
+            let seed = self
+                .scheme
+                .seed(notarization.round(), &notarization.certificate);
+            self.enter_view(view + 1, seed);
+        } else {
+            // If the failed certification is for the current view, timeout ASAP.
+            // This round may not be for the current view; it's safe to set its deadline anyway.
+            round.advance_deadline = Some(self.context.current());
         }
-
-        // Enter next view. We should have a notarization for this view,
-        // otherwise we would not have asked for certification in the first place.
-        let notarization = round
-            .notarization
-            .as_ref()
-            .expect("certified proposal should have a notarization");
-        let seed = self
-            .scheme
-            .seed(notarization.round(), &notarization.certificate);
-        self.enter_view(view + 1, seed);
     }
 
     fn since_view_start(&self, view: u64) -> Option<(bool, f64)> {
@@ -1200,9 +1242,9 @@ impl<
         let leader_deadline = self.context.current() + self.leader_timeout;
         let advance_deadline = self.context.current() + self.notarization_timeout;
         let round = self.round_mut(view);
+        round.set_leader(seed);
         round.leader_deadline = Some(leader_deadline);
         round.advance_deadline = Some(advance_deadline);
-        round.set_leader(seed);
         self.view = view;
 
         // Update metrics
@@ -1299,6 +1341,18 @@ impl<
         // Get view for notarization
         let view = notarization.view();
 
+        // If the next view does not yet have a leader, set it and add to certification candidates.
+        let next_view = view + 1;
+        if let Some(round) = self.views.get_mut(&next_view) {
+            if round.leader.is_none() {
+                let seed = self
+                    .scheme
+                    .seed(notarization.round(), &notarization.certificate);
+                round.set_leader(seed);
+                self.certification_candidates.insert(next_view);
+            }
+        }
+
         // Create round (if it doesn't exist) and add verified notarization
         if self
             .round_mut(view)
@@ -1317,7 +1371,13 @@ impl<
         // Record that this view may be eligible for certification.
         self.certification_candidates.insert(view);
 
-        // Do not yet move to the next view, we need to wait for certification.
+        // Any known children of this view may also be eligible for certification.
+        self.certification_candidates.extend(
+            self.views
+                .range(view + 1..)
+                .filter(|(_, r)| r.proposal.as_ref().is_some_and(|p| p.parent == view))
+                .map(|(v, _)| *v),
+        );
     }
 
     async fn nullification(&mut self, nullification: Nullification<S>) -> Action {
@@ -1355,7 +1415,7 @@ impl<
         let msg = Voter::Nullification(nullification.clone());
         let seed = self
             .scheme
-            .seed(nullification.round, &nullification.certificate);
+            .seed(nullification.round(), &nullification.certificate);
 
         // Create round (if it doesn't exist) and add verified nullification
         let view = nullification.view();
@@ -1446,6 +1506,13 @@ impl<
 
         // Enter next view
         self.enter_view(view + 1, seed);
+
+        self.certification_candidates.extend(
+            self.views
+                .range(view + 1..)
+                .filter(|(_, r)| r.proposal.as_ref().is_some_and(|p| p.parent == view))
+                .map(|(v, _)| *v),
+        );
     }
 
     fn construct_notarize(&mut self, view: u64) -> Option<Notarize<S, D>> {
@@ -1556,7 +1623,7 @@ impl<
                 .expect("unable to sync journal");
 
             // Broadcast the notarize
-            debug!(round=?notarize.round(), proposal=?notarize.proposal, "broadcasting notarize");
+            debug!(round=?notarize.round(), proposal=?notarize.proposal, me = self.scheme.me(), "broadcasting notarize");
             let msg = Voter::Notarize(notarize);
             pending_sender
                 .send(Recipients::All, msg, true)
@@ -1577,9 +1644,6 @@ impl<
             resolver.notarized(notarization.clone()).await;
 
             // Handle the notarization
-            self.outbound_messages
-                .get_or_create(metrics::Outbound::notarization())
-                .inc();
             self.handle_notarization(notarization.clone()).await;
 
             // Sync the journal
@@ -1596,12 +1660,8 @@ impl<
                 .await;
 
             // Broadcast the notarization
-            debug!(proposal=?notarization.proposal, "broadcasting notarization");
-            let msg = Voter::Notarization(notarization.clone());
-            recovered_sender
-                .send(Recipients::All, msg, true)
-                .await
-                .unwrap();
+            self.send_certificate(recovered_sender, Voter::Notarization(notarization), false)
+                .await;
         };
 
         // Attempt to nullification
@@ -1612,9 +1672,6 @@ impl<
             resolver.nullified(nullification.clone()).await;
 
             // Handle the nullification
-            self.outbound_messages
-                .get_or_create(metrics::Outbound::nullification())
-                .inc();
             self.handle_nullification(nullification.clone()).await;
 
             // Sync the journal
@@ -1631,12 +1688,8 @@ impl<
                 .await;
 
             // Broadcast the nullification
-            debug!(round=?nullification.round(), "broadcasting nullification");
-            let msg = Voter::Nullification(nullification.clone());
-            recovered_sender
-                .send(Recipients::All, msg, true)
-                .await
-                .unwrap();
+            self.send_certificate(recovered_sender, Voter::Nullification(nullification), false)
+                .await;
 
             // If the view isn't yet finalized and at least one honest node notarized a proposal in this view,
             // then backfill any missing certificates.
@@ -1708,9 +1761,6 @@ impl<
             resolver.finalized(view).await;
 
             // Handle the finalization
-            self.outbound_messages
-                .get_or_create(metrics::Outbound::finalization())
-                .inc();
             self.handle_finalization(finalization.clone()).await;
 
             // Sync the journal
@@ -1727,12 +1777,8 @@ impl<
                 .await;
 
             // Broadcast the finalization
-            debug!(proposal=?finalization.proposal, "broadcasting finalization");
-            let msg = Voter::Finalization(finalization.clone());
-            recovered_sender
-                .send(Recipients::All, msg, true)
-                .await
-                .unwrap();
+            self.send_certificate(recovered_sender, Voter::Finalization(finalization), false)
+                .await;
         };
     }
 
@@ -1948,8 +1994,8 @@ impl<
 
             // Drain pending certifications triggered by notarizations
             let candidates = take(&mut self.certification_candidates)
-                .into_iter()
-                .filter(|v| v > &self.last_finalized)
+                .range(self.last_finalized + 1..)
+                .copied()
                 .collect::<Vec<_>>();
             for v in candidates {
                 if let Some(Request(ctx, receiver)) = self.certify(v, &mut resolver).await {

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1200,7 +1200,7 @@ impl<
 
         // Log and prune journal if we pruned any views. Due to how `split_off` works,
         // `self.views` itself holds the views that will be pruned.
-        if self.views.len() > 0 {
+        if !self.views.is_empty() {
             let pruned_views = self.views.keys().collect::<Vec<_>>();
             debug!(
                 views = ?pruned_views,
@@ -1376,10 +1376,6 @@ impl<
         {
             self.journal_append(view, msg).await;
         }
-
-        // Enter this view if we haven't already.
-        // Certification of this view will move us to the next view.
-        self.enter_view(view);
     }
 
     async fn nullification(&mut self, nullification: Nullification<S>) -> Action {

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1033,7 +1033,6 @@ impl<
         resolver: &mut resolver::Mailbox<S, D>,
     ) -> Option<Request<D, P, bool>> {
         let round = self.views.get_mut(&view)?;
-        let leader = round.leader?;
 
         // Request certification only once
         if round.certify_handle.is_some() || round.certified_proposal.is_some() {
@@ -1051,6 +1050,24 @@ impl<
 
         // Get the context for the proposal.
         let parent_view = proposal.parent;
+
+        // Get the leader
+        let Some(leader) = round.leader else {
+            // If the leader is not set, then we may need the seed for this round.
+            // We should attempt to fetch a notarization or nullification for the previous round.
+            let last_view = view - 1;
+            let (missing_notarizations, missing_nullifications) = if parent_view == last_view {
+                (vec![last_view], vec![])
+            } else {
+                (vec![parent_view], vec![last_view])
+            };
+            resolver
+                .fetch(missing_notarizations, missing_nullifications)
+                .await;
+            self.certification_candidates.insert(view);
+            return None;
+        };
+
         // Since we have a notarization, the parent does not need to be certified by us. It is
         // implicitly certified by the fact that participants notarized the current proposal.
         let Some(parent_payload) = self.is_notarized(parent_view) else {
@@ -1128,11 +1145,11 @@ impl<
                 .append(view, msg)
                 .await
                 .expect("unable to append to journal");
+            debug!(certified = ?success, view, "certify result");
         }
 
         // Log the result and exit early if certification failed since we should not move to the
         // next view until a nullification is formed.
-        debug!(certified = ?success, view, "certify result");
         if !success {
             return;
         }
@@ -1161,6 +1178,14 @@ impl<
     }
 
     fn enter_view(&mut self, view: u64, seed: Option<S::Seed>) {
+        // Set leader if round already exists.
+        if let Some(round) = self.views.get_mut(&view) {
+            if round.leader.is_none() {
+                round.set_leader(seed);
+            }
+            return;
+        }
+
         // Ensure view is valid
         if view <= self.view {
             trace!(
@@ -1417,9 +1442,7 @@ impl<
         }
 
         // Track view finalized
-        if view > self.last_finalized {
-            self.last_finalized = view;
-        }
+        self.last_finalized = self.last_finalized.max(view);
 
         // Enter next view
         self.enter_view(view + 1, seed);
@@ -1926,6 +1949,7 @@ impl<
             // Drain pending certifications triggered by notarizations
             let candidates = take(&mut self.certification_candidates)
                 .into_iter()
+                .filter(|v| v > &self.last_finalized)
                 .collect::<Vec<_>>();
             for v in candidates {
                 if let Some(Request(ctx, receiver)) = self.certify(v, &mut resolver).await {

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -95,9 +95,6 @@ struct Round<E: Clock, S: Scheme, D: Digest> {
 
     round: Rnd,
 
-    // Leader is set as soon as we know the seed for the view (if any).
-    leader: Option<u32>,
-
     // We explicitly distinguish between the proposal being verified (we checked it)
     // and the proposal being recovered (network has determined its validity). As a sanity
     // check, we'll never notarize or finalize a proposal that we did not verify.
@@ -165,8 +162,6 @@ impl<E: Clock, S: Scheme, D: Digest> Round<E, S, D> {
 
             round,
 
-            leader: None,
-
             requested_proposal_verify: false,
             verified_proposal: false,
 
@@ -197,13 +192,6 @@ impl<E: Clock, S: Scheme, D: Digest> Round<E, S, D> {
 
             recover_latency,
         }
-    }
-
-    pub fn set_leader(&mut self, seed: Option<S::Seed>) {
-        let (leader, leader_idx) =
-            select_leader::<S, _>(self.scheme.participants().as_ref(), self.round, seed);
-        self.leader = Some(leader_idx);
-        trace!(round=?self.round, ?leader, ?leader_idx, "leader elected");
     }
 
     fn add_recovered_proposal(&mut self, proposal: Proposal<D>) {
@@ -501,9 +489,10 @@ pub struct Actor<
 
     mailbox_receiver: mpsc::Receiver<Message<S, D>>,
 
+    last_finalized: View,
     view: View,
     views: BTreeMap<View, Round<E, S, D>>,
-    last_finalized: View,
+    leaders: BTreeMap<View, u32>,
 
     current_view: Gauge,
     tracked_views: Gauge,
@@ -607,6 +596,7 @@ impl<
                 last_finalized: 0,
                 view: 0,
                 views: BTreeMap::new(),
+                leaders: BTreeMap::new(),
 
                 current_view,
                 tracked_views,
@@ -701,8 +691,8 @@ impl<
         resolver: &mut resolver::Mailbox<S, D>,
     ) -> Option<Request<D, P, D>> {
         // Check if we are leader
+        let leader = self.get_leader(self.view)?;
         let round = self.views.get_mut(&self.view).unwrap();
-        let leader = round.leader?;
         if !Self::is_me(&self.scheme, leader) {
             return None;
         }
@@ -923,7 +913,7 @@ impl<
             let round = self.views.get(&self.view)?;
 
             // If we are the leader, drop peer proposals
-            let Some(leader) = round.leader else {
+            let Some(leader) = self.get_leader(self.view) else {
                 debug!(
                     view = self.view,
                     "dropping peer proposal because leader is not set"
@@ -1046,7 +1036,7 @@ impl<
 
         // If the leader is not set, we need the seed for this round. If the parent view is not
         // the previous view, then a nullification is missing.
-        let leader_opt = round.leader;
+        let leader_opt = self.get_leader(self.view);
         if leader_opt.is_none() {
             let prev_view = view - 1;
             if parent_view != prev_view {
@@ -1149,13 +1139,8 @@ impl<
         // Log the result and exit early if certification failed since we should not move to the
         // next view until a nullification is formed.
         if success {
-            // Enter next view. We should have a notarization for this view,
-            // otherwise we would not have asked for certification in the first place.
-            let notarization = round.notarization.as_ref().unwrap();
-            let seed = self
-                .scheme
-                .seed(notarization.round(), &notarization.certificate);
-            self.enter_view(view + 1, seed);
+            // Enter next view.
+            self.enter_view(view + 1);
         } else {
             // If the failed certification is for the current view, timeout ASAP.
             // This round may not be for the current view; it's safe to set its deadline anyway.
@@ -1169,20 +1154,43 @@ impl<
             return None;
         };
         Some((
-            Self::is_me(&self.scheme, round.leader?),
+            Self::is_me(&self.scheme, self.get_leader(view)?),
             elapsed.as_secs_f64(),
         ))
     }
 
-    fn enter_view(&mut self, view: u64, seed: Option<S::Seed>) {
+    /// Sets the leader from a given round and certificate.
+    ///
+    /// The leader will be set for the next view.
+    fn set_leader(&mut self, prev_round: Rnd, certificate: Option<&S::Certificate>) {
+        // If the leader is already set, do nothing
+        let next_round = Rnd::new(self.epoch, prev_round.view() + 1);
+        if self.leaders.contains_key(&next_round.view()) {
+            return;
+        }
+
+        // Calculate the seed if there is a certificate
+        let seed = certificate.and_then(|c| self.scheme.seed(prev_round, c));
+
+        // Select and insert the leader
+        let (leader, leader_idx) =
+            select_leader::<S, _>(self.scheme.participants().as_ref(), next_round, seed);
+        self.leaders.insert(next_round.view(), leader_idx);
+
+        // This view may be eligible for certification
+        self.certification_candidates.insert(next_round.view());
+
+        // Log the leader election
+        trace!(round=?next_round, ?leader, ?leader_idx, "leader elected");
+    }
+
+    fn get_leader(&self, view: View) -> Option<u32> {
+        self.leaders.get(&view).copied()
+    }
+
+    fn enter_view(&mut self, view: u64) {
         // Don't need to create a new view
         if view <= self.view {
-            // Set leader if round already exists.
-            if let Some(round) = self.views.get_mut(&view) {
-                if round.leader.is_none() {
-                    round.set_leader(seed);
-                }
-            }
             return;
         }
 
@@ -1190,7 +1198,6 @@ impl<
         let leader_deadline = self.context.current() + self.leader_timeout;
         let advance_deadline = self.context.current() + self.notarization_timeout;
         let round = self.round_mut(view);
-        round.set_leader(seed);
         round.leader_deadline = Some(leader_deadline);
         round.advance_deadline = Some(advance_deadline);
         self.view = view;
@@ -1202,39 +1209,66 @@ impl<
     async fn prune_views(&mut self) {
         // Get last min
         let min = min_active(self.activity_timeout, self.last_finalized);
-        let mut pruned = false;
-        loop {
-            // Get next key
-            let next = match self.views.keys().next() {
-                Some(next) => *next,
-                None => return,
-            };
+        let kept_views = self.views.split_off(&min);
+        let kept_leaders = self.leaders.split_off(&min);
 
-            // If less than min, prune
-            if next >= min {
-                break;
-            }
-            self.views.remove(&next);
+        // Log and prune journal if we pruned any views
+        {
+            let pruned_views = self.views.keys().collect::<Vec<_>>();
             debug!(
-                view = next,
+                views = ?pruned_views,
                 last_finalized = self.last_finalized,
-                "pruned view"
+                "pruned views"
             );
-            pruned = true;
+            if !pruned_views.is_empty() {
+                self.journal
+                    .as_mut()
+                    .unwrap()
+                    .prune(min)
+                    .await
+                    .expect("unable to prune journal");
+            }
         }
 
-        // Prune journal up to min
-        if pruned {
-            self.journal
-                .as_mut()
-                .unwrap()
-                .prune(min)
-                .await
-                .expect("unable to prune journal");
-        }
+        // Update leaders and views with the kept ones
+        self.leaders = kept_leaders;
+        self.views = kept_views;
 
         // Update metrics
         let _ = self.tracked_views.try_set(self.views.len());
+    }
+
+    /// Handles common logic when certificates are created. This includes:
+    /// - Setting the leader for the next view
+    /// - Adding the view to the certification candidates
+    /// - Adding the children of the view to the certification candidates
+    fn handle_cert(&mut self, certificate: &Voter<S, D>) {
+        let view = certificate.view();
+        let next_view = view + 1;
+
+        // Set the leader for the next view
+        let (rnd, cert) = match &certificate {
+            Voter::Nullification(n) => (n.round(), &n.certificate),
+            Voter::Notarization(n) => (n.round(), &n.certificate),
+            Voter::Finalization(f) => (f.round(), &f.certificate),
+            _ => unreachable!(),
+        };
+        self.set_leader(rnd, Some(cert));
+
+        // If this is a notarization, it may be eligible for certification.
+        if let Voter::Notarization(_) = &certificate {
+            self.certification_candidates.insert(view);
+        }
+
+        // If this is a notarization or a finalization, its children may be eligible for certification.
+        if let Voter::Notarization(_) | Voter::Finalization(_) = &certificate {
+            self.certification_candidates.extend(
+                self.views
+                    .range(next_view..)
+                    .filter(|(_, r)| r.proposal.as_ref().is_some_and(|p| p.parent == view))
+                    .map(|(v, _)| *v),
+            );
+        }
     }
 
     /// Broadcasts a certificate (notarization, nullification, or finalization) to all validators.
@@ -1248,8 +1282,8 @@ impl<
     ) {
         // Log the broadcast and record metrics
         let (metric, name) = match &certificate {
-            Voter::Notarization(_) => (metrics::Outbound::notarization(), "notarization"),
             Voter::Nullification(_) => (metrics::Outbound::nullification(), "nullification"),
+            Voter::Notarization(_) => (metrics::Outbound::notarization(), "notarization"),
             Voter::Finalization(_) => (metrics::Outbound::finalization(), "finalization"),
             _ => unreachable!(),
         };
@@ -1258,7 +1292,8 @@ impl<
             true => format!("rebroadcast {}", name),
             false => format!("broadcast {}", name),
         };
-        debug!(view=?certificate.view(), debug_msg);
+        let view = certificate.view();
+        debug!(view=?view, debug_msg);
 
         // Send the certificate
         sender
@@ -1347,46 +1382,23 @@ impl<
     }
 
     async fn handle_notarization(&mut self, notarization: Notarization<S, D>) {
-        // Get view for notarization
-        let view = notarization.view();
-
-        // If the next view does not yet have a leader, set it and add to certification candidates.
-        let next_view = view + 1;
-        if let Some(round) = self.views.get_mut(&next_view) {
-            if round.leader.is_none() {
-                let seed = self
-                    .scheme
-                    .seed(notarization.round(), &notarization.certificate);
-                round.set_leader(seed);
-                self.certification_candidates.insert(next_view);
-            }
-        }
+        let msg = Voter::Notarization(notarization.clone());
+        self.handle_cert(&msg);
 
         // Create round (if it doesn't exist) and add verified notarization
+        let view = notarization.view();
         if self
             .round_mut(view)
             .add_verified_notarization(notarization.clone())
         {
             if let Some(journal) = self.journal.as_mut() {
                 // Store notarization
-                let msg = Voter::Notarization(notarization);
                 journal
                     .append(view, msg)
                     .await
                     .expect("unable to append to journal");
             }
         }
-
-        // Record that this view may be eligible for certification.
-        self.certification_candidates.insert(view);
-
-        // Any known children of this view may also be eligible for certification.
-        self.certification_candidates.extend(
-            self.views
-                .range(view + 1..)
-                .filter(|(_, r)| r.proposal.as_ref().is_some_and(|p| p.parent == view))
-                .map(|(v, _)| *v),
-        );
     }
 
     async fn nullification(&mut self, nullification: Nullification<S>) -> Action {
@@ -1422,9 +1434,7 @@ impl<
     async fn handle_nullification(&mut self, nullification: Nullification<S>) {
         // Store nullification
         let msg = Voter::Nullification(nullification.clone());
-        let seed = self
-            .scheme
-            .seed(nullification.round(), &nullification.certificate);
+        self.handle_cert(&msg);
 
         // Create round (if it doesn't exist) and add verified nullification
         let view = nullification.view();
@@ -1441,7 +1451,7 @@ impl<
         }
 
         // Enter next view
-        self.enter_view(view + 1, seed);
+        self.enter_view(view + 1);
     }
 
     async fn handle_finalize(&mut self, finalize: Finalize<S, D>) {
@@ -1495,9 +1505,7 @@ impl<
     async fn handle_finalization(&mut self, finalization: Finalization<S, D>) {
         // Store finalization
         let msg = Voter::Finalization(finalization.clone());
-        let seed = self
-            .scheme
-            .seed(finalization.round(), &finalization.certificate);
+        self.handle_cert(&msg);
 
         // Create round (if it doesn't exist) and add verified finalization
         let view = finalization.view();
@@ -1514,14 +1522,7 @@ impl<
         self.last_finalized = self.last_finalized.max(view);
 
         // Enter next view
-        self.enter_view(view + 1, seed);
-
-        self.certification_candidates.extend(
-            self.views
-                .range(view + 1..)
-                .filter(|(_, r)| r.proposal.as_ref().is_some_and(|p| p.parent == view))
-                .map(|(v, _)| *v),
-        );
+        self.enter_view(view + 1);
     }
 
     fn construct_notarize(&mut self, view: u64) -> Option<Notarize<S, D>> {
@@ -1636,8 +1637,8 @@ impl<
         // Attempt to notarization
         if let Some(notarization) = self.construct_notarization(view, false).await {
             // Record latency if we are the leader (only way to get unbiased observation)
-            if let Some((leader, elapsed)) = self.since_view_start(view) {
-                if leader {
+            if let Some((is_me, elapsed)) = self.since_view_start(view) {
+                if is_me {
                     self.notarization_latency.observe(elapsed);
                 }
             }
@@ -1662,7 +1663,8 @@ impl<
                 .await;
 
             // Broadcast the notarization
-            self.broadcast_cert(recovered_sender, Voter::Notarization(notarization), false)
+            let notarization = Voter::Notarization(notarization);
+            self.broadcast_cert(recovered_sender, notarization, false)
                 .await;
         };
 
@@ -1690,7 +1692,8 @@ impl<
                 .await;
 
             // Broadcast the nullification
-            self.broadcast_cert(recovered_sender, Voter::Nullification(nullification), false)
+            let nullification = Voter::Nullification(nullification);
+            self.broadcast_cert(recovered_sender, nullification, false)
                 .await;
 
             // If the view isn't yet finalized and at least one honest node notarized a proposal in this view,
@@ -1746,8 +1749,8 @@ impl<
         // Attempt to finalization
         if let Some(finalization) = self.construct_finalization(view, false).await {
             // Record latency if we are the leader (only way to get unbiased observation)
-            if let Some((leader, elapsed)) = self.since_view_start(view) {
-                if leader {
+            if let Some((is_me, elapsed)) = self.since_view_start(view) {
+                if is_me {
                     self.finalization_latency.observe(elapsed);
                 }
             }
@@ -1772,7 +1775,8 @@ impl<
                 .await;
 
             // Broadcast the finalization
-            self.broadcast_cert(recovered_sender, Voter::Finalization(finalization), false)
+            let finalization = Voter::Finalization(finalization);
+            self.broadcast_cert(recovered_sender, finalization, false)
                 .await;
         };
     }
@@ -1821,7 +1825,8 @@ impl<
         // Add initial view
         //
         // We start on view 1 because the genesis container occupies view 0/height 0.
-        self.enter_view(1, None);
+        self.enter_view(1);
+        self.set_leader(Rnd::new(self.epoch, 0), None);
 
         // Initialize journal
         let journal = Journal::<_, Voter<S, D>>::init(
@@ -1951,8 +1956,7 @@ impl<
         let _ = self.tracked_views.try_set(self.views.len());
 
         // Initialize verifier with leader
-        let round = self.views.get_mut(&observed_view).expect("missing round");
-        let leader = round.leader.unwrap();
+        let leader = self.get_leader(observed_view).expect("missing leader");
         batcher
             .update(observed_view, leader, self.last_finalized)
             .await;
@@ -2245,8 +2249,8 @@ impl<
 
             // Update the verifier if we have moved to a new view
             if self.view > start {
+                let leader = self.get_leader(self.view).expect("missing leader");
                 let round = self.views.get_mut(&self.view).expect("missing round");
-                let leader = round.leader.unwrap();
                 let is_active = batcher.update(self.view, leader, self.last_finalized).await;
 
                 // If the leader is not active (and not us), we should reduce leader timeout to now

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -30,10 +30,10 @@ use commonware_runtime::{
     Clock, ContextCell, Handle, Metrics, Spawner, Storage,
 };
 use commonware_storage::journal::segmented::variable::{Config as JConfig, Journal};
-use core::panic;
+use commonware_utils::futures::{AbortablePool, Aborter};
+use core::{future::Future, panic};
 use futures::{
     channel::{mpsc, oneshot},
-    future::Either,
     pin_mut, StreamExt,
 };
 use prometheus_client::metrics::{
@@ -41,9 +41,12 @@ use prometheus_client::metrics::{
 };
 use rand::{CryptoRng, Rng};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
+    mem::take,
     num::NonZeroUsize,
+    pin::Pin,
     sync::{atomic::AtomicI64, Arc},
+    task::{self, Poll},
     time::{Duration, SystemTime},
 };
 use tracing::{debug, info, trace, warn};
@@ -58,6 +61,32 @@ enum Action {
     Block,
     /// Process the message.
     Process,
+}
+
+/// A outstanding request to the automaton.
+struct Request<D: Digest, P: PublicKey, R>(
+    /// Attached context for the pending item.
+    Context<D, P>,
+    /// Oneshot receiver that the automaton is expected to respond over.
+    oneshot::Receiver<R>,
+);
+
+/// Adapter that polls an [Option<Request<D, P, R>>] in place.
+struct Waiter<'a, D: Digest, P: PublicKey, R>(&'a mut Option<Request<D, P, R>>);
+
+impl<'a, D: Digest, P: PublicKey, R> Future for Waiter<'a, D, P, R> {
+    type Output = (Context<D, P>, Result<R, oneshot::Canceled>);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        let Waiter(slot) = self.get_mut();
+        match slot.as_mut() {
+            None => Poll::Pending,
+            Some(Request(ctx, ref mut receiver)) => match Pin::new(receiver).poll(cx) {
+                Poll::Ready(res) => Poll::Ready((ctx.clone(), res)),
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
 }
 
 struct Round<E: Clock, S: Scheme, D: Digest> {
@@ -75,10 +104,16 @@ struct Round<E: Clock, S: Scheme, D: Digest> {
     //
     // We will, however, construct a notarization or finalization (if we have enough partial
     // signatures of either) even if we did not verify the proposal.
-    requested_proposal_build: bool,
     requested_proposal_verify: bool,
     verified_proposal: bool,
 
+    // Some if the automaton has been requested to certify the proposal.
+    // When the round is pruned, the aborter is dropped and automatically cancels the request.
+    certify_handle: Option<Aborter>,
+    // None if not responded yet
+    certified_proposal: Option<bool>,
+
+    requested_proposal_build: bool,
     proposal: Option<Proposal<D>>,
 
     leader_deadline: Option<SystemTime>,
@@ -132,10 +167,13 @@ impl<E: Clock, S: Scheme, D: Digest> Round<E, S, D> {
 
             leader: None,
 
-            requested_proposal_build: false,
             requested_proposal_verify: false,
             verified_proposal: false,
 
+            certify_handle: None,
+            certified_proposal: None,
+
+            requested_proposal_build: false,
             proposal: None,
 
             leader_deadline: None,
@@ -176,6 +214,47 @@ impl<E: Clock, S: Scheme, D: Digest> Round<E, S, D> {
         } else if let Some(previous) = &self.proposal {
             assert_eq!(proposal, *previous);
         }
+    }
+
+    /// Returns the payload if this round is finalized.
+    /// If `allow_notarized` is true, falls back to a notarized payload.
+    fn payload(&self, allow_notarized: bool) -> Option<&D> {
+        if let Some(result) = self.finalized_payload() {
+            return Some(result);
+        }
+        allow_notarized.then(|| self.notarized_payload())?
+    }
+
+    /// Returns the payload if this round is finalized (via certificate or quorum of finalizes).
+    fn finalized_payload(&self) -> Option<&D> {
+        if let Some(finalization) = &self.finalization {
+            return Some(&finalization.proposal.payload);
+        }
+        let proposal = self.proposal.as_ref()?;
+        let quorum = self.scheme.participants().quorum() as usize;
+        if self.finalizes.len() >= quorum {
+            return Some(&proposal.payload);
+        }
+        None
+    }
+
+    /// Returns the payload if this round is notarized (via certificate or quorum of notarizes).
+    fn notarized_payload(&self) -> Option<&D> {
+        if let Some(notarization) = &self.notarization {
+            return Some(&notarization.proposal.payload);
+        }
+        let proposal = self.proposal.as_ref()?;
+        let quorum = self.scheme.participants().quorum() as usize;
+        if self.notarizes.len() >= quorum {
+            return Some(&proposal.payload);
+        }
+        None
+    }
+
+    /// Returns true if this round is nullified (via certificate or quorum of nullifies).
+    fn is_nullified(&self) -> bool {
+        let quorum = self.scheme.participants().quorum() as usize;
+        self.nullification.is_some() || self.nullifies.len() >= quorum
     }
 
     async fn add_verified_notarize(&mut self, notarize: Notarize<S, D>) {
@@ -250,7 +329,7 @@ impl<E: Clock, S: Scheme, D: Digest> Round<E, S, D> {
 
     async fn notarizable(&mut self, force: bool) -> Option<Notarization<S, D>> {
         // Ensure we haven't already broadcast
-        if !force && (self.broadcast_notarization || self.broadcast_nullification) {
+        if !force && self.broadcast_notarization {
             // We want to broadcast a notarization, even if we haven't yet verified a proposal.
             return None;
         }
@@ -279,7 +358,7 @@ impl<E: Clock, S: Scheme, D: Digest> Round<E, S, D> {
 
     async fn nullifiable(&mut self, force: bool) -> Option<Nullification<S>> {
         // Ensure we haven't already broadcast
-        if !force && (self.broadcast_nullification || self.broadcast_notarization) {
+        if !force && self.broadcast_nullification {
             return None;
         }
 
@@ -294,6 +373,13 @@ impl<E: Clock, S: Scheme, D: Digest> Round<E, S, D> {
         if self.nullifies.len() < quorum {
             return None;
         }
+
+        // It is not possible to have a nullification if there is a finalization.
+        // If detected, there is a critical bug or there has been a safety violation.
+        assert!(
+            self.finalization.is_none(),
+            "finalization should not be set"
+        );
 
         // Construct nullification
         let mut timer = self.recover_latency.timer();
@@ -324,8 +410,15 @@ impl<E: Clock, S: Scheme, D: Digest> Round<E, S, D> {
             return None;
         }
 
-        // It is not possible to have a finalization that does not match the notarization proposal. If this
-        // is detected, there is a critical bug or there has been a safety violation.
+        // It is not possible to have a finalization if there is a nullification.
+        // If detected, there is a critical bug or there has been a safety violation.
+        assert!(
+            self.nullification.is_none(),
+            "nullification should not be set"
+        );
+
+        // It is not possible to have a finalization that does not match the notarization proposal.
+        // If detected, there is a critical bug or there has been a safety violation.
         if let Some(notarization) = &self.notarization {
             let proposal = self.proposal.as_ref().unwrap();
             assert_eq!(
@@ -421,6 +514,7 @@ pub struct Actor<
     notarization_latency: Histogram,
     finalization_latency: Histogram,
     recover_latency: histogram::Timed<E>,
+    certification_candidates: BTreeSet<View>,
 }
 
 impl<
@@ -523,6 +617,7 @@ impl<
                 notarization_latency,
                 finalization_latency,
                 recover_latency: histogram::Timed::new(recover_latency, clock),
+                certification_candidates: BTreeSet::new(),
             },
             mailbox,
         )
@@ -543,41 +638,40 @@ impl<
         scheme.me().map(|me| me == other).unwrap_or(false)
     }
 
+    /// Helper function to get the payload for a given view.
+    ///
+    /// Runs the provided function to determine if a notarized (but not finalized) payload should
+    /// still be returned.
+    fn payload_for_view(&self, view: View, allow_uncertified: bool) -> Option<&D> {
+        // Special case for genesis view
+        if view == GENESIS_VIEW {
+            return Some(self.genesis.as_ref().unwrap());
+        }
+
+        // Get the round and determine if we should allow a notarized payload
+        let round = self.views.get(&view)?;
+        let allow_notarized = allow_uncertified || matches!(round.certified_proposal, Some(true));
+        round.payload(allow_notarized)
+    }
+
+    /// Returns the payload of the notarized proposal for the given view.
     fn is_notarized(&self, view: View) -> Option<&D> {
-        let round = self.views.get(&view)?;
-        if let Some(notarization) = &round.notarization {
-            return Some(&notarization.proposal.payload);
-        }
-        let proposal = round.proposal.as_ref()?;
-        let quorum = self.scheme.participants().quorum() as usize;
-        if round.notarizes.len() >= quorum {
-            return Some(&proposal.payload);
-        }
-        None
+        self.payload_for_view(view, true)
     }
 
+    /// Returns the payload of the certified proposal for the given view.
+    fn is_certified(&self, view: View) -> Option<&D> {
+        self.payload_for_view(view, false)
+    }
+
+    /// Returns `true` if the view has a nullification, otherwise `false`.
     fn is_nullified(&self, view: View) -> bool {
-        let round = match self.views.get(&view) {
-            Some(round) => round,
-            None => return false,
-        };
-        let quorum = self.scheme.participants().quorum() as usize;
-        round.nullification.is_some() || round.nullifies.len() >= quorum
+        self.views.get(&view).is_some_and(|r| r.is_nullified())
     }
 
-    fn is_finalized(&self, view: View) -> Option<&D> {
-        let round = self.views.get(&view)?;
-        if let Some(finalization) = &round.finalization {
-            return Some(&finalization.proposal.payload);
-        }
-        let proposal = round.proposal.as_ref()?;
-        let quorum = self.scheme.participants().quorum() as usize;
-        if round.finalizes.len() >= quorum {
-            return Some(&proposal.payload);
-        }
-        None
-    }
-
+    /// Returns the `(view, payload)` tuple of the highest view below `self.view` that is either
+    /// finalized or both notarized and certified. The view must also have nullifications for all
+    /// views between it and `self.view` (exclusive). If no such view exists, returns an error.
     fn find_parent(&self) -> Result<(View, D), View> {
         let mut cursor = self.view - 1; // self.view always at least 1
         loop {
@@ -585,16 +679,9 @@ impl<
                 return Ok((GENESIS_VIEW, *self.genesis.as_ref().unwrap()));
             }
 
-            // If have notarization, return
-            let parent = self.is_notarized(cursor);
-            if let Some(parent) = parent {
-                return Ok((cursor, *parent));
-            }
-
-            // If have finalization, return
-            //
-            // We never want to build on some view less than finalized and this prevents that
-            let parent = self.is_finalized(cursor);
+            // If certified, return.
+            // This means that the parent is either 1) finalized or 2) notarized and certified.
+            let parent = self.is_certified(cursor);
             if let Some(parent) = parent {
                 return Ok((cursor, *parent));
             }
@@ -610,11 +697,10 @@ impl<
         }
     }
 
-    #[allow(clippy::question_mark)]
     async fn propose(
         &mut self,
         resolver: &mut resolver::Mailbox<S, D>,
-    ) -> Option<(Context<D, P>, oneshot::Receiver<D>)> {
+    ) -> Option<Request<D, P, D>> {
         // Check if we are leader
         let round = self.views.get_mut(&self.view).unwrap();
         let leader = round.leader?;
@@ -662,7 +748,8 @@ impl<
                 .clone(),
             parent: (parent_view, parent_payload),
         };
-        Some((context.clone(), self.automaton.propose(context).await))
+        let receiver = self.automaton.propose(context.clone()).await;
+        Some(Request(context, receiver))
     }
 
     fn timeout_deadline(&mut self) -> SystemTime {
@@ -709,6 +796,8 @@ impl<
         // If retry, broadcast notarization that led us to enter this view
         let past_view = self.view - 1;
         if retry && past_view > 0 {
+            let mut did_broadcast = false;
+            // If we have a previous finalization, broadcast it
             if let Some(finalization) = self.construct_finalization(past_view, true).await {
                 self.outbound_messages
                     .get_or_create(metrics::Outbound::finalization())
@@ -719,33 +808,45 @@ impl<
                     .await
                     .unwrap();
                 debug!(view = past_view, "rebroadcast entry finalization");
-            } else if let Some(notarization) = self.construct_notarization(past_view, true).await {
-                self.outbound_messages
-                    .get_or_create(metrics::Outbound::notarization())
-                    .inc();
-                let msg = Voter::Notarization(notarization);
-                recovered_sender
-                    .send(Recipients::All, msg, true)
-                    .await
-                    .unwrap();
-                debug!(view = past_view, "rebroadcast entry notarization");
-            } else if let Some(nullification) = self.construct_nullification(past_view, true).await
-            {
-                self.outbound_messages
-                    .get_or_create(metrics::Outbound::nullification())
-                    .inc();
-                let msg = Voter::Nullification(nullification);
-                recovered_sender
-                    .send(Recipients::All, msg, true)
-                    .await
-                    .unwrap();
-                debug!(view = past_view, "rebroadcast entry nullification");
-            } else {
-                warn!(
-                    current = self.view,
-                    "unable to rebroadcast entry notarization/nullification/finalization"
-                );
+                did_broadcast = true;
             }
+
+            // If we haven't broadcast a finalization, broadcast any other certificates.
+            // If we have both a notarization and a nullification, we will broadcast both.
+            if !did_broadcast {
+                // If we have a previous notarization, broadcast it.
+                // The payload may not be certified.
+                if let Some(notarization) = self.construct_notarization(past_view, true).await {
+                    self.outbound_messages
+                        .get_or_create(metrics::Outbound::notarization())
+                        .inc();
+                    let msg = Voter::Notarization(notarization);
+                    recovered_sender
+                        .send(Recipients::All, msg, true)
+                        .await
+                        .unwrap();
+                    debug!(view = past_view, "rebroadcast entry notarization");
+                    did_broadcast = true;
+                }
+
+                // If we have a previous nullification, broadcast it
+                if let Some(nullification) = self.construct_nullification(past_view, true).await {
+                    self.outbound_messages
+                        .get_or_create(metrics::Outbound::nullification())
+                        .inc();
+                    let msg = Voter::Nullification(nullification);
+                    recovered_sender
+                        .send(Recipients::All, msg, true)
+                        .await
+                        .unwrap();
+                    debug!(view = past_view, "rebroadcast entry nullification");
+                    did_broadcast = true;
+                }
+            }
+
+            // Log if we were unable to rebroadcast any certificates
+            (!did_broadcast)
+                .then(|| warn!(view = self.view, "unable to rebroadcast entry certificate"));
         }
 
         // Construct nullify
@@ -825,8 +926,7 @@ impl<
     }
 
     // Attempt to set proposal from each message received over the wire
-    #[allow(clippy::question_mark)]
-    async fn peer_proposal(&mut self) -> Option<(Context<D, P>, oneshot::Receiver<bool>)> {
+    async fn peer_proposal(&mut self) -> Option<Request<D, P, bool>> {
         // Get round
         let (proposal, leader) = {
             // Get view or exit
@@ -853,9 +953,7 @@ impl<
             }
 
             // Check if leader has signed a digest
-            let Some(ref proposal) = round.proposal else {
-                return None;
-            };
+            let proposal = round.proposal.as_ref()?;
 
             // Sanity-check the epoch is correct. It should have already been checked.
             assert_eq!(proposal.epoch(), self.epoch, "proposal epoch mismatch");
@@ -882,24 +980,14 @@ impl<
         };
 
         // Ensure we have required notarizations
-        let mut cursor = match self.view {
-            0 => {
-                return None;
-            }
-            _ => self.view - 1,
-        };
+        let mut cursor = self.view.checked_sub(1)?;
         let parent_payload = loop {
             if cursor == proposal.parent {
-                // Check if first block
-                if proposal.parent == GENESIS_VIEW {
-                    break self.genesis.as_ref().unwrap();
-                }
-
-                // Check notarization exists
-                let parent_proposal = match self.is_notarized(cursor) {
+                // Check notarization and certification exist
+                let parent_proposal = match self.is_certified(cursor) {
                     Some(parent) => parent,
                     None => {
-                        debug!(view = cursor, "parent proposal is not notarized");
+                        debug!(view = cursor, "parent proposal is not certified");
                         return None;
                     }
                 };
@@ -935,12 +1023,65 @@ impl<
         let payload = proposal.payload;
         let round = self.views.get_mut(&context.view()).unwrap();
         round.requested_proposal_verify = true;
-        Some((
-            context.clone(),
-            self.automaton.verify(context, payload).await,
-        ))
+        let receiver = self.automaton.verify(context.clone(), payload).await;
+        Some(Request(context, receiver))
     }
 
+    async fn certify(
+        &mut self,
+        view: View,
+        resolver: &mut resolver::Mailbox<S, D>,
+    ) -> Option<Request<D, P, bool>> {
+        let round = self.views.get_mut(&view)?;
+        let leader = round.leader?;
+
+        // Request certification only once
+        if round.certify_handle.is_some() || round.certified_proposal.is_some() {
+            return None;
+        }
+
+        // Request certification only if we have a notarization
+        round.notarization.as_ref()?;
+
+        // Get the proposal
+        let proposal = round
+            .proposal
+            .clone()
+            .expect("notarized proposal should have a proposal");
+
+        // Get the context for the proposal.
+        let parent_view = proposal.parent;
+        // Since we have a notarization, the parent does not need to be certified by us. It is
+        // implicitly certified by the fact that participants notarized the current proposal.
+        let Some(parent_payload) = self.is_notarized(parent_view) else {
+            // However, if the parent is not notarized, then we cannot be sure what the parent is.
+            // We should attempt to fetch its notarization and to certify this view later.
+            resolver.fetch(vec![parent_view], vec![]).await;
+            self.certification_candidates.insert(view);
+            return None;
+        };
+        let context = Context {
+            round: proposal.round,
+            leader: self
+                .scheme
+                .participants()
+                .key(leader)
+                .expect("leader not found")
+                .clone(),
+            parent: (parent_view, *parent_payload),
+        };
+
+        // Request certification.
+        let receiver = self
+            .automaton
+            .certify(context.clone(), proposal.payload)
+            .await;
+
+        // Return request. We'll store the handle when pushing to the pool.
+        Some(Request(context, receiver))
+    }
+
+    /// Handles the successful verification of a proposal.
     async fn verified(&mut self, view: View) -> bool {
         // Check if view still relevant
         let round = match self.views.get_mut(&view) {
@@ -967,6 +1108,45 @@ impl<
         // Indicate that verification is done
         debug!(round=?round.round, proposal=?round.proposal, "verified proposal");
         true
+    }
+
+    /// Handles the successful certification of a proposal.
+    async fn certified(&mut self, view: View, success: bool) {
+        // If the view has been pruned, skip safely.
+        let Some(round) = self.views.get_mut(&view) else {
+            debug!(view, reason = "view missing", "dropping certified result");
+            return;
+        };
+
+        // Mark proposal as certified
+        round.certified_proposal = Some(success);
+
+        // Persist certification result for recovery
+        if let Some(journal) = self.journal.as_mut() {
+            let msg = Voter::Certification(Rnd::new(self.epoch, view), success);
+            journal
+                .append(view, msg)
+                .await
+                .expect("unable to append to journal");
+        }
+
+        // Log the result and exit early if certification failed since we should not move to the
+        // next view until a nullification is formed.
+        debug!(certified = ?success, view, "certify result");
+        if !success {
+            return;
+        }
+
+        // Enter next view. We should have a notarization for this view,
+        // otherwise we would not have asked for certification in the first place.
+        let notarization = round
+            .notarization
+            .as_ref()
+            .expect("certified proposal should have a notarization");
+        let seed = self
+            .scheme
+            .seed(notarization.round(), &notarization.certificate);
+        self.enter_view(view + 1, seed);
     }
 
     fn since_view_start(&self, view: u64) -> Option<(bool, f64)> {
@@ -1094,15 +1274,14 @@ impl<
         // Get view for notarization
         let view = notarization.view();
 
-        // Store notarization
-        let msg = Voter::Notarization(notarization.clone());
-        let seed = self
-            .scheme
-            .seed(notarization.round(), &notarization.certificate);
-
         // Create round (if it doesn't exist) and add verified notarization
-        if self.round_mut(view).add_verified_notarization(notarization) {
+        if self
+            .round_mut(view)
+            .add_verified_notarization(notarization.clone())
+        {
             if let Some(journal) = self.journal.as_mut() {
+                // Store notarization
+                let msg = Voter::Notarization(notarization);
                 journal
                     .append(view, msg)
                     .await
@@ -1110,8 +1289,10 @@ impl<
             }
         }
 
-        // Enter next view
-        self.enter_view(view + 1, seed);
+        // Record that this view may be eligible for certification.
+        self.certification_candidates.insert(view);
+
+        // Do not yet move to the next view, we need to wait for certification.
     }
 
     async fn nullification(&mut self, nullification: Nullification<S>) -> Action {
@@ -1291,6 +1472,10 @@ impl<
         // Determine if it makes sense to broadcast a finalize
         let round = self.views.get_mut(&view)?;
         if round.broadcast_nullify {
+            return None;
+        }
+        if round.certified_proposal != Some(true) {
+            // Ensure the proposal has been certified as safe to finalize
             return None;
         }
         if !round.broadcast_notarize {
@@ -1676,6 +1861,9 @@ impl<
                         let round = self.views.get_mut(&view).expect("missing round");
                         round.broadcast_finalization = true;
                     }
+                    Voter::Certification(_round, success) => {
+                        self.certified(view, success).await;
+                    }
                 }
             }
         }
@@ -1705,48 +1893,55 @@ impl<
             .update(observed_view, leader, self.last_finalized)
             .await;
 
+        // Seed candidates with currently tracked views.
+        self.certification_candidates = self.views.keys().copied().collect();
+
         // Create shutdown tracker
         let mut shutdown = self.context.stopped();
 
         // Process messages
-        let mut pending_set = None;
-        let mut pending_propose_context = None;
-        let mut pending_propose = None;
-        let mut pending_verify_context = None;
-        let mut pending_verify = None;
+        let mut prev_view: View = self.view;
+        let mut pending_propose: Option<Request<D, P, D>> = None;
+        let mut pending_verify: Option<Request<D, P, bool>> = None;
+        let mut certify_pool: AbortablePool<(Context<D, P>, Result<bool, oneshot::Canceled>)> =
+            Default::default();
         loop {
-            // Reset pending set if we have moved to a new view
-            if let Some(view) = pending_set {
-                if view != self.view {
-                    pending_set = None;
-                    pending_propose_context = None;
-                    pending_propose = None;
-                    pending_verify_context = None;
-                    pending_verify = None;
+            // Drop any pending items if we have moved to a new view
+            if prev_view != self.view {
+                pending_propose = None;
+                pending_verify = None;
+                prev_view = self.view;
+            }
+
+            // If needed, propose a container
+            if pending_propose.is_none() {
+                pending_propose = self.propose(&mut resolver).await;
+            }
+
+            // If needed, verify current view
+            if pending_verify.is_none() {
+                pending_verify = self.peer_proposal().await;
+            }
+
+            // Drain pending certifications triggered by notarizations
+            let candidates = take(&mut self.certification_candidates)
+                .into_iter()
+                .collect::<Vec<_>>();
+            for v in candidates {
+                if let Some(Request(ctx, receiver)) = self.certify(v, &mut resolver).await {
+                    let view = ctx.view();
+                    let handle = certify_pool.push(async move { (ctx, receiver.await) });
+                    self.views
+                        .get_mut(&view)
+                        .expect("missing round")
+                        .certify_handle = Some(handle);
                 }
             }
 
-            // Attempt to propose a container
-            if let Some((context, new_propose)) = self.propose(&mut resolver).await {
-                pending_set = Some(self.view);
-                pending_propose_context = Some(context);
-                pending_propose = Some(new_propose);
-            }
-            let propose_wait = match &mut pending_propose {
-                Some(propose) => Either::Left(propose),
-                None => Either::Right(futures::future::pending()),
-            };
-
-            // Attempt to verify current view
-            if let Some((context, new_verify)) = self.peer_proposal().await {
-                pending_set = Some(self.view);
-                pending_verify_context = Some(context);
-                pending_verify = Some(new_verify);
-            }
-            let verify_wait = match &mut pending_verify {
-                Some(verify) => Either::Left(verify),
-                None => Either::Right(futures::future::pending()),
-            };
+            // Prepare waiters
+            let propose_wait = Waiter(&mut pending_propose);
+            let verify_wait = Waiter(&mut pending_verify);
+            let certify_wait = certify_pool.next_completed();
 
             // Wait for a timeout to fire or for a message to arrive
             let timeout = self.timeout_deadline();
@@ -1768,9 +1963,8 @@ impl<
                     self.timeout(&mut batcher, &mut pending_sender, &mut recovered_sender).await;
                     view = self.view;
                 },
-                proposed = propose_wait => {
+                (context, proposed) = propose_wait => {
                     // Clear propose waiter
-                    let context = pending_propose_context.take().unwrap();
                     pending_propose = None;
 
                     // Try to use result
@@ -1805,18 +1999,16 @@ impl<
                     // Notify application of proposal
                     self.relay.broadcast(proposed).await;
                 },
-                verified = verify_wait => {
+                (context, verified) = verify_wait => {
                     // Clear verify waiter
-                    let context = pending_verify_context.take().unwrap();
                     pending_verify = None;
 
                     // Try to use result
                     match verified {
-                        Ok(verified) => {
-                            if !verified {
-                                debug!(round = ?context.round, "proposal failed verification");
-                                continue;
-                            }
+                        Ok(true) => {},
+                        Ok(false) => {
+                            debug!(round = ?context.round, "proposal failed verification");
+                            continue;
                         },
                         Err(err) => {
                             debug!(?err, round = ?context.round, "failed to verify proposal");
@@ -1829,6 +2021,32 @@ impl<
                     if !self.verified(view).await {
                         continue;
                     }
+                },
+                result = certify_wait => {
+                    // Aborted futures are expected when old views are pruned.
+                    let Ok((context, certified)) = result else {
+                        continue;
+                    };
+
+                    // Handle response to our certification request.
+                    view = context.view();
+                    match certified {
+                        Ok(certified) => {
+                            self.certified(view, certified).await;
+                        }
+                        Err(err) => {
+                            debug!(
+                                ?err,
+                                round = ?context.round,
+                                "failed to certify proposal"
+                            );
+                            // Retry certification
+                            if let Some(round) = self.views.get_mut(&view) {
+                                round.certify_handle = None;
+                            }
+                            self.certification_candidates.insert(view);
+                        }
+                    };
                 },
                 mailbox = self.mailbox_receiver.next() => {
                     // Extract message
@@ -1876,7 +2094,7 @@ impl<
                             trace!(view, "received nullification from resolver");
                             self.handle_nullification(nullification).await;
                         },
-                        Voter::Finalization(_) => {
+                        Voter::Finalization(_) | Voter::Certification(_, _)=> {
                             unreachable!("unexpected message type");
                         }
                     }
@@ -1925,7 +2143,7 @@ impl<
                                 .inc();
                             self.finalization(finalization).await
                         }
-                        Voter::Notarize(_) | Voter::Nullify(_) | Voter::Finalize(_) => {
+                        Voter::Notarize(_) | Voter::Nullify(_) | Voter::Finalize(_) | Voter::Certification(_, _) => {
                             warn!(?sender, "blocking peer for invalid message type");
                             self.blocker.block(sender).await;
                             continue;

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -990,18 +990,18 @@ impl<
         let mut missing_notarizations = None;
         let mut missing_nullifications = None;
 
-        // If the leader is not set, we need the seed for this round. If the parent view is not
-        // the previous view, then a nullification is missing.
-        let leader_opt = self.get_leader(self.view);
+        // If the leader is not set, we need the seed for this round.
+        let leader_opt = self.get_leader(view);
         if leader_opt.is_none() {
+            // If the parent view is not the previous view, then a nullification is missing.
             let prev_view = view - 1;
             if parent_view != prev_view {
                 missing_nullifications = Some(prev_view);
             }
         }
 
-        // Fetch the parent notarization if we don't have it. We need to guarantee the parent
-        // payload in order to certify this view.
+        // The context requires the parent payload. Since the notarization contains only the parent
+        // view, fetch the parent notarization to know what the parent payload is for-sure.
         let parent_payload_opt = self.is_notarized(parent_view).copied();
         if parent_payload_opt.is_none() {
             missing_notarizations = Some(parent_view);

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -986,11 +986,27 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_unclean_shutdown() {
+    fn test_unclean_shutdown_bls12381_threshold_min_pk() {
         unclean_shutdown(bls12381_threshold::<MinPk, _>);
+    }
+
+    #[test_traced]
+    fn test_unclean_shutdown_bls12381_threshold_min_sig() {
         unclean_shutdown(bls12381_threshold::<MinSig, _>);
+    }
+
+    #[test_traced]
+    fn test_unclean_shutdown_bls12381_multisig_min_pk() {
         unclean_shutdown(bls12381_multisig::<MinPk, _>);
+    }
+
+    #[test_traced]
+    fn test_unclean_shutdown_bls12381_multisig_min_sig() {
         unclean_shutdown(bls12381_multisig::<MinSig, _>);
+    }
+
+    #[test_traced]
+    fn test_unclean_shutdown_ed25519() {
         unclean_shutdown(ed25519);
     }
 
@@ -1005,7 +1021,7 @@ mod tests {
         let activity_timeout = 10;
         let skip_timeout = 5;
         let namespace = b"consensus".to_vec();
-        let executor = deterministic::Runner::timed(Duration::from_secs(720));
+        let executor = deterministic::Runner::timed(Duration::from_secs(240));
         executor.start(|mut context| async move {
             // Create simulated network
             let (network, mut oracle) = Network::new(
@@ -1138,7 +1154,7 @@ mod tests {
             .await;
 
             // Wait for nullifications to accrue
-            context.sleep(Duration::from_secs(120)).await;
+            context.sleep(Duration::from_secs(60)).await;
 
             // Unlink second peer from all (except first)
             link_validators(
@@ -1244,11 +1260,27 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_backfill() {
+    fn test_backfill_bls12381_threshold_min_pk() {
         backfill(bls12381_threshold::<MinPk, _>);
+    }
+
+    #[test_traced]
+    fn test_backfill_bls12381_threshold_min_sig() {
         backfill(bls12381_threshold::<MinSig, _>);
+    }
+
+    #[test_traced]
+    fn test_backfill_bls12381_multisig_min_pk() {
         backfill(bls12381_multisig::<MinPk, _>);
+    }
+
+    #[test_traced]
+    fn test_backfill_bls12381_multisig_min_sig() {
         backfill(bls12381_multisig::<MinSig, _>);
+    }
+
+    #[test_traced]
+    fn test_backfill_ed25519() {
         backfill(ed25519);
     }
 
@@ -2259,11 +2291,27 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_slow_and_lossy_links() {
+    fn test_slow_and_lossy_links_bls_threshold_minpk() {
         slow_and_lossy_links(0, bls12381_threshold::<MinPk, _>);
+    }
+
+    #[test_traced]
+    fn test_slow_and_lossy_links_bls_threshold_minsig() {
         slow_and_lossy_links(0, bls12381_threshold::<MinSig, _>);
+    }
+
+    #[test_traced]
+    fn test_slow_and_lossy_links_bls_multisig_minpk() {
         slow_and_lossy_links(0, bls12381_multisig::<MinPk, _>);
+    }
+
+    #[test_traced]
+    fn test_slow_and_lossy_links_bls_multisig_minsig() {
         slow_and_lossy_links(0, bls12381_multisig::<MinSig, _>);
+    }
+
+    #[test_traced]
+    fn test_slow_and_lossy_links_ed25519() {
         slow_and_lossy_links(0, ed25519);
     }
 

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -378,7 +378,10 @@ impl<S: Scheme, D: Digest> BatchVerifier<S, D> {
                     self.finalizes.push(finalize);
                 }
             }
-            Voter::Notarization(_) | Voter::Nullification(_) | Voter::Finalization(_) => {
+            Voter::Notarization(_)
+            | Voter::Nullification(_)
+            | Voter::Finalization(_)
+            | Voter::Certification(_, _) => {
                 unreachable!("should not be adding recovered messages to partial verifier");
             }
         }
@@ -695,6 +698,8 @@ pub enum Voter<S: Scheme, D: Digest> {
     Finalize(Finalize<S, D>),
     /// A recovered certificate for a finalization (scheme-specific)
     Finalization(Finalization<S, D>),
+    /// A local record indicating the proposal for this round was certified by the automaton
+    Certification(Round, bool),
 }
 
 impl<S: Scheme, D: Digest> Write for Voter<S, D> {
@@ -724,6 +729,11 @@ impl<S: Scheme, D: Digest> Write for Voter<S, D> {
                 5u8.write(writer);
                 v.write(writer);
             }
+            Voter::Certification(r, b) => {
+                6u8.write(writer);
+                r.write(writer);
+                b.write(writer);
+            }
         }
     }
 }
@@ -737,6 +747,7 @@ impl<S: Scheme, D: Digest> EncodeSize for Voter<S, D> {
             Voter::Nullification(v) => v.encode_size(),
             Voter::Finalize(v) => v.encode_size(),
             Voter::Finalization(v) => v.encode_size(),
+            Voter::Certification(r, b) => r.encode_size() + b.encode_size(),
         }
     }
 }
@@ -771,6 +782,11 @@ impl<S: Scheme, D: Digest> Read for Voter<S, D> {
                 let v = Finalization::read_cfg(reader, cfg)?;
                 Ok(Voter::Finalization(v))
             }
+            6 => {
+                let r = Round::read(reader)?;
+                let b = bool::read(reader)?;
+                Ok(Voter::Certification(r, b))
+            }
             _ => Err(Error::Invalid("consensus::simplex::Voter", "Invalid type")),
         }
     }
@@ -785,6 +801,7 @@ impl<S: Scheme, D: Digest> Epochable for Voter<S, D> {
             Voter::Nullification(v) => v.epoch(),
             Voter::Finalize(v) => v.epoch(),
             Voter::Finalization(v) => v.epoch(),
+            Voter::Certification(r, _) => r.epoch(),
         }
     }
 }
@@ -798,6 +815,7 @@ impl<S: Scheme, D: Digest> Viewable for Voter<S, D> {
             Voter::Nullification(v) => v.view(),
             Voter::Finalize(v) => v.view(),
             Voter::Finalization(v) => v.view(),
+            Voter::Certification(r, _) => r.view(),
         }
     }
 }


### PR DESCRIPTION
Fixes #1767 

Changes:
- Add `certify` function to the `Automaton` trait
  - A default implementation will return a `oneshot::Receiver<bool>` with `true` sent to it
- Modify the Simplex voter actor
  - Call `automaton.certify(...)` once any proposal is notarized
  - Do not move forward views on a notarized-but-not-certified (NbnC) proposal
  - Do not build on top of a NbnC proposal
  - Do-not-finalize a NbnC proposal
  - Do not allow future proposals to build on top of a NbnC proposal
  - Write (and read on startup) `certify()` results to disk
  - Immediately nullify a NbnC proposal (by timing-out that view)

TODO: cleanup and "matrixify" tests by testing with both always-certify and sometimes-certify tests