### PR TITLE
fix: register metrics with post-start context

### DIFF
--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -118,8 +118,7 @@ impl<E: Clock + Spawner + Metrics, P: PublicKey, M: Committable + Digestible + C
         let (mailbox_sender, mailbox_receiver) = mpsc::channel(cfg.mailbox_size);
         let mailbox = Mailbox::<P, M>::new(mailbox_sender);
 
-        // TODO(#1833): Metrics should use the post-start context
-        let metrics = metrics::Metrics::init(context.clone());
+        let metrics = metrics::Metrics::default();
 
         let result = Self {
             context: ContextCell::new(context),
@@ -148,6 +147,9 @@ impl<E: Clock + Spawner + Metrics, P: PublicKey, M: Committable + Digestible + C
 
     /// Inner run loop called by `start`.
     async fn run(mut self, network: (impl Sender<PublicKey = P>, impl Receiver<PublicKey = P>)) {
+        // Register metrics with the post-start context
+        self.metrics.register(self.context.as_ref());
+
         let (mut sender, mut receiver) = wrap(self.codec_config.clone(), network.0, network.1);
         let mut shutdown = self.context.stopped();
 


### PR DESCRIPTION
Resolves TODO(#1833) by moving metrics registration from Engine::new() to Engine::run().

Metrics are now registered using the post-start context, which ensures they are properly initialized after the engine is spawned. This change separates metrics creation from registration, allowing the metrics to use the correct runtime context.