### PR TITLE
[Storage] Change `journal::contiguous::Contiguous` to remove unneeded async/Result in signatures

### DIFF
--- a/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
@@ -86,7 +86,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 JournalOperation::Size => {
-                    let size = journal.size().await.unwrap();
+                    let size = journal.size().await;
                     assert_eq!(journal_size, size, "unexpected size");
                 }
 

--- a/storage/src/adb/any/fixed/mod.rs
+++ b/storage/src/adb/any/fixed/mod.rs
@@ -109,7 +109,7 @@ pub(crate) async fn init_mmr_and_log<
     .await?;
 
     // Back up over / discard any uncommitted operations in the log.
-    let mut log_size: Location = log.size().await?.into();
+    let mut log_size: Location = log.size().await.into();
     let mut rewind_leaf_num = log_size;
     let mut inactivity_floor_loc = Location::new_unchecked(0);
     while rewind_leaf_num > 0 {
@@ -158,7 +158,7 @@ pub(crate) async fn init_mmr_and_log<
     }
 
     // At this point the MMR and log should be consistent.
-    assert_eq!(log.size().await?, mmr.leaves());
+    assert_eq!(log.size().await, mmr.leaves());
 
     Ok((inactivity_floor_loc, mmr, log))
 }
@@ -237,7 +237,7 @@ where
     O: FixedOperation,
     H: CHasher,
 {
-    let size = Location::new_unchecked(log.size().await?);
+    let size = Location::new_unchecked(log.size().await);
     if op_count > size {
         return Err(crate::mmr::Error::RangeOutOfBounds(size).into());
     }
@@ -399,7 +399,7 @@ where
         // Find the snapshot entry corresponding to the operation.
         if cursor.find(|&loc| *loc == old_loc) {
             // Update the operation's snapshot location to point to tip.
-            let tip_loc = Location::new_unchecked(self.log.size().await?);
+            let tip_loc = Location::new_unchecked(self.log.size().await);
             cursor.update(tip_loc);
             drop(cursor);
 
@@ -431,7 +431,7 @@ where
         //
         // TODO(https://github.com/commonwarexyz/monorepo/issues/1829): optimize this w/ a bitmap.
         loop {
-            let tip_loc = Location::new_unchecked(self.log.size().await?);
+            let tip_loc = Location::new_unchecked(self.log.size().await);
             assert!(
                 *inactivity_floor_loc < tip_loc,
                 "no active operations above the inactivity floor"

--- a/storage/src/adb/any/fixed/ordered.rs
+++ b/storage/src/adb/any/fixed/ordered.rs
@@ -133,7 +133,7 @@ impl<
             .replay(NZUsize!(SNAPSHOT_READ_BUFFER_SIZE), *inactivity_floor_loc)
             .await?;
         pin_mut!(stream);
-        let last_commit_loc = log.size().await?.saturating_sub(1);
+        let last_commit_loc = log.size().await.saturating_sub(1);
         while let Some(result) = stream.next().await {
             let (i, op) = result?;
             match op {
@@ -1071,7 +1071,7 @@ mod test {
             db.update(key2, new_val).await.unwrap();
             assert_eq!(db.get_all(&key2).await.unwrap().unwrap(), (new_val, key1));
 
-            assert_eq!(db.log.size().await.unwrap(), 8); // 2 new keys (4), 2 updates (2), 1 deletion (2)
+            assert_eq!(db.log.size().await, 8); // 2 new keys (4), 2 updates (2), 1 deletion (2)
             assert_eq!(db.snapshot.keys(), 2);
             assert_eq!(db.inactivity_floor_loc, 0);
             db.sync().await.unwrap();
@@ -1081,7 +1081,7 @@ mod test {
             let loc = db.inactivity_floor_loc;
             db.inactivity_floor_loc = db.as_shared().raise_floor(loc).await.unwrap();
             assert_eq!(db.inactivity_floor_loc, Location::new_unchecked(6));
-            assert_eq!(db.log.size().await.unwrap(), 9);
+            assert_eq!(db.log.size().await, 9);
             db.sync().await.unwrap();
 
             // Delete all keys and commit the changes.
@@ -1089,7 +1089,7 @@ mod test {
             db.delete(key2).await.unwrap();
             assert!(db.get(&key1).await.unwrap().is_none());
             assert!(db.get(&key2).await.unwrap().is_none());
-            assert_eq!(db.log.size().await.unwrap(), 12);
+            assert_eq!(db.log.size().await, 12);
             db.commit().await.unwrap();
             let root = db.root(&mut hasher);
 
@@ -1099,21 +1099,21 @@ mod test {
 
             // Multiple deletions of the same key should be a no-op.
             db.delete(key1).await.unwrap();
-            assert_eq!(db.log.size().await.unwrap(), 13);
+            assert_eq!(db.log.size().await, 13);
             assert_eq!(db.root(&mut hasher), root);
 
             // Deletions of non-existent keys should be a no-op.
             let key3 = Sha256::fill(5u8);
             assert!(db.delete(key3).await.is_ok());
-            assert_eq!(db.log.size().await.unwrap(), 13);
+            assert_eq!(db.log.size().await, 13);
             db.sync().await.unwrap();
             assert_eq!(db.root(&mut hasher), root);
 
             // Make sure closing/reopening gets us back to the same state.
-            assert_eq!(db.log.size().await.unwrap(), 13);
+            assert_eq!(db.log.size().await, 13);
             db.close().await.unwrap();
             let mut db = open_db(context.clone()).await;
-            assert_eq!(db.log.size().await.unwrap(), 13);
+            assert_eq!(db.log.size().await, 13);
             assert_eq!(db.root(&mut hasher), root);
 
             // Re-activate the keys by updating them.
@@ -1191,7 +1191,7 @@ mod test {
 
             assert_eq!(db.op_count(), 2619);
             assert_eq!(db.inactivity_floor_loc, 0);
-            assert_eq!(db.log.size().await.unwrap(), 2619);
+            assert_eq!(db.log.size().await, 2619);
             assert_eq!(db.snapshot.items(), 857);
 
             // Test that commit + sync w/ pruning will raise the activity floor.

--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -194,7 +194,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
         .await?;
         let last_commit = locations
             .size()
-            .await?
+            .await
             .checked_sub(1)
             .map(Location::new_unchecked);
 
@@ -359,7 +359,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
 
         // Confirm post-conditions hold.
         assert_eq!(self.log_size, self.mmr.leaves());
-        assert_eq!(self.log_size, self.locations.size().await?);
+        assert_eq!(self.log_size, self.locations.size().await);
 
         debug!(log_size = ?self.log_size, "build_snapshot_from_log complete");
 
@@ -1544,7 +1544,7 @@ pub(super) mod test {
                 Location::try_from(db.mmr.size()).ok(),
                 Some(Location::new_unchecked(1960))
             );
-            assert_eq!(db.locations.size().await.unwrap(), 1960);
+            assert_eq!(db.locations.size().await, 1960);
             assert_eq!(db.inactivity_floor_loc, Location::new_unchecked(755));
             db.sync().await.unwrap(); // test pruning boundary after sync w/ prune
             db.prune(db.inactivity_floor_loc()).await.unwrap();
@@ -1563,7 +1563,7 @@ pub(super) mod test {
                 Location::try_from(db.mmr.size()).ok(),
                 Some(Location::new_unchecked(1960))
             );
-            assert_eq!(db.locations.size().await.unwrap(), 1960);
+            assert_eq!(db.locations.size().await, 1960);
             assert_eq!(db.inactivity_floor_loc, Location::new_unchecked(755));
             assert_eq!(
                 db.oldest_retained_loc().unwrap(),

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -383,7 +383,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
 
         // Confirm post-conditions hold.
         assert_eq!(log_size, Location::try_from(mmr.size()).unwrap());
-        assert_eq!(log_size, locations.size().await?);
+        assert_eq!(log_size, locations.size().await);
 
         let oldest_retained_loc = oldest_retained_loc.unwrap_or(Location::new_unchecked(0));
         Ok((log_size, oldest_retained_loc))

--- a/storage/src/adb/immutable/sync/journal.rs
+++ b/storage/src/adb/immutable/sync/journal.rs
@@ -78,8 +78,8 @@ where
     type Op = Operation<K, V>;
     type Error = crate::journal::Error;
 
-    async fn size(&self) -> Result<u64, Self::Error> {
-        Ok(self.size)
+    async fn size(&self) -> u64 {
+        self.size
     }
 
     async fn append(&mut self, op: Self::Op) -> Result<(), Self::Error> {

--- a/storage/src/adb/immutable/sync/mod.rs
+++ b/storage/src/adb/immutable/sync/mod.rs
@@ -105,7 +105,7 @@ where
         config: &Self::Config,
         range: Range<Location>,
     ) -> Result<Self::Journal, Error> {
-        let size = journal.size().await.map_err(crate::adb::Error::from)?;
+        let size = journal.size().await;
 
         if size <= range.start {
             // Close existing journal and create new one
@@ -550,7 +550,7 @@ mod tests {
                         NextStep::Continue(new_client) => new_client,
                         NextStep::Complete(_) => panic!("client should not be complete"),
                     };
-                    let log_size = client.journal().size().await.unwrap();
+                    let log_size = client.journal().size().await;
                     if log_size > initial_lower_bound {
                         break client;
                     }

--- a/storage/src/adb/keyless.rs
+++ b/storage/src/adb/keyless.rs
@@ -333,7 +333,7 @@ impl<E: Storage + Clock + Metrics, V: Codec, H: CHasher> Keyless<E, V, H> {
             locations.sync().await?;
             mmr.pop((aligned_size - valid_size) as usize).await?;
         }
-        assert_eq!(mmr.leaves(), locations.size().await?);
+        assert_eq!(mmr.leaves(), locations.size().await);
 
         // Apply operations from the log at indices beyond the `aligned_size` to the MMR and locations journal.
         //
@@ -368,7 +368,7 @@ impl<E: Storage + Clock + Metrics, V: Codec, H: CHasher> Keyless<E, V, H> {
         )
         .await?;
         assert_eq!(size, mmr.leaves());
-        assert_eq!(size, locations.size().await?);
+        assert_eq!(size, locations.size().await);
 
         Ok(Self {
             mmr,

--- a/storage/src/adb/mod.rs
+++ b/storage/src/adb/mod.rs
@@ -82,7 +82,7 @@ async fn align_mmr_and_locations<E: Storage + Clock + Metrics, H: Hasher>(
     locations: &mut Journal<E, u32>,
 ) -> Result<u64, Error> {
     let aligned_size = {
-        let locations_size = locations.size().await?;
+        let locations_size = locations.size().await;
         let mmr_leaves = *mmr.leaves();
         if locations_size > mmr_leaves {
             warn!(
@@ -102,7 +102,7 @@ async fn align_mmr_and_locations<E: Storage + Clock + Metrics, H: Hasher>(
     };
 
     // Verify post-conditions hold.
-    assert_eq!(aligned_size, locations.size().await?);
+    assert_eq!(aligned_size, locations.size().await);
     assert_eq!(aligned_size, mmr.leaves());
 
     Ok(aligned_size)

--- a/storage/src/adb/store/mod.rs
+++ b/storage/src/adb/store/mod.rs
@@ -576,7 +576,7 @@ where
     /// Returns the number of operations that were applied to the store, the oldest retained
     /// location, and the inactivity floor location.
     async fn build_snapshot_from_log(mut self) -> Result<Self, Error> {
-        let mut locations_size = self.locations.size().await?;
+        let mut locations_size = self.locations.size().await;
 
         // The location and blob-offset of the first operation to follow the last known commit point.
         let mut after_last_commit = None;
@@ -700,11 +700,11 @@ where
         }
 
         // Confirm post-conditions hold.
-        assert_eq!(self.log_size, self.locations.size().await?);
+        assert_eq!(self.log_size, self.locations.size().await);
         self.last_commit = self
             .locations
             .size()
-            .await?
+            .await
             .checked_sub(1)
             .map(Location::new_unchecked);
         assert!(

--- a/storage/src/adb/sync/engine.rs
+++ b/storage/src/adb/sync/engine.rs
@@ -226,7 +226,7 @@ where
             .max_outstanding_requests
             .saturating_sub(self.outstanding_requests.len());
 
-        let log_size = self.journal.size().await?;
+        let log_size = self.journal.size().await;
 
         for _ in 0..num_requests {
             // Convert fetched operations to operation counts for shared gap detection
@@ -311,7 +311,7 @@ where
     /// and applies them in order. It removes stale batches and handles partial
     /// application of batches when needed.
     pub async fn apply_operations(&mut self) -> Result<(), Error<DB, R>> {
-        let mut next_loc = self.journal.size().await?;
+        let mut next_loc = self.journal.size().await;
 
         // Remove any batches of operations with stale data.
         // That is, those whose last operation is before `next_loc`.
@@ -369,7 +369,7 @@ where
 
     /// Check if sync is complete based on the current journal size and target
     pub async fn is_complete(&self) -> Result<bool, Error<DB, R>> {
-        let journal_size = self.journal.size().await?;
+        let journal_size = self.journal.size().await;
         let target_journal_size = self.target.range.end;
 
         // Check if we've completed sync

--- a/storage/src/adb/sync/journal.rs
+++ b/storage/src/adb/sync/journal.rs
@@ -9,7 +9,7 @@ pub trait Journal {
     type Error: std::error::Error + Send + 'static + Into<crate::adb::Error>;
 
     /// Get the number of operations in the journal
-    fn size(&self) -> impl Future<Output = Result<u64, Self::Error>>;
+    fn size(&self) -> impl Future<Output = u64>;
 
     /// Append an operation to the journal
     fn append(&mut self, op: Self::Op) -> impl Future<Output = Result<(), Self::Error>>;

--- a/storage/src/journal/benches/fixed_read_sequential.rs
+++ b/storage/src/journal/benches/fixed_read_sequential.rs
@@ -40,7 +40,7 @@ fn bench_fixed_read_sequential(c: &mut Criterion) {
                     let ctx = context::get::<commonware_runtime::tokio::Context>();
                     let mut j = get_journal::<ITEM_SIZE>(ctx, PARTITION, ITEMS_PER_BLOB).await;
                     append_random_data::<ITEM_SIZE>(&mut j, items).await;
-                    let sz = j.size().await.unwrap();
+                    let sz = j.size().await;
                     assert_eq!(sz, items);
 
                     // Run the benchmark

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -302,11 +302,11 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> Journal<E, A> {
 
     /// Return the total number of items in the journal, irrespective of pruning. The next value
     /// appended to the journal will be at this position.
-    pub async fn size(&self) -> Result<u64, Error> {
+    pub async fn size(&self) -> u64 {
         let size = self.tail.size().await;
         assert_eq!(size % Self::CHUNK_SIZE_U64, 0);
         let items_in_blob = size / Self::CHUNK_SIZE_U64;
-        Ok(items_in_blob + self.cfg.items_per_blob.get() * self.tail_index)
+        items_in_blob + self.cfg.items_per_blob.get() * self.tail_index
     }
 
     /// Append a new item to the journal. Return the item's position in the journal, or error if the
@@ -371,7 +371,7 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> Journal<E, A> {
     /// * This operation is not atomic, but it will always leave the journal in a consistent state
     ///   in the event of failure since blobs are always removed from newest to oldest.
     pub async fn rewind(&mut self, size: u64) -> Result<(), Error> {
-        match size.cmp(&self.size().await?) {
+        match size.cmp(&self.size().await) {
             std::cmp::Ordering::Greater => return Err(Error::InvalidRewind(size)),
             std::cmp::Ordering::Equal => return Ok(()),
             std::cmp::Ordering::Less => {}
@@ -467,7 +467,7 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> Journal<E, A> {
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + '_, Error> {
-        assert!(start_pos <= self.size().await?);
+        assert!(start_pos <= self.size().await);
 
         // Collect all blobs to replay paired with their index.
         let items_per_blob = self.cfg.items_per_blob.get();
@@ -629,7 +629,7 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()> + Send + Sync> super::Contigu
         Journal::append(self, item).await
     }
 
-    async fn size(&self) -> Result<u64, Error> {
+    async fn size(&self) -> u64 {
         Journal::size(self).await
     }
 
@@ -815,7 +815,7 @@ mod tests {
                 .await
                 .expect("failed to max-prune journal");
             let buffer = context.encode();
-            let size = journal.size().await.unwrap();
+            let size = journal.size().await;
             assert_eq!(size, 10);
             assert_eq!(journal.oldest_blob_index(), 5);
             assert_eq!(journal.tail_index, 5);
@@ -1067,7 +1067,7 @@ mod tests {
                     .await
                     .expect("failed to append data");
             }
-            assert_eq!(journal.size().await.unwrap(), item_count);
+            assert_eq!(journal.size().await, item_count);
             journal.close().await.expect("Failed to close journal");
 
             // Truncate the tail blob by one byte, which should result in the 3rd item being
@@ -1093,7 +1093,7 @@ mod tests {
                 .unwrap();
 
             // Confirm 2 items were trimmed.
-            assert_eq!(journal.size().await.unwrap(), item_count - 2);
+            assert_eq!(journal.size().await, item_count - 2);
 
             // Corrupt the last item, ensuring last blob is trimmed to empty state.
             let (blob, size) = context
@@ -1108,7 +1108,7 @@ mod tests {
                 .unwrap();
 
             // Confirm last item in blob was trimmed.
-            assert_eq!(journal.size().await.unwrap(), item_count - 3);
+            assert_eq!(journal.size().await, item_count - 3);
 
             // Cleanup.
             journal.destroy().await.expect("Failed to destroy journal");
@@ -1201,7 +1201,7 @@ mod tests {
                     .await
                     .expect("failed to append data");
             }
-            assert_eq!(journal.size().await.unwrap(), 5);
+            assert_eq!(journal.size().await, 5);
             let buffer = context.encode();
             assert!(buffer.contains("tracked 2"));
             journal.close().await.expect("Failed to close journal");
@@ -1220,7 +1220,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             // the last corrupted item should get discarded
-            assert_eq!(journal.size().await.unwrap(), 4);
+            assert_eq!(journal.size().await, 4);
             let buffer = context.encode();
             assert!(buffer.contains("tracked 2"));
             journal.close().await.expect("Failed to close journal");
@@ -1234,13 +1234,13 @@ mod tests {
             let journal = Journal::<_, Digest>::init(context.clone(), cfg.clone())
                 .await
                 .expect("Failed to re-initialize journal");
-            assert_eq!(journal.size().await.unwrap(), 3);
+            assert_eq!(journal.size().await, 3);
             let buffer = context.encode();
             // Even though it was deleted, tail blob should be re-created and left empty by the
             // recovery code. This means we have 2 blobs total, with 3 items in the first, and none
             // in the tail.
             assert!(buffer.contains("tracked 2"));
-            assert_eq!(journal.size().await.unwrap(), 3);
+            assert_eq!(journal.size().await, 3);
 
             journal.destroy().await.unwrap();
         });
@@ -1260,7 +1260,7 @@ mod tests {
                 .append(test_digest(0))
                 .await
                 .expect("failed to append data");
-            assert_eq!(journal.size().await.unwrap(), 1);
+            assert_eq!(journal.size().await, 1);
             journal.close().await.expect("Failed to close journal");
 
             // Manually truncate most recent blob to simulate a partial write.
@@ -1279,14 +1279,14 @@ mod tests {
 
             // Since there was only a single item appended which we then corrupted, recovery should
             // leave us in the state of an empty journal.
-            assert_eq!(journal.size().await.unwrap(), 0);
+            assert_eq!(journal.size().await, 0);
             assert_eq!(journal.oldest_retained_pos().await.unwrap(), None);
             // Make sure journal still works for appending.
             journal
                 .append(test_digest(0))
                 .await
                 .expect("failed to append data");
-            assert_eq!(journal.size().await.unwrap(), 1);
+            assert_eq!(journal.size().await, 1);
 
             journal.destroy().await.unwrap();
         });
@@ -1307,7 +1307,7 @@ mod tests {
                 .append(test_digest(0))
                 .await
                 .expect("failed to append data");
-            assert_eq!(journal.size().await.unwrap(), 1);
+            assert_eq!(journal.size().await, 1);
             journal.close().await.expect("Failed to close journal");
 
             // Manually extend the blob by an amount at least some multiple of the chunk size to
@@ -1328,7 +1328,7 @@ mod tests {
                 .expect("Failed to re-initialize journal");
 
             // Ensure we've recovered to the state of a single item.
-            assert_eq!(journal.size().await.unwrap(), 1);
+            assert_eq!(journal.size().await, 1);
             assert_eq!(journal.oldest_retained_pos().await.unwrap(), Some(0));
 
             // Make sure journal still works for appending.
@@ -1336,7 +1336,7 @@ mod tests {
                 .append(test_digest(1))
                 .await
                 .expect("failed to append data");
-            assert_eq!(journal.size().await.unwrap(), 2);
+            assert_eq!(journal.size().await, 2);
 
             // Get the value of the first item
             let item = journal.read(0).await.unwrap();
@@ -1370,10 +1370,10 @@ mod tests {
                 .append(test_digest(0))
                 .await
                 .expect("failed to append data 0");
-            assert_eq!(journal.size().await.unwrap(), 1);
+            assert_eq!(journal.size().await, 1);
             assert!(matches!(journal.rewind(1).await, Ok(()))); // should be no-op
             assert!(matches!(journal.rewind(0).await, Ok(())));
-            assert_eq!(journal.size().await.unwrap(), 0);
+            assert_eq!(journal.size().await, 0);
 
             // append 7 items
             for i in 0..7 {
@@ -1385,11 +1385,11 @@ mod tests {
             }
             let buffer = context.encode();
             assert!(buffer.contains("tracked 4"));
-            assert_eq!(journal.size().await.unwrap(), 7);
+            assert_eq!(journal.size().await, 7);
 
             // rewind back to item #4, which should prune 2 blobs
             assert!(matches!(journal.rewind(4).await, Ok(())));
-            assert_eq!(journal.size().await.unwrap(), 4);
+            assert_eq!(journal.size().await, 4);
             let buffer = context.encode();
             assert!(buffer.contains("tracked 3"));
 
@@ -1397,7 +1397,7 @@ mod tests {
             assert!(matches!(journal.rewind(0).await, Ok(())));
             let buffer = context.encode();
             assert!(buffer.contains("tracked 1"));
-            assert_eq!(journal.size().await.unwrap(), 0);
+            assert_eq!(journal.size().await, 0);
 
             // stress test: add 100 items, rewind 49, repeat x10.
             for _ in 0..10 {
@@ -1407,13 +1407,10 @@ mod tests {
                         .await
                         .expect("failed to append data");
                 }
-                journal
-                    .rewind(journal.size().await.unwrap() - 49)
-                    .await
-                    .unwrap();
+                journal.rewind(journal.size().await - 49).await.unwrap();
             }
             const ITEMS_REMAINING: u64 = 10 * (100 - 49);
-            assert_eq!(journal.size().await.unwrap(), ITEMS_REMAINING);
+            assert_eq!(journal.size().await, ITEMS_REMAINING);
 
             journal.close().await.expect("Failed to close journal");
 
@@ -1430,12 +1427,9 @@ mod tests {
                         .await
                         .expect("failed to append data");
                 }
-                journal
-                    .rewind(journal.size().await.unwrap() - 49)
-                    .await
-                    .unwrap();
+                journal.rewind(journal.size().await - 49).await.unwrap();
             }
-            assert_eq!(journal.size().await.unwrap(), ITEMS_REMAINING);
+            assert_eq!(journal.size().await, ITEMS_REMAINING);
 
             journal.close().await.expect("Failed to close journal");
 
@@ -1443,11 +1437,11 @@ mod tests {
             let mut journal: Journal<_, Digest> = Journal::init(context.clone(), cfg.clone())
                 .await
                 .expect("failed to re-initialize journal");
-            assert_eq!(journal.size().await.unwrap(), 10 * (100 - 49));
+            assert_eq!(journal.size().await, 10 * (100 - 49));
 
             // Make sure rewinding works after pruning
             journal.prune(300).await.expect("pruning failed");
-            assert_eq!(journal.size().await.unwrap(), ITEMS_REMAINING);
+            assert_eq!(journal.size().await, ITEMS_REMAINING);
             // Rewinding prior to our prune point should fail.
             assert!(matches!(
                 journal.rewind(299).await,
@@ -1456,7 +1450,7 @@ mod tests {
             // Rewinding to the prune point should work.
             // always remain in the journal.
             assert!(matches!(journal.rewind(300).await, Ok(())));
-            assert_eq!(journal.size().await.unwrap(), 300);
+            assert_eq!(journal.size().await, 300);
             assert_eq!(journal.oldest_retained_pos().await.unwrap(), None);
 
             journal.destroy().await.unwrap();

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -41,7 +41,7 @@ pub trait Contiguous {
     ///
     /// This count is NOT affected by pruning. The next appended item will receive this
     /// position as its value.
-    fn size(&self) -> impl std::future::Future<Output = Result<u64, Error>> + Send;
+    fn size(&self) -> impl std::future::Future<Output = u64> + Send;
 
     /// Return the position of the oldest item still retained in the journal.
     ///

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -62,7 +62,7 @@ where
     J: Contiguous<Item = u64> + Send + 'static,
 {
     let journal = factory("empty".to_string()).await.unwrap();
-    assert_eq!(journal.size().await.unwrap(), 0);
+    assert_eq!(journal.size().await, 0);
     journal.destroy().await.unwrap();
 }
 
@@ -156,7 +156,7 @@ where
     assert_eq!(pos1, 0);
     assert_eq!(pos2, 1);
     assert_eq!(pos3, 2);
-    assert_eq!(journal.size().await.unwrap(), 3);
+    assert_eq!(journal.size().await, 3);
 
     // Verify values can be read back
     assert_eq!(journal.read(0).await.unwrap(), 100);
@@ -179,7 +179,7 @@ where
         assert_eq!(pos, i);
     }
 
-    assert_eq!(journal.size().await.unwrap(), 25);
+    assert_eq!(journal.size().await, 25);
 
     for i in 0..25u64 {
         assert_eq!(journal.read(i).await.unwrap(), i * 10);
@@ -262,21 +262,21 @@ where
         journal.append(i).await.unwrap();
     }
 
-    let size_before = journal.size().await.unwrap();
+    let size_before = journal.size().await;
     journal.prune(10).await.unwrap();
-    let size_after = journal.size().await.unwrap();
+    let size_after = journal.size().await;
 
     assert_eq!(size_before, size_after);
     assert_eq!(size_after, 20);
 
     journal.prune(20).await.unwrap();
-    let size_after_all = journal.size().await.unwrap();
+    let size_after_all = journal.size().await;
     assert_eq!(size_after, size_after_all);
 
     journal.close().await.unwrap();
 
     let journal = factory("prune_retains_size".to_string()).await.unwrap();
-    let size_after_close = journal.size().await.unwrap();
+    let size_after_close = journal.size().await;
     assert_eq!(size_after_close, size_after_all);
 
     journal.destroy().await.unwrap();
@@ -296,7 +296,7 @@ where
     assert_eq!(pos1, 0);
     assert_eq!(pos2, 1);
 
-    let size = Contiguous::size(&journal).await.unwrap();
+    let size = Contiguous::size(&journal).await;
     assert_eq!(size, 2);
 
     journal.destroy().await.unwrap();
@@ -361,7 +361,7 @@ where
     let pos = journal.append(999).await.unwrap();
     assert_eq!(pos, 10);
 
-    let size = journal.size().await.unwrap();
+    let size = journal.size().await;
     assert_eq!(size, 11);
 
     journal.destroy().await.unwrap();
@@ -436,7 +436,7 @@ where
     assert_eq!(pos, 5);
     assert_eq!(journal.read(5).await.unwrap(), 100);
 
-    let size = journal.size().await.unwrap();
+    let size = journal.size().await;
     assert_eq!(size, 6);
 
     journal.destroy().await.unwrap();
@@ -477,7 +477,7 @@ where
         journal.append(i).await.unwrap();
     }
 
-    let size = journal.size().await.unwrap();
+    let size = journal.size().await;
 
     {
         let stream = journal.replay(size, NZUsize!(1024)).await.unwrap();
@@ -512,7 +512,7 @@ where
     assert!(pruned1);
     assert!(!pruned2); // Second prune should return false (nothing to prune)
 
-    let size = journal.size().await.unwrap();
+    let size = journal.size().await;
     assert_eq!(size, 20);
     assert_eq!(journal.read(10).await.unwrap(), 10);
     assert_eq!(journal.read(19).await.unwrap(), 19);
@@ -536,7 +536,7 @@ where
     journal.prune(100).await.unwrap();
 
     // Verify journal still works
-    let size = journal.size().await.unwrap();
+    let size = journal.size().await;
     assert_eq!(size, 10);
 
     let pos = journal.append(999).await.unwrap();
@@ -563,7 +563,7 @@ where
             assert_eq!(pos, i);
         }
 
-        let size = journal.size().await.unwrap();
+        let size = journal.size().await;
         assert_eq!(size, 15);
 
         journal.close().await.unwrap();
@@ -573,7 +573,7 @@ where
     {
         let journal = factory(test_name.clone()).await.unwrap();
 
-        let size = journal.size().await.unwrap();
+        let size = journal.size().await;
         assert_eq!(size, 15);
 
         // Verify reads work after persistence
@@ -622,7 +622,7 @@ where
         let pruned = journal.prune(10).await.unwrap();
         assert!(pruned);
 
-        let size = journal.size().await.unwrap();
+        let size = journal.size().await;
         assert_eq!(size, 25);
 
         journal.close().await.unwrap();
@@ -633,7 +633,7 @@ where
         let mut journal = factory(test_name.clone()).await.unwrap();
 
         // Size should still be 25
-        let size = journal.size().await.unwrap();
+        let size = journal.size().await;
         assert_eq!(size, 25);
 
         // Verify pruned positions cannot be read
@@ -750,7 +750,7 @@ where
     // Rewind to 12 items
     journal.rewind(12).await.unwrap();
 
-    assert_eq!(journal.size().await.unwrap(), 12);
+    assert_eq!(journal.size().await, 12);
 
     // Verify first 12 items are still readable
     for i in 0..12u64 {
@@ -787,7 +787,7 @@ where
 
     journal.rewind(0).await.unwrap();
 
-    assert_eq!(journal.size().await.unwrap(), 0);
+    assert_eq!(journal.size().await, 0);
     assert_eq!(journal.oldest_retained_pos().await.unwrap(), None);
 
     // Next append should get position 0
@@ -811,7 +811,7 @@ where
 
     // Rewind to current size should be no-op
     journal.rewind(10).await.unwrap();
-    assert_eq!(journal.size().await.unwrap(), 10);
+    assert_eq!(journal.size().await, 10);
 
     journal.destroy().await.unwrap();
 }
@@ -905,13 +905,13 @@ where
     journal.rewind(0).await.unwrap();
 
     // Verify journal is empty
-    assert_eq!(journal.size().await.unwrap(), 0);
+    assert_eq!(journal.size().await, 0);
     assert_eq!(journal.oldest_retained_pos().await.unwrap(), None);
 
     // Append should work
     let pos = journal.append(42).await.unwrap();
     assert_eq!(pos, 0);
-    assert_eq!(journal.size().await.unwrap(), 1);
+    assert_eq!(journal.size().await, 1);
     assert_eq!(journal.read(0).await.unwrap(), 42);
 
     journal.destroy().await.unwrap();
@@ -938,7 +938,7 @@ where
 
     // Rewind to position 20 (still in retained range)
     journal.rewind(20).await.unwrap();
-    assert_eq!(journal.size().await.unwrap(), 20);
+    assert_eq!(journal.size().await, 20);
     assert_eq!(journal.oldest_retained_pos().await.unwrap(), Some(10));
 
     // Verify items in range [oldest, 20) are still readable
@@ -951,7 +951,7 @@ where
     assert!(matches!(result, Err(Error::ItemPruned(5))));
 
     // Verify journal state is unchanged after failed rewind
-    assert_eq!(journal.size().await.unwrap(), 20);
+    assert_eq!(journal.size().await, 20);
     assert_eq!(journal.oldest_retained_pos().await.unwrap(), Some(10));
 
     // Append should continue from position 20
@@ -979,12 +979,12 @@ where
     }
 
     // Verify we're at a section boundary
-    assert_eq!(journal.size().await.unwrap(), 10);
+    assert_eq!(journal.size().await, 10);
 
     // Append one more item to cross the boundary
     let pos = journal.append(999).await.unwrap();
     assert_eq!(pos, 10);
-    assert_eq!(journal.size().await.unwrap(), 11);
+    assert_eq!(journal.size().await, 11);
 
     // Prune exactly at the section boundary
     journal.prune(10).await.unwrap();
@@ -998,18 +998,18 @@ where
     // Append another item to move past the boundary
     let pos = journal.append(888).await.unwrap();
     assert_eq!(pos, 11);
-    assert_eq!(journal.size().await.unwrap(), 12);
+    assert_eq!(journal.size().await, 12);
 
     // Rewind to exactly the section boundary (position 10)
     // This leaves size=10, oldest=10, making the journal fully pruned
     journal.rewind(10).await.unwrap();
-    assert_eq!(journal.size().await.unwrap(), 10);
+    assert_eq!(journal.size().await, 10);
     assert!(journal.oldest_retained_pos().await.unwrap().is_none());
 
     // Append after rewinding to boundary should continue from position 10
     let pos = journal.append(777).await.unwrap();
     assert_eq!(pos, 10);
-    assert_eq!(journal.size().await.unwrap(), 11);
+    assert_eq!(journal.size().await, 11);
     assert_eq!(journal.read(10).await.unwrap(), 777);
     assert_eq!(journal.oldest_retained_pos().await.unwrap(), Some(10));
 
@@ -1036,7 +1036,7 @@ where
         }
 
         journal.prune(10).await.unwrap();
-        assert_eq!(journal.size().await.unwrap(), 20);
+        assert_eq!(journal.size().await, 20);
         let oldest = journal.oldest_retained_pos().await.unwrap();
         assert!(oldest.is_some());
 
@@ -1049,7 +1049,7 @@ where
         let journal = factory(test_name.clone()).await.unwrap();
 
         // Journal should be completely empty, not contain previous data
-        assert_eq!(journal.size().await.unwrap(), 0);
+        assert_eq!(journal.size().await, 0);
         assert_eq!(journal.oldest_retained_pos().await.unwrap(), None);
 
         // Replay should yield no items

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -18,7 +18,7 @@ where
     type Op = Op;
     type Error = Error;
 
-    async fn size(&self) -> Result<u64, Self::Error> {
+    async fn size(&self) -> u64 {
         contiguous::fixed::Journal::size(self).await
     }
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -191,7 +191,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         };
         let mut journal =
             Journal::<E, H::Digest>::init(context.with_label("mmr_journal"), journal_cfg).await?;
-        let mut journal_size = Position::new(journal.size().await?);
+        let mut journal_size = Position::new(journal.size().await);
 
         let metadata_cfg = MConfig {
             partition: cfg.metadata_partition,
@@ -295,7 +295,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             s.mem_mmr.add_leaf_digest(hasher, leaf);
             assert_eq!(pos, journal_size);
             s.sync(hasher).await?;
-            assert_eq!(s.size(), s.journal.size().await?);
+            assert_eq!(s.size(), s.journal.size().await);
         }
 
         Ok(s)
@@ -349,7 +349,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
             *cfg.range.start..*cfg.range.end,
         )
         .await?;
-        let journal_size = Position::new(journal.size().await?);
+        let journal_size = Position::new(journal.size().await);
         assert!(journal_size <= *cfg.range.end);
 
         // Open the metadata.
@@ -585,7 +585,7 @@ impl<E: RStorage + Clock + Metrics, H: CHasher> Mmr<E, H> {
         }
         self.journal_size = self.size();
         self.journal.sync().await?;
-        assert_eq!(self.journal_size, self.journal.size().await?);
+        assert_eq!(self.journal_size, self.journal.size().await);
 
         // Recompute pinned nodes since we'll need to repopulate the cache after it is cleared by
         // pruning the mem_mmr.


### PR DESCRIPTION
* Remove `async` and `Result` from `contiguous::variable`'s `size()` and `oldest_retained_pos()` 
* Remove `Result` from `contiguous::Contiguous`'s `size()`