### PR TITLE
[utils] Add `values_mut` to OrderedAssociated

### DIFF
--- a/utils/src/set.rs
+++ b/utils/src/set.rs
@@ -228,6 +228,11 @@ impl<K, V> OrderedAssociated<K, V> {
         &self.values
     }
 
+    /// Returns a mutable reference to the associated values
+    pub fn values_mut(&mut self) -> &mut [V] {
+        &mut self.values
+    }
+
     /// Returns a zipped iterator over keys and values.
     pub fn iter_pairs(&self) -> impl Iterator<Item = (&K, &V)> {
         self.keys.iter().zip(self.values.iter())
@@ -519,5 +524,14 @@ mod test {
             .collect();
         let keys = map.into_keys();
         assert_eq!(keys.iter().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_values_mut() {
+        let mut map: OrderedAssociated<u8, u8> = [(1, 10), (2, 20)].into_iter().collect();
+        for value in map.values_mut() {
+            *value += 1;
+        }
+        assert_eq!(map.values(), &[11, 21]);
     }
 }


### PR DESCRIPTION
Found this useful while doing some implementation in the new math crate, and this seems harmless to add.

This helps avoid allocation needlessly when doing things involving an ordered set, since you can safely mutate the values in place, without needing to create a new ordered associated set, which would further incur the penalty of resorting items.