### PR TITLE
[cryptography] Fix minor issues with FFI use

### DIFF
--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -266,6 +266,7 @@ impl Scalar {
         let mut ret = blst_fr::default();
 
         // SAFETY: blst_fr_from_uint64 reads exactly 4 u64 values from the buffer.
+        //
         // Reference: https://github.com/supranational/blst/blob/415d4f0e2347a794091836a3065206edfd9c72f3/bindings/blst.h#L102
         let buffer = [i, 0, 0, 0];
         unsafe { blst_fr_from_uint64(&mut ret, buffer.as_ptr()) };
@@ -767,8 +768,8 @@ impl Element for G2 {
     }
 
     fn mul(&mut self, rhs: &Scalar) {
-        let ptr = &raw mut self.0;
         let mut scalar = blst_scalar::default();
+        let ptr = &raw mut self.0;
         // SAFETY: blst_p2_mult supports in-place (ret==a). Using SCALAR_BITS (255) ensures
         // constant-time execution. Raw pointer avoids aliased refs.
         unsafe {

--- a/cryptography/src/bls12381/primitives/variant.rs
+++ b/cryptography/src/bls12381/primitives/variant.rs
@@ -88,8 +88,8 @@ impl Variant for MinPk {
         let p = public.as_blst_p1_affine();
         let q = hm.as_blst_p2_affine();
 
-        // SAFETY: raw_aggregate takes (G2, G1) affine points; both are valid and in correct groups.
         // Aggregate `e(hm,pk)`
+        // SAFETY: raw_aggregate takes (G2, G1) affine points; both are valid and in correct groups.
         pairing.raw_aggregate(&q, &p);
 
         // Finalize the pairing accumulation and verify the result


### PR DESCRIPTION
I noticed that in a few places, we were doing:

```
  ffi_call(&mut x, &x)
```

which is a classic subtle undefined behavior in Rust, which is difficult to actually trigger, but can bite you unexpectedly as the compiler advances.

I added `&raw mut` pattern to avoid aliased references in all in-place operations (Scalar add/sub/mul, G1/G2 add/mul, pairing final_exp), and I spelunked with Claude through the blst code to make sure that in place operations were actually sound.

It also suggested the following changes, which seemed good to me:

- Replace raw memory copy in GT::as_slice() with blst_bendian_from_fp12 for portable canonical serialization
- Add assert for MSM scratch buffer size alignment
- Add SAFETY comments documenting FFI contracts throughout