### PR TITLE
[release] v0.0.63

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-bridge"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "clap",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "chrono",
  "clap",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "paste",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "commonware-coding",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-collector"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-collector-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "commonware-codec",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "blake3",
  "blst",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "blake3",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-estimator"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "clap",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "chrono",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-reshare"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "clap",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bimap",
  "bytes",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "async-lock",
  "axum",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "commonware-runtime",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "chacha20poly1305",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "chacha20poly1305",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-sync"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "clap",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils-fuzz"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-vrf"
-version = "0.0.62"
+version = "0.0.63"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,26 +39,26 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.62"
+version = "0.0.63"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://commonware.xyz"
 
 [workspace.dependencies]
-commonware-broadcast = { version = "0.0.62", path = "broadcast" }
-commonware-codec = { version = "0.0.62", path = "codec", default-features = false }
-commonware-coding = { version = "0.0.62", path = "coding" }
-commonware-collector = { version = "0.0.62", path = "collector" }
-commonware-consensus = { version = "0.0.62", path = "consensus" }
-commonware-cryptography = { version = "0.0.62", path = "cryptography", default-features = false }
-commonware-deployer = { version = "0.0.62", path = "deployer", default-features = false }
-commonware-macros = { version = "0.0.62", path = "macros" }
-commonware-p2p = { version = "0.0.62", path = "p2p" }
-commonware-resolver = { version = "0.0.62", path = "resolver" }
-commonware-runtime = { version = "0.0.62", path = "runtime" }
-commonware-storage = { version = "0.0.62", path = "storage", default-features = false }
-commonware-stream = { version = "0.0.62", path = "stream" }
-commonware-utils = { version = "0.0.62", path = "utils", default-features = false }
+commonware-broadcast = { version = "0.0.63", path = "broadcast" }
+commonware-codec = { version = "0.0.63", path = "codec", default-features = false }
+commonware-coding = { version = "0.0.63", path = "coding" }
+commonware-collector = { version = "0.0.63", path = "collector" }
+commonware-consensus = { version = "0.0.63", path = "consensus" }
+commonware-cryptography = { version = "0.0.63", path = "cryptography", default-features = false }
+commonware-deployer = { version = "0.0.63", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.63", path = "macros" }
+commonware-p2p = { version = "0.0.63", path = "p2p" }
+commonware-resolver = { version = "0.0.63", path = "resolver" }
+commonware-runtime = { version = "0.0.63", path = "runtime" }
+commonware-storage = { version = "0.0.63", path = "storage", default-features = false }
+commonware-stream = { version = "0.0.63", path = "stream" }
+commonware-utils = { version = "0.0.63", path = "utils", default-features = false }
 anyhow = { version = "1.0.99", default-features = false }
 thiserror = { version = "2.0.12", default-features = false }
 bytes = { version = "1.7.1", default-features = false }


### PR DESCRIPTION
```
 .github/actions/setup/action.yml                   |    8 +-
 .github/copilot-instructions.md                    |    1 +
 .github/scripts/check_no_std.sh                    |   34 +
 .github/workflows/benchmark.yml                    |   12 +-
 .github/workflows/coverage.yml                     |   15 +-
 .github/workflows/docker.yml                       |  165 +
 .github/workflows/fast.yml                         |  156 +-
 .github/workflows/publish.yml                      |    7 +-
 .github/workflows/quint.yml                        |   11 +-
 .github/workflows/slow.yml                         |   91 +-
 AGENTS.md                                          |   44 +-
 CONTRIBUTING.md                                    |   20 +-
 Cargo.lock                                         |  285 +-
 Cargo.toml                                         |   44 +-
 FUZZING.md                                         |    6 +-
 README.md                                          |    3 +
 broadcast/fuzz/Cargo.toml                          |   27 +
 .../fuzz_targets/broadcast_engine_operations.rs    |  280 ++
 broadcast/src/buffered/engine.rs                   |   30 +-
 broadcast/src/buffered/mocks.rs                    |    2 +-
 broadcast/src/buffered/mod.rs                      |   80 +-
 codec/fuzz/fuzz_targets/codec_roundtrip.rs         |   61 +-
 codec/src/config.rs                                |  194 +-
 codec/src/extensions.rs                            |   65 +-
 codec/src/types/btree_map.rs                       |    8 +-
 codec/src/types/btree_set.rs                       |    8 +-
 codec/src/types/bytes.rs                           |    2 +-
 codec/src/types/hash_map.rs                        |    8 +-
 codec/src/types/hash_set.rs                        |    8 +-
 codec/src/types/primitives.rs                      |   27 +-
 codec/src/types/vec.rs                             |    2 +-
 codec/src/varint.rs                                |   25 +-
 coding/Cargo.toml                                  |   17 +-
 coding/fuzz/Cargo.toml                             |   11 +
 coding/fuzz/fuzz_targets/no_coding.rs              |   10 +
 coding/fuzz/fuzz_targets/reed_solomon.rs           |   88 +-
 coding/fuzz/src/lib.rs                             |   89 +
 coding/src/benches/bench.rs                        |  108 +
 coding/src/benches/bench_size.rs                   |   57 +
 coding/src/benches/no_coding.rs                    |   18 +
 coding/src/benches/reed_solomon.rs                 |   18 +
 coding/src/lib.rs                                  |  391 +-
 coding/src/no_coding.rs                            |   87 +
 coding/src/reed_solomon/benches/bench.rs           |    6 -
 coding/src/reed_solomon/benches/decode.rs          |   54 -
 coding/src/reed_solomon/benches/encode.rs          |   42 -
 coding/src/reed_solomon/mod.rs                     |  569 +--
 collector/fuzz/Cargo.toml                          |   29 +
 collector/fuzz/fuzz_targets/collector.rs           |  439 ++
 collector/src/p2p/engine.rs                        |    8 +-
 collector/src/p2p/mod.rs                           |    9 +-
 consensus/Cargo.toml                               |    6 +-
 consensus/fuzz/Cargo.toml                          |   24 +
 .../fuzz/fuzz_targets/simplex_select_leader.rs     |   83 +
 consensus/src/aggregation/config.rs                |    6 +-
 consensus/src/aggregation/engine.rs                |   21 +-
 consensus/src/aggregation/metrics.rs               |   40 +-
 consensus/src/aggregation/mocks/application.rs     |    4 +-
 consensus/src/aggregation/mocks/monitor.rs         |    2 +-
 consensus/src/aggregation/mocks/reporter.rs        |    3 +-
 consensus/src/aggregation/mocks/supervisor.rs      |   14 +-
 consensus/src/aggregation/mod.rs                   |   34 +-
 consensus/src/aggregation/safe_tip.rs              |   16 +-
 consensus/src/aggregation/types.rs                 |   17 +-
 consensus/src/lib.rs                               |   26 +-
 consensus/src/marshal/actor.rs                     |  734 ++-
 consensus/src/marshal/cache.rs                     |  395 ++
 consensus/src/marshal/config.rs                    |   38 +-
 consensus/src/marshal/finalizer.rs                 |   31 +-
 consensus/src/marshal/ingress/handler.rs           |   86 +-
 consensus/src/marshal/ingress/mailbox.rs           |  182 +-
 consensus/src/marshal/ingress/mod.rs               |    2 +-
 consensus/src/marshal/mocks/application.rs         |   24 +-
 consensus/src/marshal/mod.rs                       |  779 +++-
 consensus/src/marshal/resolver/mod.rs              |    3 +
 consensus/src/marshal/resolver/p2p.rs              |   74 +
 consensus/src/ordered_broadcast/ack_manager.rs     |    3 +-
 consensus/src/ordered_broadcast/config.rs          |    4 +-
 consensus/src/ordered_broadcast/engine.rs          |   32 +-
 consensus/src/ordered_broadcast/metrics.rs         |   61 +-
 consensus/src/ordered_broadcast/mocks/automaton.rs |    4 +-
 consensus/src/ordered_broadcast/mocks/monitor.rs   |    2 +-
 consensus/src/ordered_broadcast/mocks/reporter.rs  |    3 +-
 .../src/ordered_broadcast/mocks/sequencers.rs      |    8 +-
 .../src/ordered_broadcast/mocks/validators.rs      |   12 +-
 consensus/src/ordered_broadcast/mod.rs             |   34 +-
 consensus/src/ordered_broadcast/types.rs           |   15 +-
 .../actors/batcher/actor.rs                        |  262 +-
 consensus/src/simplex/actors/batcher/ingress.rs    |   62 +
 .../actors/batcher/mod.rs                          |   12 +-
 consensus/src/simplex/actors/mod.rs                |    1 +
 consensus/src/simplex/actors/resolver/actor.rs     |  329 +-
 consensus/src/simplex/actors/resolver/ingress.rs   |   45 +-
 consensus/src/simplex/actors/resolver/mod.rs       |   13 +-
 consensus/src/simplex/actors/voter/actor.rs        | 1792 ++++----
 consensus/src/simplex/actors/voter/ingress.rs      |   50 +-
 consensus/src/simplex/actors/voter/mod.rs          | 1033 ++++-
 consensus/src/simplex/config.rs                    |   77 +-
 consensus/src/simplex/engine.rs                    |  148 +-
 consensus/src/simplex/metrics.rs                   |   89 +-
 consensus/src/simplex/mocks/application.rs         |   97 +-
 consensus/src/simplex/mocks/conflicter.rs          |  122 +-
 consensus/src/simplex/mocks/fixtures.rs            |  133 +
 .../mocks/impersonator.rs                          |   73 +-
 consensus/src/simplex/mocks/mod.rs                 |    5 +-
 consensus/src/simplex/mocks/nuller.rs              |   84 +-
 consensus/src/simplex/mocks/outdated.rs            |   90 +-
 consensus/src/simplex/mocks/reconfigurer.rs        |  101 +
 consensus/src/simplex/mocks/relay.rs               |    3 +
 consensus/src/simplex/mocks/reporter.rs            |  334 ++
 consensus/src/simplex/mocks/supervisor.rs          |  318 --
 consensus/src/simplex/mod.rs                       | 3040 +++++++++----
 .../simplex/signing_scheme/bls12381_multisig.rs    | 1112 +++++
 .../simplex/signing_scheme/bls12381_threshold.rs   | 1386 ++++++
 consensus/src/simplex/signing_scheme/ed25519.rs    | 1036 +++++
 consensus/src/simplex/signing_scheme/mod.rs        |  258 ++
 consensus/src/simplex/signing_scheme/reporter.rs   |  365 ++
 consensus/src/simplex/signing_scheme/utils.rs      |  135 +
 consensus/src/simplex/types.rs                     | 4756 ++++++++++++++------
 .../threshold_simplex/actors/batcher/ingress.rs    |   49 -
 consensus/src/threshold_simplex/actors/mod.rs      |    3 -
 .../src/threshold_simplex/actors/resolver/actor.rs |  578 ---
 .../threshold_simplex/actors/resolver/ingress.rs   |   62 -
 .../src/threshold_simplex/actors/resolver/mod.rs   |   26 -
 .../src/threshold_simplex/actors/voter/actor.rs    | 2073 ---------
 .../src/threshold_simplex/actors/voter/ingress.rs  |   28 -
 .../src/threshold_simplex/actors/voter/mod.rs      |  782 ----
 consensus/src/threshold_simplex/config.rs          |  166 -
 consensus/src/threshold_simplex/engine.rs          |  221 -
 consensus/src/threshold_simplex/metrics.rs         |   88 -
 .../src/threshold_simplex/mocks/application.rs     |  310 --
 .../src/threshold_simplex/mocks/conflicter.rs      |  109 -
 consensus/src/threshold_simplex/mocks/invalid.rs   |  106 -
 consensus/src/threshold_simplex/mocks/mod.rs       |   10 -
 consensus/src/threshold_simplex/mocks/nuller.rs    |   92 -
 consensus/src/threshold_simplex/mocks/outdated.rs  |  117 -
 consensus/src/threshold_simplex/mocks/relay.rs     |   58 -
 .../src/threshold_simplex/mocks/supervisor.rs      |  432 --
 consensus/src/threshold_simplex/mod.rs             | 3501 --------------
 consensus/src/threshold_simplex/types.rs           | 3697 ---------------
 consensus/src/types.rs                             |  102 +
 consensus/src/utils.rs                             |  108 +
 cryptography/Cargo.toml                            |   25 +-
 cryptography/fuzz/Cargo.toml                       |    4 +-
 cryptography/fuzz/fuzz_targets/blake3_hasher.rs    |    8 +-
 cryptography/fuzz/fuzz_targets/bloomfilter.rs      |   44 +-
 .../fuzz/fuzz_targets/bls12381_batch_verifier.rs   |   20 +-
 .../fuzz/fuzz_targets/ed25519_batch_verifier.rs    |   20 +-
 cryptography/src/blake3/mod.rs                     |   30 +-
 cryptography/src/bloomfilter.rs                    |   80 +-
 cryptography/src/bls12381/benches/dkg_recovery.rs  |   21 +-
 .../src/bls12381/benches/dkg_reshare_recovery.rs   |   25 +-
 cryptography/src/bls12381/dkg/arbiter.rs           |  122 +-
 cryptography/src/bls12381/dkg/dealer.rs            |   48 +-
 cryptography/src/bls12381/dkg/mod.rs               | 1242 ++---
 cryptography/src/bls12381/dkg/ops.rs               |   37 +-
 cryptography/src/bls12381/dkg/player.rs            |  171 +-
 cryptography/src/bls12381/dkg/types.rs             |  236 +
 cryptography/src/bls12381/primitives/group.rs      |    6 +
 cryptography/src/bls12381/primitives/poly.rs       |   38 +-
 cryptography/src/ed25519/scheme.rs                 |    2 +-
 cryptography/src/handshake.rs                      |  406 ++
 cryptography/src/handshake/benches/bench.rs        |   34 +
 cryptography/src/handshake/benches/handshake.rs    |    7 +
 cryptography/src/handshake/benches/transport.rs    |   13 +
 cryptography/src/handshake/cipher.rs               |   93 +
 cryptography/src/handshake/error.rs                |   37 +
 cryptography/src/handshake/key_exchange.rs         |   80 +
 cryptography/src/lib.rs                            |    2 +
 cryptography/src/secp256r1/scheme.rs               |    4 +-
 cryptography/src/sha256/mod.rs                     |   21 +-
 cryptography/src/transcript.rs                     |   98 +-
 docker/README.md                                   |   67 +
 docker/docker-bake.hcl                             |   50 +
 docker/riscv-unknown-elf-toolchain.dockerfile      |   46 +
 docker/rust-riscv-cross.dockerfile                 |   47 +
 docs/CNAME                                         |    1 -
 docs/benchmarks.html                               |   17 +-
 docs/blogs/adb-any.html                            |   15 +-
 docs/blogs/adb-current.html                        |   19 +-
 docs/blogs/buffered-signatures.html                |   21 +-
 docs/blogs/commonware-broadcast.html               |   13 +-
 docs/blogs/commonware-cryptography.html            |    7 +-
 docs/blogs/commonware-deployer.html                |   11 +-
 docs/blogs/commonware-runtime.html                 |   11 +-
 docs/blogs/commonware-the-anti-framework.html      |   19 +-
 docs/blogs/introducing-commonware.html             |    9 +-
 docs/blogs/minimmit.html                           |   13 +-
 docs/blogs/mmr.html                                |   15 +-
 docs/blogs/only-time-will-tell.html                |  136 +
 docs/blogs/threshold-simplex.html                  |   13 +-
 docs/hiring.css                                    |    2 +-
 docs/hiring.html                                   |    7 +-
 docs/imgs/battleware-duel.png                      |  Bin 0 -> 457749 bytes
 docs/imgs/creature-generation.png                  |  Bin 0 -> 500363 bytes
 docs/imgs/matchmaking.png                          |  Bin 0 -> 545796 bytes
 docs/imgs/multi-proof.png                          |  Bin 0 -> 477491 bytes
 docs/imgs/threshold-roots.png                      |  Bin 0 -> 695412 bytes
 docs/imgs/timelock-decryption.png                  |  Bin 0 -> 752677 bytes
 docs/index.html                                    |   41 +-
 docs/podcast.html                                  |  259 ++
 docs/podcast.png                                   |  Bin 0 -> 113859 bytes
 docs/shared.js                                     |   26 +-
 docs/style.css                                     |  157 +-
 examples/bridge/Cargo.toml                         |    2 +-
 examples/bridge/README.md                          |   44 +-
 examples/bridge/src/application/actor.rs           |   88 +-
 examples/bridge/src/application/ingress.rs         |   30 +-
 examples/bridge/src/application/mod.rs             |   13 +-
 examples/bridge/src/application/supervisor.rs      |   92 -
 examples/bridge/src/bin/dealer.rs                  |    7 +-
 examples/bridge/src/bin/indexer.rs                 |   83 +-
 examples/bridge/src/bin/validator.rs               |   53 +-
 examples/bridge/src/lib.rs                         |   13 +-
 examples/bridge/src/types/block.rs                 |   24 +-
 examples/bridge/src/types/inbound.rs               |   25 +-
 examples/bridge/src/types/outbound.rs              |   22 +-
 examples/chat/src/handler.rs                       |    2 +-
 examples/chat/src/main.rs                          |   22 +-
 examples/estimator/README.md                       |    4 +-
 .../estimator/alpenglow_votor_large_block.lazy     |   15 +
 .../alpenglow_votor_large_block_coding_50.lazy     |   15 +
 .../estimator/alpenglow_votor_small_block.lazy     |   15 +
 examples/estimator/minimmit.lazy                   |   10 +-
 examples/estimator/minimmit_large_block.lazy       |   14 +
 .../estimator/minimmit_large_block_coding_50.lazy  |   14 +
 examples/estimator/minimmit_small_block.lazy       |   14 +
 examples/estimator/simplex.lazy                    |    6 +-
 examples/estimator/simplex_large_block.lazy        |   15 +
 .../estimator/simplex_large_block_coding_50.lazy   |   15 +
 examples/estimator/simplex_small_block.lazy        |   15 +
 ...lex_with_sizes.lazy => simplex_with_delay.lazy} |   12 +-
 examples/estimator/src/lib.rs                      |   56 +-
 examples/estimator/src/main.rs                     |   19 +-
 examples/flood/src/bin/flood.rs                    |   10 +-
 examples/log/Cargo.toml                            |    2 +-
 examples/log/src/application/actor.rs              |   36 +-
 examples/log/src/application/ingress.rs            |   32 +-
 examples/log/src/application/mod.rs                |   17 +-
 examples/log/src/application/reporter.rs           |   39 +
 examples/log/src/application/supervisor.rs         |   75 -
 examples/log/src/main.rs                           |   53 +-
 examples/reshare/.gitignore                        |    1 +
 examples/reshare/Cargo.toml                        |   40 +
 examples/reshare/README.md                         |   51 +
 examples/reshare/src/application/actor.rs          |  250 +
 examples/reshare/src/application/ingress.rs        |  136 +
 examples/reshare/src/application/mod.rs            |   13 +
 examples/reshare/src/application/scheme.rs         |  121 +
 examples/reshare/src/application/types.rs          |  140 +
 examples/reshare/src/dkg/actor.rs                  |  659 +++
 examples/reshare/src/dkg/ingress.rs                |  100 +
 examples/reshare/src/dkg/manager.rs                |  676 +++
 examples/reshare/src/dkg/mod.rs                    |   13 +
 examples/reshare/src/dkg/types.rs                  |  237 +
 examples/reshare/src/engine.rs                     |  312 ++
 examples/reshare/src/main.rs                       |  124 +
 examples/reshare/src/orchestrator/actor.rs         |  391 ++
 examples/reshare/src/orchestrator/ingress.rs       |   51 +
 examples/reshare/src/orchestrator/mod.rs           |    7 +
 examples/reshare/src/setup.rs                      |  381 ++
 examples/reshare/src/validator.rs                  | 1709 +++++++
 examples/sync/Cargo.toml                           |    2 +-
 examples/sync/README.md                            |    2 +-
 examples/sync/src/bin/client.rs                    |   44 +-
 examples/sync/src/bin/server.rs                    |   72 +-
 examples/sync/src/databases/any.rs                 |   31 +-
 examples/sync/src/databases/immutable.rs           |   23 +-
 examples/sync/src/databases/mod.rs                 |   10 +-
 examples/sync/src/lib.rs                           |    4 +-
 examples/sync/src/net/mod.rs                       |   13 +-
 examples/sync/src/net/resolver.rs                  |    8 +-
 examples/sync/src/net/wire.rs                      |   48 +-
 examples/vrf/Cargo.toml                            |    3 +
 examples/vrf/src/handlers/arbiter.rs               |   40 +-
 examples/vrf/src/handlers/contributor.rs           |   90 +-
 examples/vrf/src/handlers/mod.rs                   |    8 +-
 examples/vrf/src/handlers/utils.rs                 |   16 -
 examples/vrf/src/handlers/vrf.rs                   |    8 +-
 examples/vrf/src/handlers/wire.rs                  |  109 +-
 examples/vrf/src/main.rs                           |   26 +-
 justfile                                           |   64 +
 macros/Cargo.toml                                  |    5 +
 macros/src/lib.rs                                  |  120 +-
 macros/tests/select.rs                             |   44 +-
 p2p/Cargo.toml                                     |    4 +
 p2p/fuzz/Cargo.toml                                |   47 +
 p2p/fuzz/fuzz_targets/discovery.rs                 |    8 +
 p2p/fuzz/fuzz_targets/lookup.rs                    |    8 +
 p2p/fuzz/fuzz_targets/simulated.rs                 |  302 ++
 p2p/fuzz/src/lib.rs                                |  629 +++
 p2p/src/authenticated/data.rs                      |    4 +-
 p2p/src/authenticated/discovery/actors/dialer.rs   |   46 +-
 p2p/src/authenticated/discovery/actors/listener.rs |  355 +-
 .../authenticated/discovery/actors/peer/actor.rs   |   64 +-
 .../authenticated/discovery/actors/peer/ingress.rs |    6 +-
 p2p/src/authenticated/discovery/actors/peer/mod.rs |   13 +-
 .../authenticated/discovery/actors/router/actor.rs |   12 +-
 .../discovery/actors/router/ingress.rs             |   10 +-
 .../discovery/actors/spawner/actor.rs              |   62 +-
 .../discovery/actors/spawner/ingress.rs            |   20 +-
 .../authenticated/discovery/actors/spawner/mod.rs  |    7 +-
 .../discovery/actors/tracker/actor.rs              |  772 ++--
 .../discovery/actors/tracker/directory.rs          |   51 +-
 .../discovery/actors/tracker/ingress.rs            |  148 +-
 .../authenticated/discovery/actors/tracker/mod.rs  |   23 +-
 .../discovery/actors/tracker/record.rs             |   35 +-
 .../discovery/actors/tracker/reservation.rs        |   32 +-
 .../authenticated/discovery/actors/tracker/set.rs  |  128 +-
 p2p/src/authenticated/discovery/channels.rs        |    2 +-
 p2p/src/authenticated/discovery/config.rs          |   36 +-
 p2p/src/authenticated/discovery/metrics.rs         |    2 +-
 p2p/src/authenticated/discovery/mod.rs             |   83 +-
 p2p/src/authenticated/discovery/network.rs         |   35 +-
 p2p/src/authenticated/discovery/types.rs           |  470 +-
 p2p/src/authenticated/ip.rs                        |  264 --
 p2p/src/authenticated/lookup/actors/dialer.rs      |   46 +-
 p2p/src/authenticated/lookup/actors/listener.rs    |  602 ++-
 p2p/src/authenticated/lookup/actors/peer/actor.rs  |   23 +-
 .../authenticated/lookup/actors/router/actor.rs    |   12 +-
 .../authenticated/lookup/actors/router/ingress.rs  |   10 +-
 .../authenticated/lookup/actors/spawner/actor.rs   |   23 +-
 .../authenticated/lookup/actors/spawner/ingress.rs |   20 +-
 .../authenticated/lookup/actors/tracker/actor.rs   |  319 +-
 .../lookup/actors/tracker/directory.rs             |  214 +-
 .../authenticated/lookup/actors/tracker/ingress.rs |  133 +-
 p2p/src/authenticated/lookup/actors/tracker/mod.rs |    8 +-
 .../authenticated/lookup/actors/tracker/record.rs  |   18 +-
 .../lookup/actors/tracker/reservation.rs           |   32 +-
 p2p/src/authenticated/lookup/channels.rs           |    2 +-
 p2p/src/authenticated/lookup/config.rs             |   41 +-
 p2p/src/authenticated/lookup/metrics.rs            |    2 +-
 p2p/src/authenticated/lookup/mod.rs                |   90 +-
 p2p/src/authenticated/lookup/network.rs            |   38 +-
 p2p/src/authenticated/lookup/types.rs              |   45 +-
 p2p/src/authenticated/mailbox.rs                   |   36 +-
 p2p/src/authenticated/mod.rs                       |    1 -
 p2p/src/authenticated/relay.rs                     |    2 +-
 p2p/src/lib.rs                                     |   38 +-
 p2p/src/simulated/bandwidth.rs                     | 1223 ++---
 p2p/src/simulated/ingress.rs                       |  111 +-
 p2p/src/simulated/mod.rs                           |  905 ++--
 p2p/src/simulated/network.rs                       |  720 +--
 p2p/src/simulated/transmitter.rs                   | 1389 ++++++
 p2p/src/utils/mux.rs                               |  497 +-
 p2p/src/utils/requester/config.rs                  |    4 +-
 p2p/src/utils/requester/requester.rs               |   12 +-
 pipeline/minimmit/quint/tests/tests_n6f1b1.qnt     |    4 +-
 resolver/src/p2p/config.rs                         |   11 +-
 resolver/src/p2p/engine.rs                         |   50 +-
 resolver/src/p2p/fetcher.rs                        |   95 +-
 resolver/src/p2p/metrics.rs                        |   60 +-
 resolver/src/p2p/mocks/coordinator.rs              |   86 -
 resolver/src/p2p/mocks/mod.rs                      |    2 -
 resolver/src/p2p/mod.rs                            |  128 +-
 runtime/Cargo.toml                                 |    3 +
 runtime/fuzz/fuzz_targets/buffer.rs                |   18 +-
 runtime/src/deterministic.rs                       | 1247 +++--
 runtime/src/iouring/mod.rs                         |  128 +-
 runtime/src/lib.rs                                 | 1119 +++--
 runtime/src/macros.rs                              |   39 +-
 runtime/src/network/iouring.rs                     |    4 +-
 runtime/src/storage/iouring.rs                     |   61 +-
 runtime/src/storage/memory.rs                      |   12 +-
 runtime/src/storage/tokio/mod.rs                   |   71 +-
 runtime/src/telemetry/metrics/task.rs              |   58 +-
 runtime/src/telemetry/traces/collector.rs          |  345 ++
 runtime/src/telemetry/traces/mod.rs                |    3 +
 runtime/src/tokio/mod.rs                           |    3 +-
 runtime/src/tokio/runtime.rs                       |  244 +-
 runtime/src/utils/cell.rs                          |  265 ++
 runtime/src/utils/handle.rs                        |  491 +-
 runtime/src/utils/mod.rs                           |  140 +-
 runtime/src/utils/signal.rs                        |    4 +
 runtime/src/utils/supervision.rs                   |  201 +
 storage/Cargo.toml                                 |   36 +-
 storage/fuzz/Cargo.toml                            |  129 +-
 storage/fuzz/fuzz_targets/adb_any_fixed_sync.rs    |  252 ++
 storage/fuzz/fuzz_targets/adb_any_variable_sync.rs |  340 ++
 storage/fuzz/fuzz_targets/adb_immutable.rs         |  275 ++
 storage/fuzz/fuzz_targets/adb_keyless.rs           |  288 ++
 .../fuzz/fuzz_targets/adb_ordered_operations.rs    |  286 ++
 storage/fuzz/fuzz_targets/adb_sync.rs              |  170 -
 ...b_operations.rs => adb_unordered_operations.rs} |    8 +-
 storage/fuzz/fuzz_targets/cache_operations.rs      |  292 ++
 .../fuzz_targets/current_ordered_operations.rs     |  369 ++
 ...erations.rs => current_unordered_operations.rs} |  115 +-
 storage/fuzz/fuzz_targets/extract_pinned_nodes.rs  |   37 +
 ...l_operations.rs => fixed_journal_operations.rs} |   37 +-
 storage/fuzz/fuzz_targets/freezer_operations.rs    |   16 +-
 storage/fuzz/fuzz_targets/index_operations.rs      |  175 -
 storage/fuzz/fuzz_targets/mmr_bitmap.rs            |  206 +
 storage/fuzz/fuzz_targets/mmr_journaled.rs         |  427 ++
 storage/fuzz/fuzz_targets/mmr_operations.rs        |   94 +-
 .../fuzz/fuzz_targets/ordered_index_operations.rs  |  180 +
 storage/fuzz/fuzz_targets/ordinal_operations.rs    |   46 +-
 storage/fuzz/fuzz_targets/proofs_malleability.rs   |  202 +
 storage/fuzz/fuzz_targets/range_proof.rs           |   60 +
 storage/fuzz/fuzz_targets/store_operations.rs      |  224 +
 storage/fuzz/fuzz_targets/translator_operations.rs |  144 +
 .../fuzz_targets/unordered_index_operations.rs     |  180 +
 storage/fuzz/fuzz_targets/verify_proof.rs          |   66 +
 storage/src/adb/any/fixed/mod.rs                   | 1857 ++------
 storage/src/adb/any/fixed/ordered.rs               | 1839 ++++++++
 storage/src/adb/any/fixed/sync.rs                  |  573 +--
 storage/src/adb/any/fixed/unordered.rs             | 1478 ++++++
 storage/src/adb/any/variable/mod.rs                | 1159 +++--
 storage/src/adb/any/variable/sync.rs               |  984 ----
 storage/src/adb/benches/bench.rs                   |    2 -
 storage/src/adb/benches/current_init.rs            |  189 -
 storage/src/adb/benches/fixed_generate.rs          |  333 +-
 storage/src/adb/benches/fixed_init.rs              |  328 +-
 storage/src/adb/benches/keyless_generate.rs        |    5 +-
 storage/src/adb/benches/variable_generate.rs       |  164 +-
 storage/src/adb/benches/variable_init.rs           |   32 +-
 storage/src/adb/current/mod.rs                     |  192 +
 storage/src/adb/current/ordered.rs                 | 1689 +++++++
 .../src/adb/{current.rs => current/unordered.rs}   |  731 ++-
 storage/src/adb/immutable/mod.rs                   |  727 ++-
 storage/src/adb/immutable/sync/journal.rs          |   91 -
 storage/src/adb/immutable/sync/mod.rs              |  408 +-
 storage/src/adb/keyless.rs                         |  293 +-
 storage/src/adb/mod.rs                             |   37 +-
 storage/src/adb/operation/fixed/mod.rs             |   28 +
 storage/src/adb/operation/fixed/ordered.rs         |  207 +
 storage/src/adb/operation/fixed/unordered.rs       |  176 +
 storage/src/adb/operation/keyless.rs               |   76 +
 storage/src/adb/operation/mod.rs                   |  342 ++
 storage/src/adb/operation/variable.rs              |  576 +++
 storage/src/{ => adb}/store/benches/bench.rs       |    0
 storage/src/{ => adb}/store/benches/restart.rs     |   16 +-
 storage/src/{ => adb}/store/mod.rs                 |  499 +-
 storage/src/adb/sync/database.rs                   |   32 +-
 storage/src/adb/sync/engine.rs                     |  134 +-
 storage/src/adb/sync/error.rs                      |   48 +-
 storage/src/adb/sync/gaps.rs                       |  190 +-
 storage/src/adb/sync/journal.rs                    |   23 +-
 storage/src/adb/sync/mod.rs                        |    6 +-
 storage/src/adb/sync/requests.rs                   |   10 +-
 storage/src/adb/sync/resolver.rs                   |   42 +-
 storage/src/adb/sync/target.rs                     |  127 +-
 storage/src/adb/verify.rs                          |  331 +-
 storage/src/archive/benches/utils.rs               |   14 +
 storage/src/archive/immutable/storage.rs           |   26 +-
 storage/src/archive/mod.rs                         |    6 +
 storage/src/archive/prunable/mod.rs                |    6 +-
 storage/src/archive/prunable/storage.rs            |   12 +-
 storage/src/bmt/mod.rs                             |   10 +-
 storage/src/cache/mod.rs                           |    2 +-
 storage/src/cache/storage.rs                       |   10 +-
 storage/src/freezer/mod.rs                         |    8 +-
 storage/src/freezer/storage.rs                     |    4 +-
 storage/src/index/benches/hashmap_insert.rs        |    7 +-
 storage/src/index/benches/hashmap_insert_fixed.rs  |    7 +-
 storage/src/index/benches/hashmap_iteration.rs     |    7 +-
 storage/src/index/benches/insert.rs                |   71 +-
 storage/src/index/mod.rs                           | 1566 +++++--
 storage/src/index/ordered.rs                       |  394 ++
 storage/src/index/storage.rs                       |  372 +-
 storage/src/index/unordered.rs                     |  252 ++
 storage/src/journal/benches/bench.rs               |    2 +-
 storage/src/journal/benches/fixed_read_random.rs   |    2 +-
 .../src/journal/benches/fixed_read_sequential.rs   |    4 +-
 storage/src/journal/benches/fixed_replay.rs        |    2 +-
 storage/src/journal/{ => contiguous}/fixed.rs      |  119 +-
 storage/src/journal/contiguous/mod.rs              |  135 +
 storage/src/journal/contiguous/tests.rs            | 1069 +++++
 storage/src/journal/contiguous/variable.rs         | 2230 +++++++++
 storage/src/journal/mod.rs                         |   24 +-
 storage/src/journal/segmented/mod.rs               |    6 +
 storage/src/journal/{ => segmented}/variable.rs    |  194 +-
 storage/src/lib.rs                                 |   30 +-
 storage/src/metadata/mod.rs                        |   12 +-
 storage/src/metadata/storage.rs                    |   25 +
 storage/src/mmr/benches/append.rs                  |   11 +-
 storage/src/mmr/benches/append_additional.rs       |   13 +-
 storage/src/mmr/benches/prove_many_elements.rs     |   41 +-
 storage/src/mmr/benches/prove_single_element.rs    |   26 +-
 storage/src/mmr/benches/update.rs                  |   28 +-
 storage/src/mmr/bitmap.rs                          |  860 ++--
 storage/src/mmr/grafting.rs                        | 1019 +++++
 storage/src/mmr/hasher.rs                          |  818 +---
 storage/src/mmr/iterator.rs                        |  215 +-
 storage/src/mmr/journaled.rs                       |  632 +--
 storage/src/mmr/location.rs                        |  589 +++
 storage/src/mmr/mem.rs                             |  804 +++-
 storage/src/mmr/mod.rs                             |  112 +-
 storage/src/mmr/position.rs                        |  495 ++
 storage/src/mmr/proof.rs                           | 1619 +++++++
 storage/src/mmr/{tests/mod.rs => stability.rs}     |   77 +-
 storage/src/mmr/storage.rs                         |   94 +-
 storage/src/mmr/verification.rs                    | 1759 +-------
 storage/src/ordinal/mod.rs                         |   72 +-
 storage/src/ordinal/storage.rs                     |   24 +-
 storage/src/rmap/mod.rs                            |   36 +
 storage/src/store/operation.rs                     |  548 ---
 storage/src/translator.rs                          |   78 +-
 stream/Cargo.toml                                  |   11 +-
 stream/fuzz/Cargo.toml                             |   17 +-
 stream/fuzz/fuzz_targets/confirmation.rs           |   39 -
 stream/fuzz/fuzz_targets/connection.rs             |   38 +-
 stream/fuzz/fuzz_targets/e2e.rs                    |  776 +---
 stream/fuzz/fuzz_targets/handshake.rs              |  120 -
 stream/fuzz/fuzz_targets/lazy_transport.rs         |   59 +-
 stream/fuzz/fuzz_targets/transport.rs              |   36 +-
 stream/src/lib.rs                                  |  415 +-
 stream/src/public_key/benches/bench.rs             |    6 -
 stream/src/public_key/benches/receiver_receive.rs  |   55 -
 stream/src/public_key/benches/sender_send.rs       |   40 -
 stream/src/public_key/cipher.rs                    |  507 ---
 stream/src/public_key/connection.rs                | 1105 -----
 stream/src/public_key/handshake.rs                 |  746 ---
 stream/src/public_key/mod.rs                       |  128 -
 stream/src/public_key/nonce.rs                     |  187 -
 stream/src/public_key/x25519.rs                    |  102 -
 stream/src/utils/codec.rs                          |   34 -
 utils/Cargo.toml                                   |   22 +-
 utils/fuzz/Cargo.toml                              |   18 +-
 utils/fuzz/fuzz_targets/{bitvec.rs => bitmap.rs}   |  257 +-
 utils/fuzz/fuzz_targets/historical_bitmap.rs       |  216 +
 utils/fuzz/fuzz_targets/prunable.rs                |  111 +
 utils/fuzz/fuzz_targets/time.rs                    |    4 +-
 utils/src/bitmap/historical/batch.rs               |  514 +++
 utils/src/bitmap/historical/bitmap.rs              |  525 +++
 utils/src/bitmap/historical/error.rs               |   15 +
 utils/src/bitmap/historical/mod.rs                 |   93 +
 utils/src/bitmap/historical/tests.rs               | 1050 +++++
 utils/src/bitmap/mod.rs                            | 2120 +++++++++
 utils/src/bitmap/prunable.rs                       | 1225 +++++
 utils/src/bitvec.rs                                | 1002 -----
 utils/src/concurrency.rs                           |  162 +
 utils/src/hex_literal.rs                           |  240 +
 utils/src/lib.rs                                   |   41 +-
 utils/src/net.rs                                   |  379 ++
 utils/src/rational.rs                              |  143 +
 utils/src/sequence/fixed_bytes.rs                  |   12 +-
 utils/src/sequence/prefixed_u64.rs                 |   11 +-
 utils/src/sequence/u32.rs                          |    2 +-
 utils/src/sequence/u64.rs                          |    2 +-
 utils/src/set.rs                                   |  523 +++
 utils/src/time.rs                                  |  466 +-
 541 files changed, 72801 insertions(+), 41086 deletions(-)
```