### PR TITLE
[consensus/simplex] Use enum for message type labels in metrics

### DIFF
--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -705,7 +705,7 @@ impl<
         if retry && past_view > 0 {
             if let Some(finalization) = self.construct_finalization(past_view, true).await {
                 self.outbound_messages
-                    .get_or_create(&metrics::FINALIZATION)
+                    .get_or_create(metrics::Outbound::finalization())
                     .inc();
                 let msg = Voter::Finalization(finalization);
                 recovered_sender
@@ -715,7 +715,7 @@ impl<
                 debug!(view = past_view, "rebroadcast entry finalization");
             } else if let Some(notarization) = self.construct_notarization(past_view, true).await {
                 self.outbound_messages
-                    .get_or_create(&metrics::NOTARIZATION)
+                    .get_or_create(metrics::Outbound::notarization())
                     .inc();
                 let msg = Voter::Notarization(notarization);
                 recovered_sender
@@ -726,7 +726,7 @@ impl<
             } else if let Some(nullification) = self.construct_nullification(past_view, true).await
             {
                 self.outbound_messages
-                    .get_or_create(&metrics::NULLIFICATION)
+                    .get_or_create(metrics::Outbound::nullification())
                     .inc();
                 let msg = Voter::Nullification(nullification);
                 recovered_sender
@@ -767,7 +767,7 @@ impl<
 
         // Broadcast nullify
         self.outbound_messages
-            .get_or_create(&metrics::NULLIFY)
+            .get_or_create(metrics::Outbound::nullify())
             .inc();
         let msg = Voter::Nullify(nullify);
         pending_sender
@@ -1321,7 +1321,7 @@ impl<
         if let Some(notarize) = self.construct_notarize(view) {
             // Handle the notarize
             self.outbound_messages
-                .get_or_create(&metrics::NOTARIZE)
+                .get_or_create(metrics::Outbound::notarize())
                 .inc();
             batcher.constructed(Voter::Notarize(notarize.clone())).await;
             self.handle_notarize(notarize.clone()).await;
@@ -1356,7 +1356,7 @@ impl<
 
             // Handle the notarization
             self.outbound_messages
-                .get_or_create(&metrics::NOTARIZATION)
+                .get_or_create(metrics::Outbound::notarization())
                 .inc();
             self.handle_notarization(notarization.clone()).await;
 
@@ -1390,7 +1390,7 @@ impl<
 
             // Handle the nullification
             self.outbound_messages
-                .get_or_create(&metrics::NULLIFICATION)
+                .get_or_create(metrics::Outbound::nullification())
                 .inc();
             self.handle_nullification(nullification.clone()).await;
 
@@ -1468,7 +1468,7 @@ impl<
         if let Some(finalize) = self.construct_finalize(view) {
             // Handle the finalize
             self.outbound_messages
-                .get_or_create(&metrics::FINALIZE)
+                .get_or_create(metrics::Outbound::finalize())
                 .inc();
             batcher.constructed(Voter::Finalize(finalize.clone())).await;
             self.handle_finalize(finalize.clone()).await;
@@ -1503,7 +1503,7 @@ impl<
 
             // Handle the finalization
             self.outbound_messages
-                .get_or_create(&metrics::FINALIZATION)
+                .get_or_create(metrics::Outbound::finalization())
                 .inc();
             self.handle_finalization(finalization.clone()).await;
 

--- a/consensus/src/simplex/metrics.rs
+++ b/consensus/src/simplex/metrics.rs
@@ -1,88 +1,105 @@
 use commonware_utils::Array;
-use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
 
-const NOTARIZE_TYPE: i32 = 1;
-const NOTARIZATION_TYPE: i32 = 2;
-const NULLIFY_TYPE: i32 = 3;
-const NULLIFICATION_TYPE: i32 = 4;
-const FINALIZE_TYPE: i32 = 5;
-const FINALIZATION_TYPE: i32 = 6;
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+pub enum MessageType {
+    Notarize,
+    Notarization,
+    Nullify,
+    Nullification,
+    Finalize,
+    Finalization,
+}
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct Outbound {
-    pub message: i32,
+    pub message: MessageType,
 }
 
-pub const NOTARIZE: Outbound = Outbound {
-    message: NOTARIZE_TYPE,
-};
+impl Outbound {
+    pub fn notarize() -> &'static Self {
+        &Self {
+            message: MessageType::Notarize,
+        }
+    }
 
-pub const NOTARIZATION: Outbound = Outbound {
-    message: NOTARIZATION_TYPE,
-};
+    pub fn notarization() -> &'static Self {
+        &Self {
+            message: MessageType::Notarization,
+        }
+    }
 
-pub const NULLIFY: Outbound = Outbound {
-    message: NULLIFY_TYPE,
-};
+    pub fn nullify() -> &'static Self {
+        &Self {
+            message: MessageType::Nullify,
+        }
+    }
 
-pub const NULLIFICATION: Outbound = Outbound {
-    message: NULLIFICATION_TYPE,
-};
+    pub fn nullification() -> &'static Self {
+        &Self {
+            message: MessageType::Nullification,
+        }
+    }
 
-pub const FINALIZE: Outbound = Outbound {
-    message: FINALIZE_TYPE,
-};
+    pub fn finalize() -> &'static Self {
+        &Self {
+            message: MessageType::Finalize,
+        }
+    }
 
-pub const FINALIZATION: Outbound = Outbound {
-    message: FINALIZATION_TYPE,
-};
+    pub fn finalization() -> &'static Self {
+        &Self {
+            message: MessageType::Finalization,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct Inbound {
     pub peer: String,
-    pub message: i32,
+    pub message: MessageType,
 }
 
 impl Inbound {
     pub fn notarize(peer: &impl Array) -> Self {
         Self {
             peer: peer.to_string(),
-            message: NOTARIZE_TYPE,
+            message: MessageType::Notarize,
         }
     }
 
     pub fn notarization(peer: &impl Array) -> Self {
         Self {
             peer: peer.to_string(),
-            message: NOTARIZATION_TYPE,
+            message: MessageType::Notarization,
         }
     }
 
     pub fn nullify(peer: &impl Array) -> Self {
         Self {
             peer: peer.to_string(),
-            message: NULLIFY_TYPE,
+            message: MessageType::Nullify,
         }
     }
 
     pub fn nullification(peer: &impl Array) -> Self {
         Self {
             peer: peer.to_string(),
-            message: NULLIFICATION_TYPE,
+            message: MessageType::Nullification,
         }
     }
 
     pub fn finalize(peer: &impl Array) -> Self {
         Self {
             peer: peer.to_string(),
-            message: FINALIZE_TYPE,
+            message: MessageType::Finalize,
         }
     }
 
     pub fn finalization(peer: &impl Array) -> Self {
         Self {
             peer: peer.to_string(),
-            message: FINALIZATION_TYPE,
+            message: MessageType::Finalization,
         }
     }
 }


### PR DESCRIPTION
Replaced raw `i32` constants with a proper `MessageType` enum in the simplex metrics module to improve discoverability. Also replaced public constants with static methods on `Outbound`.