### PR TITLE
[ci/benchmarks] Limit Data Points

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,3 +79,4 @@ jobs:
           gh-pages-branch: main
           benchmark-data-dir-path: 'docs'
           auto-push: true
+          max-items-in-chart: 60


### PR DESCRIPTION
The benchmarks page is becoming unstable because it has so much data. Let's limit how many points we display per chart.

Source: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#max-items-in-chart-optional