### PR TITLE
[workspace] read nightly version in justfile from env

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         tool: just@1.43.0
     - name: Fmt
-      run: just check-fmt +${{ env.NIGHTLY_VERSION }}
+      run: just check-fmt
     - name: Lint
       run: just clippy ${{ matrix.flags }}
     - name: Check docs
@@ -168,7 +168,7 @@ jobs:
       with:
         tool: just@1.43.0,cargo-udeps@${{ env.UDEPS_VERSION }}
     - name: Check for unused dependencies
-      run: just udeps +${{ env.NIGHTLY_VERSION }}
+      run: just udeps
 
   Lock:
     runs-on: ubuntu-latest

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -134,7 +134,7 @@ jobs:
       with:
         tool: just@1.43.0
     - name: Test all targets
-      run: just fuzz ${{ matrix.fuzz_dir }} 60 +${{ env.NIGHTLY_VERSION }}
+      run: just fuzz ${{ matrix.fuzz_dir }} 60
 
   Unsafe:
     name: "Miri Tests (partition: ${{ matrix.partition }}/8)"

--- a/justfile
+++ b/justfile
@@ -1,5 +1,8 @@
 set positional-arguments := true
 
+env_nightly_version := env("NIGHTLY_VERSION", "nightly")
+nightly_version := if env_nightly_version != "" { "+" + env_nightly_version } else { "" }
+
 alias f := fix-fmt
 alias l := lint
 alias b := build
@@ -18,7 +21,7 @@ build *args='':
 pre-pr: lint test-docs test
 
 # Fixes the formatting of the workspace
-fix-fmt nightly_version='+nightly':
+fix-fmt:
     cargo {{ nightly_version }} fmt --all
 
 # Fixes the formatting of the `Cargo.toml` files in the workspace
@@ -26,7 +29,7 @@ fix-toml-fmt:
    find . -name Cargo.toml -type f -print0 | xargs -0 -n1 ./.github/scripts/lint_cargo_toml.py
 
 # Check the formatting of the workspace
-check-fmt nightly_version='+nightly':
+check-fmt:
     cargo {{ nightly_version }} fmt --all -- --check
 
 # Run clippy lints
@@ -53,14 +56,14 @@ check-docs *args='':
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items $@
 
 # Run all fuzz tests in a given directory
-fuzz fuzz_dir max_time='60' nightly_version='+nightly' max_mem='4000':
+fuzz fuzz_dir max_time='60' max_mem='4000':
     #!/usr/bin/env bash
     for target in $(cargo {{nightly_version}} fuzz list --fuzz-dir {{fuzz_dir}}); do
         cargo {{nightly_version}} fuzz run $target --fuzz-dir {{fuzz_dir}} -- -max_total_time={{max_time}} -rss_limit_mb={{max_mem}}
     done
 
 # Check for unused dependencies
-udeps nightly_version='+nightly':
+udeps:
     cargo {{ nightly_version }} udeps --all-targets
 
 # Run miri tests on a given module


### PR DESCRIPTION
Since I don't use rustup this allows me to completely override the usage of `+nightly` by just setting `NIGHTLY_VERSION=""` in my nix shell, which is something that I can't currently do for composite commands (like `lint` or `pre-pr`). This is the same env var that CI already uses.