### PR TITLE
[consensus] Stream `Update`s instead of `Block`s to `Application`

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -128,9 +128,6 @@ cfg_if::cfg_if! {
                 context: (E, Self::Context),
                 ancestry: AncestorStream<Self::SigningScheme, Self::Block>,
             ) -> impl Future<Output = Option<Self::Block>> + Send;
-
-            /// Receive a finalized block from [crate::marshal].
-            fn finalize(&mut self, block: Self::Block) -> impl Future<Output = ()> + Send;
         }
 
         /// An extension of [Application] that provides the ability to implementations to verify blocks.
@@ -138,7 +135,7 @@ cfg_if::cfg_if! {
         /// Some [Application]s may not require this functionality. When employing
         /// erasure coding, for example, verification only serves to verify the integrity of the
         /// received shard relative to the consensus commitment, and can therefore be
-        /// hidden from the application (any invalid blocks will be discarded in [Application::finalize]).
+        /// hidden from the application.
         pub trait VerifyingApplication<E>: Application<E>
         where
             E: Rng + Spawner + Metrics + Clock

--- a/examples/reshare/src/application/core.rs
+++ b/examples/reshare/src/application/core.rs
@@ -54,9 +54,9 @@ where
     C: Signer,
     V: Variant,
 {
-    type Block = Block<H, C, V>;
-    type SigningScheme = S;
     type Context = Context<H::Digest, C::PublicKey>;
+    type SigningScheme = S;
+    type Block = Block<H, C, V>;
 
     async fn genesis(&mut self) -> Self::Block {
         genesis_block::<H, C, V>()
@@ -84,10 +84,6 @@ where
             parent_block.height() + 1,
             reshare,
         ))
-    }
-
-    async fn finalize(&mut self, _: Self::Block) {
-        // no-op: the reshare application does not process finalized blocks
     }
 }
 


### PR DESCRIPTION
## Overview

Small follow-up to #2067 that changes `Reporter::Activity` to `Update` for `application::Marshaled`.