### PR TITLE
[CI] Change fast workflow to run `just lint` instead of `just clippy`

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Fmt
       run: just check-fmt
     - name: Lint
-      run: just clippy ${{ matrix.flags }}
+      run: just lint ${{ matrix.flags }}
     - name: Check docs
       run: just check-docs ${{ matrix.flags }}
     - name: Test docs

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ fix-clippy *args='':
     cargo clippy --all-targets --fix --allow-dirty $@
 
 # Runs all lints (fmt, clippy, docs, and features.)
-lint: check-fmt clippy check-docs check-features
+lint *args='': check-fmt (clippy args) (check-docs args) check-features
 
 # Fixes all lint issues in the workspace
 fix: fix-clippy fix-fmt fix-toml-fmt fix-features


### PR DESCRIPTION
`just lint` includes additional linting checks