### PR TITLE
Fix clippy lints for rust 1.92.0

### DIFF
--- a/codec/src/types/hash_set.rs
+++ b/codec/src/types/hash_set.rs
@@ -306,7 +306,7 @@ mod tests {
         2u8.write(&mut expected2); // Item 2
         5u8.write(&mut expected2); // Item 5
         assert_eq!(set2.encode(), expected2.freeze());
-        assert_eq!(set2.encode_size(), 1 + 3 * u8::SIZE);
+        assert_eq!(set2.encode_size(), 1 + 3);
 
         // Case 3: HashSet<Bytes>
         // HashSet sorts items for encoding: "apple", "banana", "cherry"

--- a/examples/estimator/src/lib.rs
+++ b/examples/estimator/src/lib.rs
@@ -70,8 +70,8 @@ pub enum Command {
     Reply(u32, Option<usize>),     // id, size in bytes
     Collect(u32, Threshold, Option<(Duration, Duration)>),
     Wait(u32, Threshold, Option<(Duration, Duration)>),
-    Or(Box<Command>, Box<Command>),
-    And(Box<Command>, Box<Command>),
+    Or(Box<Self>, Box<Self>),
+    And(Box<Self>, Box<Self>),
 }
 
 #[derive(Clone)]

--- a/storage/src/index/benches/hashmap_insert.rs
+++ b/storage/src/index/benches/hashmap_insert.rs
@@ -11,7 +11,7 @@ struct MockIndex {
     _section: u64,
     _offset: u32,
     _len: u32,
-    _next: Option<Box<MockIndex>>,
+    _next: Option<Box<Self>>,
 }
 
 fn benchmark_hashmap_insert(c: &mut Criterion) {

--- a/storage/src/index/benches/hashmap_insert_fixed.rs
+++ b/storage/src/index/benches/hashmap_insert_fixed.rs
@@ -11,7 +11,7 @@ struct MockIndex {
     _section: u64,
     _offset: u32,
     _len: u32,
-    _next: Option<Box<MockIndex>>,
+    _next: Option<Box<Self>>,
 }
 
 fn benchmark_hashmap_insert_fixed(c: &mut Criterion) {

--- a/storage/src/index/benches/hashmap_iteration.rs
+++ b/storage/src/index/benches/hashmap_iteration.rs
@@ -11,7 +11,7 @@ struct MockIndex {
     section: u64,
     _offset: u32,
     _len: u32,
-    _next: Option<Box<MockIndex>>,
+    _next: Option<Box<Self>>,
 }
 
 fn benchmark_hashmap_iteration(c: &mut Criterion) {


### PR DESCRIPTION
When upgrading to the latest stable rust version, `just lint` fails.

This fixes the new complaints.