### PR TITLE
deployer: remove unused VPC and subnet CIDR maps

### DIFF
--- a/deployer/src/ec2/create.rs
+++ b/deployer/src/ec2/create.rs
@@ -104,8 +104,6 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
 
     // Initialize resources for each region
     info!(?regions, "initializing resources");
-    let mut vpc_cidrs = HashMap::new();
-    let mut subnet_cidrs = HashMap::new();
     let mut ec2_clients = HashMap::new();
     let mut region_resources = HashMap::new();
     for (idx, region) in regions.iter().enumerate() {
@@ -129,7 +127,6 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
 
         // Create VPC, IGW, route table, subnet, security groups, and key pair
         let vpc_cidr = format!("10.{idx}.0.0/16");
-        vpc_cidrs.insert(region.clone(), vpc_cidr.clone());
         let vpc_id = create_vpc(&ec2_clients[region], &vpc_cidr, tag).await?;
         info!(
             vpc = vpc_id.as_str(),
@@ -152,7 +149,6 @@ pub async fn create(config: &PathBuf) -> Result<(), Error> {
             "created route table"
         );
         let subnet_cidr = format!("10.{idx}.1.0/24");
-        subnet_cidrs.insert(region.clone(), subnet_cidr.clone());
         let subnet_id = create_subnet(
             &ec2_clients[region],
             &vpc_id,


### PR DESCRIPTION
Removed the vpc_cidrs and subnet_cidrs HashMaps from the EC2 create path because they were only written to and never read. The effective VPC CIDR per region is already stored in RegionResources.vpc_cidr and used for peering routes and security group rules, so these extra maps were redundant.