### PR TITLE
[runtime] Create ergonomic metric wrappers

### DIFF
--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -9,7 +9,7 @@ use commonware_p2p::{
 };
 use commonware_runtime::{
     spawn_cell,
-    telemetry::metrics::status::{CounterExt, Status},
+    telemetry::metrics::status::{CounterExt, GaugeExt, Status},
     Clock, ContextCell, Handle, Metrics, Spawner,
 };
 use futures::{
@@ -154,7 +154,7 @@ impl<E: Clock + Spawner + Metrics, P: PublicKey, M: Committable + Digestible + C
         loop {
             // Cleanup waiters
             self.cleanup_waiters();
-            self.metrics.waiters.set(self.waiters.len() as i64);
+            let _ = self.metrics.waiters.try_set(self.waiters.len());
 
             select! {
                 // Handle shutdown signal

--- a/collector/src/p2p/engine.rs
+++ b/collector/src/p2p/engine.rs
@@ -10,7 +10,9 @@ use commonware_codec::Codec;
 use commonware_cryptography::{Committable, Digestible, PublicKey};
 use commonware_macros::select;
 use commonware_p2p::{utils::codec::wrap, Blocker, Receiver, Recipients, Sender};
-use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Metrics, Spawner};
+use commonware_runtime::{
+    spawn_cell, telemetry::metrics::status::GaugeExt, Clock, ContextCell, Handle, Metrics, Spawner,
+};
 use commonware_utils::futures::Pool;
 use futures::{
     channel::{mpsc, oneshot},
@@ -159,7 +161,7 @@ where
                                 if self.tracked.remove(&commitment).is_none() {
                                     debug!(?commitment, "ignoring removal of unknown commitment");
                                 }
-                                self.outstanding.set(self.tracked.len() as i64);
+                                let _ = self.outstanding.try_set(self.tracked.len());
                             }
                         }
                     }

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -24,7 +24,7 @@ use commonware_runtime::{
     spawn_cell,
     telemetry::metrics::{
         histogram,
-        status::{CounterExt, Status},
+        status::{CounterExt, GaugeExt, Status},
     },
     Clock, ContextCell, Handle, Metrics, Spawner, Storage,
 };
@@ -264,7 +264,7 @@ impl<
         );
 
         loop {
-            self.metrics.tip.set(self.tip as i64);
+            let _ = self.metrics.tip.try_set(self.tip);
 
             // Propose a new digest if we are processing less than the window
             let next = self.next();

--- a/consensus/src/application/marshaled.rs
+++ b/consensus/src/application/marshaled.rs
@@ -39,7 +39,7 @@ use crate::{
     types::{Epoch, Round},
     utils, Application, Automaton, Block, Epochable, Relay, Reporter, VerifyingApplication,
 };
-use commonware_runtime::{Clock, Metrics, Spawner};
+use commonware_runtime::{telemetry::metrics::status::GaugeExt, Clock, Metrics, Spawner};
 use commonware_utils::futures::ClosedExt;
 use futures::{
     channel::oneshot::{self, Canceled},
@@ -251,7 +251,7 @@ where
                         return;
                     }
                 };
-                build_duration.set(start.elapsed().as_millis() as i64);
+                let _ = build_duration.try_set(start.elapsed().as_millis());
 
                 let digest = built_block.commitment();
                 {

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -27,7 +27,7 @@ use commonware_runtime::{
     spawn_cell,
     telemetry::metrics::{
         histogram,
-        status::{CounterExt, Status},
+        status::{CounterExt, GaugeExt, Status},
     },
     Clock, ContextCell, Handle, Metrics, Spawner, Storage,
 };
@@ -614,10 +614,11 @@ impl<
         // If a higher height than the previous tip...
         if is_new {
             // Update metrics for sequencer height
-            self.metrics
+            let _ = self
+                .metrics
                 .sequencer_heights
                 .get_or_create(&metrics::SequencerLabel::from(&node.chunk.sequencer))
-                .set(node.chunk.height as i64);
+                .try_set(node.chunk.height);
 
             // Append to journal if the `Node` is new, making sure to sync the journal
             // to prevent sending two conflicting chunks to the automaton, even if

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -20,7 +20,9 @@ use commonware_p2p::{
     },
     Blocker, Receiver, Recipients, Sender,
 };
-use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Metrics, Spawner};
+use commonware_runtime::{
+    spawn_cell, telemetry::metrics::status::GaugeExt, Clock, ContextCell, Handle, Metrics, Spawner,
+};
 use futures::{channel::mpsc, future::Either, StreamExt};
 use governor::clock::Clock as GClock;
 use prometheus_client::{
@@ -433,7 +435,7 @@ impl<
         let mut finalized_view = 0;
         loop {
             // Record outstanding metric
-            self.outstanding.set(self.requester.len() as i64);
+            let _ = self.outstanding.try_set(self.requester.len());
 
             // Set timeout for retry
             let retry = match self.retry {

--- a/p2p/src/authenticated/discovery/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/directory.rs
@@ -5,7 +5,9 @@ use crate::authenticated::discovery::{
     types::{self, Info},
 };
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Clock, Metrics as RuntimeMetrics, Spawner};
+use commonware_runtime::{
+    telemetry::metrics::status::GaugeExt, Clock, Metrics as RuntimeMetrics, Spawner,
+};
 use commonware_utils::{set::Ordered, SystemTimeExt};
 use governor::{
     clock::Clock as GClock, middleware::NoOpMiddleware, state::keyed::HashMapStateStore, Quota,
@@ -87,7 +89,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: PublicKey> Directory
         // Other initialization.
         // TODO(#1833): Metrics should use the post-start context
         let metrics = Metrics::init(context.clone());
-        metrics.tracked.set((peers.len() - 1) as i64); // Exclude self
+        let _ = metrics.tracked.try_set(peers.len() - 1); // Exclude self
 
         Self {
             context,

--- a/p2p/src/authenticated/lookup/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/directory.rs
@@ -1,7 +1,9 @@
 use super::{metrics::Metrics, record::Record, Metadata, Reservation};
 use crate::authenticated::lookup::{actors::tracker::ingress::Releaser, metrics};
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Clock, Metrics as RuntimeMetrics, Spawner};
+use commonware_runtime::{
+    telemetry::metrics::status::GaugeExt, Clock, Metrics as RuntimeMetrics, Spawner,
+};
 use commonware_utils::set::{Ordered, OrderedAssociated};
 use governor::{
     clock::Clock as GClock, middleware::NoOpMiddleware, state::keyed::HashMapStateStore, Quota,
@@ -67,7 +69,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: PublicKey> Directory
 
         // TODO(#1833): Metrics should use the post-start context
         let metrics = Metrics::init(context.clone());
-        metrics.tracked.set((peers.len() - 1) as i64); // Exclude self
+        let _ = metrics.tracked.try_set(peers.len() - 1); // Exclude self
 
         Self {
             max_sets: cfg.max_sets,

--- a/p2p/src/utils/requester/requester.rs
+++ b/p2p/src/utils/requester/requester.rs
@@ -3,7 +3,7 @@
 use super::{Config, PeerLabel};
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{
-    telemetry::metrics::status::{CounterExt, Status},
+    telemetry::metrics::status::{CounterExt, GaugeExt, Status},
     Clock, Metrics,
 };
 use commonware_utils::PrioritySet;
@@ -170,10 +170,11 @@ impl<E: Clock + GClock + Rng + Metrics, P: PublicKey> Requester<E, P> {
             return;
         };
         let next = past.saturating_add(elapsed.as_millis()) / 2;
-        self.metrics
+        let _ = self
+            .metrics
             .performance
             .get_or_create(&PeerLabel::from(&participant))
-            .set(next as i64);
+            .try_set(next);
         self.participants.put(participant, next);
     }
 

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -16,7 +16,7 @@ use commonware_runtime::{
     spawn_cell,
     telemetry::metrics::{
         histogram,
-        status::{CounterExt, Status},
+        status::{CounterExt, GaugeExt, Status},
     },
     Clock, ContextCell, Handle, Metrics, Spawner,
 };
@@ -155,16 +155,16 @@ impl<
 
         loop {
             // Update metrics
-            self.metrics
+            let _ = self
+                .metrics
                 .fetch_pending
-                .set(self.fetcher.len_pending() as i64);
-            self.metrics
-                .fetch_active
-                .set(self.fetcher.len_active() as i64);
-            self.metrics
+                .try_set(self.fetcher.len_pending());
+            let _ = self.metrics.fetch_active.try_set(self.fetcher.len_active());
+            let _ = self
+                .metrics
                 .peers_blocked
-                .set(self.fetcher.len_blocked() as i64);
-            self.metrics.serve_processing.set(self.serves.len() as i64);
+                .try_set(self.fetcher.len_blocked());
+            let _ = self.metrics.serve_processing.try_set(self.serves.len());
 
             // Get retry timeout (if any)
             let deadline_pending = match self.fetcher.get_pending_deadline() {

--- a/runtime/src/process/metered.rs
+++ b/runtime/src/process/metered.rs
@@ -1,5 +1,6 @@
 //! Process metrics collection.
 
+use crate::telemetry::metrics::status::GaugeExt;
 use prometheus_client::{metrics::gauge::Gauge, registry::Registry};
 use std::{future::Future, time::Duration};
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
@@ -57,8 +58,8 @@ impl Metrics {
 
         // If the process exists, update the metrics
         if let Some(process) = self.system.process(self.pid) {
-            self.rss.set(process.memory() as i64);
-            self.virtual_memory.set(process.virtual_memory() as i64);
+            let _ = self.rss.try_set(process.memory());
+            let _ = self.virtual_memory.try_set(process.virtual_memory());
         }
     }
 

--- a/storage/src/adb/any/fixed/sync.rs
+++ b/storage/src/adb/any/fixed/sync.rs
@@ -11,7 +11,9 @@ use crate::{
 };
 use commonware_codec::{CodecFixed, Encode as _};
 use commonware_cryptography::Hasher;
-use commonware_runtime::{buffer::Append, Blob, Clock, Metrics, Storage};
+use commonware_runtime::{
+    buffer::Append, telemetry::metrics::status::GaugeExt, Blob, Clock, Metrics, Storage,
+};
 use commonware_utils::Array;
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use std::{collections::BTreeMap, marker::PhantomData, ops::Range};
@@ -254,7 +256,7 @@ pub(crate) async fn init_journal_at_size<E: Storage + Metrics, A: CodecFixed<Cfg
 
     // Initialize metrics
     let tracked = Gauge::default();
-    tracked.set(tail_index as i64 + 1);
+    let _ = tracked.try_set(tail_index + 1);
     let synced = Counter::default();
     let pruned = Counter::default();
     context.register("tracked", "Number of blobs", tracked.clone());

--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bytes::{Buf, BufMut};
 use commonware_codec::{varint::UInt, Codec, EncodeSize, Read, ReadExt, Write};
-use commonware_runtime::{Metrics, Storage};
+use commonware_runtime::{telemetry::metrics::status::GaugeExt, Metrics, Storage};
 use futures::{future::try_join_all, pin_mut, StreamExt};
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use std::collections::{BTreeMap, BTreeSet};
@@ -127,7 +127,7 @@ impl<E: Storage + Metrics, V: Codec> Cache<E, V> {
         context.register("gets", "Number of gets performed", gets.clone());
         context.register("has", "Number of has performed", has.clone());
         context.register("syncs", "Number of syncs called", syncs.clone());
-        items_tracked.set(indices.len() as i64);
+        let _ = items_tracked.try_set(indices.len());
 
         // Return populated cache
         Ok(Self {
@@ -235,7 +235,7 @@ impl<E: Storage + Metrics, V: Codec> Cache<E, V> {
         // Update last pruned (to prevent reads from
         // pruned sections)
         self.oldest_allowed = Some(min);
-        self.items_tracked.set(self.indices.len() as i64);
+        let _ = self.items_tracked.try_set(self.indices.len());
         Ok(())
     }
 
@@ -269,7 +269,7 @@ impl<E: Storage + Metrics, V: Codec> Cache<E, V> {
         self.pending.insert(section);
 
         // Update metrics
-        self.items_tracked.set(self.indices.len() as i64);
+        let _ = self.items_tracked.try_set(self.indices.len());
         Ok(())
     }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -60,6 +60,7 @@ use bytes::BufMut;
 use commonware_codec::{CodecFixed, DecodeExt, FixedSize};
 use commonware_runtime::{
     buffer::{Append, PoolRef, Read},
+    telemetry::metrics::status::GaugeExt,
     Blob, Error as RError, Metrics, Storage,
 };
 use commonware_utils::hex;
@@ -198,7 +199,7 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> Journal<E, A> {
         context.register("tracked", "Number of blobs", tracked.clone());
         context.register("synced", "Number of syncs", synced.clone());
         context.register("pruned", "Number of blobs pruned", pruned.clone());
-        tracked.set(blobs.len() as i64);
+        let _ = tracked.try_set(blobs.len());
 
         // Initialize the tail blob.
         let (mut tail_index, (mut tail, mut tail_size)) = blobs.pop_last().unwrap();

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -105,6 +105,7 @@ use bytes::BufMut;
 use commonware_codec::Codec;
 use commonware_runtime::{
     buffer::{Append, PoolRef, Read},
+    telemetry::metrics::status::GaugeExt,
     Blob, Error as RError, Metrics, Storage,
 };
 use commonware_utils::hex;
@@ -206,7 +207,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
         context.register("tracked", "Number of blobs", tracked.clone());
         context.register("synced", "Number of syncs", synced.clone());
         context.register("pruned", "Number of blobs pruned", pruned.clone());
-        tracked.set(blobs.len() as i64);
+        let _ = tracked.try_set(blobs.len());
 
         // Create journal instance
         Ok(Self {


### PR DESCRIPTION
Introduces `GaugeExt` to extend implementation of `Gauge` (similarly to `CounterExt` for `Counter`).

It provides a record method that allows setting gauge values that aren't inherently `i64`. This replaces the previous `as`-based conversion, removing the unchecked and potentially lossy cast in favor of a safe, clean and checked conversion.

```rust
/// Trait providing convenience methods for `Gauge`.
pub trait GaugeExt {
    fn record<T: TryInto<i64>>(&self, val: T) -> Option<i64>;
}

impl GaugeExt for Gauge {
    fn record<T: TryInto<i64>>(&self, val: T) -> Option<i64> {
        // Prevent casting if conversion is lossy
        let val = val.try_into().ok()?;
        let out = self.set(val);
        Some(out)
    }
}
```

Closes #2151