### PR TITLE
[p2p] Graceful shutdown for Network

### DIFF
--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -777,14 +777,13 @@ mod tests {
             let addresses = vec![signer.public_key()];
 
             // Create network with separate labeled context
-            let network_context = context.with_label("network");
             let config = Config::test(
                 signer.clone(),
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3000),
                 Vec::new(),
                 1_024 * 1_024, // 1MB
             );
-            let (mut network, mut oracle) = Network::new(network_context.clone(), config);
+            let (mut network, mut oracle) = Network::new(context.clone(), config);
 
             // Register peers
             oracle.register(0, addresses.into()).await;
@@ -800,7 +799,7 @@ mod tests {
             context.sleep(Duration::from_millis(100)).await;
 
             // Stop the network context to trigger shutdown
-            network_context.stop(0, Some(Duration::from_secs(2))).await.unwrap();
+            context.stop(0, Some(Duration::from_secs(2))).await.unwrap();
 
             handle.await.unwrap();
         });

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -525,7 +525,7 @@ mod tests {
         let executor = tokio::Runner::default();
         executor.start(|context| async move {
             const MAX_MESSAGE_SIZE: usize = 1_024 * 1_024; // 1MB
-            let base_port = 3000;
+            let base_port = 3001;
             let n = 10;
             run_network(context, MAX_MESSAGE_SIZE, base_port, n, Mode::One).await;
         });

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -766,4 +766,43 @@ mod tests {
             }
         });
     }
+
+    #[test_traced]
+    fn test_shutdown() {
+        // Initialize context
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Create single peer
+            let signer = ed25519::PrivateKey::from_seed(0);
+            let addresses = vec![signer.public_key()];
+
+            // Create network with separate labeled context
+            let network_context = context.with_label("network");
+            let config = Config::test(
+                signer.clone(),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3000),
+                Vec::new(),
+                1_024 * 1_024, // 1MB
+            );
+            let (mut network, mut oracle) = Network::new(network_context.clone(), config);
+
+            // Register peers
+            oracle.register(0, addresses.into()).await;
+
+            // Register channel
+            let (_sender, _receiver) =
+                network.register(0, Quota::per_second(NZU32!(10)), DEFAULT_MESSAGE_BACKLOG);
+
+            // Start network
+            let handle = network.start();
+
+            // Give network time to start
+            context.sleep(Duration::from_millis(100)).await;
+
+            // Stop the network context to trigger shutdown
+            network_context.stop(0, Some(Duration::from_secs(2))).await.unwrap();
+
+            handle.await.unwrap();
+        });
+    }
 }

--- a/p2p/src/authenticated/discovery/network.rs
+++ b/p2p/src/authenticated/discovery/network.rs
@@ -215,13 +215,6 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metr
             },
         };
 
-        // Ensure all tasks close
-        tracker_task.abort();
-        router_task.abort();
-        spawner_task.abort();
-        listener_task.abort();
-        dialer_task.abort();
-
         // Log error if not clean shutdown
         if let Err(err) = result {
             warn!(error=?err, "network shutdown")

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -708,4 +708,44 @@ mod tests {
             }
         });
     }
+
+    #[test_traced]
+    fn test_shutdown() {
+        // Initialize context
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Create single peer
+            let signer = ed25519::PrivateKey::from_seed(0);
+            let addresses = vec![(
+                signer.public_key(),
+                SocketAddr::V4("127.0.0.1:8080".parse().unwrap()),
+            )];
+
+            // Create network with separate labeled context
+            let config = Config::test(
+                signer.clone(),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3000),
+                1_024 * 1_024, // 1MB
+            );
+            let (mut network, mut oracle) = Network::new(context.clone(), config);
+
+            // Register peers
+            oracle.register(0, addresses.into()).await;
+
+            // Register channel
+            let (_sender, _receiver) =
+                network.register(0, Quota::per_second(NZU32!(10)), DEFAULT_MESSAGE_BACKLOG);
+
+            // Start network
+            let handle = network.start();
+
+            // Give network time to start
+            context.sleep(Duration::from_millis(100)).await;
+
+            // Stop the network context to trigger shutdown
+            context.stop(0, Some(Duration::from_secs(2))).await.unwrap();
+
+            handle.await.unwrap();
+        });
+    }
 }

--- a/p2p/src/authenticated/lookup/network.rs
+++ b/p2p/src/authenticated/lookup/network.rs
@@ -207,13 +207,6 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + RNetwork + Metr
             },
         };
 
-        // Ensure all tasks close
-        tracker_task.abort();
-        router_task.abort();
-        spawner_task.abort();
-        listener_task.abort();
-        dialer_task.abort();
-
         // Log error if not clean shutdown
         if let Err(err) = result {
             warn!(error=?err, "network shutdown")


### PR DESCRIPTION
This adds graceful shutdown to the p2p networks (discovery, lookup, and simulated), as discussed here https://github.com/commonwarexyz/monorepo/discussions/1944.

Changes:
- Applies the same shutdown pattern used in [Simplex](https://github.com/commonwarexyz/monorepo/blob/5d945b62736ef5ed072b759c9715c8d85309abd9/consensus/src/simplex/engine.rs#L174) to the p2p networks
- Aborts all tasks in the lookup network after the shutdown was triggered (to be in line with the discovery network)