### PR TITLE
[coding] Reed-Solomon optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "rayon",
  "reed-solomon-simd",
  "thiserror 2.0.17",
 ]

--- a/coding/Cargo.toml
+++ b/coding/Cargo.toml
@@ -20,6 +20,7 @@ futures.workspace = true
 num-rational.workspace = true
 rand.workspace = true
 rand_core.workspace = true
+rayon.workspace = true
 reed-solomon-simd.workspace = true
 thiserror.workspace = true
 

--- a/coding/src/benches/bench_size.rs
+++ b/coding/src/benches/bench_size.rs
@@ -4,6 +4,8 @@ use commonware_cryptography::Sha256;
 use rand::{RngCore as _, SeedableRng as _};
 use rand_chacha::ChaCha8Rng;
 
+const CONCURRENCY: usize = 1;
+
 fn benchmark_size<S: Scheme>(name: &str) {
     let mut rng = ChaCha8Rng::seed_from_u64(0);
     let cases = [8, 12, 16, 19, 20, 24].map(|i| 2usize.pow(i));
@@ -22,7 +24,8 @@ fn benchmark_size<S: Scheme>(name: &str) {
                 data
             };
 
-            let (commitment, mut shards) = S::encode(&config, data.as_slice()).unwrap();
+            let (commitment, mut shards) =
+                S::encode(&config, data.as_slice(), CONCURRENCY).unwrap();
             let shard = shards.pop().unwrap();
             println!(
                 "{} (shard)/msg_len={} chunks={}: {} B",

--- a/coding/src/no_coding.rs
+++ b/coding/src/no_coding.rs
@@ -93,6 +93,7 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
     fn encode(
         config: &crate::Config,
         mut data: impl bytes::Buf,
+        _concurrency: usize,
     ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error> {
         let data: Vec<u8> = data.copy_to_bytes(data.remaining()).to_vec();
         let commitment = H::new().update(&data).finalize();
@@ -130,6 +131,7 @@ impl<H: Hasher> crate::Scheme for NoCoding<H> {
         _commitment: &Self::Commitment,
         checking_data: Self::CheckingData,
         _shards: &[Self::CheckedShard],
+        _concurrency: usize,
     ) -> Result<Vec<u8>, Self::Error> {
         Ok(checking_data)
     }


### PR DESCRIPTION
## Overview

Adds a few low-hanging optimizations to the `reed_solomon` coding scheme:
1. When preparing data for encoding, the data is copied as a slice rather than byte-by-byte. (godbolt: [byte-by-byte](https://godbolt.org/z/dqMf8eWfT) vs. [slice-copy](https://godbolt.org/z/YnrnEvsTx))
2. Reduces unnecessary copies in `decode`
3. Allows for (optional) parallel hashing of shards when constructing the leaves of the BMT. Hashing is by far the hottest part of `reed_solomon`'s `encode/decode` path, comprising of over 90% of the samples in a profile:
<img width="2536" height="340" alt="Screenshot 2025-11-17 at 1 42 39 PM" src="https://github.com/user-attachments/assets/39658dc6-7f43-4421-a017-738254428c57" />
