### PR TITLE
[p2p/simulated] remove redundant sort/dedup in rebalance

### DIFF
--- a/p2p/src/simulated/transmitter.rs
+++ b/p2p/src/simulated/transmitter.rs
@@ -373,9 +373,9 @@ impl<P: PublicKey> State<P> {
     /// Recomputes bandwidth allocations and collects any flows that finished in the interval.
     fn rebalance(&mut self, now: SystemTime) -> Vec<Completion<P>> {
         let mut completed = Vec::new();
-
+        let mut active: Vec<Flow<P>> = Vec::new();
         for (&flow_id, meta) in self.all_flows.iter_mut() {
-            // First, account for bytes already in flight since the previous tick.
+            // Account for bytes already in flight since the last tick
             if !meta.remaining.is_zero() {
                 let elapsed = now
                     .duration_since(meta.last_update)
@@ -389,22 +389,15 @@ impl<P: PublicKey> State<P> {
             meta.last_update = now;
             if meta.remaining.is_zero() {
                 completed.push(flow_id);
+            } else {
+                active.push(Flow {
+                    id: flow_id,
+                    origin: meta.origin.clone(),
+                    recipient: meta.recipient.clone(),
+                    delivered: meta.sequence.is_some(),
+                });
             }
         }
-
-        let mut active: Vec<Flow<P>> = Vec::new();
-        for (&flow_id, meta) in self.all_flows.iter() {
-            if meta.remaining.is_zero() {
-                continue;
-            }
-            active.push(Flow {
-                id: flow_id,
-                origin: meta.origin.clone(),
-                recipient: meta.recipient.clone(),
-                delivered: meta.sequence.is_some(),
-            });
-        }
-
         if active.is_empty() {
             self.next_bandwidth_event = None;
             return self.finish(completed, now);
@@ -414,7 +407,6 @@ impl<P: PublicKey> State<P> {
         let mut ingress_cap = |pk: &P| self.ingress_cap(pk);
         let allocations = bandwidth::allocate(&active, &mut egress_cap, &mut ingress_cap);
         let mut earliest: Option<Duration> = None;
-
         for (flow_id, rate) in allocations {
             if let Some(meta) = self.all_flows.get_mut(&flow_id) {
                 meta.rate = rate.clone();
@@ -443,7 +435,6 @@ impl<P: PublicKey> State<P> {
                 }
             }
         }
-
         completed.sort();
 
         // Record the next time at which a bandwidth event should fire.


### PR DESCRIPTION
The initial pass over `self.all_flows` iterates a `BTreeMap` in key order and pushes each completed flow ID at most once, so the completed vector produced there is already sorted and unique, making the first `sort()` and `dedup()` unnecessary. Later, the allocation phase may append additional completions (e.g., unlimited-rate assignments), so a final `sort()` preserves deterministic ordering; however, duplicates cannot occur by construction because Phase B operates only on flows that still had remaining work, while Phase A already excluded them, thus `dedup()` is redundant. This change preserves behavior and determinism while removing unnecessary work.