### PR TITLE
[runtime] Add option to instrument `spawn`ed tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,7 @@ version = "0.0.62"
 dependencies = [
  "futures",
  "futures-timer",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1866,7 +1867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1993,7 +1994,7 @@ checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "hashbrown",
+ "hashbrown 0.14.5",
  "hex",
  "rand_core 0.6.4",
  "serde",
@@ -2369,6 +2370,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -2759,12 +2766,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -2931,7 +2938,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3456,6 +3463,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4103,18 +4119,28 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4682,6 +4708,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -5381,6 +5437,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,6 +21,7 @@ futures = { workspace = true }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+proc-macro-crate = "3.4.0"
 
 [dev-dependencies]
 futures-timer = "3.0.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -35,6 +35,7 @@ sysinfo = { workspace = true }
 [features]
 default = []
 external = ["pin-project"]
+test-utils = []
 iouring-storage = ["io-uring"]
 iouring-network = ["io-uring"]
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -140,6 +140,9 @@ pub trait Spawner: Clone + Send + Sync + 'static {
     /// This is not the default behavior. See [`Spawner::shared`] for more information.
     fn dedicated(self) -> Self;
 
+    /// Return a [`Spawner`] that instruments the next spawned task with the label of the spawning context.
+    fn instrumented(self) -> Self;
+
     /// Spawn a task with the current context.
     ///
     /// Unlike directly awaiting a future, the task starts running immediately even if the caller
@@ -517,8 +520,9 @@ pub trait Blob: Clone + Send + Sync + 'static {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::telemetry::traces::collector::TraceStorage;
     use bytes::Bytes;
-    use commonware_macros::select;
+    use commonware_macros::{select, test_collect_traces};
     use futures::{
         channel::{mpsc, oneshot},
         future::{pending, ready},
@@ -2595,5 +2599,60 @@ mod tests {
             // Wait for the client task to complete
             client_handle.await.unwrap();
         });
+    }
+
+    #[test_collect_traces]
+    fn test_deterministic_instrument_tasks(traces: TraceStorage) {
+        let executor = deterministic::Runner::new(deterministic::Config::default());
+        executor.start(|context| async move {
+            context
+                .with_label("test")
+                .instrumented()
+                .spawn(|context| async move {
+                    tracing::info!(field = "test field", "test log");
+
+                    context
+                        .with_label("inner")
+                        .instrumented()
+                        .spawn(|_| async move {
+                            tracing::info!("inner log");
+                        })
+                        .await
+                        .unwrap();
+                })
+                .await
+                .unwrap();
+        });
+
+        let info_traces = traces.get_by_level(Level::INFO);
+        assert_eq!(info_traces.len(), 2);
+
+        // Outer log (single span)
+        info_traces
+            .expect_event_at_index(0, |event| {
+                event.metadata.expect_content_exact("test log")?;
+                event.metadata.expect_field_count(1)?;
+                event.metadata.expect_field_exact("field", "test field")?;
+                event.expect_span_count(1)?;
+                event.expect_span_at_index(0, |span| {
+                    span.expect_content_exact("task")?;
+                    span.expect_field_count(1)?;
+                    span.expect_field_exact("name", "test")
+                })
+            })
+            .unwrap();
+
+        info_traces
+            .expect_event_at_index(1, |event| {
+                event.metadata.expect_content_exact("inner log")?;
+                event.metadata.expect_field_count(0)?;
+                event.expect_span_count(1)?;
+                event.expect_span_at_index(0, |span| {
+                    span.expect_content_exact("task")?;
+                    span.expect_field_count(1)?;
+                    span.expect_field_exact("name", "test_inner")
+                })
+            })
+            .unwrap();
     }
 }

--- a/runtime/src/telemetry/traces/collector.rs
+++ b/runtime/src/telemetry/traces/collector.rs
@@ -1,0 +1,345 @@
+//! In-memory [tracing_subscriber::Layer] to collect spans and events for testing purposes.
+
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex},
+};
+use thiserror::Error;
+use tracing::{field, span, Event, Level, Subscriber};
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+
+/// An error that occurs when a trace assertion fails.
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
+#[error("Trace assertion error: {0}")]
+pub struct TraceAssertionError(String);
+
+impl From<String> for TraceAssertionError {
+    fn from(value: String) -> Self {
+        TraceAssertionError(value)
+    }
+}
+
+/// A [tracing] event with its content and associated fields.
+#[derive(Default, Clone, Debug)]
+pub struct EventMetadata {
+    /// The message content of the event.
+    pub content: String,
+    /// The fields associated with the event.
+    pub fields: Vec<(String, String)>,
+}
+
+impl EventMetadata {
+    /// Expects that the content of the event matches the string.
+    pub fn expect_content_exact(&self, content: &str) -> Result<(), TraceAssertionError> {
+        if self.content == content {
+            Ok(())
+        } else {
+            Err(format!("Expected content '{content}', found '{}'", self.content).into())
+        }
+    }
+
+    /// Expects that the content of the event contains the substring.
+    pub fn expect_content_contains(&self, substring: &str) -> Result<(), TraceAssertionError> {
+        if self.content.contains(substring) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Expected content containing '{substring}', found '{}'",
+                self.content
+            )
+            .into())
+        }
+    }
+
+    /// Expects that there are `n` fields associated with the event.
+    pub fn expect_field_count(&self, n: usize) -> Result<(), TraceAssertionError> {
+        if self.fields.len() == n {
+            Ok(())
+        } else {
+            Err(format!("Expected {n} fields, found {}", self.fields.len()).into())
+        }
+    }
+
+    /// Expects that a given field at the specified index matches the predicate.
+    pub fn expect_field_at_index<F>(
+        &self,
+        index: usize,
+        predicate: F,
+    ) -> Result<(), TraceAssertionError>
+    where
+        F: Fn(&(String, String)) -> Result<(), TraceAssertionError>,
+    {
+        match self.fields.get(index) {
+            Some(field) => predicate(field),
+            None => Err(format!("Missing field at index {index}").into()),
+        }
+    }
+
+    /// Expects that the event has a field with exactly the specified name and value.
+    pub fn expect_field_exact(
+        &self,
+        field_name: &str,
+        field_value: &str,
+    ) -> Result<(), TraceAssertionError> {
+        let found = self
+            .fields
+            .iter()
+            .any(|(name, value)| name == field_name && value == field_value);
+        if found {
+            Ok(())
+        } else {
+            Err(format!("Expected a field '{field_name}' with value '{field_value}'").into())
+        }
+    }
+
+    /// Expects that the event has a field with the specified name and a value that contains
+    /// the substring.
+    pub fn expect_field_contains(
+        &self,
+        field_name: &str,
+        field_value: &str,
+    ) -> Result<(), TraceAssertionError> {
+        let found = self
+            .fields
+            .iter()
+            .any(|(name, value)| name == field_name && value.contains(field_value));
+        if found {
+            Ok(())
+        } else {
+            Err(format!("Expected a field '{field_name}' containing value '{field_value}'").into())
+        }
+    }
+}
+
+impl field::Visit for EventMetadata {
+    fn record_str(&mut self, field: &field::Field, value: &str) {
+        if field.name() == "message" {
+            self.content = value.to_string();
+        } else {
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
+        let rendered = format!("{value:?}");
+        if field.name() == "message" {
+            self.content = rendered;
+        } else {
+            self.fields.push((field.name().to_string(), rendered));
+        }
+    }
+}
+
+/// A recorded event with its [Level], target, active spans, message, and fields.
+#[derive(Debug, Clone)]
+pub struct RecordedEvent {
+    /// The [Level] of the event.
+    pub level: Level,
+    /// The target of the event.
+    pub target: String,
+    /// The spans active during the event, in innermost -> outermost order.
+    pub spans: Vec<EventMetadata>,
+    /// The [EventMetadata].
+    pub metadata: EventMetadata,
+}
+
+impl RecordedEvent {
+    /// Expects that there are `n` spans active during the event.
+    pub fn expect_span_count(&self, n: usize) -> Result<(), TraceAssertionError> {
+        if self.spans.len() == n {
+            Ok(())
+        } else {
+            Err(format!("Expected {n} active spans, found {}", self.spans.len()).into())
+        }
+    }
+
+    /// Expects that the span at the specified index matches the predicate.
+    pub fn expect_span_at_index<F>(
+        &self,
+        index: usize,
+        predicate: F,
+    ) -> Result<(), TraceAssertionError>
+    where
+        F: Fn(&EventMetadata) -> Result<(), TraceAssertionError>,
+    {
+        match self.spans.get(index) {
+            Some(span) => predicate(span),
+            None => Err(format!("Missing span at index {index}").into()),
+        }
+    }
+
+    /// Expects that any span matches the predicate.
+    pub fn expect_span<F>(&self, predicate: F) -> Result<(), TraceAssertionError>
+    where
+        F: Fn(&EventMetadata) -> bool,
+    {
+        if self.spans.iter().any(predicate) {
+            Ok(())
+        } else {
+            Err("Missing span matching predicate".to_string().into())
+        }
+    }
+}
+
+/// A collection of [RecordedEvent]s.
+#[derive(Default, Debug, Clone)]
+pub struct RecordedEvents(Vec<RecordedEvent>);
+
+impl RecordedEvents {
+    /// Expects that the event at the specified index matches the predicate.
+    pub fn expect_event_at_index<F>(
+        &self,
+        index: usize,
+        predicate: F,
+    ) -> Result<(), TraceAssertionError>
+    where
+        F: Fn(&RecordedEvent) -> Result<(), TraceAssertionError>,
+    {
+        match self.get(index) {
+            Some(field) => predicate(field),
+            None => Err(format!("Missing event at index {index}").into()),
+        }
+    }
+
+    /// Expects that any [RecordedEvent] matches the predicate.
+    pub fn expect_event<F>(&self, predicate: F) -> Result<(), TraceAssertionError>
+    where
+        F: Fn(&RecordedEvent) -> bool,
+    {
+        if self.iter().any(predicate) {
+            Ok(())
+        } else {
+            Err("Missing event matching predicate".to_string().into())
+        }
+    }
+
+    /// Expects that any [RecordedEvent] contains a message that exactly matches the specified string.
+    pub fn expect_message_exact(&self, message: &str) -> Result<(), TraceAssertionError> {
+        let found = self.iter().any(|event| event.metadata.content == message);
+        if found {
+            Ok(())
+        } else {
+            Err(format!("Missing message: '{message}'").into())
+        }
+    }
+
+    /// Expects that any [RecordedEvent] contains a message that contains the specified substring.
+    pub fn expect_message_contains(&self, substring: &str) -> Result<(), TraceAssertionError> {
+        let found = self
+            .iter()
+            .any(|event| event.metadata.content.contains(substring));
+        if found {
+            Ok(())
+        } else {
+            Err(format!("Missing message containing: '{substring}'").into())
+        }
+    }
+}
+
+impl Deref for RecordedEvents {
+    type Target = Vec<RecordedEvent>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for RecordedEvents {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<Vec<RecordedEvent>> for RecordedEvents {
+    fn from(events: Vec<RecordedEvent>) -> Self {
+        Self(events)
+    }
+}
+
+/// The storage for the collected traces.
+#[derive(Debug, Default, Clone)]
+pub struct TraceStorage(Arc<Mutex<RecordedEvents>>);
+
+impl TraceStorage {
+    /// Returns the [RecordedEvent]s that match the specified [Level].
+    pub fn get_by_level(&self, level: Level) -> RecordedEvents {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| (event.level == level).then_some(event.clone()))
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    /// Returns all [RecordedEvent]s in the storage.
+    pub fn get_all(&self) -> RecordedEvents {
+        self.0.lock().unwrap().clone()
+    }
+
+    /// Returns if the storage is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.lock().unwrap().is_empty()
+    }
+}
+
+/// A subscriber layer for [tracing] that collects traces and their log levels.
+#[derive(Debug, Default)]
+pub struct CollectingLayer(TraceStorage);
+
+impl CollectingLayer {
+    /// Creates a new collecting layer with the specified [TraceStorage].
+    pub const fn new(storage: TraceStorage) -> Self {
+        Self(storage)
+    }
+}
+
+impl<S> Layer<S> for CollectingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut span_fields = EventMetadata::default();
+            attrs.record(&mut span_fields);
+            span.extensions_mut().insert(span_fields);
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        let level = *metadata.level();
+
+        let mut event_meta = EventMetadata::default();
+        event.record(&mut event_meta);
+
+        let mut spans = Vec::new();
+        if let Some(current) = ctx.lookup_current() {
+            let mut current = Some(current);
+            while let Some(span) = current {
+                let metadata = span.metadata();
+                let EventMetadata { fields, .. } = span
+                    .extensions()
+                    .get::<EventMetadata>()
+                    .cloned()
+                    .unwrap_or_default();
+
+                spans.push(EventMetadata {
+                    content: metadata.name().to_string(),
+                    fields,
+                });
+                current = span.parent();
+            }
+        }
+
+        let mut storage = self.0 .0.lock().unwrap();
+        storage.push(RecordedEvent {
+            level,
+            target: metadata.target().to_string(),
+            spans,
+            metadata: event_meta,
+        });
+    }
+}

--- a/runtime/src/telemetry/traces/mod.rs
+++ b/runtime/src/telemetry/traces/mod.rs
@@ -1,3 +1,6 @@
 //! Utility functions for traces
 
 pub mod status;
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod collector;

--- a/runtime/src/utils/cell.rs
+++ b/runtime/src/utils/cell.rs
@@ -102,6 +102,10 @@ where
         Self::Present(self.into().shared(blocking))
     }
 
+    fn instrumented(self) -> Self {
+        Self::Present(self.into().instrumented())
+    }
+
     fn spawn<F, Fut, T>(self, f: F) -> Handle<T>
     where
         F: FnOnce(Self) -> Fut + Send + 'static,


### PR DESCRIPTION
## Overview

Adds an option to the deterministic + tokio runtime to instrument spawned tasks with info-level spans. This is particularly helpful in tests that spin up several versions of the same actor to disambiguate log sources, ex.:

<img width="1468" height="853" alt="Screenshot 2025-10-24 at 3 46 20 PM" src="https://github.com/user-attachments/assets/3a5aa204-0bcd-410f-9364-053d28d8265a" />

---

Also adds a tracing layer that can collect traces in-memory, so tests can assert that certain traces were emitted. A new proc macro, `test_collect_traces`, was added for convenient use of this utility.

```rust
use commonware_macros::test_collect_traces;
use commonware_runtime::telemetry::traces::collector::TraceStorage;
use tracing::{debug, info};

#[test_collect_traces("INFO")]
fn test_info_level(traces: TraceStorage) {
    info!("This is an info log");
    debug!(my_field = "example", "This is a debug log (won't be shown in console output)");

    // Trace store collects all traces on all levels.
    let traces = traces.get_all();
    assert_eq!(traces.len(), 2);
    traces.expect_message_exact("This is an info log").unwrap();
    traces
        .expect_message_contains("This is a debug log")
        .unwrap();
    traces
        .expect_event(|event| {
            event
                .metadata
                .expect_field_exact("my_field", "example")
                .is_ok()
        })
        .unwrap();
}
```