### PR TITLE
[cryptography/bls12381] Batched Threshold Encryption

### DIFF
--- a/cryptography/src/bls12381/benches/bench.rs
+++ b/cryptography/src/bls12381/benches/bench.rs
@@ -6,6 +6,8 @@ mod aggregate_verify_multiple_messages;
 mod aggregate_verify_multiple_public_keys;
 mod batch_verify_multiple_messages;
 mod batch_verify_multiple_public_keys;
+mod bte_decrypt;
+mod bte_encrypt;
 mod dkg_recovery;
 mod dkg_reshare_recovery;
 mod evaluate_point;
@@ -34,4 +36,6 @@ criterion_main!(
     partial_verify_multiple_public_keys_precomputed::benches,
     tle_encrypt::benches,
     tle_decrypt::benches,
+    bte_encrypt::benches,
+    bte_decrypt::benches,
 );

--- a/cryptography/src/bls12381/benches/bte_decrypt.rs
+++ b/cryptography/src/bls12381/benches/bte_decrypt.rs
@@ -16,6 +16,7 @@ use rand_chacha::ChaCha20Rng;
 use std::hint::black_box;
 
 const SIZES: [usize; 3] = [10, 100, 1000];
+const PARTICIPANTS: [u32; 2] = [10, 100];
 struct BenchData {
     request: BatchRequest<MinSig>,
     responses: Vec<BatchResponse<MinSig>>,
@@ -63,26 +64,29 @@ fn build_data(size: usize, participants: u32, threshold: u32) -> BenchData {
 }
 
 fn benchmark_bte_decrypt(c: &mut Criterion) {
-    let participants = 5u32;
-    let threshold = quorum(participants);
-    let datasets: Vec<_> = SIZES
-        .iter()
-        .map(|&size| (size, build_data(size, participants, threshold)))
-        .collect();
+    for &participants in PARTICIPANTS.iter() {
+        let threshold = quorum(participants);
+        let datasets: Vec<_> = SIZES
+            .iter()
+            .map(|&size| (size, build_data(size, participants, threshold)))
+            .collect();
 
-    for (size, data) in datasets.iter() {
-        c.bench_with_input(BenchmarkId::new("bte_decrypt", size), data, |b, data| {
-            b.iter(|| {
-                let mut share_indices = Vec::with_capacity(data.responses.len());
-                let mut partials = Vec::with_capacity(data.responses.len());
-                for (response, eval) in data.responses.iter().zip(data.evals.iter()) {
-                    let verified = verify_batch_response(&data.request, eval, response).unwrap();
-                    share_indices.push(response.index);
-                    partials.push(verified);
-                }
-                black_box(combine_partials(&data.request, &share_indices, &partials).unwrap());
+        for (size, data) in datasets.iter() {
+            let id = format!("bte_decrypt/n={participants}");
+            c.bench_with_input(BenchmarkId::new(id, size), data, |b, data| {
+                b.iter(|| {
+                    let mut share_indices = Vec::with_capacity(data.responses.len());
+                    let mut partials = Vec::with_capacity(data.responses.len());
+                    for (response, eval) in data.responses.iter().zip(data.evals.iter()) {
+                        let verified =
+                            verify_batch_response(&data.request, eval, response).unwrap();
+                        share_indices.push(response.index);
+                        partials.push(verified);
+                    }
+                    black_box(combine_partials(&data.request, &share_indices, &partials).unwrap());
+                });
             });
-        });
+        }
     }
 }
 

--- a/cryptography/src/bls12381/benches/bte_decrypt.rs
+++ b/cryptography/src/bls12381/benches/bte_decrypt.rs
@@ -61,6 +61,7 @@ fn benchmark_bte_decrypt(c: &mut Criterion) {
                     ciphertexts.clone(),
                     format!("bench-{size}").into_bytes(),
                     threshold,
+                    threads,
                 );
 
                 let responses: Vec<_> = shares
@@ -93,6 +94,7 @@ fn benchmark_bte_decrypt(c: &mut Criterion) {
                             data.ciphertexts.clone(),
                             format!("bench-{size}").into_bytes(),
                             threshold,
+                            threads,
                         );
                         black_box(respond_to_batch(&mut rng, &data.shares[0], &request));
 

--- a/cryptography/src/bls12381/benches/bte_decrypt.rs
+++ b/cryptography/src/bls12381/benches/bte_decrypt.rs
@@ -105,7 +105,8 @@ fn benchmark_bte_decrypt(c: &mut Criterion) {
                             partials.push(verified);
                         }
                         black_box(
-                            combine_partials(&data.request, &share_indices, &partials).unwrap(),
+                            combine_partials(&data.request, &share_indices, &partials, threads)
+                                .unwrap(),
                         );
                     });
                 });

--- a/cryptography/src/bls12381/benches/bte_decrypt.rs
+++ b/cryptography/src/bls12381/benches/bte_decrypt.rs
@@ -16,15 +16,13 @@ use rand_chacha::ChaCha20Rng;
 use std::hint::black_box;
 
 const SIZES: [usize; 3] = [10, 100, 1000];
-const CONCURRENCY: [usize; 2] = [1, 8];
-
 struct BenchData {
     request: BatchRequest<MinSig>,
     responses: Vec<BatchResponse<MinSig>>,
     evals: Vec<Eval<<MinSig as Variant>::Public>>,
 }
 
-fn build_data(size: usize, concurrency: usize, participants: u32, threshold: u32) -> BenchData {
+fn build_data(size: usize, participants: u32, threshold: u32) -> BenchData {
     let mut rng = ChaCha20Rng::from_seed([size as u8; 32]);
     let (commitment, shares) =
         generate_shares::<_, MinSig>(&mut rng, None, participants, threshold);
@@ -67,28 +65,24 @@ fn build_data(size: usize, concurrency: usize, participants: u32, threshold: u32
 fn benchmark_bte_decrypt(c: &mut Criterion) {
     let participants = 5u32;
     let threshold = quorum(participants);
-    for &concurrency in CONCURRENCY.iter() {
-        let label = format!("bte_decrypt/{} threads", concurrency);
-        let datasets: Vec<_> = SIZES
-            .iter()
-            .map(|&size| (size, build_data(size, concurrency, participants, threshold)))
-            .collect();
+    let datasets: Vec<_> = SIZES
+        .iter()
+        .map(|&size| (size, build_data(size, participants, threshold)))
+        .collect();
 
-        for (size, data) in datasets.iter() {
-            c.bench_with_input(BenchmarkId::new(&label, size), data, |b, data| {
-                b.iter(|| {
-                    let mut share_indices = Vec::with_capacity(data.responses.len());
-                    let mut partials = Vec::with_capacity(data.responses.len());
-                    for (response, eval) in data.responses.iter().zip(data.evals.iter()) {
-                        let verified =
-                            verify_batch_response(&data.request, eval, response).unwrap();
-                        share_indices.push(response.index);
-                        partials.push(verified);
-                    }
-                    black_box(combine_partials(&data.request, &share_indices, &partials).unwrap());
-                });
+    for (size, data) in datasets.iter() {
+        c.bench_with_input(BenchmarkId::new("bte_decrypt", size), data, |b, data| {
+            b.iter(|| {
+                let mut share_indices = Vec::with_capacity(data.responses.len());
+                let mut partials = Vec::with_capacity(data.responses.len());
+                for (response, eval) in data.responses.iter().zip(data.evals.iter()) {
+                    let verified = verify_batch_response(&data.request, eval, response).unwrap();
+                    share_indices.push(response.index);
+                    partials.push(verified);
+                }
+                black_box(combine_partials(&data.request, &share_indices, &partials).unwrap());
             });
-        }
+        });
     }
 }
 

--- a/cryptography/src/bls12381/benches/bte_decrypt.rs
+++ b/cryptography/src/bls12381/benches/bte_decrypt.rs
@@ -1,0 +1,75 @@
+use commonware_cryptography::bls12381::{
+    bte::{
+        combine_partials, encrypt, respond_to_batch, verify_batch_response, BatchRequest, PublicKey,
+    },
+    dkg::ops::generate_shares,
+    primitives::{
+        poly::Eval,
+        variant::{MinSig, Variant},
+    },
+};
+use commonware_utils::quorum;
+use criterion::{criterion_group, BatchSize, Criterion};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use std::hint::black_box;
+
+fn benchmark_bte_decrypt(c: &mut Criterion) {
+    let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
+    let participants = 5u32;
+    let threshold = quorum(participants);
+    let (commitment, shares) =
+        generate_shares::<_, MinSig>(&mut rng, None, participants, threshold);
+    let public = PublicKey::<MinSig>::new(*commitment.constant());
+
+    let messages: Vec<Vec<u8>> = (0..8)
+        .map(|i| format!("batched-message-{i}").into_bytes())
+        .collect();
+    let ciphertexts = messages
+        .iter()
+        .map(|m| encrypt(&mut rng, &public, b"bench-label", m))
+        .collect();
+    let request = BatchRequest {
+        ciphertexts,
+        context: b"bench-context".to_vec(),
+        threshold,
+    };
+
+    let responses: Vec<_> = shares
+        .iter()
+        .take(threshold as usize)
+        .map(|share| respond_to_batch(&mut rng, share, &request))
+        .collect();
+    let evals: Vec<Eval<<MinSig as Variant>::Public>> = shares
+        .iter()
+        .take(threshold as usize)
+        .map(|share| Eval {
+            index: share.index,
+            value: share.public::<MinSig>(),
+        })
+        .collect();
+
+    c.bench_function(module_path!(), |b| {
+        b.iter_batched(
+            || (request.clone(), responses.clone(), evals.clone()),
+            |(request, responses, evals)| {
+                let mut indices = Vec::with_capacity(responses.len());
+                let mut partials = Vec::with_capacity(responses.len());
+                for ((response, eval)) in responses.iter().zip(evals.iter()) {
+                    let verified =
+                        verify_batch_response(&public, &request, eval, response).unwrap();
+                    indices.push(response.index);
+                    partials.push(verified);
+                }
+                black_box(combine_partials(&request, &indices, &partials).unwrap());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_bte_decrypt
+}

--- a/cryptography/src/bls12381/benches/bte_encrypt.rs
+++ b/cryptography/src/bls12381/benches/bte_encrypt.rs
@@ -1,0 +1,28 @@
+use commonware_cryptography::bls12381::{
+    bte::{encrypt, PublicKey},
+    dkg::ops::generate_shares,
+    primitives::variant::MinSig,
+};
+use criterion::{criterion_group, Criterion};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use std::hint::black_box;
+
+fn benchmark_bte_encrypt(c: &mut Criterion) {
+    let mut rng = ChaCha20Rng::from_seed([7u8; 32]);
+    let (commitment, _) = generate_shares::<_, MinSig>(&mut rng, None, 1, 1);
+    let public = PublicKey::<MinSig>::new(*commitment.constant());
+    let message = vec![0x42u8; 64];
+
+    c.bench_function(module_path!(), |b| {
+        b.iter(|| {
+            black_box(encrypt(&mut rng, &public, b"bench-label", &message));
+        });
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_bte_encrypt
+}

--- a/cryptography/src/bls12381/bte.rs
+++ b/cryptography/src/bls12381/bte.rs
@@ -1103,7 +1103,7 @@ mod tests {
         let honest = respond_to_batch(&mut rng, share, &request);
 
         // Malicious server tampers with the first partial and adjusts the last one
-        // to keep the old aggregated sum identical (the previously exploitable path).
+        // to keep the old aggregated sum identical.
         let mut forged_partials = honest.partials.clone();
         let tweak = <MinSig as Variant>::Public::one();
         forged_partials[0].add(&tweak);

--- a/cryptography/src/bls12381/bte.rs
+++ b/cryptography/src/bls12381/bte.rs
@@ -21,7 +21,12 @@
 //! discrete log with respect to its public share `h_i`. The proof uses the
 //! standard random-linear-combination trick (`ρ_j ← H(...)`, `U = Π u_j^{ρ_j}`,
 //! `Û_i = Π u_{i,j}^{ρ_j}`) so the Chaum–Pedersen check is constant size
-//! regardless of batch length.
+//! regardless of batch length. Each `ρ_j` is derived from a transcript that
+//! commits to the batch context, responder index, ciphertext position, header,
+//! and claimed partial, ensuring the aggregated bases correspond to the single
+//! DLEQ proof `log_g U = log_{h_i} Û_i`
+//! (the Chaum–Pedersen equality-of-discrete-log argument) and therefore cover
+//! exactly the ciphertexts this responder processed.
 //!
 //! *Combination.* Once `t` distinct responses pass verification, the client
 //! scales each partial vector by the Lagrange coefficient for that responder and

--- a/cryptography/src/bls12381/bte.rs
+++ b/cryptography/src/bls12381/bte.rs
@@ -2,7 +2,7 @@
 //!
 //! This module instantiates the Shoup–Gennaro TDH2 construction over the
 //! library’s BLS12-381 primitives and adds the “batch DLEQ” technique from
-//! Aditya et al. (ACNS 2004) to prove many partial decryptions at once. Each
+//! Aditya et al. to prove many partial decryptions at once. Each
 //! ciphertext is first validated with a Chaum–Pedersen proof, then all valid
 //! headers are folded into a single aggregated proof so a server only sends one
 //! transcript regardless of batch size. Clients verify a single proof per
@@ -14,16 +14,14 @@
 //! *Ciphertexts.* Encryption matches TDH2: sample `r`, compute the header in
 //! G1 (and a secondary header for the Chaum–Pedersen relation), mask the payload
 //! with a KDF over `h^r`, and attach the Chaum–Pedersen proof linking both
-//! headers to the same exponent. (See “Securing Threshold Cryptosystems against
-//! Chosen-Ciphertext Attack”, Shoup & Gennaro.)
+//! headers to the same exponent.
 //!
 //! *Server responses.* A server with share `x_i` exponentiates every valid
 //! header `u_j` to obtain `u_j^{x_i}` and proves that all outputs share the same
 //! discrete log with respect to its public share `h_i`. The proof uses the
 //! standard random-linear-combination trick (`ρ_j ← H(...)`, `U = Π u_j^{ρ_j}`,
 //! `Û_i = Π u_{i,j}^{ρ_j}`) so the Chaum–Pedersen check is constant size
-//! regardless of batch length. (See “Batch Verification for Equality of
-//! Discrete Logarithms and Threshold Decryptions”, Aditya et al., ACNS 2004.)
+//! regardless of batch length.
 //!
 //! *Combination.* Once `t` distinct responses pass verification, the client
 //! scales each partial vector by the Lagrange coefficient for that responder and
@@ -32,13 +30,13 @@
 //! plaintexts. Malformed ciphertexts simply appear as missing indices in the
 //! canonical batch, so a byzantine sender cannot block honest decryptions.
 //!
-//! # References
+//! # Acknowledgements
 //!
-//! * V. Shoup and R. Gennaro. “Securing Threshold Cryptosystems against
-//!   Chosen-Ciphertext Attack.” Journal of Cryptology 15(2), 2002.
-//! * K. Gandhewar Aditya, C. Boyd, and E. Dawson. “Batch Verification for
-//!   Equality of Discrete Logarithms and Threshold Decryptions.” ACNS 2004.
-//! * Chaum–Pedersen proofs of discrete-log equality (CRYPTO 1992).
+//! The following resources were used as references when implementing this crate:
+//!
+//! * <https://link.springer.com/chapter/10.1007/3-540-48071-4_7>: Wallet Databases with Observers
+//! * <https://link.springer.com/chapter/10.1007/BFb0054113>: Securing threshold cryptosystems against chosen ciphertext attack
+//! * <https://link.springer.com/chapter/10.1007/978-3-540-24852-1_36>: Batch Verification for Equality of Discrete Logarithms and Threshold Decryptions
 
 use crate::{
     bls12381::primitives::{

--- a/cryptography/src/bls12381/bte.rs
+++ b/cryptography/src/bls12381/bte.rs
@@ -693,8 +693,7 @@ fn aggregated_challenge<V: Variant>(
 /// * `pos` – the ciphertext position in the canonical filtered list so both sides agree on order.
 /// * `header` – the ciphertext’s TDH header; without this the verifier could replace headers.
 /// * `partials[pos]` – the responder’s claimed partial decryption for this header; this ensures the
-///   aggregated DLEQ challenge commits to every `(header_j, partial_{i,j})` pair, blocking the rogue
-///   tampering attack fixed in this patch.
+///   aggregated DLEQ challenge commits to every `(header_j, partial_{i,j})` pair.
 fn derive_rhos<V: Variant>(
     context: &[u8],
     index: u32,

--- a/cryptography/src/bls12381/bte.rs
+++ b/cryptography/src/bls12381/bte.rs
@@ -235,7 +235,7 @@ pub fn encrypt<R: CryptoRngCore, V: Variant>(
     let body = xor(message, &mask);
 
     let challenge = ciphertext_challenge::<V>(
-        &public,
+        public,
         label,
         &body,
         &header,
@@ -334,8 +334,8 @@ pub fn respond_to_batch<R: CryptoRngCore, V: Variant>(
         };
     }
 
-    let rhos = derive_rhos::<V>(&request.context, index, &headers);
-    let aggregate_base = V::Public::msm(&headers, &rhos);
+    let rhos = derive_rhos::<V>(&request.context, index, headers);
+    let aggregate_base = V::Public::msm(headers, &rhos);
     let aggregate_share = V::Public::msm(&partials, &rhos);
 
     let s = random_scalar(rng);
@@ -730,8 +730,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let n = 5;
         let threshold = quorum(n);
-        let (commitment, shares) =
-            generate_shares::<_, MinSig>(&mut rng, None, n as u32, threshold);
+        let (commitment, shares) = generate_shares::<_, MinSig>(&mut rng, None, n, threshold);
         let public = PublicKey::<MinSig>::new(*commitment.constant());
 
         let messages: Vec<Vec<u8>> = (0..3).map(|i| format!("batch-{i}").into_bytes()).collect();
@@ -791,8 +790,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(55);
         let n = 5;
         let threshold = quorum(n);
-        let (commitment, shares) =
-            generate_shares::<_, MinSig>(&mut rng, None, n as u32, threshold);
+        let (commitment, shares) = generate_shares::<_, MinSig>(&mut rng, None, n, threshold);
         let public = PublicKey::<MinSig>::new(*commitment.constant());
 
         let mut ciphertexts: Vec<_> = (0..4)
@@ -823,7 +821,7 @@ mod tests {
             if idx == 1 {
                 panic!("invalid ciphertext should be skipped");
             }
-            let expected = format!("msg-{}", idx).into_bytes();
+            let expected = format!("msg-{idx}").into_bytes();
             assert_eq!(plaintext, expected);
         }
     }
@@ -913,8 +911,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(777);
         let n = 4;
         let threshold = quorum(n);
-        let (commitment, shares) =
-            generate_shares::<_, MinSig>(&mut rng, None, n as u32, threshold);
+        let (commitment, shares) = generate_shares::<_, MinSig>(&mut rng, None, n, threshold);
         let public = PublicKey::<MinSig>::new(*commitment.constant());
         let request = BatchRequest::new(
             &public,
@@ -934,7 +931,7 @@ mod tests {
         assert!(matches!(
             err,
             BatchError::InsufficientResponses { expected, actual }
-            if expected as usize == threshold as usize && actual == 1
+            if expected == threshold as usize && actual == 1
         ));
     }
 
@@ -943,8 +940,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(888);
         let n = 4;
         let threshold = quorum(n);
-        let (commitment, shares) =
-            generate_shares::<_, MinSig>(&mut rng, None, n as u32, threshold);
+        let (commitment, shares) = generate_shares::<_, MinSig>(&mut rng, None, n, threshold);
         let public = PublicKey::<MinSig>::new(*commitment.constant());
         let request = BatchRequest::new(
             &public,

--- a/cryptography/src/bls12381/bte.rs
+++ b/cryptography/src/bls12381/bte.rs
@@ -1,0 +1,675 @@
+//! Batched Threshold Diffie–Hellman (TDH2) encryption/decryption over BLS12-381.
+//!
+//! This module keeps TDH2 encryption intact while batching decryption shares so
+//! that each server proves correctness for *all* ciphertexts with a single
+//! aggregated Chaum–Pedersen proof. The batching technique follows the classic
+//! random-linear-combination approach: clients derive coefficients for every
+//! ciphertext header, servers fold them into one DLEQ proof, and verifiers check
+//! a single transcript per server.
+//!
+//! # Overview
+//!
+//! * **Encryption** – identical to TDH2: sample randomness `r`, compute `u =
+//!   r·G`, mask the message with a KDF over `h^{r}`, and attach a per-ciphertext
+//!   Chaum–Pedersen proof binding `(u, ū)` to the same exponent.
+//! * **Batched partial decryptions** – a server holding share `x_i` returns the
+//!   vector `u_j^{x_i}` for all ciphertexts plus a single aggregated proof that
+//!   `log_G(h_i) = log_U(U_i)`, where `U = Σ ρ_j u_j` and
+//!   `U_i = Σ ρ_j u_{i,j}`.
+//! * **Combination** – once `t` distinct, valid servers respond, clients
+//!   interpolate the shares at zero (same Lagrange coefficients used for
+//!   threshold signatures) and reuse the TDH KDF to recover all plaintexts.
+//!
+//! The implementation relies entirely on the internal BLS12-381 primitives
+//! (`group`, `poly`, and `variant`) and uses the repository transcript utility
+//! for Fiat–Shamir challenges.
+
+use crate::{
+    bls12381::primitives::{
+        group::{Element, Point, Scalar, Share},
+        poly::{self, Eval},
+        variant::Variant,
+        Error as PrimitivesError,
+    },
+    sha256::Sha256,
+    transcript::Transcript,
+    Hasher,
+};
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+use commonware_codec::{FixedSize, Write};
+use core::cmp::min;
+use rand_core::CryptoRngCore;
+use thiserror::Error;
+
+/// Transcript namespace for ciphertext Chaum–Pedersen proofs.
+const CT_TRANSCRIPT: &[u8] = b"commonware.bls12381.bte.ct";
+/// Transcript label for ciphertext proof challenges.
+const CT_NOISE: &[u8] = b"ct-chal";
+/// Transcript namespace for aggregated DLEQ proofs.
+const DLEQ_TRANSCRIPT: &[u8] = b"commonware.bls12381.bte.dleq";
+/// Transcript label for aggregated proof challenges.
+const DLEQ_NOISE: &[u8] = b"dleq-chal";
+/// Transcript namespace for deriving batch coefficients.
+const RHO_TRANSCRIPT: &[u8] = b"commonware.bls12381.bte.rho";
+/// Transcript label for rho scalars.
+const RHO_NOISE: &[u8] = b"rho";
+/// Domain label for the TDH KDF.
+const KDF_LABEL: &[u8] = b"commonware.bls12381.bte.kdf";
+/// Fixed string mapped into a secondary generator for Chaum–Pedersen proofs.
+const PROOF_GENERATOR_MSG: &[u8] = b"commonware.bls12381.bte.proof-generator";
+
+/// Public key for TDH encryption (the commitment's constant term).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PublicKey<V: Variant> {
+    point: V::Public,
+}
+
+impl<V: Variant> PublicKey<V> {
+    /// Create a public key from a commitment constant (e.g., `poly::Public::constant()`).
+    pub fn new(point: V::Public) -> Self {
+        Self { point }
+    }
+
+    /// Returns the underlying point.
+    pub fn as_point(&self) -> &V::Public {
+        &self.point
+    }
+}
+
+/// Chaum–Pedersen proof ensuring `(u, ū)` share the same exponent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChaumPedersenProof<V: Variant> {
+    pub commitment_generator: V::Public,
+    pub commitment_aux: V::Public,
+    pub challenge: Scalar,
+    pub response: Scalar,
+}
+
+/// Ciphertext produced by TDH2 encryption.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Ciphertext<V: Variant> {
+    pub label: Vec<u8>,
+    pub body: Vec<u8>,
+    pub header: V::Public,
+    pub header_aux: V::Public,
+    pub proof: ChaumPedersenProof<V>,
+}
+
+/// Batch of ciphertexts plus a caller-chosen context (e.g., request id).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatchRequest<V: Variant> {
+    pub ciphertexts: Vec<Ciphertext<V>>,
+    pub context: Vec<u8>,
+    pub threshold: u32,
+}
+
+/// Aggregated Chaum–Pedersen proof over all ciphertexts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AggregatedProof<V: Variant> {
+    pub commitment_generator: V::Public,
+    pub commitment_aggregate: V::Public,
+    pub challenge: Scalar,
+    pub response: Scalar,
+}
+
+/// Server response containing partial decryptions and a single proof.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatchResponse<V: Variant> {
+    pub index: u32,
+    pub partials: Vec<V::Public>,
+    pub proof: AggregatedProof<V>,
+}
+
+/// Errors that can surface while verifying or combining batches.
+#[derive(Error, Debug)]
+pub enum BatchError {
+    #[error("ciphertext {0} failed verification")]
+    InvalidCiphertext(usize),
+    #[error("response index {provided} does not match public share {expected}")]
+    IndexMismatch { expected: u32, provided: u32 },
+    #[error("partials length mismatch: expected {expected}, got {actual}")]
+    LengthMismatch { expected: usize, actual: usize },
+    #[error("aggregated proof failed for index {0}")]
+    InvalidAggregatedProof(u32),
+    #[error("duplicate response index {0}")]
+    DuplicateIndex(u32),
+    #[error("missing lagrange weight for index {0}")]
+    MissingWeight(u32),
+    #[error("insufficient responses: need {expected}, have {actual}")]
+    InsufficientResponses { expected: usize, actual: usize },
+    #[error("weight computation failed: {0}")]
+    WeightComputation(#[from] PrimitivesError),
+}
+
+/// Encrypt a message with TDH2 using the provided public key.
+pub fn encrypt<R: CryptoRngCore, V: Variant>(
+    rng: &mut R,
+    public: &PublicKey<V>,
+    label: &[u8],
+    message: &[u8],
+) -> Ciphertext<V> {
+    let r = random_scalar(rng);
+    let s = random_scalar(rng);
+
+    let mut header = V::Public::one();
+    header.mul(&r);
+
+    let proof_generator = proof_generator::<V>();
+    let mut header_aux = proof_generator;
+    header_aux.mul(&r);
+
+    let mut hr = public.point;
+    hr.mul(&r);
+
+    let mut commitment_generator = V::Public::one();
+    commitment_generator.mul(&s);
+
+    let mut commitment_aux = proof_generator;
+    commitment_aux.mul(&s);
+
+    let mask = keystream::<V>(&hr, label, message.len());
+    let body = xor(message, &mask);
+
+    let challenge = ciphertext_challenge::<V>(
+        &public,
+        label,
+        &body,
+        &header,
+        &header_aux,
+        &commitment_generator,
+        &commitment_aux,
+    );
+
+    let mut response = s;
+    let mut tmp = r;
+    tmp.mul(&challenge);
+    response.add(&tmp);
+
+    let proof = ChaumPedersenProof {
+        commitment_generator,
+        commitment_aux,
+        challenge,
+        response,
+    };
+
+    Ciphertext {
+        label: label.to_vec(),
+        body,
+        header,
+        header_aux,
+        proof,
+    }
+}
+
+/// Verify a TDH2 ciphertext's Chaum–Pedersen proof.
+pub fn verify_ciphertext<V: Variant>(public: &PublicKey<V>, ciphertext: &Ciphertext<V>) -> bool {
+    let challenge = ciphertext_challenge::<V>(
+        public,
+        &ciphertext.label,
+        &ciphertext.body,
+        &ciphertext.header,
+        &ciphertext.header_aux,
+        &ciphertext.proof.commitment_generator,
+        &ciphertext.proof.commitment_aux,
+    );
+
+    if challenge != ciphertext.proof.challenge {
+        return false;
+    }
+
+    let mut lhs = V::Public::one();
+    lhs.mul(&ciphertext.proof.response);
+    let mut rhs = ciphertext.proof.commitment_generator;
+    let mut header_term = ciphertext.header;
+    header_term.mul(&ciphertext.proof.challenge);
+    rhs.add(&header_term);
+    if lhs != rhs {
+        return false;
+    }
+
+    let proof_generator = proof_generator::<V>();
+    let mut lhs_aux = proof_generator;
+    lhs_aux.mul(&ciphertext.proof.response);
+    let mut rhs_aux = ciphertext.proof.commitment_aux;
+    let mut aux_term = ciphertext.header_aux;
+    aux_term.mul(&ciphertext.proof.challenge);
+    rhs_aux.add(&aux_term);
+
+    lhs_aux == rhs_aux
+}
+
+/// Produce a batched response for all ciphertexts using a private share.
+pub fn respond_to_batch<R: CryptoRngCore, V: Variant>(
+    rng: &mut R,
+    share: &Share,
+    request: &BatchRequest<V>,
+) -> BatchResponse<V> {
+    let index = share.index;
+    let partials: Vec<V::Public> = request
+        .ciphertexts
+        .iter()
+        .map(|ct| {
+            let mut partial = ct.header;
+            partial.mul(&share.private);
+            partial
+        })
+        .collect();
+
+    let headers: Vec<V::Public> = request.ciphertexts.iter().map(|ct| ct.header).collect();
+    let rhos = derive_rhos::<V>(&request.context, index, &headers);
+    let aggregate_base = V::Public::msm(&headers, &rhos);
+    let aggregate_share = V::Public::msm(&partials, &rhos);
+
+    let s = random_scalar(rng);
+
+    let mut commitment_generator = V::Public::one();
+    commitment_generator.mul(&s);
+
+    let mut commitment_aggregate = aggregate_base;
+    commitment_aggregate.mul(&s);
+
+    let public_share = share.public::<V>();
+    let challenge = aggregated_challenge::<V>(
+        &request.context,
+        index,
+        &public_share,
+        &aggregate_base,
+        &aggregate_share,
+        &commitment_generator,
+        &commitment_aggregate,
+    );
+
+    let mut response = s;
+    let mut tmp = share.private.clone();
+    tmp.mul(&challenge);
+    response.add(&tmp);
+
+    BatchResponse {
+        index,
+        partials,
+        proof: AggregatedProof {
+            commitment_generator,
+            commitment_aggregate,
+            challenge,
+            response,
+        },
+    }
+}
+
+/// Verify a server response and return its partial decryptions.
+pub fn verify_batch_response<V: Variant>(
+    public: &PublicKey<V>,
+    request: &BatchRequest<V>,
+    public_share: &Eval<V::Public>,
+    response: &BatchResponse<V>,
+) -> Result<Vec<V::Public>, BatchError> {
+    if response.index != public_share.index {
+        return Err(BatchError::IndexMismatch {
+            expected: public_share.index,
+            provided: response.index,
+        });
+    }
+
+    if response.partials.len() != request.ciphertexts.len() {
+        return Err(BatchError::LengthMismatch {
+            expected: request.ciphertexts.len(),
+            actual: response.partials.len(),
+        });
+    }
+
+    for (idx, ciphertext) in request.ciphertexts.iter().enumerate() {
+        if !verify_ciphertext(public, ciphertext) {
+            return Err(BatchError::InvalidCiphertext(idx));
+        }
+    }
+
+    let headers: Vec<V::Public> = request.ciphertexts.iter().map(|ct| ct.header).collect();
+    let rhos = derive_rhos::<V>(&request.context, response.index, &headers);
+    let aggregate_base = V::Public::msm(&headers, &rhos);
+    let aggregate_share = V::Public::msm(&response.partials, &rhos);
+
+    let expected = aggregated_challenge::<V>(
+        &request.context,
+        response.index,
+        &public_share.value,
+        &aggregate_base,
+        &aggregate_share,
+        &response.proof.commitment_generator,
+        &response.proof.commitment_aggregate,
+    );
+
+    if expected != response.proof.challenge {
+        return Err(BatchError::InvalidAggregatedProof(response.index));
+    }
+
+    let mut lhs = V::Public::one();
+    lhs.mul(&response.proof.response);
+    let mut rhs = response.proof.commitment_generator;
+    let mut pk_term = public_share.value;
+    pk_term.mul(&response.proof.challenge);
+    rhs.add(&pk_term);
+    if lhs != rhs {
+        return Err(BatchError::InvalidAggregatedProof(response.index));
+    }
+
+    let mut lhs_agg = aggregate_base;
+    lhs_agg.mul(&response.proof.response);
+    let mut rhs_agg = response.proof.commitment_aggregate;
+    let mut agg_term = aggregate_share;
+    agg_term.mul(&response.proof.challenge);
+    rhs_agg.add(&agg_term);
+    if lhs_agg != rhs_agg {
+        return Err(BatchError::InvalidAggregatedProof(response.index));
+    }
+
+    Ok(response.partials.clone())
+}
+
+/// Combine verified partials from at least `threshold` distinct servers.
+pub fn combine_partials<V: Variant>(
+    request: &BatchRequest<V>,
+    indices: &[u32],
+    partials: &[Vec<V::Public>],
+) -> Result<Vec<Vec<u8>>, BatchError> {
+    if indices.len() != partials.len() {
+        return Err(BatchError::LengthMismatch {
+            expected: indices.len(),
+            actual: partials.len(),
+        });
+    }
+
+    if indices.len() < request.threshold as usize {
+        return Err(BatchError::InsufficientResponses {
+            expected: request.threshold as usize,
+            actual: indices.len(),
+        });
+    }
+
+    let mut sorted = indices.to_vec();
+    sorted.sort_unstable();
+    for window in sorted.windows(2) {
+        if window[0] == window[1] {
+            return Err(BatchError::DuplicateIndex(window[0]));
+        }
+    }
+
+    let weights = poly::compute_weights(indices.to_vec())?;
+    let decrypt_count = request.ciphertexts.len();
+
+    let mut plaintexts = Vec::with_capacity(decrypt_count);
+    for idx in 0..decrypt_count {
+        let points: Vec<V::Public> = partials.iter().map(|p| p[idx]).collect();
+        let scalars: Vec<Scalar> = indices
+            .iter()
+            .map(|i| {
+                weights
+                    .get(i)
+                    .ok_or(BatchError::MissingWeight(*i))
+                    .map(|w| w.as_scalar().clone())
+            })
+            .collect::<Result<_, _>>()?;
+
+        let hr = V::Public::msm(&points, &scalars);
+        let keystream = keystream::<V>(
+            &hr,
+            &request.ciphertexts[idx].label,
+            request.ciphertexts[idx].body.len(),
+        );
+        plaintexts.push(xor(&request.ciphertexts[idx].body, &keystream));
+    }
+
+    Ok(plaintexts)
+}
+
+fn ciphertext_challenge<V: Variant>(
+    public: &PublicKey<V>,
+    label: &[u8],
+    body: &[u8],
+    header: &V::Public,
+    header_aux: &V::Public,
+    commitment_generator: &V::Public,
+    commitment_aux: &V::Public,
+) -> Scalar {
+    let mut transcript = Transcript::new(CT_TRANSCRIPT);
+    transcript.commit(label);
+    transcript.commit(body);
+    transcript.commit(encode_field(header).as_slice());
+    transcript.commit(encode_field(header_aux).as_slice());
+    transcript.commit(encode_field(commitment_generator).as_slice());
+    transcript.commit(encode_field(commitment_aux).as_slice());
+    transcript.commit(encode_field(public.as_point()).as_slice());
+    scalar_from_transcript(&transcript, CT_NOISE)
+}
+
+fn aggregated_challenge<V: Variant>(
+    context: &[u8],
+    index: u32,
+    public_share: &V::Public,
+    aggregate_base: &V::Public,
+    aggregate_share: &V::Public,
+    commitment_generator: &V::Public,
+    commitment_aggregate: &V::Public,
+) -> Scalar {
+    let mut transcript = Transcript::new(DLEQ_TRANSCRIPT);
+    transcript.commit(context);
+    transcript.commit(index.to_le_bytes().as_slice());
+    transcript.commit(encode_field(public_share).as_slice());
+    transcript.commit(encode_field(aggregate_base).as_slice());
+    transcript.commit(encode_field(aggregate_share).as_slice());
+    transcript.commit(encode_field(commitment_generator).as_slice());
+    transcript.commit(encode_field(commitment_aggregate).as_slice());
+    scalar_from_transcript(&transcript, DLEQ_NOISE)
+}
+
+fn derive_rhos<V: Variant>(context: &[u8], index: u32, headers: &[V::Public]) -> Vec<Scalar> {
+    headers
+        .iter()
+        .enumerate()
+        .map(|(pos, header)| {
+            let mut transcript = Transcript::new(RHO_TRANSCRIPT);
+            transcript.commit(context);
+            transcript.commit(index.to_le_bytes().as_slice());
+            transcript.commit((pos as u64).to_le_bytes().as_slice());
+            transcript.commit(encode_field(header).as_slice());
+            scalar_from_transcript(&transcript, RHO_NOISE)
+        })
+        .collect()
+}
+
+fn keystream<V: Variant>(hr: &V::Public, label: &[u8], len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    let hr_bytes = encode_field(hr);
+    let mut counter = 0u32;
+    while out.len() < len {
+        let mut hasher = Sha256::new();
+        hasher.update(KDF_LABEL);
+        hasher.update(&counter.to_le_bytes());
+        hasher.update(&hr_bytes);
+        hasher.update(label);
+        let digest = hasher.finalize();
+        let chunk = digest.as_ref();
+        let take = min(chunk.len(), len - out.len());
+        out.extend_from_slice(&chunk[..take]);
+        counter = counter.wrapping_add(1);
+    }
+    out
+}
+
+fn xor(a: &[u8], b: &[u8]) -> Vec<u8> {
+    assert_eq!(a.len(), b.len());
+    a.iter().zip(b.iter()).map(|(x, y)| x ^ y).collect()
+}
+
+fn scalar_from_transcript(transcript: &Transcript, label: &'static [u8]) -> Scalar {
+    let mut rng = transcript.noise(label);
+    loop {
+        let scalar = Scalar::from_rand(&mut rng);
+        if scalar != Scalar::zero() {
+            return scalar;
+        }
+    }
+}
+
+fn random_scalar<R: CryptoRngCore>(rng: &mut R) -> Scalar {
+    loop {
+        let scalar = Scalar::from_rand(rng);
+        if scalar != Scalar::zero() {
+            return scalar;
+        }
+    }
+}
+
+fn encode_field<E: FixedSize + Write>(value: &E) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(E::SIZE);
+    value.write(&mut buf);
+    buf
+}
+
+fn proof_generator<V: Variant>() -> V::Public {
+    let mut point = V::Public::zero();
+    point.map(V::MESSAGE, PROOF_GENERATOR_MSG);
+    point
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bls12381::{dkg::ops::generate_shares, primitives::variant::MinSig};
+    use commonware_utils::quorum;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    fn setup_request<V: Variant>(
+        rng: &mut StdRng,
+        count: usize,
+    ) -> (PublicKey<V>, BatchRequest<V>, Vec<Vec<u8>>) {
+        let (commitment, _) = generate_shares::<_, V>(rng, None, 1, 1);
+        let public = PublicKey::<V>::new(*commitment.constant());
+        let mut ciphertexts = Vec::with_capacity(count);
+        let mut messages = Vec::with_capacity(count);
+        for i in 0..count {
+            let msg = format!("secret-{i}").into_bytes();
+            messages.push(msg.clone());
+            ciphertexts.push(encrypt(rng, &public, b"label", &msg));
+        }
+        let request = BatchRequest {
+            ciphertexts,
+            context: b"context".to_vec(),
+            threshold: 1,
+        };
+        (public, request, messages)
+    }
+
+    #[test]
+    fn test_ciphertext_roundtrip() {
+        let mut rng = StdRng::seed_from_u64(7);
+        let (public, request, messages) = setup_request::<MinSig>(&mut rng, 2);
+        for (ct, msg) in request.ciphertexts.iter().zip(messages.iter()) {
+            let computed = super::ciphertext_challenge::<MinSig>(
+                &public,
+                &ct.label,
+                &ct.body,
+                &ct.header,
+                &ct.header_aux,
+                &ct.proof.commitment_generator,
+                &ct.proof.commitment_aux,
+            );
+            assert_eq!(computed, ct.proof.challenge);
+            assert!(verify_ciphertext(&public, ct));
+            assert_ne!(ct.body, *msg);
+        }
+    }
+
+    #[test]
+    fn test_batch_flow() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let n = 5;
+        let threshold = quorum(n);
+        let (commitment, shares) =
+            generate_shares::<_, MinSig>(&mut rng, None, n as u32, threshold);
+        let public = PublicKey::<MinSig>::new(*commitment.constant());
+
+        let messages: Vec<Vec<u8>> = (0..3).map(|i| format!("batch-{i}").into_bytes()).collect();
+        let ciphertexts: Vec<_> = messages
+            .iter()
+            .map(|m| encrypt(&mut rng, &public, b"label", m))
+            .collect();
+        let request = BatchRequest {
+            ciphertexts,
+            context: b"ctx".to_vec(),
+            threshold,
+        };
+
+        let mut indices = Vec::new();
+        let mut all_partials = Vec::new();
+        for share in shares.iter().take(threshold as usize) {
+            let response = respond_to_batch(&mut rng, share, &request);
+            let public_share = Eval {
+                index: share.index,
+                value: share.public::<MinSig>(),
+            };
+            let partials =
+                verify_batch_response(&public, &request, &public_share, &response).unwrap();
+            indices.push(response.index);
+            all_partials.push(partials);
+        }
+
+        let recovered = combine_partials(&request, &indices, &all_partials).unwrap();
+        assert_eq!(recovered, messages);
+    }
+
+    #[test]
+    fn test_invalid_ciphertext_detection() {
+        let mut rng = StdRng::seed_from_u64(9);
+        let (commitment, shares) = generate_shares::<_, MinSig>(&mut rng, None, 4, 3);
+        let public = PublicKey::<MinSig>::new(*commitment.constant());
+
+        let msg = b"attack".to_vec();
+        let mut ciphertext = encrypt(&mut rng, &public, b"label", &msg);
+        ciphertext.proof.challenge = random_scalar(&mut rng);
+        let request = BatchRequest {
+            ciphertexts: vec![ciphertext],
+            context: b"ctx".to_vec(),
+            threshold: 3,
+        };
+        let share = &shares[0];
+        let response = respond_to_batch(&mut rng, share, &request);
+        let eval = Eval {
+            index: share.index,
+            value: share.public::<MinSig>(),
+        };
+        assert!(matches!(
+            verify_batch_response(&public, &request, &eval, &response),
+            Err(BatchError::InvalidCiphertext(0))
+        ));
+    }
+
+    #[test]
+    fn test_invalid_share_detection() {
+        let mut rng = StdRng::seed_from_u64(99);
+        let (commitment, shares) = generate_shares::<_, MinSig>(&mut rng, None, 4, 3);
+        let public = PublicKey::<MinSig>::new(*commitment.constant());
+
+        let messages: Vec<Vec<u8>> = (0..2).map(|i| format!("secret-{i}").into_bytes()).collect();
+        let request = BatchRequest {
+            ciphertexts: messages
+                .iter()
+                .map(|m| encrypt(&mut rng, &public, b"label", m))
+                .collect(),
+            context: b"ctx".to_vec(),
+            threshold: 3,
+        };
+
+        let share = &shares[0];
+        let mut response = respond_to_batch(&mut rng, share, &request);
+        response.proof.challenge = random_scalar(&mut rng);
+        let eval = Eval {
+            index: share.index,
+            value: share.public::<MinSig>(),
+        };
+        assert!(matches!(
+            verify_batch_response(&public, &request, &eval, &response),
+            Err(BatchError::InvalidAggregatedProof(_))
+        ));
+    }
+}

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -9,6 +9,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+pub mod bte;
 #[cfg(feature = "std")]
 pub mod dkg;
 pub mod primitives;


### PR DESCRIPTION
## Summary

Fixes: #2182 

Adds [TDH2-based](https://link.springer.com/chapter/10.1007/BFb0054113) Threshold Encryption support for BLS12-381 (with support for [batch decryption via DLEQ](https://link.springer.com/chapter/10.1007/978-3-540-24852-1_36)).

## Initial Benchmarks

```
cargo bench -p commonware-cryptography --bench bls12381 -- bte_encrypt
  bls12381::bte_encrypt               ≈ 0.69 ms per ciphertext

cargo bench -p commonware-cryptography --bench bls12381 -- bte_decrypt

Participants n = 10:
  Threads = 1  -> 10 cts ≈ 31.7 ms | 100 cts ≈ 236 ms  | 1000 cts ≈ 1.96 s
  Threads = 8  -> 10 cts ≈ 9.84 ms | 100 cts ≈ 66.5 ms | 1000 cts ≈ 0.48 s

Participants n = 100:
  Threads = 1  -> 10 cts ≈ 216 ms  | 100 cts ≈ 1.54 s  | 1000 cts ≈ 12.4 s
  Threads = 8  -> 10 cts ≈ 38.9 ms | 100 cts ≈ 0.27 s  | 1000 cts ≈ 2.34 s
```
