### PR TITLE
[bitmap] pre-reserve capacity in From<[bool]> to avoid reallocations

### DIFF
--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -583,7 +583,7 @@ impl<const N: usize> Default for BitMap<N> {
 impl<T: AsRef<[bool]>, const N: usize> From<T> for BitMap<N> {
     fn from(t: T) -> Self {
         let bools = t.as_ref();
-        let mut bv = Self::new();
+        let mut bv = Self::with_capacity(bools.len() as u64);
         for &b in bools {
             bv.push(b);
         }


### PR DESCRIPTION
When constructing BitMap from a slice of bools we previously started from an empty bitmap and pushed bits one by one, which could trigger multiple re-allocations of the internal VecDeque for large inputs. This patch switches the constructor to call 
with_capacity(bools.len() as u64), which computes the exact number of chunks needed and reserves them up-front. This aligns the conversion path with other constructors (zeroes, ones, and read_cfg) that already pre-allocate, preserves all invariants and behavior, and reduces allocation churn for large boolean inputs.