### PR TITLE
docs: fix typos and broken links

### DIFF
--- a/docs/blogs/zoda.html
+++ b/docs/blogs/zoda.html
@@ -367,7 +367,7 @@ Meier</a></div>
         particular row of <span class="math inline">\(Y\)</span>, here
         we receive <span class="math inline">\(S\)</span> rows, sampled
         at random. (We may modify <span class="math inline">\(m\)</span>
-        and <span class="math inline">\(n\)</span> to accomodate this
+        and <span class="math inline">\(n\)</span> to accommodate this
         fact). We also receive proofs of inclusion for each row.</p>
         <p>In order to convince us that our rows <span
         class="math inline">\(Y_S\)</span> came from <span

--- a/docs/blogs/zoda.md
+++ b/docs/blogs/zoda.md
@@ -39,7 +39,7 @@ The simplest approach is to have the leader send the data to every follower.
 The leader's transmission cost is $m \cdot D$ bytes, and the followers' cost
 is $0$ bytes, since they send nothing.
 
-![Figure 1: A leader transmits a block of data to 4 followers](/imgs/zoda-000.png)
+![Figure 1: A leader transmits a block of data to 4 followers](../imgs/zoda-000.png)
 
 Networked protocols are often bottlenecked by sending data, since moving
 bits around the planet, a country, or a building is hopelessly slow compared
@@ -75,7 +75,7 @@ All together, the participants hold it all, distributed as thinly as possible.
 (They do still need to communicate to recover the data, of course, but it is
 recoverable).
 
-![Figure 2: A leader splits data into 4 chunks, each sent to 1 follower](/imgs/zoda-001.png)
+![Figure 2: A leader splits data into 4 chunks, each sent to 1 follower](../imgs/zoda-001.png)
 
 In this case, the leader's transmission cost is now just $m \cdot \frac{D}{m} = D$,
 quite the improvement.
@@ -141,7 +141,7 @@ Each shard can be a row of this matrix.
 Given $n$ shards, the original matrix can be recovered, proceeding columnwise
 once more.
 
-![Figure 3: Data is encoded, growing from 2 pieces into 4, and split across the followers](/imgs/zoda-002.png)
+![Figure 3: Data is encoded, growing from 2 pieces into 4, and split across the followers](../imgs/zoda-002.png)
 
 The cost of this scheme is now:
 - $m \cdot \frac{D}{n}$ for the leader,
@@ -185,7 +185,7 @@ in the vector is that of the shard.
 A binary Merkle Tree is an example of such a scheme (but others might work better,
 e.g. playing with arity, or using a Polynomial Commitment Scheme).
 
-![Figure 4: The encoded rows are hashed into a tree](/imgs/zoda-003.png)
+![Figure 4: The encoded rows are hashed into a tree](../imgs/zoda-003.png)
 
 As a side-effect, our scheme now produces a fingerprint, attesting uniquely to
 the encoded data.
@@ -249,7 +249,7 @@ of randomness in what follows, according to the _Fiat-Shamir_ paradigm.
 
 Whereas in the plain coding scheme, we received one particular row of $Y$,
 here we receive $S$ rows, sampled at random.
-(We may modify $m$ and $n$ to accomodate this fact).
+(We may modify $m$ and $n$ to accommodate this fact).
 We also receive proofs of inclusion for each row.
 
 In order to convince us that our rows $Y_S$ came from $G X$,

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -8,8 +8,8 @@ Continuously synchronize state between a server and client with [adb::any::Any](
 
 - [Server](src/bin/server.rs): Serves historical operations and proofs to clients.
 - [Client](src/bin/client.rs): Continuously syncs to the server's database state.
-- [Resolver](src/resolver.rs): Used by client to communicate with server.
-- [Protocol](src/protocol.rs): Defines network messages.
+- [Resolver](src/net/resolver.rs): Used by client to communicate with server.
+- [Wire](src/net/wire.rs): Defines network messages.
 
 ## Usage
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -598,7 +598,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
         position_to_section(self.size, self.items_per_section)
     }
 
-    /// Align the offsets journal and data journal to be consistent in case a crash occured
+    /// Align the offsets journal and data journal to be consistent in case a crash occurred
     /// on a previous run and left the journals in an inconsistent state.
     ///
     /// The data journal is the source of truth. This function scans it to determine
@@ -628,7 +628,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
         };
 
         // Data journal is empty if there are no sections or if there is one section and it has no items.
-        // The latter should only occur if a crash occured after opening a data journal blob but
+        // The latter should only occur if a crash occurred after opening a data journal blob but
         // before writing to it.
         let data_empty =
             data.blobs.is_empty() || (data.blobs.len() == 1 && items_in_last_section == 0);


### PR DESCRIPTION
## Summary

Fixes typos and broken links found in documentation and code comments.

## Changes

### Typos Fixed
- **docs/blogs/zoda.md:252** - "accomodate" → "accommodate"
- **docs/blogs/zoda.html:370** - "accomodate" → "accommodate"
- **storage/src/journal/contiguous/variable.rs:601,631** - "occured" → "occurred" (2 places)

### Broken Links Fixed
- **examples/sync/README.md:11** - Fixed broken link: `src/resolver.rs` → `src/net/resolver.rs`
- **examples/sync/README.md:12** - Fixed broken link: `src/protocol.rs` → `src/net/wire.rs`
- **docs/blogs/zoda.md** - Fixed 4 broken image links:
  - `/imgs/zoda-000.png` → `../imgs/zoda-000.png`
  - `/imgs/zoda-001.png` → `../imgs/zoda-001.png`
  - `/imgs/zoda-002.png` → `../imgs/zoda-002.png`
  - `/imgs/zoda-003.png` → `../imgs/zoda-003.png`

## Verification

- ✅ All typos corrected
- ✅ All broken internal links fixed
- ✅ All tests passing (`cargo test --package commonware-storage --lib journal::contiguous::variable`)
- ✅ No functionality changes

## Impact

- Improves documentation quality
- Fixes broken links that could confuse users
- Corrects spelling errors in code comments

## Files Changed

- `docs/blogs/zoda.md` - 1 typo, 4 image links
- `docs/blogs/zoda.html` - 1 typo
- `examples/sync/README.md` - 2 broken links
- `storage/src/journal/contiguous/variable.rs` - 2 typos in comments