### PR TITLE
[codec] fix IsUnit docs, remove stale DefaultExt reference

### DIFF
--- a/codec/src/extensions.rs
+++ b/codec/src/extensions.rs
@@ -24,7 +24,9 @@ impl<T: Read<Cfg = ()>> ReadExt for T {}
 
 /// Trait for types that are unit-like, i.e. have only one possible value.
 ///
-/// This is typically used to implement the `DefaultExt` trait for types that are unit-like.
+/// Used to mark configuration types that have a single sensible value and can be supplied via
+/// `Default` to extension traits like [DecodeExt], [ReadRangeExt], and [DecodeRangeExt] for
+/// ergonomic APIs when the configuration is uniquely determined.
 pub trait IsUnit: Default {}
 
 // Generate `IsUnit` implementations for types with only one possible value.


### PR DESCRIPTION
The IsUnit documentation in codec/src/extensions.rs referenced a non-existent DefaultExt trait. Full-repo search confirms there is no DefaultExt in the codebase or docs, and external search shows no relevant usage across Commonware repositories. The intended concept is captured by IsUnit, which marks configuration types with a single sensible value and is used directly by DecodeExt, ReadRangeExt, and DecodeRangeExt to pass Default configs for ergonomic APIs. This change updates the comment to accurately describe current behavior and removes the misleading reference.