### PR TITLE
[reshare] Don't panic if `Dkg` message fails to decode

### DIFF
--- a/examples/reshare/src/dkg/manager.rs
+++ b/examples/reshare/src/dkg/manager.rs
@@ -351,16 +351,19 @@ where
         while let Some(msg) = self.receiver.recv().now_or_never() {
             let (peer, msg) = msg.expect("receiver closed");
 
-            let msg =
+            let Ok(msg) =
                 Dkg::<V, C::Signature>::decode_cfg(&mut msg.as_ref(), &(self.players.len() as u32))
-                    .unwrap();
+            else {
+                debug!(round, "failed to decode DKG message");
+                continue;
+            };
             if msg.round != round {
                 warn!(
                     round,
                     msg_round = msg.round,
                     "ignoring message for different round"
                 );
-                return;
+                continue;
             }
 
             match msg.payload {
@@ -374,18 +377,18 @@ where
                     }) = &mut self.dealer_meta
                     else {
                         warn!(round, "ignoring ack; not a dealer");
-                        return;
+                        continue;
                     };
 
                     // Verify index matches
                     let Some(player) = self.players.get(ack.player as usize) else {
                         warn!(round, index = ack.player, "invalid ack index");
-                        return;
+                        continue;
                     };
 
                     if player != &peer {
                         warn!(round, index = ack.player, "mismatched ack index");
-                        return;
+                        continue;
                     }
 
                     // Verify signature on incoming ack
@@ -397,13 +400,13 @@ where
                         commitment,
                     ) {
                         warn!(round, index = ack.player, "invalid ack signature");
-                        return;
+                        continue;
                     }
 
                     // Store ack
                     if let Err(e) = dealer.ack(peer) {
                         debug!(round, index = ack.player, error = ?e, "failed to store ack");
-                        return;
+                        continue;
                     }
                     info!(round, index = ack.player, "stored ack");
 
@@ -428,13 +431,13 @@ where
                 Payload::Share(Share { commitment, share }) => {
                     let Some((signer_index, ref mut player)) = self.player else {
                         warn!(round, "ignoring share; not a player");
-                        return;
+                        continue;
                     };
 
                     // Store share
                     if let Err(e) = player.share(peer.clone(), commitment.clone(), share.clone()) {
                         debug!(round, error = ?e, "failed to store share");
-                        return;
+                        continue;
                     }
 
                     // Persist the share to storage.


### PR DESCRIPTION
## Overview

Drops any `Dkg` messages that fail to decode in the `DkgManager`.

closes #1962 