### PR TITLE
[consensus] Pass consensus context to `Application::verify`

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -143,7 +143,7 @@ cfg_if::cfg_if! {
             /// Verify a block produced by the application's proposer, relative to its ancestry.
             fn verify(
                 &mut self,
-                context: E,
+                context: (E, Self::Context),
                 ancestry: AncestorStream<Self::SigningScheme, Self::Block>,
             ) -> impl Future<Output = bool> + Send;
         }

--- a/examples/reshare/src/application/core.rs
+++ b/examples/reshare/src/application/core.rs
@@ -97,7 +97,7 @@ where
 {
     async fn verify(
         &mut self,
-        _context: E,
+        _: (E, Self::Context),
         mut ancestry: AncestorStream<Self::SigningScheme, Self::Block>,
     ) -> bool {
         let Some(block) = ancestry.next().await else {


### PR DESCRIPTION
## Overview

Passes the consensus context to `Application::verify`.