### PR TITLE
[ci] Partition miri tests

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -20,13 +20,13 @@ env:
 
 jobs:
   Tests:
-    name: "Tests (os: ${{ matrix.os }}, flags: \"${{ matrix.flags }}\") (partition: ${{ matrix.partition }}/6)"
+    name: "Tests (os: ${{ matrix.os }}, flags: \"${{ matrix.flags }}\") (partition: ${{ matrix.partition }}/8)"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        partition: [1, 2, 3, 4, 5, 6]
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
         flags:
           - "--features commonware-runtime/iouring-storage"
           - "--features commonware-runtime/iouring-network"
@@ -57,7 +57,7 @@ jobs:
       with:
         tool: just@1.43.0,cargo-nextest@0.9.104
     - name: Run ignored tests
-      run: just test ${{ matrix.flags }} --partition hash:${{matrix.partition}}/6 --verbose -- --ignored
+      run: just test ${{ matrix.flags }} --partition hash:${{matrix.partition}}/8 --verbose -- --ignored
 
   Tests-Gate:
     name: "Slow-Tests"
@@ -135,8 +135,12 @@ jobs:
       run: just fuzz ${{ matrix.fuzz_dir }} 60 +${{ env.NIGHTLY_VERSION }}
 
   Unsafe:
+    name: "Miri Tests (partition: ${{ matrix.partition }}/8)"
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
     - name: Checkout repository
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -147,11 +151,25 @@ jobs:
         rustup toolchain install ${{ env.NIGHTLY_VERSION }} --component miri
         rustup override set ${{ env.NIGHTLY_VERSION }}
         cargo miri setup
-    - name: Install just
+    - name: Install just & nextest
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
-        tool: just@1.43.0
+        tool: just@1.43.0,cargo-nextest@0.9.104
     - name: Run miri tests for storage::index
       run: |
         cd storage
-        just miri index::
+        just miri index:: --partition hash:${{matrix.partition}}/8
+
+  Unsafe-Tests-Gate:
+    name: "Unsafe-Tests"
+    runs-on: ubuntu-latest
+    needs: Unsafe
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.Unsafe.result }}" != "success" ]; then
+            echo "Tests failed or were cancelled"
+            exit 1
+          fi
+          echo "All tests passed successfully!"

--- a/justfile
+++ b/justfile
@@ -64,5 +64,5 @@ udeps nightly_version='+nightly':
     cargo {{ nightly_version }} udeps --all-targets
 
 # Run miri tests on a given module
-miri module:
-    MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --lib {{ module }}
+miri module *args='':
+    MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run --lib {{ module }} {{ args }}


### PR DESCRIPTION
## Overview

Partitions miri tests into 8 separate runners and bumps the partition count for the slow test suite to 8.