### PR TITLE
[storage/qmdb] optimized batch processing for current dbs

### DIFF
--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -647,6 +647,213 @@ where
         self.delete_with_callback(key, |_, _| r = true).await?;
         Ok(r)
     }
+
+    /// Performs a batch update, invoking the callback for each resulting operation. The first
+    /// argument of the callback is the activity status of the operation, and the second argument is
+    /// the location of the operation it inactivates (if any).
+    pub(crate) async fn write_batch_with_callback<F>(
+        &mut self,
+        iter: impl Iterator<Item = (K, Option<V::Value>)>,
+        mut callback: F,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(bool, Option<Location>),
+    {
+        // Collect all the possible matching `locations` for any referenced key, while retaining
+        // each item in the batch in a `mutations` map.
+        let mut mutations = BTreeMap::new();
+        let mut locations = Vec::with_capacity(iter.size_hint().0);
+        for (key, value) in iter {
+            let iter = self.snapshot.get(&key);
+            locations.extend(iter.copied());
+            mutations.insert(key, value);
+        }
+
+        // Concurrently look up all possible matching locations.
+        locations.sort();
+        locations.dedup();
+        let futures = locations.iter().map(|loc| self.log.read(*loc));
+        let results = try_join_all(futures).await?;
+
+        // A set of possible "next_key" values for any keys whose next_key value will need to be
+        // updated.
+        let mut possible_next = BTreeSet::new();
+        // A set of possible previous keys to any new or deleted keys.
+        let mut possible_previous = BTreeMap::new();
+
+        // We divide keys in the batch into three disjoint sets:
+        //   - `deleted`
+        //   - `created`
+        //   - `updated`
+        //
+        // Populate the the deleted and updated sets, and for deleted keys only, immediately update
+        // the log and snapshot.
+        let mut deleted = Vec::new();
+        let mut updated = BTreeMap::new();
+        for (op, old_loc) in (results.into_iter()).zip(locations) {
+            let Operation::Update(key_data) = op else {
+                unreachable!("updates should have key data");
+            };
+            let key = key_data.key.clone();
+            possible_previous.insert(key.clone(), (key_data.value, old_loc));
+            possible_next.insert(key_data.next_key);
+
+            let Some(update) = mutations.remove(&key) else {
+                // Due to translated key collisions, we may look up keys that aren't in the
+                // mutations set. Note that these could still end up next or previous keys to other
+                // keys in the batch, so they are still added to these sets above.
+                continue;
+            };
+
+            if let Some(value) = update {
+                // This is an update of an existing key.
+                updated.insert(key.clone(), (value, old_loc));
+            } else {
+                // This is a delete of an existing key.
+                deleted.push(key.clone());
+
+                // Update the log and snapshot.
+                delete_known_loc(&mut self.snapshot, &key, old_loc);
+                self.log.append(Operation::Delete(key)).await?;
+                callback(false, Some(old_loc));
+
+                // Each delete reduces the active key count by one and inactivates that key.
+                self.active_keys -= 1;
+                self.steps += 1;
+            }
+        }
+
+        // Any key remaining in `mutations` must be a new key so move it to the created map.
+        let mut created = BTreeMap::new();
+        for (key, value) in mutations {
+            let Some(value) = value else {
+                continue; // can happen from attempt to delete a non-existent key
+            };
+            created.insert(key.clone(), value);
+
+            // Any newly created key must be a next_key for some remaining key.
+            possible_next.insert(key);
+        }
+
+        // Complete the `possible_previous` and `possible_next` sets by including entries from the
+        // previous _translated_ key for any created or deleted key.
+        let mut locations = Vec::new();
+        for key in deleted.iter().chain(created.keys()) {
+            let iter = self.snapshot.prev_translated_key(key);
+            let Some(iter) = iter else {
+                continue;
+            };
+            locations.extend(iter.copied());
+        }
+        locations.sort();
+        locations.dedup();
+        let futures = locations.iter().map(|loc| self.log.read(*loc));
+        let results = try_join_all(futures).await?;
+
+        for (op, old_loc) in (results.into_iter()).zip(locations) {
+            let Operation::Update(key_data) = op else {
+                unreachable!("updates should have key data");
+            };
+            possible_next.insert(key_data.next_key);
+            possible_previous.insert(key_data.key, (key_data.value, old_loc));
+        }
+
+        // Remove deleted keys from the possible_* sets.
+        for key in deleted.iter() {
+            possible_previous.remove(key);
+            possible_next.remove(key);
+        }
+
+        // Apply the updates of existing keys.
+        let mut already_updated = BTreeSet::new();
+        for (key, (value, loc)) in updated {
+            let new_loc = self.op_count();
+            update_known_loc(&mut self.snapshot, &key, loc, new_loc);
+
+            let next_key = find_next_key(&key, &possible_next);
+            let op = Operation::Update(KeyData {
+                key: key.clone(),
+                value: value.clone(),
+                next_key,
+            });
+            self.log.append(op).await?;
+            callback(true, Some(loc));
+
+            // Each update of an existing key inactivates its previous location.
+            self.steps += 1;
+            already_updated.insert(key);
+        }
+
+        // Create each new key, and update its previous key if it hasn't already been updated.
+        for (key, value) in created {
+            let new_loc = self.op_count();
+            self.snapshot.insert(&key, new_loc);
+            let next_key = find_next_key(&key, &possible_next);
+            let op = Operation::Update(KeyData {
+                key: key.clone(),
+                value: value.clone(),
+                next_key,
+            });
+
+            // Each newly created key increases the active key count.
+            self.log.append(op).await?;
+            callback(true, None);
+            self.active_keys += 1;
+
+            // Update the next_key value of its previous key (unless there are no existing keys).
+            if possible_previous.is_empty() {
+                continue;
+            }
+            let (prev_key, (prev_value, prev_loc)) = find_prev_key(&key, &possible_previous);
+            if already_updated.contains(prev_key) {
+                continue;
+            }
+            already_updated.insert(prev_key.clone());
+
+            let new_loc = self.op_count();
+            update_known_loc(&mut self.snapshot, prev_key, *prev_loc, new_loc);
+            let next_key = find_next_key(prev_key, &possible_next);
+            let op = Operation::Update(KeyData {
+                key: prev_key.clone(),
+                value: prev_value.clone(),
+                next_key,
+            });
+            self.log.append(op).await?;
+            callback(true, Some(*prev_loc));
+
+            // Each key whose next-key value is updated inactivates its previous location.
+            self.steps += 1;
+        }
+
+        if possible_next.is_empty() || possible_previous.is_empty() {
+            return Ok(());
+        }
+
+        // Update the previous key of each deleted key if it hasn't already been updated.
+        for key in deleted.iter() {
+            let (prev_key, (prev_value, prev_loc)) = find_prev_key(key, &possible_previous);
+            if already_updated.contains(prev_key) {
+                continue;
+            }
+            already_updated.insert(prev_key.clone());
+
+            let new_loc = self.op_count();
+            update_known_loc(&mut self.snapshot, prev_key, *prev_loc, new_loc);
+            let next_key = find_next_key(prev_key, &possible_next);
+            let op = Operation::Update(KeyData {
+                key: prev_key.clone(),
+                value: prev_value.clone(),
+                next_key,
+            });
+            self.log.append(op).await?;
+            callback(true, Some(*prev_loc));
+
+            // Each key whose next-key value is updated inactivates its previous location.
+            self.steps += 1;
+        }
+
+        Ok(())
+    }
 }
 
 impl<
@@ -752,6 +959,26 @@ where
             log: &mut self.log,
         }
     }
+
+    /// Prunes historical operations prior to `prune_loc`. This does not affect the db's root or
+    /// snapshot.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [Error::PruneBeyondMinRequired] if `prune_loc` > inactivity floor.
+    /// - Returns [crate::mmr::Error::LocationOverflow] if `prune_loc` > [crate::mmr::MAX_LOCATION].
+    pub async fn prune(&mut self, prune_loc: Location) -> Result<(), Error> {
+        if prune_loc > self.inactivity_floor_loc {
+            return Err(Error::PruneBeyondMinRequired(
+                prune_loc,
+                self.inactivity_floor_loc,
+            ));
+        }
+
+        self.log.prune(prune_loc).await?;
+
+        Ok(())
+    }
 }
 
 impl<
@@ -775,38 +1002,6 @@ where
             steps: self.steps,
             active_keys: self.active_keys,
         }
-    }
-}
-
-impl<
-        E: Storage + Clock + Metrics,
-        K: Array,
-        V: ValueEncoding,
-        C: MutableContiguous<Item = Operation<K, V>>,
-        I: Index<Value = Location>,
-        H: Hasher,
-    > IndexedLog<E, C, I, H>
-where
-    Operation<K, V>: Codec,
-{
-    /// Prunes historical operations prior to `prune_loc`. This does not affect the db's root or
-    /// snapshot.
-    ///
-    /// # Errors
-    ///
-    /// - Returns [Error::PruneBeyondMinRequired] if `prune_loc` > inactivity floor.
-    /// - Returns [crate::mmr::Error::LocationOverflow] if `prune_loc` > [crate::mmr::MAX_LOCATION].
-    pub async fn prune(&mut self, prune_loc: Location) -> Result<(), Error> {
-        if prune_loc > self.inactivity_floor_loc {
-            return Err(Error::PruneBeyondMinRequired(
-                prune_loc,
-                self.inactivity_floor_loc,
-            ));
-        }
-
-        self.log.prune(prune_loc).await?;
-
-        Ok(())
     }
 }
 
@@ -1208,195 +1403,7 @@ where
         &mut self,
         iter: impl Iterator<Item = (K, Option<V::Value>)>,
     ) -> Result<(), Error> {
-        // Collect all the possible matching `locations` for any referenced key, while retaining
-        // each item in the batch in a `mutations` map.
-        let mut mutations = BTreeMap::new();
-        let mut locations = Vec::with_capacity(iter.size_hint().0);
-        for (key, value) in iter {
-            let iter = self.snapshot.get(&key);
-            locations.extend(iter.copied());
-            mutations.insert(key, value);
-        }
-
-        // Concurrently look up all possible matching locations.
-        locations.sort();
-        locations.dedup();
-        let futures = locations.iter().map(|loc| self.log.read(*loc));
-        let results = try_join_all(futures).await?;
-
-        // A set of possible "next_key" values for any keys whose next_key value will need to be
-        // updated.
-        let mut possible_next = BTreeSet::new();
-        // A set of possible previous keys to any new or deleted keys.
-        let mut possible_previous = BTreeMap::new();
-
-        // We divide keys in the batch into three disjoint sets:
-        //   - `deleted`
-        //   - `created`
-        //   - `updated`
-        //
-        // Populate the the deleted and updated sets, and for deleted keys only, immediately update
-        // the log and snapshot.
-        let mut deleted = Vec::new();
-        let mut updated = BTreeMap::new();
-        for (op, old_loc) in (results.into_iter()).zip(locations) {
-            let Operation::Update(key_data) = op else {
-                unreachable!("updates should have key data");
-            };
-            let key = key_data.key.clone();
-            possible_previous.insert(key.clone(), (key_data.value, old_loc));
-            possible_next.insert(key_data.next_key);
-
-            let Some(update) = mutations.remove(&key) else {
-                // Due to translated key collisions, we may look up keys that aren't in the
-                // mutations set. Note that these could still end up next or previous keys to other
-                // keys in the batch, so they are still added to these sets above.
-                continue;
-            };
-
-            if let Some(value) = update {
-                // This is an update of an existing key.
-                updated.insert(key.clone(), (value, old_loc));
-            } else {
-                // This is a delete of an existing key.
-                deleted.push(key.clone());
-
-                // Update the log and snapshot.
-                delete_known_loc(&mut self.snapshot, &key, old_loc);
-                self.log.append(Operation::Delete(key)).await?;
-
-                // Each delete reduces the active key count by one and inactivates that key.
-                self.active_keys -= 1;
-                self.steps += 1;
-            }
-        }
-
-        // Any key remaining in `mutations` must be a new key so move it to the created map.
-        let mut created = BTreeMap::new();
-        for (key, value) in mutations {
-            let Some(value) = value else {
-                continue; // can happen from attempt to delete a non-existent key
-            };
-            created.insert(key.clone(), value);
-
-            // Any newly created key must be a next_key for some remaining key.
-            possible_next.insert(key);
-        }
-
-        // Complete the `possible_previous` and `possible_next` sets by including entries from the
-        // previous _translated_ key for any created or deleted key.
-        let mut locations = Vec::new();
-        for key in deleted.iter().chain(created.keys()) {
-            let iter = self.snapshot.prev_translated_key(key);
-            let Some(iter) = iter else {
-                continue;
-            };
-            locations.extend(iter.copied());
-        }
-        locations.sort();
-        locations.dedup();
-        let futures = locations.iter().map(|loc| self.log.read(*loc));
-        let results = try_join_all(futures).await?;
-
-        for (op, old_loc) in (results.into_iter()).zip(locations) {
-            let Operation::Update(key_data) = op else {
-                unreachable!("updates should have key data");
-            };
-            possible_next.insert(key_data.next_key);
-            possible_previous.insert(key_data.key, (key_data.value, old_loc));
-        }
-
-        // Remove deleted keys from the possible_* sets.
-        for key in deleted.iter() {
-            possible_previous.remove(key);
-            possible_next.remove(key);
-        }
-
-        // Apply the updates of existing keys.
-        let mut already_updated = BTreeSet::new();
-        for (key, (value, loc)) in updated {
-            let new_loc = self.op_count();
-            update_known_loc(&mut self.snapshot, &key, loc, new_loc);
-
-            let next_key = find_next_key(&key, &possible_next);
-            let op = Operation::Update(KeyData {
-                key: key.clone(),
-                value: value.clone(),
-                next_key,
-            });
-            self.log.append(op).await?;
-
-            // Each update of an existing key inactivates its previous location.
-            self.steps += 1;
-            already_updated.insert(key);
-        }
-
-        // Create each new key, and update its previous key if it hasn't already been updated.
-        for (key, value) in created {
-            let new_loc = self.op_count();
-            self.snapshot.insert(&key, new_loc);
-            let next_key = find_next_key(&key, &possible_next);
-            let op = Operation::Update(KeyData {
-                key: key.clone(),
-                value: value.clone(),
-                next_key,
-            });
-
-            // Each newly created key increases the active key count.
-            self.log.append(op).await?;
-            self.active_keys += 1;
-
-            // Update the next_key value of its previous key (unless there are no existing keys).
-            if possible_previous.is_empty() {
-                continue;
-            }
-            let (prev_key, (prev_value, prev_loc)) = find_prev_key(&key, &possible_previous);
-            if already_updated.contains(prev_key) {
-                continue;
-            }
-            already_updated.insert(prev_key.clone());
-
-            let new_loc = self.op_count();
-            update_known_loc(&mut self.snapshot, prev_key, *prev_loc, new_loc);
-            let next_key = find_next_key(prev_key, &possible_next);
-            let op = Operation::Update(KeyData {
-                key: prev_key.clone(),
-                value: prev_value.clone(),
-                next_key,
-            });
-            self.log.append(op).await?;
-
-            // Each key whose next-key value is updated inactivates its previous location.
-            self.steps += 1;
-        }
-
-        if possible_next.is_empty() || possible_previous.is_empty() {
-            return Ok(());
-        }
-
-        // Update the previous key of each deleted key if it hasn't already been updated.
-        for key in deleted.iter() {
-            let (prev_key, (prev_value, prev_loc)) = find_prev_key(key, &possible_previous);
-            if already_updated.contains(prev_key) {
-                continue;
-            }
-            already_updated.insert(prev_key.clone());
-
-            let new_loc = self.op_count();
-            update_known_loc(&mut self.snapshot, prev_key, *prev_loc, new_loc);
-            let next_key = find_next_key(prev_key, &possible_next);
-            let op = Operation::Update(KeyData {
-                key: prev_key.clone(),
-                value: prev_value.clone(),
-                next_key,
-            });
-            self.log.append(op).await?;
-
-            // Each key whose next-key value is updated inactivates its previous location.
-            self.steps += 1;
-        }
-
-        Ok(())
+        self.write_batch_with_callback(iter, |_, _| {}).await
     }
 }
 

--- a/storage/src/qmdb/current/ordered.rs
+++ b/storage/src/qmdb/current/ordered.rs
@@ -836,6 +836,20 @@ where
     T: Translator,
     H: Hasher,
 {
+    async fn write_batch(
+        &mut self,
+        iter: impl Iterator<Item = (K, Option<V>)>,
+    ) -> Result<(), Error> {
+        let status = &mut self.status;
+        self.any
+            .write_batch_with_callback(iter, move |append: bool, loc: Option<Location>| {
+                status.push(append);
+                if let Some(loc) = loc {
+                    status.set_bit(*loc, false);
+                }
+            })
+            .await
+    }
 }
 
 impl<

--- a/storage/src/qmdb/current/unordered.rs
+++ b/storage/src/qmdb/current/unordered.rs
@@ -674,6 +674,20 @@ where
     T: Translator,
     H: Hasher,
 {
+    async fn write_batch(
+        &mut self,
+        iter: impl Iterator<Item = (K, Option<V>)>,
+    ) -> Result<(), Error> {
+        let status = &mut self.status;
+        self.any
+            .write_batch_with_callback(iter, move |append: bool, loc: Option<Location>| {
+                status.push(append);
+                if let Some(loc) = loc {
+                    status.set_bit(*loc, false);
+                }
+            })
+            .await
+    }
 }
 
 impl<


### PR DESCRIPTION
Makes the Batchable impl for current dbs use the optimized batch implementations within the any dbs.

Also consolidates a couple equivalent impl blocks in the any dbs and improves style consistency a bit.