### PR TITLE
[utils] Add `hex_literal` macro

### DIFF
--- a/consensus/src/marshal/cache.rs
+++ b/consensus/src/marshal/cache.rs
@@ -14,7 +14,7 @@ use commonware_storage::{
     metadata::{self, Metadata},
     translator::TwoCap,
 };
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{fixed_bytes, sequence::FixedBytes};
 use governor::clock::Clock as GClock;
 use rand::Rng;
 use std::{
@@ -26,7 +26,7 @@ use std::{
 use tracing::{debug, info};
 
 // The key used to store the current epoch in the metadata store.
-const CACHED_EPOCHS_KEY: FixedBytes<1> = FixedBytes::new([0u8]);
+const CACHED_EPOCHS_KEY: FixedBytes<1> = fixed_bytes!("0x00");
 
 /// Configuration parameters for prunable archives.
 pub(crate) struct Config {

--- a/consensus/src/marshal/finalizer.rs
+++ b/consensus/src/marshal/finalizer.rs
@@ -1,12 +1,12 @@
 use crate::{marshal::ingress::orchestrator::Orchestrator, Block, Reporter};
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Metrics, Spawner, Storage};
 use commonware_storage::metadata::{self, Metadata};
-use commonware_utils::sequence::FixedBytes;
+use commonware_utils::{fixed_bytes, sequence::FixedBytes};
 use futures::{channel::mpsc, StreamExt};
 use tracing::{debug, error};
 
 // The key used to store the last indexed height in the metadata store.
-const LATEST_KEY: FixedBytes<1> = FixedBytes::new([0u8]);
+const LATEST_KEY: FixedBytes<1> = fixed_bytes!("00");
 
 /// Requests the finalized blocks (in order) from the orchestrator, sends them to the application,
 /// waits for confirmation that the application has processed the block.

--- a/cryptography/src/blake3/mod.rs
+++ b/cryptography/src/blake3/mod.rs
@@ -186,7 +186,10 @@ mod tests {
     use commonware_codec::{DecodeExt, Encode};
     use commonware_utils::hex;
 
-    const HELLO_DIGEST: &str = "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24";
+    const HELLO_DIGEST: [u8; DIGEST_LENGTH] =
+        hex!("d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24");
+    const EMPTY_DIGEST: [u8; DIGEST_LENGTH] =
+        hex!("af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262");
 
     #[test]
     fn test_blake3() {
@@ -197,17 +200,17 @@ mod tests {
         hasher.update(msg);
         let digest = hasher.finalize();
         assert!(Digest::decode(digest.as_ref()).is_ok());
-        assert_eq!(hex(digest.as_ref()), HELLO_DIGEST);
+        assert_eq!(digest.as_ref(), HELLO_DIGEST);
 
         // Reuse hasher
         hasher.update(msg);
         let digest = hasher.finalize();
         assert!(Digest::decode(digest.as_ref()).is_ok());
-        assert_eq!(hex(digest.as_ref()), HELLO_DIGEST);
+        assert_eq!(digest.as_ref(), HELLO_DIGEST);
 
         // Test simple hasher
         let hash = hash(msg);
-        assert_eq!(hex(hash.as_ref()), HELLO_DIGEST);
+        assert_eq!(hash.as_ref(), HELLO_DIGEST);
     }
 
     #[test]
@@ -226,15 +229,7 @@ mod tests {
     #[test]
     fn test_blake3_empty() {
         let empty_digest = Blake3::empty();
-
-        // BLAKE3 hash of empty string:
-        // af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
-        let expected_bytes = [
-            0xaf, 0x13, 0x49, 0xb9, 0xf5, 0xf9, 0xa1, 0xa6, 0xa0, 0x40, 0x4d, 0xea, 0x36, 0xdc,
-            0xc9, 0x49, 0x9b, 0xcb, 0x25, 0xc9, 0xad, 0xc1, 0x12, 0xb7, 0xcc, 0x9a, 0x93, 0xca,
-            0xe4, 0x1f, 0x32, 0x62,
-        ];
-        let expected_digest = Digest::from(expected_bytes);
+        let expected_digest = Digest::from(EMPTY_DIGEST);
 
         assert_eq!(empty_digest, expected_digest);
     }

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -559,7 +559,7 @@ mod tests {
             0816ed13ba3303ac5deb911548908025
             ",
         );
-        let message: [u8; 2] = [0xaf, 0x82];
+        let message = hex!("0xaf82");
         let signature = parse_signature(
             "
             6291d657deec24024827e69c3abe01a3

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -163,7 +163,10 @@ mod tests {
     use commonware_codec::{DecodeExt, Encode};
     use commonware_utils::hex;
 
-    const HELLO_DIGEST: &str = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+    const HELLO_DIGEST: [u8; DIGEST_LENGTH] =
+        hex!("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
+    const EMPTY_DIGEST: [u8; DIGEST_LENGTH] =
+        hex!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
     #[test]
     fn test_sha256() {
@@ -174,17 +177,17 @@ mod tests {
         hasher.update(msg);
         let digest = hasher.finalize();
         assert!(Digest::decode(digest.as_ref()).is_ok());
-        assert_eq!(hex(digest.as_ref()), HELLO_DIGEST);
+        assert_eq!(digest.as_ref(), HELLO_DIGEST);
 
         // Reuse hasher
         hasher.update(msg);
         let digest = hasher.finalize();
         assert!(Digest::decode(digest.as_ref()).is_ok());
-        assert_eq!(hex(digest.as_ref()), HELLO_DIGEST);
+        assert_eq!(digest.as_ref(), HELLO_DIGEST);
 
         // Test simple hasher
         let hash = Sha256::hash(msg);
-        assert_eq!(hex(hash.as_ref()), HELLO_DIGEST);
+        assert_eq!(hash.as_ref(), HELLO_DIGEST);
     }
 
     #[test]
@@ -203,15 +206,7 @@ mod tests {
     #[test]
     fn test_sha256_empty() {
         let empty_digest = Sha256::empty();
-
-        // SHA-256 hash of empty string:
-        // e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-        let expected_bytes = [
-            0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
-            0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
-            0x78, 0x52, 0xb8, 0x55,
-        ];
-        let expected_digest = Digest::from(expected_bytes);
+        let expected_digest = Digest::from(EMPTY_DIGEST);
 
         assert_eq!(empty_digest, expected_digest);
     }

--- a/examples/reshare/src/dkg/actor.rs
+++ b/examples/reshare/src/dkg/actor.rs
@@ -21,7 +21,7 @@ use commonware_p2p::{utils::mux::Muxer, Receiver, Sender};
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Metrics, Spawner, Storage};
 use commonware_storage::metadata::Metadata;
 use commonware_utils::{
-    hex, quorum,
+    fixed_bytes, hex, quorum,
     sequence::{FixedBytes, U64},
     set::Ordered,
 };
@@ -37,7 +37,7 @@ use rand_core::CryptoRngCore;
 use std::{cmp::Ordering, collections::BTreeMap, path::PathBuf};
 use tracing::info;
 
-const EPOCH_METADATA_KEY: FixedBytes<1> = FixedBytes::new([0xFF]);
+const EPOCH_METADATA_KEY: FixedBytes<1> = fixed_bytes!("0xFF");
 
 pub struct Config<C> {
     pub participant_config: Option<(PathBuf, ParticipantConfig)>,

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -244,7 +244,7 @@ mod tests {
     use commonware_codec::DecodeExt;
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
-    use commonware_utils::{sequence::FixedBytes, NZUsize};
+    use commonware_utils::{hex, sequence::FixedBytes, NZUsize};
     use rand::{Rng, RngCore};
 
     const DEFAULT_JOURNAL_WRITE_BUFFER: usize = 1024;
@@ -829,7 +829,7 @@ mod tests {
             {
                 let (blob, size) = context.open(&cfg.table_partition, b"table").await.unwrap();
                 // Append garbage data
-                blob.write_at(vec![0xDE, 0xAD, 0xBE, 0xEF], size)
+                blob.write_at(hex!("0xdeadbeef").to_vec(), size)
                     .await
                     .unwrap();
                 blob.sync().await.unwrap();

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -312,6 +312,7 @@ mod tests {
     use crate::translator::OneCap;
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Runner};
+    use commonware_utils::hex;
 
     #[test_traced]
     fn test_ordered_index_ordering() {
@@ -320,10 +321,10 @@ mod tests {
             let mut index = Index::<_, u64>::init(context, OneCap);
             assert_eq!(index.keys(), 0);
 
-            let k1 = &[0x0b, 0x02, 0xAA]; // translated key 0b
-            let k2 = &[0x1c, 0x04, 0xCC]; // translated key 1c
-            let k2_collides = &[0x1c, 0x03, 0x11];
-            let k3 = &[0x2d, 0x06, 0xEE]; // translated key 2d
+            let k1 = &hex!("0x0b02AA"); // translated key 0b
+            let k2 = &hex!("0x1c04CC"); // translated key 1c
+            let k2_collides = &hex!("0x1c0311");
+            let k3 = &hex!("0x2d06EE"); // translated key 2d
             index.insert(k1, 1);
             index.insert(k2, 21);
             index.insert(k2_collides, 22);
@@ -341,19 +342,19 @@ mod tests {
             assert_eq!(next.next(), None);
 
             // Next translated key to 0x0b is 1c.
-            let mut next = index.next_translated_key(&[0x0b, 0x01, 0x02]);
+            let mut next = index.next_translated_key(&hex!("0x0b0102"));
             assert_eq!(next.next().unwrap(), &21);
             assert_eq!(next.next().unwrap(), &22);
             assert_eq!(next.next(), None);
 
             // Next translated key to 0x1b is 1c.
-            let mut next = index.next_translated_key(&[0x1b, 0x01, 0x02, 0x03]);
+            let mut next = index.next_translated_key(&hex!("0x1b010203"));
             assert_eq!(next.next().unwrap(), &21);
             assert_eq!(next.next().unwrap(), &22);
             assert_eq!(next.next(), None);
 
             // Next translated key to 0x2a is 2d.
-            let mut next = index.next_translated_key(&[0x2a, 0x01, 0x02, 0x03, 0x04]);
+            let mut next = index.next_translated_key(&hex!("0x2a01020304"));
             assert_eq!(next.next().unwrap(), &3);
             assert_eq!(next.next(), None);
 
@@ -361,7 +362,7 @@ mod tests {
             let mut next = index.next_translated_key(k3);
             assert_eq!(next.next(), None);
 
-            let mut next = index.next_translated_key(&[0x2e, 0xFF]);
+            let mut next = index.next_translated_key(&hex!("0x2eFF"));
             assert_eq!(next.next(), None);
 
             // Previous translated key is None.
@@ -369,18 +370,18 @@ mod tests {
             assert_eq!(prev.next(), None);
 
             // Previous translated key is 0b.
-            let mut prev = index.prev_translated_key(&[0x0c, 0x01, 0x02]);
+            let mut prev = index.prev_translated_key(&hex!("0x0c0102"));
             assert_eq!(prev.next().unwrap(), &1);
             assert_eq!(prev.next(), None);
 
             // Previous translated key is 1c.
-            let mut prev = index.prev_translated_key(&[0x1d, 0x01, 0x02]);
+            let mut prev = index.prev_translated_key(&hex!("0x1d0102"));
             assert_eq!(prev.next().unwrap(), &21);
             assert_eq!(prev.next().unwrap(), &22);
             assert_eq!(prev.next(), None);
 
             // Previous translated key is 2d.
-            let mut prev = index.prev_translated_key(&[0xCC, 0x01, 0x02]);
+            let mut prev = index.prev_translated_key(&hex!("0xCC0102"));
             assert_eq!(prev.next().unwrap(), &3);
             assert_eq!(prev.next(), None);
 

--- a/storage/src/journal/variable.rs
+++ b/storage/src/journal/variable.rs
@@ -1339,7 +1339,7 @@ mod tests {
                 .expect("Failed to create blob");
 
             // Write incomplete size data (less than 4 bytes)
-            let incomplete_data = vec![0x00, 0x01]; // Less than 4 bytes
+            let incomplete_data = hex!("0x0001").to_vec(); // Less than 4 bytes
             blob.write_at(incomplete_data, 0)
                 .await
                 .expect("Failed to write incomplete data");

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -93,7 +93,7 @@ mod tests {
     use super::*;
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
-    use commonware_utils::sequence::U64;
+    use commonware_utils::{hex, sequence::U64};
     use rand::{Rng, RngCore};
 
     #[test_traced]
@@ -1079,7 +1079,7 @@ mod tests {
             assert!(all_keys.contains(&U64::new(0x3000)));
 
             // Test iterating with prefix 0x10
-            let prefix = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10];
+            let prefix = hex!("0x00000000000010");
             let prefix_keys: Vec<_> = metadata.keys(Some(&prefix)).cloned().collect();
             assert_eq!(prefix_keys.len(), 3);
             assert!(prefix_keys.contains(&U64::new(0x1000)));
@@ -1088,14 +1088,14 @@ mod tests {
             assert!(!prefix_keys.contains(&U64::new(0x2000)));
 
             // Test iterating with prefix 0x20
-            let prefix = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20];
+            let prefix = hex!("0x00000000000020");
             let prefix_keys: Vec<_> = metadata.keys(Some(&prefix)).cloned().collect();
             assert_eq!(prefix_keys.len(), 2);
             assert!(prefix_keys.contains(&U64::new(0x2000)));
             assert!(prefix_keys.contains(&U64::new(0x2001)));
 
             // Test with non-matching prefix
-            let prefix = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40];
+            let prefix = hex!("0x00000000000040");
             let prefix_keys: Vec<_> = metadata.keys(Some(&prefix)).cloned().collect();
             assert_eq!(prefix_keys.len(), 0);
 
@@ -1130,7 +1130,7 @@ mod tests {
             assert!(buffer.contains("keys 6"));
 
             // Remove keys with prefix 0x10
-            let prefix = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10];
+            let prefix = hex!("0x00000000000010");
             metadata.remove_prefix(&prefix);
 
             // Check metrics after removal
@@ -1162,7 +1162,7 @@ mod tests {
             assert_eq!(metadata.keys(None).count(), 3);
 
             // Remove non-existing prefix
-            let prefix = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40];
+            let prefix = hex!("0x00000000000040");
             metadata.remove_prefix(&prefix);
 
             // Remove all remaining keys

--- a/storage/src/ordinal/mod.rs
+++ b/storage/src/ordinal/mod.rs
@@ -137,7 +137,7 @@ mod tests {
     use commonware_codec::{FixedSize, Read, ReadExt, Write};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, Metrics, Runner, Storage};
-    use commonware_utils::{bitmap::BitMap, sequence::FixedBytes, NZUsize, NZU64};
+    use commonware_utils::{bitmap::BitMap, hex, sequence::FixedBytes, NZUsize, NZU64};
     use rand::RngCore;
     use std::collections::BTreeMap;
 
@@ -719,7 +719,7 @@ mod tests {
                     .await
                     .unwrap();
                 // Corrupt some bytes in the value of the first record
-                blob.write_at(vec![0xFF, 0xFF, 0xFF, 0xFF], 10)
+                blob.write_at(hex!("0xFFFFFFFF").to_vec(), 10)
                     .await
                     .unwrap();
                 blob.sync().await.unwrap();

--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -816,6 +816,7 @@ impl<const N: usize> ExactSizeIterator for Iterator<'_, N> {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hex;
     use bytes::BytesMut;
     use commonware_codec::{Decode, Encode};
 
@@ -1012,7 +1013,7 @@ mod tests {
     #[test]
     fn test_chunk_operations() {
         let mut bv: BitMap<4> = BitMap::new();
-        let test_chunk = [0xAB, 0xCD, 0xEF, 0x12];
+        let test_chunk = hex!("0xABCDEF12");
 
         // Test push_chunk
         bv.push_chunk(&test_chunk);
@@ -1070,7 +1071,7 @@ mod tests {
         const CHUNK_SIZE: u64 = BitMap::<3>::CHUNK_SIZE_BITS;
 
         // Test 1: Pop a single chunk and verify it returns the correct data
-        let chunk1 = [0xAA, 0xBB, 0xCC];
+        let chunk1 = hex!("0xAABBCC");
         bv.push_chunk(&chunk1);
         assert_eq!(bv.len(), CHUNK_SIZE);
         let popped = bv.pop_chunk();
@@ -1079,9 +1080,9 @@ mod tests {
         assert!(bv.is_empty());
 
         // Test 2: Pop multiple chunks in reverse order
-        let chunk2 = [0x11, 0x22, 0x33];
-        let chunk3 = [0x44, 0x55, 0x66];
-        let chunk4 = [0x77, 0x88, 0x99];
+        let chunk2 = hex!("0x112233");
+        let chunk3 = hex!("0x445566");
+        let chunk4 = hex!("0x778899");
 
         bv.push_chunk(&chunk2);
         bv.push_chunk(&chunk3);
@@ -1098,8 +1099,8 @@ mod tests {
         assert_eq!(bv.len(), 0);
 
         // Test 3: Verify data integrity when popping chunks
-        let first_chunk = [0xAA, 0xBB, 0xCC];
-        let second_chunk = [0x11, 0x22, 0x33];
+        let first_chunk = hex!("0xAABBCC");
+        let second_chunk = hex!("0x112233");
         bv.push_chunk(&first_chunk);
         bv.push_chunk(&second_chunk);
 
@@ -1341,8 +1342,8 @@ mod tests {
         let mut bv2: BitMap<4> = BitMap::new();
 
         // Fill multiple chunks
-        let chunk1 = [0xAA, 0xBB, 0xCC, 0xDD]; // 10101010 10111011 11001100 11011101
-        let chunk2 = [0x55, 0x66, 0x77, 0x88]; // 01010101 01100110 01110111 10001000
+        let chunk1 = hex!("0xAABBCCDD"); // 10101010 10111011 11001100 11011101
+        let chunk2 = hex!("0x55667788"); // 01010101 01100110 01110111 10001000
 
         bv1.push_chunk(&chunk1);
         bv1.push_chunk(&chunk1);

--- a/utils/src/bitmap/prunable.rs
+++ b/utils/src/bitmap/prunable.rs
@@ -382,6 +382,7 @@ impl<const N: usize> EncodeSize for Prunable<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hex;
     use bytes::BytesMut;
     use commonware_codec::Encode;
 
@@ -454,7 +455,7 @@ mod tests {
     #[test]
     fn test_push_chunk() {
         let mut prunable: Prunable<4> = Prunable::new();
-        let chunk = [0xAA, 0xBB, 0xCC, 0xDD];
+        let chunk = hex!("0xAABBCCDD");
 
         prunable.push_chunk(&chunk);
         assert_eq!(prunable.len(), 32); // 4 bytes * 8 bits
@@ -488,9 +489,9 @@ mod tests {
         let mut prunable: Prunable<4> = Prunable::new();
 
         // Add multiple chunks (4 bytes each)
-        let chunk1 = [0x01, 0x02, 0x03, 0x04];
-        let chunk2 = [0x05, 0x06, 0x07, 0x08];
-        let chunk3 = [0x09, 0x0A, 0x0B, 0x0C];
+        let chunk1 = hex!("0x01020304");
+        let chunk2 = hex!("0x05060708");
+        let chunk3 = hex!("0x090A0B0C");
 
         prunable.push_chunk(&chunk1);
         prunable.push_chunk(&chunk2);
@@ -772,9 +773,9 @@ mod tests {
     #[test]
     fn test_get_chunk() {
         let mut prunable: Prunable<4> = Prunable::new();
-        let chunk1 = [0x11, 0x22, 0x33, 0x44];
-        let chunk2 = [0x55, 0x66, 0x77, 0x88];
-        let chunk3 = [0x99, 0xAA, 0xBB, 0xCC];
+        let chunk1 = hex!("0x11223344");
+        let chunk2 = hex!("0x55667788");
+        let chunk3 = hex!("0x99AABBCC");
 
         prunable.push_chunk(&chunk1);
         prunable.push_chunk(&chunk2);
@@ -830,7 +831,7 @@ mod tests {
         const CHUNK_SIZE: u64 = Prunable::<4>::CHUNK_SIZE_BITS;
 
         // Test 1: Pop a single chunk and verify it returns the correct data
-        let chunk1 = [0xAA, 0xBB, 0xCC, 0xDD];
+        let chunk1 = hex!("0xAABBCCDD");
         prunable.push_chunk(&chunk1);
         assert_eq!(prunable.len(), CHUNK_SIZE);
         let popped = prunable.pop_chunk();
@@ -839,9 +840,9 @@ mod tests {
         assert!(prunable.is_empty());
 
         // Test 2: Pop multiple chunks in reverse order
-        let chunk2 = [0x11, 0x22, 0x33, 0x44];
-        let chunk3 = [0x55, 0x66, 0x77, 0x88];
-        let chunk4 = [0x99, 0xAA, 0xBB, 0xCC];
+        let chunk2 = hex!("0x11223344");
+        let chunk3 = hex!("0x55667788");
+        let chunk4 = hex!("0x99AABBCC");
 
         prunable.push_chunk(&chunk2);
         prunable.push_chunk(&chunk3);
@@ -859,8 +860,8 @@ mod tests {
 
         // Test 3: Verify data integrity when popping chunks
         prunable = Prunable::new();
-        let first_chunk = [0xAA, 0xBB, 0xCC, 0xDD];
-        let second_chunk = [0x11, 0x22, 0x33, 0x44];
+        let first_chunk = hex!("0xAABBCCDD");
+        let second_chunk = hex!("0x11223344");
         prunable.push_chunk(&first_chunk);
         prunable.push_chunk(&second_chunk);
 
@@ -919,8 +920,8 @@ mod tests {
     #[test]
     fn test_write_read_non_empty() {
         let mut original: Prunable<4> = Prunable::new();
-        original.push_chunk(&[0xAA, 0xBB, 0xCC, 0xDD]);
-        original.push_chunk(&[0x11, 0x22, 0x33, 0x44]);
+        original.push_chunk(&hex!("0xAABBCCDD"));
+        original.push_chunk(&hex!("0x11223344"));
         original.push(true);
         original.push(false);
         original.push(true);
@@ -941,9 +942,9 @@ mod tests {
     #[test]
     fn test_write_read_with_pruning() {
         let mut original: Prunable<4> = Prunable::new();
-        original.push_chunk(&[0x01, 0x02, 0x03, 0x04]);
-        original.push_chunk(&[0x05, 0x06, 0x07, 0x08]);
-        original.push_chunk(&[0x09, 0x0A, 0x0B, 0x0C]);
+        original.push_chunk(&hex!("0x01020304"));
+        original.push_chunk(&hex!("0x05060708"));
+        original.push_chunk(&hex!("0x090A0B0C"));
 
         // Prune first chunk
         original.prune_to_bit(32);
@@ -959,8 +960,8 @@ mod tests {
         assert_eq!(decoded.len(), 96);
 
         // Verify remaining chunks match
-        assert_eq!(decoded.get_chunk_containing(32), &[0x05, 0x06, 0x07, 0x08]);
-        assert_eq!(decoded.get_chunk_containing(64), &[0x09, 0x0A, 0x0B, 0x0C]);
+        assert_eq!(decoded.get_chunk_containing(32), &hex!("0x05060708"));
+        assert_eq!(decoded.get_chunk_containing(64), &hex!("0x090A0B0C"));
     }
 
     #[test]

--- a/utils/src/hex_literal.rs
+++ b/utils/src/hex_literal.rs
@@ -1,0 +1,240 @@
+//! Hex literal macro implementation.
+//!
+//! Modified from the [`hex-literal`](https://github.com/RustCrypto/utils/tree/master/hex-literal)
+//! crate to allow `0x` prefixes.
+//!
+//! Vendored from [`alloy-primitives`](https://github.com/alloy-rs/core/tree/main/crates/primitives).
+
+const fn next_hex_char(string: &[u8], mut pos: usize) -> Option<(u8, usize)> {
+    while pos < string.len() {
+        let raw_val = string[pos];
+        pos += 1;
+        let val = match raw_val {
+            b'0'..=b'9' => raw_val - 48,
+            b'A'..=b'F' => raw_val - 55,
+            b'a'..=b'f' => raw_val - 87,
+            b' ' | b'\r' | b'\n' | b'\t' => continue,
+            0..=127 => panic!("Encountered invalid ASCII character"),
+            _ => panic!("Encountered non-ASCII character"),
+        };
+        return Some((val, pos));
+    }
+    None
+}
+
+const fn next_byte(string: &[u8], pos: usize) -> Option<(u8, usize)> {
+    let (half1, pos) = match next_hex_char(string, pos) {
+        Some(v) => v,
+        None => return None,
+    };
+    let (half2, pos) = match next_hex_char(string, pos) {
+        Some(v) => v,
+        None => panic!("Odd number of hex characters"),
+    };
+    Some(((half1 << 4) + half2, pos))
+}
+
+/// Strips the `0x` prefix from a hex string.
+///
+/// This function is an implementation detail and SHOULD NOT be called directly!
+#[doc(hidden)]
+pub const fn strip_hex_prefix(string: &[u8]) -> &[u8] {
+    if let [b'0', b'x' | b'X', rest @ ..] = string {
+        rest
+    } else {
+        string
+    }
+}
+
+/// Compute length of a byte array which will be decoded from the strings.
+///
+/// This function is an implementation detail and SHOULD NOT be called directly!
+#[doc(hidden)]
+pub const fn len(strings: &[&[u8]]) -> usize {
+    let mut i = 0;
+    let mut len = 0;
+    while i < strings.len() {
+        let mut pos = 0;
+        while let Some((_, new_pos)) = next_byte(strings[i], pos) {
+            len += 1;
+            pos = new_pos;
+        }
+        i += 1;
+    }
+    len
+}
+
+/// Decode hex strings into a byte array of pre-computed length.
+///
+/// This function is an implementation detail and SHOULD NOT be called directly!
+#[doc(hidden)]
+pub const fn decode<const LEN: usize>(strings: &[&[u8]]) -> [u8; LEN] {
+    let mut i = 0;
+    let mut buf = [0u8; LEN];
+    let mut buf_pos = 0;
+    while i < strings.len() {
+        let mut pos = 0;
+        while let Some((byte, new_pos)) = next_byte(strings[i], pos) {
+            buf[buf_pos] = byte;
+            buf_pos += 1;
+            pos = new_pos;
+        }
+        i += 1;
+    }
+    if LEN != buf_pos {
+        panic!("Length mismatch. Please report this bug.");
+    }
+    buf
+}
+
+/// Macro for converting sequence of string literals containing hex-encoded data
+/// into an array of bytes.
+#[macro_export]
+macro_rules! hex {
+    ($($s:literal)*) => {const {
+        const STRINGS: &[&[u8]] = &[$( $crate::hex_literal::strip_hex_prefix($s.as_bytes()), )*];
+        $crate::hex_literal::decode::<{ $crate::hex_literal::len(STRINGS) }>(STRINGS)
+    }};
+}
+
+/// Macro for converting sequence of string literals containing hex-encoded data
+/// into a [FixedBytes] type.
+///
+/// [FixedBytes]: crate::sequence::FixedBytes
+#[macro_export]
+macro_rules! fixed_bytes {
+    ($s:tt) => {
+        const { $crate::sequence::FixedBytes::new($crate::hex!($s)) }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sequence::FixedBytes;
+
+    #[test]
+    fn single_literal() {
+        assert_eq!(hex!("ff e4"), [0xff, 0xe4]);
+    }
+
+    #[test]
+    fn empty() {
+        let nothing: [u8; 0] = hex!();
+        let empty_literals: [u8; 0] = hex!("" "" "");
+        let expected: [u8; 0] = [];
+        assert_eq!(nothing, expected);
+        assert_eq!(empty_literals, expected);
+    }
+
+    #[test]
+    fn upper_case() {
+        assert_eq!(hex!("AE DF 04 B2"), [0xae, 0xdf, 0x04, 0xb2]);
+        assert_eq!(hex!("FF BA 8C 00 01"), [0xff, 0xba, 0x8c, 0x00, 0x01]);
+    }
+
+    #[test]
+    fn mixed_case() {
+        assert_eq!(hex!("bF dd E4 Cd"), [0xbf, 0xdd, 0xe4, 0xcd]);
+    }
+
+    #[test]
+    fn can_strip_prefix() {
+        assert_eq!(hex!("0x1a2b3c"), [0x1a, 0x2b, 0x3c]);
+        assert_eq!(hex!("0xa1" "0xb2" "0xc3"), [0xa1, 0xb2, 0xc3]);
+    }
+
+    #[test]
+    fn multiple_literals() {
+        assert_eq!(
+            hex!(
+                "01 dd f7 7f"
+                "ee f0 d8"
+            ),
+            [0x01, 0xdd, 0xf7, 0x7f, 0xee, 0xf0, 0xd8]
+        );
+        assert_eq!(
+            hex!(
+                "ff"
+                "e8 d0"
+                ""
+                "01 1f"
+                "ab"
+            ),
+            [0xff, 0xe8, 0xd0, 0x01, 0x1f, 0xab]
+        );
+    }
+
+    #[test]
+    fn no_spacing() {
+        assert_eq!(hex!("abf0d8bb0f14"), [0xab, 0xf0, 0xd8, 0xbb, 0x0f, 0x14]);
+        assert_eq!(
+            hex!("09FFd890cbcCd1d08F"),
+            [0x09, 0xff, 0xd8, 0x90, 0xcb, 0xcc, 0xd1, 0xd0, 0x8f]
+        );
+    }
+
+    #[test]
+    fn allows_various_spacing() {
+        // newlines
+        assert_eq!(
+            hex!(
+                "f
+                f
+                d
+                0
+                e
+
+                8
+                "
+            ),
+            [0xff, 0xd0, 0xe8]
+        );
+        // tabs
+        assert_eq!(hex!("9f	d		1		f07	3		01	"), [0x9f, 0xd1, 0xf0, 0x73, 0x01]);
+        // spaces
+        assert_eq!(hex!(" e    e d0  9 1   f  f  "), [0xee, 0xd0, 0x91, 0xff]);
+    }
+
+    #[test]
+    const fn can_use_const() {
+        const _: [u8; 4] = hex!("ff d3 01 7f");
+    }
+
+    #[test]
+    fn fixed_bytes() {
+        let bytes = fixed_bytes!("0x112233");
+        assert_eq!(bytes.as_ref(), &[0x11, 0x22, 0x33]);
+        assert_eq!(format!("{}", bytes), "112233");
+    }
+
+    #[test]
+    const fn const_fixed_bytes() {
+        const _: FixedBytes<4> = fixed_bytes!("0badc0de");
+    }
+}
+
+// https://github.com/alloy-rs/core/blob/main/LICENSE-MIT
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -23,6 +23,7 @@ pub use sequence::{Array, Span};
 pub mod bitmap;
 #[cfg(feature = "std")]
 pub mod channels;
+pub mod hex_literal;
 #[cfg(feature = "std")]
 pub mod net;
 pub mod set;
@@ -264,13 +265,13 @@ mod tests {
         assert_eq!(from_hex(&h).unwrap(), b.to_vec());
 
         // Test case 1: single byte
-        let b = &[0x01];
+        let b = &hex!("0x01");
         let h = hex(b);
         assert_eq!(h, "01");
         assert_eq!(from_hex(&h).unwrap(), b.to_vec());
 
         // Test case 2: multiple bytes
-        let b = &[0x01, 0x02, 0x03];
+        let b = &hex!("0x010203");
         let h = hex(b);
         assert_eq!(h, "010203");
         assert_eq!(from_hex(&h).unwrap(), b.to_vec());
@@ -300,13 +301,13 @@ mod tests {
         assert_eq!(from_hex_formatted(&h).unwrap(), b.to_vec());
 
         // Test case 1: single byte
-        let b = &[0x01];
+        let b = &hex!("0x01");
         let h = hex(b);
         assert_eq!(h, "01");
         assert_eq!(from_hex_formatted(&h).unwrap(), b.to_vec());
 
         // Test case 2: multiple bytes
-        let b = &[0x01, 0x02, 0x03];
+        let b = &hex!("0x010203");
         let h = hex(b);
         assert_eq!(h, "010203");
         assert_eq!(from_hex_formatted(&h).unwrap(), b.to_vec());
@@ -393,12 +394,12 @@ mod tests {
         assert_eq!(union(&[], &[]), []);
 
         // Test case 1: empty and non-empty slices
-        assert_eq!(union(&[], &[0x01, 0x02, 0x03]), [0x01, 0x02, 0x03]);
+        assert_eq!(union(&[], &hex!("0x010203")), hex!("0x010203"));
 
         // Test case 2: non-empty and non-empty slices
         assert_eq!(
-            union(&[0x01, 0x02, 0x03], &[0x04, 0x05, 0x06]),
-            [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]
+            union(&hex!("0x010203"), &hex!("0x040506")),
+            hex!("0x010203040506")
         );
     }
 
@@ -456,10 +457,10 @@ mod tests {
         assert_eq!(modulo(&[], 1), 0);
 
         // Test case 1: single byte
-        assert_eq!(modulo(&[0x01], 1), 0);
+        assert_eq!(modulo(&hex!("0x01"), 1), 0);
 
         // Test case 2: multiple bytes
-        assert_eq!(modulo(&[0x01, 0x02, 0x03], 10), 1);
+        assert_eq!(modulo(&hex!("0x010203"), 10), 1);
 
         // Test case 3: check equivalence with BigUint
         for i in 0..100 {
@@ -489,7 +490,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_modulo_zero_panics() {
-        modulo(&[0x01, 0x02, 0x03], 0);
+        modulo(&hex!("0x010203"), 0);
     }
 
     #[test]

--- a/utils/src/sequence/fixed_bytes.rs
+++ b/utils/src/sequence/fixed_bytes.rs
@@ -78,6 +78,7 @@ impl<const N: usize> From<[u8; N]> for FixedBytes<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fixed_bytes;
     use bytes::{Buf, BytesMut};
     use commonware_codec::{DecodeExt, Encode};
 
@@ -141,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_display() {
-        let bytes = FixedBytes::new([0x01, 0x02, 0x03, 0x04]);
+        let bytes = fixed_bytes!("0x01020304");
         assert_eq!(format!("{bytes}"), "01020304");
     }
 


### PR DESCRIPTION
## Overview

Vendors the `hex!` macro from [`alloy-primitives`](https://docs.rs/alloy-primitives/latest/alloy_primitives/) and also adds a convenience macro for `FixedBytes` that wraps it.

This is particularly useful for testing with static byte array cases.