### PR TITLE
[cryptography] derive Clone for DKG objects

### DIFF
--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -65,6 +65,7 @@ pub struct Output<V: Variant> {
 }
 
 /// Gather commitments, acknowledgements, and reveals from all dealers.
+#[derive(Clone)]
 pub struct Arbiter<P: PublicKey, V: Variant> {
     previous: Option<poly::Public<V>>,
     dealer_threshold: u32,

--- a/cryptography/src/bls12381/dkg/dealer.rs
+++ b/cryptography/src/bls12381/dkg/dealer.rs
@@ -24,6 +24,7 @@ pub struct Output {
 }
 
 /// Track acknowledgements from players.
+#[derive(Clone)]
 pub struct Dealer<P: PublicKey, V: Variant> {
     threshold: u32,
     players: Ordered<P>,

--- a/cryptography/src/bls12381/dkg/player.rs
+++ b/cryptography/src/bls12381/dkg/player.rs
@@ -31,6 +31,7 @@ pub struct Output<V: Variant> {
 }
 
 /// Track commitments and dealings distributed by dealers.
+#[derive(Clone)]
 pub struct Player<P: PublicKey, V: Variant> {
     me: u32,
     dealer_threshold: u32,


### PR DESCRIPTION
There seems to be no downside to making `dkg::{Arbiter, Player, Dealer}: Clone`. I need this for my use case to do "speculative" finalization of the DKG ceremony: I need to write the DKG ceremony on the last block of an epoch, but since DKG acts on finalized blocks but proposals on notarized block, there is no guarantee that the outcome of the DKG process is ready in time.

Cloning the DKG objects allows me to finalize on propose and verify and - in case of mismatch - keep processing finalized blocks.

This is likely a stopgap solution until a more efficient method is implemented.