### PR TITLE
[storage/qmdb] make qmdb associated value type require Clone

### DIFF
--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -326,7 +326,7 @@ fn fuzz(data: FuzzInput) {
                             let verification_result = Current::<deterministic::Context, Key, Value, Sha256, TwoCap, 32>::verify_exclusion_proof(
                                 hasher.inner(),
                                 &k,
-                                proof,
+                                &proof,
                                 &current_root,
                             );
                             assert!(verification_result, "Exclusion proof verification failed for key {key:?}");

--- a/storage/src/qmdb/current/ordered.rs
+++ b/storage/src/qmdb/current/ordered.rs
@@ -156,7 +156,7 @@ impl<
     pub fn verify_exclusion_proof(
         hasher: &mut H,
         key: &K,
-        proof: ExclusionProof<K, V, H::Digest, N>,
+        proof: &ExclusionProof<K, V, H::Digest, N>,
         root: &H::Digest,
     ) -> bool {
         let (op_proof, op) = match proof {
@@ -171,14 +171,17 @@ impl<
                     return false;
                 }
 
-                (op_proof, Operation::Update(data))
+                (op_proof, Operation::Update(data.clone()))
             }
             ExclusionProof::Commit(op_proof, metadata) => {
                 // Handle the case where the proof shows the db is empty, hence any key is proven
                 // excluded. For the db to be empty, the floor must equal the commit operation's
                 // location.
                 let floor_loc = op_proof.loc;
-                (op_proof, Operation::CommitFloor(metadata, floor_loc))
+                (
+                    op_proof,
+                    Operation::CommitFloor(metadata.clone(), floor_loc),
+                )
             }
         };
 
@@ -1602,7 +1605,7 @@ pub mod test {
             assert!(CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &key_exists_1,
-                empty_proof.clone(),
+                &empty_proof,
                 &empty_root,
             ));
 
@@ -1637,20 +1640,20 @@ pub mod test {
             assert!(CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &greater_key,
-                proof.clone(),
+                &proof,
                 &root,
             ));
             assert!(CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &lesser_key,
-                proof.clone(),
+                &proof,
                 &root,
             ));
             // Exclusion should fail if we test it on a key that exists.
             assert!(!CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &key_exists_1,
-                proof.clone(),
+                &proof,
                 &root,
             ));
 
@@ -1678,19 +1681,19 @@ pub mod test {
             assert!(CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &greater_key,
-                proof.clone(),
+                &proof,
                 &root,
             ));
             assert!(CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &lesser_key,
-                proof.clone(),
+                &proof,
                 &root,
             ));
             assert!(!CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &middle_key,
-                proof.clone(),
+                &proof,
                 &root,
             ));
 
@@ -1710,20 +1713,20 @@ pub mod test {
             assert!(!CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &key_exists_1,
-                proof.clone(),
+                &proof,
                 &root,
             ));
             // `middle_key` should succeed since it's in range.
             assert!(CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &middle_key,
-                proof.clone(),
+                &proof,
                 &root,
             ));
             assert!(!CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &key_exists_2,
-                proof.clone(),
+                &proof,
                 &root,
             ));
 
@@ -1731,7 +1734,7 @@ pub mod test {
             assert!(CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &conflicting_middle_key,
-                proof.clone(),
+                &proof,
                 &root,
             ));
 
@@ -1739,13 +1742,13 @@ pub mod test {
             assert!(!CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &greater_key,
-                proof.clone(),
+                &proof,
                 &root,
             ));
             assert!(!CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &lesser_key,
-                proof.clone(),
+                &proof,
                 &root,
             ));
 
@@ -1771,13 +1774,13 @@ pub mod test {
             assert!(CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &key_exists_1,
-                proof.clone(),
+                &proof,
                 &root,
             ));
             assert!(CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &key_exists_2,
-                proof.clone(),
+                &proof,
                 &root,
             ));
 
@@ -1785,13 +1788,13 @@ pub mod test {
             assert!(!CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &key_exists_1,
-                empty_proof, // wrong proof
+                &empty_proof, // wrong proof
                 &root,
             ));
             assert!(!CleanCurrentTest::verify_exclusion_proof(
                 hasher.inner(),
                 &key_exists_1,
-                proof,
+                &proof,
                 &empty_root, // wrong root
             ));
         });

--- a/storage/src/qmdb/store/mod.rs
+++ b/storage/src/qmdb/store/mod.rs
@@ -138,7 +138,7 @@ pub struct Config<T: Translator, C> {
 
 /// A trait for any key-value store based on an append-only log of operations.
 pub trait LogStore {
-    type Value: Codec;
+    type Value: Codec + Clone;
 
     /// Returns true if there are no active keys in the database.
     fn is_empty(&self) -> bool;


### PR DESCRIPTION
Changes the qmdb associated value type to require the Clone trait, which doesn't seem to have any significant downsides. 

Also changes ExclusionProof verification to accept the proof by reference, which is now possible thanks to being able to clone the value within it.