### PR TITLE
Ensures the runtime cleans up tasks before panicking due to a timeout.

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -583,6 +583,9 @@ impl Runner {
             "executor still has weak references"
         );
 
+        // Panic after the cleanup if a timeout has occurred.
+        let output = output.expect("runtime timeout");
+
         // Extract the executor from the Arc
         let executor = Arc::into_inner(executor).expect("executor still has strong references");
 
@@ -596,9 +599,6 @@ impl Runner {
             storage,
             catch_panics: executor.panicker.catch(),
         };
-
-        // Panic after the cleanup if a timeout has occurred.
-        let output = output.expect("runtime timeout");
 
         (output, checkpoint)
     }


### PR DESCRIPTION
Fixes #2136 in a concise way.

I had trouble writing a test which can reproduce this outside of observed fuzzing crashes. Please note that a double panic results in an immediate abort so I'm not sure to which extent a test is feasible to begin with.