### PR TITLE
fix(sync-example): config not getting logged

### DIFF
--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -366,17 +366,6 @@ fn main() {
         eprintln!("❌ Configuration error: {e}");
         std::process::exit(1);
     });
-    info!(
-        database_type = %config.database_type.as_str(),
-        server = %config.server,
-        batch_size = config.batch_size,
-        storage_dir = %config.storage_dir,
-        metrics_port = config.metrics_port,
-        target_update_interval = ?config.target_update_interval,
-        sync_interval = ?config.sync_interval,
-        max_outstanding_requests = config.max_outstanding_requests,
-        "client starting with configuration"
-    );
 
     let executor_config =
         tokio_runtime::Config::default().with_storage_directory(config.storage_dir.clone());
@@ -390,6 +379,17 @@ fn main() {
             },
             Some(SocketAddr::from((Ipv4Addr::LOCALHOST, config.metrics_port))),
             None,
+        );
+        info!(
+            database_type = %config.database_type.as_str(),
+            server = %config.server,
+            batch_size = config.batch_size,
+            storage_dir = %config.storage_dir,
+            metrics_port = config.metrics_port,
+            target_update_interval = ?config.target_update_interval,
+            sync_interval = ?config.sync_interval,
+            max_outstanding_requests = config.max_outstanding_requests,
+            "client starting with configuration"
         );
 
         // Dispatch based on database type

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -590,16 +590,6 @@ fn main() {
         eprintln!("❌ {e}");
         std::process::exit(1);
     });
-    info!(
-        database_type = %config.database_type.as_str(),
-        port = config.port,
-        initial_ops = config.initial_ops,
-        storage_dir = %config.storage_dir,
-        metrics_port = config.metrics_port,
-        op_interval = ?config.op_interval,
-        ops_per_interval = config.ops_per_interval,
-        "configuration"
-    );
 
     let executor_config =
         tokio_runtime::Config::default().with_storage_directory(config.storage_dir.clone());
@@ -613,6 +603,16 @@ fn main() {
             },
             Some(SocketAddr::from((Ipv4Addr::LOCALHOST, config.metrics_port))),
             None,
+        );
+        info!(
+            database_type = %config.database_type.as_str(),
+            port = config.port,
+            initial_ops = config.initial_ops,
+            storage_dir = %config.storage_dir,
+            metrics_port = config.metrics_port,
+            op_interval = ?config.op_interval,
+            ops_per_interval = config.ops_per_interval,
+            "configuration"
         );
 
         // Run the appropriate server based on database type


### PR DESCRIPTION
info! was being called before the tracing context was initialized.