### PR TITLE
Add consensus weights support for ed25519 and bls12381_multisig

### DIFF
--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -446,7 +446,7 @@ mod tests {
         sha256::Digest as Sha256,
         PrivateKeyExt, Signer,
     };
-    use commonware_utils::{quorum, quorum_from_slice, set::Ordered};
+    use commonware_utils::{quorum, quorum_from_slice};
     use rand::{
         rngs::{OsRng, StdRng},
         SeedableRng,
@@ -481,10 +481,16 @@ mod tests {
     }
 
     fn generate_ed25519_schemes(n: usize, seed: u64) -> Vec<ed25519::Scheme> {
+        use commonware_utils::set::OrderedWeighted;
+
         let mut rng = StdRng::seed_from_u64(seed);
         let private_keys: Vec<_> = (0..n).map(|_| EdPrivateKey::from_rng(&mut rng)).collect();
 
-        let participants: Ordered<_> = private_keys.iter().map(|p| p.public_key()).collect();
+        // Create weighted participants with uniform weight of 1
+        let participants: OrderedWeighted<_> = private_keys
+            .iter()
+            .map(|p| (p.public_key(), 1u64))
+            .collect();
 
         private_keys
             .into_iter()

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -14,14 +14,15 @@ use rand::{CryptoRng, Rng};
 /// and signals they are ready to be verified (when there exist enough messages to potentially reach
 /// a quorum).
 ///
-/// To avoid unnecessary verification, it also tracks the number of already verified messages (ensuring
-/// we no longer attempt to verify messages after a quorum of valid messages have already been verified).
+/// To avoid unnecessary verification, it also tracks the accumulated weight of already verified
+/// messages (ensuring we no longer attempt to verify messages after a quorum weight of valid
+/// messages have already been verified).
 pub struct Verifier<S: Scheme, D: Digest> {
     /// Signing scheme used to verify votes and assemble certificates.
     scheme: S,
 
-    /// Required quorum size.
-    quorum: usize,
+    /// Required weighted quorum threshold.
+    quorum: u64,
 
     /// Current leader index.
     leader: Option<u32>,
@@ -30,18 +31,18 @@ pub struct Verifier<S: Scheme, D: Digest> {
 
     /// Pending notarize votes waiting to be verified.
     notarizes: Vec<Notarize<S, D>>,
-    /// Count of already-verified notarize votes.
-    notarizes_verified: usize,
+    /// Accumulated weight of already-verified notarize votes.
+    notarizes_verified_weight: u64,
 
     /// Pending nullify votes waiting to be verified.
     nullifies: Vec<Nullify<S>>,
-    /// Count of already-verified nullify votes.
-    nullifies_verified: usize,
+    /// Accumulated weight of already-verified nullify votes.
+    nullifies_verified_weight: u64,
 
     /// Pending finalize votes waiting to be verified.
     finalizes: Vec<Finalize<S, D>>,
-    /// Count of already-verified finalize votes.
-    finalizes_verified: usize,
+    /// Accumulated weight of already-verified finalize votes.
+    finalizes_verified_weight: u64,
 }
 
 impl<S: Scheme, D: Digest> Verifier<S, D> {
@@ -49,28 +50,25 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
     ///
     /// # Arguments
     ///
-    /// * `signing` - Scheme handle used to verify and aggregate votes.
-    /// * `quorum` - An optional `u32` specifying the number of votes (2f+1)
-    ///   required to reach a quorum. If `None`, batch verification readiness
-    ///   checks based on quorum size are skipped.
-    pub const fn new(scheme: S, quorum: u32) -> Self {
+    /// * `scheme` - Scheme handle used to verify and aggregate votes.
+    /// * `quorum` - The weighted quorum threshold required to reach consensus.
+    pub const fn new(scheme: S, quorum: u64) -> Self {
         Self {
             scheme,
 
-            // Store quorum as usize to simplify comparisons against queue lengths.
-            quorum: quorum as usize,
+            quorum,
 
             leader: None,
             leader_proposal: None,
 
             notarizes: Vec::new(),
-            notarizes_verified: 0,
+            notarizes_verified_weight: 0,
 
             nullifies: Vec::new(),
-            nullifies_verified: 0,
+            nullifies_verified_weight: 0,
 
             finalizes: Vec::new(),
-            finalizes_verified: 0,
+            finalizes_verified_weight: 0,
         }
     }
 
@@ -94,8 +92,8 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
 
     /// Adds a [Vote] message to the batch for later verification.
     ///
-    /// If the message has already been verified (e.g., we built it), it increments
-    /// the count of verified messages directly. Otherwise, it adds the message to
+    /// If the message has already been verified (e.g., we built it), it adds the
+    /// signer's weight to the verified weight. Otherwise, it adds the message to
     /// the appropriate pending queue.
     ///
     /// If a leader is known and the message is a [Vote::Notarize] from that leader,
@@ -128,7 +126,7 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
 
                 // If we've made it this far, add the notarize
                 if verified {
-                    self.notarizes_verified += 1;
+                    self.notarizes_verified_weight += self.scheme.weight(notarize.signer());
                 } else {
                     self.notarizes.push(notarize);
                 }
@@ -136,7 +134,7 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
             }
             Vote::Nullify(nullify) => {
                 if verified {
-                    self.nullifies_verified += 1;
+                    self.nullifies_verified_weight += self.scheme.weight(nullify.signer());
                 } else {
                     self.nullifies.push(nullify);
                 }
@@ -152,7 +150,7 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
 
                 // If we've made it this far, add the finalize
                 if verified {
-                    self.finalizes_verified += 1;
+                    self.finalizes_verified_weight += self.scheme.weight(finalize.signer());
                 } else {
                     self.finalizes.push(finalize);
                 }
@@ -175,6 +173,30 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
             return;
         };
         self.set_leader_proposal(notarize.proposal.clone());
+    }
+
+    /// Computes the total weight of pending notarize votes.
+    fn pending_notarizes_weight(&self) -> u64 {
+        self.notarizes
+            .iter()
+            .map(|n| self.scheme.weight(n.signer()))
+            .sum()
+    }
+
+    /// Computes the total weight of pending nullify votes.
+    fn pending_nullifies_weight(&self) -> u64 {
+        self.nullifies
+            .iter()
+            .map(|n| self.scheme.weight(n.signer()))
+            .sum()
+    }
+
+    /// Computes the total weight of pending finalize votes.
+    fn pending_finalizes_weight(&self) -> u64 {
+        self.finalizes
+            .iter()
+            .map(|f| self.scheme.weight(f.signer()))
+            .sum()
     }
 
     /// Verifies a batch of pending [Vote::Notarize] messages.
@@ -217,7 +239,10 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
             .scheme
             .verify_votes(rng, namespace, Subject::Notarize { proposal }, signatures);
 
-        self.notarizes_verified += verified.len();
+        // Accumulate weight of verified votes
+        for sig in &verified {
+            self.notarizes_verified_weight += self.scheme.weight(sig.signer);
+        }
 
         (
             verified
@@ -239,9 +264,9 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
     /// Verification is considered "ready" when all of the following are true:
     /// 1. There are pending notarize messages to verify.
     /// 2. The leader and their proposal are known (so we know which proposal to verify for).
-    /// 3. We haven't already verified enough messages to reach quorum.
-    /// 4. The sum of verified and pending messages could potentially reach quorum.
-    pub const fn ready_notarizes(&self) -> bool {
+    /// 3. We haven't already verified enough weight to reach quorum.
+    /// 4. The sum of verified and pending weight could potentially reach quorum.
+    pub fn ready_notarizes(&self) -> bool {
         // If there are no pending notarizes, there is nothing to do.
         if self.notarizes.is_empty() {
             return false;
@@ -253,13 +278,13 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
             return false;
         }
 
-        // If we have already verified enough messages, there is nothing more to do.
-        if self.notarizes_verified >= self.quorum {
+        // If we have already verified enough weight, there is nothing more to do.
+        if self.notarizes_verified_weight >= self.quorum {
             return false;
         }
 
-        // If we don't have enough to reach the quorum, there is nothing to do yet.
-        if self.notarizes_verified + self.notarizes.len() < self.quorum {
+        // If we don't have enough weight to reach the quorum, there is nothing to do yet.
+        if self.notarizes_verified_weight + self.pending_notarizes_weight() < self.quorum {
             return false;
         }
 
@@ -304,7 +329,10 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
             nullifies.into_iter().map(|nullify| nullify.signature),
         );
 
-        self.nullifies_verified += verified.len();
+        // Accumulate weight of verified votes
+        for sig in &verified {
+            self.nullifies_verified_weight += self.scheme.weight(sig.signer);
+        }
 
         (
             verified
@@ -319,21 +347,21 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
     ///
     /// Verification is considered "ready" when all of the following are true:
     /// 1. There are pending nullify messages to verify.
-    /// 2. We haven't already verified enough messages to reach quorum.
-    /// 3. The sum of verified and pending messages could potentially reach quorum.
-    pub const fn ready_nullifies(&self) -> bool {
+    /// 2. We haven't already verified enough weight to reach quorum.
+    /// 3. The sum of verified and pending weight could potentially reach quorum.
+    pub fn ready_nullifies(&self) -> bool {
         // If there are no pending nullifies, there is nothing to do.
         if self.nullifies.is_empty() {
             return false;
         }
 
-        // If we have already verified enough messages, there is nothing more to do.
-        if self.nullifies_verified >= self.quorum {
+        // If we have already verified enough weight, there is nothing more to do.
+        if self.nullifies_verified_weight >= self.quorum {
             return false;
         }
 
-        // If we don't have enough to reach the quorum, there is nothing to do yet.
-        if self.nullifies_verified + self.nullifies.len() < self.quorum {
+        // If we don't have enough weight to reach the quorum, there is nothing to do yet.
+        if self.nullifies_verified_weight + self.pending_nullifies_weight() < self.quorum {
             return false;
         }
 
@@ -380,7 +408,10 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
             .scheme
             .verify_votes(rng, namespace, Subject::Finalize { proposal }, signatures);
 
-        self.finalizes_verified += verified.len();
+        // Accumulate weight of verified votes
+        for sig in &verified {
+            self.finalizes_verified_weight += self.scheme.weight(sig.signer);
+        }
 
         (
             verified
@@ -402,9 +433,9 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
     /// Verification is considered "ready" when all of the following are true:
     /// 1. There are pending finalize messages to verify.
     /// 2. The leader and their proposal are known (so we know which proposal to verify for).
-    /// 3. We haven't already verified enough messages to reach quorum.
-    /// 4. The sum of verified and pending messages could potentially reach quorum.
-    pub const fn ready_finalizes(&self) -> bool {
+    /// 3. We haven't already verified enough weight to reach quorum.
+    /// 4. The sum of verified and pending weight could potentially reach quorum.
+    pub fn ready_finalizes(&self) -> bool {
         // If there are no pending finalizes, there is nothing to do.
         if self.finalizes.is_empty() {
             return false;
@@ -416,13 +447,13 @@ impl<S: Scheme, D: Digest> Verifier<S, D> {
             return false;
         }
 
-        // If we have already verified enough messages, there is nothing more to do.
-        if self.finalizes_verified >= self.quorum {
+        // If we have already verified enough weight, there is nothing more to do.
+        if self.finalizes_verified_weight >= self.quorum {
             return false;
         }
 
-        // If we don't have enough to reach the quorum, there is nothing to do yet.
-        if self.finalizes_verified + self.finalizes.len() < self.quorum {
+        // If we don't have enough weight to reach the quorum, there is nothing to do yet.
+        if self.finalizes_verified_weight + self.pending_finalizes_weight() < self.quorum {
             return false;
         }
 
@@ -446,7 +477,7 @@ mod tests {
         sha256::Digest as Sha256,
         PrivateKeyExt, Signer,
     };
-    use commonware_utils::{quorum, quorum_from_slice};
+    use commonware_utils::quorum;
     use rand::{
         rngs::{OsRng, StdRng},
         SeedableRng,
@@ -526,7 +557,7 @@ mod tests {
     }
 
     fn add_notarize<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
 
         let round = Round::new(Epoch::new(0), View::new(1));
@@ -536,11 +567,11 @@ mod tests {
 
         verifier.add(Vote::Notarize(notarize1.clone()), false);
         assert_eq!(verifier.notarizes.len(), 1);
-        assert_eq!(verifier.notarizes_verified, 0);
+        assert_eq!(verifier.notarizes_verified_weight, 0);
 
         verifier.add(Vote::Notarize(notarize1.clone()), true);
         assert_eq!(verifier.notarizes.len(), 1);
-        assert_eq!(verifier.notarizes_verified, 1);
+        assert_eq!(verifier.notarizes_verified_weight, 1);
 
         verifier.set_leader(notarize1.signer());
         assert!(verifier.leader_proposal.is_some());
@@ -582,7 +613,7 @@ mod tests {
     }
 
     fn set_leader<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
 
         let round = Round::new(Epoch::new(0), View::new(1));
@@ -614,7 +645,7 @@ mod tests {
     }
 
     fn ready_and_verify_notarizes<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let mut rng = OsRng;
         let round = Round::new(Epoch::new(0), View::new(1));
@@ -641,7 +672,7 @@ mod tests {
         let (verified_bulk, failed_bulk) = verifier.verify_notarizes(&mut rng, NAMESPACE);
         assert_eq!(verified_bulk.len(), 4);
         assert!(failed_bulk.is_empty());
-        assert_eq!(verifier.notarizes_verified, 4);
+        assert_eq!(verifier.notarizes_verified_weight, 4);
         assert!(verifier.notarizes.is_empty());
         assert!(!verifier.ready_notarizes());
 
@@ -654,7 +685,10 @@ mod tests {
         faulty_vote.signature.signer = (schemes.len() as u32) + 10;
         verifier2.add(Vote::Notarize(faulty_vote.clone()), false);
 
-        for scheme in schemes.iter().skip(2).take(quorum as usize - 2) {
+        // Add quorum - 1 more valid votes to reach quorum weight.
+        // The faulty vote has weight 0 (invalid signer), so we need quorum - 1 valid votes
+        // plus the leader vote (total quorum weight) to be ready.
+        for scheme in schemes.iter().skip(2).take(quorum as usize - 1) {
             verifier2.add(
                 Vote::Notarize(create_notarize(scheme, round2, View::new(1), 10)),
                 false,
@@ -676,18 +710,18 @@ mod tests {
     }
 
     fn add_nullify<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let nullify = create_nullify(&schemes[0], round);
 
         verifier.add(Vote::Nullify(nullify.clone()), false);
         assert_eq!(verifier.nullifies.len(), 1);
-        assert_eq!(verifier.nullifies_verified, 0);
+        assert_eq!(verifier.nullifies_verified_weight, 0);
 
         verifier.add(Vote::Nullify(nullify), true);
         assert_eq!(verifier.nullifies.len(), 1);
-        assert_eq!(verifier.nullifies_verified, 1);
+        assert_eq!(verifier.nullifies_verified_weight, 1);
     }
 
     #[test]
@@ -697,7 +731,7 @@ mod tests {
     }
 
     fn ready_and_verify_nullifies<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let mut rng = OsRng;
         let round = Round::new(Epoch::new(0), View::new(1));
@@ -707,7 +741,7 @@ mod tests {
             .collect();
 
         verifier.add(Vote::Nullify(nullifies[0].clone()), true);
-        assert_eq!(verifier.nullifies_verified, 1);
+        assert_eq!(verifier.nullifies_verified_weight, 1);
 
         verifier.add(Vote::Nullify(nullifies[1].clone()), false);
         assert!(!verifier.ready_nullifies());
@@ -720,7 +754,7 @@ mod tests {
         let (verified, failed) = verifier.verify_nullifies(&mut rng, NAMESPACE);
         assert_eq!(verified.len(), 3);
         assert!(failed.is_empty());
-        assert_eq!(verifier.nullifies_verified, 4);
+        assert_eq!(verifier.nullifies_verified_weight, 4);
         assert!(verifier.nullifies.is_empty());
         assert!(!verifier.ready_nullifies());
     }
@@ -732,7 +766,7 @@ mod tests {
     }
 
     fn add_finalize<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let finalize_a = create_finalize(&schemes[0], round, View::new(0), 1);
@@ -740,7 +774,7 @@ mod tests {
 
         verifier.add(Vote::Finalize(finalize_b.clone()), false);
         assert_eq!(verifier.finalizes.len(), 1);
-        assert_eq!(verifier.finalizes_verified, 0);
+        assert_eq!(verifier.finalizes_verified_weight, 0);
 
         verifier.add(Vote::Finalize(finalize_a.clone()), false);
         assert_eq!(verifier.finalizes.len(), 2);
@@ -750,15 +784,15 @@ mod tests {
         verifier.set_leader_proposal(finalize_a.proposal.clone());
         assert_eq!(verifier.finalizes.len(), 1);
         assert_eq!(verifier.finalizes[0], finalize_a);
-        assert_eq!(verifier.finalizes_verified, 0);
+        assert_eq!(verifier.finalizes_verified_weight, 0);
 
         verifier.add(Vote::Finalize(finalize_a), true);
         assert_eq!(verifier.finalizes.len(), 1);
-        assert_eq!(verifier.finalizes_verified, 1);
+        assert_eq!(verifier.finalizes_verified_weight, 1);
 
         verifier.add(Vote::Finalize(finalize_b), false);
         assert_eq!(verifier.finalizes.len(), 1);
-        assert_eq!(verifier.finalizes_verified, 1);
+        assert_eq!(verifier.finalizes_verified_weight, 1);
     }
 
     #[test]
@@ -768,7 +802,7 @@ mod tests {
     }
 
     fn ready_and_verify_finalizes<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let mut rng = OsRng;
         let round = Round::new(Epoch::new(0), View::new(1));
@@ -783,7 +817,7 @@ mod tests {
         verifier.set_leader_proposal(finalizes[0].proposal.clone());
 
         verifier.add(Vote::Finalize(finalizes[0].clone()), true);
-        assert_eq!(verifier.finalizes_verified, 1);
+        assert_eq!(verifier.finalizes_verified_weight, 1);
         assert!(verifier.finalizes.is_empty());
 
         verifier.add(Vote::Finalize(finalizes[1].clone()), false);
@@ -796,7 +830,7 @@ mod tests {
         let (verified, failed) = verifier.verify_finalizes(&mut rng, NAMESPACE);
         assert_eq!(verified.len(), 3);
         assert!(failed.is_empty());
-        assert_eq!(verifier.finalizes_verified, 4);
+        assert_eq!(verifier.finalizes_verified_weight, 4);
         assert!(verifier.finalizes.is_empty());
         assert!(!verifier.ready_finalizes());
     }
@@ -808,7 +842,7 @@ mod tests {
     }
 
     fn leader_proposal_filters_messages<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let proposal_a = Proposal::new(round, View::new(0), sample_digest(10));
@@ -859,7 +893,7 @@ mod tests {
         set_leader_twice_panics(generate_ed25519_schemes(3, 213));
     }
     fn notarizes_wait_for_quorum<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let mut rng = OsRng;
         let round = Round::new(Epoch::new(0), View::new(1));
@@ -892,7 +926,7 @@ mod tests {
     }
 
     fn ready_notarizes_without_leader<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
 
@@ -925,7 +959,7 @@ mod tests {
     }
 
     fn ready_finalizes_without_leader<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let finalizes: Vec<_> = schemes
@@ -957,7 +991,7 @@ mod tests {
     }
 
     fn verify_notarizes_empty<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_proposal = Proposal::new(round, View::new(0), sample_digest(1));
@@ -973,7 +1007,7 @@ mod tests {
     }
 
     fn verify_nullifies_empty<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let mut rng = OsRng;
         assert!(verifier.nullifies.is_empty());
@@ -981,7 +1015,7 @@ mod tests {
         let (verified, failed) = verifier.verify_nullifies(&mut rng, NAMESPACE);
         assert!(verified.is_empty());
         assert!(failed.is_empty());
-        assert_eq!(verifier.nullifies_verified, 0);
+        assert_eq!(verifier.nullifies_verified_weight, 0);
     }
 
     #[test]
@@ -991,7 +1025,7 @@ mod tests {
     }
 
     fn verify_finalizes_empty<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let mut rng = OsRng;
         verifier.set_leader(0);
@@ -1000,7 +1034,7 @@ mod tests {
         let (verified, failed) = verifier.verify_finalizes(&mut rng, NAMESPACE);
         assert!(verified.is_empty());
         assert!(failed.is_empty());
-        assert_eq!(verifier.finalizes_verified, 0);
+        assert_eq!(verifier.finalizes_verified_weight, 0);
     }
 
     #[test]
@@ -1010,7 +1044,7 @@ mod tests {
     }
 
     fn ready_notarizes_exact_quorum<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let mut rng = OsRng;
         let round = Round::new(Epoch::new(0), View::new(1));
@@ -1018,7 +1052,7 @@ mod tests {
         let leader_vote = create_notarize(&schemes[0], round, View::new(0), 1);
         verifier.set_leader(leader_vote.signer());
         verifier.add(Vote::Notarize(leader_vote), true);
-        assert_eq!(verifier.notarizes_verified, 1);
+        assert_eq!(verifier.notarizes_verified_weight, 1);
 
         for (i, scheme) in schemes.iter().enumerate().skip(1).take(quorum as usize - 1) {
             let is_last = i == quorum as usize - 1;
@@ -1041,7 +1075,7 @@ mod tests {
         let (verified, failed) = verifier.verify_notarizes(&mut rng, NAMESPACE);
         assert_eq!(verified.len(), quorum as usize - 1);
         assert!(failed.is_empty());
-        assert_eq!(verifier.notarizes_verified, quorum as usize);
+        assert_eq!(verifier.notarizes_verified_weight, quorum);
         assert!(!verifier.ready_notarizes());
     }
 
@@ -1052,12 +1086,12 @@ mod tests {
     }
 
     fn ready_nullifies_exact_quorum<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
 
         verifier.add(Vote::Nullify(create_nullify(&schemes[0], round)), true);
-        assert_eq!(verifier.nullifies_verified, 1);
+        assert_eq!(verifier.nullifies_verified_weight, 1);
 
         for scheme in schemes.iter().take(quorum as usize).skip(1) {
             assert!(!verifier.ready_nullifies());
@@ -1074,14 +1108,14 @@ mod tests {
     }
 
     fn ready_finalizes_exact_quorum<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_finalize = create_finalize(&schemes[0], round, View::new(0), 1);
         verifier.set_leader(leader_finalize.signer());
         verifier.set_leader_proposal(leader_finalize.proposal.clone());
         verifier.add(Vote::Finalize(leader_finalize), true);
-        assert_eq!(verifier.finalizes_verified, 1);
+        assert_eq!(verifier.finalizes_verified_weight, 1);
 
         for scheme in schemes.iter().take(quorum as usize).skip(1) {
             assert!(!verifier.ready_finalizes());
@@ -1101,7 +1135,7 @@ mod tests {
     }
 
     fn ready_notarizes_quorum_already_met_by_verified<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         assert!(
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
@@ -1121,7 +1155,7 @@ mod tests {
                 true,
             );
         }
-        assert_eq!(verifier.notarizes_verified, quorum as usize);
+        assert_eq!(verifier.notarizes_verified_weight, quorum);
         assert!(
             !verifier.ready_notarizes(),
             "Should not be ready if quorum already met by verified messages"
@@ -1143,7 +1177,7 @@ mod tests {
     }
 
     fn ready_nullifies_quorum_already_met_by_verified<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         assert!(
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
@@ -1155,7 +1189,7 @@ mod tests {
         for scheme in schemes.iter().take(quorum as usize) {
             verifier.add(Vote::Nullify(create_nullify(scheme, round)), true);
         }
-        assert_eq!(verifier.nullifies_verified, quorum as usize);
+        assert_eq!(verifier.nullifies_verified_weight, quorum);
         assert!(
             !verifier.ready_nullifies(),
             "Should not be ready if quorum already met by verified messages"
@@ -1177,7 +1211,7 @@ mod tests {
     }
 
     fn ready_finalizes_quorum_already_met_by_verified<S: Scheme + Clone>(schemes: Vec<S>) {
-        let quorum = quorum_from_slice(&schemes);
+        let quorum = schemes[0].weighted_quorum();
         assert!(
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
@@ -1197,7 +1231,7 @@ mod tests {
                 true,
             );
         }
-        assert_eq!(verifier.finalizes_verified, quorum as usize);
+        assert_eq!(verifier.finalizes_verified_weight, quorum);
         assert!(
             !verifier.ready_finalizes(),
             "Should not be ready if quorum already met by verified messages"

--- a/consensus/src/simplex/mocks/fixtures.rs
+++ b/consensus/src/simplex/mocks/fixtures.rs
@@ -8,7 +8,7 @@ use commonware_cryptography::{
     },
     ed25519, PrivateKeyExt, Signer,
 };
-use commonware_utils::{quorum, set::OrderedAssociated};
+use commonware_utils::{quorum, set::OrderedWeighted, set::OrderedWeightedAssociated};
 use rand::{CryptoRng, RngCore};
 
 /// A test fixture consisting of ed25519 keys and signing schemes for each validator, and a single
@@ -22,11 +22,13 @@ pub struct Fixture<S> {
     pub verifier: S,
 }
 
-/// Generates ed25519 participants.
+/// Generates ed25519 participants with uniform weights.
+///
+/// All participants have a weight of 1.
 pub fn ed25519_participants<R>(
     rng: &mut R,
     n: u32,
-) -> OrderedAssociated<ed25519::PublicKey, ed25519::PrivateKey>
+) -> OrderedWeightedAssociated<ed25519::PublicKey, ed25519::PrivateKey>
 where
     R: RngCore + CryptoRng,
 {
@@ -34,7 +36,26 @@ where
         .map(|_| {
             let private_key = ed25519::PrivateKey::from_rng(rng);
             let public_key = private_key.public_key();
-            (public_key, private_key)
+            // Default weight of 1 for uniform weighting
+            (public_key, private_key, 1u64)
+        })
+        .collect()
+}
+
+/// Generates ed25519 participants with custom weights.
+pub fn ed25519_participants_weighted<R>(
+    rng: &mut R,
+    weights: &[u64],
+) -> OrderedWeightedAssociated<ed25519::PublicKey, ed25519::PrivateKey>
+where
+    R: RngCore + CryptoRng,
+{
+    weights
+        .iter()
+        .map(|&weight| {
+            let private_key = ed25519::PrivateKey::from_rng(rng);
+            let public_key = private_key.public_key();
+            (public_key, private_key, weight)
         })
         .collect()
 }
@@ -42,6 +63,7 @@ where
 /// Builds ed25519 identities alongside the ed25519 signing scheme.
 ///
 /// Returns a [`Fixture`] whose keys and scheme instances share a consistent ordering.
+/// All participants have uniform weight of 1.
 pub fn ed25519<R>(rng: &mut R, n: u32) -> Fixture<ed_scheme::Scheme>
 where
     R: RngCore + CryptoRng,
@@ -49,16 +71,51 @@ where
     assert!(n > 0);
 
     let ed25519_associated = ed25519_participants(rng, n);
-    let participants = ed25519_associated.keys().clone();
+
+    // Build participants with uniform weights (weight = 1 for each)
+    let participants: OrderedWeighted<ed25519::PublicKey> = ed25519_associated
+        .iter_all()
+        .map(|(pk, _, weight)| (pk.clone(), weight))
+        .collect();
 
     let schemes = ed25519_associated
         .into_iter()
-        .map(|(_, sk)| ed_scheme::Scheme::new(participants.clone(), sk))
+        .map(|(_, sk, _)| ed_scheme::Scheme::new(participants.clone(), sk))
         .collect();
     let verifier = ed_scheme::Scheme::verifier(participants.clone());
 
     Fixture {
-        participants: participants.into(),
+        participants: participants.into_keys().into(),
+        schemes,
+        verifier,
+    }
+}
+
+/// Builds ed25519 identities alongside the ed25519 signing scheme with custom weights.
+///
+/// Returns a [`Fixture`] whose keys and scheme instances share a consistent ordering.
+pub fn ed25519_weighted<R>(rng: &mut R, weights: &[u64]) -> Fixture<ed_scheme::Scheme>
+where
+    R: RngCore + CryptoRng,
+{
+    assert!(!weights.is_empty());
+
+    let ed25519_associated = ed25519_participants_weighted(rng, weights);
+
+    // Build participants with custom weights
+    let participants: OrderedWeighted<ed25519::PublicKey> = ed25519_associated
+        .iter_all()
+        .map(|(pk, _, weight)| (pk.clone(), weight))
+        .collect();
+
+    let schemes = ed25519_associated
+        .into_iter()
+        .map(|(_, sk, _)| ed_scheme::Scheme::new(participants.clone(), sk))
+        .collect();
+    let verifier = ed_scheme::Scheme::verifier(participants.clone());
+
+    Fixture {
+        participants: participants.into_keys().into(),
         schemes,
         verifier,
     }
@@ -67,6 +124,7 @@ where
 /// Builds ed25519 identities and matching BLS multisig schemes for tests.
 ///
 /// Returns a [`Fixture`] whose keys and scheme instances share a consistent ordering.
+/// All participants have uniform weight of 1.
 pub fn bls12381_multisig<V, R>(
     rng: &mut R,
     n: u32,
@@ -77,26 +135,69 @@ where
 {
     assert!(n > 0);
 
-    let participants = ed25519_participants(rng, n).into_keys();
+    let ed_participants = ed25519_participants(rng, n);
     let bls_privates: Vec<_> = (0..n).map(|_| group::Private::from_rand(rng)).collect();
     let bls_public: Vec<_> = bls_privates
         .iter()
         .map(|sk| commonware_cryptography::bls12381::primitives::ops::compute_public::<V>(sk))
         .collect();
 
-    let signers = participants
-        .clone()
-        .into_iter()
+    // Build weighted signers with uniform weight of 1
+    let signers: OrderedWeightedAssociated<_, _> = ed_participants
+        .iter_all()
         .zip(bls_public)
-        .collect::<OrderedAssociated<_, _>>();
+        .map(|((pk, _, weight), bls_pk)| (pk.clone(), bls_pk, weight))
+        .collect();
     let schemes: Vec<_> = bls_privates
         .into_iter()
         .map(|sk| bls12381_multisig::Scheme::new(signers.clone(), sk))
         .collect();
-    let verifier = bls12381_multisig::Scheme::verifier(signers);
+    let verifier = bls12381_multisig::Scheme::verifier(signers.clone());
 
     Fixture {
-        participants: participants.into(),
+        participants: signers.into_keys().into(),
+        schemes,
+        verifier,
+    }
+}
+
+/// Builds ed25519 identities and matching BLS multisig schemes for tests with custom weights.
+///
+/// Returns a [`Fixture`] whose keys and scheme instances share a consistent ordering.
+pub fn bls12381_multisig_weighted<V, R>(
+    rng: &mut R,
+    weights: &[u64],
+) -> Fixture<bls12381_multisig::Scheme<ed25519::PublicKey, V>>
+where
+    V: Variant,
+    R: RngCore + CryptoRng,
+{
+    assert!(!weights.is_empty());
+
+    let ed_participants = ed25519_participants_weighted(rng, weights);
+    let bls_privates: Vec<_> = weights
+        .iter()
+        .map(|_| group::Private::from_rand(rng))
+        .collect();
+    let bls_public: Vec<_> = bls_privates
+        .iter()
+        .map(|sk| commonware_cryptography::bls12381::primitives::ops::compute_public::<V>(sk))
+        .collect();
+
+    // Build weighted signers with custom weights
+    let signers: OrderedWeightedAssociated<_, _> = ed_participants
+        .iter_all()
+        .zip(bls_public)
+        .map(|((pk, _, weight), bls_pk)| (pk.clone(), bls_pk, weight))
+        .collect();
+    let schemes: Vec<_> = bls_privates
+        .into_iter()
+        .map(|sk| bls12381_multisig::Scheme::new(signers.clone(), sk))
+        .collect();
+    let verifier = bls12381_multisig::Scheme::verifier(signers.clone());
+
+    Fixture {
+        participants: signers.into_keys().into(),
         schemes,
         verifier,
     }
@@ -105,6 +206,8 @@ where
 /// Builds ed25519 identities and matching BLS threshold schemes for tests.
 ///
 /// Returns a [`Fixture`] whose keys and scheme instances share a consistent ordering.
+/// Note: BLS threshold schemes do not support weighted quorum - they use a fixed
+/// polynomial threshold instead.
 pub fn bls12381_threshold<V, R>(
     rng: &mut R,
     n: u32,
@@ -115,7 +218,9 @@ where
 {
     assert!(n > 0);
 
-    let participants = ed25519_participants(rng, n).into_keys();
+    // bls12381_threshold doesn't support weights, so extract just the keys
+    let ed_participants = ed25519_participants(rng, n);
+    let participants = ed_participants.into_keys();
     let t = quorum(n);
     let (polynomial, shares) = ops::generate_shares::<_, V>(rng, None, n, t);
 

--- a/consensus/src/simplex/signing_scheme/bls12381_multisig.rs
+++ b/consensus/src/simplex/signing_scheme/bls12381_multisig.rs
@@ -137,6 +137,14 @@ impl<P: PublicKey, V: Variant + Send + Sync> signing_scheme::Scheme for Scheme<P
         self.participants.keys()
     }
 
+    fn weighted_quorum(&self) -> u64 {
+        self.participants.weighted_quorum()
+    }
+
+    fn weight(&self, index: u32) -> u64 {
+        self.participants.weight(index as usize).unwrap_or(0)
+    }
+
     fn sign_vote<D: Digest>(
         &self,
         namespace: &[u8],

--- a/consensus/src/simplex/signing_scheme/bls12381_multisig.rs
+++ b/consensus/src/simplex/signing_scheme/bls12381_multisig.rs
@@ -25,15 +25,15 @@ use commonware_cryptography::{
     },
     Digest, PublicKey,
 };
-use commonware_utils::set::{Ordered, OrderedAssociated, OrderedQuorum};
+use commonware_utils::set::{Ordered, OrderedWeightedAssociated};
 use rand::{CryptoRng, Rng};
 use std::{collections::BTreeSet, fmt::Debug};
 
 /// BLS12-381 multi-signature implementation of the [`Scheme`] trait.
 #[derive(Clone, Debug)]
 pub struct Scheme<P: PublicKey, V: Variant> {
-    /// Participants in the committee.
-    participants: OrderedAssociated<P, V::Public>,
+    /// Participants in the committee with their consensus keys and weights.
+    participants: OrderedWeightedAssociated<P, V::Public>,
     /// Key used for generating signatures.
     signer: Option<(u32, Private)>,
 }
@@ -41,13 +41,13 @@ pub struct Scheme<P: PublicKey, V: Variant> {
 impl<P: PublicKey, V: Variant> Scheme<P, V> {
     /// Creates a new scheme instance with the provided key material.
     ///
-    /// Participants have both an identity key and a consensus key. The identity key
-    /// is used for committee ordering and indexing, while the consensus key is used for
-    /// signing and verification.
+    /// Participants have an identity key, a consensus key, and a weight. The identity key
+    /// is used for committee ordering and indexing, the consensus key is used for
+    /// signing and verification, and the weight is used for weighted quorum calculations.
     ///
     /// If the provided private key does not match any consensus key in the committee,
     /// the instance will act as a verifier (unable to generate signatures).
-    pub fn new(participants: OrderedAssociated<P, V::Public>, private_key: Private) -> Self {
+    pub fn new(participants: OrderedWeightedAssociated<P, V::Public>, private_key: Private) -> Self {
         let public_key = compute_public::<V>(&private_key);
         let signer = participants
             .values()
@@ -63,14 +63,22 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
 
     /// Builds a verifier that can authenticate votes and certificates.
     ///
-    /// Participants have both an identity key and a consensus key. The identity key
-    /// is used for committee ordering and indexing, while the consensus key is used for
-    /// verification.
-    pub const fn verifier(participants: OrderedAssociated<P, V::Public>) -> Self {
+    /// Participants have an identity key, a consensus key, and a weight. The identity key
+    /// is used for committee ordering and indexing, the consensus key is used for
+    /// verification, and the weight is used for weighted quorum calculations.
+    pub const fn verifier(participants: OrderedWeightedAssociated<P, V::Public>) -> Self {
         Self {
             participants,
             signer: None,
         }
+    }
+
+    /// Computes the total weight of all signers in the certificate.
+    fn signers_weight(&self, signers: &Signers) -> u64 {
+        signers
+            .iter()
+            .filter_map(|index| self.participants.weight(index as usize))
+            .sum()
     }
 }
 
@@ -126,7 +134,7 @@ impl<P: PublicKey, V: Variant + Send + Sync> signing_scheme::Scheme for Scheme<P
     }
 
     fn participants(&self) -> &Ordered<Self::PublicKey> {
-        &self.participants
+        self.participants.keys()
     }
 
     fn sign_vote<D: Digest>(
@@ -235,16 +243,21 @@ impl<P: PublicKey, V: Variant + Send + Sync> signing_scheme::Scheme for Scheme<P
     where
         I: IntoIterator<Item = Signature<Self>>,
     {
-        // Collect the signers and signatures.
+        // Collect the signers and signatures, computing total weight.
         let mut entries = Vec::new();
+        let mut total_weight = 0u64;
         for Signature { signer, signature } in signatures {
             if signer as usize >= self.participants.len() {
                 return None;
             }
 
+            let weight = self.participants.weight(signer as usize).unwrap_or(0);
+            total_weight = total_weight.saturating_add(weight);
             entries.push((signer, signature));
         }
-        if entries.len() < self.participants.quorum() as usize {
+
+        // Check if the weighted quorum is met.
+        if total_weight < self.participants.weighted_quorum() {
             return None;
         }
 
@@ -268,8 +281,8 @@ impl<P: PublicKey, V: Variant + Send + Sync> signing_scheme::Scheme for Scheme<P
             return false;
         }
 
-        // If the certificate does not meet the quorum, return false.
-        if certificate.signers.count() < self.participants.quorum() as usize {
+        // If the certificate does not meet the weighted quorum, return false.
+        if self.signers_weight(&certificate.signers) < self.participants.weighted_quorum() {
             return false;
         }
 
@@ -346,7 +359,7 @@ mod tests {
         seed: u64,
     ) -> (
         Vec<Scheme<ed25519::PublicKey, V>>,
-        OrderedAssociated<ed25519::PublicKey, V::Public>,
+        OrderedWeightedAssociated<ed25519::PublicKey, V::Public>,
     ) {
         let mut rng = StdRng::seed_from_u64(seed);
         let Fixture { schemes, .. } = bls12381_multisig::<V, _>(&mut rng, n);

--- a/consensus/src/simplex/signing_scheme/bls12381_threshold.rs
+++ b/consensus/src/simplex/signing_scheme/bls12381_threshold.rs
@@ -378,6 +378,20 @@ impl<P: PublicKey, V: Variant + Send + Sync> signing_scheme::Scheme for Scheme<P
         self.participants()
     }
 
+    fn weighted_quorum(&self) -> u64 {
+        // bls12381_threshold uses uniform weights (each participant has weight 1)
+        self.participants().quorum() as u64
+    }
+
+    fn weight(&self, index: u32) -> u64 {
+        // bls12381_threshold uses uniform weights (each participant has weight 1)
+        if (index as usize) < self.participants().len() {
+            1
+        } else {
+            0
+        }
+    }
+
     fn sign_vote<D: Digest>(
         &self,
         namespace: &[u8],

--- a/consensus/src/simplex/signing_scheme/ed25519.rs
+++ b/consensus/src/simplex/signing_scheme/ed25519.rs
@@ -18,15 +18,15 @@ use commonware_cryptography::{
     ed25519::{self, Batch},
     BatchVerifier, Digest, Signer as _, Verifier as _,
 };
-use commonware_utils::set::{Ordered, OrderedQuorum};
+use commonware_utils::set::{Ordered, OrderedWeighted};
 use rand::{CryptoRng, Rng};
 use std::collections::BTreeSet;
 
 /// Ed25519 implementation of the [`Scheme`] trait.
 #[derive(Clone, Debug)]
 pub struct Scheme {
-    /// Participants in the committee.
-    participants: Ordered<ed25519::PublicKey>,
+    /// Participants in the committee with their consensus weights.
+    participants: OrderedWeighted<ed25519::PublicKey>,
     /// Key used for generating signatures.
     signer: Option<(u32, ed25519::PrivateKey)>,
 }
@@ -34,12 +34,13 @@ pub struct Scheme {
 impl Scheme {
     /// Creates a new scheme instance with the provided key material.
     ///
-    /// Participants use the same key for both identity and consensus.
+    /// Participants use the same key for both identity and consensus. Each participant
+    /// has an associated weight used for weighted quorum calculations.
     ///
     /// If the provided private key does not match any consensus key in the committee,
     /// the instance will act as a verifier (unable to generate signatures).
     pub fn new(
-        participants: Ordered<ed25519::PublicKey>,
+        participants: OrderedWeighted<ed25519::PublicKey>,
         private_key: ed25519::PrivateKey,
     ) -> Self {
         let signer = participants
@@ -54,12 +55,21 @@ impl Scheme {
 
     /// Builds a verifier that can authenticate votes without generating signatures.
     ///
-    /// Participants use the same key for both identity and consensus.
-    pub const fn verifier(participants: Ordered<ed25519::PublicKey>) -> Self {
+    /// Participants use the same key for both identity and consensus. Each participant
+    /// has an associated weight used for weighted quorum calculations.
+    pub const fn verifier(participants: OrderedWeighted<ed25519::PublicKey>) -> Self {
         Self {
             participants,
             signer: None,
         }
+    }
+
+    /// Computes the total weight of all signers in the certificate.
+    fn signers_weight(&self, signers: &Signers) -> u64 {
+        signers
+            .iter()
+            .filter_map(|index| self.participants.weight(index as usize))
+            .sum()
     }
 
     /// Stage a certificate for batch verification.
@@ -80,8 +90,8 @@ impl Scheme {
             return false;
         }
 
-        // If the certificate does not meet the quorum, return false.
-        if certificate.signers.count() < self.participants.quorum() as usize {
+        // If the certificate does not meet the weighted quorum, return false.
+        if self.signers_weight(&certificate.signers) < self.participants.weighted_quorum() {
             return false;
         }
 
@@ -158,7 +168,7 @@ impl signing_scheme::Scheme for Scheme {
     }
 
     fn participants(&self) -> &Ordered<Self::PublicKey> {
-        &self.participants
+        self.participants.keys()
     }
 
     fn sign_vote<D: Digest>(
@@ -252,16 +262,21 @@ impl signing_scheme::Scheme for Scheme {
     where
         I: IntoIterator<Item = Signature<Self>>,
     {
-        // Collect the signers and signatures.
+        // Collect the signers and signatures, computing total weight.
         let mut entries = Vec::new();
+        let mut total_weight = 0u64;
         for Signature { signer, signature } in signatures {
             if signer as usize >= self.participants.len() {
                 return None;
             }
 
+            let weight = self.participants.weight(signer as usize).unwrap_or(0);
+            total_weight = total_weight.saturating_add(weight);
             entries.push((signer, signature));
         }
-        if entries.len() < self.participants.quorum() as usize {
+
+        // Check if the weighted quorum is met.
+        if total_weight < self.participants.weighted_quorum() {
             return None;
         }
 
@@ -350,15 +365,19 @@ mod tests {
 
     const NAMESPACE: &[u8] = b"ed25519-signing-scheme";
 
-    fn setup_signers(n: u32, seed: u64) -> (Vec<Scheme>, Ordered<ed25519::PublicKey>) {
+    fn setup_signers(
+        n: u32,
+        seed: u64,
+    ) -> (Vec<Scheme>, OrderedWeighted<ed25519::PublicKey>, Scheme) {
         let mut rng = StdRng::seed_from_u64(seed);
         let Fixture {
-            participants,
-            schemes,
-            ..
+            schemes, verifier, ..
         } = ed25519(&mut rng, n);
 
-        (schemes, participants.into())
+        // Get the weighted participants from the first scheme
+        let participants = schemes.first().unwrap().participants.clone();
+
+        (schemes, participants, verifier)
     }
 
     fn sample_proposal(round: u64, view: u64, tag: u8) -> Proposal<Sha256Digest> {
@@ -371,7 +390,7 @@ mod tests {
 
     #[test]
     fn test_sign_vote_roundtrip_for_each_context() {
-        let (schemes, _) = setup_signers(4, 42);
+        let (schemes, ..) = setup_signers(4, 42);
         let scheme = &schemes[0];
 
         let proposal = sample_proposal(0, 2, 1);
@@ -426,7 +445,7 @@ mod tests {
 
     #[test]
     fn test_verify_votes_filters_bad_signers() {
-        let (schemes, _) = setup_signers(5, 42);
+        let (schemes, ..) = setup_signers(5, 42);
         let quorum = quorum_from_slice(&schemes) as usize;
         let proposal = sample_proposal(0, 5, 3);
 
@@ -487,7 +506,7 @@ mod tests {
 
     #[test]
     fn test_assemble_certificate_sorts_signers() {
-        let (schemes, _) = setup_signers(4, 42);
+        let (schemes, ..) = setup_signers(4, 42);
         let proposal = sample_proposal(0, 7, 4);
 
         let votes = [
@@ -528,7 +547,7 @@ mod tests {
 
     #[test]
     fn test_assemble_certificate_requires_quorum() {
-        let (schemes, _) = setup_signers(4, 42);
+        let (schemes, ..) = setup_signers(4, 42);
         let proposal = sample_proposal(0, 9, 5);
 
         let votes: Vec<_> = schemes
@@ -551,7 +570,7 @@ mod tests {
 
     #[test]
     fn test_assemble_certificate_rejects_out_of_range_signer() {
-        let (schemes, _) = setup_signers(4, 42);
+        let (schemes, ..) = setup_signers(4, 42);
         let proposal = sample_proposal(0, 13, 7);
 
         let mut votes: Vec<_> = schemes
@@ -576,7 +595,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "duplicate signer index: 2")]
     fn test_assemble_certificate_rejects_duplicate_signers() {
-        let (schemes, _) = setup_signers(4, 42);
+        let (schemes, ..) = setup_signers(4, 42);
         let proposal = sample_proposal(0, 25, 13);
 
         let mut votes: Vec<_> = schemes
@@ -601,7 +620,7 @@ mod tests {
 
     #[test]
     fn test_verify_certificate_detects_corruption() {
-        let (schemes, participants) = setup_signers(4, 42);
+        let (schemes, _, verifier) = setup_signers(4, 42);
         let proposal = sample_proposal(0, 15, 8);
 
         let votes: Vec<_> = schemes
@@ -623,7 +642,6 @@ mod tests {
             .assemble_certificate(votes)
             .expect("assemble certificate");
 
-        let verifier = Scheme::verifier(participants);
         assert!(verifier.verify_certificate(
             &mut thread_rng(),
             NAMESPACE,
@@ -647,7 +665,7 @@ mod tests {
 
     #[test]
     fn test_certificate_codec_roundtrip() {
-        let (schemes, _) = setup_signers(4, 42);
+        let (schemes, ..) = setup_signers(4, 42);
         let proposal = sample_proposal(0, 17, 9);
 
         let votes: Vec<_> = schemes
@@ -675,7 +693,7 @@ mod tests {
 
     #[test]
     fn test_scheme_clone_and_verifier() {
-        let (schemes, participants) = setup_signers(4, 42);
+        let (schemes, _, verifier) = setup_signers(4, 42);
         let signer = schemes[0].clone();
         let proposal = sample_proposal(0, 21, 11);
 
@@ -691,7 +709,6 @@ mod tests {
             "signer should produce votes"
         );
 
-        let verifier = Scheme::verifier(participants);
         assert!(
             verifier
                 .sign_vote(
@@ -707,7 +724,8 @@ mod tests {
 
     #[test]
     fn test_certificate_decode_validation() {
-        let (schemes, participants) = setup_signers(4, 42);
+        let (schemes, participants, _) = setup_signers(4, 42);
+        let n = participants.len();
         let proposal = sample_proposal(0, 19, 10);
 
         let votes: Vec<_> = schemes
@@ -732,39 +750,38 @@ mod tests {
         // Well-formed certificate decodes successfully.
         let encoded = certificate.encode();
         let mut cursor = &encoded[..];
-        let decoded =
-            Certificate::read_cfg(&mut cursor, &participants.len()).expect("decode certificate");
+        let decoded = Certificate::read_cfg(&mut cursor, &n).expect("decode certificate");
         assert_eq!(decoded, certificate);
 
         // Certificate with no signers is rejected.
         let empty = Certificate {
-            signers: Signers::from(participants.len(), std::iter::empty::<u32>()),
+            signers: Signers::from(n, std::iter::empty::<u32>()),
             signatures: Vec::new(),
         };
-        assert!(Certificate::decode_cfg(empty.encode(), &participants.len()).is_err());
+        assert!(Certificate::decode_cfg(empty.encode(), &n).is_err());
 
         // Certificate with mismatched signature count is rejected.
         let mismatched = Certificate {
-            signers: Signers::from(participants.len(), [0u32, 1]),
+            signers: Signers::from(n, [0u32, 1]),
             signatures: vec![certificate.signatures[0].clone()],
         };
-        assert!(Certificate::decode_cfg(mismatched.encode(), &participants.len()).is_err());
+        assert!(Certificate::decode_cfg(mismatched.encode(), &n).is_err());
 
         // Certificate containing more signers than the participant set is rejected.
         let mut signers = certificate.signers.iter().collect::<Vec<_>>();
-        signers.push(participants.len() as u32);
+        signers.push(n as u32);
         let mut signatures = certificate.signatures.clone();
         signatures.push(certificate.signatures[0].clone());
         let extended = Certificate {
-            signers: Signers::from(participants.len() + 1, signers),
+            signers: Signers::from(n + 1, signers),
             signatures,
         };
-        assert!(Certificate::decode_cfg(extended.encode(), &participants.len()).is_err());
+        assert!(Certificate::decode_cfg(extended.encode(), &n).is_err());
     }
 
     #[test]
     fn test_verify_certificate() {
-        let (schemes, participants) = setup_signers(4, 42);
+        let (schemes, _, verifier) = setup_signers(4, 42);
         let quorum = quorum_from_slice(&schemes) as usize;
         let proposal = sample_proposal(0, 21, 11);
 
@@ -787,7 +804,6 @@ mod tests {
             .assemble_certificate(votes)
             .expect("assemble certificate");
 
-        let verifier = Scheme::verifier(participants);
         assert!(verifier.verify_certificate(
             &mut OsRng,
             NAMESPACE,
@@ -800,7 +816,8 @@ mod tests {
 
     #[test]
     fn test_verify_certificate_rejects_sub_quorum() {
-        let (schemes, participants) = setup_signers(4, 42);
+        let (schemes, participants, verifier) = setup_signers(4, 42);
+        let n = participants.len();
         let proposal = sample_proposal(0, 23, 12);
 
         let votes: Vec<_> = schemes
@@ -825,10 +842,9 @@ mod tests {
         let mut truncated = certificate;
         let mut signers: Vec<u32> = truncated.signers.iter().collect();
         signers.pop();
-        truncated.signers = Signers::from(participants.len(), signers);
+        truncated.signers = Signers::from(n, signers);
         truncated.signatures.pop();
 
-        let verifier = Scheme::verifier(participants);
         assert!(!verifier.verify_certificate(
             &mut thread_rng(),
             NAMESPACE,
@@ -841,7 +857,8 @@ mod tests {
 
     #[test]
     fn test_verify_certificate_rejects_unknown_signer() {
-        let (schemes, participants) = setup_signers(4, 42);
+        let (schemes, participants, verifier) = setup_signers(4, 42);
+        let n = participants.len();
         let proposal = sample_proposal(0, 25, 13);
 
         let votes: Vec<_> = schemes
@@ -864,13 +881,12 @@ mod tests {
             .expect("assemble certificate");
 
         let mut signers: Vec<u32> = certificate.signers.iter().collect();
-        signers.push(participants.len() as u32);
-        certificate.signers = Signers::from(participants.len() + 1, signers);
+        signers.push(n as u32);
+        certificate.signers = Signers::from(n + 1, signers);
         certificate
             .signatures
             .push(certificate.signatures[0].clone());
 
-        let verifier = Scheme::verifier(participants);
         assert!(!verifier.verify_certificate(
             &mut thread_rng(),
             NAMESPACE,
@@ -883,7 +899,8 @@ mod tests {
 
     #[test]
     fn test_verify_certificate_rejects_invalid_certificate_signers_size() {
-        let (schemes, participants) = setup_signers(4, 42);
+        let (schemes, participants, verifier) = setup_signers(4, 42);
+        let n = participants.len();
         let proposal = sample_proposal(0, 26, 14);
 
         let votes: Vec<_> = schemes
@@ -906,7 +923,6 @@ mod tests {
             .expect("assemble certificate");
 
         // The certificate is valid
-        let verifier = Scheme::verifier(participants.clone());
         assert!(verifier.verify_certificate(
             &mut thread_rng(),
             NAMESPACE,
@@ -918,7 +934,7 @@ mod tests {
 
         // Make the signers bitmap size smaller
         let signers: Vec<u32> = certificate.signers.iter().collect();
-        certificate.signers = Signers::from(participants.len() - 1, signers);
+        certificate.signers = Signers::from(n - 1, signers);
 
         // The certificate verification should fail
         assert!(!verifier.verify_certificate(
@@ -933,7 +949,7 @@ mod tests {
 
     #[test]
     fn test_verify_certificate_rejects_mismatched_signature_count() {
-        let (schemes, participants) = setup_signers(4, 42);
+        let (schemes, _, verifier) = setup_signers(4, 42);
         let proposal = sample_proposal(0, 27, 14);
 
         let votes: Vec<_> = schemes
@@ -956,7 +972,6 @@ mod tests {
             .expect("assemble certificate");
         certificate.signatures.pop();
 
-        let verifier = Scheme::verifier(participants);
         assert!(!verifier.verify_certificate(
             &mut thread_rng(),
             NAMESPACE,
@@ -969,7 +984,7 @@ mod tests {
 
     #[test]
     fn test_verify_certificates_batch_detects_failure() {
-        let (schemes, participants) = setup_signers(4, 42);
+        let (schemes, _, verifier) = setup_signers(4, 42);
         let proposal_a = sample_proposal(0, 23, 12);
         let proposal_b = sample_proposal(1, 24, 13);
 
@@ -1010,7 +1025,6 @@ mod tests {
             .expect("assemble certificate");
         bad_certificate.signatures[0] = bad_certificate.signatures[1].clone();
 
-        let verifier = Scheme::verifier(participants);
         let mut iter = [
             (
                 Subject::Notarize {

--- a/consensus/src/simplex/signing_scheme/mod.rs
+++ b/consensus/src/simplex/signing_scheme/mod.rs
@@ -76,6 +76,17 @@ pub trait Scheme: Clone + Debug + Send + Sync + 'static {
     /// Returns the ordered set of participant public identity keys managed by the scheme.
     fn participants(&self) -> &Ordered<Self::PublicKey>;
 
+    /// Returns the weighted quorum threshold (total weight needed for a valid certificate).
+    ///
+    /// For weighted schemes, this is `total_weight - max_faulty_weight`.
+    /// For uniform schemes, this equals the count-based quorum.
+    fn weighted_quorum(&self) -> u64;
+
+    /// Returns the weight of a participant at the given index.
+    ///
+    /// Returns 0 if the index is out of bounds.
+    fn weight(&self, index: u32) -> u64;
+
     /// Signs a vote for the given context using the supplied namespace for domain separation.
     /// Returns `None` if the scheme cannot sign (e.g. it's a verifier-only instance).
     fn sign_vote<D: Digest>(

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -2120,7 +2120,7 @@ mod tests {
         sha256::Digest as Sha256,
         PrivateKeyExt, Signer,
     };
-    use commonware_utils::{quorum, quorum_from_slice, set::Ordered};
+    use commonware_utils::{quorum, quorum_from_slice};
     use rand::{
         rngs::{OsRng, StdRng},
         SeedableRng,
@@ -2171,10 +2171,16 @@ mod tests {
     }
 
     fn generate_ed25519_schemes(n: usize, seed: u64) -> Vec<ed25519::Scheme> {
+        use commonware_utils::set::OrderedWeighted;
+
         let mut rng = StdRng::seed_from_u64(seed);
         let private_keys: Vec<_> = (0..n).map(|_| EdPrivateKey::from_rng(&mut rng)).collect();
 
-        let participants: Ordered<_> = private_keys.iter().map(|p| p.public_key()).collect();
+        // Create weighted participants with uniform weight of 1
+        let participants: OrderedWeighted<_> = private_keys
+            .iter()
+            .map(|p| (p.public_key(), 1u64))
+            .collect();
 
         private_keys
             .into_iter()


### PR DESCRIPTION
This implements weighted quorum support in the simplex signing schemes,
addressing issue #443. The changes include:

- Add `Weight` type in consensus/src/types.rs following the View/Epoch
  pattern for type safety (explicit constructors, safe arithmetic)

- Add `OrderedWeighted<K>` and `OrderedWeightedAssociated<K, V>` types
  in utils/src/set.rs for storing participants with weights

- Add `weighted_quorum()` and `max_faulty_weight()` functions in utils
  for BFT-safe weighted threshold calculations

- Update ed25519 signing scheme to accept `OrderedWeighted<PublicKey>`
  and perform weighted quorum checks in certificate assembly/verification

- Update bls12381_multisig signing scheme similarly with
  `OrderedWeightedAssociated<P, V::Public>` for identity/consensus key pairs

- Update test fixtures with `ed25519_weighted` and `bls12381_multisig_weighted`
  helpers for testing non-uniform weight distributions

Note: bls12381_threshold is unchanged as it uses polynomial threshold
which is incompatible with arbitrary weights.