### PR TITLE
[storage/adb/operation] require Clone for operation values

### DIFF
--- a/storage/src/adb/any/ordered/fixed.rs
+++ b/storage/src/adb/any/ordered/fixed.rs
@@ -11,7 +11,10 @@ use crate::{
             ordered::{IndexedLog, Operation as OperationTrait},
             FixedConfig as Config,
         },
-        operation::{fixed::ordered::Operation, KeyData},
+        operation::{
+            fixed::{ordered::Operation, Value},
+            KeyData,
+        },
         Error,
     },
     index::ordered::Index,
@@ -19,12 +22,11 @@ use crate::{
     mmr::{mem::Clean, Location},
     translator::Translator,
 };
-use commonware_codec::CodecFixed;
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_utils::Array;
 
-impl<K: Array, V: CodecFixed<Cfg = ()>> OperationTrait for Operation<K, V> {
+impl<K: Array, V: Value> OperationTrait for Operation<K, V> {
     fn new_update(key: K, value: V, next_key: K) -> Self {
         Self::Update(KeyData {
             key,
@@ -47,7 +49,7 @@ impl<K: Array, V: CodecFixed<Cfg = ()>> OperationTrait for Operation<K, V> {
 pub type Any<E, K, V, H, T, S = Clean<DigestOf<H>>> =
     IndexedLog<E, Journal<E, Operation<K, V>>, Index<T, Location>, H, S>;
 
-impl<E: Storage + Clock + Metrics, K: Array, V: CodecFixed<Cfg = ()>, H: Hasher, T: Translator>
+impl<E: Storage + Clock + Metrics, K: Array, V: Value, H: Hasher, T: Translator>
     Any<E, K, V, H, T>
 {
     /// Returns an [Any] adb initialized from `cfg`. Any uncommitted log operations will be

--- a/storage/src/adb/any/ordered/variable.rs
+++ b/storage/src/adb/any/ordered/variable.rs
@@ -11,7 +11,10 @@ use crate::{
             ordered::{IndexedLog, Operation as OperationTrait},
             VariableConfig,
         },
-        operation::{variable::ordered::Operation, Committable as _, KeyData},
+        operation::{
+            variable::{ordered::Operation, Value},
+            Committable as _, KeyData,
+        },
         Error,
     },
     index::ordered::Index,
@@ -22,12 +25,12 @@ use crate::{
     mmr::{journaled::Config as MmrConfig, mem::Clean, Location},
     translator::Translator,
 };
-use commonware_codec::{Codec, Read};
+use commonware_codec::Read;
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_utils::Array;
 
-impl<K: Array, V: Codec> OperationTrait for Operation<K, V> {
+impl<K: Array, V: Value> OperationTrait for Operation<K, V> {
     fn new_update(key: K, value: V, next_key: K) -> Self {
         Self::Update(KeyData {
             key,
@@ -50,7 +53,7 @@ impl<K: Array, V: Codec> OperationTrait for Operation<K, V> {
 pub type Any<E, K, V, H, T, S = Clean<DigestOf<H>>> =
     IndexedLog<E, Journal<E, Operation<K, V>>, Index<T, Location>, H, S>;
 
-impl<E: Storage + Clock + Metrics, K: Array, V: Codec, H: Hasher, T: Translator>
+impl<E: Storage + Clock + Metrics, K: Array, V: Value, H: Hasher, T: Translator>
     Any<E, K, V, H, T>
 {
     /// Returns an [Any] adb initialized from `cfg`. Any uncommitted log operations will be

--- a/storage/src/adb/any/unordered/fixed.rs
+++ b/storage/src/adb/any/unordered/fixed.rs
@@ -7,7 +7,7 @@ use crate::{
             unordered::{IndexedLog, Operation as OperationTrait},
             FixedConfig as Config,
         },
-        operation::fixed::unordered::Operation,
+        operation::fixed::{unordered::Operation, Value},
         Error,
     },
     index::unordered::Index,
@@ -15,12 +15,11 @@ use crate::{
     mmr::{mem::Clean, Location},
     translator::Translator,
 };
-use commonware_codec::CodecFixed;
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_utils::Array;
 
-impl<K: Array, V: CodecFixed<Cfg = ()>> OperationTrait for Operation<K, V> {
+impl<K: Array, V: Value> OperationTrait for Operation<K, V> {
     fn new_update(key: K, value: V) -> Self {
         Self::Update(key, value)
     }
@@ -39,7 +38,7 @@ impl<K: Array, V: CodecFixed<Cfg = ()>> OperationTrait for Operation<K, V> {
 pub type Any<E, K, V, H, T, S = Clean<DigestOf<H>>> =
     IndexedLog<E, Journal<E, Operation<K, V>>, Index<T, Location>, H, S>;
 
-impl<E: Storage + Clock + Metrics, K: Array, V: CodecFixed<Cfg = ()>, H: Hasher, T: Translator>
+impl<E: Storage + Clock + Metrics, K: Array, V: Value, H: Hasher, T: Translator>
     Any<E, K, V, H, T>
 {
     /// Returns an [Any] adb initialized from `cfg`. Any uncommitted log operations will be

--- a/storage/src/adb/any/unordered/sync.rs
+++ b/storage/src/adb/any/unordered/sync.rs
@@ -3,7 +3,7 @@ use crate::{
     adb::{
         self,
         any::{unordered::fixed::Any, AnyDb},
-        operation::fixed::unordered::Operation,
+        operation::fixed::{unordered::Operation, Value},
     },
     index::unordered::Index,
     journal::{authenticated, contiguous::fixed},
@@ -24,7 +24,7 @@ impl<E, K, V, H, T> adb::sync::Database for Any<E, K, V, H, T>
 where
     E: Storage + Clock + Metrics,
     K: Array,
-    V: CodecFixed<Cfg = ()>,
+    V: Value,
     H: Hasher,
     T: Translator,
 {

--- a/storage/src/adb/any/unordered/variable.rs
+++ b/storage/src/adb/any/unordered/variable.rs
@@ -10,7 +10,10 @@ use crate::{
             unordered::{IndexedLog, Operation as OperationTrait},
             VariableConfig,
         },
-        operation::{variable::unordered::Operation, Committable as _},
+        operation::{
+            variable::{unordered::Operation, Value},
+            Committable as _,
+        },
         Error,
     },
     index::unordered::Index,
@@ -21,12 +24,12 @@ use crate::{
     mmr::{journaled::Config as MmrConfig, mem::Clean, Location},
     translator::Translator,
 };
-use commonware_codec::{Codec, Read};
+use commonware_codec::Read;
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_utils::Array;
 
-impl<K: Array, V: Codec> OperationTrait for Operation<K, V> {
+impl<K: Array, V: Value> OperationTrait for Operation<K, V> {
     fn new_update(key: K, value: V) -> Self {
         Self::Update(key, value)
     }
@@ -45,7 +48,7 @@ impl<K: Array, V: Codec> OperationTrait for Operation<K, V> {
 pub type Any<E, K, V, H, T, S = Clean<DigestOf<H>>> =
     IndexedLog<E, Journal<E, Operation<K, V>>, Index<T, Location>, H, S>;
 
-impl<E: Storage + Clock + Metrics, K: Array, V: Codec, H: Hasher, T: Translator>
+impl<E: Storage + Clock + Metrics, K: Array, V: Value, H: Hasher, T: Translator>
     Any<E, K, V, H, T>
 {
     /// Returns an [Any] adb initialized from `cfg`. Any uncommitted log operations will be

--- a/storage/src/adb/current/mod.rs
+++ b/storage/src/adb/current/mod.rs
@@ -5,7 +5,7 @@
 //! "grafted" together to minimize proof sizes.
 
 use crate::{
-    adb::{any::FixedConfig as AConfig, operation::Keyed, Error},
+    adb::{any::FixedConfig as AConfig, Error, Keyed},
     journal::contiguous::Contiguous,
     mmr::{
         grafting::{Hasher as GraftingHasher, Storage as GraftingStorage, Verifier},

--- a/storage/src/adb/current/ordered.rs
+++ b/storage/src/adb/current/ordered.rs
@@ -5,7 +5,10 @@ use crate::{
     adb::{
         any::{ordered::fixed::Any, AnyDb as _},
         current::{merkleize_grafted_bitmap, verify_key_value_proof, verify_range_proof, Config},
-        operation::{fixed::ordered::Operation, Committable as _, KeyData, Keyed as _},
+        operation::{
+            fixed::{ordered::Operation, Value},
+            Committable as _, KeyData, Keyed as _,
+        },
         store::Db,
         Error,
     },
@@ -17,7 +20,7 @@ use crate::{
     translator::Translator,
     AuthenticatedBitMap as BitMap,
 };
-use commonware_codec::{CodecFixed, FixedSize};
+use commonware_codec::FixedSize;
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage as RStorage};
 use commonware_utils::Array;
@@ -33,7 +36,7 @@ use std::num::NonZeroU64;
 pub struct Current<
     E: RStorage + Clock + Metrics,
     K: Array,
-    V: CodecFixed<Cfg = ()>,
+    V: Value,
     H: Hasher,
     T: Translator,
     const N: usize,
@@ -54,7 +57,7 @@ pub struct Current<
 
 /// The information required to verify a key value proof from a Current adb.
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub struct KeyValueProofInfo<K: Array, V: CodecFixed<Cfg = ()>, const N: usize> {
+pub struct KeyValueProofInfo<K: Array, V: Value, const N: usize> {
     /// The key whose value is being proven.
     pub key: K,
 
@@ -73,7 +76,7 @@ pub struct KeyValueProofInfo<K: Array, V: CodecFixed<Cfg = ()>, const N: usize> 
 
 // The information required to verify an exclusion proof.
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub enum ExclusionProofInfo<K: Array, V: CodecFixed<Cfg = ()>, const N: usize> {
+pub enum ExclusionProofInfo<K: Array, V: Value, const N: usize> {
     /// For the KeyValue variant, we're proving that a span over the keyspace exists in the
     /// database, allowing one to prove any key falling within that span (but not at the beginning)
     /// is excluded.
@@ -93,7 +96,7 @@ pub enum ExclusionProofInfo<K: Array, V: CodecFixed<Cfg = ()>, const N: usize> {
 impl<
         E: RStorage + Clock + Metrics,
         K: Array,
-        V: CodecFixed<Cfg = ()>,
+        V: Value,
         H: Hasher,
         T: Translator,
         const N: usize,
@@ -512,7 +515,7 @@ impl<
 impl<
         E: RStorage + Clock + Metrics,
         K: Array,
-        V: CodecFixed<Cfg = ()>,
+        V: Value,
         H: Hasher,
         T: Translator,
         const N: usize,

--- a/storage/src/adb/current/unordered.rs
+++ b/storage/src/adb/current/unordered.rs
@@ -6,7 +6,10 @@ use crate::{
     adb::{
         any::unordered::fixed::Any,
         current::{merkleize_grafted_bitmap, verify_key_value_proof, verify_range_proof, Config},
-        operation::{fixed::unordered::Operation, Keyed as _},
+        operation::{
+            fixed::{unordered::Operation, Value},
+            Keyed as _,
+        },
         store::Db,
         Error,
     },
@@ -18,7 +21,7 @@ use crate::{
     translator::Translator,
     AuthenticatedBitMap as BitMap,
 };
-use commonware_codec::{CodecFixed, FixedSize};
+use commonware_codec::FixedSize;
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage as RStorage};
 use commonware_utils::Array;
@@ -34,7 +37,7 @@ use std::num::NonZeroU64;
 pub struct Current<
     E: RStorage + Clock + Metrics,
     K: Array,
-    V: CodecFixed<Cfg = ()>,
+    V: Value,
     H: Hasher,
     T: Translator,
     const N: usize,
@@ -55,7 +58,7 @@ pub struct Current<
 
 /// The information required to verify a key value proof from a Current adb.
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub struct KeyValueProofInfo<K: Array, V: CodecFixed<Cfg = ()>, const N: usize> {
+pub struct KeyValueProofInfo<K: Array, V: Value, const N: usize> {
     /// The key whose value is being proven.
     pub key: K,
 
@@ -72,7 +75,7 @@ pub struct KeyValueProofInfo<K: Array, V: CodecFixed<Cfg = ()>, const N: usize> 
 impl<
         E: RStorage + Clock + Metrics,
         K: Array,
-        V: CodecFixed<Cfg = ()>,
+        V: Value,
         H: Hasher,
         T: Translator,
         const N: usize,
@@ -340,7 +343,7 @@ impl<
 impl<
         E: RStorage + Clock + Metrics,
         K: Array,
-        V: CodecFixed<Cfg = ()>,
+        V: Value,
         H: Hasher,
         T: Translator,
         const N: usize,

--- a/storage/src/adb/immutable/mod.rs
+++ b/storage/src/adb/immutable/mod.rs
@@ -2,7 +2,11 @@
 //! deletions), where values can have varying sizes.
 
 use crate::{
-    adb::{build_snapshot_from_log, operation::variable::immutable::Operation, Error},
+    adb::{
+        build_snapshot_from_log,
+        operation::variable::{immutable::Operation, Value},
+        Error,
+    },
     index::{unordered::Index, Unordered as _},
     journal::{
         authenticated,
@@ -15,7 +19,7 @@ use crate::{
     },
     translator::Translator,
 };
-use commonware_codec::{Codec, Read};
+use commonware_codec::Read;
 use commonware_cryptography::{DigestOf, Hasher as CHasher};
 use commonware_runtime::{buffer::PoolRef, Clock, Metrics, Storage as RStorage, ThreadPool};
 use commonware_utils::Array;
@@ -71,7 +75,7 @@ pub struct Config<T: Translator, C> {
 pub struct Immutable<
     E: RStorage + Clock + Metrics,
     K: Array,
-    V: Codec,
+    V: Value,
     H: CHasher,
     T: Translator,
     S: State<DigestOf<H>> = Clean<DigestOf<H>>,
@@ -93,7 +97,7 @@ pub struct Immutable<
 impl<
         E: RStorage + Clock + Metrics,
         K: Array,
-        V: Codec,
+        V: Value,
         H: CHasher,
         T: Translator,
         S: State<DigestOf<H>>,
@@ -172,7 +176,7 @@ impl<
     }
 }
 
-impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translator>
+impl<E: RStorage + Clock + Metrics, K: Array, V: Value, H: CHasher, T: Translator>
     Immutable<E, K, V, H, T, Clean<H::Digest>>
 {
     /// Returns an [Immutable] adb initialized from `cfg`. Any uncommitted log operations will be
@@ -435,7 +439,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translato
     }
 }
 
-impl<E: RStorage + Clock + Metrics, K: Array, V: Codec, H: CHasher, T: Translator>
+impl<E: RStorage + Clock + Metrics, K: Array, V: Value, H: CHasher, T: Translator>
     Immutable<E, K, V, H, T, Dirty>
 {
     /// Merkleize the database and compute the root digest.

--- a/storage/src/adb/immutable/sync/mod.rs
+++ b/storage/src/adb/immutable/sync/mod.rs
@@ -1,10 +1,13 @@
 use crate::{
-    adb::{immutable, operation::variable::immutable::Operation, sync, Error},
+    adb::{
+        immutable,
+        operation::variable::{immutable::Operation, Value},
+        sync, Error,
+    },
     journal::contiguous::variable,
     mmr::Location,
     translator::Translator,
 };
-use commonware_codec::Codec;
 use commonware_cryptography::Hasher;
 use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_utils::Array;
@@ -14,7 +17,7 @@ impl<E, K, V, H, T> sync::Database for immutable::Immutable<E, K, V, H, T>
 where
     E: Storage + Clock + Metrics,
     K: Array,
-    V: Codec,
+    V: Value,
     H: Hasher,
     T: Translator,
 {
@@ -120,7 +123,7 @@ pub struct Config<E, K, V, T, D, C>
 where
     E: Storage + Metrics,
     K: Array,
-    V: Codec,
+    V: Value,
     T: Translator,
     D: commonware_cryptography::Digest,
 {

--- a/storage/src/adb/keyless.rs
+++ b/storage/src/adb/keyless.rs
@@ -9,7 +9,10 @@
 
 use crate::{
     adb::{
-        operation::{variable::keyless::Operation, Committable},
+        operation::{
+            variable::{keyless::Operation, Value},
+            Committable,
+        },
         Error,
     },
     journal::{
@@ -22,7 +25,6 @@ use crate::{
         Location, Proof,
     },
 };
-use commonware_codec::Codec;
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{buffer::PoolRef, Clock, Metrics, Storage, ThreadPool};
 use std::num::{NonZeroU64, NonZeroUsize};
@@ -68,7 +70,7 @@ pub struct Config<C> {
 /// A keyless ADB for variable length data.
 type Journal<E, V, H, S> = authenticated::Journal<E, ContiguousJournal<E, Operation<V>>, H, S>;
 
-pub struct Keyless<E: Storage + Clock + Metrics, V: Codec, H: Hasher, S: State<DigestOf<H>> = Dirty>
+pub struct Keyless<E: Storage + Clock + Metrics, V: Value, H: Hasher, S: State<DigestOf<H>> = Dirty>
 {
     /// Authenticated journal of operations.
     journal: Journal<E, V, H, S>,
@@ -77,7 +79,7 @@ pub struct Keyless<E: Storage + Clock + Metrics, V: Codec, H: Hasher, S: State<D
     last_commit_loc: Option<Location>,
 }
 
-impl<E: Storage + Clock + Metrics, V: Codec, H: Hasher, S: State<DigestOf<H>>> Keyless<E, V, H, S> {
+impl<E: Storage + Clock + Metrics, V: Value, H: Hasher, S: State<DigestOf<H>>> Keyless<E, V, H, S> {
     /// Get the value at location `loc` in the database.
     ///
     /// # Errors
@@ -136,7 +138,7 @@ impl<E: Storage + Clock + Metrics, V: Codec, H: Hasher, S: State<DigestOf<H>>> K
     }
 }
 
-impl<E: Storage + Clock + Metrics, V: Codec, H: Hasher> Keyless<E, V, H, Clean<H::Digest>> {
+impl<E: Storage + Clock + Metrics, V: Value, H: Hasher> Keyless<E, V, H, Clean<H::Digest>> {
     /// Returns a [Keyless] adb initialized from `cfg`. Any uncommitted operations will be discarded
     /// and the state of the db will be as of the last committed operation.
     pub async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {

--- a/storage/src/adb/operation/fixed/mod.rs
+++ b/storage/src/adb/operation/fixed/mod.rs
@@ -1,8 +1,12 @@
 use bytes::Buf;
-use commonware_codec::{Error as CodecError, ReadExt};
+use commonware_codec::{CodecFixed, Error as CodecError, ReadExt as _};
 
 pub mod ordered;
 pub mod unordered;
+
+pub trait Value: CodecFixed<Cfg = ()> + Clone {}
+
+impl<T: CodecFixed<Cfg = ()> + Clone> Value for T {}
 
 /// Ensures the next `size` bytes are all zeroes in the provided buffer, returning a [CodecError]
 /// otherwise.

--- a/storage/src/adb/operation/variable/mod.rs
+++ b/storage/src/adb/operation/variable/mod.rs
@@ -1,4 +1,10 @@
+use commonware_codec::Codec;
+
 pub mod immutable;
 pub mod keyless;
 pub mod ordered;
 pub mod unordered;
+
+pub trait Value: Codec + Clone {}
+
+impl<T: Codec + Clone> Value for T {}

--- a/storage/src/adb/store/mod.rs
+++ b/storage/src/adb/store/mod.rs
@@ -86,7 +86,10 @@
 use crate::{
     adb::{
         build_snapshot_from_log, create_key, delete_key,
-        operation::{variable::unordered::Operation, Committable as _, Keyed as _},
+        operation::{
+            variable::{unordered::Operation, Value},
+            Committable as _, Keyed as _,
+        },
         update_key, Error, FloorHelper,
     },
     index::{unordered::Index, Unordered as _},
@@ -220,7 +223,7 @@ pub struct Store<E, K, V, T>
 where
     E: RStorage + Clock + Metrics,
     K: Array,
-    V: Codec,
+    V: Value,
     T: Translator,
 {
     /// A log of all [Operation]s that have been applied to the store.
@@ -257,7 +260,7 @@ impl<E, K, V, T> Store<E, K, V, T>
 where
     E: RStorage + Clock + Metrics,
     K: Array,
-    V: Codec,
+    V: Value,
     T: Translator,
 {
     /// Initializes a new [`Store`] database with the given configuration.
@@ -362,7 +365,7 @@ impl<E, K, V, T> Db<K, V> for Store<E, K, V, T>
 where
     E: RStorage + Clock + Metrics,
     K: Array,
-    V: Codec,
+    V: Value,
     T: Translator,
 {
     fn op_count(&self) -> Location {

--- a/storage/src/adb/sync/resolver.rs
+++ b/storage/src/adb/sync/resolver.rs
@@ -4,13 +4,13 @@ use crate::{
         any::{unordered::fixed::Any, AnyDb},
         immutable::Immutable,
         operation::{
-            fixed::unordered::Operation as Fixed, variable::immutable::Operation as ImmutableOp,
+            fixed::{unordered::Operation as Fixed, Value as FixedValue},
+            variable::{immutable::Operation as ImmutableOp, Value as VariableValue},
         },
     },
     mmr::{Location, Proof},
     translator::Translator,
 };
-use commonware_codec::CodecFixed;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_runtime::{Clock, Metrics, RwLock, Storage};
 use commonware_utils::Array;
@@ -64,7 +64,7 @@ impl<E, K, V, H, T> Resolver for Arc<Any<E, K, V, H, T>>
 where
     E: Storage + Clock + Metrics,
     K: Array,
-    V: CodecFixed<Cfg = ()> + Send + Sync + 'static,
+    V: FixedValue + Send + Sync + 'static,
     H: Hasher,
     T: Translator + Send + Sync + 'static,
     T::Key: Send + Sync,
@@ -96,7 +96,7 @@ impl<E, K, V, H, T> Resolver for Arc<RwLock<Any<E, K, V, H, T>>>
 where
     E: Storage + Clock + Metrics,
     K: Array,
-    V: CodecFixed<Cfg = ()> + Send + Sync + 'static,
+    V: FixedValue + Send + Sync + 'static,
     H: Hasher,
     T: Translator + Send + Sync + 'static,
     T::Key: Send + Sync,
@@ -127,7 +127,7 @@ impl<E, K, V, H, T> Resolver for Arc<Immutable<E, K, V, H, T>>
 where
     E: Storage + Clock + Metrics,
     K: Array,
-    V: commonware_codec::Codec + Send + Sync + 'static,
+    V: VariableValue + Send + Sync + 'static,
     H: Hasher,
     T: Translator + Send + Sync + 'static,
     T::Key: Send + Sync,
@@ -159,7 +159,7 @@ impl<E, K, V, H, T> Resolver for Arc<RwLock<Immutable<E, K, V, H, T>>>
 where
     E: Storage + Clock + Metrics,
     K: Array,
-    V: commonware_codec::Codec + Send + Sync + 'static,
+    V: VariableValue + Send + Sync + 'static,
     H: Hasher,
     T: Translator + Send + Sync + 'static,
     T::Key: Send + Sync,
@@ -202,7 +202,7 @@ pub(crate) mod tests {
     where
         D: Digest,
         K: Array,
-        V: CodecFixed<Cfg = ()> + Clone + Send + Sync + 'static,
+        V: FixedValue + Clone + Send + Sync + 'static,
     {
         type Digest = D;
         type Op = Fixed<K, V>;

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -383,7 +383,7 @@ const APPLY_BATCH_SIZE: u64 = 1 << 16;
 impl<E, O, H> Journal<E, fixed::Journal<E, O>, H, Clean<H::Digest>>
 where
     E: Storage + Clock + Metrics,
-    O: CodecFixed<Cfg = ()> + Encode,
+    O: CodecFixed<Cfg = ()>,
     H: Hasher,
 {
     /// Create a new [Journal] for fixed-length operations.

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -60,7 +60,7 @@ use crate::journal::{
     Error,
 };
 use bytes::BufMut;
-use commonware_codec::{CodecFixed, DecodeExt, FixedSize};
+use commonware_codec::{CodecFixed, DecodeExt as _, FixedSize};
 use commonware_runtime::{
     buffer::{Append, PoolRef, Read},
     telemetry::metrics::status::GaugeExt,
@@ -100,7 +100,7 @@ pub struct Config {
 }
 
 /// Implementation of `Journal` storage.
-pub struct Journal<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> {
+pub struct Journal<E: Storage + Metrics, A: CodecFixed> {
     pub(crate) context: E,
     pub(crate) cfg: Config,
 


### PR DESCRIPTION
Clone is required for values in the Batchable trait which should be implemented by all adbs, so we may as well require it for all values.

For convenience, added two `Value` traits for fixed & variable sized values respectively which specialize Codec[Fixed] + Clone, and changes the various implementations to use them.