### PR TITLE
[consensus/marshal] Cache proposed blocks

### DIFF
--- a/consensus/src/application/marshaled.rs
+++ b/consensus/src/application/marshaled.rs
@@ -451,7 +451,7 @@ where
             height = block.height(),
             "requested broadcast of built block"
         );
-        self.marshal.broadcast(round, block).await;
+        self.marshal.proposed(round, block).await;
     }
 }
 

--- a/consensus/src/marshal/actor.rs
+++ b/consensus/src/marshal/actor.rs
@@ -355,7 +355,7 @@ where
                             };
                             let _ = response.send(info);
                         }
-                        Message::Broadcast { round, block } => {
+                        Message::Proposed { round, block } => {
                             self.cache_verified(round, block.commitment(), block.clone()).await;
                             let _peers = buffer.broadcast(Recipients::All, block).await;
                         }

--- a/consensus/src/marshal/ingress/mailbox.rs
+++ b/consensus/src/marshal/ingress/mailbox.rs
@@ -97,8 +97,8 @@ pub(crate) enum Message<S: Scheme, B: Block> {
         /// A channel to send the retrieved block.
         response: oneshot::Sender<B>,
     },
-    /// A request to broadcast a block to all peers.
-    Broadcast {
+    /// A request to broadcast a proposed block to all peers.
+    Proposed {
         /// The round in which the block was proposed.
         round: Round,
         /// The block to broadcast.
@@ -266,15 +266,15 @@ impl<S: Scheme, B: Block> Mailbox<S, B> {
             .map(|block| AncestorStream::new(self.clone(), [block]))
     }
 
-    /// Broadcast indicates that a block should be sent to all peers.
-    pub async fn broadcast(&mut self, round: Round, block: B) {
+    /// Proposed requests that a proposed block is sent to all peers.
+    pub async fn proposed(&mut self, round: Round, block: B) {
         if self
             .sender
-            .send(Message::Broadcast { round, block })
+            .send(Message::Proposed { round, block })
             .await
             .is_err()
         {
-            error!("failed to send broadcast message to actor: receiver dropped");
+            error!("failed to send proposed message to actor: receiver dropped");
         }
     }
 

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -513,7 +513,7 @@ mod tests {
                 // Broadcast block by one validator
                 let actor_index: usize = (height % (NUM_VALIDATORS as u64)) as usize;
                 let mut actor = actors[actor_index].clone();
-                actor.broadcast(round, block.clone()).await;
+                actor.proposed(round, block.clone()).await;
                 actor.verified(round, block.clone()).await;
 
                 // Wait for the block to be broadcast, but due to jitter, we may or may not receive
@@ -657,7 +657,7 @@ mod tests {
                 // Broadcast block by one validator
                 let actor_index: usize = (height % (applications.len() as u64)) as usize;
                 let mut actor = actors[actor_index].clone();
-                actor.broadcast(round, block.clone()).await;
+                actor.proposed(round, block.clone()).await;
                 actor.verified(round, block.clone()).await;
 
                 // Wait for the block to be broadcast, but due to jitter, we may or may not receive
@@ -1005,7 +1005,7 @@ mod tests {
 
             // Block1: Broadcasted by the actor
             actor
-                .broadcast(Round::new(Epoch::zero(), View::new(1)), block1.clone())
+                .proposed(Round::new(Epoch::zero(), View::new(1)), block1.clone())
                 .await;
             context.sleep(Duration::from_millis(20)).await;
 
@@ -1064,7 +1064,7 @@ mod tests {
             // Block5: Broadcasted by a remote node (different actor)
             let remote_actor = &mut actors[1].clone();
             remote_actor
-                .broadcast(Round::new(Epoch::zero(), View::new(5)), block5.clone())
+                .proposed(Round::new(Epoch::zero(), View::new(5)), block5.clone())
                 .await;
             context.sleep(Duration::from_millis(20)).await;
 
@@ -1524,7 +1524,7 @@ mod tests {
             let malicious_commitment = malicious_block.commitment();
             marshal
                 .clone()
-                .broadcast(
+                .proposed(
                     Round::new(Epoch::new(1), View::new(35)),
                     malicious_block.clone(),
                 )
@@ -1564,7 +1564,7 @@ mod tests {
             let malicious_commitment = malicious_block.commitment();
             marshal
                 .clone()
-                .broadcast(
+                .proposed(
                     Round::new(Epoch::new(1), View::new(22)),
                     malicious_block.clone(),
                 )
@@ -1740,7 +1740,7 @@ mod tests {
 
             // Broadcast the block
             actor
-                .broadcast(Round::new(Epoch::new(0), View::new(1)), block.clone())
+                .proposed(Round::new(Epoch::new(0), View::new(1)), block.clone())
                 .await;
 
             // Ensure the block is cached and retrievable; This should hit the in-memory cache


### PR DESCRIPTION
Future Work: https://github.com/commonwarexyz/monorepo/issues/2394

## Overview

Changes marshal to cache proposed blocks on `broadcast`.