### PR TITLE
[Storage] Replace `IndexedLog` generic `I: Index` with `T: Translator`

### DIFF
--- a/storage/src/adb/any/ordered/fixed.rs
+++ b/storage/src/adb/any/ordered/fixed.rs
@@ -47,7 +47,7 @@ impl<K: Array, V: Value> OperationTrait for Operation<K, V> {
 /// A key-value ADB based on an authenticated log of operations, supporting authentication of any
 /// value ever associated with a key.
 pub type Any<E, K, V, H, T, S = Clean<DigestOf<H>>> =
-    IndexedLog<E, Journal<E, Operation<K, V>>, Index<T, Location>, H, S>;
+    IndexedLog<E, Journal<E, Operation<K, V>>, T, H, S>;
 
 impl<E: Storage + Clock + Metrics, K: Array, V: Value, H: Hasher, T: Translator>
     Any<E, K, V, H, T>

--- a/storage/src/adb/any/ordered/variable.rs
+++ b/storage/src/adb/any/ordered/variable.rs
@@ -51,7 +51,7 @@ impl<K: Array, V: Value> OperationTrait for Operation<K, V> {
 /// A key-value ADB based on an authenticated log of operations, supporting authentication of any
 /// value ever associated with a key.
 pub type Any<E, K, V, H, T, S = Clean<DigestOf<H>>> =
-    IndexedLog<E, Journal<E, Operation<K, V>>, Index<T, Location>, H, S>;
+    IndexedLog<E, Journal<E, Operation<K, V>>, T, H, S>;
 
 impl<E: Storage + Clock + Metrics, K: Array, V: Value, H: Hasher, T: Translator>
     Any<E, K, V, H, T>

--- a/storage/src/adb/any/unordered/fixed.rs
+++ b/storage/src/adb/any/unordered/fixed.rs
@@ -36,7 +36,7 @@ impl<K: Array, V: Value> OperationTrait for Operation<K, V> {
 /// A key-value ADB based on an authenticated log of operations, supporting authentication of any
 /// value ever associated with a key.
 pub type Any<E, K, V, H, T, S = Clean<DigestOf<H>>> =
-    IndexedLog<E, Journal<E, Operation<K, V>>, Index<T, Location>, H, S>;
+    IndexedLog<E, Journal<E, Operation<K, V>>, T, H, S>;
 
 impl<E: Storage + Clock + Metrics, K: Array, V: Value, H: Hasher, T: Translator>
     Any<E, K, V, H, T>

--- a/storage/src/adb/any/unordered/variable.rs
+++ b/storage/src/adb/any/unordered/variable.rs
@@ -46,7 +46,7 @@ impl<K: Array, V: Value> OperationTrait for Operation<K, V> {
 /// A key-value ADB based on an authenticated log of operations, supporting authentication of any
 /// value ever associated with a key.
 pub type Any<E, K, V, H, T, S = Clean<DigestOf<H>>> =
-    IndexedLog<E, Journal<E, Operation<K, V>>, Index<T, Location>, H, S>;
+    IndexedLog<E, Journal<E, Operation<K, V>>, T, H, S>;
 
 impl<E: Storage + Clock + Metrics, K: Array, V: Value, H: Hasher, T: Translator>
     Any<E, K, V, H, T>


### PR DESCRIPTION
For the unordered/ordered implementations of `IndexedLog`, we always use the same index implementation `I`.

This PR reflects that by explicitly naming the concrete index type in `IndexedLog`.