### PR TITLE
[ci] require label for conformance.toml changes

### DIFF
--- a/.github/workflows/conformance-label.yml
+++ b/.github/workflows/conformance-label.yml
@@ -1,0 +1,23 @@
+name: Conformance Label
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  conformance-label-check:
+    name: Conformance Label Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          sparse-checkout: .github/scripts
+      - name: Check for conformance changes requiring label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./.github/scripts/check_conformance_label.sh

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -282,18 +282,3 @@ jobs:
         run: zepter format features
       - name: Lint feature propagation
         run: zepter run check
-
-  conformance-label-check:
-    name: Conformance Label Check
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-        with:
-          sparse-checkout: .github/scripts
-      - name: Check for conformance changes requiring label
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: ./.github/scripts/check_conformance_label.sh


### PR DESCRIPTION
When a PR modifies any conformance.toml file, it must have either the breaking-format or breaking-api label to pass CI.

Closes #2502.