### PR TITLE
[deployer] avoid full HashSet clone in destroy job scheduling

### DIFF
--- a/deployer/src/ec2/destroy.rs
+++ b/deployer/src/ec2/destroy.rs
@@ -41,7 +41,7 @@ pub async fn destroy(config: &PathBuf) -> Result<(), Error> {
     // First pass: Delete instances, security groups, subnets, route tables, peering, IGWs, and key pairs
     info!(regions=?all_regions, "removing resources");
     let mut jobs = Vec::with_capacity(all_regions.len());
-    for region in all_regions.clone() {
+    for region in all_regions.iter().cloned() {
         // Stage region teardown
         let job = async move {
             let ec2_client = create_ec2_client(Region::new(region.clone())).await;


### PR DESCRIPTION
Replace iteration over a cloned HashSet with iter().cloned() in destroy.rs to eliminate unnecessary allocation and re-hashing. The loop body requires an owned String for the async move closure, which iter().cloned() provides without duplicating the entire set. This change aligns with how other EC2 modules iterate region sets (e.g., create.rs and update.rs), keeps all_regions intact for the second pass, and has no behavioral impact beyond reduced overhead.