### PR TITLE
[p2p] Accept `Set` in `Oracle::register`

### DIFF
--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -9,11 +9,11 @@ use crate::{
 pub use actor::Actor;
 use commonware_cryptography::PublicKey;
 use commonware_p2p::Blocker;
-use commonware_utils::set::Set;
+use commonware_utils::set::Ordered;
 pub use ingress::{Mailbox, Message};
 
 pub struct Config<P: PublicKey, S: Scheme, B: Blocker, R: Reporter> {
-    pub participants: Set<P>,
+    pub participants: Ordered<P>,
     pub scheme: S,
 
     pub blocker: B,

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -21,7 +21,6 @@ use commonware_p2p::{
     Blocker, Receiver, Recipients, Sender,
 };
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Metrics, Spawner};
-use commonware_utils::set::Set;
 use futures::{channel::mpsc, future::Either, StreamExt};
 use governor::clock::Clock as GClock;
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
@@ -152,8 +151,7 @@ impl<
             timeout: cfg.fetch_timeout,
         };
         let mut requester = requester::Requester::new(context.with_label("requester"), config);
-        let participants: Set<_> = cfg.participants.into_iter().collect();
-        requester.reconcile(participants.as_ref());
+        requester.reconcile(cfg.participants.as_ref());
 
         // Initialize metrics
         let unfulfilled = Gauge::default();

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -5,7 +5,7 @@ use crate::{simplex::signing_scheme::Scheme, types::Epoch};
 pub use actor::Actor;
 use commonware_cryptography::PublicKey;
 use commonware_p2p::Blocker;
-use commonware_utils::set::Set;
+use commonware_utils::set::Ordered;
 use governor::Quota;
 pub use ingress::Mailbox;
 #[cfg(test)]
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 pub struct Config<P: PublicKey, S: Scheme, B: Blocker> {
     pub me: P,
-    pub participants: Set<P>,
+    pub participants: Ordered<P>,
     pub scheme: S,
 
     pub blocker: B,

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -13,7 +13,7 @@ pub use actor::Actor;
 use commonware_cryptography::{Digest, PublicKey};
 use commonware_p2p::Blocker;
 use commonware_runtime::buffer::PoolRef;
-use commonware_utils::set::Set;
+use commonware_utils::set::Ordered;
 pub use ingress::{Mailbox, Message};
 use std::{num::NonZeroUsize, time::Duration};
 
@@ -27,7 +27,7 @@ pub struct Config<
     F: Reporter<Activity = Activity<S, D>>,
 > {
     pub me: P,
-    pub participants: Set<P>,
+    pub participants: Ordered<P>,
     pub scheme: S,
     pub blocker: B,
     pub automaton: A,

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -7,7 +7,7 @@ use crate::{
 use commonware_cryptography::{Digest, PublicKey};
 use commonware_p2p::Blocker;
 use commonware_runtime::buffer::PoolRef;
-use commonware_utils::set::Set;
+use commonware_utils::set::Ordered;
 use governor::Quota;
 use std::{num::NonZeroUsize, time::Duration};
 
@@ -26,7 +26,7 @@ pub struct Config<
 
     /// List of validators for the consensus engine, this is static for the
     /// lifetime of the engine (i.e. the epoch).
-    pub participants: Set<P>,
+    pub participants: Ordered<P>,
 
     /// Signing scheme for the consensus engine.
     ///

--- a/consensus/src/simplex/mocks/reporter.rs
+++ b/consensus/src/simplex/mocks/reporter.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use commonware_codec::{Decode, DecodeExt, Encode};
 use commonware_cryptography::{Digest, PublicKey};
-use commonware_utils::set::Set;
+use commonware_utils::set::Ordered;
 use futures::channel::mpsc::{Receiver, Sender};
 use rand::{CryptoRng, Rng};
 use std::{
@@ -32,7 +32,7 @@ type Faults<P, S, D> = HashMap<P, HashMap<View, HashSet<Activity<S, D>>>>;
 #[derive(Clone, Debug)]
 pub struct Config<P: PublicKey, S: Scheme> {
     pub namespace: Vec<u8>,
-    pub participants: Set<P>,
+    pub participants: Ordered<P>,
     pub scheme: S,
 }
 

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -8,7 +8,7 @@ use crate::{
 use bytes::{Buf, BufMut};
 use commonware_codec::{varint::UInt, EncodeSize, Error, Read, ReadExt, ReadRangeExt, Write};
 use commonware_cryptography::{Digest, PublicKey};
-use commonware_utils::{max_faults, quorum_from_slice, set::Set};
+use commonware_utils::{max_faults, quorum_from_slice, set::Ordered};
 use rand::{CryptoRng, Rng};
 use std::{collections::HashSet, fmt::Debug, hash::Hash, ops::Deref};
 
@@ -149,7 +149,7 @@ impl<S: Scheme> VoteVerification<S> {
 #[derive(Clone, Debug)]
 pub struct Participants<P: PublicKey> {
     /// Set of participants' public keys.
-    keys: Set<P>,
+    keys: Ordered<P>,
     /// Quorum (2f+1) computed from the participant set.
     quorum: u32,
     /// Maximum number of faults (f) tolerated by the participant set.
@@ -158,7 +158,7 @@ pub struct Participants<P: PublicKey> {
 
 impl<P: PublicKey> Participants<P> {
     /// Builds a new participant set from the provided keys.
-    pub fn new(keys: Set<P>) -> Self {
+    pub fn new(keys: Ordered<P>) -> Self {
         let quorum = quorum_from_slice(keys.as_ref());
         let max_faults = max_faults(keys.len() as u32);
 
@@ -198,8 +198,8 @@ impl<P: PublicKey> Deref for Participants<P> {
     }
 }
 
-impl<P: PublicKey> From<Set<P>> for Participants<P> {
-    fn from(keys: Set<P>) -> Self {
+impl<P: PublicKey> From<Ordered<P>> for Participants<P> {
+    fn from(keys: Ordered<P>) -> Self {
         Self::new(keys)
     }
 }

--- a/cryptography/src/bls12381/benches/dkg_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_recovery.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::{
     },
     ed25519, PrivateKeyExt as _, Signer as _,
 };
-use commonware_utils::{quorum, set::Set};
+use commonware_utils::{quorum, set::Ordered};
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{collections::BTreeMap, hint::black_box};
@@ -29,7 +29,7 @@ fn benchmark_dkg_recovery(c: &mut Criterion) {
                     // Create contributors
                     let contributors = (0..n)
                         .map(|i| ed25519::PrivateKey::from_seed(i as u64).public_key())
-                        .collect::<Set<_>>();
+                        .collect::<Ordered<_>>();
 
                     // Create player
                     let me = contributors[0].clone();

--- a/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
+++ b/cryptography/src/bls12381/benches/dkg_reshare_recovery.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::{
     },
     ed25519, PrivateKeyExt as _, Signer as _,
 };
-use commonware_utils::{quorum, set::Set};
+use commonware_utils::{quorum, set::Ordered};
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{collections::BTreeMap, hint::black_box};
@@ -27,7 +27,7 @@ fn benchmark_dkg_reshare_recovery(c: &mut Criterion) {
         // Create contributors
         let contributors = (0..n)
             .map(|i| ed25519::PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create players
         let mut players = Vec::with_capacity(n);

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -48,7 +48,7 @@ use crate::{
     },
     PublicKey,
 };
-use commonware_utils::{max_faults, quorum, set::Set};
+use commonware_utils::{max_faults, quorum, set::Ordered};
 use std::collections::{BTreeMap, HashSet};
 
 /// Output of the DKG/Resharing procedure.
@@ -71,8 +71,8 @@ pub struct Arbiter<P: PublicKey, V: Variant> {
     player_threshold: u32,
     concurrency: usize,
 
-    dealers: Set<P>,
-    players: Set<P>,
+    dealers: Ordered<P>,
+    players: Ordered<P>,
 
     #[allow(clippy::type_complexity)]
     commitments: BTreeMap<u32, (poly::Public<V>, Vec<u32>, Vec<Share>)>,
@@ -83,8 +83,8 @@ impl<P: PublicKey, V: Variant> Arbiter<P, V> {
     /// Create a new arbiter for a DKG/Resharing procedure.
     pub fn new(
         previous: Option<poly::Public<V>>,
-        dealers: Set<P>,
-        players: Set<P>,
+        dealers: Ordered<P>,
+        players: Ordered<P>,
         concurrency: usize,
     ) -> Self {
         Self {

--- a/cryptography/src/bls12381/dkg/dealer.rs
+++ b/cryptography/src/bls12381/dkg/dealer.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     PublicKey,
 };
-use commonware_utils::{quorum, set::Set};
+use commonware_utils::{quorum, set::Ordered};
 use rand_core::CryptoRngCore;
 use std::{collections::HashSet, marker::PhantomData};
 
@@ -16,17 +16,17 @@ use std::{collections::HashSet, marker::PhantomData};
 #[derive(Clone)]
 pub struct Output {
     /// List of active players.
-    pub active: Set<u32>,
+    pub active: Ordered<u32>,
 
     /// List of inactive players (that we need to send
     /// a reveal for).
-    pub inactive: Set<u32>,
+    pub inactive: Ordered<u32>,
 }
 
 /// Track acknowledgements from players.
 pub struct Dealer<P: PublicKey, V: Variant> {
     threshold: u32,
-    players: Set<P>,
+    players: Ordered<P>,
 
     acks: HashSet<u32>,
 
@@ -38,8 +38,8 @@ impl<P: PublicKey, V: Variant> Dealer<P, V> {
     pub fn new<R: CryptoRngCore>(
         rng: &mut R,
         share: Option<Share>,
-        players: Set<P>,
-    ) -> (Self, poly::Public<V>, Set<Share>) {
+        players: Ordered<P>,
+    ) -> (Self, poly::Public<V>, Ordered<Share>) {
         // Generate shares and commitment
         let players_len = players.len() as u32;
         let threshold = quorum(players_len);
@@ -90,8 +90,8 @@ impl<P: PublicKey, V: Variant> Dealer<P, V> {
             }
         }
         Some(Output {
-            active: Set::from_iter(active),
-            inactive: Set::from_iter(inactive),
+            active: Ordered::from_iter(active),
+            inactive: Ordered::from_iter(inactive),
         })
     }
 }

--- a/cryptography/src/bls12381/dkg/mod.rs
+++ b/cryptography/src/bls12381/dkg/mod.rs
@@ -227,7 +227,7 @@ mod tests {
         ed25519::{PrivateKey, PublicKey},
         PrivateKeyExt as _, Signer as _,
     };
-    use commonware_utils::{quorum, set::Set};
+    use commonware_utils::{quorum, set::Ordered};
     use rand::{rngs::StdRng, SeedableRng};
     use std::collections::{BTreeMap, HashMap};
 
@@ -240,7 +240,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, _, shares) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -272,7 +272,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -310,7 +310,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -352,7 +352,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -390,7 +390,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -423,7 +423,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -462,7 +462,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create invalid commitments
         let mut commitments = Vec::new();
@@ -508,7 +508,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -538,7 +538,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create arbiter
         let mut arb =
@@ -586,7 +586,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -624,7 +624,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -653,7 +653,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -690,7 +690,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -721,7 +721,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -750,7 +750,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -782,7 +782,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -815,7 +815,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -843,7 +843,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -871,7 +871,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (_, commitment, shares) =
@@ -904,7 +904,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (mut dealer, _, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -929,7 +929,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (mut dealer, _, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -954,7 +954,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (mut dealer, _, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -977,7 +977,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (mut dealer, _, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -1000,7 +1000,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create dealer
         let (mut dealer, _, _) = Dealer::<_, MinSig>::new(&mut rng, None, contributors.clone());
@@ -1021,7 +1021,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create player
         let mut player = Player::<_, MinSig>::new(
@@ -1063,7 +1063,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create player
         let mut player = Player::<_, MinSig>::new(
@@ -1102,7 +1102,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create player
         let mut player = Player::<_, MinSig>::new(
@@ -1139,7 +1139,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create player
         let mut player = Player::<_, MinSig>::new(
@@ -1182,7 +1182,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create player
         let mut player = Player::<_, MinSig>::new(
@@ -1224,7 +1224,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create player
         let mut player = Player::<_, MinSig>::new(
@@ -1269,7 +1269,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create player
         let mut player = Player::<_, MinSig>::new(
@@ -1320,7 +1320,7 @@ mod tests {
         // Create contributors (must be in sorted order)
         let contributors = (0..n)
             .map(|i| PrivateKey::from_seed(i as u64).public_key())
-            .collect::<Set<_>>();
+            .collect::<Ordered<_>>();
 
         // Create player
         let mut player = Player::<_, MinSig>::new(
@@ -1420,7 +1420,7 @@ mod tests {
             let mut rng = StdRng::seed_from_u64(self.seed);
             let mut current_public: Option<poly::Public<V>> = None;
             let mut participant_states: HashMap<PublicKey, player::Output<V>> = HashMap::new();
-            let mut share_holders: Option<Set<PublicKey>> = None;
+            let mut share_holders: Option<Ordered<PublicKey>> = None;
 
             // Process rounds
             for (round_idx, round) in self.rounds.iter().enumerate() {
@@ -1492,7 +1492,7 @@ mod tests {
                 let mut dealers = BTreeMap::new();
                 let mut dealer_outputs = BTreeMap::new();
                 let mut expected_reveals = BTreeMap::new();
-                let expected_inactive: Set<u32> = absent_players
+                let expected_inactive: Ordered<u32> = absent_players
                     .iter()
                     .map(|player_pk| player_set.position(player_pk).unwrap() as u32)
                     .collect();
@@ -1672,10 +1672,10 @@ mod tests {
     }
 
     // Compute the participant set from a list of IDs
-    fn participants(ids: &[u64]) -> Set<PublicKey> {
+    fn participants(ids: &[u64]) -> Ordered<PublicKey> {
         ids.iter()
             .map(|id| PrivateKey::from_seed(*id).public_key())
-            .collect::<Set<_>>()
+            .collect::<Ordered<_>>()
     }
 
     #[test]

--- a/cryptography/src/bls12381/dkg/player.rs
+++ b/cryptography/src/bls12381/dkg/player.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     PublicKey,
 };
-use commonware_utils::{quorum, set::Set};
+use commonware_utils::{quorum, set::Ordered};
 use std::collections::{btree_map::Entry, BTreeMap};
 
 /// Output of a DKG/Resharing procedure.
@@ -38,7 +38,7 @@ pub struct Player<P: PublicKey, V: Variant> {
     previous: Option<poly::Public<V>>,
     concurrency: usize,
 
-    dealers: Set<P>,
+    dealers: Ordered<P>,
 
     dealings: BTreeMap<u32, (poly::Public<V>, Share)>,
 }
@@ -48,8 +48,8 @@ impl<P: PublicKey, V: Variant> Player<P, V> {
     pub fn new(
         me: P,
         previous: Option<poly::Public<V>>,
-        dealers: Set<P>,
-        recipients: Set<P>,
+        dealers: Ordered<P>,
+        recipients: Ordered<P>,
         concurrency: usize,
     ) -> Self {
         let me_idx = recipients.position(&me).expect("player not in recipients") as u32;

--- a/examples/bridge/src/application/mod.rs
+++ b/examples/bridge/src/application/mod.rs
@@ -15,7 +15,7 @@ mod actor;
 pub use actor::Application;
 use commonware_runtime::{Sink, Stream};
 use commonware_stream::{Receiver, Sender};
-use commonware_utils::set::Set;
+use commonware_utils::set::Ordered;
 mod ingress;
 
 /// Configuration for the application.
@@ -30,7 +30,7 @@ pub struct Config<H: Hasher, Si: Sink, St: Stream, P: PublicKey> {
     pub other_public: <MinSig as Variant>::Public,
 
     /// Participants active in consensus.
-    pub participants: Set<P>,
+    pub participants: Ordered<P>,
 
     pub share: group::Share,
 

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -59,7 +59,7 @@ use clap::{value_parser, Arg, Command};
 use commonware_cryptography::{ed25519, PrivateKeyExt as _, Signer as _};
 use commonware_p2p::authenticated::discovery;
 use commonware_runtime::{tokio, Metrics, Runner as _};
-use commonware_utils::NZU32;
+use commonware_utils::{set::Ordered, NZU32};
 use governor::Quota;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -119,7 +119,6 @@ fn main() {
     info!(port, "loaded port");
 
     // Configure allowed peers
-    let mut recipients = Vec::new();
     let allowed_keys = matches
         .get_many::<u64>("friends")
         .expect("Please provide friends to chat with")
@@ -127,11 +126,14 @@ fn main() {
     if allowed_keys.len() == 0 {
         panic!("Please provide at least one friend");
     }
-    for peer in allowed_keys {
-        let verifier = ed25519::PrivateKey::from_seed(peer).public_key();
-        info!(key = ?verifier, "registered authorized key");
-        recipients.push(verifier);
-    }
+    let recipients = allowed_keys
+        .into_iter()
+        .map(|peer| {
+            let verifier = ed25519::PrivateKey::from_seed(peer).public_key();
+            info!(key = ?verifier, "registered authorized key");
+            verifier
+        })
+        .collect::<Ordered<_>>();
 
     // Configure bootstrappers (if provided)
     let bootstrappers = matches.get_many::<String>("bootstrappers");

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -8,7 +8,7 @@ use commonware_deployer::ec2::{Hosts, METRICS_PORT};
 use commonware_flood::Config;
 use commonware_p2p::{authenticated::discovery, Receiver, Recipients, Sender};
 use commonware_runtime::{tokio, Metrics, Runner, Spawner};
-use commonware_utils::{from_hex_formatted, union, NZU32};
+use commonware_utils::{from_hex_formatted, set::Ordered, union, NZU32};
 use futures::future::try_join_all;
 use governor::Quota;
 use prometheus_client::metrics::counter::Counter;
@@ -96,7 +96,7 @@ fn main() {
         );
 
         // Configure peers and bootstrappers
-        let peer_keys = peers.keys().cloned().collect::<Vec<_>>();
+        let peer_keys = peers.keys().cloned().collect::<Ordered<_>>();
         let mut bootstrappers = Vec::new();
         for bootstrapper in &config.bootstrappers {
             let key = from_hex_formatted(bootstrapper).expect("Could not parse bootstrapper key");

--- a/examples/log/src/application/mod.rs
+++ b/examples/log/src/application/mod.rs
@@ -6,7 +6,7 @@ use commonware_cryptography::{
     ed25519::{PrivateKey, PublicKey},
     Hasher,
 };
-use commonware_utils::set::Set;
+use commonware_utils::set::Ordered;
 
 mod actor;
 pub use actor::Application;
@@ -21,7 +21,7 @@ pub struct Config<H: Hasher> {
     pub hasher: H,
 
     /// Participants active in consensus.
-    pub participants: Set<PublicKey>,
+    pub participants: Ordered<PublicKey>,
 
     /// Our private key.
     pub private_key: PrivateKey,

--- a/examples/reshare/src/application/scheme.rs
+++ b/examples/reshare/src/application/scheme.rs
@@ -12,6 +12,7 @@ use commonware_cryptography::{
     ed25519, PublicKey, Signer,
 };
 use commonware_resolver::p2p;
+use commonware_utils::set::Ordered;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -123,11 +124,11 @@ impl EpochSchemeProvider for SchemeProvider<EdScheme, ed25519::PrivateKey> {
 
 #[derive(Clone)]
 pub struct Coordinator<P> {
-    pub participants: Vec<P>,
+    pub participants: Ordered<P>,
 }
 
 impl<P> Coordinator<P> {
-    pub fn new(participants: Vec<P>) -> Self {
+    pub fn new(participants: Ordered<P>) -> Self {
         Self { participants }
     }
 }

--- a/examples/reshare/src/orchestrator/actor.rs
+++ b/examples/reshare/src/orchestrator/actor.rs
@@ -26,7 +26,7 @@ use commonware_p2p::{
 use commonware_runtime::{
     buffer::PoolRef, spawn_cell, Clock, ContextCell, Handle, Metrics, Network, Spawner, Storage,
 };
-use commonware_utils::{set::Set, NZUsize, NZU32};
+use commonware_utils::{set::Ordered, NZUsize, NZU32};
 use futures::{channel::mpsc, StreamExt};
 use governor::{clock::Clock as GClock, Quota};
 use rand::{CryptoRng, Rng};
@@ -280,7 +280,7 @@ where
     async fn enter_epoch(
         &mut self,
         epoch: Epoch,
-        participants: Set<C::PublicKey>,
+        participants: Ordered<C::PublicKey>,
         scheme: S,
         pending_mux: &mut MuxHandle<
             impl Sender<PublicKey = C::PublicKey>,

--- a/examples/reshare/src/orchestrator/ingress.rs
+++ b/examples/reshare/src/orchestrator/ingress.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::{
     bls12381::primitives::{group, poly::Public, variant::Variant},
     PublicKey,
 };
-use commonware_utils::set::Set;
+use commonware_utils::set::Ordered;
 use futures::{channel::mpsc, SinkExt};
 
 /// Messages that can be sent to the orchestrator.
@@ -23,7 +23,7 @@ pub struct EpochTransition<V: Variant, P: PublicKey> {
     /// The share for the local participant for the epoch, if participating.
     pub share: Option<group::Share>,
     /// The new participants for the epoch.
-    pub participants: Set<P>,
+    pub participants: Ordered<P>,
 }
 
 /// Inbound communication channel for epoch transitions.

--- a/examples/reshare/src/setup.rs
+++ b/examples/reshare/src/setup.rs
@@ -13,7 +13,7 @@ use commonware_cryptography::{
     ed25519::{PrivateKey, PublicKey},
     PrivateKeyExt, Signer,
 };
-use commonware_utils::{from_hex, hex, quorum};
+use commonware_utils::{from_hex, hex, quorum, set::Ordered};
 use rand::{rngs::OsRng, seq::IteratorRandom};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -83,7 +83,7 @@ impl PeerConfig {
         quorum(self.num_participants_per_epoch)
     }
 
-    pub fn all_peers(&self) -> Vec<PublicKey> {
+    pub fn all_peers(&self) -> Ordered<PublicKey> {
         self.active
             .iter()
             .chain(self.inactive.iter())

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -167,7 +167,7 @@ mod test {
         deterministic::{self, Runner},
         Clock, Metrics, Runner as _, Spawner, Storage,
     };
-    use commonware_utils::{quorum, sequence::U64, union};
+    use commonware_utils::{quorum, sequence::U64, set::Ordered, union};
     use futures::channel::mpsc;
     use governor::Quota;
     use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -199,6 +199,7 @@ mod test {
         ),
     > {
         let mut registrations = HashMap::new();
+        let ordered_validators = validators.iter().cloned().collect::<Ordered<_>>();
         for validator in validators.iter() {
             let (pending_sender, pending_receiver) =
                 oracle.register(validator.clone(), 0).await.unwrap();
@@ -212,7 +213,7 @@ mod test {
             let (dkg_sender, dkg_receiver) = oracle.register(validator.clone(), 5).await.unwrap();
 
             // Create a static resolver for backfill
-            let coordinator = Coordinator::new(validators.to_vec());
+            let coordinator = Coordinator::new(ordered_validators.clone());
             let resolver_cfg = p2p_resolver::Config {
                 public_key: validator.clone(),
                 coordinator: coordinator.clone(),

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -10,7 +10,7 @@ use commonware_cryptography::{
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Spawner};
-use commonware_utils::set::Set;
+use commonware_utils::set::Ordered;
 use std::{
     collections::{BTreeMap, HashSet},
     time::Duration,
@@ -21,7 +21,7 @@ pub struct Arbiter<E: Clock + Spawner, C: PublicKey> {
     context: ContextCell<E>,
     dkg_frequency: Duration,
     dkg_phase_timeout: Duration,
-    contributors: Set<C>,
+    contributors: Ordered<C>,
 }
 
 /// Implementation of a "trusted arbiter" that tracks commitments,
@@ -31,7 +31,7 @@ impl<E: Clock + Spawner, C: PublicKey> Arbiter<E, C> {
         context: E,
         dkg_frequency: Duration,
         dkg_phase_timeout: Duration,
-        contributors: Set<C>,
+        contributors: Ordered<C>,
     ) -> Self {
         Self {
             context: ContextCell::new(context),

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -14,7 +14,7 @@ use commonware_cryptography::{
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Spawner};
-use commonware_utils::{quorum, set::Set};
+use commonware_utils::{quorum, set::Ordered};
 use futures::{channel::mpsc, SinkExt};
 use rand_core::CryptoRngCore;
 use std::time::Duration;
@@ -28,7 +28,7 @@ pub struct Contributor<E: Clock + CryptoRngCore + Spawner, C: Signer> {
     dkg_phase_timeout: Duration,
     arbiter: C::PublicKey,
     t: u32,
-    contributors: Set<C::PublicKey>,
+    contributors: Ordered<C::PublicKey>,
 
     corrupt: bool,
     lazy: bool,
@@ -44,7 +44,7 @@ impl<E: Clock + CryptoRngCore + Spawner, C: Signer> Contributor<E, C> {
         crypto: C,
         dkg_phase_timeout: Duration,
         arbiter: C::PublicKey,
-        contributors: Set<C::PublicKey>,
+        contributors: Ordered<C::PublicKey>,
         corrupt: bool,
         lazy: bool,
         forger: bool,

--- a/examples/vrf/src/main.rs
+++ b/examples/vrf/src/main.rs
@@ -85,7 +85,7 @@ use commonware_cryptography::{
 };
 use commonware_p2p::authenticated::discovery;
 use commonware_runtime::{tokio, Metrics, Runner};
-use commonware_utils::{quorum, set::Set, NZU32};
+use commonware_utils::{quorum, set::Ordered, NZU32};
 use governor::Quota;
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -178,7 +178,6 @@ fn main() {
     tracing::info!(port, "loaded port");
 
     // Configure allowed peers
-    let mut recipients = Vec::new();
     let participants = matches
         .get_many::<u64>("participants")
         .expect("Please provide allowed keys")
@@ -186,11 +185,14 @@ fn main() {
     if participants.len() == 0 {
         panic!("Please provide at least one participant");
     }
-    for peer in participants {
-        let verifier = PrivateKey::from_seed(peer).public_key();
-        tracing::info!(key = ?verifier, "registered authorized key",);
-        recipients.push(verifier);
-    }
+    let recipients = participants
+        .into_iter()
+        .map(|peer| {
+            let verifier = PrivateKey::from_seed(peer).public_key();
+            tracing::info!(key = ?verifier, "registered authorized key",);
+            verifier
+        })
+        .collect::<Ordered<_>>();
 
     // Configure bootstrappers (if provided)
     let bootstrappers = matches.get_many::<String>("bootstrappers");
@@ -269,7 +271,7 @@ fn main() {
                 signer,
                 DKG_PHASE_TIMEOUT,
                 arbiter,
-                Set::from_iter(contributors.clone()),
+                Ordered::from_iter(contributors.clone()),
                 corrupt,
                 lazy,
                 forger,
@@ -300,7 +302,7 @@ fn main() {
                 context.with_label("arbiter"),
                 DKG_FREQUENCY,
                 DKG_PHASE_TIMEOUT,
-                Set::from_iter(contributors),
+                Ordered::from_iter(contributors),
             );
             arbiter.start(arbiter_sender, arbiter_receiver);
         }

--- a/p2p/src/authenticated/discovery/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/actor.rs
@@ -249,7 +249,7 @@ mod tests {
         PrivateKeyExt as _, Signer,
     };
     use commonware_runtime::{deterministic, Clock, Runner};
-    use commonware_utils::{bitmap::BitMap, NZU32};
+    use commonware_utils::{bitmap::BitMap, set::Ordered, NZU32};
     use futures::future::Either;
     use governor::Quota;
     use std::{
@@ -380,7 +380,7 @@ mod tests {
                 mut mailbox,
                 ..
             } = setup_actor(context.clone(), cfg_initial);
-            let too_many_peers: Vec<PublicKey> = (1..=cfg.max_peer_set_size + 1)
+            let too_many_peers: Ordered<PublicKey> = (1..=cfg.max_peer_set_size + 1)
                 .map(|i| new_signer_and_pk(i).1)
                 .collect();
             oracle.register(0, too_many_peers).await;
@@ -433,7 +433,7 @@ mod tests {
 
             let (_auth_signer, auth_pk) = new_signer_and_pk(1);
             oracle
-                .register(0, vec![tracker_pk.clone(), auth_pk.clone()])
+                .register(0, Ordered::from_iter([tracker_pk.clone(), auth_pk.clone()]))
                 .await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -501,7 +501,9 @@ mod tests {
             } = setup_actor(context.clone(), cfg_initial);
 
             let (_, pk1) = new_signer_and_pk(1);
-            oracle.register(0, vec![tracker_pk, pk1.clone()]).await;
+            oracle
+                .register(0, Ordered::from_iter([tracker_pk, pk1.clone()]))
+                .await;
             context.sleep(Duration::from_millis(10)).await;
 
             let (peer_mailbox_pk1, mut peer_receiver_pk1) = Mailbox::new(1);
@@ -540,7 +542,7 @@ mod tests {
 
             let (_s1_signer, pk1) = new_signer_and_pk(1);
             oracle
-                .register(0, vec![tracker_pk.clone(), pk1.clone()])
+                .register(0, Ordered::from_iter([tracker_pk.clone(), pk1.clone()]))
                 .await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -574,7 +576,7 @@ mod tests {
 
             let (_s1_signer, pk1) = new_signer_and_pk(1);
             oracle
-                .register(0, vec![tracker_pk.clone(), pk1.clone()])
+                .register(0, Ordered::from_iter([tracker_pk.clone(), pk1.clone()]))
                 .await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -623,7 +625,7 @@ mod tests {
             let (mut s2_signer, pk2) = new_signer_and_pk(2);
 
             oracle
-                .register(0, vec![tracker_pk.clone(), pk1.clone()])
+                .register(0, Ordered::from_iter([tracker_pk.clone(), pk1.clone()]))
                 .await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -638,8 +640,7 @@ mod tests {
                 false,
             );
 
-            let mut set1 = vec![tracker_pk.clone(), pk1.clone(), pk2.clone()];
-            set1.sort();
+            let set1 = Ordered::from_iter([tracker_pk.clone(), pk1.clone(), pk2.clone()]);
             oracle.register(1, set1.clone()).await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -695,7 +696,8 @@ mod tests {
             let (_, pk1) = new_signer_and_pk(1);
             let (mut s2_signer, pk2) = new_signer_and_pk(2);
 
-            let peer_set_0_peers = vec![tracker_pk.clone(), pk1.clone(), pk2.clone()];
+            let peer_set_0_peers =
+                Ordered::from_iter([tracker_pk.clone(), pk1.clone(), pk2.clone()]);
             oracle.register(0, peer_set_0_peers.clone()).await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -732,14 +734,9 @@ mod tests {
             mailbox.peers(vec![pk2_info_older]);
             context.sleep(Duration::from_millis(10)).await;
 
-            let mut sorted_set0_peers = peer_set_0_peers.clone();
-            sorted_set0_peers.sort();
-            let mut knowledge_for_set0 = BitMap::zeroes(sorted_set0_peers.len() as u64);
-            let idx_tracker_in_set0 = sorted_set0_peers
-                .iter()
-                .position(|p| p == &tracker_pk)
-                .unwrap();
-            let idx_pk1_in_set0 = sorted_set0_peers.iter().position(|p| p == &pk1).unwrap();
+            let mut knowledge_for_set0 = BitMap::zeroes(peer_set_0_peers.len() as u64);
+            let idx_tracker_in_set0 = peer_set_0_peers.position(&tracker_pk).unwrap();
+            let idx_pk1_in_set0 = peer_set_0_peers.position(&pk1).unwrap();
             knowledge_for_set0.set(idx_tracker_in_set0 as u64, true);
             knowledge_for_set0.set(idx_pk1_in_set0 as u64, true);
 
@@ -781,7 +778,7 @@ mod tests {
             assert!(!mailbox.listenable(peer_pk3.clone()).await);
 
             oracle
-                .register(0, vec![peer_pk.clone(), peer_pk2.clone()])
+                .register(0, Ordered::from_iter([peer_pk.clone(), peer_pk2.clone()]))
                 .await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -810,7 +807,9 @@ mod tests {
             let reservation = mailbox.listen(peer_pk.clone()).await;
             assert!(reservation.is_none());
 
-            oracle.register(0, vec![peer_pk.clone()]).await;
+            oracle
+                .register(0, Ordered::from_iter([peer_pk.clone()]))
+                .await;
             context.sleep(Duration::from_millis(10)).await; // Allow register to process
 
             assert!(mailbox.listenable(peer_pk.clone()).await);
@@ -894,7 +893,10 @@ mod tests {
             let (_s1, pk1) = new_signer_and_pk(1);
             let (_s2, pk2) = new_signer_and_pk(2);
             oracle
-                .register(0, vec![tracker_pk, pk1.clone(), pk2.clone()])
+                .register(
+                    0,
+                    Ordered::from_iter([tracker_pk, pk1.clone(), pk2.clone()]),
+                )
                 .await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -937,8 +939,8 @@ mod tests {
             );
 
             // --- Register set 0, then Construct for authorized peer1 ---
-            let mut set0_peers = vec![tracker_pk.clone(), peer1_pk.clone(), peer2_pk.clone()];
-            set0_peers.sort(); // Directory expects sorted, Oracle also benefits
+            let set0_peers =
+                Ordered::from_iter([tracker_pk.clone(), peer1_pk.clone(), peer2_pk.clone()]);
             oracle.register(0, set0_peers.clone()).await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -1007,13 +1009,11 @@ mod tests {
 
             // --- Set eviction and peer killing ---
             let (_peer3_s, peer3_pk) = new_signer_and_pk(3);
-            let mut set1_peers = vec![tracker_pk.clone(), peer2_pk.clone()]; // New set without peer1
-            set1_peers.sort();
+            let set1_peers = Ordered::from_iter([tracker_pk.clone(), peer2_pk.clone()]); // New set without peer1
             oracle.register(1, set1_peers.clone()).await;
             context.sleep(Duration::from_millis(10)).await;
 
-            let mut set2_peers = vec![tracker_pk.clone(), peer3_pk.clone()]; // Another new set without peer1
-            set2_peers.sort();
+            let set2_peers = Ordered::from_iter([tracker_pk.clone(), peer3_pk.clone()]); // Another new set without peer1
             oracle.register(2, set2_peers.clone()).await; // This should evict set 0 (max_sets = 2)
             context.sleep(Duration::from_millis(10)).await;
 

--- a/p2p/src/authenticated/discovery/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/directory.rs
@@ -6,7 +6,7 @@ use crate::authenticated::discovery::{
 };
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Clock, Metrics as RuntimeMetrics, Spawner};
-use commonware_utils::SystemTimeExt;
+use commonware_utils::{set::Ordered, SystemTimeExt};
 use governor::{
     clock::Clock as GClock, middleware::NoOpMiddleware, state::keyed::HashMapStateStore, Quota,
     RateLimiter,
@@ -173,7 +173,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: PublicKey> Directory
     }
 
     /// Stores a new peer set.
-    pub fn add_set(&mut self, index: u64, peers: Vec<C>) {
+    pub fn add_set(&mut self, index: u64, peers: Ordered<C>) {
         // Check if peer set already exists
         if self.sets.contains_key(&index) {
             debug!(index, "peer set already exists");

--- a/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
@@ -8,15 +8,14 @@ use crate::authenticated::{
     Mailbox,
 };
 use commonware_cryptography::PublicKey;
+use commonware_utils::set::Ordered;
 use futures::channel::oneshot;
 
 /// Messages that can be sent to the tracker actor.
 pub enum Message<C: PublicKey> {
     // ---------- Used by oracle ----------
     /// Register a peer set at a given index.
-    ///
-    /// The vector of peers must be sorted in ascending order by public key.
-    Register { index: u64, peers: Vec<C> },
+    Register { index: u64, peers: Ordered<C> },
 
     // ---------- Used by blocker ----------
     /// Block a peer, disconnecting them if currently connected and preventing future connections
@@ -226,9 +225,9 @@ impl<C: PublicKey> Oracle<C> {
     /// # Parameters
     ///
     /// * `index` - Index of the set of authorized peers (like a blockchain height).
-    ///   Should be monotonically increasing.
+    ///   Must be monotonically increasing, per the rules of [Ordered].
     /// * `peers` - Vector of authorized peers at an `index` (does not need to be sorted).
-    pub async fn register(&mut self, index: u64, peers: Vec<C>) {
+    pub async fn register(&mut self, index: u64, peers: Ordered<C>) {
         let _ = self.sender.send(Message::Register { index, peers });
     }
 }

--- a/p2p/src/authenticated/discovery/actors/tracker/set.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/set.rs
@@ -1,41 +1,29 @@
 use commonware_cryptography::PublicKey;
-use std::collections::HashMap;
+use commonware_utils::set::Ordered;
 
 // Use chunk size of 1 to minimize encoded size.
 type BitMap = commonware_utils::bitmap::BitMap<1>;
 
 /// Represents a set of peers and their knowledge of each other.
 pub struct Set<P: PublicKey> {
-    /// The list of peers, sorted.
-    sorted: Vec<P>,
-
-    /// The index of each peer in the sorted list, for quick lookup.
-    order: HashMap<P, usize>,
+    /// The list of peers, sorted and deduplicated.
+    ordered: Ordered<P>,
 
     /// For each peer, whether I know their peer info or not.
     knowledge: BitMap,
 }
 
 impl<P: PublicKey> Set<P> {
-    /// Creates a new set for the given index.
-    pub fn new(mut peers: Vec<P>) -> Self {
-        peers.sort();
-        let mut order = HashMap::new();
-        for (i, peer) in peers.iter().enumerate() {
-            order.insert(peer.clone(), i);
-        }
-        let knowledge = BitMap::zeroes(peers.len() as u64);
-        Self {
-            sorted: peers,
-            order,
-            knowledge,
-        }
+    /// Creates a new [Set] for the given index.
+    pub fn new(ordered: Ordered<P>) -> Self {
+        let knowledge = BitMap::zeroes(ordered.len() as u64);
+        Self { ordered, knowledge }
     }
 
     /// Marks the given peer as known or unknown.
     pub fn update(&mut self, peer: &P, known: bool) -> bool {
-        if let Some(idx) = self.order.get(peer) {
-            self.knowledge.set(*idx as u64, known);
+        if let Some(idx) = self.ordered.position(peer) {
+            self.knowledge.set(idx as u64, known);
             return true;
         }
         false
@@ -43,7 +31,7 @@ impl<P: PublicKey> Set<P> {
 
     /// Returns the number of peers in the set.
     pub fn len(&self) -> usize {
-        self.sorted.len()
+        self.ordered.len()
     }
 
     /// Returns the bit vector indicating which peers are known.
@@ -57,7 +45,7 @@ impl<'a, P: PublicKey> IntoIterator for &'a Set<P> {
     type IntoIter = std::slice::Iter<'a, P>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.sorted.iter()
+        self.ordered.iter()
     }
 }
 
@@ -65,7 +53,7 @@ impl<P: PublicKey> std::ops::Index<usize> for Set<P> {
     type Output = P;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.sorted[index]
+        &self.ordered[index]
     }
 }
 
@@ -94,16 +82,20 @@ mod tests {
     #[test]
     fn test_set_initialization_and_sorting() {
         let peers = create_test_peers();
-        let set = Set::new(peers);
+        let set = Set::new(peers.into());
 
         let expected_peers = expected_sorted_peers();
         assert_eq!(set.len(), 3, "Set length should be 3");
-        assert_eq!(set.sorted, expected_peers, "Peers should be sorted");
+        assert_eq!(
+            set.ordered.as_ref(),
+            expected_peers,
+            "Peers should be sorted"
+        );
 
         for (i, peer) in expected_peers.iter().enumerate() {
             assert_eq!(
-                set.order.get(peer),
-                Some(&i),
+                set.ordered.position(peer),
+                Some(i),
                 "Peer {peer} should map to index {i}"
             );
         }
@@ -117,7 +109,7 @@ mod tests {
     #[test]
     fn test_update_knowledge_single_peer() {
         let peers = create_test_peers();
-        let mut set = Set::new(peers);
+        let mut set = Set::new(peers.into());
         let peer_to_update = ed25519::PrivateKey::from_seed(3).public_key();
         let non_existent_peer = ed25519::PrivateKey::from_seed(4).public_key();
 
@@ -169,7 +161,7 @@ mod tests {
     #[test]
     fn test_update_multiple_peers() {
         let peers = create_test_peers();
-        let mut set = Set::new(peers);
+        let mut set = Set::new(peers.into());
         let peer1 = ed25519::PrivateKey::from_seed(2).public_key();
         let peer2 = ed25519::PrivateKey::from_seed(3).public_key();
         let peer3 = ed25519::PrivateKey::from_seed(1).public_key();
@@ -195,22 +187,22 @@ mod tests {
     #[test]
     fn test_len() {
         let peers = create_test_peers();
-        let set = Set::new(peers);
+        let set = Set::new(peers.into());
         assert_eq!(set.len(), 3);
 
         let single_peer = vec![ed25519::PrivateKey::from_seed(10).public_key()];
-        let single_set = Set::new(single_peer);
+        let single_set = Set::new(single_peer.into());
         assert_eq!(single_set.len(), 1);
 
         let empty_peers: Vec<ed25519::PublicKey> = vec![];
-        let empty_set = Set::new(empty_peers);
+        let empty_set = Set::new(empty_peers.into());
         assert_eq!(empty_set.len(), 0);
     }
 
     #[test]
     fn test_knowledge_reflects_updates_and_cloning() {
         let peers = create_test_peers();
-        let mut set = Set::new(peers);
+        let mut set = Set::new(peers.into());
         let peer1 = ed25519::PrivateKey::from_seed(2).public_key();
         let peer2 = ed25519::PrivateKey::from_seed(3).public_key();
 
@@ -252,7 +244,7 @@ mod tests {
     #[test]
     fn test_into_iterator() {
         let peers_data = create_test_peers();
-        let set = Set::new(peers_data);
+        let set = Set::new(peers_data.into());
 
         let expected_peers = expected_sorted_peers();
         let iterated_peers: Vec<&ed25519::PublicKey> = set.into_iter().collect();
@@ -274,7 +266,7 @@ mod tests {
     #[test]
     fn test_index() {
         let peers = create_test_peers();
-        let set = Set::new(peers);
+        let set = Set::new(peers.into());
         let expected_peers = expected_sorted_peers();
 
         assert_eq!(set[0], expected_peers[0]);
@@ -286,14 +278,14 @@ mod tests {
     #[should_panic]
     fn test_index_out_of_bounds_positive() {
         let peers: Vec<ed25519::PublicKey> = vec![ed25519::PrivateKey::from_seed(1).public_key()];
-        let set = Set::new(peers);
+        let set = Set::new(peers.into());
         let _ = set[1];
     }
 
     #[test]
     fn test_empty_set_behavior() {
         let peers: Vec<ed25519::PublicKey> = Vec::new();
-        let mut set = Set::new(peers);
+        let mut set = Set::new(peers.into());
 
         assert_eq!(set.len(), 0);
         assert_eq!(set.knowledge(), BitMap::zeroes(0));
@@ -311,17 +303,17 @@ mod tests {
     #[test]
     fn test_single_peer_set() {
         let peers = vec![ed25519::PrivateKey::from_seed(42).public_key()];
-        let mut set = Set::new(peers.clone());
+        let mut set = Set::new(peers.clone().into());
 
         assert_eq!(set.len(), 1);
         assert_eq!(
-            set.sorted,
+            set.ordered.as_ref(),
             vec![ed25519::PrivateKey::from_seed(42).public_key()]
         );
         assert_eq!(
-            set.order
-                .get(&ed25519::PrivateKey::from_seed(42).public_key()),
-            Some(&0)
+            set.ordered
+                .position(&ed25519::PrivateKey::from_seed(42).public_key()),
+            Some(0)
         );
         assert_eq!(set.knowledge(), BitMap::from(vec![false]));
 

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -178,7 +178,7 @@
 //!     //
 //!     // In production, this would be updated as new peer sets are created (like when
 //!     // the composition of a validator set changes).
-//!     oracle.register(0, vec![signer.public_key(), peer1, peer2, peer3]).await;
+//!     oracle.register(0, vec![signer.public_key(), peer1, peer2, peer3].into()).await;
 //!
 //!     // Register some channel
 //!     const MAX_MESSAGE_BACKLOG: usize = 128;
@@ -231,7 +231,7 @@ mod tests {
     use commonware_runtime::{
         deterministic, tokio, Clock, Metrics, Network as RNetwork, Runner, Spawner,
     };
-    use commonware_utils::NZU32;
+    use commonware_utils::{set::Ordered, NZU32};
     use futures::{channel::mpsc, SinkExt, StreamExt};
     use governor::{clock::ReasonablyRealtime, Quota};
     use rand::{CryptoRng, Rng};
@@ -313,7 +313,7 @@ mod tests {
             let (mut network, mut oracle) = Network::new(context.with_label("network"), config);
 
             // Register peers
-            oracle.register(0, addresses.clone()).await;
+            oracle.register(0, addresses.clone().into()).await;
 
             // Register basic application
             let (mut sender, mut receiver) =
@@ -576,9 +576,14 @@ mod tests {
                 let (mut network, mut oracle) = Network::new(context.with_label("network"), config);
 
                 // Register peers at separate indices
-                oracle.register(0, vec![addresses[0].clone()]).await;
                 oracle
-                    .register(1, vec![addresses[1].clone(), addresses[2].clone()])
+                    .register(0, Ordered::from_iter([addresses[0].clone()]))
+                    .await;
+                oracle
+                    .register(
+                        1,
+                        Ordered::from_iter([addresses[1].clone(), addresses[2].clone()]),
+                    )
                     .await;
                 oracle
                     .register(2, addresses.iter().skip(2).cloned().collect())
@@ -647,7 +652,7 @@ mod tests {
             for i in 0..n {
                 peers.push(ed25519::PrivateKey::from_seed(i as u64));
             }
-            let addresses = peers.iter().map(|p| p.public_key()).collect::<Vec<_>>();
+            let addresses = peers.iter().map(|p| p.public_key()).collect::<Ordered<_>>();
 
             // Create network
             let signer = peers[0].clone();
@@ -708,7 +713,7 @@ mod tests {
                 1_024 * 1_024, // 1MB
             );
             let (mut network0, mut oracle0) = Network::new(context.with_label("peer-0"), config0);
-            oracle0.register(0, addresses.clone()).await;
+            oracle0.register(0, addresses.clone().into()).await;
             let (mut sender0, _receiver0) =
                 network0.register(0, Quota::per_hour(NZU32!(1)), DEFAULT_MESSAGE_BACKLOG);
             network0.start();
@@ -722,7 +727,7 @@ mod tests {
                 1_024 * 1_024, // 1MB
             );
             let (mut network1, mut oracle1) = Network::new(context.with_label("peer-1"), config1);
-            oracle1.register(0, addresses.clone()).await;
+            oracle1.register(0, addresses.clone().into()).await;
             let (_sender1, _receiver1) =
                 network1.register(0, Quota::per_hour(NZU32!(1)), DEFAULT_MESSAGE_BACKLOG);
             network1.start();

--- a/p2p/src/authenticated/lookup/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/actor.rs
@@ -190,7 +190,7 @@ mod tests {
         deterministic::{self},
         Clock, Runner,
     };
-    use commonware_utils::NZU32;
+    use commonware_utils::{set::Ordered, NZU32};
     use governor::Quota;
     use std::{
         net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -269,7 +269,9 @@ mod tests {
 
             let (_, pk) = new_signer_and_pk(1);
             let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1001);
-            oracle.register(0, vec![(pk.clone(), addr)]).await;
+            oracle
+                .register(0, Ordered::new_by_key([(pk.clone(), addr)], |(pk, _)| pk))
+                .await;
             context.sleep(Duration::from_millis(10)).await;
 
             let dialable_peers = mailbox.dialable().await;
@@ -296,7 +298,9 @@ mod tests {
 
             let (_, pk1) = new_signer_and_pk(1);
             let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1001);
-            oracle.register(0, vec![(pk1.clone(), addr)]).await;
+            oracle
+                .register(0, Ordered::new_by_key([(pk1.clone(), addr)], |(pk, _)| pk))
+                .await;
             context.sleep(Duration::from_millis(10)).await;
 
             oracle.block(pk1.clone()).await;
@@ -351,7 +355,10 @@ mod tests {
             oracle
                 .register(
                     0,
-                    vec![(peer_pk.clone(), peer_addr), (peer_pk2.clone(), peer_addr2)],
+                    Ordered::new_by_key(
+                        [(peer_pk.clone(), peer_addr), (peer_pk2.clone(), peer_addr2)],
+                        |(pk, _)| pk,
+                    ),
                 )
                 .await;
             context.sleep(Duration::from_millis(10)).await;
@@ -382,7 +389,12 @@ mod tests {
             let reservation = mailbox.listen(peer_pk.clone()).await;
             assert!(reservation.is_none());
 
-            oracle.register(0, vec![(peer_pk.clone(), peer_addr)]).await;
+            oracle
+                .register(
+                    0,
+                    Ordered::new_by_key([(peer_pk.clone(), peer_addr)], |(pk, _)| pk),
+                )
+                .await;
             context.sleep(Duration::from_millis(10)).await; // Allow register to process
 
             assert!(mailbox.listenable(peer_pk.clone()).await);
@@ -415,7 +427,12 @@ mod tests {
                 mut oracle,
                 ..
             } = setup_actor(context.clone(), cfg_initial);
-            oracle.register(0, vec![(boot_pk.clone(), boot_addr)]).await;
+            oracle
+                .register(
+                    0,
+                    Ordered::new_by_key([(boot_pk.clone(), boot_addr)], |(pk, _)| pk),
+                )
+                .await;
 
             let dialable_peers = mailbox.dialable().await;
             assert_eq!(dialable_peers.len(), 1);
@@ -437,7 +454,12 @@ mod tests {
                 ..
             } = setup_actor(context.clone(), cfg_initial);
 
-            oracle.register(0, vec![(boot_pk.clone(), boot_addr)]).await;
+            oracle
+                .register(
+                    0,
+                    Ordered::new_by_key([(boot_pk.clone(), boot_addr)], |(pk, _)| pk),
+                )
+                .await;
 
             let reservation = mailbox.dial(boot_pk.clone()).await;
             assert!(reservation.is_some());
@@ -472,7 +494,12 @@ mod tests {
             // 2) Register & connect an authorized peer
             let (_peer_signer, peer_pk) = new_signer_and_pk(1);
             let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 12345);
-            oracle.register(0, vec![(peer_pk.clone(), peer_addr)]).await;
+            oracle
+                .register(
+                    0,
+                    Ordered::new_by_key([(peer_pk.clone(), peer_addr)], |(pk, _)| pk),
+                )
+                .await;
             // let the register take effect
             context.sleep(Duration::from_millis(10)).await;
 
@@ -523,7 +550,13 @@ mod tests {
 
             // Register set with myself and one other peer
             oracle
-                .register(0, vec![(my_pk.clone(), my_addr), (pk_1.clone(), addr_1)])
+                .register(
+                    0,
+                    Ordered::new_by_key(
+                        vec![(my_pk.clone(), my_addr), (pk_1.clone(), addr_1)],
+                        |(pk, _)| pk,
+                    ),
+                )
                 .await;
             // let the register take effect
             context.sleep(Duration::from_millis(10)).await;
@@ -542,7 +575,12 @@ mod tests {
             mailbox.connect(my_pk.clone(), peer_mailbox);
 
             // Register another set which doesn't include first peer
-            oracle.register(1, vec![(pk_2.clone(), addr_2)]).await;
+            oracle
+                .register(
+                    1,
+                    Ordered::new_by_key([(pk_2.clone(), addr_2)], |(pk, _)| pk),
+                )
+                .await;
 
             // Wait for a listener update
             let registered_ips = listener_receiver.next().await.unwrap();

--- a/p2p/src/authenticated/lookup/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/directory.rs
@@ -2,6 +2,7 @@ use super::{metrics::Metrics, record::Record, Metadata, Reservation};
 use crate::authenticated::lookup::{actors::tracker::ingress::Releaser, metrics};
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Clock, Metrics as RuntimeMetrics, Spawner};
+use commonware_utils::set::Ordered;
 use governor::{
     clock::Clock as GClock, middleware::NoOpMiddleware, state::keyed::HashMapStateStore, Quota,
     RateLimiter,
@@ -104,7 +105,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: PublicKey> Directory
     }
 
     /// Stores a new peer set.
-    pub fn add_set(&mut self, index: u64, peers: Vec<(C, SocketAddr)>) -> Vec<C> {
+    pub fn add_set(&mut self, index: u64, peers: Ordered<(C, SocketAddr)>) -> Vec<C> {
         // Check if peer set already exists
         if self.sets.contains_key(&index) {
             debug!(index, "peer set already exists");
@@ -274,7 +275,7 @@ mod tests {
     };
     use commonware_cryptography::{ed25519, PrivateKeyExt, Signer};
     use commonware_runtime::{deterministic, Runner};
-    use commonware_utils::NZU32;
+    use commonware_utils::{set::Ordered, NZU32};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     #[test]
@@ -300,23 +301,33 @@ mod tests {
         runtime.start(|context| async move {
             let mut directory = Directory::init(context, (my_pk, my_addr), config, releaser);
 
-            let deleted =
-                directory.add_set(0, vec![(pk_1.clone(), addr_1), (pk_2.clone(), addr_2)]);
+            let deleted = directory.add_set(
+                0,
+                Ordered::new_by_key(
+                    [(pk_1.clone(), addr_1), (pk_2.clone(), addr_2)],
+                    |(pk, _)| pk,
+                ),
+            );
             assert!(
                 deleted.is_empty(),
                 "No peers should be deleted on first set"
             );
 
-            let deleted =
-                directory.add_set(1, vec![(pk_2.clone(), addr_2), (pk_3.clone(), addr_3)]);
+            let deleted = directory.add_set(
+                1,
+                Ordered::new_by_key(
+                    [(pk_2.clone(), addr_2), (pk_3.clone(), addr_3)],
+                    |(pk, _)| pk,
+                ),
+            );
             assert_eq!(deleted.len(), 1, "One peer should be deleted");
             assert!(deleted.contains(&pk_1), "Deleted peer should be pk_1");
 
-            let deleted = directory.add_set(2, vec![(pk_3.clone(), addr_3)]);
+            let deleted = directory.add_set(2, vec![(pk_3.clone(), addr_3)].into());
             assert_eq!(deleted.len(), 1, "One peer should be deleted");
             assert!(deleted.contains(&pk_2), "Deleted peer should be pk_2");
 
-            let deleted = directory.add_set(3, vec![(pk_3.clone(), addr_3)]);
+            let deleted = directory.add_set(3, vec![(pk_3.clone(), addr_3)].into());
             assert!(deleted.is_empty(), "No peers should be deleted");
         });
     }

--- a/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
@@ -5,6 +5,7 @@ use crate::authenticated::{
     Mailbox,
 };
 use commonware_cryptography::PublicKey;
+use commonware_utils::set::Ordered;
 use futures::channel::oneshot;
 use std::net::SocketAddr;
 
@@ -14,7 +15,7 @@ pub enum Message<C: PublicKey> {
     /// Register a peer set at a given index.
     Register {
         index: u64,
-        peers: Vec<(C, SocketAddr)>,
+        peers: Ordered<(C, SocketAddr)>,
     },
 
     // ---------- Used by blocker ----------
@@ -168,10 +169,10 @@ impl<C: PublicKey> Oracle<C> {
     ///
     /// * `index` - Index of the set of authorized peers (like a blockchain height).
     ///   Should be monotonically increasing.
-    /// * `peers` - Vector of authorized peers at an `index` (does not need to be sorted).
+    /// * `peers` - Vector of authorized peers at an `index`.
     ///   Each element is a tuple containing the public key and the socket address of the peer.
     ///   The peer must be dialable at and dial from the given socket address.
-    pub async fn register(&mut self, index: u64, peers: Vec<(C, SocketAddr)>) {
+    pub async fn register(&mut self, index: u64, peers: Ordered<(C, SocketAddr)>) {
         let _ = self.sender.send(Message::Register { index, peers });
     }
 }


### PR DESCRIPTION
## Overview

Adjusts the API of `Oracle::register` to accept `Set` rather than `Vec` to ensure the set of peers is sorted and deduplicated.

Also renames `commonware_utils::set::Set` -> `commonware_utils::set::Ordered`

closes #1977 