### PR TITLE
[storage/journal] operation->item terminology cleanup

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1,4 +1,4 @@
-//! An append-only log for storing fixed length items on disk.
+//! An append-only log for storing fixed length _items_ on disk.
 //!
 //! In addition to replay, stored items can be fetched directly by their `position` in the journal,
 //! where position is defined as the item's order of insertion starting from 0, unaffected by


### PR DESCRIPTION
Cleans up the terminology around items vs operations.  Journals store items. "operation" is a Db concept.

No code changes.