### PR TITLE
[utils] NZU* macros validate literals at compile time

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -577,10 +577,14 @@ mod tests {
 
         // Zero runtime values panic
         let zero_usize: usize = 0;
+        let zero_u8: u8 = 0;
+        let zero_u16: u16 = 0;
         let zero_u32: u32 = 0;
         let zero_u64: u64 = 0;
 
         assert!(std::panic::catch_unwind(|| NZUsize!(zero_usize)).is_err());
+        assert!(std::panic::catch_unwind(|| NZU8!(zero_u8)).is_err());
+        assert!(std::panic::catch_unwind(|| NZU16!(zero_u16)).is_err());
         assert!(std::panic::catch_unwind(|| NZU32!(zero_u32)).is_err());
         assert!(std::panic::catch_unwind(|| NZU64!(zero_u64)).is_err());
 


### PR DESCRIPTION
Updates the `NZUsize!`, `NZU8!`, `NZU16!`, `NZU32!`, and `NZU64!` macros to validate at compile time when passed literal values. Previously, all validation happened at runtime, now literals are wrapped in a `const { }` block, so `NZU32!(0)` fails to compile rather than panicking at runtime.