### PR TITLE
[consensus::simplex] Explicitly avoid nullify after finalize

### DIFF
--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -833,4 +833,30 @@ mod tests {
         round.replay(&Voter::Finalization(finalization));
         assert!(round.has_broadcast_finalization());
     }
+
+    #[test]
+    fn construct_nullify_blocked_by_finalize() {
+        let mut rng = StdRng::seed_from_u64(2029);
+        let Fixture { schemes, .. } = ed25519(&mut rng, 4);
+        let namespace = b"ns";
+        let local_scheme = schemes[0].clone();
+
+        // Setup round and proposal
+        let now = SystemTime::UNIX_EPOCH;
+        let view = 2;
+        let round_info = Rnd::new(Epoch::new(5), View::new(view));
+        let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([40u8; 32]));
+
+        // Create finalized vote
+        let finalize_local =
+            Finalize::sign(&local_scheme, namespace, proposal.clone()).expect("finalize");
+
+        // Replay finalize and verify nullify is blocked
+        let mut round = Round::new(local_scheme.clone(), round_info, now);
+        round.set_leader(None);
+        round.replay(&Voter::Finalize(finalize_local));
+
+        // Check that construct_nullify returns None
+        assert!(round.construct_nullify().is_none());
+    }
 }

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -214,19 +214,17 @@ impl<E: Clock + Rng + CryptoRng + Metrics, S: Scheme, D: Digest> State<E, S, D> 
 
         // Try to construct entry certificates for the previous view
         // Prefer the strongest proof available so lagging replicas can re-enter quickly.
-        if let Some(finalization) = self.finalization(entry_view).cloned() {
-            return (retry, nullify, Some(Voter::Finalization(finalization)));
-        }
-        if let Some(notarization) = self.notarization(entry_view).cloned() {
-            return (retry, nullify, Some(Voter::Notarization(notarization)));
-        }
-        if let Some(nullification) = self.nullification(entry_view).cloned() {
-            return (retry, nullify, Some(Voter::Nullification(nullification)));
-        }
-
-        // If we couldn't find any entry certificates, return the nullify
-        warn!(%entry_view, "entry certificate not found during timeout");
-        (retry, nullify, None)
+        let cert = if let Some(finalization) = self.finalization(entry_view).cloned() {
+            Some(Voter::Finalization(finalization))
+        } else if let Some(notarization) = self.notarization(entry_view).cloned() {
+            Some(Voter::Notarization(notarization))
+        } else if let Some(nullification) = self.nullification(entry_view).cloned() {
+            Some(Voter::Nullification(nullification))
+        } else {
+            warn!(%entry_view, "entry certificate not found during timeout");
+            None
+        };
+        (retry, nullify, cert)
     }
 
     /// Creates (if necessary) the round for this view and inserts the notarize vote.


### PR DESCRIPTION
Renamed function to more closely match `Round::construct_notarize()` and `Round::construct_finalize()`.
Fixes #2284 