### PR TITLE
Add support for separate ingress/egress sockets and DNS resolution

### DIFF
--- a/p2p/src/authenticated/discovery/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/actor.rs
@@ -509,8 +509,10 @@ mod tests {
         executor.start(|context| async move {
             let (_boot_signer, boot_pk) = new_signer_and_pk(99);
             let boot_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9999);
-            let cfg_with_boot =
-                default_test_config(PrivateKey::from_seed(0), vec![(boot_pk.clone(), boot_addr)]);
+            let cfg_with_boot = default_test_config(
+                PrivateKey::from_seed(0),
+                vec![(boot_pk.clone(), boot_addr.into())],
+            );
             let TestHarness {
                 mailbox: mut new_mailbox,
                 ..
@@ -879,8 +881,10 @@ mod tests {
         executor.start(|context| async move {
             let (_boot_signer, boot_pk) = new_signer_and_pk(99);
             let boot_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9000);
-            let cfg_initial =
-                default_test_config(PrivateKey::from_seed(0), vec![(boot_pk.clone(), boot_addr)]);
+            let cfg_initial = default_test_config(
+                PrivateKey::from_seed(0),
+                vec![(boot_pk.clone(), boot_addr.into())],
+            );
             let TestHarness { mut mailbox, .. } = setup_actor(context.clone(), cfg_initial);
 
             let dialable_peers = mailbox.dialable().await;
@@ -895,8 +899,10 @@ mod tests {
         executor.start(|context| async move {
             let (_boot_signer, boot_pk) = new_signer_and_pk(99);
             let boot_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9000);
-            let cfg_initial =
-                default_test_config(PrivateKey::from_seed(0), vec![(boot_pk.clone(), boot_addr)]);
+            let cfg_initial = default_test_config(
+                PrivateKey::from_seed(0),
+                vec![(boot_pk.clone(), boot_addr.into())],
+            );
 
             let TestHarness { mut mailbox, .. } = setup_actor(context.clone(), cfg_initial);
 

--- a/p2p/src/authenticated/discovery/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/actor.rs
@@ -71,7 +71,7 @@ impl<E: Spawner + Rng + Clock + GClock + RuntimeMetrics, C: Signer> Actor<E, C> 
         let socket = cfg.address;
         let timestamp = context.current().epoch_millis();
         let ip_namespace = union(&cfg.namespace, NAMESPACE_SUFFIX_IP);
-        let myself = types::Info::sign(&cfg.crypto, &ip_namespace, socket, timestamp);
+        let myself = types::Info::sign(&cfg.crypto, &ip_namespace, socket.into(), timestamp);
 
         // General initialization
         let directory_cfg = directory::Config {
@@ -285,6 +285,7 @@ mod tests {
             },
             Mailbox,
         },
+        Address,
         Blocker,
         Manager,
         // Blocker is implicitly available via oracle.block() due to Oracle implementing crate::Blocker
@@ -342,7 +343,8 @@ mod tests {
         make_sig_invalid: bool,
     ) -> Info<PublicKey> {
         let peer_info_pk = target_pk_override.unwrap_or_else(|| signer.public_key());
-        let mut signature = signer.sign(ip_namespace, &(socket, timestamp).encode());
+        let address: Address = socket.into();
+        let mut signature = signer.sign(ip_namespace, &(address.clone(), timestamp).encode());
 
         if make_sig_invalid && !signature.as_ref().is_empty() {
             let mut sig_bytes = signature.encode();
@@ -351,7 +353,7 @@ mod tests {
         }
 
         Info {
-            socket,
+            address,
             timestamp,
             public_key: peer_info_pk,
             signature,
@@ -495,7 +497,7 @@ mod tests {
                     assert_eq!(infos.len(), 1);
                     let tracker_info = &infos[0];
                     assert_eq!(tracker_info.public_key, tracker_pk);
-                    assert_eq!(tracker_info.socket, cfg.address);
+                    assert_eq!(tracker_info.egress(), cfg.address);
                     assert!(tracker_info.verify(&ip_namespace));
                 }
                 _ => panic!("Expected Peers message with tracker info"),
@@ -717,7 +719,7 @@ mod tests {
                     assert_eq!(received_peers_info.len(), 1);
                     let received_pk2_info = &received_peers_info[0];
                     assert_eq!(received_pk2_info.public_key, pk2);
-                    assert_eq!(received_pk2_info.socket, pk2_addr);
+                    assert_eq!(received_pk2_info.egress(), pk2_addr);
                     assert_eq!(received_pk2_info.timestamp, pk2_timestamp);
                 }
                 _ => panic!("pk1 did not receive expected Info for pk2",),
@@ -1048,7 +1050,7 @@ mod tests {
                 Some(peer::Message::Peers(infos)) => {
                     assert_eq!(infos.len(), 1, "Expected 1 Info (for peer1)");
                     assert_eq!(infos[0].public_key, peer1_pk);
-                    assert_eq!(infos[0].socket, peer1_addr);
+                    assert_eq!(infos[0].egress(), peer1_addr);
                 }
                 _ => panic!("Expected Peers message from tracker"),
             }

--- a/p2p/src/authenticated/discovery/config.rs
+++ b/p2p/src/authenticated/discovery/config.rs
@@ -1,10 +1,15 @@
+use crate::Address;
 use commonware_cryptography::Signer;
 use commonware_utils::NZU32;
 use governor::Quota;
 use std::{net::SocketAddr, num::NonZeroU32, time::Duration};
 
 /// Known peer and its accompanying address that will be dialed on startup.
-pub type Bootstrapper<P> = (P, SocketAddr);
+///
+/// The address can be either a single socket address (same for ingress/egress)
+/// or separate addresses for each direction. When using separate addresses,
+/// the ingress address can be a DNS entry that will be resolved at connection time.
+pub type Bootstrapper<P> = (P, Address);
 
 /// Configuration for the peer-to-peer instance.
 ///

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -298,7 +298,7 @@ mod tests {
             if i > 0 {
                 bootstrappers.push((
                     addresses[0].clone(),
-                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port).into(),
                 ));
             }
 
@@ -561,7 +561,7 @@ mod tests {
                 if i > 0 {
                     bootstrappers.push((
                         addresses[0].clone(),
-                        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port),
+                        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port).into(),
                     ));
                 }
 
@@ -709,7 +709,7 @@ mod tests {
             let config0 = Config::test(
                 signer0.clone(),
                 socket0,
-                vec![(peers[1].public_key(), socket1)],
+                vec![(peers[1].public_key(), socket1.into())],
                 1_024 * 1_024, // 1MB
             );
             let (mut network0, mut oracle0) = Network::new(context.with_label("peer-0"), config0);
@@ -723,7 +723,7 @@ mod tests {
             let config1 = Config::test(
                 signer1.clone(),
                 socket1,
-                vec![(peers[0].public_key(), socket0)],
+                vec![(peers[0].public_key(), socket0.into())],
                 1_024 * 1_024, // 1MB
             );
             let (mut network1, mut oracle1) = Network::new(context.with_label("peer-1"), config1);
@@ -784,7 +784,7 @@ mod tests {
             let config = Config::test(
                 peer0.0,
                 peer0.2,
-                vec![(peer0.1.clone(), peer0.2)],
+                vec![(peer0.1.clone(), peer0.2.into())],
                 1_024 * 1_024,
             );
             let (network, mut oracle) = Network::new(context.with_label("network"), config);
@@ -853,7 +853,7 @@ mod tests {
                 if i > 0 {
                     bootstrappers.push((
                         addresses[0].clone(),
-                        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port),
+                        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port).into(),
                     ));
                 }
 

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -149,7 +149,7 @@
 //! // Configure bootstrappers
 //! //
 //! // In production, it is likely that the address of bootstrappers will be some public address.
-//! let bootstrappers = vec![(peer1.clone(), SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3001))];
+//! let bootstrappers = vec![(peer1.clone(), SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3001).into())];
 //!
 //! // Configure namespace
 //! //

--- a/p2p/src/authenticated/lookup/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/actor.rs
@@ -225,6 +225,7 @@ mod tests {
     use super::*;
     use crate::{
         authenticated::lookup::actors::peer,
+        Address,
         Blocker,
         Manager,
         // Blocker is implicitly available via oracle.block() due to Oracle implementing crate::Blocker
@@ -316,7 +317,7 @@ mod tests {
             let (_, pk) = new_signer_and_pk(1);
             let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1001);
             oracle
-                .update(0, OrderedAssociated::from([(pk.clone(), addr)]))
+                .update(0, OrderedAssociated::from([(pk.clone(), Address::from(addr))]))
                 .await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -345,7 +346,7 @@ mod tests {
             let (_, pk1) = new_signer_and_pk(1);
             let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1001);
             oracle
-                .update(0, OrderedAssociated::from([(pk1.clone(), addr)]))
+                .update(0, OrderedAssociated::from([(pk1.clone(), Address::from(addr))]))
                 .await;
             context.sleep(Duration::from_millis(10)).await;
 
@@ -402,8 +403,8 @@ mod tests {
                 .update(
                     0,
                     OrderedAssociated::from([
-                        (peer_pk.clone(), peer_addr),
-                        (peer_pk2.clone(), peer_addr2),
+                        (peer_pk.clone(), Address::from(peer_addr)),
+                        (peer_pk2.clone(), Address::from(peer_addr2)),
                     ]),
                 )
                 .await;
@@ -436,7 +437,7 @@ mod tests {
             assert!(reservation.is_none());
 
             oracle
-                .update(0, OrderedAssociated::from([(peer_pk.clone(), peer_addr)]))
+                .update(0, OrderedAssociated::from([(peer_pk.clone(), Address::from(peer_addr))]))
                 .await;
             context.sleep(Duration::from_millis(10)).await; // Allow register to process
 
@@ -471,7 +472,7 @@ mod tests {
                 ..
             } = setup_actor(context.clone(), cfg_initial);
             oracle
-                .update(0, OrderedAssociated::from([(boot_pk.clone(), boot_addr)]))
+                .update(0, OrderedAssociated::from([(boot_pk.clone(), Address::from(boot_addr))]))
                 .await;
 
             let dialable_peers = mailbox.dialable().await;
@@ -495,7 +496,7 @@ mod tests {
             } = setup_actor(context.clone(), cfg_initial);
 
             oracle
-                .update(0, OrderedAssociated::from([(boot_pk.clone(), boot_addr)]))
+                .update(0, OrderedAssociated::from([(boot_pk.clone(), Address::from(boot_addr))]))
                 .await;
 
             let reservation = mailbox.dial(boot_pk.clone()).await;
@@ -532,7 +533,7 @@ mod tests {
             let (_peer_signer, peer_pk) = new_signer_and_pk(1);
             let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 12345);
             oracle
-                .update(0, OrderedAssociated::from([(peer_pk.clone(), peer_addr)]))
+                .update(0, OrderedAssociated::from([(peer_pk.clone(), Address::from(peer_addr))]))
                 .await;
             // let the register take effect
             context.sleep(Duration::from_millis(10)).await;
@@ -586,7 +587,10 @@ mod tests {
             oracle
                 .update(
                     0,
-                    OrderedAssociated::from([(my_pk.clone(), my_addr), (pk_1.clone(), addr_1)]),
+                    OrderedAssociated::from([
+                        (my_pk.clone(), Address::from(my_addr)),
+                        (pk_1.clone(), Address::from(addr_1)),
+                    ]),
                 )
                 .await;
             // let the register take effect
@@ -607,7 +611,7 @@ mod tests {
 
             // Register another set which doesn't include first peer
             oracle
-                .update(1, OrderedAssociated::from([(pk_2.clone(), addr_2)]))
+                .update(1, OrderedAssociated::from([(pk_2.clone(), Address::from(addr_2))]))
                 .await;
 
             // Wait for a listener update

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -64,7 +64,7 @@
 //! # Example
 //!
 //! ```rust
-//! use commonware_p2p::{authenticated::lookup::{self, Network}, Manager, Sender, Recipients};
+//! use commonware_p2p::{authenticated::lookup::{self, Network}, Address, Manager, Sender, Recipients};
 //! use commonware_cryptography::{ed25519, Signer, PrivateKey as _, PublicKey as _, PrivateKeyExt as _};
 //! use commonware_runtime::{deterministic, Spawner, Runner, Metrics};
 //! use commonware_utils::{NZU32, set::OrderedAssociated};
@@ -119,7 +119,12 @@
 //!     // the composition of a validator set changes).
 //!     oracle.update(
 //!         0,
-//!         OrderedAssociated::from([(my_sk.public_key(), my_addr), (peer1, peer1_addr), (peer2, peer2_addr), (peer3, peer3_addr)])
+//!         OrderedAssociated::from([
+//!             (my_sk.public_key(), Address::from(my_addr)),
+//!             (peer1, Address::from(peer1_addr)),
+//!             (peer2, Address::from(peer2_addr)),
+//!             (peer3, Address::from(peer3_addr)),
+//!         ])
 //!     ).await;
 //!
 //!     // Register some channel
@@ -167,7 +172,7 @@ pub use network::Network;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Manager, Receiver, Recipients, Sender};
+    use crate::{Address, Manager, Receiver, Recipients, Sender};
     use commonware_cryptography::{ed25519, PrivateKeyExt as _, Signer as _};
     use commonware_macros::{select, test_group, test_traced};
     use commonware_runtime::{
@@ -232,7 +237,7 @@ mod tests {
         }
         let peers = peers_and_sks
             .iter()
-            .map(|(_, pub_key, addr)| (pub_key.clone(), *addr))
+            .map(|(_, pub_key, addr)| (pub_key.clone(), Address::from(*addr)))
             .collect::<Vec<_>>();
 
         // Create networks
@@ -499,10 +504,10 @@ mod tests {
                 let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port + i as u16);
                 peers_and_sks.push((sk, pk, addr));
             }
-            let peers = peers_and_sks
+            let peers: Vec<_> = peers_and_sks
                 .iter()
-                .map(|(_, pk, addr)| (pk.clone(), *addr))
-                .collect::<Vec<_>>();
+                .map(|(_, pk, addr)| (pk.clone(), Address::from(*addr)))
+                .collect();
 
             // Create networks
             let mut waiters = Vec::new();
@@ -601,7 +606,7 @@ mod tests {
             }
             let peers: OrderedAssociated<_, _> = peers_and_sks
                 .iter()
-                .map(|(_, pk, addr)| (pk.clone(), *addr))
+                .map(|(_, pk, addr)| (pk.clone(), (*addr).into()))
                 .collect();
 
             // Create network
@@ -654,7 +659,7 @@ mod tests {
             }
             let peers: OrderedAssociated<_, _> = peers_and_sks
                 .iter()
-                .map(|(_, pk, addr)| (pk.clone(), *addr))
+                .map(|(_, pk, addr)| (pk.clone(), (*addr).into()))
                 .collect();
             let (sk0, _, addr0) = peers_and_sks[0].clone();
             let (sk1, pk1, addr1) = peers_and_sks[1].clone();
@@ -731,7 +736,7 @@ mod tests {
             let set10: OrderedAssociated<_, _> = peers_and_sks
                 .iter()
                 .take(2)
-                .map(|(_, pk, addr)| (pk.clone(), *addr))
+                .map(|(_, pk, addr)| (pk.clone(), (*addr).into()))
                 .collect();
             oracle.update(10, set10.clone()).await;
             let (id, new, all) = subscription.next().await.unwrap();
@@ -743,7 +748,7 @@ mod tests {
             let set9: OrderedAssociated<_, _> = peers_and_sks
                 .iter()
                 .skip(2)
-                .map(|(_, pk, addr)| (pk.clone(), *addr))
+                .map(|(_, pk, addr)| (pk.clone(), (*addr).into()))
                 .collect();
             oracle.update(9, set9.clone()).await;
 
@@ -751,7 +756,7 @@ mod tests {
             let set11: OrderedAssociated<_, _> = peers_and_sks
                 .iter()
                 .skip(4)
-                .map(|(_, pk, addr)| (pk.clone(), *addr))
+                .map(|(_, pk, addr)| (pk.clone(), (*addr).into()))
                 .collect();
             oracle.update(11, set11.clone()).await;
             let (id, new, all) = subscription.next().await.unwrap();
@@ -783,7 +788,7 @@ mod tests {
             }
             let peers: OrderedAssociated<_, _> = peers_and_sks
                 .iter()
-                .map(|(_, pk, addr)| (pk.clone(), *addr))
+                .map(|(_, pk, addr)| (pk.clone(), (*addr).into()))
                 .collect();
 
             // Create networks for all peers

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -97,6 +97,8 @@ pub enum Error {
     OffsetOverflow,
     #[error("io error: {0}")]
     Io(#[from] IoError),
+    #[error("not found")]
+    NotFound,
 }
 
 /// Interface that any task scheduler must implement to start
@@ -437,6 +439,23 @@ pub trait Stream: Sync + Send + 'static {
         &mut self,
         buf: impl Into<StableBuf> + Send,
     ) -> impl Future<Output = Result<StableBuf, Error>> + Send;
+}
+
+/// Interface for resolving domain names to socket addresses.
+///
+/// This trait enables DNS resolution that works across different runtime
+/// implementations:
+/// - In the deterministic runtime, resolution uses a configurable mapping
+/// - In the tokio runtime, resolution uses tokio's built-in DNS functionality
+pub trait Resolver: Clone + Send + Sync + 'static {
+    /// Resolve a domain name and port to a socket address.
+    ///
+    /// Returns the first resolved address, or an error if resolution fails.
+    fn resolve(
+        &self,
+        host: &str,
+        port: u16,
+    ) -> impl Future<Output = Result<SocketAddr, Error>> + Send;
 }
 
 /// Interface to interact with storage.

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -656,3 +656,14 @@ impl crate::Storage for Context {
         self.storage.scan(partition).await
     }
 }
+
+impl crate::Resolver for Context {
+    async fn resolve(&self, host: &str, port: u16) -> Result<SocketAddr, Error> {
+        let addr = tokio::net::lookup_host(format!("{host}:{port}"))
+            .await
+            .map_err(|_| Error::NotFound)?
+            .next()
+            .ok_or(Error::NotFound)?;
+        Ok(addr)
+    }
+}


### PR DESCRIPTION
This commit introduces the ability for peers to register either a single
socket address or separate addresses for ingress and egress connections.
Additionally, DNS entries are now supported for ingress addresses.

Key changes:
- Add Resolver trait to runtime for DNS resolution
- Implement DNS resolver for deterministic runtime with configurable mappings
- Implement DNS resolver for tokio runtime using built-in DNS functionality
- Add Socket enum (Direct/Dns) and Address enum (Single/Split) to p2p
- Update Bootstrapper type to use Address instead of SocketAddr
- Update Directory::init to handle the new Address type

The new Address type allows:
- Single(SocketAddr): Same address for both ingress and egress (backward compatible)
- Split { ingress: Socket, egress: SocketAddr }: Different addresses for each direction

For DNS resolution:
- Deterministic runtime: Uses configurable dns_mappings in Config
- Tokio runtime: Uses tokio::net::lookup_host for real DNS resolution

Closes #2033, closes #1578, closes #1742