### PR TITLE
chore: add collector-demo example showcasing commonware-collector primitive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "utils",
     "examples/bridge",
     "examples/chat",
+    "examples/collector-demo",
     "examples/estimator",
     "examples/flood",
     "examples/log",

--- a/examples/collector-demo/Cargo.toml
+++ b/examples/collector-demo/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "commonware-collector-demo"
+edition.workspace = true
+publish = true
+version.workspace = true
+license.workspace = true
+description = "Demonstrate collecting responses from multiple nodes using commonware-collector."
+readme = "README.md"
+homepage.workspace = true
+repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/collector-demo"
+documentation = "https://docs.rs/commonware-collector-demo"
+
+[dependencies]
+bytes.workspace = true
+clap.workspace = true
+commonware-codec.workspace = true
+commonware-collector.workspace = true
+commonware-cryptography.workspace = true
+commonware-macros.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime.workspace = true
+commonware-utils.workspace = true
+async-lock.workspace = true
+futures.workspace = true
+governor.workspace = true
+prometheus-client.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[[bin]]
+name = "commonware-collector-demo"
+bench = false

--- a/examples/collector-demo/README.md
+++ b/examples/collector-demo/README.md
@@ -1,0 +1,50 @@
+# commonware-collector-demo
+
+[![Crates.io](https://img.shields.io/crates/v/commonware-collector-demo.svg)](https://crates.io/crates/commonware-collector-demo)
+
+Demonstrate collecting responses from multiple nodes using [commonware-collector](https://crates.io/crates/commonware-collector) and [commonware-p2p](https://crates.io/crates/commonware-p2p).
+
+## Overview
+
+This example demonstrates how to use `commonware-collector` to send queries to multiple nodes and collect their responses. One node acts as an **originator** that sends queries, while other nodes act as **handlers** that process queries and send responses back. The originator uses a **monitor** to track all collected responses.
+
+## Usage (3 Nodes)
+
+_To run this example, you must first install [Rust](https://www.rust-lang.org/tools/install)._
+
+**Important**: Each instance must use a unique port. The format is `--me=<node_id>@<port>` where each node uses a different port number.
+
+### Node 1 (Originator - Bootstrapper)
+
+```sh
+cargo run --release -- --me=1@3001 --participants=1,2,3 --role=originator
+```
+
+### Node 2 (Handler)
+
+```sh
+cargo run --release -- --me=2@3002 --participants=1,2,3 --role=handler --bootstrappers=1@127.0.0.1:3001
+```
+
+### Node 3 (Handler)
+
+```sh
+cargo run --release -- --me=3@3003 --participants=1,2,3 --role=handler --bootstrappers=1@127.0.0.1:3001
+```
+
+**Note**: If you get a "failed to bind listener" error, it means the port is already in use. Make sure:
+- Each instance uses a different port number
+- No other processes are using the ports (3001, 3002, 3003)
+- Previous instances have been properly terminated
+
+## How It Works
+
+1. **Originator**: Sends queries to all handler nodes asking them to compute a value (e.g., multiply a number by 2).
+2. **Handlers**: Receive queries, process them, and send responses back.
+3. **Monitor**: Collects all responses and displays them as they arrive.
+
+The example demonstrates:
+- How to implement a `Handler` trait to process requests
+- How to implement a `Monitor` trait to track collected responses
+- How to use `collector::p2p::Engine` to coordinate request/response flow
+- How responses are collected from multiple nodes concurrently

--- a/examples/collector-demo/src/main.rs
+++ b/examples/collector-demo/src/main.rs
@@ -1,0 +1,367 @@
+//! Demonstrate collecting responses from multiple nodes using commonware-collector and commonware-p2p.
+//!
+//! This example shows how to use `commonware-collector` to send queries to multiple nodes and
+//! collect their responses. One node acts as an **originator** that sends queries, while other
+//! nodes act as **handlers** that process queries and send responses back.
+//!
+//! # Usage (3 Nodes)
+//!
+//! _To run this example, you must first install [Rust](https://www.rust-lang.org/tools/install)._
+//!
+//! ## Node 1 (Originator - Bootstrapper)
+//!
+//! ```sh
+//! cargo run --release -- --me=1@3001 --participants=1,2,3 --role=originator
+//! ```
+//!
+//! ## Node 2 (Handler)
+//!
+//! ```sh
+//! cargo run --release -- --me=2@3002 --participants=1,2,3 --role=handler --bootstrappers=1@127.0.0.1:3001
+//! ```
+//!
+//! ## Node 3 (Handler)
+//!
+//! ```sh
+//! cargo run --release -- --me=3@3003 --participants=1,2,3 --role=handler --bootstrappers=1@127.0.0.1:3001
+//! ```
+
+mod types;
+
+use clap::{value_parser, Arg, Command};
+use commonware_collector::p2p::{Config, Engine, Mailbox};
+use commonware_collector::{Handler, Monitor, Originator};
+use commonware_cryptography::{ed25519, PrivateKeyExt as _, Signer as _};
+use commonware_p2p::{authenticated::discovery, Manager, Recipients};
+use commonware_runtime::{tokio, Clock, Metrics, Runner, Spawner};
+use commonware_utils::{set::Ordered, NZU32};
+use futures::channel::oneshot;
+use governor::Quota;
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
+use async_lock::Mutex;
+use tracing::{info, warn};
+use types::{Query, QueryResult};
+
+/// Unique namespace to avoid message replay attacks.
+const APPLICATION_NAMESPACE: &[u8] = b"commonware-collector-demo";
+
+/// Handler that processes queries and sends responses.
+#[derive(Clone)]
+struct QueryHandler {
+    node_id: u64,
+}
+
+impl Handler for QueryHandler {
+    type PublicKey = ed25519::PublicKey;
+    type Request = Query;
+    type Response = QueryResult;
+
+    async fn process(
+        &mut self,
+        origin: Self::PublicKey,
+        request: Query,
+        responder: oneshot::Sender<Self::Response>,
+    ) {
+        info!(
+            node_id = self.node_id,
+            origin = ?origin,
+            query_id = request.id,
+            value = request.value,
+            "received query"
+        );
+
+        // Process the query: multiply the value by 2 and add node_id
+        let result = request.value.wrapping_mul(2).wrapping_add(self.node_id as u32);
+
+        let response = QueryResult {
+            id: request.id,
+            result,
+            node_id: self.node_id,
+        };
+
+        info!(
+            node_id = self.node_id,
+            query_id = request.id,
+            result = response.result,
+            "sending response"
+        );
+
+        // Send the response
+        if let Err(_) = responder.send(response) {
+            warn!(node_id = self.node_id, "failed to send response");
+        }
+    }
+}
+
+/// Monitor that tracks collected responses.
+#[derive(Clone)]
+struct ResponseMonitor {
+    node_id: u64,
+    collected: Arc<Mutex<HashMap<u64, Vec<(ed25519::PublicKey, QueryResult)>>>>,
+}
+
+impl ResponseMonitor {
+    fn new(node_id: u64) -> Self {
+        Self {
+            node_id,
+            collected: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Monitor for ResponseMonitor {
+    type PublicKey = ed25519::PublicKey;
+    type Response = QueryResult;
+
+    async fn collected(
+        &mut self,
+        handler: Self::PublicKey,
+        response: Self::Response,
+        count: usize,
+    ) {
+        info!(
+            node_id = self.node_id,
+            handler = ?handler,
+            query_id = response.id,
+            result = response.result,
+            count,
+            "collected response"
+        );
+
+        let mut collected = self.collected.lock().await;
+        collected
+            .entry(response.id)
+            .or_insert_with(Vec::new)
+            .push((handler, response));
+    }
+}
+
+/// Send queries periodically and display collected responses.
+async fn run_originator<E>(
+    context: E,
+    mut mailbox: Mailbox<ed25519::PublicKey, Query>,
+    handlers: Ordered<ed25519::PublicKey>,
+) where
+    E: Clock + Spawner,
+{
+    info!("starting originator");
+
+    let mut query_id = 0u64;
+    loop {
+        context.sleep(Duration::from_secs(5)).await;
+
+        query_id += 1;
+        let value = (query_id % 1000) as u32;
+        let query = Query {
+            id: query_id,
+            value,
+        };
+
+        info!(
+            query_id,
+            value,
+            handlers_count = handlers.len(),
+            "sending query to all handlers"
+        );
+
+        // Send query to all handlers
+        let recipients = if handlers.len() == 1 {
+            Recipients::One(handlers.iter().next().unwrap().clone())
+        } else {
+            Recipients::Some(handlers.iter().cloned().collect())
+        };
+        match mailbox.send(recipients, query).await
+        {
+            Ok(sent_to) => {
+                info!(
+                    query_id,
+                    sent_to_count = sent_to.len(),
+                    "query sent successfully"
+                );
+            }
+            Err(e) => {
+                warn!(?e, "failed to send query");
+                continue;
+            }
+        }
+
+        // Wait a bit for responses to arrive
+        context.sleep(Duration::from_secs(2)).await;
+    }
+}
+
+fn main() {
+    // Initialize context
+    let executor = tokio::Runner::default();
+
+    // Parse arguments
+    let matches = Command::new("commonware-collector-demo")
+        .about("demonstrate collecting responses from multiple nodes")
+        .arg(Arg::new("me").long("me").required(true))
+        .arg(
+            Arg::new("participants")
+                .long("participants")
+                .required(true)
+                .value_delimiter(',')
+                .value_parser(value_parser!(u64)),
+        )
+        .arg(
+            Arg::new("role")
+                .long("role")
+                .required(true)
+                .value_parser(["originator", "handler"])
+                .help("Role: 'originator' sends queries, 'handler' processes queries"),
+        )
+        .arg(
+            Arg::new("bootstrappers")
+                .long("bootstrappers")
+                .required(false)
+                .value_delimiter(',')
+                .value_parser(value_parser!(String)),
+        )
+        .get_matches();
+
+    // Create logger
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    // Configure my identity
+    let me = matches
+        .get_one::<String>("me")
+        .expect("Please provide identity");
+    let parts = me.split('@').collect::<Vec<&str>>();
+    if parts.len() != 2 {
+        panic!("Identity not well-formed");
+    }
+    let key = parts[0].parse::<u64>().expect("Key not well-formed");
+    let signer = ed25519::PrivateKey::from_seed(key);
+    info!(key = ?signer.public_key(), "loaded signer");
+
+    // Configure my port
+    let port = parts[1].parse::<u16>().expect("Port not well-formed");
+    info!(port, "loaded port");
+
+    // Configure allowed peers
+    let participants = matches
+        .get_many::<u64>("participants")
+        .expect("Please provide participants")
+        .copied();
+    if participants.len() == 0 {
+        panic!("Please provide at least one participant");
+    }
+    let recipients = participants
+        .into_iter()
+        .map(|peer| {
+            let verifier = ed25519::PrivateKey::from_seed(peer).public_key();
+            info!(key = ?verifier, "registered authorized key");
+            verifier
+        })
+        .collect::<Ordered<_>>();
+
+    // Configure bootstrappers (if provided)
+    let bootstrappers = matches.get_many::<String>("bootstrappers");
+    let mut bootstrapper_identities = Vec::new();
+    if let Some(bootstrappers) = bootstrappers {
+        for bootstrapper in bootstrappers {
+            let parts = bootstrapper.split('@').collect::<Vec<&str>>();
+            let bootstrapper_key = parts[0]
+                .parse::<u64>()
+                .expect("Bootstrapper key not well-formed");
+            let verifier = ed25519::PrivateKey::from_seed(bootstrapper_key).public_key();
+            let bootstrapper_address =
+                SocketAddr::from_str(parts[1]).expect("Bootstrapper address not well-formed");
+            bootstrapper_identities.push((verifier, bootstrapper_address));
+        }
+    }
+
+    // Get role
+    let role = matches
+        .get_one::<String>("role")
+        .expect("Please provide role");
+
+    // Configure network
+    const MAX_MESSAGE_SIZE: usize = 1024;
+    let p2p_cfg = discovery::Config::local(
+        signer.clone(),
+        APPLICATION_NAMESPACE,
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+        bootstrapper_identities.clone(),
+        MAX_MESSAGE_SIZE,
+    );
+
+    // Start context
+    executor.start(|context| async move {
+        // Initialize network
+        let (mut network, mut oracle) =
+            discovery::Network::new(context.with_label("network"), p2p_cfg);
+
+        // Provide authorized peers
+        oracle.update(0, recipients.clone()).await;
+
+        // Register channels for collector
+        let (request_sender, request_receiver) = network.register(
+            0,
+            Quota::per_second(NZU32!(128)),
+            256,
+        );
+        let (response_sender, response_receiver) = network.register(
+            1,
+            Quota::per_second(NZU32!(128)),
+            256,
+        );
+
+        // Start network
+        let network_handler = network.start();
+
+        // Both originator and handler need monitor and handler
+        let monitor = ResponseMonitor::new(key);
+        let handler = QueryHandler { node_id: key };
+
+        // Oracle implements Blocker trait directly
+        let blocker = oracle;
+        let cfg = Config {
+            blocker,
+            monitor: monitor.clone(),
+            handler,
+            mailbox_size: 256,
+            priority_request: false,
+            request_codec: (),
+            priority_response: false,
+            response_codec: (),
+        };
+
+        let (engine, mailbox) = Engine::new(context.with_label("engine"), cfg);
+        engine.start(
+            (request_sender, request_receiver),
+            (response_sender, response_receiver),
+        );
+
+        if role == "originator" {
+            // Get handlers (all participants except self)
+            let handlers: Ordered<_> = recipients
+                .iter()
+                .filter(|&pk| *pk != signer.public_key())
+                .cloned()
+                .collect();
+
+            // Run originator in a separate task
+            let originator_context = context.with_label("originator");
+            originator_context.spawn(move |context| {
+                run_originator(context, mailbox, handlers)
+            });
+        } else {
+            info!("handler started, waiting for queries...");
+        }
+
+        // Keep running
+        network_handler.await.expect("Network failed");
+    });
+}

--- a/examples/collector-demo/src/types.rs
+++ b/examples/collector-demo/src/types.rs
@@ -1,0 +1,98 @@
+use bytes::{Buf, BufMut};
+use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
+use commonware_cryptography::{sha256::Digest, Committable, Digestible, Hasher, Sha256};
+
+/// A query request sent from originator to handlers.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Query {
+    pub id: u64,
+    pub value: u32,
+}
+
+impl Write for Query {
+    fn write(&self, buf: &mut impl BufMut) {
+        buf.put_u64(self.id);
+        buf.put_u32(self.value);
+    }
+}
+
+impl Read for Query {
+    type Cfg = ();
+    fn read_cfg(buf: &mut impl Buf, _cfg: &()) -> Result<Self, CodecError> {
+        let id = u64::read(buf)?;
+        let value = u32::read(buf)?;
+        Ok(Self { id, value })
+    }
+}
+
+impl FixedSize for Query {
+    const SIZE: usize = u64::SIZE + u32::SIZE;
+}
+
+impl Committable for Query {
+    type Commitment = Digest;
+
+    fn commitment(&self) -> Self::Commitment {
+        Sha256::hash(&self.id.to_be_bytes())
+    }
+}
+
+impl Digestible for Query {
+    type Digest = Digest;
+    fn digest(&self) -> Self::Digest {
+        let mut hasher = Sha256::new();
+        hasher.update(&self.id.to_be_bytes());
+        hasher.update(&self.value.to_be_bytes());
+        hasher.finalize()
+    }
+}
+
+/// A query result response sent from handlers to originator.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct QueryResult {
+    pub id: u64,
+    pub result: u32,
+    pub node_id: u64,
+}
+
+impl Write for QueryResult {
+    fn write(&self, buf: &mut impl BufMut) {
+        buf.put_u64(self.id);
+        buf.put_u32(self.result);
+        buf.put_u64(self.node_id);
+    }
+}
+
+impl Read for QueryResult {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _cfg: &()) -> Result<Self, CodecError> {
+        let id = u64::read(buf)?;
+        let result = u32::read(buf)?;
+        let node_id = u64::read(buf)?;
+        Ok(Self { id, result, node_id })
+    }
+}
+
+impl FixedSize for QueryResult {
+    const SIZE: usize = u64::SIZE + u32::SIZE + u64::SIZE;
+}
+
+impl Committable for QueryResult {
+    type Commitment = Digest;
+    fn commitment(&self) -> Self::Commitment {
+        Sha256::hash(&self.id.to_be_bytes())
+    }
+}
+
+impl Digestible for QueryResult {
+    type Digest = <Sha256 as Hasher>::Digest;
+
+    fn digest(&self) -> Self::Digest {
+        let mut hasher = Sha256::new();
+        hasher.update(&self.id.to_be_bytes());
+        hasher.update(&self.result.to_be_bytes());
+        hasher.update(&self.node_id.to_be_bytes());
+        hasher.finalize()
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a new example `collector-demo` that demonstrates how to use the `commonware-collector` primitive to send queries to multiple nodes and collect their responses.

## What This Example Demonstrates

- How to implement the `Handler` trait to process incoming requests
- How to implement the `Monitor` trait to track collected responses  
- How to use `collector::p2p::Engine` to coordinate request/response flow
- How responses are collected from multiple nodes concurrently

## Features

- **Originator role**: Sends queries to all handler nodes periodically
- **Handler role**: Processes queries and sends responses back
- **Monitor**: Tracks all collected responses with logging

## Usage

The example can be run with 3 nodes:
- 1 originator node that sends queries
- 2 handler nodes that process queries and respond

See `examples/collector-demo/README.md` for detailed usage instructions.

## Testing

The example follows the same patterns as other examples in the repository and has been verified to compile without errors.