### PR TITLE
fix(cryptography): prevent BloomFilter arbitrary from generating zero hashers

### DIFF
--- a/cryptography/conformance.toml
+++ b/cryptography/conformance.toml
@@ -4,7 +4,7 @@ hash = "c0501d4a691d1fccec7c5906e8608228569d24164150edd215838593e3b77512"
 
 ["commonware_cryptography::bloomfilter::tests::conformance::CodecConformance<BloomFilter>"]
 n_cases = 65536
-hash = "a75d6312366816126114abdc9d7fbd246891cab210eeae6a02781625aa1ad6a4"
+hash = "b48e0f23d3f405f5b9306df0460e6301ecc3fe541a17a4a9d3013663fdf9b785"
 
 ["commonware_cryptography::bls12381::certificate::multisig::tests::conformance::CodecConformance<Certificate<MinSig>>"]
 n_cases = 65536

--- a/cryptography/src/bloomfilter.rs
+++ b/cryptography/src/bloomfilter.rs
@@ -124,7 +124,9 @@ impl EncodeSize for BloomFilter {
 #[cfg(feature = "arbitrary")]
 impl arbitrary::Arbitrary<'_> for BloomFilter {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        let hashers = u8::arbitrary(u)?;
+        // Ensure at least 1 hasher to avoid empty iterator in indices(),
+        // which would cause contains() to always return true
+        let hashers = u8::arbitrary(u)?.max(1);
         // Ensure at least 1 bit to avoid empty bitmap
         let bits_len = u.arbitrary_len::<u64>()?.max(1);
         let mut bits = BitMap::with_capacity(bits_len as u64);


### PR DESCRIPTION
Fixed a bug in BloomFilter's Arbitrary implementation where hashers could be zero.
When hashers=0, the indices() method returns an empty iterator, which causes contains() to always return true regardless of whether the item was actually inserted. This completely breaks the bloom filter semantics (100% false positive rate).

The public constructor already requires NonZeroU8, so arbitrary should respect the same invariant. Added .max(1) to ensure at least one hasher is always generated.