### PR TITLE
[macros] avoid String clone on HashSet insert in load_nextest_groups

### DIFF
--- a/macros/src/nextest.rs
+++ b/macros/src/nextest.rs
@@ -89,13 +89,14 @@ fn load_nextest_groups() -> Result<NextestGroups, String> {
                 msg
             )
         })?;
-        if !names.insert(normalized.clone()) {
+        if names.contains(&normalized) {
             return Err(format!(
                 "duplicate normalized test group `{}` in {}",
                 normalized,
                 path.display()
             ));
         }
+        names.insert(normalized);
     }
 
     if names.is_empty() {


### PR DESCRIPTION
Removed unnecessary allocation by avoiding normalized.clone() when inserting into a HashSet during test group collection. Since HashSet::insert takes ownership, the previous code cloned the string to still use it in the duplicate error path. We now first check contains(&normalized) to format the error while retaining ownership and then insert(normalized) on the non-duplicate path. This preserves exact behavior and error messages, reduces allocations on the hot path, and trades it for an additional hash lookup which is negligible given the small expected number of test groups