### PR TITLE
[ci] Add `Cargo.toml` linter script

### DIFF
--- a/.github/scripts/lint_cargo_toml.py
+++ b/.github/scripts/lint_cargo_toml.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S uv run -s
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["tomlkit==0.13.3"]
+# ///
+"""
+Usage:
+  ./sort_deps.py                # edits ./Cargo.toml in place
+  ./sort_deps.py path/to/Cargo.toml
+"""
+
+import re
+import sys
+from pathlib import Path
+
+from tomlkit import parse, dumps, key, item
+from tomlkit.items import Table, InlineTable
+
+def reorder_table_inplace(tbl: Table):
+    """Sort keys in alphabetical order while preserving comments/formatting."""
+    items = [(k, tbl[k]) for k in list(tbl.keys())]
+    for k, _ in items:
+        del tbl[k]
+
+    for k, v in sorted(items, key=lambda kv: kv[0]):
+        if len(v) == 1 and isinstance(v, dict) and next(iter(v)) == 'workspace':
+            tbl.append(key([k, "workspace"]), item(True))
+        else:
+            tbl.append(k, v)
+
+def walk(node):
+    if hasattr(node, "items"):
+        for k, v in list(node.items()):
+            if k.endswith("dependencies"):
+                reorder_table_inplace(v)
+            walk(v)
+
+def normalize_blank_lines(s: str) -> str:
+    # Collapse accidental double+ newlines before table headers to exactly two
+    # https://github.com/python-poetry/tomlkit/issues/48
+    s = re.sub(r"\n{2,}(\[)", r"\n\n\1", s)
+    return s
+
+def main(path: Path):
+    text = path.read_text(encoding="utf-8")
+    doc = parse(text)
+    walk(doc)
+    out = dumps(doc)
+    out = normalize_blank_lines(out)
+    path.write_text(out, encoding="utf-8")
+
+if __name__ == "__main__":
+    cargo_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("Cargo.toml")
+    main(cargo_path)

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -242,3 +242,18 @@ jobs:
       run: |
         cd storage
         just miri index::
+
+  lint-toml:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - name: Install just
+      uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
+      with:
+        tool: just@1.43.0
+    - name: Install UV
+      uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
+    - name: Check Cargo.toml formatting
+      run: just fix-toml-fmt && git diff --exit-code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,82 +45,77 @@ license = "MIT OR Apache-2.0"
 homepage = "https://commonware.xyz"
 
 [workspace.dependencies]
-# Commonware
-commonware-p2p = { version = "0.0.63", path = "p2p" }
-commonware-codec = { version = "0.0.63", path = "codec", default-features = false }
-commonware-utils = { version = "0.0.63", path = "utils", default-features = false }
-commonware-coding = { version = "0.0.63", path = "coding" }
-commonware-macros = { version = "0.0.63", path = "macros" }
-commonware-stream = { version = "0.0.63", path = "stream" }
-commonware-runtime = { version = "0.0.63", path = "runtime" }
-commonware-storage = { version = "0.0.63", path = "storage", default-features = false }
-commonware-deployer = { version = "0.0.63", path = "deployer", default-features = false }
-commonware-resolver = { version = "0.0.63", path = "resolver" }
+anyhow = { version = "1.0.99", default-features = false }
+arbitrary = "1.4.1"
+async-lock = "3.4.0"
+axum = "0.8.1"
+bimap = "0.6.3"
+blake3 = { version = "1.8.2", default-features = false }
+blst = { version = "0.3.13", default-features = false }
+bytes = { version = "1.7.1", default-features = false }
+cfg-if = "1.0.0"
+chacha20poly1305 = { version = "0.10.1", default-features = false }
+chrono = "0.4.39"
+clap = "4.5.18"
 commonware-broadcast = { version = "0.0.63", path = "broadcast" }
+commonware-codec = { version = "0.0.63", path = "codec", default-features = false }
+commonware-coding = { version = "0.0.63", path = "coding" }
 commonware-collector = { version = "0.0.63", path = "collector" }
 commonware-consensus = { version = "0.0.63", path = "consensus" }
 commonware-cryptography = { version = "0.0.63", path = "cryptography", default-features = false }
-
-# External
-axum = "0.8.1"
-clap = "4.5.18"
-libc = "0.2.172"
-uuid = "1.15.1"
-zstd = "0.13.2"
-bimap = "0.6.3"
-paste = "1.0.15"
-prost = "0.13.5"
-serde = "1.0.218"
-tokio = "1.43.0"
-cfg-if = "1.0.0"
-chrono = "0.4.39"
-either = "1.13.0"
-futures = "0.3.31"
-ratatui = "0.27.0"
-reqwest = "0.12.12"
-sysinfo = "0.33.0"
-tracing = "0.1.41"
-zeroize = "1.5.7"
-governor = "0.6.3"
-io-uring = "0.7.4"
+commonware-deployer = { version = "0.0.63", path = "deployer", default-features = false }
+commonware-macros = { version = "0.0.63", path = "macros" }
+commonware-p2p = { version = "0.0.63", path = "p2p" }
+commonware-resolver = { version = "0.0.63", path = "resolver" }
+commonware-runtime = { version = "0.0.63", path = "runtime" }
+commonware-storage = { version = "0.0.63", path = "storage", default-features = false }
+commonware-stream = { version = "0.0.63", path = "stream" }
+commonware-utils = { version = "0.0.63", path = "utils", default-features = false }
+console-subscriber = "0.5.0"
 criterion = "0.5.1"
 crossterm = "0.28.1"
-rand_core = "0.6.4"
-test-case = "3.3.1"
-async-lock = "3.4.0"
+either = "1.13.0"
+futures = "0.3.31"
+futures-util = "0.3.31"
+governor = "0.6.3"
+io-uring = "0.7.4"
+libc = "0.2.172"
+libfuzzer-sys = "0.4.9"
 num-bigint = "0.4.6"
+num-integer = "0.1.46"
+num-rational = { version = "0.4.2", features = ["num-bigint"] }
 num-traits = "0.2.19"
+opentelemetry = "0.28.0"
+opentelemetry-otlp = "0.28.0"
+opentelemetry_sdk = "0.28.0"
+p256 = { version = "0.13.2", default-features = false }
+paste = "1.0.15"
+pin-project = "1.1.10"
+prometheus-client = "0.22.3"
+prost = "0.13.5"
+prost-build = "0.13.5"
+rand = { version = "0.8.5", default-features = false }
+rand_chacha = { version = "0.3", default-features = false }
+rand_core = "0.6.4"
 rand_distr = "0.4.3"
+ratatui = "0.27.0"
+rayon = { version = "1.10.0", default-features = false }
+reqwest = "0.12.12"
+serde = "1.0.218"
 serde_json = "1.0.122"
 serde_yaml = "0.9.34"
-num-integer = "0.1.46"
-pin-project = "1.1.10"
-prost-build = "0.13.5"
-futures-util = "0.3.31"
-x25519-dalek = "2.0.1"
-opentelemetry = "0.28.0"
-opentelemetry_sdk =  "0.28.0"
-prometheus-client = "0.22.3"
-console-subscriber = "0.5.0"
-opentelemetry-otlp = "0.28.0"
-tracing-subscriber = "0.3.19"
-tracing-opentelemetry = "0.29.0"
-blst = { version = "0.3.13", default-features = false }
-p256 = { version = "0.13.2", default-features = false }
-rand = { version = "0.8.5", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
-bytes = { version = "1.7.1", default-features = false }
-rayon = { version = "1.10.0", default-features = false }
-anyhow = { version = "1.0.99", default-features = false }
-blake3 = { version = "1.8.2", default-features = false }
+sysinfo = "0.33.0"
+test-case = "3.3.1"
 thiserror = { version = "2.0.12", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
-num-rational = { version = "0.4.2", features = ["num-bigint"] }
-chacha20poly1305 = { version = "0.10.1", default-features = false }
-
-# Fuzz deps
-arbitrary = "1.4.1"
-libfuzzer-sys = "0.4.9"
+tokio = "1.43.0"
+tracing = "0.1.41"
+tracing-opentelemetry = "0.29.0"
+tracing-subscriber = "0.3.19"
+uuid = "1.15.1"
+x25519-dalek = "2.0.1"
+zeroize = "1.5.7"
+zstd = "0.13.2"
 
 [profile.bench]
 # Because we enable overflow checks in "release," we should benchmark with them.

--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -11,20 +11,20 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/broadcast"
 documentation = "https://docs.rs/commonware-broadcast"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-utils = { workspace = true }
-bytes = { workspace = true }
-futures = { workspace = true }
-prometheus-client = { workspace = true }
-thiserror = { workspace = true }
-tracing = { workspace = true }
+bytes.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+prometheus-client.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true }
+tracing-subscriber.workspace = true
 
 [lib]
 bench = false

--- a/broadcast/fuzz/Cargo.toml
+++ b/broadcast/fuzz/Cargo.toml
@@ -9,15 +9,15 @@ license.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-commonware-broadcast = { path = ".." }
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-libfuzzer-sys = { workspace = true }
-bytes = { workspace = true }
-rand = { workspace = true }
+bytes.workspace = true
+commonware-broadcast = { path = ".." }
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+libfuzzer-sys.workspace = true
+rand.workspace = true
 
 [[bin]]
 name = "broadcast_engine_operations"

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -15,6 +15,6 @@ default = ["std"]
 std = ["thiserror/std", "bytes/std"]
 
 [dependencies]
-thiserror = { workspace = true }
-bytes = { workspace = true }
-paste = { workspace = true }
+bytes.workspace = true
+paste.workspace = true
+thiserror.workspace = true

--- a/codec/fuzz/Cargo.toml
+++ b/codec/fuzz/Cargo.toml
@@ -9,11 +9,11 @@ license.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = { workspace = true }
-bytes = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-thiserror = { workspace = true }
-paste = { workspace = true }
+bytes.workspace = true
+libfuzzer-sys.workspace = true
+paste.workspace = true
+thiserror.workspace = true
 
 [dependencies.commonware-codec]
 path = ".."

--- a/coding/Cargo.toml
+++ b/coding/Cargo.toml
@@ -11,21 +11,21 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/coding"
 documentation = "https://docs.rs/commonware-coding"
 
 [dependencies]
+bytes.workspace = true
 commonware-codec = { workspace = true, features = ["std"] }
 commonware-cryptography = { workspace = true, features = ["std"] }
 commonware-storage = { workspace = true, features = ["std"] }
-bytes = { workspace = true }
-thiserror = { workspace = true }
+rand_core.workspace = true
 reed-solomon-simd = "3.0.1"
-rand_core = { workspace = true }
+thiserror.workspace = true
 
 [lib]
 bench = false
 
 [dev-dependencies]
-criterion = { workspace = true }
-rand = { workspace = true }
-rand_chacha = { workspace = true }
+criterion.workspace = true
+rand.workspace = true
+rand_chacha.workspace = true
 
 [[bench]]
 name = "coding_scheme_times"

--- a/coding/fuzz/Cargo.toml
+++ b/coding/fuzz/Cargo.toml
@@ -9,10 +9,10 @@ license.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-commonware-cryptography = { workspace = true }
-libfuzzer-sys = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-rand_chacha = { workspace = true }
+commonware-cryptography.workspace = true
+libfuzzer-sys.workspace = true
+rand_chacha.workspace = true
 
 [dependencies.commonware-coding]
 path = ".."

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -11,24 +11,24 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/collector"
 documentation = "https://docs.rs/commonware-collector"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-stream = { workspace = true }
-commonware-utils = { workspace = true }
-bytes = { workspace = true }
-rand = { workspace = true }
-futures = { workspace = true }
-tracing = { workspace = true }
-governor = { workspace = true }
-prometheus-client = { workspace = true }
-thiserror = { workspace = true }
-anyhow = { workspace = true }
+anyhow.workspace = true
+bytes.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+commonware-stream.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true }
+tracing-subscriber.workspace = true
 
 [lib]
 bench = false

--- a/collector/fuzz/Cargo.toml
+++ b/collector/fuzz/Cargo.toml
@@ -9,17 +9,17 @@ license.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-commonware-collector = { workspace = true}
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-libfuzzer-sys = { workspace = true }
-rand = { workspace = true }
-futures = { workspace = true }
-bytes = { workspace = true }
-thiserror = { workspace = true }
+bytes.workspace = true
+commonware-codec.workspace = true
+commonware-collector.workspace = true
+commonware-cryptography.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+futures.workspace = true
+libfuzzer-sys.workspace = true
+rand.workspace = true
+thiserror.workspace = true
 
 [[bin]]
 name = "collector"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -11,31 +11,31 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/consensus"
 documentation = "https://docs.rs/commonware-consensus"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-broadcast = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-resolver = { workspace = true }
-commonware-utils = { workspace = true }
-bytes = { workspace = true }
-cfg-if = { workspace = true }
-futures = { workspace = true }
-rand = { workspace = true }
-thiserror = { workspace = true }
+bytes.workspace = true
+cfg-if.workspace = true
+commonware-broadcast.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-resolver.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+rand.workspace = true
+thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
 commonware-storage = { workspace = true, features = ["std"] }
-prometheus-client = { workspace = true }
-governor = { workspace = true }
-rand_distr = { workspace = true }
-tracing = { workspace = true }
-pin-project = { workspace = true }
+governor.workspace = true
+pin-project.workspace = true
+prometheus-client.workspace = true
+rand_distr.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 commonware-resolver = { workspace = true, features = ["mocks"] }
-tracing-subscriber = { workspace = true }
+tracing-subscriber.workspace = true
 
 [lib]
 bench = false

--- a/consensus/fuzz/Cargo.toml
+++ b/consensus/fuzz/Cargo.toml
@@ -9,12 +9,12 @@ license.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-commonware-consensus = { workspace = true}
-commonware-cryptography = { workspace = true}
 arbitrary = { workspace = true, features = ["derive"] }
-libfuzzer-sys = { workspace = true }
-rand = { workspace = true }
-commonware-codec = { workspace = true }
+commonware-codec.workspace = true
+commonware-consensus.workspace = true
+commonware-cryptography.workspace = true
+libfuzzer-sys.workspace = true
+rand.workspace = true
 
 [[bin]]
 name = "simplex_select_leader"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -14,31 +14,31 @@ documentation = "https://docs.rs/commonware-cryptography"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(full_bench)'] }
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-utils = { workspace = true }
-bytes = { workspace = true }
-thiserror = { workspace = true }
-rand = { workspace = true }
-rand_core = { workspace = true }
-sha2 = { workspace = true }
 blake3 = { workspace = true, features = ["zeroize"] }
-rayon = { workspace = true, optional = true }
-zeroize = { workspace = true, features = ["zeroize_derive"] }
-ed25519-consensus = { version = "2.1.0", default-features = false }
 blst = { workspace = true, features = ["no-threads"] }
-p256 = { workspace = true, features = ["ecdsa"] }
-rand_chacha = { workspace = true }
-cfg-if = { workspace = true }
-x25519-dalek = { workspace = true, features = ["zeroize"] }
+bytes.workspace = true
+cfg-if.workspace = true
 chacha20poly1305 = { workspace = true, default-features = false, features = ["alloc"] }
+commonware-codec.workspace = true
+commonware-utils.workspace = true
+ed25519-consensus = { version = "2.1.0", default-features = false }
+p256 = { workspace = true, features = ["ecdsa"] }
+rand.workspace = true
+rand_chacha.workspace = true
+rand_core.workspace = true
+rayon = { workspace = true, optional = true }
+sha2.workspace = true
+thiserror.workspace = true
+x25519-dalek = { workspace = true, features = ["zeroize"] }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
-# Enable "js" feature when WASM is target
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+# Enable "js" feature when WASM is target
 version = "0.2.15"
 features = ["js"]
 
 [dev-dependencies]
-criterion = { workspace = true }
+criterion.workspace = true
 
 [lib]
 bench = false

--- a/cryptography/fuzz/Cargo.toml
+++ b/cryptography/fuzz/Cargo.toml
@@ -9,17 +9,17 @@ license.workspace = true
 cargo-fuzz = true
 
 [dependencies]
+arbitrary = { workspace = true, features = ["derive"] }
+blake3.workspace = true
+blst = { workspace = true, features = ["no-threads"] }
 commonware-codec = { workspace = true, features = ["std"] }
 commonware-cryptography = { workspace = true, features = ["std"] }
-arbitrary = { workspace = true, features = ["derive"] }
-blst = { workspace = true, features = ["no-threads"] }
-libfuzzer-sys = { workspace = true }
-p256 = { workspace = true, features = ["ecdsa"] }
-sha2 = { workspace = true }
 ed25519-zebra = "4.0.3"
-rand = { workspace = true }
-blake3 = { workspace = true }
-zeroize = { workspace = true }
+libfuzzer-sys.workspace = true
+p256 = { workspace = true, features = ["ecdsa"] }
+rand.workspace = true
+sha2.workspace = true
+zeroize.workspace = true
 
 [[bin]]
 name = "bls12381_decode"

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -15,19 +15,19 @@ default = ["aws"]
 aws = ["aws-config", "aws-sdk-ec2", "reqwest", "tokio", "tracing", "tracing-subscriber", "thiserror", "futures", "clap", "uuid"]
 
 [dependencies]
-cfg-if = { workspace = true }
-serde_yaml = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+aws-config = { version = "1.6.0", optional = true }
+aws-sdk-ec2 = { version = "1.118.1", optional = true }
+cfg-if.workspace = true
 clap = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+serde_yaml.workspace = true
+thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"], optional = true }
-uuid = { workspace = true, features = ["v4"], optional = true }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
-thiserror = { workspace = true, optional = true }
-aws-config = { version = "1.6.0", optional = true }
-aws-sdk-ec2 = { version = "1.118.1", optional = true }
+uuid = { workspace = true, features = ["v4"], optional = true }
 
 [[bin]]
 name = "deployer"

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -11,22 +11,22 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/bridg
 documentation = "https://docs.rs/commonware-bridge"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-utils = { workspace = true }
-commonware-consensus = { workspace = true }
+bytes.workspace = true
+clap.workspace = true
+commonware-codec.workspace = true
+commonware-consensus.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
 commonware-storage = { workspace = true, features = ["std"] }
-commonware-stream = { workspace = true }
-bytes = { workspace = true }
-rand = { workspace = true }
-tracing = { workspace = true }
-futures = { workspace = true }
-clap = { workspace = true }
-prometheus-client = { workspace = true }
-governor = { workspace = true }
+commonware-stream.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
+tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 
 [[bin]]

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -11,21 +11,21 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/chat"
 documentation = "https://docs.rs/commonware-chat"
 
 [dependencies]
-commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-utils = { workspace = true }
-tracing = { workspace = true }
-futures = { workspace = true }
-clap = { workspace = true }
-prometheus-client = { workspace = true }
-governor = { workspace = true }
+chrono.workspace = true
+clap.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+commonware-utils.workspace = true
+crossterm.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+ratatui.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
-chrono = { workspace = true }
-ratatui = { workspace = true }
-crossterm = { workspace = true }
-serde_json = { workspace = true }
 
 [[bin]]
 name = "commonware-chat"

--- a/examples/estimator/Cargo.toml
+++ b/examples/estimator/Cargo.toml
@@ -11,24 +11,24 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/estim
 documentation = "https://docs.rs/commonware-estimator"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-utils = { workspace = true }
-bytes = { workspace = true }
-rand = { workspace = true }
-tracing = { workspace = true }
-futures = { workspace = true }
-clap = { workspace = true }
-prometheus-client = { workspace = true }
-governor = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
-serde_json = { workspace = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls", "blocking"] }
-serde   = { workspace = true, features = ["derive"] }
+bytes.workspace = true
+clap.workspace = true
 colored = "3.0.0"
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
+reqwest = { workspace = true, features = ["json", "rustls-tls", "blocking"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 
 [lib]
 name = "estimator"

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -11,21 +11,21 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/flood
 documentation = "https://docs.rs/commonware-flood"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-deployer = { workspace = true }
-commonware-utils = { workspace = true }
-clap = { workspace = true }
-prometheus-client = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
+clap.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-deployer.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
-serde_yaml = { workspace = true }
-governor = { workspace = true }
-rand = { workspace = true }
-futures = { workspace = true }
+serde_yaml.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [[bin]]

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -11,25 +11,25 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/log"
 documentation = "https://docs.rs/commonware-log"
 
 [dependencies]
-commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-utils = { workspace = true }
-commonware-consensus = { workspace = true }
+bytes.workspace = true
+chrono.workspace = true
+clap.workspace = true
+commonware-consensus.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
 commonware-storage = { workspace = true, features = ["std"] }
-bytes = { workspace = true }
-rand = { workspace = true }
-tracing = { workspace = true }
-futures = { workspace = true }
-clap = { workspace = true }
-prometheus-client = { workspace = true }
-governor = { workspace = true }
+commonware-utils.workspace = true
+crossterm.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
+ratatui.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
-chrono = { workspace = true }
-ratatui = { workspace = true }
-crossterm = { workspace = true }
-serde_json = { workspace = true }
 
 [[bin]]
 name = "commonware-log"

--- a/examples/reshare/Cargo.toml
+++ b/examples/reshare/Cargo.toml
@@ -11,26 +11,26 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/resha
 documentation = "https://docs.rs/commonware-reshare"
 
 [dependencies]
-rand.workspace = true
 bytes.workspace = true
-serde.workspace = true
-futures.workspace = true
-tracing.workspace = true
-governor.workspace = true
-rand_core.workspace = true
-serde_json.workspace = true
-commonware-p2p.workspace = true
-commonware-codec.workspace = true
-commonware-utils.workspace = true
-commonware-macros.workspace = true
-prometheus-client.workspace = true
-commonware-runtime.workspace = true
-commonware-storage.workspace = true
-commonware-resolver.workspace = true
+clap = { workspace = true, features = ["derive"] }
 commonware-broadcast.workspace = true
+commonware-codec.workspace = true
 commonware-consensus.workspace = true
 commonware-cryptography.workspace = true
-clap = { workspace = true, features = ["derive"] }
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-resolver.workspace = true
+commonware-runtime.workspace = true
+commonware-storage.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
+rand_core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -19,20 +19,20 @@ name = "client"
 path = "src/bin/client.rs"
 
 [dependencies]
+bytes.workspace = true
+clap.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-runtime.workspace = true
 commonware-storage = { workspace = true, features = ["std"] }
-commonware-runtime = { workspace = true }
-commonware-codec = { workspace = true }
-commonware-utils = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-stream = { workspace = true }
-commonware-macros = { workspace = true }
+commonware-stream.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
-tokio = {workspace = true }
-bytes = { workspace = true }
-futures = { workspace = true }
-clap = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-rand = { workspace = true }
-thiserror = { workspace = true }
-prometheus-client = { workspace = true }

--- a/examples/vrf/Cargo.toml
+++ b/examples/vrf/Cargo.toml
@@ -11,24 +11,24 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/vrf"
 documentation = "https://docs.rs/commonware-vrf"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-utils = { workspace = true }
-bytes = { workspace = true }
-rand = { workspace = true }
-rand_core = { workspace = true }
-tracing = { workspace = true }
-futures = { workspace = true }
-clap = { workspace = true }
-tracing-subscriber = { workspace = true }
-prometheus-client = { workspace = true }
-governor = { workspace = true }
+bytes.workspace = true
+clap.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
+rand_core.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
-rand_chacha = { workspace = true }
+rand_chacha.workspace = true
 
 [[bin]]
 name = "commonware-vrf"

--- a/justfile
+++ b/justfile
@@ -21,6 +21,10 @@ pre-pr: lint test-docs test
 fix-fmt nightly_version='+nightly':
     cargo {{ nightly_version }} fmt --all
 
+# Fixes the formatting of the `Cargo.toml` files in the workspace
+fix-toml-fmt:
+   find . -name Cargo.toml -type f -print0 | xargs -0 -n1 ./.github/scripts/lint_cargo_toml.py
+
 # Check the formatting of the workspace
 check-fmt nightly_version='+nightly':
     cargo {{ nightly_version }} fmt --all -- --check

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -15,17 +15,17 @@ bench = false
 proc-macro = true
 
 [dependencies]
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-futures = { workspace = true }
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+futures.workspace = true
 proc-macro-crate = "3.4.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["full"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 futures-timer = "3.0.3"
 
-# `futures-timer` is exercised only in doctests, so cargo-udeps flags it falsely.
 [package.metadata.cargo-udeps.ignore]
+# `futures-timer` is exercised only in doctests, so cargo-udeps flags it falsely.
 development = ["futures-timer"]

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -11,28 +11,28 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/p2p"
 documentation = "https://docs.rs/commonware-p2p"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-stream = { workspace = true }
-commonware-utils = { workspace = true }
-bytes = { workspace = true }
-rand = { workspace = true }
-rand_distr = { workspace = true }
-thiserror = { workspace = true }
-futures = { workspace = true }
-tracing = { workspace = true }
-governor = { workspace = true }
-prometheus-client = { workspace = true }
-either = { workspace = true }
-num-bigint = { workspace = true }
-num-integer = { workspace = true }
-num-rational = { workspace = true }
-num-traits = { workspace = true }
+bytes.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-runtime.workspace = true
+commonware-stream.workspace = true
+commonware-utils.workspace = true
+either.workspace = true
+futures.workspace = true
+governor.workspace = true
+num-bigint.workspace = true
+num-integer.workspace = true
+num-rational.workspace = true
+num-traits.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
+rand_distr.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true }
+tracing-subscriber.workspace = true
 
 [lib]
 bench = false

--- a/p2p/fuzz/Cargo.toml
+++ b/p2p/fuzz/Cargo.toml
@@ -9,18 +9,18 @@ license.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-commonware-p2p = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-utils = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-codec = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-libfuzzer-sys = { workspace = true }
-rand = { workspace = true }
-futures = { workspace = true }
-bytes = { workspace = true }
-governor = { workspace = true }
+bytes.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+governor.workspace = true
+libfuzzer-sys.workspace = true
+rand.workspace = true
 
 [lib]
 bench = false

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -11,29 +11,29 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/resolver"
 documentation = "https://docs.rs/commonware-resolver"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-macros = { workspace = true }
-commonware-p2p = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-stream = { workspace = true }
-commonware-utils = { workspace = true }
-bimap = { workspace = true }
-bytes = { workspace = true }
-rand = { workspace = true }
-futures = { workspace = true }
-tracing = { workspace = true }
-governor = { workspace = true }
-prometheus-client = { workspace = true }
-thiserror = { workspace = true }
+bimap.workspace = true
+bytes.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+commonware-stream.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+rand.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true }
 commonware-resolver = { path = ".", features = ["mocks"] }
+tracing-subscriber.workspace = true
 
+[package.metadata.cargo-udeps.ignore]
 # Tell cargo-udeps to ignore the use of commonware-resolver in [dev-dependencies],
 # which we use to enable the mocks feature in tests
-[package.metadata.cargo-udeps.ignore]
 development = ["commonware-resolver"]
 
 [lib]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,26 +11,39 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/runtime"
 documentation = "https://docs.rs/commonware-runtime"
 
 [dependencies]
-libc = { workspace = true }
-rand = { workspace = true }
-sha2 = { workspace = true }
-bytes = { workspace = true }
-rayon = { workspace = true }
-cfg-if = { workspace = true }
-futures = { workspace = true }
-sysinfo = { workspace = true }
-tracing = { workspace = true }
-governor = { workspace = true }
-io-uring = { workspace = true, optional = true }
-thiserror = { workspace = true }
-async-lock = { workspace = true }
-pin-project = { workspace = true, optional = true }
-opentelemetry = { workspace = true }
+async-lock.workspace = true
+bytes.workspace = true
+cfg-if.workspace = true
+commonware-macros.workspace = true
 commonware-utils = { workspace = true, features = ["std"] }
-commonware-macros = { workspace = true }
-prometheus-client = { workspace = true }
+futures.workspace = true
+governor.workspace = true
+io-uring = { workspace = true, optional = true }
+libc.workspace = true
+opentelemetry.workspace = true
+pin-project = { workspace = true, optional = true }
+prometheus-client.workspace = true
+rand.workspace = true
+rayon.workspace = true
+sha2.workspace = true
+sysinfo.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-opentelemetry.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
-tracing-opentelemetry = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+# Enable "js" feature when WASM is target
+version = "0.2.15"
+features = ["js"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+axum.workspace = true
+console-subscriber = { workspace = true, features = ["parking_lot"], optional = true }
+criterion = { workspace = true, features = ["async"] }
+opentelemetry-otlp = { workspace = true, features = ["http-proto"] }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
+tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = []
@@ -39,21 +52,6 @@ test-utils = []
 iouring-storage = ["io-uring"]
 iouring-network = ["io-uring"]
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
-
-# Enable "js" feature when WASM is target
-[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
-version = "0.2.15"
-features = ["js"]
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-axum = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
-criterion = { workspace = true, features = ["async"] }
-opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
-opentelemetry-otlp = { workspace = true, features = ["http-proto"] }
-
-# `tokio-console` feature dependencies
-console-subscriber = { workspace = true, features = ["parking_lot"], optional = true }
 
 [lib]
 bench = false

--- a/runtime/fuzz/Cargo.toml
+++ b/runtime/fuzz/Cargo.toml
@@ -10,9 +10,9 @@ cargo-fuzz = true
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-libfuzzer-sys = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-utils = {workspace = true }
+commonware-runtime.workspace = true
+commonware-utils.workspace = true
+libfuzzer-sys.workspace = true
 
 [[bin]]
 name = "buffer"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -14,28 +14,28 @@ documentation = "https://docs.rs/commonware-storage"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(full_bench)'] }
 
 [dependencies]
+bytes = { workspace = true, default-features = false }
+cfg-if.workspace = true
 commonware-codec = {workspace = true, default-features = false }
 commonware-cryptography = {workspace = true, default-features = false }
-commonware-macros = { workspace = true }
+commonware-macros.workspace = true
 commonware-runtime = { workspace = true, optional = true }
 commonware-utils = { workspace = true, default-features = false }
-bytes = { workspace = true, default-features = false }
-cfg-if = { workspace = true }
-thiserror = { workspace = true }
-futures = { workspace = true, optional = true }
 crc32fast = { version = "1.4.2", optional = true }
-prometheus-client = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
+prometheus-client = { workspace = true, optional = true }
+rayon = { workspace = true, optional = true }
+thiserror.workspace = true
 tracing = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
-rayon = { workspace = true, optional = true }
 
 [dev-dependencies]
 commonware-storage = { path = ".", features = ["std"] }
-tracing-subscriber = { workspace = true }
-rand = { workspace = true }
-criterion = { workspace = true }
-test-case = { workspace = true }
+criterion.workspace = true
+rand.workspace = true
+test-case.workspace = true
+tracing-subscriber.workspace = true
 
 [features]
 default = ["std"]

--- a/storage/fuzz/Cargo.toml
+++ b/storage/fuzz/Cargo.toml
@@ -9,16 +9,16 @@ license.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-storage = { workspace = true, features = ["std", "fuzzing"] }
-commonware-utils = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-libfuzzer-sys = { workspace = true }
-futures = { workspace = true }
-rand = { workspace = true }
-bytes = { workspace = true }
+bytes.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-runtime.workspace = true
+commonware-storage = { workspace = true, features = ["std", "fuzzing"] }
+commonware-utils.workspace = true
+futures.workspace = true
+libfuzzer-sys.workspace = true
+rand.workspace = true
 
 [[bin]]
 name = "adb_unordered_operations"

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -11,22 +11,22 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/stream"
 documentation = "https://docs.rs/commonware-stream"
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true, features = ["std"] }
-commonware-macros = { workspace = true }
-commonware-runtime = { workspace = true }
-commonware-utils = { workspace = true }
-thiserror = { workspace = true }
-bytes = { workspace = true }
-futures = { workspace = true }
-rand = { workspace = true }
-rand_core = { workspace = true }
-zeroize = { workspace = true }
+bytes.workspace = true
 chacha20poly1305 = { workspace = true, default-features = false, features = ["std", "getrandom"] }
+commonware-codec.workspace = true
+commonware-cryptography = { workspace = true, features = ["std"] }
+commonware-macros.workspace = true
+commonware-runtime.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+rand.workspace = true
+rand_core.workspace = true
+thiserror.workspace = true
 x25519-dalek = "2.0.1"
+zeroize.workspace = true
 
 [dev-dependencies]
-criterion = { workspace = true }
+criterion.workspace = true
 
 [lib]
 bench = false

--- a/stream/fuzz/Cargo.toml
+++ b/stream/fuzz/Cargo.toml
@@ -9,16 +9,16 @@ license.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-commonware-codec = { workspace = true }
-commonware-cryptography = { workspace = true }
-commonware-stream = { workspace = true}
-commonware-runtime = { workspace = true }
-commonware-utils = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-futures = { workspace = true }
-libfuzzer-sys = { workspace = true }
 chacha20poly1305 = { workspace = true, default-features = false, features = ["std", "getrandom"] }
-rand_core = { workspace = true }
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-runtime.workspace = true
+commonware-stream.workspace = true
+commonware-utils.workspace = true
+futures.workspace = true
+libfuzzer-sys.workspace = true
+rand_core.workspace = true
 
 [[bin]]
 name = "transport"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,19 +11,19 @@ repository = "https://github.com/commonwarexyz/monorepo/tree/main/utils"
 documentation = "https://docs.rs/commonware-utils"
 
 [dependencies]
+bytes.workspace = true
+cfg-if.workspace = true
 commonware-codec = { workspace = true, default-features = false }
-bytes = { workspace = true }
 futures = { workspace = true, optional = true }
-rand = { workspace = true }
-thiserror = { workspace = true }
-cfg-if = { workspace = true }
 num-bigint = { workspace = true, optional = true }
-num-rational = { workspace = true, optional = true }
 num-integer = { workspace = true, optional = true }
+num-rational = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
+rand.workspace = true
+thiserror.workspace = true
 
-# Enable "js" feature when WASM is target
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+# Enable "js" feature when WASM is target
 version = "0.2.15"
 features = ["js"]
 

--- a/utils/fuzz/Cargo.toml
+++ b/utils/fuzz/Cargo.toml
@@ -10,12 +10,12 @@ cargo-fuzz = true
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-libfuzzer-sys = { workspace = true }
+bytes.workspace = true
+commonware-codec.workspace = true
 commonware-utils = { path = ".." }
-commonware-codec = { workspace = true }
-bytes = { workspace = true }
+futures.workspace = true
+libfuzzer-sys.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
-futures = { workspace = true }
 
 [[bin]]
 name = "lib_functions"


### PR DESCRIPTION
## Overview

Adds a script to format `Cargo.toml` files' dependencies.

### Formatting Rules

- `dep = { workspace = true }` is disallowed; use an inline table instead: `dep.workspace = true`.
- Dependencies are sorted in alphabetical order.