### PR TITLE
fix(utils): swap incorrect comments in capture_appended_chunks

### DIFF
--- a/utils/src/bitmap/historical/bitmap.rs
+++ b/utils/src/bitmap/historical/bitmap.rs
@@ -437,9 +437,9 @@ impl<const N: usize> BitMap<N> {
             // by capture_modified_chunks (which runs first and takes precedence).
             changes.entry(chunk_idx).or_insert_with(|| {
                 self.get_chunk(chunk_idx).map_or(
-                    // Chunk existed before: store its old data
-                    ChunkDiff::Added,
                     // Chunk is brand new: mark as Added
+                    ChunkDiff::Added,
+                    // Chunk existed before: store its old data
                     ChunkDiff::Modified,
                 )
             });


### PR DESCRIPTION
Comments for map_or arguments were swapped - Added was labeled as "existed before" and Modified as "brand new". Fixed to match actual map_or semantics.