### PR TITLE
[docs] Add Canonical Link Meta

### DIFF
--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -10,6 +10,8 @@
     <meta name="description" content="Benchmarks for the Commonware Library.">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/benchmarks.html" />
+
     <meta property="og:url" content="https://commonware.xyz/benchmarks.html" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="commonware > Benchmarks" />

--- a/docs/blogs/adb-any.html
+++ b/docs/blogs/adb-any.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Roberto Bayardo, Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/adb-any.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/adb-any.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/adb-current.html
+++ b/docs/blogs/adb-current.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Roberto Bayardo">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/adb-current.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/adb-current.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/buffered-signatures.html
+++ b/docs/blogs/buffered-signatures.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/buffered-signatures.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/buffered-signatures.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/commonware-broadcast.html
+++ b/docs/blogs/commonware-broadcast.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Brendan Chou">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/commonware-broadcast.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/commonware-broadcast.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/commonware-cryptography.html
+++ b/docs/blogs/commonware-cryptography.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/commonware-cryptography.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/commonware-cryptography.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/commonware-deployer.html
+++ b/docs/blogs/commonware-deployer.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/commonware-deployer.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/commonware-deployer.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/commonware-runtime.html
+++ b/docs/blogs/commonware-runtime.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/commonware-runtime.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/commonware-runtime.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/commonware-the-anti-framework.html
+++ b/docs/blogs/commonware-the-anti-framework.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/commonware-the-anti-framework.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/commonware-the-anti-framework.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/introducing-commonware.html
+++ b/docs/blogs/introducing-commonware.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/introducing-commonware.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/introducing-commonware.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/minimmit.html
+++ b/docs/blogs/minimmit.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady, Brendan Chou">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto, minimmit, consensus">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/minimmit.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/minimmit.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/mmr.html
+++ b/docs/blogs/mmr.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Roberto Bayardo">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/mmr.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/mmr.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/only-time-will-tell.html
+++ b/docs/blogs/only-time-will-tell.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, timelock encryption, BTLE, battleware, cryptography, blockchain, temporal privacy, VRF, threshold signatures">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/only-time-will-tell.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/only-time-will-tell.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/qmdb.html
+++ b/docs/blogs/qmdb.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/qmdb.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/qmdb.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/reshare.html
+++ b/docs/blogs/reshare.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Ben Clabby, Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/reshare.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/reshare.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/threshold-simplex.html
+++ b/docs/blogs/threshold-simplex.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/threshold-simplex.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/threshold-simplex.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/welcome-tempo.html
+++ b/docs/blogs/welcome-tempo.html
@@ -11,6 +11,8 @@
     <meta name="author" content="Patrick O'Grady">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/welcome-tempo.html" />
+
     <meta property="og:url" content="https://commonware.xyz/blogs/welcome-tempo.html" />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="commonware" />

--- a/docs/blogs/zoda.html
+++ b/docs/blogs/zoda.html
@@ -29,6 +29,8 @@ or updating state, requires disseminating (a lot of) data." />
     <meta property="article:published_time" content="2025-11-04T00:00:00Z" />
     <meta property="article:modified_time" content="2025-11-04T00:00:00Z" />
 
+    <link rel="canonical" href="https://commonware.xyz/blogs/zoda.html" />
+
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="twitter:domain" content="commonware.xyz" />
     <meta property="twitter:url" content="https://commonware.xyz/blogs/zoda.html" />

--- a/docs/hiring.html
+++ b/docs/hiring.html
@@ -10,6 +10,8 @@
     <meta name="description" content="Backed by Haun Ventures, Dragonfly Capital, Mert Mumtaz, Nick White, Dan Romero, Sreeram Kannan, and other experienced operators, Commonware is now hiring for ambitious engineers that can help us expand the Commonware Library to a broader set of applications and deploy cloud-based primitives to augment it.">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
+    <link rel="canonical" href="https://commonware.xyz/hiring.html" />
+
     <meta property="og:url" content="https://commonware.xyz/hiring.html" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="commonware > Hiring" />

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,9 @@
     <meta name="description" content="">
     <meta name="keywords" content="commonware, open source, common goods, software, internet, ownership, trust, blockchain, decentralization, crypto">
 
-    <meta property="og:url" content="https://commonware.xyz" />
+    <link rel="canonical" href="https://commonware.xyz/" />
+
+    <meta property="og:url" content="https://commonware.xyz/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="commonware" />
     <meta property="og:title" content="commonware" />

--- a/docs/podcast.html
+++ b/docs/podcast.html
@@ -10,6 +10,8 @@
     <meta name="description" content="Exploring how blockchains (and the mechanisms that power them) work.">
     <meta name="keywords" content="commonware, podcast, distributed systems, consensus, blockchain, infrastructure, open source, how things work">
 
+    <link rel="canonical" href="https://commonware.xyz/podcast.html" />
+
     <meta property="og:url" content="https://commonware.xyz/podcast.html" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="commonware > How Things Work" />

--- a/docs/template.html
+++ b/docs/template.html
@@ -21,6 +21,8 @@
     <meta property="article:published_time" content="$published-time$" />
     <meta property="article:modified_time" content="$modified-time$" />
 
+    <link rel="canonical" href="$url$" />
+
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="twitter:domain" content="commonware.xyz" />
     <meta property="twitter:url" content="$url$" />


### PR DESCRIPTION
Because Cloudflare Pages automatically re-directs `/page` to `/page.html`, we need to add canonical meta tags.