### PR TITLE
[Storage] Remove unused constraints from `adb::store::Db`

### DIFF
--- a/storage/src/adb/any/fixed/ordered.rs
+++ b/storage/src/adb/any/fixed/ordered.rs
@@ -651,7 +651,7 @@ impl<
 }
 
 impl<E: Storage + Clock + Metrics, K: Array, V: CodecFixed<Cfg = ()>, H: Hasher, T: Translator>
-    Db<E, K, V, T> for Any<E, K, V, H, T>
+    Db<K, V> for Any<E, K, V, H, T>
 {
     fn op_count(&self) -> Location {
         self.log.size()

--- a/storage/src/adb/any/fixed/unordered.rs
+++ b/storage/src/adb/any/fixed/unordered.rs
@@ -229,7 +229,7 @@ impl<E: Storage + Clock + Metrics, K: Array, V: CodecFixed<Cfg = ()>, H: Hasher,
 }
 
 impl<E: Storage + Clock + Metrics, K: Array, V: CodecFixed<Cfg = ()>, H: Hasher, T: Translator>
-    Db<E, K, V, T> for Any<E, K, V, H, T>
+    Db<K, V> for Any<E, K, V, H, T>
 {
     fn op_count(&self) -> Location {
         self.log.size()

--- a/storage/src/adb/any/variable/mod.rs
+++ b/storage/src/adb/any/variable/mod.rs
@@ -300,7 +300,7 @@ impl<E: Storage + Clock + Metrics, K: Array, V: Codec, H: Hasher, T: Translator>
     }
 }
 
-impl<E: Storage + Clock + Metrics, K: Array, V: Codec, H: Hasher, T: Translator> Db<E, K, V, T>
+impl<E: Storage + Clock + Metrics, K: Array, V: Codec, H: Hasher, T: Translator> Db<K, V>
     for Any<E, K, V, H, T>
 {
     fn op_count(&self) -> Location {

--- a/storage/src/adb/benches/fixed/generate.rs
+++ b/storage/src/adb/benches/fixed/generate.rs
@@ -10,7 +10,7 @@ use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::{Config, Context},
 };
-use commonware_storage::{adb::store::Db, translator::EightCap};
+use commonware_storage::adb::store::Db;
 use criterion::{criterion_group, Criterion};
 use std::time::{Duration, Instant};
 
@@ -92,9 +92,7 @@ fn bench_fixed_generate(c: &mut Criterion) {
     }
 }
 
-async fn test_db<
-    A: Db<Context, <Sha256 as Hasher>::Digest, <Sha256 as Hasher>::Digest, EightCap>,
->(
+async fn test_db<A: Db<<Sha256 as Hasher>::Digest, <Sha256 as Hasher>::Digest>>(
     db: A,
     elements: u64,
     operations: u64,

--- a/storage/src/adb/benches/fixed/mod.rs
+++ b/storage/src/adb/benches/fixed/mod.rs
@@ -215,9 +215,7 @@ async fn get_variable_any(ctx: Context) -> VariableAnyDb {
 /// `num_operations` over these elements, each selected uniformly at random for each operation. The
 /// database is committed after every `commit_frequency` operations (if Some), or at the end (if
 /// None).
-async fn gen_random_kv<
-    A: Db<Context, <Sha256 as Hasher>::Digest, <Sha256 as Hasher>::Digest, EightCap>,
->(
+async fn gen_random_kv<A: Db<<Sha256 as Hasher>::Digest, <Sha256 as Hasher>::Digest>>(
     mut db: A,
     num_elements: u64,
     num_operations: u64,

--- a/storage/src/adb/benches/variable/mod.rs
+++ b/storage/src/adb/benches/variable/mod.rs
@@ -100,7 +100,7 @@ async fn get_any(ctx: Context) -> AnyDb {
 /// `num_operations` over these elements, each selected uniformly at random for each operation. The
 /// ratio of updates to deletes is configured with `DELETE_FREQUENCY`. The database is committed
 /// after every `commit_frequency` operations.
-async fn gen_random_kv<A: Db<Context, <Sha256 as Hasher>::Digest, Vec<u8>, EightCap>>(
+async fn gen_random_kv<A: Db<<Sha256 as Hasher>::Digest, Vec<u8>>>(
     mut db: A,
     num_elements: u64,
     num_operations: u64,

--- a/storage/src/adb/current/ordered.rs
+++ b/storage/src/adb/current/ordered.rs
@@ -671,7 +671,7 @@ impl<
         H: Hasher,
         T: Translator,
         const N: usize,
-    > Db<E, K, V, T> for Current<E, K, V, H, T, N>
+    > Db<K, V> for Current<E, K, V, H, T, N>
 {
     fn op_count(&self) -> Location {
         self.any.op_count()

--- a/storage/src/adb/current/unordered.rs
+++ b/storage/src/adb/current/unordered.rs
@@ -582,7 +582,7 @@ impl<
         H: Hasher,
         T: Translator,
         const N: usize,
-    > Db<E, K, V, T> for Current<E, K, V, H, T, N>
+    > Db<K, V> for Current<E, K, V, H, T, N>
 {
     fn op_count(&self) -> Location {
         self.any.op_count()

--- a/storage/src/adb/store/mod.rs
+++ b/storage/src/adb/store/mod.rs
@@ -127,7 +127,7 @@ pub struct Config<T: Translator, C> {
 }
 
 /// A trait for any key-value store based on an append-only log of operations.
-pub trait Db<E: RStorage + Clock + Metrics, K: Array, V: Codec, T: Translator> {
+pub trait Db<K: Array, V: Codec> {
     /// The number of operations that have been applied to this db, including those that have been
     /// pruned and those that are not yet committed.
     fn op_count(&self) -> Location;
@@ -457,7 +457,7 @@ where
     }
 }
 
-impl<E, K, V, T> Db<E, K, V, T> for Store<E, K, V, T>
+impl<E, K, V, T> Db<K, V> for Store<E, K, V, T>
 where
     E: RStorage + Clock + Metrics,
     K: Array,


### PR DESCRIPTION
The `Db` doesn't use `E` or `T`