### PR TITLE
fix(consensus): correct assertion message in determinism test

### DIFF
--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -2307,7 +2307,7 @@ mod tests {
                 assert_ne!(
                     pair[0].1, pair[1].1,
                     "state {} equals state {}",
-                    pair[0].0, pair[0].0
+                    pair[0].0, pair[1].0
                 );
             }
         }


### PR DESCRIPTION
Fixed error in the simplex determinism test where the assertion failure message was displaying the same state name twice 
instead of showing both states being compared.

Changed:
- pair[0].0, pair[0].0  (shows same name twice)
+ pair[0].0, pair[1].0  (shows both compared state names)

This ensures that when the assertion fails, it correctly displays: `state threshold-minpk equals state threshold-minsig`
instead of: `state threshold-minpk equals state threshold-minpk`