### PR TITLE
[Storage] avoid extra copy in create_proof_store

### DIFF
--- a/storage/src/adb/verify.rs
+++ b/storage/src/adb/verify.rs
@@ -105,7 +105,7 @@ where
     D: Digest,
 {
     // Encode operations for verification
-    let elements: Vec<Vec<u8>> = operations.iter().map(|op| op.encode().to_vec()).collect();
+    let elements = operations.iter().map(|op| op.encode()).collect::<Vec<_>>();
 
     // Create ProofStore by verifying the proof and extracting all digests
     ProofStore::new(hasher, proof, &elements, start_loc, root)


### PR DESCRIPTION
 Replace encode().to_vec() with encode() when preparing elements for ProofStore::new. ProofStore::new only needs AsRef<[u8]>, and Encode::encode() returns BytesMut which qualifies. This eliminates unnecessary allocations and copies per operation and aligns with how verify_proof and verify_proof_and_extract_digests already pass elements.