### PR TITLE
[cryptography/bte] First Optimization Pass

### DIFF
--- a/cryptography/src/bls12381/benches/bench.rs
+++ b/cryptography/src/bls12381/benches/bench.rs
@@ -6,7 +6,8 @@ mod aggregate_verify_multiple_messages;
 mod aggregate_verify_multiple_public_keys;
 mod batch_verify_multiple_messages;
 mod batch_verify_multiple_public_keys;
-mod bte_decrypt;
+mod bte_decrypt_prepare;
+mod bte_decrypt_verify;
 mod bte_encrypt;
 mod dkg_recovery;
 mod dkg_reshare_recovery;
@@ -37,5 +38,6 @@ criterion_main!(
     tle_encrypt::benches,
     tle_decrypt::benches,
     bte_encrypt::benches,
-    bte_decrypt::benches,
+    bte_decrypt_prepare::benches,
+    bte_decrypt_verify::benches,
 );

--- a/cryptography/src/bls12381/benches/bench.rs
+++ b/cryptography/src/bls12381/benches/bench.rs
@@ -6,6 +6,7 @@ mod aggregate_verify_multiple_messages;
 mod aggregate_verify_multiple_public_keys;
 mod batch_verify_multiple_messages;
 mod batch_verify_multiple_public_keys;
+mod bte_decrypt_combine;
 mod bte_decrypt_prepare;
 mod bte_decrypt_verify;
 mod bte_encrypt;
@@ -40,4 +41,5 @@ criterion_main!(
     bte_encrypt::benches,
     bte_decrypt_prepare::benches,
     bte_decrypt_verify::benches,
+    bte_decrypt_combine::benches,
 );

--- a/cryptography/src/bls12381/benches/bench.rs
+++ b/cryptography/src/bls12381/benches/bench.rs
@@ -6,8 +6,8 @@ mod aggregate_verify_multiple_messages;
 mod aggregate_verify_multiple_public_keys;
 mod batch_verify_multiple_messages;
 mod batch_verify_multiple_public_keys;
-mod bte_decrypt_combine;
 mod bte_decrypt_prepare;
+mod bte_decrypt_recover;
 mod bte_decrypt_verify;
 mod bte_encrypt;
 mod dkg_recovery;
@@ -41,5 +41,5 @@ criterion_main!(
     bte_encrypt::benches,
     bte_decrypt_prepare::benches,
     bte_decrypt_verify::benches,
-    bte_decrypt_combine::benches,
+    bte_decrypt_recover::benches,
 );

--- a/cryptography/src/bls12381/benches/bte_decrypt_combine.rs
+++ b/cryptography/src/bls12381/benches/bte_decrypt_combine.rs
@@ -1,0 +1,97 @@
+use commonware_cryptography::bls12381::{
+    bte::{combine_partials, encrypt, respond_to_batch, verify_batch_response, BatchRequest},
+    dkg::ops::generate_shares,
+    primitives::{poly::Eval, variant::MinSig},
+};
+use commonware_utils::quorum;
+use criterion::{black_box, criterion_group, Criterion};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use rayon::{prelude::*, ThreadPoolBuilder};
+use std::sync::Arc;
+
+const SIZES: [usize; 3] = [10, 100, 1000];
+const PARTICIPANTS: [u32; 2] = [10, 100];
+const THREADS: [usize; 2] = [1, 8];
+
+fn benchmark_bte_decrypt_combine(c: &mut Criterion) {
+    for &threads in THREADS.iter() {
+        let pool = Arc::new(
+            ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .expect("pool"),
+        );
+        for &participants in PARTICIPANTS.iter() {
+            let threshold = quorum(participants);
+            for &size in SIZES.iter() {
+                let mut rng = ChaCha20Rng::from_seed([size as u8; 32]);
+                let (commitment, shares) =
+                    generate_shares::<_, MinSig>(&mut rng, None, participants, threshold);
+                let public = commonware_cryptography::bls12381::bte::PublicKey::<MinSig>::new(
+                    *commitment.constant(),
+                );
+                let ciphertexts: Vec<_> = (0..size)
+                    .map(|i| {
+                        let msg = format!("bench-msg-{i}").into_bytes();
+                        encrypt(&mut rng, &public, b"bench-label", &msg)
+                    })
+                    .collect();
+                let request = BatchRequest::new(
+                    &public,
+                    ciphertexts.clone(),
+                    format!("bench-{size}").into_bytes(),
+                    threshold,
+                    threads,
+                );
+                let responses: Vec<_> = shares
+                    .iter()
+                    .take(threshold as usize)
+                    .map(|share| respond_to_batch(&mut rng, share, &request))
+                    .collect();
+                let evals: Vec<Eval<<MinSig as commonware_cryptography::bls12381::primitives::variant::Variant>::Public>> =
+                    shares
+                        .iter()
+                        .take(threshold as usize)
+                        .map(|share| Eval {
+                            index: share.index,
+                            value: share.public::<MinSig>(),
+                        })
+                        .collect();
+
+                let results = pool.install(|| {
+                    responses
+                        .par_iter()
+                        .zip(evals.par_iter())
+                        .map(|(response, eval)| {
+                            verify_batch_response(&request, eval, response)
+                                .map(|partials| (response.index, partials))
+                        })
+                        .collect::<Vec<_>>()
+                });
+                let mut share_indices = Vec::with_capacity(results.len());
+                let mut partials = Vec::with_capacity(results.len());
+                for entry in results {
+                    let (idx, verified) = entry.unwrap();
+                    share_indices.push(idx);
+                    partials.push(verified);
+                }
+
+                let id = format!("bte_decrypt_combine/n={participants}/threads={threads}");
+                c.bench_function(&format!("{id}/size={size}"), |b| {
+                    b.iter(|| {
+                        black_box(
+                            combine_partials(&request, &share_indices, &partials, threads).unwrap(),
+                        );
+                    });
+                });
+            }
+        }
+    }
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_bte_decrypt_combine
+);

--- a/cryptography/src/bls12381/benches/bte_decrypt_prepare.rs
+++ b/cryptography/src/bls12381/benches/bte_decrypt_prepare.rs
@@ -1,0 +1,77 @@
+use commonware_cryptography::bls12381::{
+    bte::{encrypt, respond_to_batch, BatchRequest, PublicKey},
+    dkg::ops::generate_shares,
+};
+use commonware_utils::quorum;
+use criterion::{black_box, criterion_group, Criterion};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+const SIZES: [usize; 3] = [10, 100, 1000];
+const PARTICIPANTS: [u32; 2] = [10, 100];
+const THREADS: [usize; 2] = [1, 8];
+
+struct PrepareData {
+    public: PublicKey<commonware_cryptography::bls12381::primitives::variant::MinSig>,
+    ciphertexts: Vec<
+        commonware_cryptography::bls12381::bte::Ciphertext<
+            commonware_cryptography::bls12381::primitives::variant::MinSig,
+        >,
+    >,
+    shares: Vec<commonware_cryptography::bls12381::primitives::group::Share>,
+    threshold: u32,
+    threads: usize,
+    label: Vec<u8>,
+}
+
+fn benchmark_bte_decrypt_prepare(c: &mut Criterion) {
+    use commonware_cryptography::bls12381::primitives::variant::MinSig;
+
+    for &threads in THREADS.iter() {
+        for &participants in PARTICIPANTS.iter() {
+            let threshold = quorum(participants);
+            for &size in SIZES.iter() {
+                let mut rng = ChaCha20Rng::from_seed([size as u8; 32]);
+                let (commitment, shares) =
+                    generate_shares::<_, MinSig>(&mut rng, None, participants, threshold);
+                let public = PublicKey::<MinSig>::new(*commitment.constant());
+                let ciphertexts: Vec<_> = (0..size)
+                    .map(|i| {
+                        let msg = format!("bench-msg-{i}").into_bytes();
+                        encrypt(&mut rng, &public, b"bench-label", &msg)
+                    })
+                    .collect();
+
+                let data = PrepareData {
+                    public,
+                    ciphertexts,
+                    shares,
+                    threshold,
+                    threads,
+                    label: format!("bench-{size}").into_bytes(),
+                };
+
+                let id = format!("bte_decrypt_prepare/n={participants}/threads={threads}");
+                let mut bench_rng = ChaCha20Rng::from_seed([size as u8; 32]);
+                c.bench_function(&format!("{id}/size={size}"), |b| {
+                    b.iter(|| {
+                        let request = BatchRequest::new(
+                            &data.public,
+                            data.ciphertexts.clone(),
+                            data.label.clone(),
+                            data.threshold,
+                            data.threads,
+                        );
+                        black_box(respond_to_batch(&mut bench_rng, &data.shares[0], &request));
+                    });
+                });
+            }
+        }
+    }
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_bte_decrypt_prepare
+);

--- a/cryptography/src/bls12381/benches/bte_decrypt_recover.rs
+++ b/cryptography/src/bls12381/benches/bte_decrypt_recover.rs
@@ -14,7 +14,7 @@ const SIZES: [usize; 3] = [10, 100, 1000];
 const PARTICIPANTS: [u32; 2] = [10, 100];
 const THREADS: [usize; 2] = [1, 8];
 
-fn benchmark_bte_decrypt_combine(c: &mut Criterion) {
+fn benchmark_bte_decrypt_recover(c: &mut Criterion) {
     for &threads in THREADS.iter() {
         let pool = Arc::new(
             ThreadPoolBuilder::new()
@@ -77,7 +77,7 @@ fn benchmark_bte_decrypt_combine(c: &mut Criterion) {
                     partials.push(verified);
                 }
 
-                let id = format!("bte_decrypt_combine/n={participants}/threads={threads}");
+                let id = format!("bte_decrypt_recover/n={participants}/threads={threads}");
                 c.bench_function(&format!("{id}/size={size}"), |b| {
                     b.iter(|| {
                         black_box(
@@ -93,5 +93,5 @@ fn benchmark_bte_decrypt_combine(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = benchmark_bte_decrypt_combine
+    targets = benchmark_bte_decrypt_recover
 );

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -48,6 +48,27 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 /// Reference: <https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-ciphersuites>
 pub type DST = &'static [u8];
 
+/// Scratch space reused across MSM invocations.
+#[derive(Default)]
+pub struct MsmScratch {
+    buf: Vec<MaybeUninit<u64>>,
+}
+
+impl MsmScratch {
+    /// Create a new, empty scratch buffer.
+    pub fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+
+    /// Ensure the buffer can hold at least `len` elements.
+    pub fn ensure(&mut self, len: usize) -> &mut [MaybeUninit<u64>] {
+        if self.buf.len() < len {
+            self.buf.resize_with(len, || MaybeUninit::<u64>::uninit());
+        }
+        &mut self.buf
+    }
+}
+
 /// An element of a group.
 pub trait Element:
     Read<Cfg = ()> + Write + FixedSize + Clone + Eq + PartialEq + Ord + PartialOrd + Hash + Send + Sync
@@ -67,11 +88,27 @@ pub trait Element:
 
 /// A point on a curve.
 pub trait Point: Element {
+    /// Affine representation used for MSMs.
+    type Affine: Copy + Send + Sync + Debug + PartialEq + Eq;
+
     /// Maps the provided data to a group element.
     fn map(&mut self, dst: DST, message: &[u8]);
 
     /// Performs a multi‑scalar multiplication of the provided points and scalars.
     fn msm(points: &[Self], scalars: &[Scalar]) -> Self;
+
+    /// Convert the point to its affine representation.
+    fn to_affine(&self) -> Self::Affine;
+
+    /// Perform MSM on affine points using the provided reusable scratch space.
+    fn msm_affine_with_scratch(
+        points: &[Self::Affine],
+        scalars: &[Scalar],
+        scratch: &mut MsmScratch,
+    ) -> Self;
+
+    /// Returns the required scratch buffer length (in `u64`s) for an MSM of `len` points.
+    fn msm_scratch_len(len: usize) -> usize;
 }
 
 /// Wrapper around [blst_fr] that represents an element of the BLS12‑381
@@ -607,6 +644,8 @@ impl Ord for G1 {
 }
 
 impl Point for G1 {
+    type Affine = blst_p1_affine;
+
     fn map(&mut self, dst: DST, data: &[u8]) {
         unsafe {
             blst_hash_to_g1(
@@ -630,53 +669,77 @@ impl Point for G1 {
         // Assert input validity
         assert_eq!(points.len(), scalars.len(), "mismatched lengths");
 
-        // Prepare points (affine) and scalars (raw blst_scalar)
-        let mut points_filtered = Vec::with_capacity(points.len());
-        let mut scalars_filtered = Vec::with_capacity(scalars.len());
+        let mut affine_points = Vec::with_capacity(points.len());
+        let mut filtered_scalars = Vec::with_capacity(scalars.len());
         for (point, scalar) in points.iter().zip(scalars.iter()) {
-            // `blst` does not filter out infinity, so we must ensure it is impossible.
-            //
-            // Sources:
-            // * https://github.com/supranational/blst/blob/cbc7e166a10d7286b91a3a7bea341e708962db13/src/multi_scalar.c#L10-L12
-            // * https://github.com/MystenLabs/fastcrypto/blob/0acf0ff1a163c60e0dec1e16e4fbad4a4cf853bd/fastcrypto/src/groups/bls12381.rs#L160-L194
-            if *point == G1::zero() || scalar == &Scalar::zero() {
+            if *point == G1::zero() {
                 continue;
             }
-
-            // Add to filtered vectors
-            points_filtered.push(point.as_blst_p1_affine());
-            scalars_filtered.push(scalar.as_blst_scalar());
+            affine_points.push(point.to_affine());
+            filtered_scalars.push(scalar.clone());
         }
 
-        // If all points were filtered, return zero.
-        if points_filtered.is_empty() {
+        if affine_points.is_empty() {
             return G1::zero();
         }
 
-        // Create vectors of pointers for the blst API.
-        // These vectors hold pointers *to* the elements in the filtered vectors above.
-        let points: Vec<*const blst_p1_affine> =
-            points_filtered.iter().map(|p| p as *const _).collect();
-        let scalars: Vec<*const u8> = scalars_filtered.iter().map(|s| s.b.as_ptr()).collect();
+        let mut scratch = MsmScratch::new();
+        G1::msm_affine_with_scratch(&affine_points, &filtered_scalars, &mut scratch)
+    }
 
-        // Allocate scratch space for Pippenger's algorithm.
-        let scratch_size = unsafe { blst_p1s_mult_pippenger_scratch_sizeof(points.len()) };
-        let mut scratch = vec![MaybeUninit::<u64>::uninit(); scratch_size / 8];
+    fn to_affine(&self) -> Self::Affine {
+        self.as_blst_p1_affine()
+    }
 
-        // Perform multi-scalar multiplication
+    fn msm_affine_with_scratch(
+        points: &[Self::Affine],
+        scalars: &[Scalar],
+        scratch: &mut MsmScratch,
+    ) -> Self {
+        assert_eq!(points.len(), scalars.len(), "mismatched lengths");
+        if points.is_empty() {
+            return G1::zero();
+        }
+
+        let mut point_ptrs = Vec::with_capacity(points.len());
+        let mut scalar_storage = Vec::with_capacity(scalars.len());
+        for (point, scalar) in points.iter().zip(scalars.iter()) {
+            if *scalar == Scalar::zero() {
+                continue;
+            }
+            point_ptrs.push(point as *const blst_p1_affine);
+            scalar_storage.push(scalar.as_blst_scalar());
+        }
+
+        if point_ptrs.is_empty() {
+            return G1::zero();
+        }
+
+        let scalar_ptrs: Vec<*const u8> = scalar_storage.iter().map(|s| s.b.as_ptr()).collect();
+        let required = G1::msm_scratch_len(point_ptrs.len());
+        let scratch_buf = scratch.ensure(required);
+
         let mut msm_result = blst_p1::default();
         unsafe {
             blst_p1s_mult_pippenger(
                 &mut msm_result,
-                points.as_ptr(),
-                points.len(),
-                scalars.as_ptr(),
-                SCALAR_BITS, // Using SCALAR_BITS (255) ensures full scalar range
-                scratch.as_mut_ptr() as *mut _,
+                point_ptrs.as_ptr(),
+                point_ptrs.len(),
+                scalar_ptrs.as_ptr(),
+                SCALAR_BITS,
+                scratch_buf.as_mut_ptr() as *mut _,
             );
         }
 
         G1::from_blst_p1(msm_result)
+    }
+
+    fn msm_scratch_len(len: usize) -> usize {
+        if len == 0 {
+            return 0;
+        }
+        let bytes = unsafe { blst_p1s_mult_pippenger_scratch_sizeof(len) };
+        (bytes + core::mem::size_of::<u64>() - 1) / core::mem::size_of::<u64>()
     }
 }
 
@@ -816,6 +879,8 @@ impl Ord for G2 {
 }
 
 impl Point for G2 {
+    type Affine = blst_p2_affine;
+
     fn map(&mut self, dst: DST, data: &[u8]) {
         unsafe {
             blst_hash_to_g2(
@@ -839,50 +904,77 @@ impl Point for G2 {
         // Assert input validity
         assert_eq!(points.len(), scalars.len(), "mismatched lengths");
 
-        // Prepare points (affine) and scalars (raw blst_scalar), filtering identity points
-        let mut points_filtered = Vec::with_capacity(points.len());
-        let mut scalars_filtered = Vec::with_capacity(scalars.len());
+        let mut affine_points = Vec::with_capacity(points.len());
+        let mut filtered_scalars = Vec::with_capacity(scalars.len());
         for (point, scalar) in points.iter().zip(scalars.iter()) {
-            // `blst` does not filter out infinity, so we must ensure it is impossible.
-            //
-            // Sources:
-            // * https://github.com/supranational/blst/blob/cbc7e166a10d7286b91a3a7bea341e708962db13/src/multi_scalar.c#L10-L12
-            // * https://github.com/MystenLabs/fastcrypto/blob/0acf0ff1a163c60e0dec1e16e4fbad4a4cf853bd/fastcrypto/src/groups/bls12381.rs#L160-L194
-            if *point == G2::zero() || scalar == &Scalar::zero() {
+            if *point == G2::zero() {
                 continue;
             }
-            points_filtered.push(point.as_blst_p2_affine());
-            scalars_filtered.push(scalar.as_blst_scalar());
+            affine_points.push(point.to_affine());
+            filtered_scalars.push(scalar.clone());
         }
 
-        // If all points were filtered, return zero.
-        if points_filtered.is_empty() {
+        if affine_points.is_empty() {
             return G2::zero();
         }
 
-        // Create vectors of pointers for the blst API
-        let points: Vec<*const blst_p2_affine> =
-            points_filtered.iter().map(|p| p as *const _).collect();
-        let scalars: Vec<*const u8> = scalars_filtered.iter().map(|s| s.b.as_ptr()).collect();
+        let mut scratch = MsmScratch::new();
+        G2::msm_affine_with_scratch(&affine_points, &filtered_scalars, &mut scratch)
+    }
 
-        // Allocate scratch space for Pippenger algorithm
-        let scratch_size = unsafe { blst_p2s_mult_pippenger_scratch_sizeof(points.len()) };
-        let mut scratch = vec![MaybeUninit::<u64>::uninit(); scratch_size / 8];
+    fn to_affine(&self) -> Self::Affine {
+        self.as_blst_p2_affine()
+    }
 
-        // Perform multi-scalar multiplication
+    fn msm_affine_with_scratch(
+        points: &[Self::Affine],
+        scalars: &[Scalar],
+        scratch: &mut MsmScratch,
+    ) -> Self {
+        assert_eq!(points.len(), scalars.len(), "mismatched lengths");
+        if points.is_empty() {
+            return G2::zero();
+        }
+
+        let mut point_ptrs = Vec::with_capacity(points.len());
+        let mut scalar_storage = Vec::with_capacity(scalars.len());
+        for (point, scalar) in points.iter().zip(scalars.iter()) {
+            if *scalar == Scalar::zero() {
+                continue;
+            }
+            point_ptrs.push(point as *const blst_p2_affine);
+            scalar_storage.push(scalar.as_blst_scalar());
+        }
+
+        if point_ptrs.is_empty() {
+            return G2::zero();
+        }
+
+        let scalar_ptrs: Vec<*const u8> = scalar_storage.iter().map(|s| s.b.as_ptr()).collect();
+        let required = G2::msm_scratch_len(point_ptrs.len());
+        let scratch_buf = scratch.ensure(required);
+
         let mut msm_result = blst_p2::default();
         unsafe {
             blst_p2s_mult_pippenger(
                 &mut msm_result,
-                points.as_ptr(),
-                points.len(),
-                scalars.as_ptr(),
-                SCALAR_BITS, // Using SCALAR_BITS (255) ensures full scalar range
-                scratch.as_mut_ptr() as *mut _,
+                point_ptrs.as_ptr(),
+                point_ptrs.len(),
+                scalar_ptrs.as_ptr(),
+                SCALAR_BITS,
+                scratch_buf.as_mut_ptr() as *mut _,
             );
         }
 
         G2::from_blst_p2(msm_result)
+    }
+
+    fn msm_scratch_len(len: usize) -> usize {
+        if len == 0 {
+            return 0;
+        }
+        let bytes = unsafe { blst_p2s_mult_pippenger_scratch_sizeof(len) };
+        (bytes + core::mem::size_of::<u64>() - 1) / core::mem::size_of::<u64>()
     }
 }
 


### PR DESCRIPTION
Related: #2184 

### Changes (Summarized by LLM)

#### BTE Implementation

- BatchRequest now caches affine headers, rho transcript seeds, and the desired concurrency level during the one-time ciphertext filtering pass; optional Rayon parallelism accelerates Chaum–Pedersen validation, and each header’s rho seed is stored as a Transcript::Summary for later reuse (cryptography/src/bls12381/bte.rs:124-224).
- Added BatchVerifyScratch (rho buffer + shared MsmScratch) plus a canonical InvalidCiphertextSet error so verifiers can enforce that servers prove over exactly the caller’s filtered indices without repeated allocations (cryptography/src/bls12381/bte.rs:255-294).
- respond_to_batch now uses cached raw scalars (Share::private.to_raw()) and optional Rayon parallelism to exponentiate headers, derives rho scalars once, and performs MSMs over cached affine headers using the new scratch space before forming the aggregated proof (cryptography/src/bls12381/bte.rs:400-498).
- Verification reuses caller-provided scratch, checks the server-reported indices against the canonical set, recomputes rho scalars from stored seeds, batch-converts partials to affine form, and MSMs both bases and partials before validating the aggregated Chaum–Pedersen proof (cryptography/src/bls12381/bte.rs:511-589).
- combine_partials accepts a concurrency argument so column-wise MSMs over verified partials can run serially or via a Rayon pool; helper functions perform MSMs with reusable scratch to avoid per-column allocations (cryptography/src/bls12381/bte.rs:591-716).
- derive_rhos now resumes the per-header transcripts captured in the request, appends the responder index plus claimed partial, and feeds that into the transcript RNG—eliminating repeated domain initialization during verification (cryptography/src/bls12381/bte.rs:784-812).
- The TDH keystream migrated from SHA-256 to CoreBlake3 and now commits to label length/output length, while the XOR helper applies unaligned u64 chunks for faster masking (cryptography/src/bls12381/bte.rs:815-856).

#### Group Primitives Infrastructure

- Introduced reusable MSM infrastructure: MsmScratch for cached Pippenger scratch buffers, RawScalar/Scalar::to_raw for pre-serialized scalars, and extended the Point trait with affine conversions, scratch-aware MSMs, and raw-scalar multiplication hooks that both G1 and G2 implement (cryptography/src/bls12381/primitives/group.rs:51-369).
- G1::msm/G2::msm now convert inputs to affine form (using the new blst_*s_to_affine helpers), drop zero points/scalars up front, and delegate to msm_affine_with_scratch, drastically reducing temporary allocations during large MSMs (cryptography/src/bls12381/primitives/group.rs:607-742 and cryptography/src/bls12381/primitives/group.rs:972-1113).
- Both groups expose batch_to_affine, mul_raw, and msm_scratch_len, which the revamped BTE code uses for faster header exponentiation and aggregated-proof verification (cryptography/src/bls12381/primitives/group.rs:637-742 and cryptography/src/bls12381/primitives/group.rs:1004-1113).

### Performance (`decrypt == prepare + verify + recover`)

```
bte_decrypt_prepare/n=10/threads=1/size=10
    time:   [7.5457 ms 7.6023 ms 7.6468 ms]
bte_decrypt_verify/n=10/threads=1/size=10
    time:   [19.562 ms 19.815 ms 20.303 ms]
bte_decrypt_recover/n=10/threads=1/size=10
    time:   [5.6933 ms 5.8327 ms 6.0476 ms]

=> 33.2ms

bte_decrypt_prepare/n=10/threads=1/size=100
    time:   [70.264 ms 70.964 ms 72.520 ms]
bte_decrypt_verify/n=10/threads=1/size=100
    time:   [129.21 ms 131.55 ms 134.98 ms]
bte_decrypt_recover/n=10/threads=1/size=100
    time:   [56.797 ms 56.972 ms 57.228 ms]

=> 259ms

bte_decrypt_prepare/n=10/threads=1/size=1000
    time:   [677.37 ms 684.25 ms 694.33 ms]
bte_decrypt_verify/n=10/threads=1/size=1000
    time:   [972.14 ms 976.19 ms 980.86 ms]
bte_decrypt_recover/n=10/threads=1/size=1000
    time:   [568.26 ms 569.14 ms 570.20 ms]

=> 2.23s

bte_decrypt_prepare/n=10/threads=8/size=10
    time:   [2.9143 ms 3.0526 ms 3.2288 ms]
bte_decrypt_verify/n=10/threads=8/size=10
    time:   [4.6297 ms 4.6338 ms 4.6386 ms]
bte_decrypt_recover/n=10/threads=8/size=10
    time:   [1.3080 ms 1.3270 ms 1.3654 ms]

=> 8.9ms

bte_decrypt_prepare/n=10/threads=8/size=100
    time:   [17.366 ms 18.219 ms 19.423 ms]
bte_decrypt_verify/n=10/threads=8/size=100
    time:   [25.075 ms 25.718 ms 26.592 ms]
bte_decrypt_recover/n=10/threads=8/size=100
    time:   [9.3808 ms 9.8714 ms 10.375 ms]

-> 53.7ms

bte_decrypt_prepare/n=10/threads=8/size=1000
    time:   [144.96 ms 146.63 ms 148.85 ms]
bte_decrypt_verify/n=10/threads=8/size=1000
    time:   [165.95 ms 168.70 ms 173.53 ms]
bte_decrypt_recover/n=10/threads=8/size=1000
    time:   [89.563 ms 91.839 ms 94.958 ms]

=> 0.41s

bte_decrypt_prepare/n=100/threads=1/size=10
    time:   [7.7492 ms 7.9252 ms 8.0643 ms]
bte_decrypt_verify/n=100/threads=1/size=10
    time:   [150.86 ms 151.23 ms 151.66 ms]
bte_decrypt_recover/n=100/threads=1/size=10
   time:   [19.074 ms 19.104 ms 19.166 ms]

=> 178.25ms (-17%)

bte_decrypt_prepare/n=100/threads=1/size=100
    time:   [71.399 ms 72.270 ms 73.838 ms]
bte_decrypt_verify/n=100/threads=1/size=100
    time:   [884.55 ms 897.72 ms 916.62 ms]
bte_decrypt_recover/n=100/threads=1/size=100
    time:   [189.17 ms 190.43 ms 191.73 ms]

=> 1.16s (-24%)

bte_decrypt_prepare/n=100/threads=1/size=1000
    time:   [691.80 ms 694.54 ms 697.17 ms]
bte_decrypt_verify/n=100/threads=1/size=1000
    time:   [5.8849 s 5.9193 s 5.9614 s]
bte_decrypt_recover/n=100/threads=1/size=1000
    time:   [1.8874 s 1.8967 s 1.9109 s]

=> 8.54s (-31%)

bte_decrypt_prepare/n=100/threads=8/size=10
    time:   [2.8861 ms 2.9442 ms 3.0289 ms]
bte_decrypt_verify/n=100/threads=8/size=10
    time:   [25.752 ms 26.454 ms 27.418 ms]
bte_decrypt_recover/n=100/threads=8/size=10
    time:   [4.3780 ms 4.4140 ms 4.4518 ms]

=> 33.8ms (-13%)

bte_decrypt_prepare/n=100/threads=8/size=100
    time:   [17.135 ms 17.375 ms 17.853 ms]
bte_decrypt_verify/n=100/threads=8/size=100
    time:   [142.00 ms 142.38 ms 143.35 ms]
bte_decrypt_recover/n=100/threads=8/size=100
    time:   [30.809 ms 31.409 ms 32.639 ms]

=> 191ms (-29%)

bte_decrypt_prepare/n=100/threads=8/size=1000
    time:   [142.87 ms 146.59 ms 151.91 ms]
bte_decrypt_verify/n=100/threads=8/size=1000
    time:   [947.65 ms 950.88 ms 954.25 ms]
bte_decrypt_recover/n=100/threads=8/size=1000
    time:   [299.12 ms 303.67 ms 309.80 ms]

=> 1.40s (-40%)
```
