### PR TITLE
Provide `with_rng` to runtime

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -391,7 +391,11 @@ impl From<Config> for Runner {
 
 impl From<(Config, Box<dyn RngCore + Send>)> for Runner {
     fn from((cfg, rng): (Config, Box<dyn RngCore + Send>)) -> Self {
-        Self::new(cfg).with_rng(rng)
+        cfg.assert();
+        Self {
+            state: State::Config(cfg),
+            rng: Some(rng),
+        }
     }
 }
 
@@ -843,8 +847,8 @@ impl Context {
         // Initialize panicker
         let (panicker, panicked) = Panicker::new(cfg.catch_panics);
 
-        let rng: Box<dyn RngCore + Send> = rng
-            .unwrap_or_else(|| Box::new(StdRng::seed_from_u64(cfg.seed)));
+        let rng: Box<dyn RngCore + Send> =
+            rng.unwrap_or_else(|| Box::new(StdRng::seed_from_u64(cfg.seed)));
 
         let executor = Arc::new(Executor {
             registry: Mutex::new(registry),


### PR DESCRIPTION
Draft for: https://github.com/commonwarexyz/monorepo/issues/2376.

Adds `Runner::with_rng()` to allow injecting a custom RNG implementation into the deterministic runtime. This enables fuzzing scenarios where the fuzzer controls randomness by providing its own `RngCore` implementation instead of the default seeded `StdRng`.

The change is backwards compatible since existing seed-based usage continues to work unchanged. When `with_rng` is not called, the runtime falls back to `StdRng::seed_from_u64(cfg.seed)`. The custom RNG is ignored when recovering from a `Checkpoint` since the checkpoint already contains the RNG state.

However, we currently add this on `Runner` rather than `Config` because `Config` derives `Clone` and maintains `const fn` setters while `Box<dyn RngCore + Send>` is not cloneable.

@patrick-ogrady Please advise if this is acceptable given we have `with_seed` on the `Config` and this does feel somewhat clunky.


