### PR TITLE
 fix: Fetcher::retain doc to reflect predicate-based API

### DIFF
--- a/resolver/src/p2p/fetcher.rs
+++ b/resolver/src/p2p/fetcher.rs
@@ -143,7 +143,8 @@ impl<E: Clock + GClock + Rng + Metrics, P: PublicKey, Key: Span, NetS: Sender<Pu
         }
     }
 
-    /// Retains only the fetches with keys greater than the given key.
+    /// Retains only the fetches whose keys satisfy the predicate.
+    /// Applies to both active and pending fetches.
     pub fn retain(&mut self, predicate: impl Fn(&Key) -> bool) {
         self.active.retain(|_, k| predicate(k));
         self.pending.retain(predicate);


### PR DESCRIPTION
The previous comment incorrectly stated that retain keeps “keys greater than the given key,” but the method accepts an arbitrary predicate.