### PR TITLE
[storage/mmr/bitmap] return error instead of panic if pruned chunks data is corrupt

### DIFF
--- a/storage/src/mmr/bitmap.rs
+++ b/storage/src/mmr/bitmap.rs
@@ -121,7 +121,7 @@ impl<H: CHasher, const N: usize> BitMap<H, N> {
         let pruned_chunks = match metadata.get(&key) {
             Some(bytes) => u64::from_be_bytes(bytes.as_slice().try_into().map_err(|_| {
                 error!("pruned chunks value not a valid u64");
-                Error::DataCorrupted("pruned chunks bytes not a valid u64".to_string())
+                Error::DataCorrupted("pruned chunks value not a valid u64")
             })?),
             None => {
                 warn!("bitmap metadata does not contain pruned chunks, initializing as empty");

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -138,5 +138,5 @@ pub enum Error {
     #[error("invalid pinned nodes")]
     InvalidPinnedNodes,
     #[error("data corrupted: {0}")]
-    DataCorrupted(String),
+    DataCorrupted(&'static str),
 }


### PR DESCRIPTION
Resolves https://github.com/commonwarexyz/monorepo/issues/1951