### PR TITLE
Add new clippy lints and fix all warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,11 @@ semicolon_if_nothing_returned = "warn"
 match_same_arms = "warn"
 flat_map_option = "warn"
 inconsistent_struct_constructor = "warn"
+map_unwrap_or = "warn"
+implicit_clone = "warn"
+cloned_instead_of_copied = "warn"
+inefficient_to_string = "warn"
+trivially_copy_pass_by_ref = "warn"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.99", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,11 @@ use-self = "warn"
 redundant-clone = "warn"
 option-if-let-else = "warn"
 undocumented_unsafe_blocks = "deny"
+manual_let_else = "warn"
+semicolon_if_nothing_returned = "warn"
+match_same_arms = "warn"
+flat_map_option = "warn"
+inconsistent_struct_constructor = "warn"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.99", default-features = false }

--- a/codec/src/types/vec.rs
+++ b/codec/src/types/vec.rs
@@ -11,7 +11,7 @@ use bytes::{Buf, BufMut};
 impl<T: Write> Write for Vec<T> {
     #[inline]
     fn write(&self, buf: &mut impl BufMut) {
-        self.as_slice().write(buf)
+        self.as_slice().write(buf);
     }
 }
 

--- a/coding/src/field.rs
+++ b/coding/src/field.rs
@@ -18,7 +18,7 @@ impl FixedSize for F {
 
 impl Write for F {
     fn write(&self, buf: &mut impl bytes::BufMut) {
-        self.0.write(buf)
+        self.0.write(buf);
     }
 }
 
@@ -463,7 +463,7 @@ mod test {
 
         #[test]
         fn test_div2(x in any_f()) {
-            assert_eq!((x + x).div_2(), x)
+            assert_eq!((x + x).div_2(), x);
         }
 
         #[test]

--- a/coding/src/no_coding.rs
+++ b/coding/src/no_coding.rs
@@ -38,7 +38,7 @@ impl EncodeSize for Shard {
 
 impl Write for Shard {
     fn write(&self, buf: &mut impl bytes::BufMut) {
-        self.0.write(buf)
+        self.0.write(buf);
     }
 }
 

--- a/coding/src/poly.rs
+++ b/coding/src/poly.rs
@@ -274,7 +274,7 @@ impl Matrix {
                 let c = self[(i, j)];
                 let other_j = &other[j];
                 for k in 0..other.cols {
-                    out[(i, k)] = out[(i, k)] + c * other_j[k]
+                    out[(i, k)] = out[(i, k)] + c * other_j[k];
                 }
             }
         }
@@ -282,7 +282,7 @@ impl Matrix {
     }
 
     fn ntt<const FORWARD: bool>(&mut self) {
-        ntt::<FORWARD, Self>(self.rows, self.cols, self)
+        ntt::<FORWARD, Self>(self.rows, self.cols, self);
     }
 
     pub const fn rows(&self) -> usize {
@@ -531,9 +531,9 @@ impl Polynomial {
                         ntt::<true, _>(new_polynomial_size, 1, &mut Column { data: &mut scratch });
                         ntt::<true, _>(new_polynomial_size, 1, &mut Column { data: slice });
                         for (s_i, p_i) in scratch.drain(..).zip(slice.iter_mut()) {
-                            *p_i = *p_i * s_i
+                            *p_i = *p_i * s_i;
                         }
-                        ntt::<false, _>(new_polynomial_size, 1, &mut Column { data: slice })
+                        ntt::<false, _>(new_polynomial_size, 1, &mut Column { data: slice });
                     }
                 }
                 // If there was a polynomial on the left or the right, then on the next iteration
@@ -1024,7 +1024,7 @@ mod test {
             data: vec![F::one()],
             present: vec![false, true].into(),
         }
-        .test()
+        .test();
     }
 
     proptest! {

--- a/coding/src/reed_solomon/mod.rs
+++ b/coding/src/reed_solomon/mod.rs
@@ -858,6 +858,6 @@ mod tests {
             [].as_slice(),
             CONCURRENCY,
         )
-        .is_err())
+        .is_err());
     }
 }

--- a/coding/src/reed_solomon/mod.rs
+++ b/coding/src/reed_solomon/mod.rs
@@ -34,7 +34,7 @@ pub enum Error {
     TooManyTotalShards(u32),
 }
 
-fn total_shards(config: &Config) -> Result<u16, Error> {
+fn total_shards(config: Config) -> Result<u16, Error> {
     let total = config.total_shards();
     total
         .try_into()
@@ -508,7 +508,7 @@ impl<H: Hasher> Scheme for ReedSolomon<H> {
     ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error> {
         let data: Vec<u8> = data.copy_to_bytes(data.remaining()).to_vec();
         encode(
-            total_shards(config)?,
+            total_shards(*config)?,
             config.minimum_shards,
             data,
             concurrency,
@@ -555,7 +555,7 @@ impl<H: Hasher> Scheme for ReedSolomon<H> {
         concurrency: usize,
     ) -> Result<Vec<u8>, Self::Error> {
         decode(
-            total_shards(config)?,
+            total_shards(*config)?,
             config.minimum_shards,
             commitment,
             shards,

--- a/coding/src/zoda.rs
+++ b/coding/src/zoda.rs
@@ -261,7 +261,7 @@ mod topology {
         }
 
         /// Figure out what size different values will have, based on the config and the data.
-        pub fn reckon(config: &Config, data_bytes: usize) -> Self {
+        pub fn reckon(config: Config, data_bytes: usize) -> Self {
             let n = config.minimum_shards as usize;
             let k = config.extra_shards as usize;
             // The following calculations don't tolerate data_bytes = 0, so we
@@ -465,7 +465,7 @@ impl<H: Hasher> CheckingData<H> {
     ///
     /// We're also give a `checksum` matrix used to check the shards we receive.
     fn reckon(
-        config: &Config,
+        config: Config,
         commitment: &Summary,
         data_bytes: usize,
         root: H::Digest,
@@ -587,7 +587,7 @@ impl<H: Hasher> Scheme for Zoda<H> {
     ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error> {
         // Step 1: arrange the data as a matrix.
         let data_bytes = data.remaining();
-        let topology = Topology::reckon(config, data_bytes);
+        let topology = Topology::reckon(*config, data_bytes);
         let data = Matrix::init(
             topology.data_rows,
             topology.data_cols,
@@ -678,7 +678,7 @@ impl<H: Hasher> Scheme for Zoda<H> {
             shard: shard.rows,
         };
         let checking_data = CheckingData::reckon(
-            config,
+            *config,
             commitment,
             shard.data_bytes,
             shard.root,
@@ -760,7 +760,7 @@ mod tests {
             minimum_shards: 3,
             extra_shards: 1,
         };
-        let topology = Topology::reckon(&config, 16);
+        let topology = Topology::reckon(config, 16);
         assert_eq!(topology.min_shards, 3);
         assert_eq!(topology.total_shards, 4);
 

--- a/consensus/src/aggregation/mocks/reporter.rs
+++ b/consensus/src/aggregation/mocks/reporter.rs
@@ -129,7 +129,7 @@ impl<V: Variant, D: Digest> Reporter<V, D> {
                     }
 
                     // Update the highest contiguous height
-                    let mut next_contiguous = self.contiguous.map(|c| c + 1).unwrap_or(0);
+                    let mut next_contiguous = self.contiguous.map_or(0, |c| c + 1);
                     while self.digests.contains_key(&next_contiguous) {
                         next_contiguous += 1;
                     }
@@ -149,7 +149,7 @@ impl<V: Variant, D: Digest> Reporter<V, D> {
                     sender.send(self.contiguous).unwrap();
                 }
                 Message::Get(index, sender) => {
-                    let digest = self.digests.get(&index).cloned();
+                    let digest = self.digests.get(&index).copied();
                     sender.send(digest).unwrap();
                 }
             }

--- a/consensus/src/aggregation/mocks/supervisor.rs
+++ b/consensus/src/aggregation/mocks/supervisor.rs
@@ -66,7 +66,7 @@ impl<P: PublicKey, V: Variant> S for Supervisor<P, V> {
     }
 
     fn is_participant(&self, epoch: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {
-        self.validators_maps.get(&epoch)?.get(candidate).cloned()
+        self.validators_maps.get(&epoch)?.get(candidate).copied()
     }
 }
 

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -493,7 +493,7 @@ mod tests {
                                 Epoch::new(111),
                                 share.clone(),
                                 polynomial.clone(),
-                                pks.to_vec(),
+                                pks.clone(),
                             );
                             s
                         };
@@ -655,7 +655,7 @@ mod tests {
                             Epoch::new(111),
                             share.clone(),
                             polynomial_clone.clone(),
-                            pks.to_vec(),
+                            pks.clone(),
                         );
                         s
                     };
@@ -744,7 +744,7 @@ mod tests {
                             Epoch::new(111),
                             share.clone(),
                             polynomial.clone(),
-                            pks.to_vec(),
+                            pks.clone(),
                         );
                         s
                     };
@@ -1056,7 +1056,7 @@ mod tests {
                         Epoch::new(111),
                         share.clone(),
                         polynomial.clone(),
-                        pks.to_vec(),
+                        pks.clone(),
                     );
                     s
                 };

--- a/consensus/src/application/marshaled.rs
+++ b/consensus/src/application/marshaled.rs
@@ -467,7 +467,7 @@ where
 
     /// Relays a report to the underlying [Application].
     async fn report(&mut self, update: Self::Activity) {
-        self.application.report(update).await
+        self.application.report(update).await;
     }
 }
 

--- a/consensus/src/marshal/actor.rs
+++ b/consensus/src/marshal/actor.rs
@@ -960,7 +960,7 @@ where
             // Compute the lower bound of the recursive repair. `gap_start` is `Some`
             // if `start` is not in a gap. We add one to it to ensure we don't
             // re-persist it to the database in the repair loop below.
-            let gap_start = gap_start.map(|s| s.saturating_add(1)).unwrap_or(start);
+            let gap_start = gap_start.map_or(start, |s| s.saturating_add(1));
 
             // Iterate backwards, repairing blocks as we go.
             while cursor.height() > gap_start {

--- a/consensus/src/marshal/actor.rs
+++ b/consensus/src/marshal/actor.rs
@@ -998,7 +998,7 @@ where
             .map(|height| Request::<B>::Finalized { height })
             .collect::<Vec<_>>();
         if !requests.is_empty() {
-            resolver.fetch_all(requests).await
+            resolver.fetch_all(requests).await;
         }
     }
 

--- a/consensus/src/marshal/cache.rs
+++ b/consensus/src/marshal/cache.rs
@@ -116,7 +116,7 @@ impl<R: Rng + Spawner + Metrics + Clock + GClock + Storage, B: Block, S: Scheme>
     fn get_metadata(&self) -> (Epoch, Epoch) {
         self.metadata
             .get(&CACHED_EPOCHS_KEY)
-            .cloned()
+            .copied()
             .unwrap_or((Epoch::zero(), Epoch::zero()))
     }
 

--- a/consensus/src/marshal/ingress/handler.rs
+++ b/consensus/src/marshal/ingress/handler.rs
@@ -129,9 +129,8 @@ impl<B: Block> Request<B> {
             (Self::Finalized { height: mine }, Self::Finalized { height: theirs }) => {
                 *theirs > *mine
             }
-            (Self::Finalized { .. }, _) => true,
             (Self::Notarized { round: mine }, Self::Notarized { round: theirs }) => *theirs > *mine,
-            (Self::Notarized { .. }, _) => true,
+            (Self::Finalized { .. }, _) | (Self::Notarized { .. }, _) => true,
         }
     }
 }

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -762,7 +762,7 @@ mod tests {
                     assert_eq!(block.unwrap().height(), height);
                 }
             }
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -817,7 +817,7 @@ mod tests {
             let received_block = subscription_rx.await.unwrap();
             assert_eq!(received_block.digest(), block.digest());
             assert_eq!(received_block.height(), 1);
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -893,7 +893,7 @@ mod tests {
             assert_eq!(received1_sub1.height(), 1);
             assert_eq!(received2.height(), 2);
             assert_eq!(received1_sub3.height(), 1);
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -961,7 +961,7 @@ mod tests {
             let received2 = sub2_rx.await.unwrap();
             assert_eq!(received2.digest(), block2.digest());
             assert_eq!(received2.height(), 2);
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -1068,7 +1068,7 @@ mod tests {
             let received5 = sub5_rx.await.unwrap();
             assert_eq!(received5.digest(), block5.digest());
             assert_eq!(received5.height(), 5);
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -1128,7 +1128,7 @@ mod tests {
             // Missing commitment
             let missing = Sha256::hash(b"missing");
             assert!(actor.get_info(&missing).await.is_none());
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -1210,7 +1210,7 @@ mod tests {
             actor.report(Activity::Finalization(f3)).await;
             let latest = actor.get_info(Identifier::Latest).await;
             assert_eq!(latest, Some((3, d3)));
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -1269,7 +1269,7 @@ mod tests {
             // Missing height
             let by_height = actor.get_block(2).await;
             assert!(by_height.is_none());
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -1327,7 +1327,7 @@ mod tests {
             let missing = Sha256::hash(b"definitely-missing");
             let missing_block = actor.get_block(&missing).await;
             assert!(missing_block.is_none());
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -1381,7 +1381,7 @@ mod tests {
             assert_eq!(finalization.proposal.payload, commitment);
 
             assert!(actor.get_finalization(2).await.is_none());
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -1432,7 +1432,7 @@ mod tests {
             (0..5).for_each(|i| {
                 assert_eq!(blocks[i].height(), 5 - i as u64);
             });
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -1580,7 +1580,7 @@ mod tests {
                 !verify.await.unwrap(),
                 "Byzantine block with mismatched parent commitment should be rejected"
             );
-        })
+        });
     }
 
     #[test_traced("WARN")]
@@ -1692,6 +1692,6 @@ mod tests {
             // Validator 1 should still have the original finalization (v2)
             let fin0_after = actors[1].get_finalization(1).await.unwrap();
             assert_eq!(fin0_after.round().view(), View::new(2));
-        })
+        });
     }
 }

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -890,8 +890,7 @@ impl<
             let bound_lo = self
                 .tip_manager
                 .get(&ack.chunk.sequencer)
-                .map(|t| t.chunk.height)
-                .unwrap_or(0);
+                .map_or(0, |t| t.chunk.height);
             let bound_hi = bound_lo + self.height_bound;
             if ack.chunk.height < bound_lo || ack.chunk.height > bound_hi {
                 return Err(Error::AckHeightOutsideBounds(

--- a/consensus/src/ordered_broadcast/mocks/reporter.rs
+++ b/consensus/src/ordered_broadcast/mocks/reporter.rs
@@ -158,7 +158,7 @@ impl<C: PublicKey, V: Variant, D: Digest> Reporter<C, V, D> {
                         .digests
                         .get(&sequencer)
                         .and_then(|map| map.get(&height))
-                        .cloned();
+                        .copied();
                     sender.send(digest).unwrap();
                 }
             }

--- a/consensus/src/ordered_broadcast/mocks/sequencers.rs
+++ b/consensus/src/ordered_broadcast/mocks/sequencers.rs
@@ -33,6 +33,6 @@ impl<P: PublicKey> Supervisor for Sequencers<P> {
     }
 
     fn is_participant(&self, _: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {
-        self.participants_map.get(candidate).cloned()
+        self.participants_map.get(candidate).copied()
     }
 }

--- a/consensus/src/ordered_broadcast/mocks/validators.rs
+++ b/consensus/src/ordered_broadcast/mocks/validators.rs
@@ -48,7 +48,7 @@ impl<P: PublicKey, V: Variant> Supervisor for Validators<P, V> {
     }
 
     fn is_participant(&self, _: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {
-        self.validators_map.get(candidate).cloned()
+        self.validators_map.get(candidate).copied()
     }
 }
 

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -1017,7 +1017,7 @@ mod tests {
                 (1_000, Epoch::new(111), false),
             )
             .await;
-        })
+        });
     }
 
     #[test_group("slow")]

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -383,7 +383,7 @@ impl<C: PublicKey, V: Variant, D: Digest> Node<C, V, D> {
         );
 
         // Verify signature
-        let message = Ack::<_, V, _>::payload(&parent_chunk, &parent.epoch);
+        let message = Ack::<_, V, _>::payload(&parent_chunk, parent.epoch);
         let ack_namespace = ack_namespace(namespace);
         if ops::verify_message::<V>(
             public,
@@ -514,7 +514,7 @@ impl<P: PublicKey, V: Variant, D: Digest> Ack<P, V, D> {
     /// This constructs the message that is signed by validators when acknowledging a chunk.
     /// It contains both the chunk and the epoch to ensure domain separation and prevent
     /// signature reuse across epochs.
-    fn payload(chunk: &Chunk<P, D>, epoch: &Epoch) -> Vec<u8> {
+    fn payload(chunk: &Chunk<P, D>, epoch: Epoch) -> Vec<u8> {
         let mut message = Vec::with_capacity(chunk.encode_size() + epoch.encode_size());
         chunk.write(&mut message);
         epoch.write(&mut message);
@@ -530,7 +530,7 @@ impl<P: PublicKey, V: Variant, D: Digest> Ack<P, V, D> {
     pub fn verify(&self, namespace: &[u8], polynomial: &poly::Public<V>) -> bool {
         // Construct signing payload
         let ack_namespace = ack_namespace(namespace);
-        let message = Self::payload(&self.chunk, &self.epoch);
+        let message = Self::payload(&self.chunk, self.epoch);
 
         // Verify signature
         ops::partial_verify_message::<V>(
@@ -549,7 +549,7 @@ impl<P: PublicKey, V: Variant, D: Digest> Ack<P, V, D> {
     pub fn sign(namespace: &[u8], share: &Share, chunk: Chunk<P, D>, epoch: Epoch) -> Self {
         // Construct signing payload
         let ack_namespace = ack_namespace(namespace);
-        let message = Self::payload(&chunk, &epoch);
+        let message = Self::payload(&chunk, epoch);
 
         // Sign message
         let signature =
@@ -761,7 +761,7 @@ impl<P: PublicKey, V: Variant, D: Digest> Lock<P, V, D> {
     ///
     /// Returns true if the signature is valid, false otherwise.
     pub fn verify(&self, namespace: &[u8], public_key: &V::Public) -> bool {
-        let message = Ack::<_, V, _>::payload(&self.chunk, &self.epoch);
+        let message = Ack::<_, V, _>::payload(&self.chunk, self.epoch);
         let ack_namespace = ack_namespace(namespace);
         ops::verify_message::<V>(
             public_key,
@@ -866,7 +866,7 @@ mod tests {
         let epoch = Epoch::new(5);
 
         // Generate partial signatures for the chunk
-        let message = Ack::<_, V, _>::payload(&chunk, &epoch);
+        let message = Ack::<_, V, _>::payload(&chunk, epoch);
         let ack_namespace = ack_namespace(NAMESPACE);
         let partials: Vec<_> = shares
             .iter()
@@ -921,7 +921,7 @@ mod tests {
         let parent_epoch = Epoch::new(5);
 
         // Generate partial signatures for the parent chunk
-        let parent_message = Ack::<_, V, _>::payload(&parent_chunk, &parent_epoch);
+        let parent_message = Ack::<_, V, _>::payload(&parent_chunk, parent_epoch);
         let ack_namespace = ack_namespace(NAMESPACE);
         let partials: Vec<_> = shares
             .iter()
@@ -1021,7 +1021,7 @@ mod tests {
 
         let epoch = Epoch::new(5);
         // Generate partial signatures for the chunk
-        let lock_message = Ack::<_, V, _>::payload(&chunk, &epoch);
+        let lock_message = Ack::<_, V, _>::payload(&chunk, epoch);
         let ack_namespace = ack_namespace(NAMESPACE);
         let partials: Vec<_> = shares
             .iter()
@@ -1092,7 +1092,7 @@ mod tests {
         let (polynomial, shares) = generate_test_data::<V>(n, t, 0);
 
         // Generate partial signatures for the chunk
-        let message = Ack::<_, V, _>::payload(&chunk, &epoch);
+        let message = Ack::<_, V, _>::payload(&chunk, epoch);
         let ack_namespace = ack_namespace(NAMESPACE);
         let partials: Vec<_> = shares
             .iter()
@@ -1148,7 +1148,7 @@ mod tests {
         let parent_epoch = Epoch::new(5);
 
         // Create threshold signature for parent
-        let message = Ack::<_, V, _>::payload(&parent_chunk, &parent_epoch);
+        let message = Ack::<_, V, _>::payload(&parent_chunk, parent_epoch);
         let ack_namespace = ack_namespace(NAMESPACE);
         let parent_sigs: Vec<_> = shares
             .iter()
@@ -1249,7 +1249,7 @@ mod tests {
         let epoch = Epoch::new(5);
 
         // Create threshold signature
-        let message = Ack::<_, V, _>::payload(&chunk, &epoch);
+        let message = Ack::<_, V, _>::payload(&chunk, epoch);
         let ack_namespace = ack_namespace(NAMESPACE);
         let partials: Vec<_> = shares
             .iter()
@@ -1309,7 +1309,7 @@ mod tests {
 
         let parent_chunk = Chunk::new(public_key, 0, sample_digest(0));
         let parent_epoch = Epoch::new(5);
-        let parent_message = Ack::<_, MinSig, _>::payload(&parent_chunk, &parent_epoch);
+        let parent_message = Ack::<_, MinSig, _>::payload(&parent_chunk, parent_epoch);
         let ack_namespace = ack_namespace(NAMESPACE);
         let partials: Vec<_> = shares
             .iter()
@@ -1395,7 +1395,7 @@ mod tests {
         let epoch = Epoch::new(5);
 
         // Generate a valid threshold signature for the parent
-        let message = Ack::<_, V, _>::payload(&parent_chunk, &epoch);
+        let message = Ack::<_, V, _>::payload(&parent_chunk, epoch);
         let ack_namespace = ack_namespace(NAMESPACE);
         let partials: Vec<_> = shares
             .iter()
@@ -1528,7 +1528,7 @@ mod tests {
         let epoch = Epoch::new(5);
 
         // Generate threshold signature
-        let message = Ack::<_, V, _>::payload(&chunk, &epoch);
+        let message = Ack::<_, V, _>::payload(&chunk, epoch);
         let ack_namespace = ack_namespace(NAMESPACE);
         let partials: Vec<_> = shares
             .iter()

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -114,8 +114,7 @@ impl<S: Scheme, D: Digest> State<S, D> {
     fn floor_view(&self) -> View {
         self.floor
             .as_ref()
-            .map(|floor| floor.view())
-            .unwrap_or(View::zero())
+            .map_or(View::zero(), |floor| floor.view())
     }
 
     /// Inform the [Resolver] of any missing nullifications.

--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -266,7 +266,7 @@ impl<S: Scheme, D: Digest> Round<S, D> {
                 debug!(?proposal, "setting verified proposal from certificate");
                 None
             }
-            ProposalChange::Unchanged => None,
+            ProposalChange::Unchanged | ProposalChange::Skipped => None,
             ProposalChange::Equivocated { dropped, retained } => {
                 // Receiving a certificate for a conflicting proposal means the
                 // leader signed two different payloads for the same (epoch,
@@ -280,7 +280,6 @@ impl<S: Scheme, D: Digest> Round<S, D> {
                 );
                 equivocator
             }
-            ProposalChange::Skipped => None,
         }
     }
 

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -374,8 +374,7 @@ impl<E: Clock + Rng + CryptoRng + Metrics, S: Scheme, D: Digest> State<E, S, D> 
     pub fn proposed(&mut self, proposal: Proposal<D>) -> bool {
         self.views
             .get_mut(&proposal.view())
-            .map(|round| round.proposed(proposal))
-            .unwrap_or(false)
+            .is_some_and(|round| round.proposed(proposal))
     }
 
     /// Sets a proposal received from the batcher (leader's first notarize vote).
@@ -410,8 +409,7 @@ impl<E: Clock + Rng + CryptoRng + Metrics, S: Scheme, D: Digest> State<E, S, D> 
     pub fn verified(&mut self, view: View) -> bool {
         self.views
             .get_mut(&view)
-            .map(|round| round.verified())
-            .unwrap_or(false)
+            .is_some_and(|round| round.verified())
     }
 
     /// Drops any views that fall below the activity horizon and returns them for logging.

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -450,9 +450,8 @@ impl<E: Clock + Rng + CryptoRng + Metrics, S: Scheme, D: Digest> State<E, S, D> 
             return false;
         }
 
-        let round = match self.views.get(&view) {
-            Some(round) => round,
-            None => return false,
+        let Some(round) = self.views.get(&view) else {
+            return false;
         };
         round.nullification().is_some()
     }

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -268,9 +268,8 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                 debug!("context shutdown, stopping application");
             },
             message = self.mailbox.next() => {
-                let message =match message {
-                    Some(message) => message,
-                    None => break,
+                let Some(message) = message else {
+                    break;
                 };
                 match message {
                     Message::Genesis { epoch, response } => {

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -4055,7 +4055,7 @@ mod tests {
 
                 // Check notarizes
                 let notarizes = reporter.notarizes.lock().unwrap();
-                let last_view = notarizes.keys().max().cloned().unwrap_or_default();
+                let last_view = notarizes.keys().max().copied().unwrap_or_default();
                 for (view, payloads) in notarizes.iter() {
                     if *view == last_view {
                         continue; // Skip last view

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -2459,10 +2459,8 @@ mod tests {
                     for (_, faults) in faulter.iter() {
                         for fault in faults.iter() {
                             match fault {
-                                Activity::ConflictingNotarize(_) => {
-                                    count_conflicting += 1;
-                                }
-                                Activity::ConflictingFinalize(_) => {
+                                Activity::ConflictingNotarize(_)
+                                | Activity::ConflictingFinalize(_) => {
                                     count_conflicting += 1;
                                 }
                                 _ => panic!("unexpected fault: {fault:?}"),
@@ -3713,7 +3711,7 @@ mod tests {
             // Ensure no blocked connections
             let blocked = oracle.blocked().await.unwrap();
             assert!(blocked.is_empty());
-        })
+        });
     }
 
     #[test_group("slow")]

--- a/consensus/src/simplex/signing_scheme/bls12381_threshold.rs
+++ b/consensus/src/simplex/signing_scheme/bls12381_threshold.rs
@@ -155,8 +155,7 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
     /// Returns the ordered set of participant public identity keys in the committee.
     pub fn participants(&self) -> &Ordered<P> {
         match self {
-            Self::Signer { participants, .. } => participants,
-            Self::Verifier { participants, .. } => participants,
+            Self::Signer { participants, .. } | Self::Verifier { participants, .. } => participants,
             _ => panic!("can only be called for signer and verifier"),
         }
     }
@@ -164,9 +163,9 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
     /// Returns the public identity of the committee (constant across reshares).
     pub const fn identity(&self) -> &V::Public {
         match self {
-            Self::Signer { identity, .. } => identity,
-            Self::Verifier { identity, .. } => identity,
-            Self::CertificateVerifier { identity, .. } => identity,
+            Self::Signer { identity, .. }
+            | Self::Verifier { identity, .. }
+            | Self::CertificateVerifier { identity, .. } => identity,
         }
     }
 
@@ -181,8 +180,9 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
     /// Returns the evaluated public polynomial for validating partial signatures produced by committee members.
     pub fn polynomial(&self) -> &[V::Public] {
         match self {
-            Self::Signer { participants, .. } => participants.values(),
-            Self::Verifier { participants, .. } => participants.values(),
+            Self::Signer { participants, .. } | Self::Verifier { participants, .. } => {
+                participants.values()
+            }
             _ => panic!("can only be called for signer and verifier"),
         }
     }

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -242,9 +242,8 @@ pub enum Subject<'a, D: Digest> {
 impl<D: Digest> Viewable for Subject<'_, D> {
     fn view(&self) -> View {
         match self {
-            Subject::Notarize { proposal } => proposal.view(),
+            Subject::Notarize { proposal } | Subject::Finalize { proposal } => proposal.view(),
             Subject::Nullify { round } => round.view(),
-            Subject::Finalize { proposal } => proposal.view(),
         }
     }
 }
@@ -656,7 +655,7 @@ impl<D: Digest> Write for Proposal<D> {
     fn write(&self, writer: &mut impl BufMut) {
         self.round.write(writer);
         self.parent.write(writer);
-        self.payload.write(writer)
+        self.payload.write(writer);
     }
 }
 
@@ -1653,15 +1652,13 @@ impl<S: Scheme, D: Digest> Activity<S, D> {
     /// Indicates whether the activity is guaranteed to have been verified by consensus.
     pub const fn verified(&self) -> bool {
         match self {
-            Self::Notarize(_) => false,
-            Self::Notarization(_) => true,
-            Self::Nullify(_) => false,
-            Self::Nullification(_) => true,
-            Self::Finalize(_) => false,
-            Self::Finalization(_) => true,
-            Self::ConflictingNotarize(_) => false,
-            Self::ConflictingFinalize(_) => false,
-            Self::NullifyFinalize(_) => false,
+            Self::Notarization(_) | Self::Nullification(_) | Self::Finalization(_) => true,
+            Self::Notarize(_)
+            | Self::Nullify(_)
+            | Self::Finalize(_)
+            | Self::ConflictingNotarize(_)
+            | Self::ConflictingFinalize(_)
+            | Self::NullifyFinalize(_) => false,
         }
     }
 

--- a/cryptography/src/bls12381/dkg/arbiter.rs
+++ b/cryptography/src/bls12381/dkg/arbiter.rs
@@ -132,9 +132,8 @@ impl<P: PublicKey, V: Variant> Arbiter<P, V> {
         }
 
         // Find the index of the dealer
-        let idx = match self.dealers.index(&dealer) {
-            Some(idx) => idx,
-            None => return Err(Error::DealerInvalid),
+        let Some(idx) = self.dealers.index(&dealer) else {
+            return Err(Error::DealerInvalid);
         };
 
         // Check if commitment already exists

--- a/cryptography/src/bls12381/dkg/dealer.rs
+++ b/cryptography/src/bls12381/dkg/dealer.rs
@@ -61,9 +61,8 @@ impl<P: PublicKey, V: Variant> Dealer<P, V> {
     /// Track acknowledgement from a player.
     pub fn ack(&mut self, player: P) -> Result<(), Error> {
         // Ensure player is valid
-        let idx = match self.players.index(&player) {
-            Some(player) => player,
-            None => return Err(Error::PlayerInvalid),
+        let Some(idx) = self.players.index(&player) else {
+            return Err(Error::PlayerInvalid);
         };
 
         // Store ack

--- a/cryptography/src/bls12381/dkg/ops.rs
+++ b/cryptography/src/bls12381/dkg/ops.rs
@@ -183,7 +183,7 @@ pub fn recover_public<V: Variant>(
     }
 
     // Precompute Barycentric Weights for all coefficients
-    let indices: Vec<u32> = commitments.keys().cloned().collect();
+    let indices: Vec<u32> = commitments.keys().copied().collect();
     let weights = compute_weights(indices).map_err(|_| Error::PublicKeyInterpolationFailed)?;
 
     // Perform interpolation over each coefficient using the precomputed weights

--- a/cryptography/src/bls12381/dkg/player.rs
+++ b/cryptography/src/bls12381/dkg/player.rs
@@ -75,9 +75,8 @@ impl<P: PublicKey, V: Variant> Player<P, V> {
         share: Share,
     ) -> Result<(), Error> {
         // Ensure dealer is valid
-        let dealer_idx = match self.dealers.index(&dealer) {
-            Some(contributor) => contributor,
-            None => return Err(Error::DealerInvalid),
+        let Some(dealer_idx) = self.dealers.index(&dealer) else {
+            return Err(Error::DealerInvalid);
         };
 
         // Check that share is valid

--- a/cryptography/src/bls12381/dkg2.rs
+++ b/cryptography/src/bls12381/dkg2.rs
@@ -482,11 +482,7 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
 
     fn required_commitments(&self) -> u32 {
         let dealer_quorum = self.dealers.quorum();
-        let prev_quorum = self
-            .previous
-            .as_ref()
-            .map(Output::quorum)
-            .unwrap_or(u32::MIN);
+        let prev_quorum = self.previous.as_ref().map_or(u32::MIN, Output::quorum);
         dealer_quorum.max(prev_quorum)
     }
 
@@ -1308,11 +1304,8 @@ impl<V: Variant, S: Signer> Player<V, S> {
         let dealings = selected
             .iter()
             .map(|(dealer, log)| {
-                let share = self
-                    .view
-                    .get(dealer)
-                    .map(|(_, priv_msg)| priv_msg.share.clone())
-                    .unwrap_or_else(|| {
+                let share = self.view.get(dealer).map_or_else(
+                    || {
                         log.get_reveal(&self.me_pub).map_or_else(
                             || {
                                 unreachable!(
@@ -1321,7 +1314,9 @@ impl<V: Variant, S: Signer> Player<V, S> {
                             },
                             |priv_msg| priv_msg.share.clone(),
                         )
-                    });
+                    },
+                    |(_, priv_msg)| priv_msg.share.clone(),
+                );
                 let index = if let Some(previous) = self.info.previous.as_ref() {
                     previous
                         .players

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1236,8 +1236,8 @@ mod tests {
 
         // Test that we can use these types as keys in hash maps, which relies on `Hash` and `Eq`.
         let scalar_map: HashMap<_, _> = scalar_set.iter().cloned().zip(0..).collect();
-        let g1_map: HashMap<_, _> = g1_set.iter().cloned().zip(0..).collect();
-        let g2_map: HashMap<_, _> = g2_set.iter().cloned().zip(0..).collect();
+        let g1_map: HashMap<_, _> = g1_set.iter().copied().zip(0..).collect();
+        let g2_map: HashMap<_, _> = g2_set.iter().copied().zip(0..).collect();
         let share_map: HashMap<_, _> = share_set.iter().cloned().zip(0..).collect();
 
         // Verify that the maps contain the expected number of unique items.

--- a/cryptography/src/bls12381/primitives/ops.rs
+++ b/cryptography/src/bls12381/primitives/ops.rs
@@ -522,7 +522,7 @@ where
                 .map(|evals| {
                     threshold_signature_recover_with_weights::<V, _>(
                         &weights,
-                        evals.iter().cloned(),
+                        evals.iter().copied(),
                     )
                 })
                 .collect();
@@ -541,7 +541,7 @@ where
                 .map(|evals| {
                     threshold_signature_recover_with_weights::<V, _>(
                         &weights,
-                        evals.iter().cloned(),
+                        evals.iter().copied(),
                     )
                 })
                 .collect()

--- a/cryptography/src/bls12381/primitives/poly.rs
+++ b/cryptography/src/bls12381/primitives/poly.rs
@@ -267,10 +267,10 @@ impl<C: Element> Poly<C> {
 
         // if we have a smaller degree we should pad with zeros
         if self.0.len() < other.0.len() {
-            self.0.resize(other.0.len(), C::zero())
+            self.0.resize(other.0.len(), C::zero());
         }
 
-        self.0.iter_mut().zip(&other.0).for_each(|(a, b)| a.add(b))
+        self.0.iter_mut().zip(&other.0).for_each(|(a, b)| a.add(b));
     }
 
     /// Evaluates the polynomial at the specified index (provided value offset by 1).
@@ -288,7 +288,7 @@ impl<C: Element> Poly<C> {
             sum.add(coeff);
             sum
         });
-        Eval { value, index }
+        Eval { index, value }
     }
 
     /// Recovers the constant term of a polynomial of degree less than `t` using `t` evaluations of the polynomial
@@ -464,7 +464,7 @@ pub mod tests {
     fn pow(base: Scalar, pow: usize) -> Scalar {
         let mut res = Scalar::one();
         for _ in 0..pow {
-            res.mul(&base)
+            res.mul(&base);
         }
         res
     }

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -2,7 +2,7 @@ use crate::{Array, PrivateKeyExt};
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         use crate::BatchVerifier;
-        use std::borrow::{Cow, ToOwned};
+        use std::borrow::Cow;
     } else {
         use alloc::borrow::{Cow, ToOwned};
     }
@@ -45,7 +45,7 @@ impl crate::Signer for PrivateKey {
         let raw = self.key.verification_key().to_bytes();
         Self::PublicKey {
             raw,
-            key: self.key.verification_key().to_owned(),
+            key: self.key.verification_key(),
         }
     }
 }
@@ -53,9 +53,10 @@ impl crate::Signer for PrivateKey {
 impl PrivateKey {
     #[inline(always)]
     fn sign_inner(&self, namespace: Option<&[u8]>, msg: &[u8]) -> Signature {
-        let payload = namespace
-            .map(|namespace| Cow::Owned(union_unique(namespace, msg)))
-            .unwrap_or_else(|| Cow::Borrowed(msg));
+        let payload = namespace.map_or_else(
+            || Cow::Borrowed(msg),
+            |namespace| Cow::Owned(union_unique(namespace, msg)),
+        );
         let sig = self.key.sign(&payload);
         Signature::from(sig)
     }
@@ -181,9 +182,10 @@ impl crate::Verifier for PublicKey {
 impl PublicKey {
     #[inline(always)]
     fn verify_inner(&self, namespace: Option<&[u8]>, msg: &[u8], sig: &Signature) -> bool {
-        let payload = namespace
-            .map(|namespace| Cow::Owned(union_unique(namespace, msg)))
-            .unwrap_or_else(|| Cow::Borrowed(msg));
+        let payload = namespace.map_or_else(
+            || Cow::Borrowed(msg),
+            |namespace| Cow::Owned(union_unique(namespace, msg)),
+        );
         self.key.verify(&sig.signature, &payload).is_ok()
     }
 }

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -541,7 +541,7 @@ mod tests {
     #[test]
     fn rfc8032_test_vector_1() {
         let (private_key, public_key, message, signature) = vector_1();
-        test_sign_and_verify(private_key, public_key, &message, signature)
+        test_sign_and_verify(private_key, public_key, &message, signature);
     }
 
     // sanity check the test infra rejects bad signatures
@@ -566,7 +566,7 @@ mod tests {
     #[test]
     fn rfc8032_test_vector_2() {
         let (private_key, public_key, message, signature) = vector_2();
-        test_sign_and_verify(private_key, public_key, &message, signature)
+        test_sign_and_verify(private_key, public_key, &message, signature);
     }
 
     #[test]
@@ -592,7 +592,7 @@ mod tests {
             4a7c15e9716ed28dc027beceea1ec40a
             ",
         );
-        test_sign_and_verify(private_key, public_key, &message, signature)
+        test_sign_and_verify(private_key, public_key, &message, signature);
     }
 
     #[test]
@@ -686,7 +686,7 @@ mod tests {
             5e8fcd4f681e30a6ac00a9704a188a03
             ",
         );
-        test_sign_and_verify(private_key, public_key, &message, signature)
+        test_sign_and_verify(private_key, public_key, &message, signature);
     }
 
     #[test]
@@ -728,7 +728,7 @@ mod tests {
             PublicKey::decode(public_key.as_ref()).unwrap(),
             &message,
             Signature::decode(signature.as_ref()).unwrap(),
-        )
+        );
     }
 
     #[test]

--- a/cryptography/src/handshake/benches/transport.rs
+++ b/cryptography/src/handshake/benches/transport.rs
@@ -5,7 +5,7 @@ fn bench_transport(c: &mut Criterion) {
     for n in [1 << 12, 1 << 16, 1 << 20] {
         let data = vec![0; n];
         c.bench_function(&format!("{}/n={}", module_path!(), n), |b| {
-            b.iter(|| recv.recv(&send.send(&data).unwrap()).unwrap())
+            b.iter(|| recv.recv(&send.send(&data).unwrap()).unwrap());
         });
     }
 }

--- a/cryptography/src/secp256r1/recoverable.rs
+++ b/cryptography/src/secp256r1/recoverable.rs
@@ -166,8 +166,8 @@ impl Read for Signature {
         }
         Ok(Self {
             raw,
-            signature,
             recovery_id,
+            signature,
         })
     }
 }

--- a/cryptography/src/transcript.rs
+++ b/cryptography/src/transcript.rs
@@ -293,7 +293,7 @@ impl FixedSize for Summary {
 
 impl Write for Summary {
     fn write(&self, buf: &mut impl bytes::BufMut) {
-        self.hash.as_bytes().write(buf)
+        self.hash.as_bytes().write(buf);
     }
 }
 

--- a/examples/chat/src/handler.rs
+++ b/examples/chat/src/handler.rs
@@ -68,10 +68,7 @@ pub async fn run(
                 }
                 Err(_) => break,
             };
-            let e = match event::read() {
-                Ok(e) => e,
-                Err(_) => break,
-            };
+            let Ok(e) = event::read() else { break };
             if let CEvent::Key(key) = e {
                 if tx.send(Event::Input(key)).await.is_err() {
                     break;
@@ -202,10 +199,7 @@ pub async fn run(
         let formatted_me = format!("{}**{}", &me[..4], &me[me.len() - 4..]);
         select! {
             event = rx.next() => {
-                let event = match event {
-                    Some(event) => event,
-                    None => break,
-                };
+                let Some(event) = event else { break };
                 match event {
                     Event::Input(event) => match event.code {
                         KeyCode::Char(c) => {

--- a/examples/estimator/src/lib.rs
+++ b/examples/estimator/src/lib.rs
@@ -567,9 +567,7 @@ pub fn can_command_advance(
     received: &BTreeMap<u32, BTreeSet<PublicKey>>,
 ) -> bool {
     match cmd {
-        Command::Propose(_, _) => true, // Propose always advances (proposer check handled by caller)
-        Command::Broadcast(_, _) => true, // Broadcast always advances
-        Command::Reply(_, _) => true,   // Reply always advances
+        Command::Propose(_, _) | Command::Broadcast(_, _) | Command::Reply(_, _) => true,
         Command::Collect(id, thresh, _) => {
             if is_proposer {
                 let count = received.get(id).map_or(0, |s| s.len());
@@ -655,13 +653,10 @@ pub fn validate(commands: &[(usize, Command)], peers: usize, proposer: usize) ->
                                 messages.push((p, Recipients::One(proposer_key), *id));
                             }
                         }
-                        Command::Collect(_, _, _) | Command::Wait(_, _, _) => {
-                            // No side effects for collect/wait - just advancement
-                        }
-                        Command::Or(_, _) | Command::And(_, _) => {
-                            // No direct side effects for compound commands
-                            // Side effects come from their sub-commands when they execute
-                        }
+                        Command::Collect(_, _, _)
+                        | Command::Wait(_, _, _)
+                        | Command::Or(_, _)
+                        | Command::And(_, _) => {}
                     }
                 }
 

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -736,7 +736,7 @@ fn print_simulation_results(result: &Simulation, task_content: &str) {
 
     // Emit results
     let dsl_lines: Vec<String> = task_content.lines().map(|s| s.to_string()).collect();
-    let mut wait_lines: Vec<usize> = result.steps.all.keys().cloned().collect();
+    let mut wait_lines: Vec<usize> = result.steps.all.keys().copied().collect();
     wait_lines.sort();
     let mut wait_idx = 0;
     for (i, line) in dsl_lines.iter().enumerate() {
@@ -792,7 +792,7 @@ fn print_aggregated_results(results: &[Simulation], task_content: &str) {
     // Emit results
     let (observations, proposer_observations) = aggregate_simulation_results(results);
     let dsl_lines: Vec<String> = task_content.lines().map(|s| s.to_string()).collect();
-    let mut wait_lines: Vec<usize> = observations.keys().cloned().collect();
+    let mut wait_lines: Vec<usize> = observations.keys().copied().collect();
     wait_lines.sort();
     let mut wait_idx = 0;
     for (i, line) in dsl_lines.iter().enumerate() {

--- a/examples/log/src/gui.rs
+++ b/examples/log/src/gui.rs
@@ -174,10 +174,7 @@ impl<E: Spawner + Metrics> Gui<E> {
                     }
                     Err(_) => break,
                 };
-                let e = match event::read() {
-                    Ok(e) => e,
-                    Err(_) => break,
-                };
+                let Ok(e) = event::read() else { break };
                 if let CEvent::Key(key) = e {
                     if tx.send(Event::Input(key)).await.is_err() {
                         break;
@@ -283,36 +280,36 @@ impl<E: Spawner + Metrics> Gui<E> {
                     }
                     KeyCode::Up => match focused_window {
                         Focus::Progress => {
-                            progress_scroll_vertical = progress_scroll_vertical.saturating_sub(1)
+                            progress_scroll_vertical = progress_scroll_vertical.saturating_sub(1);
                         }
                         Focus::Logs => {
-                            logs_scroll_vertical = logs_scroll_vertical.saturating_sub(1)
+                            logs_scroll_vertical = logs_scroll_vertical.saturating_sub(1);
                         }
                     },
                     KeyCode::Down => match focused_window {
                         Focus::Progress => {
-                            progress_scroll_vertical = progress_scroll_vertical.saturating_add(1)
+                            progress_scroll_vertical = progress_scroll_vertical.saturating_add(1);
                         }
                         Focus::Logs => {
-                            logs_scroll_vertical = logs_scroll_vertical.saturating_add(1)
+                            logs_scroll_vertical = logs_scroll_vertical.saturating_add(1);
                         }
                     },
                     KeyCode::Left => match focused_window {
                         Focus::Progress => {
                             progress_scroll_horizontal =
-                                progress_scroll_horizontal.saturating_sub(1)
+                                progress_scroll_horizontal.saturating_sub(1);
                         }
                         Focus::Logs => {
-                            logs_scroll_horizontal = logs_scroll_horizontal.saturating_sub(1)
+                            logs_scroll_horizontal = logs_scroll_horizontal.saturating_sub(1);
                         }
                     },
                     KeyCode::Right => match focused_window {
                         Focus::Progress => {
                             progress_scroll_horizontal =
-                                progress_scroll_horizontal.saturating_add(1)
+                                progress_scroll_horizontal.saturating_add(1);
                         }
                         Focus::Logs => {
-                            logs_scroll_horizontal = logs_scroll_horizontal.saturating_add(1)
+                            logs_scroll_horizontal = logs_scroll_horizontal.saturating_add(1);
                         }
                     },
                     KeyCode::Esc => {

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -109,7 +109,7 @@ fn main() {
     let participants = matches
         .get_many::<u64>("participants")
         .expect("Please provide allowed keys")
-        .cloned()
+        .copied()
         .collect::<Vec<_>>();
     if participants.is_empty() {
         panic!("Please provide at least one participant");

--- a/examples/reshare/src/application/scheme.rs
+++ b/examples/reshare/src/application/scheme.rs
@@ -50,9 +50,9 @@ impl<S: Scheme, C: Signer> SchemeProvider<S, C> {
     /// Unregisters the signing scheme for the given epoch.
     ///
     /// Returns `false` if no scheme was registered for the epoch.
-    pub fn unregister(&self, epoch: &Epoch) -> bool {
+    pub fn unregister(&self, epoch: Epoch) -> bool {
         let mut schemes = self.schemes.lock().unwrap();
-        schemes.remove(epoch).is_some()
+        schemes.remove(&epoch).is_some()
     }
 }
 

--- a/examples/reshare/src/main.rs
+++ b/examples/reshare/src/main.rs
@@ -117,7 +117,7 @@ fn main() {
             Subcommands::Setup(args) => setup::run(args),
             Subcommands::Dkg(args) => validator::run::<EdScheme>(context, args).await,
             Subcommands::Validator(args) => {
-                validator::run::<ThresholdScheme<MinSig>>(context, args).await
+                validator::run::<ThresholdScheme<MinSig>>(context, args).await;
             }
         }
     });

--- a/examples/reshare/src/orchestrator/actor.rs
+++ b/examples/reshare/src/orchestrator/actor.rs
@@ -330,7 +330,7 @@ where
                         engine.abort();
 
                         // Unregister the signing scheme for the epoch.
-                        assert!(self.scheme_provider.unregister(&epoch));
+                        assert!(self.scheme_provider.unregister(epoch));
 
                         info!(%epoch, "exited epoch");
                     }

--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -318,10 +318,7 @@ fn parse_config() -> Result<Config, Box<dyn std::error::Error>> {
         .map_err(|e| format!("Invalid batch size: {e}"))?;
 
     let storage_dir = {
-        let storage_dir = matches
-            .get_one::<String>("storage-dir")
-            .unwrap()
-            .to_string();
+        let storage_dir = matches.get_one::<String>("storage-dir").unwrap().clone();
         // Only add suffix if using the default value
         if storage_dir == DEFAULT_CLIENT_DIR_PREFIX {
             let suffix: u64 = rand::thread_rng().gen();

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -559,10 +559,7 @@ fn parse_config() -> Result<Config, Box<dyn std::error::Error>> {
             .parse()
             .map_err(|e| format!("Invalid initial operations count: {e}"))?,
         storage_dir: {
-            let storage_dir = matches
-                .get_one::<String>("storage-dir")
-                .unwrap()
-                .to_string();
+            let storage_dir = matches.get_one::<String>("storage-dir").unwrap().clone();
             // Only add suffix if using the default value
             if storage_dir == "/tmp/commonware-sync/server" {
                 let suffix: u64 = rand::thread_rng().gen();

--- a/examples/sync/src/net/mod.rs
+++ b/examples/sync/src/net/mod.rs
@@ -134,11 +134,11 @@ mod tests {
 
         // Verify they match
         match (&error_code, &decoded) {
-            (ErrorCode::InvalidRequest, ErrorCode::InvalidRequest) => {}
-            (ErrorCode::DatabaseError, ErrorCode::DatabaseError) => {}
-            (ErrorCode::NetworkError, ErrorCode::NetworkError) => {}
-            (ErrorCode::Timeout, ErrorCode::Timeout) => {}
-            (ErrorCode::InternalError, ErrorCode::InternalError) => {}
+            (ErrorCode::InvalidRequest, ErrorCode::InvalidRequest)
+            | (ErrorCode::DatabaseError, ErrorCode::DatabaseError)
+            | (ErrorCode::NetworkError, ErrorCode::NetworkError)
+            | (ErrorCode::Timeout, ErrorCode::Timeout)
+            | (ErrorCode::InternalError, ErrorCode::InternalError) => {}
             _ => panic!("ErrorCode roundtrip failed: {error_code:?} != {decoded:?}"),
         }
     }

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -95,12 +95,9 @@ impl<E: Clock + Spawner, C: PublicKey> Arbiter<E, C> {
                 match result {
                     Ok((peer, msg)) =>{
                         // Parse msg
-                        let msg = match wire::Dkg::decode_cfg(msg, &self.contributors.len()) {
-                            Ok(msg) => msg,
-                            Err(_) => {
-                                arbiter.disqualify(peer).expect("failed to disqualify peer");
-                                continue;
-                            }
+                        let Ok(msg) = wire::Dkg::decode_cfg(msg, &self.contributors.len()) else {
+                            arbiter.disqualify(peer).expect("failed to disqualify peer");
+                            continue;
                         };
                         if msg.round != round {
                             continue;

--- a/examples/vrf/src/handlers/arbiter.rs
+++ b/examples/vrf/src/handlers/arbiter.rs
@@ -109,9 +109,9 @@ impl<E: Clock + Spawner, C: PublicKey> Arbiter<E, C> {
 
                         // Validate the signature of each ack
                         if !acks.iter().all(|ack| {
-                            self.contributors.get(ack.player as usize).map(|signer| {
+                            self.contributors.get(ack.player as usize).is_some_and(|signer| {
                                 ack.verify::<MinSig, _>(ACK_NAMESPACE, signer, round, &peer, &commitment)
-                            }).unwrap_or(false)
+                            })
                         }) {
                             arbiter.disqualify(peer).expect("failed to disqualify peer");
                             continue;

--- a/examples/vrf/src/handlers/contributor.rs
+++ b/examples/vrf/src/handlers/contributor.rs
@@ -252,12 +252,9 @@ impl<E: Clock + CryptoRngCore + Spawner, C: Signer> Contributor<E, C> {
             result = receiver.recv() => {
                 match result {
                     Ok((peer, msg)) => {
-                        let msg = match wire::Dkg::<C::Signature>::decode_cfg(msg, &self.contributors.len()) {
-                            Ok(msg) => msg,
-                            Err(_) => {
-                                warn!("received invalid message from arbiter");
-                                return (round, None);
-                            }
+                        let Ok(msg) = wire::Dkg::<C::Signature>::decode_cfg(msg, &self.contributors.len()) else {
+                            warn!("received invalid message from arbiter");
+                            return (round, None);
                         };
                         if msg.round != round {
                             warn!(
@@ -382,15 +379,11 @@ impl<E: Clock + CryptoRngCore + Spawner, C: Signer> Contributor<E, C> {
         loop {
             match receiver.recv().await {
                 Ok((peer, msg)) => {
-                    let msg = match wire::Dkg::<C::Signature>::decode_cfg(
-                        msg,
-                        &self.contributors.len(),
-                    ) {
-                        Ok(msg) => msg,
-                        Err(_) => {
-                            warn!("received invalid message from arbiter");
-                            return (round, None);
-                        }
+                    let Ok(msg) =
+                        wire::Dkg::<C::Signature>::decode_cfg(msg, &self.contributors.len())
+                    else {
+                        warn!("received invalid message from arbiter");
+                        return (round, None);
                     };
                     if round != msg.round {
                         warn!(

--- a/examples/vrf/src/handlers/vrf.rs
+++ b/examples/vrf/src/handlers/vrf.rs
@@ -99,12 +99,9 @@ impl<E: Clock + Spawner, P: PublicKey> Vrf<E, P> {
             result = receiver.recv() => {
                 match result {
                     Ok((peer, msg)) => {
-                        let dealer = match self.ordered_contributors.get(&peer) {
-                            Some(dealer) => dealer,
-                            None => {
-                                warn!(round, "received signature from invalid player");
-                                continue;
-                            }
+                        let Some(dealer) = self.ordered_contributors.get(&peer) else {
+                            warn!(round, "received signature from invalid player");
+                            continue;
                         };
                         // We mark we received a message from a dealer during this round before checking if its valid to
                         // avoid doing useless work (where the dealer can keep sending us outdated/invalid messages).
@@ -112,12 +109,9 @@ impl<E: Clock + Spawner, P: PublicKey> Vrf<E, P> {
                             warn!(round, dealer, "received duplicate signature");
                             continue;
                         }
-                        let msg = match wire::Vrf::decode(msg) {
-                            Ok(msg) => msg,
-                            Err(_) => {
-                                warn!(round, "received invalid message from player");
-                                continue;
-                            }
+                        let Ok(msg) = wire::Vrf::decode(msg) else {
+                            warn!(round, "received invalid message from player");
+                            continue;
                         };
                         if msg.round != round {
                             warn!(
@@ -174,11 +168,8 @@ impl<E: Clock + Spawner, P: PublicKey> Vrf<E, P> {
         mut receiver: impl Receiver<PublicKey = P>,
     ) {
         loop {
-            let (round, output) = match self.requests.next().await {
-                Some(request) => request,
-                None => {
-                    return;
-                }
+            let Some((round, output)) = self.requests.next().await else {
+                return;
             };
 
             match self

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -163,12 +163,9 @@ pub fn test_group(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(group) => group,
         Err(err) => return err.to_compile_error().into(),
     };
-    let groups = match configured_test_groups() {
-        Ok(groups) => groups,
-        Err(_) => {
-            // Don't fail the compilation if the file isn't found; just return the original input.
-            return TokenStream::from(quote!(#input));
-        }
+    let Ok(groups) = configured_test_groups() else {
+        // Don't fail the compilation if the file isn't found; just return the original input.
+        return TokenStream::from(quote!(#input));
     };
 
     if let Err(err) = nextest::ensure_group_known(groups, &group, group_literal.span()) {

--- a/macros/src/nextest.rs
+++ b/macros/src/nextest.rs
@@ -48,8 +48,7 @@ fn normalize_group_name(raw: &str) -> Result<String, &'static str> {
         match ch {
             'a'..='z' | '0'..='9' => sanitized.push(ch),
             'A'..='Z' => sanitized.push(ch.to_ascii_lowercase()),
-            '_' => sanitized.push('_'),
-            '-' => sanitized.push('_'),
+            '_' | '-' => sanitized.push('_'),
             _ => {
                 return Err(
                     "filter group names may only contain ASCII letters, digits, '_' or '-'",

--- a/p2p/src/authenticated/discovery/actors/peer/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/actor.rs
@@ -78,9 +78,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
         msg: Option<Data>,
         rate_limits: &HashMap<u64, V>,
     ) -> Result<Data, Error> {
-        let data = match msg {
-            Some(data) => data,
-            None => return Err(Error::PeerDisconnected),
+        let Some(data) = msg else {
+            return Err(Error::PeerDisconnected);
         };
         assert!(
             rate_limits.contains_key(&data.channel),
@@ -141,9 +140,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                         deadline = context.current() + self.gossip_bit_vec_frequency;
                     },
                     msg_control = self.control.next() => {
-                        let msg = match msg_control {
-                            Some(msg_control) => msg_control,
-                            None => return Err(Error::PeerDisconnected),
+                        let Some(msg) = msg_control else {
+                            return Err(Error::PeerDisconnected);
                         };
                         let (metric, payload) = match msg {
                             Message::BitVec(bit_vec) =>

--- a/p2p/src/authenticated/discovery/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/actor.rs
@@ -988,9 +988,8 @@ mod tests {
                 connect_to_peer(&mut mailbox, &peer1_pk, &peer_mailbox1, &mut peer_receiver1).await;
 
             mailbox.construct(peer1_pk.clone(), peer_mailbox1.clone());
-            let bit_vec0 = match peer_receiver1.next().await {
-                Some(peer::Message::BitVec(bv)) => bv,
-                _ => panic!("Expected BitVec for set 0"),
+            let Some(peer::Message::BitVec(bit_vec0)) = peer_receiver1.next().await else {
+                panic!("Expected BitVec for set 0")
             };
             assert_eq!(bit_vec0.index, 0);
             assert_eq!(bit_vec0.bits.len(), set0_peers.len() as u64);
@@ -1015,9 +1014,8 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
 
             mailbox.construct(peer1_pk.clone(), peer_mailbox1.clone());
-            let bit_vec0_updated = match peer_receiver1.next().await {
-                Some(peer::Message::BitVec(bv)) => bv,
-                _ => panic!("Expected updated BitVec for set 0"),
+            let Some(peer::Message::BitVec(bit_vec0_updated)) = peer_receiver1.next().await else {
+                panic!("Expected updated BitVec for set 0")
             };
             let peer1_idx_s0 = set0_peers.iter().position(|p| p == &peer1_pk).unwrap();
             assert!(bit_vec0_updated.bits.get(tracker_idx_s0 as u64));

--- a/p2p/src/authenticated/discovery/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/actor.rs
@@ -164,7 +164,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
             }
             Message::PeerSet { index, responder } => {
                 // Send the peer set at the given index.
-                let _ = responder.send(self.directory.get_set(&index).cloned());
+                let _ = responder.send(self.directory.get_set(index).cloned());
             }
             Message::Subscribe { responder } => {
                 // Create a new subscription channel
@@ -172,7 +172,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
 
                 // Send the latest peer set immediately
                 if let Some(latest_set_id) = self.directory.latest_set_index() {
-                    let latest_set = self.directory.get_set(&latest_set_id).cloned().unwrap();
+                    let latest_set = self.directory.get_set(latest_set_id).cloned().unwrap();
                     sender
                         .unbounded_send((latest_set_id, latest_set, self.directory.tracked()))
                         .ok();

--- a/p2p/src/authenticated/discovery/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/directory.rs
@@ -221,8 +221,8 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: PublicKey> Directory
     }
 
     /// Gets a peer set by index.
-    pub fn get_set(&self, index: &u64) -> Option<&Ordered<C>> {
-        self.sets.get(index).map(Deref::deref)
+    pub fn get_set(&self, index: u64) -> Option<&Ordered<C>> {
+        self.sets.get(&index).map(Deref::deref)
     }
 
     /// Returns the latest peer set index.

--- a/p2p/src/authenticated/discovery/actors/tracker/metadata.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/metadata.rs
@@ -22,8 +22,7 @@ impl<P: PublicKey> Metadata<P> {
     /// Get the public key of the peer associated with this metadata.
     pub const fn public_key(&self) -> &P {
         match self {
-            Self::Dialer(public_key, _) => public_key,
-            Self::Listener(public_key) => public_key,
+            Self::Dialer(public_key, _) | Self::Listener(public_key) => public_key,
         }
     }
 }

--- a/p2p/src/authenticated/discovery/actors/tracker/record.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/record.rs
@@ -99,8 +99,7 @@ impl<C: PublicKey> Record<C> {
     /// Returns true if the update was successful.
     pub fn update(&mut self, info: Info<C>) -> bool {
         match &self.address {
-            Address::Myself(_) => false,
-            Address::Blocked => false,
+            Address::Myself(_) | Address::Blocked => false,
             Address::Unknown | Address::Bootstrapper(_) => {
                 self.address = Address::Discovered(info, 0);
                 true
@@ -234,11 +233,9 @@ impl<C: PublicKey> Record<C> {
     /// Return the socket of the peer, if known.
     pub const fn socket(&self) -> Option<SocketAddr> {
         match &self.address {
-            Address::Unknown => None,
-            Address::Myself(info) => Some(info.socket),
+            Address::Myself(info) | Address::Discovered(info, _) => Some(info.socket),
             Address::Bootstrapper(socket) => Some(*socket),
-            Address::Discovered(info, _) => Some(info.socket),
-            Address::Blocked => None,
+            Address::Unknown | Address::Blocked => None,
         }
     }
 
@@ -246,11 +243,9 @@ impl<C: PublicKey> Record<C> {
     /// known and we are connected to the peer.
     pub fn sharable(&self) -> Option<Info<C>> {
         match &self.address {
-            Address::Unknown => None,
             Address::Myself(info) => Some(info),
-            Address::Bootstrapper(_) => None,
             Address::Discovered(info, _) => (self.status == Status::Active).then_some(info),
-            Address::Blocked => None,
+            Address::Unknown | Address::Bootstrapper(_) | Address::Blocked => None,
         }
         .cloned()
     }

--- a/p2p/src/authenticated/discovery/types.rs
+++ b/p2p/src/authenticated/discovery/types.rs
@@ -417,18 +417,20 @@ mod tests {
             bits: BitMap::ones(100),
         };
         let encoded: BytesMut = Payload::<PublicKey>::BitVec(original.clone()).encode();
-        let decoded = match Payload::<PublicKey>::decode_cfg(encoded, &cfg) {
-            Ok(Payload::<PublicKey>::BitVec(b)) => b,
-            _ => panic!(),
+        let Ok(Payload::<PublicKey>::BitVec(decoded)) =
+            Payload::<PublicKey>::decode_cfg(encoded, &cfg)
+        else {
+            panic!()
         };
         assert_eq!(original, decoded);
 
         // Test Peers
         let original = vec![signed_peer_info(), signed_peer_info()];
         let encoded = Payload::Peers(original.clone()).encode();
-        let decoded = match Payload::<PublicKey>::decode_cfg(encoded, &cfg) {
-            Ok(Payload::<PublicKey>::Peers(p)) => p,
-            _ => panic!(),
+        let Ok(Payload::<PublicKey>::Peers(decoded)) =
+            Payload::<PublicKey>::decode_cfg(encoded, &cfg)
+        else {
+            panic!()
         };
         for (a, b) in original.iter().zip(decoded.iter()) {
             assert_eq!(a.socket, b.socket);
@@ -443,9 +445,10 @@ mod tests {
             message: Bytes::from("Hello, world!"),
         };
         let encoded = Payload::<PublicKey>::Data(original.clone()).encode();
-        let decoded = match Payload::<PublicKey>::decode_cfg(encoded, &cfg) {
-            Ok(Payload::<PublicKey>::Data(d)) => d,
-            _ => panic!(),
+        let Ok(Payload::<PublicKey>::Data(decoded)) =
+            Payload::<PublicKey>::decode_cfg(encoded, &cfg)
+        else {
+            panic!()
         };
         assert_eq!(original, decoded);
     }

--- a/p2p/src/authenticated/lookup/actors/peer/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/peer/actor.rs
@@ -63,9 +63,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
         msg: Option<Data>,
         rate_limits: &HashMap<u64, V>,
     ) -> Result<Data, Error> {
-        let data = match msg {
-            Some(data) => data,
-            None => return Err(Error::PeerDisconnected),
+        let Some(data) = msg else {
+            return Err(Error::PeerDisconnected);
         };
         assert!(
             rate_limits.contains_key(&data.channel),
@@ -130,9 +129,8 @@ impl<E: Spawner + Clock + ReasonablyRealtime + Rng + CryptoRng + Metrics, C: Pub
                         deadline = context.current() + self.ping_frequency;
                     },
                     msg_control = self.control.next() => {
-                        let msg = match msg_control {
-                            Some(msg_control) => msg_control,
-                            None => return Err(Error::PeerDisconnected),
+                        let Some(msg) = msg_control else {
+                            return Err(Error::PeerDisconnected);
                         };
                         match msg {
                             Message::Kill => {

--- a/p2p/src/authenticated/lookup/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/actor.rs
@@ -157,7 +157,7 @@ impl<
                                 }
                                 router.release(peer).await;
                                 // Release the reservation
-                                drop(reservation)
+                                drop(reservation);
                             });
                     }
                 }

--- a/p2p/src/authenticated/lookup/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/actor.rs
@@ -618,7 +618,7 @@ mod tests {
 
             // The first peer should be have received a kill message because its
             // peer set was removed because `tracked_peer_sets` is 1.
-            assert!(matches!(peer_rx.next().await, Some(peer::Message::Kill)),)
+            assert!(matches!(peer_rx.next().await, Some(peer::Message::Kill)));
         });
     }
 }

--- a/p2p/src/authenticated/lookup/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/actor.rs
@@ -144,7 +144,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
             }
             Message::PeerSet { index, responder } => {
                 // Send the peer set at the given index.
-                let _ = responder.send(self.directory.get_set(&index).cloned());
+                let _ = responder.send(self.directory.get_set(index).cloned());
             }
             Message::Subscribe { responder } => {
                 // Create a new subscription channel
@@ -152,7 +152,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
 
                 // Send the latest peer set immediately
                 if let Some(latest_set_id) = self.directory.latest_set_index() {
-                    let latest_set = self.directory.get_set(&latest_set_id).cloned().unwrap();
+                    let latest_set = self.directory.get_set(latest_set_id).cloned().unwrap();
                     sender
                         .unbounded_send((latest_set_id, latest_set, self.directory.tracked()))
                         .ok();

--- a/p2p/src/authenticated/lookup/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/directory.rs
@@ -163,8 +163,8 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: PublicKey> Directory
     }
 
     /// Gets a peer set by index.
-    pub fn get_set(&self, index: &u64) -> Option<&Ordered<C>> {
-        self.sets.get(index)
+    pub fn get_set(&self, index: u64) -> Option<&Ordered<C>> {
+        self.sets.get(&index)
     }
 
     /// Returns the latest peer set index.

--- a/p2p/src/authenticated/lookup/actors/tracker/metadata.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/metadata.rs
@@ -22,8 +22,7 @@ impl<P: PublicKey> Metadata<P> {
     /// Get the public key of the peer associated with this metadata.
     pub const fn public_key(&self) -> &P {
         match self {
-            Self::Dialer(public_key, _) => public_key,
-            Self::Listener(public_key) => public_key,
+            Self::Dialer(public_key, _) | Self::Listener(public_key) => public_key,
         }
     }
 }

--- a/p2p/src/authenticated/lookup/actors/tracker/record.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/record.rs
@@ -170,9 +170,8 @@ impl Record {
     /// Return the socket of the peer, if known.
     pub const fn socket(&self) -> Option<SocketAddr> {
         match &self.address {
-            Address::Myself => None,
             Address::Known(addr) => Some(*addr),
-            Address::Blocked => None,
+            Address::Myself | Address::Blocked => None,
         }
     }
 

--- a/p2p/src/simulated/bandwidth.rs
+++ b/p2p/src/simulated/bandwidth.rs
@@ -259,13 +259,10 @@ impl<'a, P: Clone + Ord> Planner<'a, P> {
             // Step 2: if the limiting resources still have headroom, advance every active flow by
             // `delta`. If `delta` is zero we already exhausted a resource, so we skip the advance
             // and immediately freeze the affected flows instead.
-            let delta = match min_delta {
-                Some(delta) => delta,
-                None => {
-                    // Every active flow should have been tied to at least one limited resource.
-                    assert_eq!(self.active, 0, "active flows without constraints");
-                    break;
-                }
+            let Some(delta) = min_delta else {
+                // Every active flow should have been tied to at least one limited resource.
+                assert_eq!(self.active, 0, "active flows without constraints");
+                break;
             };
             if delta.is_zero() {
                 for &res_idx in &limiting {
@@ -637,15 +634,12 @@ mod tests {
         let allocations = allocate(
             &flows,
             |origin: &char| match origin {
-                'A' => Some(1_000_000),
-                'B' => Some(1_000_000),
-                'C' => Some(1_000_000),
+                'A' | 'B' | 'C' => Some(1_000_000),
                 _ => None,
             },
             |recipient: &char| match recipient {
-                'A' => Some(500_000),
+                'A' | 'C' => Some(500_000),
                 'B' => Some(1_000),
-                'C' => Some(500_000),
                 _ => None,
             },
         );
@@ -678,14 +672,12 @@ mod tests {
             &flows,
             |origin: &char| match origin {
                 'A' => Some(50_000),
-                'B' => Some(1_000_000),
-                'C' => Some(1_000_000),
+                'B' | 'C' => Some(1_000_000),
                 _ => None,
             },
             |recipient: &char| match recipient {
-                'A' => Some(500_000),
+                'A' | 'C' => Some(500_000),
                 'B' => Some(1_000),
-                'C' => Some(500_000),
                 _ => None,
             },
         );

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -1292,7 +1292,7 @@ mod tests {
                 assert_eq!(origin, pk1);
                 assert_eq!(received_msg, expected_msg);
             }
-        })
+        });
     }
 
     #[test]
@@ -1399,7 +1399,7 @@ mod tests {
                     && arrival_gap <= egress_time + tolerance,
                 "next arrival deviated from transmit duration (gap = {arrival_gap:?}, expected {egress_time:?} ± {tolerance:?})"
             );
-        })
+        });
     }
 
     #[test]

--- a/p2p/src/simulated/transmitter.rs
+++ b/p2p/src/simulated/transmitter.rs
@@ -276,7 +276,7 @@ impl<P: PublicKey> State<P> {
         should_deliver: bool,
     ) -> Vec<Completion<P>> {
         let key = (origin.clone(), recipient.clone());
-        let last_arrival = self.last_arrival_complete.get(&key).cloned();
+        let last_arrival = self.last_arrival_complete.get(&key).copied();
 
         let completions = if should_deliver {
             let ready_at = Self::compute_ready_at(None, now, last_arrival, latency);
@@ -348,7 +348,7 @@ impl<P: PublicKey> State<P> {
                 continue;
             }
 
-            let last_arrival = self.last_arrival_complete.get(&key).cloned();
+            let last_arrival = self.last_arrival_complete.get(&key).copied();
             let Some(queue) = self.queued.get_mut(&key) else {
                 continue;
             };
@@ -577,7 +577,7 @@ impl<P: PublicKey> State<P> {
                 continue;
             }
 
-            let last_arrival = self.last_arrival_complete.get(&key).cloned();
+            let last_arrival = self.last_arrival_complete.get(&key).copied();
             let Some(queue) = self.queued.get_mut(&key) else {
                 continue;
             };
@@ -603,7 +603,7 @@ impl<P: PublicKey> State<P> {
         let mut remove_queue = false;
 
         if let Some(queue) = self.queued.get_mut(&key) {
-            let last_arrival = self.last_arrival_complete.get(&key).cloned();
+            let last_arrival = self.last_arrival_complete.get(&key).copied();
             match Self::refresh_front_ready_at(queue, now, last_arrival) {
                 Some(ready_at) if ready_at <= now => {
                     entry_to_start = queue.pop_front();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1099,7 +1099,7 @@ mod tests {
             // Read data past file length (non-empty file)
             let result = blob.read_at(vec![0u8; 20], 0).await;
             assert!(result.is_err());
-        })
+        });
     }
 
     fn test_blob_clone_and_concurrent_read<R: Runner>(runner: R)
@@ -1433,7 +1433,7 @@ mod tests {
                 parent_initialized_tx.send(()).unwrap();
 
                 // Parent task runs until aborted
-                pending::<()>().await
+                pending::<()>().await;
             });
 
             // Wait for parent task to spawn the children
@@ -1921,7 +1921,7 @@ mod tests {
     {
         runner.start(|context| async move {
             context.with_label(METRICS_PREFIX);
-        })
+        });
     }
 
     #[test]

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -73,9 +73,8 @@ impl crate::Storage for Storage {
 
         // Construct the full path
         let path = self.cfg.storage_directory.join(partition).join(hex(name));
-        let parent = match path.parent() {
-            Some(parent) => parent,
-            None => return Err(Error::PartitionCreationFailed(partition.into())),
+        let Some(parent) = path.parent() else {
+            return Err(Error::PartitionCreationFailed(partition.into()));
         };
 
         // Check if partition exists before creating

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -553,7 +553,7 @@ impl crate::Metrics for Context {
             .registry
             .lock()
             .unwrap()
-            .register(prefixed_name, help, metric)
+            .register(prefixed_name, help, metric);
     }
 
     fn encode(&self) -> String {

--- a/runtime/src/utils/buffer/append.rs
+++ b/runtime/src/utils/buffer/append.rs
@@ -113,7 +113,7 @@ impl<B: Blob> Append<B> {
         // the append buffer to maintain its page-boundary alignment.
         if remaining != 0 {
             buffer.offset -= remaining as u64;
-            buffer.data.extend_from_slice(&buf[buf.len() - remaining..])
+            buffer.data.extend_from_slice(&buf[buf.len() - remaining..]);
         }
 
         // Calculate where new data starts in the buffer to skip already-written trailing bytes.

--- a/runtime/src/utils/cell.rs
+++ b/runtime/src/utils/cell.rs
@@ -141,7 +141,7 @@ where
     }
 
     fn register<N: Into<String>, H: Into<String>>(&self, name: N, help: H, metric: impl Metric) {
-        self.as_ref().register(name, help, metric)
+        self.as_ref().register(name, help, metric);
     }
 
     fn encode(&self) -> String {
@@ -241,7 +241,7 @@ where
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.as_mut().fill_bytes(dest)
+        self.as_mut().fill_bytes(dest);
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -63,7 +63,7 @@ pub async fn reschedule() {
         }
     }
 
-    Reschedule { yielded: false }.await
+    Reschedule { yielded: false }.await;
 }
 
 fn extract_panic_message(err: &(dyn Any + Send)) -> String {

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -72,7 +72,7 @@ fn extract_panic_message(err: &(dyn Any + Send)) -> String {
             err.downcast_ref::<String>()
                 .map_or_else(|| format!("{err:?}"), |s| s.clone())
         },
-        |s| s.to_string(),
+        |s| (*s).to_string(),
     )
 }
 

--- a/storage/src/adb/any/ordered/fixed.rs
+++ b/storage/src/adb/any/ordered/fixed.rs
@@ -567,7 +567,7 @@ mod test {
             // Simulate a failed commit and test that the log replay doesn't leave behind old data.
             let db = open_db(context.clone()).await;
             let iter = db.snapshot.get(&k);
-            assert_eq!(iter.cloned().collect::<Vec<_>>().len(), 1);
+            assert_eq!(iter.copied().collect::<Vec<_>>().len(), 1);
             assert_eq!(db.root(), root);
 
             db.destroy().await.unwrap();
@@ -946,7 +946,7 @@ mod test {
 
                 // Delete some random keys and check order agreement again.
                 for _ in 0..500 {
-                    let key = keys.keys().choose(rng).cloned().unwrap();
+                    let key = keys.keys().choose(rng).copied().unwrap();
                     keys.remove(&key);
                     db.delete(key).await.unwrap();
                 }
@@ -964,7 +964,7 @@ mod test {
 
                 // Delete the rest of the keys and make sure we get back to empty.
                 for _ in 0..500 {
-                    let key = keys.keys().choose(rng).cloned().unwrap();
+                    let key = keys.keys().choose(rng).copied().unwrap();
                     keys.remove(&key);
                     db.delete(key).await.unwrap();
                 }

--- a/storage/src/adb/any/unordered/fixed.rs
+++ b/storage/src/adb/any/unordered/fixed.rs
@@ -431,7 +431,7 @@ pub(super) mod test {
             // Simulate a failed commit and test that the log replay doesn't leave behind old data.
             let db = open_db(context.clone()).await;
             let iter = db.snapshot.get(&k);
-            assert_eq!(iter.cloned().collect::<Vec<_>>().len(), 1);
+            assert_eq!(iter.copied().collect::<Vec<_>>().len(), 1);
             assert_eq!(db.root(), root);
 
             db.destroy().await.unwrap();

--- a/storage/src/adb/any/unordered/variable.rs
+++ b/storage/src/adb/any/unordered/variable.rs
@@ -286,7 +286,7 @@ pub(super) mod test {
             // Simulate a failed commit and test that the log replay doesn't leave behind old data.
             let db = open_db(context.clone()).await;
             let iter = db.snapshot.get(&k);
-            assert_eq!(iter.cloned().collect::<Vec<_>>().len(), 1);
+            assert_eq!(iter.copied().collect::<Vec<_>>().len(), 1);
             assert_eq!(db.root(), root);
 
             db.destroy().await.unwrap();

--- a/storage/src/adb/benches/fixed/mod.rs
+++ b/storage/src/adb/benches/fixed/mod.rs
@@ -34,7 +34,7 @@ enum Variant {
 }
 
 impl Variant {
-    pub const fn name(&self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         match self {
             Self::Store => "store",
             Self::AnyUnordered => "any::fixed::unordered",

--- a/storage/src/adb/benches/variable/mod.rs
+++ b/storage/src/adb/benches/variable/mod.rs
@@ -23,7 +23,7 @@ enum Variant {
 }
 
 impl Variant {
-    pub const fn name(&self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         match self {
             Self::Store => "store",
             Self::Any => "any",

--- a/storage/src/adb/current/ordered.rs
+++ b/storage/src/adb/current/ordered.rs
@@ -298,8 +298,8 @@ impl<
             KeyValueProofInfo {
                 key,
                 value,
-                next_key,
                 loc,
+                next_key,
                 chunk,
             },
         ))

--- a/storage/src/adb/keyless.rs
+++ b/storage/src/adb/keyless.rs
@@ -822,12 +822,8 @@ mod test {
             for i in 0..*oldest_retained {
                 let result = db.get(Location::new_unchecked(i)).await;
                 // Should either return None (for commit ops) or encounter pruned data
-                match result {
-                    Ok(None) => {} // Commit operation or pruned
-                    Ok(Some(_)) => {
-                        panic!("Should not be able to get pruned value at location {i}")
-                    }
-                    Err(_) => {} // Expected error for pruned data
+                if let Ok(Some(_)) = result {
+                    panic!("Should not be able to get pruned value at location {i}")
                 }
             }
 

--- a/storage/src/adb/operation/fixed/unordered.rs
+++ b/storage/src/adb/operation/fixed/unordered.rs
@@ -57,8 +57,7 @@ impl<K: Array, V: Value> Keyed for Operation<K, V> {
 
     fn key(&self) -> Option<&Self::Key> {
         match self {
-            Self::Delete(key) => Some(key),
-            Self::Update(key, _) => Some(key),
+            Self::Delete(key) | Self::Update(key, _) => Some(key),
             Self::CommitFloor(_, _) => None,
         }
     }

--- a/storage/src/adb/operation/variable/unordered.rs
+++ b/storage/src/adb/operation/variable/unordered.rs
@@ -25,8 +25,7 @@ impl<K: Array, V: Value> Operation<K, V> {
     /// If this is an operation involving a key, returns the key. Otherwise, returns None.
     pub const fn key(&self) -> Option<&K> {
         match self {
-            Self::Delete(key) => Some(key),
-            Self::Update(key, _) => Some(key),
+            Self::Delete(key) | Self::Update(key, _) => Some(key),
             Self::CommitFloor(_, _) => None,
         }
     }

--- a/storage/src/adb/sync/target.rs
+++ b/storage/src/adb/sync/target.rs
@@ -193,8 +193,8 @@ mod tests {
                 (
                     TestError::Engine(EngineError::SyncTargetMovedBackward { .. }),
                     TestError::Engine(EngineError::SyncTargetMovedBackward { .. }),
-                ) => {}
-                (
+                )
+                | (
                     TestError::Engine(EngineError::SyncTargetRootUnchanged),
                     TestError::Engine(EngineError::SyncTargetRootUnchanged),
                 ) => {}

--- a/storage/src/archive/benches/get.rs
+++ b/storage/src/archive/benches/get.rs
@@ -83,9 +83,7 @@ fn bench_get(c: &mut Criterion) {
                             variant.name(),
                             mode,
                             pattern,
-                            compression
-                                .map(|l| l.to_string())
-                                .unwrap_or_else(|| "off".into()),
+                            compression.map_or_else(|| "off".into(), |l| l.to_string()),
                             reads
                         );
                         c.bench_function(&label, |b| {

--- a/storage/src/archive/benches/get.rs
+++ b/storage/src/archive/benches/get.rs
@@ -101,14 +101,15 @@ fn bench_get(c: &mut Criterion) {
                                         for _ in 0..iters {
                                             match mode {
                                                 "serial" => {
-                                                    read_serial_keys(&archive, &selected_keys).await
+                                                    read_serial_keys(&archive, &selected_keys)
+                                                        .await;
                                                 }
                                                 "concurrent" => {
                                                     read_concurrent_keys(
                                                         &archive,
                                                         selected_keys.clone(),
                                                     )
-                                                    .await
+                                                    .await;
                                                 }
                                                 _ => unreachable!(),
                                             }
@@ -120,15 +121,18 @@ fn bench_get(c: &mut Criterion) {
                                         for _ in 0..iters {
                                             match mode {
                                                 "serial" => {
-                                                    read_serial_indices(&archive, &selected_indices)
-                                                        .await
+                                                    read_serial_indices(
+                                                        &archive,
+                                                        &selected_indices,
+                                                    )
+                                                    .await;
                                                 }
                                                 "concurrent" => {
                                                     read_concurrent_indices(
                                                         &archive,
                                                         &selected_indices,
                                                     )
-                                                    .await
+                                                    .await;
                                                 }
                                                 _ => unreachable!(),
                                             }

--- a/storage/src/archive/benches/put.rs
+++ b/storage/src/archive/benches/put.rs
@@ -14,9 +14,7 @@ fn bench_put(c: &mut Criterion) {
                     module_path!(),
                     variant.name(),
                     items,
-                    compression
-                        .map(|l| l.to_string())
-                        .unwrap_or_else(|| "off".into()),
+                    compression.map_or_else(|| "off".into(), |l| l.to_string()),
                 );
                 c.bench_function(&label, |b| {
                     b.to_async(&runner).iter_custom(move |iters| async move {

--- a/storage/src/archive/benches/restart.rs
+++ b/storage/src/archive/benches/restart.rs
@@ -29,9 +29,7 @@ fn bench_restart(c: &mut Criterion) {
                         module_path!(),
                         variant.name(),
                         items,
-                        compression
-                            .map(|l| l.to_string())
-                            .unwrap_or_else(|| "off".into())
+                        compression.map_or_else(|| "off".into(), |l| l.to_string())
                     ),
                     |b| {
                         b.to_async(&runner).iter_custom(|iters| async move {

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -37,7 +37,7 @@ pub enum Variant {
 }
 
 impl Variant {
-    pub const fn name(&self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         match self {
             Self::Immutable => "immutable",
             Self::Prunable => "prunable",

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -528,7 +528,7 @@ mod tests {
 
         {
             let archive = creator(context, compression).await;
-            let sorted_indices: Vec<u64> = keys.keys().cloned().collect();
+            let sorted_indices: Vec<u64> = keys.keys().copied().collect();
 
             // Check gap before the first element
             let (current_end, start_next) = archive.next_gap(0);

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -181,9 +181,8 @@ impl<T: Translator, E: Storage + Metrics, K: Array, V: Codec> Archive<T, E, K, V
         self.gets.inc();
 
         // Get index location
-        let location = match self.indices.get(&index) {
-            Some(offset) => offset,
-            None => return Ok(None),
+        let Some(location) = self.indices.get(&index) else {
+            return Ok(None);
         };
 
         // Fetch item from disk

--- a/storage/src/bitmap/authenticated.rs
+++ b/storage/src/bitmap/authenticated.rs
@@ -988,7 +988,7 @@ mod tests {
                     );
                 }
             }
-        })
+        });
     }
 
     #[test_traced]

--- a/storage/src/bmt/benches/build.rs
+++ b/storage/src/bmt/benches/build.rs
@@ -21,7 +21,7 @@ fn bench_new(c: &mut Criterion) {
                     builder.add(element);
                 }
                 builder.build();
-            })
+            });
         });
     }
 }

--- a/storage/src/bmt/benches/prove_range.rs
+++ b/storage/src/bmt/benches/prove_range.rs
@@ -41,7 +41,7 @@ fn bench_prove_range(c: &mut Criterion) {
                             .is_ok());
                     },
                     criterion::BatchSize::SmallInput,
-                )
+                );
             },
         );
     }

--- a/storage/src/bmt/benches/prove_single.rs
+++ b/storage/src/bmt/benches/prove_single.rs
@@ -27,7 +27,7 @@ fn bench_prove_single(c: &mut Criterion) {
                     || {
                         let samples = queries
                             .choose_multiple(&mut sampler, SAMPLE_SIZE)
-                            .cloned()
+                            .copied()
                             .collect::<Vec<_>>();
                         samples
                     },

--- a/storage/src/bmt/benches/prove_single.rs
+++ b/storage/src/bmt/benches/prove_single.rs
@@ -39,7 +39,7 @@ fn bench_prove_single(c: &mut Criterion) {
                         }
                     },
                     criterion::BatchSize::SmallInput,
-                )
+                );
             },
         );
     }

--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -150,9 +150,8 @@ impl<E: Storage + Metrics, V: Codec> Cache<E, V> {
         self.gets.inc();
 
         // Get index location
-        let location = match self.indices.get(&index) {
-            Some(offset) => offset,
-            None => return Ok(None),
+        let Some(location) = self.indices.get(&index) else {
+            return Ok(None);
         };
 
         // Fetch item from disk

--- a/storage/src/freezer/benches/get.rs
+++ b/storage/src/freezer/benches/get.rs
@@ -89,7 +89,7 @@ fn bench_get(c: &mut Criterion) {
                                 match mode {
                                     "serial" => read_serial_keys(&store, &selected_keys).await,
                                     "concurrent" => {
-                                        read_concurrent_keys(&store, &selected_keys).await
+                                        read_concurrent_keys(&store, &selected_keys).await;
                                     }
                                     _ => unreachable!(),
                                 }

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -749,7 +749,7 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> Freezer<E, K, V> {
         // Update the number of items added to the entry.
         //
         // We use `saturating_add` to handle overflow (when the table is at max size) gracefully.
-        let mut added = head.map(|(_, _, added)| added).unwrap_or(0);
+        let mut added = head.map_or(0, |(_, _, added)| added);
         added = added.saturating_add(1);
 
         // If we've reached the threshold for resizing, increment the resizable entries

--- a/storage/src/index/benches/hashmap_insert.rs
+++ b/storage/src/index/benches/hashmap_insert.rs
@@ -50,7 +50,7 @@ fn benchmark_hashmap_insert(c: &mut Criterion) {
                         }
                     },
                     BatchSize::SmallInput,
-                )
+                );
             });
         }
     }

--- a/storage/src/index/benches/hashmap_insert_fixed.rs
+++ b/storage/src/index/benches/hashmap_insert_fixed.rs
@@ -48,7 +48,7 @@ fn benchmark_hashmap_insert_fixed(c: &mut Criterion) {
                     }
                 },
                 BatchSize::SmallInput,
-            )
+            );
         });
     }
 }

--- a/storage/src/index/benches/hashmap_iteration.rs
+++ b/storage/src/index/benches/hashmap_iteration.rs
@@ -43,7 +43,7 @@ fn benchmark_hashmap_iteration(c: &mut Criterion) {
                         }
                     },
                     BatchSize::SmallInput,
-                )
+                );
             });
         }
     }

--- a/storage/src/index/benches/insert.rs
+++ b/storage/src/index/benches/insert.rs
@@ -25,7 +25,7 @@ enum Variant {
 }
 
 impl Variant {
-    pub const fn name(&self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         match self {
             Self::Ordered => "ordered",
             Self::Unordered => "unordered",

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -61,7 +61,7 @@ impl<K: Ord, V: Eq> CursorTrait for Cursor<'_, K, V> {
     type Value = V;
 
     fn update(&mut self, v: V) {
-        self.inner.update(v)
+        self.inner.update(v);
     }
 
     fn next(&mut self) -> Option<&V> {
@@ -69,15 +69,15 @@ impl<K: Ord, V: Eq> CursorTrait for Cursor<'_, K, V> {
     }
 
     fn insert(&mut self, v: V) {
-        self.inner.insert(v)
+        self.inner.insert(v);
     }
 
     fn delete(&mut self) {
-        self.inner.delete()
+        self.inner.delete();
     }
 
     fn prune(&mut self, predicate: &impl Fn(&V) -> bool) {
-        self.inner.prune(predicate)
+        self.inner.prune(predicate);
     }
 }
 

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -306,15 +306,16 @@ impl<V: Eq, E: IndexEntry<V>> Drop for Cursor<'_, V, E> {
 
         // If there is a dangling next, we should add it to past.
         match std::mem::replace(&mut self.phase, Phase::Done) {
-            Phase::Initial | Phase::Entry => {
+            Phase::Initial
+            | Phase::Entry
+            | Phase::Done
+            | Phase::PostDeleteEntry
+            | Phase::PostDeleteNext(None) => {
                 // No action needed.
             }
             Phase::Next(next) => {
                 // If there is a next, we should add it to past.
                 self.past_push(next);
-            }
-            Phase::Done => {
-                // No action needed.
             }
             Phase::EntryDeleted => {
                 // If the entry is deleted, we should remove it.
@@ -322,15 +323,9 @@ impl<V: Eq, E: IndexEntry<V>> Drop for Cursor<'_, V, E> {
                 entry.remove();
                 return;
             }
-            Phase::PostDeleteEntry => {
-                // No action needed.
-            }
             Phase::PostDeleteNext(Some(next)) => {
                 // If there is a stale record, we should add it to past.
                 self.past_push(next);
-            }
-            Phase::PostDeleteNext(None) => {
-                // No action needed.
             }
             Phase::PostInsert(next) => {
                 // If there is a current record, we should add it to past.

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -62,19 +62,19 @@ impl<K, V: Eq> CursorTrait for Cursor<'_, K, V> {
     }
 
     fn insert(&mut self, value: V) {
-        self.inner.insert(value)
+        self.inner.insert(value);
     }
 
     fn delete(&mut self) {
-        self.inner.delete()
+        self.inner.delete();
     }
 
     fn update(&mut self, value: V) {
-        self.inner.update(value)
+        self.inner.update(value);
     }
 
     fn prune(&mut self, predicate: &impl Fn(&V) -> bool) {
-        self.inner.prune(predicate)
+        self.inner.prune(predicate);
     }
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -634,10 +634,7 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> Journal<E, A> {
             .await?;
 
         match self.context.remove(&self.cfg.partition, None).await {
-            Ok(()) => {}
-            Err(RError::PartitionMissing(_)) => {
-                // Partition already removed or never existed.
-            }
+            Ok(()) | Err(RError::PartitionMissing(_)) => {}
             Err(err) => return Err(Error::Runtime(err)),
         }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -693,9 +693,6 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
                     "offsets oldest pos ({oldest_retained_pos}) > data oldest pos ({data_oldest_pos})"
                 )));
             }
-            Some(_) => {
-                // Both journals are pruned to the same position.
-            }
             None if data_oldest_pos > 0 => {
                 // Offsets journal is empty (size == oldest_retained_pos).
                 // This can happen if we pruned all data, then appended new data, persisted the
@@ -709,8 +706,8 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
                 }
                 info!("crash repair: offsets journal empty at {data_oldest_pos}");
             }
-            None => {
-                // Both journals are empty/fully pruned.
+            Some(_) | None => {
+                // Both journals are pruned to the same position, or both empty/fully pruned.
             }
         }
 

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -556,9 +556,8 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
         // Ensure item is not too large
         let item_len = encoded.len();
         let entry_len = 4 + item_len + 4;
-        let item_len = match item_len.try_into() {
-            Ok(len) => len,
-            Err(_) => return Err(Error::ItemTooLarge(item_len)),
+        let Ok(item_len) = item_len.try_into() else {
+            return Err(Error::ItemTooLarge(item_len));
         };
 
         // Get existing blob or create new one
@@ -621,9 +620,8 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     ///    undefined.
     pub async fn get(&self, section: u64, offset: u32) -> Result<V, Error> {
         self.prune_guard(section)?;
-        let blob = match self.blobs.get(&section) {
-            Some(blob) => blob,
-            None => return Err(Error::SectionOutOfRange(section)),
+        let Some(blob) = self.blobs.get(&section) else {
+            return Err(Error::SectionOutOfRange(section));
         };
 
         // Perform a multi-op read.
@@ -640,9 +638,8 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     /// Retrieves an item from `Journal` at a given `section` and `offset` with a given size.
     pub async fn get_exact(&self, section: u64, offset: u32, size: u32) -> Result<V, Error> {
         self.prune_guard(section)?;
-        let blob = match self.blobs.get(&section) {
-            Some(blob) => blob,
-            None => return Err(Error::SectionOutOfRange(section)),
+        let Some(blob) = self.blobs.get(&section) else {
+            return Err(Error::SectionOutOfRange(section));
         };
 
         // Perform a multi-op read.
@@ -714,9 +711,8 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
         }
 
         // If the section exists, truncate it to the given offset
-        let blob = match self.blobs.get_mut(&section) {
-            Some(blob) => blob,
-            None => return Ok(()),
+        let Some(blob) = self.blobs.get_mut(&section) else {
+            return Ok(());
         };
         let current = blob.size().await;
         if size >= current {
@@ -744,9 +740,8 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
         self.prune_guard(section)?;
 
         // Get the blob at the given section
-        let blob = match self.blobs.get_mut(&section) {
-            Some(blob) => blob,
-            None => return Ok(()),
+        let Some(blob) = self.blobs.get_mut(&section) else {
+            return Ok(());
         };
 
         // Truncate the blob to the given size
@@ -764,9 +759,8 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
     /// If the `section` does not exist, no error will be returned.
     pub async fn sync(&self, section: u64) -> Result<(), Error> {
         self.prune_guard(section)?;
-        let blob = match self.blobs.get(&section) {
-            Some(blob) => blob,
-            None => return Ok(()),
+        let Some(blob) = self.blobs.get(&section) else {
+            return Ok(());
         };
         self.synced.inc();
         blob.sync().await.map_err(Error::Runtime)
@@ -831,10 +825,7 @@ impl<E: Storage + Metrics, V: Codec> Journal<E, V> {
                 .await?;
         }
         match self.context.remove(&self.cfg.partition, None).await {
-            Ok(()) => {}
-            Err(RError::PartitionMissing(_)) => {
-                // Partition already removed or never existed.
-            }
+            Ok(()) | Err(RError::PartitionMissing(_)) => {}
             Err(err) => return Err(Error::Runtime(err)),
         }
         Ok(())

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -441,8 +441,7 @@ impl<E: Clock + Storage + Metrics, K: Array, V: Codec> Metadata<E, K, V> {
             debug!(blob = i, "destroyed blob");
         }
         match self.context.remove(&self.partition, None).await {
-            Ok(()) => {}
-            Err(RError::PartitionMissing(_)) => {
+            Ok(()) | Err(RError::PartitionMissing(_)) => {
                 // Partition already removed or never existed.
             }
             Err(err) => return Err(Error::Runtime(err)),

--- a/storage/src/mmr/benches/append.rs
+++ b/storage/src/mmr/benches/append.rs
@@ -28,7 +28,7 @@ fn bench_append(c: &mut Criterion) {
                     for digest in &elements {
                         mmr.add(&mut h, digest);
                     }
-                })
+                });
             });
         });
     }

--- a/storage/src/mmr/benches/append_additional.rs
+++ b/storage/src/mmr/benches/append_additional.rs
@@ -47,7 +47,7 @@ fn bench_append_additional(c: &mut Criterion) {
                         });
                     },
                     criterion::BatchSize::SmallInput,
-                )
+                );
             });
         }
     }

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -46,7 +46,7 @@ fn bench_prove_many_elements(c: &mut Criterion) {
                             let start_locs: Vec<u64> = (0u64..n as u64 - range).collect();
                             let start_loc_samples = start_locs
                                 .choose_multiple(&mut sampler, SAMPLE_SIZE)
-                                .cloned()
+                                .copied()
                                 .collect::<Vec<_>>();
                             let mut samples = Vec::with_capacity(SAMPLE_SIZE);
                             block_on(async {

--- a/storage/src/mmr/benches/prove_many_elements.rs
+++ b/storage/src/mmr/benches/prove_many_elements.rs
@@ -70,10 +70,10 @@ fn bench_prove_many_elements(c: &mut Criterion) {
                                         &root,
                                     ));
                                 }
-                            })
+                            });
                         },
                         criterion::BatchSize::SmallInput,
-                    )
+                    );
                 },
             );
         }

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -55,7 +55,7 @@ fn bench_prove_single_element(c: &mut Criterion) {
                         });
                     },
                     criterion::BatchSize::SmallInput,
-                )
+                );
             },
         );
     }

--- a/storage/src/mmr/benches/prove_single_element.rs
+++ b/storage/src/mmr/benches/prove_single_element.rs
@@ -35,7 +35,7 @@ fn bench_prove_single_element(c: &mut Criterion) {
                     || {
                         let samples = elements
                             .choose_multiple(&mut sampler, SAMPLE_SIZE)
-                            .cloned()
+                            .copied()
                             .map(|(loc, element)| (Location::new(loc as u64).unwrap(), element))
                             .collect::<Vec<_>>();
                         samples

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -381,7 +381,7 @@ impl<E: RStorage + Clock + Metrics, D: Digest> CleanMmr<E, D> {
             }
             journal.rewind(*last_valid_size).await?;
             journal.sync().await?;
-            journal_size = last_valid_size
+            journal_size = last_valid_size;
         }
 
         // Initialize the mem_mmr in the "prune_all" state.

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -1959,7 +1959,7 @@ mod tests {
                 let pos = Position::new(pos);
                 assert_eq!(
                     sync_mmr.get_node(pos).await.unwrap(),
-                    expected_nodes.get(&pos).cloned()
+                    expected_nodes.get(&pos).copied()
                 );
             }
 
@@ -2021,7 +2021,7 @@ mod tests {
                 let pos = Position::new(pos);
                 assert_eq!(
                     sync_mmr.get_node(pos).await.unwrap(),
-                    expected_nodes.get(&pos).cloned()
+                    expected_nodes.get(&pos).copied()
                 );
             }
 

--- a/storage/src/mmr/proof.rs
+++ b/storage/src/mmr/proof.rs
@@ -818,13 +818,13 @@ mod tests {
         const PEAK_COUNT: usize = 3;
         proof2
             .digests
-            .extend(proof.digests[0..PEAK_COUNT - 1].iter().cloned());
+            .extend(proof.digests[0..PEAK_COUNT - 1].iter().copied());
         // sneak in an extra hash that won't be used in the computation and make sure it's
         // detected
         proof2.digests.push(test_digest(0));
         proof2
             .digests
-            .extend(proof.digests[PEAK_COUNT - 1..].iter().cloned());
+            .extend(proof.digests[PEAK_COUNT - 1..].iter().copied());
         assert!(
             !proof2.verify_element_inclusion(&mut hasher, &element, LEAF, root),
             "proof verification should fail with extra hash even if it's unused by the computation"

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -68,7 +68,7 @@ impl<D: Digest> ProofStore<D> {
 
 impl<D: Digest> Storage<D> for ProofStore<D> {
     async fn get_node(&self, pos: Position) -> Result<Option<D>, Error> {
-        Ok(self.digests.get(&pos).cloned())
+        Ok(self.digests.get(&pos).copied())
     }
 
     fn size(&self) -> Position {

--- a/storage/src/ordinal/benches/get.rs
+++ b/storage/src/ordinal/benches/get.rs
@@ -65,7 +65,7 @@ fn bench_get(c: &mut Criterion) {
                         match mode {
                             "serial" => read_serial_indices(&store, &selected_indices).await,
                             "concurrent" => {
-                                read_concurrent_indices(&store, &selected_indices).await
+                                read_concurrent_indices(&store, &selected_indices).await;
                             }
                             _ => unreachable!(),
                         }

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -403,8 +403,7 @@ impl<E: Storage + Metrics + Clock, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
             debug!(section = i, "destroyed blob");
         }
         match self.context.remove(&self.config.partition, None).await {
-            Ok(()) => {}
-            Err(RError::PartitionMissing(_)) => {
+            Ok(()) | Err(RError::PartitionMissing(_)) => {
                 // Partition already removed or never existed.
             }
             Err(err) => return Err(Error::Runtime(err)),

--- a/utils/src/hex_literal.rs
+++ b/utils/src/hex_literal.rs
@@ -23,13 +23,11 @@ const fn next_hex_char(string: &[u8], mut pos: usize) -> Option<(u8, usize)> {
 }
 
 const fn next_byte(string: &[u8], pos: usize) -> Option<(u8, usize)> {
-    let (half1, pos) = match next_hex_char(string, pos) {
-        Some(v) => v,
-        None => return None,
+    let Some((half1, pos)) = next_hex_char(string, pos) else {
+        return None;
     };
-    let (half2, pos) = match next_hex_char(string, pos) {
-        Some(v) => v,
-        None => panic!("Odd number of hex characters"),
+    let Some((half2, pos)) = next_hex_char(string, pos) else {
+        panic!("Odd number of hex characters")
     };
     Some(((half1 << 4) + half2, pos))
 }

--- a/utils/src/priority_set.rs
+++ b/utils/src/priority_set.rs
@@ -68,7 +68,7 @@ impl<I: Ord + Hash + Clone, P: Ord + Copy> PrioritySet<I, P> {
 
     /// Get the current priority of an item.
     pub fn get(&self, item: &I) -> Option<P> {
-        self.keys.get(item).cloned()
+        self.keys.get(item).copied()
     }
 
     /// Remove an item from the set.


### PR DESCRIPTION
Add the following clippy lints to Cargo.toml:
- manual_let_else = "warn"
- semicolon_if_nothing_returned = "warn"
- match_same_arms = "warn"
- flat_map_option = "warn"
- inconsistent_struct_constructor = "warn"

Fix all resulting warnings across the codebase:
- Convert match statements to let...else pattern where appropriate
- Add semicolons to statements that return unit
- Merge match arms with identical bodies
- Fix struct constructor field ordering to match definition

Replaces: #2371