### PR TITLE
[broadcast] move constructor and keep one impl block

### DIFF
--- a/broadcast/src/buffered/ingress.rs
+++ b/broadcast/src/buffered/ingress.rs
@@ -49,9 +49,7 @@ impl<P: PublicKey, M: Committable + Digestible + Codec> Mailbox<P, M> {
     pub(super) const fn new(sender: mpsc::Sender<Message<P, M>>) -> Self {
         Self { sender }
     }
-}
 
-impl<P: PublicKey, M: Committable + Digestible + Codec> Mailbox<P, M> {
     /// Subscribe to a message by peer (optionally), commitment, and digest (optionally).
     ///
     /// The responder will be sent the first message for an commitment when it is available; either


### PR DESCRIPTION
minor readability improv, consolidate impl blocks