### PR TITLE
fix: spelling errors in zoda.md

### DIFF
--- a/docs/blogs/zoda.md
+++ b/docs/blogs/zoda.md
@@ -229,7 +229,7 @@ this issue.
 We can be convinced that our shard comes from a valid encoding of some unique
 piece of data, as soon as we receive our shard.
 
-(For ZODA afficionados, what we describe subsequently is the application of the
+(For ZODA aficionados, what we describe subsequently is the application of the
 "Hadamard" variant from section D of the paper).
 
 This involves sending, along with the shard, some additional data, of use not in
@@ -249,7 +249,7 @@ of randomness in what follows, according to the _Fiat-Shamir_ paradigm.
 
 Whereas in the plain coding scheme, we received one particular row of $Y$,
 here we receive $S$ rows, sampled at random.
-(We may modify $m$ and $n$ to accomodate this fact).
+(We may modify $m$ and $n$ to accommodate this fact).
 We also receive proofs of inclusion for each row.
 
 In order to convince us that our rows $Y_S$ came from $G X$,


### PR DESCRIPTION


## Changes

- Corrected "afficionados" → "aficionados" 
- Corrected "accomodate" → "accommodate" 


