### PR TITLE
[workspace] Migrate to `rstest` for test matrices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,7 @@ dependencies = [
  "prometheus-client",
  "rand 0.8.5",
  "rand_distr",
+ "rstest",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
@@ -1202,6 +1203,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
+ "rstest",
  "sha2 0.10.8",
  "thiserror 2.0.12",
  "x25519-dalek",
@@ -1485,7 +1487,7 @@ dependencies = [
  "prometheus-client",
  "rand 0.8.5",
  "rayon",
- "test-case",
+ "rstest",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
@@ -1560,6 +1562,7 @@ dependencies = [
  "futures",
  "prometheus-client",
  "rand 0.8.5",
+ "rstest",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -1581,6 +1584,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "rand 0.8.5",
+ "rstest",
  "thiserror 2.0.12",
 ]
 
@@ -3745,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -3956,6 +3960,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +4040,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.98",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4043,9 +4082,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -4647,39 +4686,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-case"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
-dependencies = [
- "test-case-macros",
-]
-
-[[package]]
-name = "test-case-core"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "test-case-macros"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
- "test-case-core",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5122,9 +5128,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,12 +102,12 @@ rand_distr = "0.4.3"
 ratatui = "0.27.0"
 rayon = { version = "1.10.0", default-features = false }
 reqwest = "0.12.12"
+rstest = "0.26.1"
 serde = "1.0.218"
 serde_json = "1.0.122"
 serde_yaml = "0.9.34"
 sha2 = { version = "0.10.8", default-features = false }
 sysinfo = "0.33.0"
-test-case = "3.3.1"
 thiserror = { version = "2.0.12", default-features = false }
 tokio = "1.43.0"
 tracing = "0.1.41"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -35,6 +35,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 commonware-resolver = { workspace = true, features = ["mocks"] }
+rstest.workspace = true
 tracing-subscriber.workspace = true
 
 [lib]

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -39,6 +39,7 @@ features = ["js"]
 
 [dev-dependencies]
 criterion.workspace = true
+rstest.workspace = true
 
 [lib]
 bench = false

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -396,6 +396,7 @@ mod tests {
     use super::*;
     use crate::{bls12381, Verifier as _};
     use commonware_codec::{DecodeExt, Encode};
+    use rstest::rstest;
 
     #[test]
     fn test_codec_private_key() {
@@ -430,24 +431,19 @@ mod tests {
         assert_eq!(original, decoded);
     }
 
-    #[test]
-    fn test_sign() {
-        let cases = [
-            vector_sign_1(),
-            vector_sign_2(),
-            vector_sign_3(),
-            vector_sign_4(),
-            vector_sign_5(),
-            vector_sign_6(),
-            vector_sign_7(),
-            vector_sign_8(),
-            vector_sign_9(),
-        ];
-        for (index, test) in cases.into_iter().enumerate() {
-            let (private_key, message, expected) = test;
-            let signature = private_key.sign(None, &message);
-            assert_eq!(signature, expected, "vector_sign_{}", index + 1);
-        }
+    #[rstest]
+    #[case(vector_sign_1())]
+    #[case(vector_sign_2())]
+    #[case(vector_sign_3())]
+    #[case(vector_sign_4())]
+    #[case(vector_sign_5())]
+    #[case(vector_sign_6())]
+    #[case(vector_sign_7())]
+    #[case(vector_sign_8())]
+    #[case(vector_sign_9())]
+    fn test_sign(#[case] (private_key, message, expected): (PrivateKey, Vec<u8>, Signature)) {
+        let signature = private_key.sign(None, &message);
+        assert_eq!(signature, expected);
     }
 
     #[test]
@@ -457,58 +453,58 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_verify() {
-        let cases = [
-            vector_verify_1(),
-            vector_verify_2(),
-            vector_verify_3(),
-            vector_verify_4(),
-            vector_verify_5(),
-            vector_verify_6(),
-            vector_verify_7(),
-            vector_verify_8(),
-            vector_verify_9(),
-            vector_verify_10(),
-            vector_verify_11(),
-            vector_verify_12(),
-            vector_verify_13(),
-            vector_verify_14(),
-            vector_verify_15(),
-            vector_verify_16(),
-            vector_verify_17(),
-            vector_verify_18(),
-            vector_verify_19(),
-            vector_verify_20(),
-            vector_verify_21(),
-            vector_verify_22(),
-            vector_verify_23(),
-            vector_verify_24(),
-            vector_verify_25(),
-            vector_verify_26(),
-            vector_verify_27(),
-            vector_verify_28(),
-            vector_verify_29(),
-        ];
-
+    #[rstest]
+    #[case(vector_verify_1())]
+    #[case(vector_verify_2())]
+    #[case(vector_verify_3())]
+    #[case(vector_verify_4())]
+    #[case(vector_verify_5())]
+    #[case(vector_verify_6())]
+    #[case(vector_verify_7())]
+    #[case(vector_verify_8())]
+    #[case(vector_verify_9())]
+    #[case(vector_verify_10())]
+    #[case(vector_verify_11())]
+    #[case(vector_verify_12())]
+    #[case(vector_verify_13())]
+    #[case(vector_verify_14())]
+    #[case(vector_verify_15())]
+    #[case(vector_verify_16())]
+    #[case(vector_verify_17())]
+    #[case(vector_verify_18())]
+    #[case(vector_verify_19())]
+    #[case(vector_verify_20())]
+    #[case(vector_verify_21())]
+    #[case(vector_verify_22())]
+    #[case(vector_verify_23())]
+    #[case(vector_verify_24())]
+    #[case(vector_verify_25())]
+    #[case(vector_verify_26())]
+    #[case(vector_verify_27())]
+    #[case(vector_verify_28())]
+    #[case(vector_verify_29())]
+    fn test_verify(
+        #[case] (public_key, message, signature, expected): (
+            Result<PublicKey, CodecError>,
+            Vec<u8>,
+            Result<Signature, CodecError>,
+            bool,
+        ),
+    ) {
         let mut batch = Batch::new();
-        for (index, test) in cases.into_iter().enumerate() {
-            let (public_key, message, signature, expected) = test;
-            let expected = if !expected {
-                public_key.is_err()
-                    || signature.is_err()
-                    || !public_key
-                        .unwrap()
-                        .verify(None, &message, &signature.unwrap())
-            } else {
-                let public_key = public_key.unwrap();
-                let signature = signature.unwrap();
-                batch.add(None, &message, &public_key, &signature);
-                public_key.verify(None, &message, &signature)
-            };
-            assert!(expected, "vector_verify_{}", index + 1);
-        }
-        assert!(batch.verify(&mut rand::thread_rng()));
+        let expected = if !expected {
+            public_key.is_err()
+                || signature.is_err()
+                || !public_key
+                    .unwrap()
+                    .verify(None, &message, &signature.unwrap())
+        } else {
+            let public_key = public_key.unwrap();
+            let signature = signature.unwrap();
+            batch.add(None, &message, &public_key, &signature);
+            public_key.verify(None, &message, &signature)
+        };
+        assert!(expected);
     }
 
     /// Parse `sign` vector from hex encoded data.

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -36,3 +36,5 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
+[dev-dependencies]
+rstest.workspace = true

--- a/examples/sync/src/net/mod.rs
+++ b/examples/sync/src/net/mod.rs
@@ -117,33 +117,29 @@ mod tests {
     use commonware_codec::{DecodeExt as _, Encode as _};
     use commonware_storage::mmr::Location;
     use commonware_utils::NZU64;
+    use rstest::rstest;
 
-    #[test]
-    fn test_error_code_roundtrip_serialization() {
-        let test_cases = vec![
-            ErrorCode::InvalidRequest,
-            ErrorCode::DatabaseError,
-            ErrorCode::NetworkError,
-            ErrorCode::Timeout,
-            ErrorCode::InternalError,
-        ];
+    #[rstest]
+    #[case(ErrorCode::InvalidRequest)]
+    #[case(ErrorCode::DatabaseError)]
+    #[case(ErrorCode::NetworkError)]
+    #[case(ErrorCode::Timeout)]
+    #[case(ErrorCode::InternalError)]
+    fn test_error_code_roundtrip_serialization(#[case] error_code: ErrorCode) {
+        // Serialize
+        let encoded = error_code.encode().to_vec();
 
-        for error_code in test_cases {
-            // Serialize
-            let encoded = error_code.encode().to_vec();
+        // Deserialize
+        let decoded = ErrorCode::decode(&encoded[..]).expect("Failed to decode ErrorCode");
 
-            // Deserialize
-            let decoded = ErrorCode::decode(&encoded[..]).expect("Failed to decode ErrorCode");
-
-            // Verify they match
-            match (&error_code, &decoded) {
-                (ErrorCode::InvalidRequest, ErrorCode::InvalidRequest) => {}
-                (ErrorCode::DatabaseError, ErrorCode::DatabaseError) => {}
-                (ErrorCode::NetworkError, ErrorCode::NetworkError) => {}
-                (ErrorCode::Timeout, ErrorCode::Timeout) => {}
-                (ErrorCode::InternalError, ErrorCode::InternalError) => {}
-                _ => panic!("ErrorCode roundtrip failed: {error_code:?} != {decoded:?}"),
-            }
+        // Verify they match
+        match (&error_code, &decoded) {
+            (ErrorCode::InvalidRequest, ErrorCode::InvalidRequest) => {}
+            (ErrorCode::DatabaseError, ErrorCode::DatabaseError) => {}
+            (ErrorCode::NetworkError, ErrorCode::NetworkError) => {}
+            (ErrorCode::Timeout, ErrorCode::Timeout) => {}
+            (ErrorCode::InternalError, ErrorCode::InternalError) => {}
+            _ => panic!("ErrorCode roundtrip failed: {error_code:?} != {decoded:?}"),
         }
     }
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -34,7 +34,7 @@ zstd = { workspace = true, optional = true }
 commonware-storage = { path = ".", features = ["std"] }
 criterion.workspace = true
 rand.workspace = true
-test-case.workspace = true
+rstest.workspace = true
 tracing-subscriber.workspace = true
 
 [features]

--- a/storage/src/adb/immutable/sync/mod.rs
+++ b/storage/src/adb/immutable/sync/mod.rs
@@ -168,12 +168,12 @@ mod tests {
     use commonware_utils::{NZUsize, NZU64};
     use futures::{channel::mpsc, SinkExt as _};
     use rand::{rngs::StdRng, RngCore as _, SeedableRng as _};
+    use rstest::rstest;
     use std::{
         collections::HashMap,
         num::{NonZeroU64, NonZeroUsize},
         sync::Arc,
     };
-    use test_case::test_case;
 
     /// Type alias for sync tests with simple codec config
     type ImmutableSyncTest = immutable::Immutable<
@@ -248,15 +248,16 @@ mod tests {
         }
     }
 
-    #[test_case(1, NZU64!(1); "singleton db with batch size == 1")]
-    #[test_case(1, NZU64!(2); "singleton db with batch size > db size")]
-    #[test_case(100, NZU64!(1); "db with batch size 1")]
-    #[test_case(100, NZU64!(3); "db size not evenly divided by batch size")]
-    #[test_case(100, NZU64!(99); "db size not evenly divided by batch size; different batch size")]
-    #[test_case(100, NZU64!(50); "db size divided by batch size")]
-    #[test_case(100, NZU64!(100); "db size == batch size")]
-    #[test_case(100, NZU64!(101); "batch size > db size")]
-    fn test_sync(target_db_ops: usize, fetch_batch_size: NonZeroU64) {
+    #[rstest]
+    #[case::singleton_batch_size_one(1, NZU64!(1))]
+    #[case::singleton_batch_size_gt_db_size(1, NZU64!(2))]
+    #[case::batch_size_one(1000, NZU64!(1))]
+    #[case::floor_div_db_batch_size(1000, NZU64!(3))]
+    #[case::floor_div_db_batch_size_2(1000, NZU64!(999))]
+    #[case::div_db_batch_size(1000, NZU64!(100))]
+    #[case::db_size_eq_batch_size(1000, NZU64!(1000))]
+    #[case::batch_size_gt_db_size(1000, NZU64!(1001))]
+    fn test_sync(#[case] target_db_ops: usize, #[case] fetch_batch_size: NonZeroU64) {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let mut target_db = create_test_db(context.clone()).await;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -30,6 +30,7 @@ features = ["js"]
 [dev-dependencies]
 criterion.workspace = true
 num-bigint = { version = "0.4.6", default-features = false }
+rstest.workspace = true
 
 [features]
 default = ["std"]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -255,6 +255,7 @@ mod tests {
     use super::*;
     use num_bigint::BigUint;
     use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rstest::rstest;
 
     #[test]
     fn test_hex() {
@@ -354,38 +355,36 @@ mod tests {
         quorum(0);
     }
 
-    #[test]
-    fn test_quorum_and_max_faults() {
-        // n, expected_f, expected_q
-        let test_cases = [
-            (1, 0, 1),
-            (2, 0, 2),
-            (3, 0, 3),
-            (4, 1, 3),
-            (5, 1, 4),
-            (6, 1, 5),
-            (7, 2, 5),
-            (8, 2, 6),
-            (9, 2, 7),
-            (10, 3, 7),
-            (11, 3, 8),
-            (12, 3, 9),
-            (13, 4, 9),
-            (14, 4, 10),
-            (15, 4, 11),
-            (16, 5, 11),
-            (17, 5, 12),
-            (18, 5, 13),
-            (19, 6, 13),
-            (20, 6, 14),
-            (21, 6, 15),
-        ];
-
-        for (n, ef, eq) in test_cases {
-            assert_eq!(max_faults(n), ef);
-            assert_eq!(quorum(n), eq);
-            assert_eq!(n, ef + eq);
-        }
+    #[rstest]
+    #[case(1, 0, 1)]
+    #[case(2, 0, 2)]
+    #[case(3, 0, 3)]
+    #[case(4, 1, 3)]
+    #[case(5, 1, 4)]
+    #[case(6, 1, 5)]
+    #[case(7, 2, 5)]
+    #[case(8, 2, 6)]
+    #[case(9, 2, 7)]
+    #[case(10, 3, 7)]
+    #[case(11, 3, 8)]
+    #[case(12, 3, 9)]
+    #[case(13, 4, 9)]
+    #[case(14, 4, 10)]
+    #[case(15, 4, 11)]
+    #[case(16, 5, 11)]
+    #[case(17, 5, 12)]
+    #[case(18, 5, 13)]
+    #[case(19, 6, 13)]
+    #[case(20, 6, 14)]
+    #[case(21, 6, 15)]
+    fn test_quorum_and_max_faults(
+        #[case] n: u32,
+        #[case] expected_f: u32,
+        #[case] expected_q: u32,
+    ) {
+        assert_eq!(max_faults(n), expected_f);
+        assert_eq!(quorum(n), expected_q);
+        assert_eq!(n, expected_f + expected_q);
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Migrates existing test matrices from `test_case` over to `rstest`, which is actively maintained and [offers quite a few more features](https://docs.rs/rstest/latest/rstest/attr.rstest.html). Also updates a few tests that manually ran through test cases over to `rstest`.