### PR TITLE
[consensus/marshal] Optimize finalization fetching

### DIFF
--- a/consensus/src/marshal/actor.rs
+++ b/consensus/src/marshal/actor.rs
@@ -47,8 +47,7 @@ use rand::{CryptoRng, Rng};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     future::Future,
-    num::NonZeroU64,
-    ops::Range,
+    num::NonZeroUsize,
     time::Instant,
 };
 use tracing::{debug, error, info, warn};
@@ -120,7 +119,7 @@ pub struct Actor<
     // Minimum number of views to retain temporary data after the application processes a block
     view_retention_timeout: ViewDelta,
     // Maximum number of blocks to repair at once
-    max_repair: NonZeroU64,
+    max_repair: NonZeroUsize,
     // Codec configuration for block type
     block_codec_config: B::Cfg,
 
@@ -801,7 +800,11 @@ impl<
             .put_sync(LATEST_KEY.clone(), height)
             .await?;
 
+        // Cancel any useless requests
         resolver.cancel(Request::<B>::Block(commitment)).await;
+        resolver
+            .retain(Request::<B>::Finalized { height }.predicate())
+            .await;
 
         if let Some(finalization) = self.get_finalization_by_height(height).await {
             // Trail the previous processed finalized block by the timeout
@@ -979,30 +982,26 @@ impl<
         resolver: &mut impl Resolver<Key = Request<B>>,
         application: &mut impl Reporter<Activity = Update<B, A>>,
     ) {
-        let gaps = self.identify_gaps();
-
-        // Cancel any outstanding requests by height that sit outside of identified gaps.
-        // These requests are no longer needed, and clog up the resolver.
-        let predicate = {
-            let gaps = gaps.clone();
-            move |height: &u64| gaps.iter().any(|range| range.contains(height))
-        };
-        resolver
-            .retain(move |key| match key {
-                Request::Finalized { height } => predicate(height),
-                _ => true,
-            })
-            .await;
-
-        for Range { start, end } in gaps {
-            // Attempt to repair the gap backwards from the end of the gap, using
-            // blocks from our local storage.
-            let Some(mut cursor) = self.get_finalized_block(end).await else {
-                panic!("gapped block missing that should exist: {end}");
+        let start = self.last_processed_height.saturating_add(1);
+        'cache_repair: loop {
+            let (gap_start, Some(gap_end)) = self.finalized_blocks.next_gap(start) else {
+                // No gaps detected
+                return;
             };
 
+            // Attempt to repair the gap backwards from the end of the gap, using
+            // blocks from our local storage.
+            let Some(mut cursor) = self.get_finalized_block(gap_end).await else {
+                panic!("gapped block missing that should exist: {gap_end}");
+            };
+
+            // Compute the lower bound of the recursive repair. `gap_start` is `Some`
+            // if `start` is not in a gap. We add one to it to ensure we don't
+            // re-persist it to the database in the repair loop below.
+            let gap_start = gap_start.map(|s| s.saturating_add(1)).unwrap_or(start);
+
             // Iterate backwards, repairing blocks as we go.
-            while cursor.height() > start {
+            while cursor.height() > gap_start {
                 let commitment = cursor.parent();
                 if let Some(block) = self.find_block(buffer, commitment).await {
                     let finalization = self.cache.get_finalization_for(commitment).await;
@@ -1019,57 +1018,25 @@ impl<
                 } else {
                     // Request the next missing block digest
                     resolver.fetch(Request::<B>::Block(commitment)).await;
-                    break;
+                    break 'cache_repair;
                 }
             }
-
-            // If we haven't fully repaired the gap, then also request any possible
-            // finalizations for the blocks in the remaining gap. This may help
-            // shrink the size of the gap if finalizations for the requests heights
-            // exist. If not, we rely on the recursive digest fetch above.
-            let end = std::cmp::max(cursor.height(), start);
-            debug!(start, end, "requesting any finalized blocks");
-            let requests = (start..end)
-                .map(|height| Request::<B>::Finalized { height })
-                .collect();
-            resolver.fetch_all(requests).await;
         }
-    }
 
-    /// Identifies one or more of the earliest gaps in the finalized blocks archive. The gaps
-    /// returned are half-open ranges, where `start` is inclusive and `end` is exclusive. The total
-    /// number of missing heights covered by the returned gaps is bounded by `self.max_repair`.
-    ///
-    /// The last gap may in the returned list be partial, i.e., it may cover fewer heights
-    /// than the full gap size, if the remaining number of heights to repair exceeds the
-    /// `max_repair` limit.
-    fn identify_gaps(&self) -> Vec<Range<u64>> {
-        // Ignore ranges below the last processed height
-        let start = self.last_processed_height.saturating_add(1);
-        // The remaining number of items to repair
-        let mut rem = self.max_repair.get();
-        // All gaps must be before a range, so we iterate over the ranges and collect the gaps.
-        // Remember that (s, e) are the start and end of the next full range, but we want to collect the gaps.
-        let mut gaps = Vec::new();
-        for (s, _) in self.finalized_blocks.ranges() {
-            // Break if finished
-            if rem == 0 {
-                break;
-            }
-
-            // Found a filled range that starts above the start of our gap
-            if s > start {
-                // The end of the gap is equal to the beginning of the filled range
-                let end = s;
-
-                // Bound the size of the gap by the remaining amount
-                let len = (end - start).min(rem);
-                rem -= len;
-
-                // Prefer the elements at the end of the range
-                gaps.push((end - len)..end);
-            }
+        // Request any finalizations for missing items in the archive, up to
+        // the `max_repair` quota. This may help shrink the size of the gap
+        // closest to the application's processed height if finalizations
+        // for the requests' heights exist. If not, we rely on the recursive
+        // digest fetches above.
+        let missing_items = self
+            .finalized_blocks
+            .missing_items(start, self.max_repair.get());
+        let requests = missing_items
+            .into_iter()
+            .map(|height| Request::<B>::Finalized { height })
+            .collect::<Vec<_>>();
+        if !requests.is_empty() {
+            resolver.fetch_all(requests).await
         }
-        gaps
     }
 }

--- a/consensus/src/marshal/config.rs
+++ b/consensus/src/marshal/config.rs
@@ -68,7 +68,7 @@ where
     pub block_codec_config: B::Cfg,
 
     /// Maximum number of blocks to repair at once.
-    pub max_repair: NonZeroU64,
+    pub max_repair: NonZeroUsize,
 
     pub _marker: PhantomData<S>,
 }

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -205,7 +205,7 @@ mod tests {
             mailbox_size: 100,
             namespace: NAMESPACE.to_vec(),
             view_retention_timeout: ViewDelta::new(10),
-            max_repair: NZU64!(10),
+            max_repair: NZUsize!(10),
             block_codec_config: (),
             partition_prefix: format!("validator-{}", validator.clone()),
             prunable_items_per_section: NZU64!(10),
@@ -336,7 +336,7 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_finalize_good_links_always_finalize() {
+    fn test_finalize_good_links_quorum_sees_finalization() {
         for seed in 0..5 {
             let result1 = finalize(seed, LINK, true);
             let result2 = finalize(seed, LINK, true);
@@ -346,8 +346,8 @@ mod tests {
         }
     }
 
-    #[test_traced("WARN")]
-    fn test_finalize_bad_links_always_finalize() {
+    #[test_traced("DEBUG")]
+    fn test_finalize_bad_links_quorum_sees_finalization() {
         for seed in 0..5 {
             let result1 = finalize(seed, UNRELIABLE_LINK, true);
             let result2 = finalize(seed, UNRELIABLE_LINK, true);
@@ -361,7 +361,7 @@ mod tests {
         let runner = deterministic::Runner::new(
             deterministic::Config::new()
                 .with_seed(seed)
-                .with_timeout(Some(Duration::from_secs(300))),
+                .with_timeout(Some(Duration::from_secs(600))),
         );
         runner.start(|mut context| async move {
             let mut oracle = setup_network(context.clone(), Some(3));
@@ -447,7 +447,7 @@ mod tests {
                         .iter_mut()
                         .enumerate()
                     {
-                        if (do_finalize && i <= QUORUM as usize)
+                        if (do_finalize && i < QUORUM as usize)
                             || height == NUM_BLOCKS
                             || utils::is_last_block_in_epoch(BLOCKS_PER_EPOCH, height).is_some()
                         {

--- a/examples/reshare/src/engine.rs
+++ b/examples/reshare/src/engine.rs
@@ -42,7 +42,7 @@ const REPLAY_BUFFER: NonZero<usize> = NZUsize!(8 * 1024 * 1024); // 8MB
 const WRITE_BUFFER: NonZero<usize> = NZUsize!(1024 * 1024); // 1MB
 const BUFFER_POOL_PAGE_SIZE: NonZero<usize> = NZUsize!(4_096); // 4KB
 const BUFFER_POOL_CAPACITY: NonZero<usize> = NZUsize!(8_192); // 32MB
-const MAX_REPAIR: NonZero<u64> = NZU64!(50);
+const MAX_REPAIR: NonZero<usize> = NZUsize!(50);
 
 pub struct Config<C, P, B, V>
 where

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -136,6 +136,13 @@ impl ArchiveTrait for Archive {
         }
     }
 
+    fn missing_items(&self, index: u64, max: usize) -> Vec<u64> {
+        match self {
+            Archive::Immutable(a) => a.missing_items(index, max),
+            Archive::Prunable(a) => a.missing_items(index, max),
+        }
+    }
+
     fn ranges(&self) -> impl Iterator<Item = (u64, u64)> {
         match self {
             Archive::Immutable(a) => a.ranges().collect::<Vec<_>>().into_iter(),

--- a/storage/src/archive/immutable/storage.rs
+++ b/storage/src/archive/immutable/storage.rs
@@ -305,6 +305,10 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> crate::archive::Archive
         self.ordinal.next_gap(index)
     }
 
+    fn missing_items(&self, index: u64, max: usize) -> Vec<u64> {
+        self.ordinal.missing_items(index, max)
+    }
+
     fn ranges(&self) -> impl Iterator<Item = (u64, u64)> {
         self.ordinal.ranges()
     }

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -86,6 +86,12 @@ pub trait Archive {
     /// This is useful for driving backfill operations over the archive.
     fn next_gap(&self, index: u64) -> (Option<u64>, Option<u64>);
 
+    /// Returns up to `max` missing items starting from `start`.
+    ///
+    /// This method iterates through gaps between existing ranges, collecting missing indices
+    /// until either `max` items are found or there are no more gaps to fill.
+    fn missing_items(&self, index: u64, max: usize) -> Vec<u64>;
+
     /// Retrieve an iterator over all populated ranges (inclusive) within the [Archive].
     fn ranges(&self) -> impl Iterator<Item = (u64, u64)>;
 

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -356,6 +356,10 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> crate::archive::Ar
         self.intervals.next_gap(index)
     }
 
+    fn missing_items(&self, index: u64, max: usize) -> Vec<u64> {
+        self.intervals.missing_items(index, max)
+    }
+
     fn ranges(&self) -> impl Iterator<Item = (u64, u64)> {
         self.intervals.iter().map(|(&s, &e)| (s, e))
     }

--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -174,7 +174,10 @@ impl<E: Storage + Metrics, V: Codec> Cache<E, V> {
         self.intervals.iter().next().map(|(&start, _)| start)
     }
 
-    /// Get up to the next `max` missing items after `start`.
+    /// Returns up to `max` missing items starting from `start`.
+    ///
+    /// This method iterates through gaps between existing ranges, collecting missing indices
+    /// until either `max` items are found or there are no more gaps to fill.
     pub fn missing_items(&self, start: u64, max: usize) -> Vec<u64> {
         self.intervals.missing_items(start, max)
     }

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -319,7 +319,10 @@ impl<E: Storage + Metrics + Clock, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         self.intervals.last_index()
     }
 
-    /// Get up to the next `max` missing items after `start`.
+    /// Returns up to `max` missing items starting from `start`.
+    ///
+    /// This method iterates through gaps between existing ranges, collecting missing indices
+    /// until either `max` items are found or there are no more gaps to fill.
     pub fn missing_items(&self, start: u64, max: usize) -> Vec<u64> {
         self.intervals.missing_items(start, max)
     }


### PR DESCRIPTION
## Overview

Fetches finalizations towards the beginning of the gap rather than the end. We'll still attempt to consult the cache towards the end of the next gap (in-case we can repair part of it,) but favor fetching finalizations towards the tip of the application.

closes #2279 