### PR TITLE
[coding] Avoid u16 overflow

### DIFF
--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -42,8 +42,8 @@ pub struct Config {
 
 impl Config {
     /// Returns the total number of shards produced by this configuration.
-    pub fn total_shards(&self) -> u16 {
-        self.minimum_shards + self.extra_shards
+    pub fn total_shards(&self) -> u32 {
+        u32::from(self.minimum_shards) + u32::from(self.extra_shards)
     }
 }
 

--- a/coding/src/no_coding.rs
+++ b/coding/src/no_coding.rs
@@ -96,7 +96,7 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
     ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error> {
         let data: Vec<u8> = data.copy_to_bytes(data.remaining()).to_vec();
         let commitment = H::new().update(&data).finalize();
-        let shards = (0..config.minimum_shards + config.extra_shards)
+        let shards = (0..config.total_shards())
             .map(|_| Shard(data.clone()))
             .collect();
         Ok((commitment, shards))


### PR DESCRIPTION
Closes #1700.
Closes #1754.

This makes the `total_shards` function return a u32, and then has the reed solomon code return an error if that u32 doesn't fit in a u16.