### PR TITLE
docs(p2p): fix typo in bandwidth comment in simulated test

### DIFF
--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -1003,7 +1003,7 @@ mod tests {
             );
             network.start();
 
-            // Both sender and receiver have the same bandiwdth (1000 B/s)
+            // Both sender and receiver have the same bandwidth (1000 B/s)
             // 500 bytes at 1000 B/s = 0.5 seconds
             test_bandwidth_between_peers(
                 &mut context,


### PR DESCRIPTION

Fixes a single spelling typo in a comment: “bandiwdth” → “ bandwidth”.

