### PR TITLE
[storage] make Persistable trait a top-level Storage construct

### DIFF
--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -1055,12 +1055,15 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> crate::store::StoreMut fo
     }
 }
 
-impl<E: Storage + Metrics + Clock, K: Array, V: Codec> crate::store::StorePersistable
-    for Freezer<E, K, V>
-{
-    async fn commit(&mut self) -> Result<(), Self::Error> {
-        self.sync().await?;
-        Ok(())
+impl<E: Storage + Metrics + Clock, K: Array, V: Codec> crate::Persistable for Freezer<E, K, V> {
+    type Error = Error;
+
+    async fn sync(&mut self) -> Result<(), Self::Error> {
+        self.sync().await.map(|_| ())
+    }
+
+    async fn close(self) -> Result<(), Self::Error> {
+        self.close().await.map(|_| ())
     }
 
     async fn destroy(self) -> Result<(), Self::Error> {

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     journal::{
-        contiguous::{fixed, variable, Contiguous, MutableContiguous, PersistableContiguous},
+        contiguous::{fixed, variable, Contiguous, MutableContiguous},
         Error as JournalError,
     },
     mmr::{
@@ -15,6 +15,7 @@ use crate::{
         mem::{Clean, Dirty, State},
         Location, Position, Proof, StandardHasher,
     },
+    Persistable,
 };
 use commonware_codec::{Codec, CodecFixed, Encode};
 use commonware_cryptography::{DigestOf, Hasher};
@@ -109,7 +110,7 @@ where
 impl<E, C, H, S> Journal<E, C, H, S>
 where
     E: Storage + Clock + Metrics,
-    C: PersistableContiguous<Item: Encode>,
+    C: Contiguous<Item: Encode> + Persistable<Error = JournalError>,
     H: Hasher,
     S: State<DigestOf<H>>,
 {
@@ -320,7 +321,7 @@ where
 impl<E, C, H> Journal<E, C, H, Clean<H::Digest>>
 where
     E: Storage + Clock + Metrics,
-    C: PersistableContiguous<Item: Encode>,
+    C: Contiguous<Item: Encode> + Persistable<Error = JournalError>,
     H: Hasher,
 {
     /// Close the authenticated journal, syncing all pending writes.
@@ -593,12 +594,14 @@ where
     }
 }
 
-impl<E, C, H> PersistableContiguous for Journal<E, C, H, Clean<H::Digest>>
+impl<E, C, H> Persistable for Journal<E, C, H, Clean<H::Digest>>
 where
     E: Storage + Clock + Metrics,
-    C: PersistableContiguous<Item: Encode>,
+    C: Contiguous<Item: Encode> + Persistable<Error = JournalError>,
     H: Hasher,
 {
+    type Error = JournalError;
+
     async fn commit(&mut self) -> Result<(), JournalError> {
         self.commit().await.map_err(|e| match e {
             Error::Journal(inner) => inner,

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -55,9 +55,9 @@
 //!
 //! The `replay` method supports fast reading of all unpruned items into memory.
 
-use crate::journal::{
-    contiguous::{MutableContiguous, PersistableContiguous},
-    Error,
+use crate::{
+    journal::{contiguous::MutableContiguous, Error},
+    Persistable,
 };
 use bytes::BufMut;
 use commonware_codec::{CodecFixed, DecodeExt as _, FixedSize};
@@ -688,10 +688,8 @@ impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> MutableContiguous for Journa
     }
 }
 
-impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> PersistableContiguous for Journal<E, A> {
-    async fn commit(&mut self) -> Result<(), Error> {
-        Self::sync(self).await
-    }
+impl<E: Storage + Metrics, A: CodecFixed<Cfg = ()>> Persistable for Journal<E, A> {
+    type Error = Error;
 
     async fn sync(&mut self) -> Result<(), Error> {
         Self::sync(self).await

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -164,27 +164,3 @@ pub trait MutableContiguous: Contiguous {
         }
     }
 }
-
-pub trait PersistableContiguous: MutableContiguous {
-    /// Durably persist the journal but does not write all data, potentially leaving recovery
-    /// required on startup.
-    ///
-    /// For a stronger guarantee that eliminates potential recovery, use [Self::sync] instead.
-    fn commit(&mut self) -> impl std::future::Future<Output = Result<(), Error>>;
-
-    /// Durably persist the journal and write all data, guaranteeing no recovery will be required
-    /// on startup.
-    ///
-    /// This provides a stronger guarantee than [Self::commit] but may be slower.
-    fn sync(&mut self) -> impl std::future::Future<Output = Result<(), Error>>;
-
-    /// Close the journal, syncing all pending writes and releasing resources.
-    fn close(self) -> impl std::future::Future<Output = Result<(), Error>>;
-
-    /// Destroy the journal, removing all associated storage.
-    ///
-    /// This method consumes the journal and deletes all persisted data including blobs,
-    /// metadata, and any other storage artifacts. Use this for cleanup in tests or when
-    /// permanently removing a journal.
-    fn destroy(self) -> impl std::future::Future<Output = Result<(), Error>>;
-}

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -1,12 +1,21 @@
 //! Generic test suite for [Contiguous] trait implementations.
 
 use super::Contiguous;
-use crate::journal::{
-    contiguous::{MutableContiguous, PersistableContiguous},
-    Error,
+use crate::{
+    journal::{contiguous::MutableContiguous, Error},
+    Persistable,
 };
 use commonware_utils::NZUsize;
 use futures::{future::BoxFuture, StreamExt};
+
+pub(super) trait PersistableContiguous:
+    MutableContiguous<Item = u64> + Persistable<Error = Error>
+{
+}
+impl<T> PersistableContiguous for T where
+    T: MutableContiguous<Item = u64> + Persistable<Error = Error>
+{
+}
 
 /// Run the full suite of generic tests on a [Contiguous] implementation.
 ///
@@ -21,7 +30,7 @@ use futures::{future::BoxFuture, StreamExt};
 pub(super) async fn run_contiguous_tests<F, J>(factory: F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     test_empty_journal_size(&factory).await;
     test_empty_journal_oldest_retained_pos(&factory).await;
@@ -63,7 +72,7 @@ where
 async fn test_empty_journal_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let journal = factory("empty".to_string()).await.unwrap();
     assert_eq!(journal.size(), 0);
@@ -74,7 +83,7 @@ where
 async fn test_empty_journal_oldest_retained_pos<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let journal = factory("oldest_empty".to_string()).await.unwrap();
     assert_eq!(journal.oldest_retained_pos(), None);
@@ -85,7 +94,7 @@ where
 async fn test_oldest_retained_pos_with_items<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("oldest_with_items".to_string()).await.unwrap();
 
@@ -105,7 +114,7 @@ where
 async fn test_oldest_retained_pos_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("oldest_after_prune".to_string()).await.unwrap();
 
@@ -151,7 +160,7 @@ where
 async fn test_pruning_boundary<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     // Test empty journal: should return size (0)
     let journal = factory("pruning_boundary_empty".to_string()).await.unwrap();
@@ -198,7 +207,7 @@ where
 async fn test_append_and_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("append_and_size".to_string()).await.unwrap();
 
@@ -223,7 +232,7 @@ where
 async fn test_sequential_appends<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("sequential_appends".to_string()).await.unwrap();
 
@@ -245,7 +254,7 @@ where
 async fn test_replay_from_start<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("replay_from_start".to_string()).await.unwrap();
 
@@ -276,7 +285,7 @@ where
 async fn test_replay_from_middle<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("replay_from_middle".to_string()).await.unwrap();
 
@@ -307,7 +316,7 @@ where
 async fn test_prune_retains_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("prune_retains_size".to_string()).await.unwrap();
 
@@ -339,7 +348,7 @@ where
 async fn test_through_trait<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("through_trait".to_string()).await.unwrap();
 
@@ -359,7 +368,7 @@ where
 async fn test_replay_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("replay_after_prune".to_string()).await.unwrap();
 
@@ -397,7 +406,7 @@ where
 async fn test_prune_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("prune_then_append".to_string()).await.unwrap();
 
@@ -424,7 +433,7 @@ where
 async fn test_position_stability<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("position_stability".to_string()).await.unwrap();
 
@@ -473,7 +482,7 @@ where
 async fn test_sync_behavior<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("sync_behavior".to_string()).await.unwrap();
 
@@ -499,7 +508,7 @@ where
 async fn test_replay_on_empty<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let journal = factory("replay_on_empty".to_string()).await.unwrap();
 
@@ -522,7 +531,7 @@ where
 async fn test_replay_at_exact_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("replay_at_exact_size".to_string()).await.unwrap();
 
@@ -551,7 +560,7 @@ where
 async fn test_multiple_prunes<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("multiple_prunes".to_string()).await.unwrap();
 
@@ -577,7 +586,7 @@ where
 async fn test_prune_beyond_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("prune_beyond_size".to_string()).await.unwrap();
 
@@ -603,7 +612,7 @@ where
 async fn test_persistence_basic<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let test_name = "persistence_basic".to_string();
 
@@ -659,7 +668,7 @@ where
 async fn test_persistence_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let test_name = "persistence_after_prune".to_string();
 
@@ -732,7 +741,7 @@ where
 pub(super) async fn test_read_by_position<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("read_by_position".to_string()).await.unwrap();
 
@@ -753,7 +762,7 @@ where
 pub(super) async fn test_read_out_of_range<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("read_out_of_range".to_string()).await.unwrap();
 
@@ -770,7 +779,7 @@ where
 pub(super) async fn test_read_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("read_after_prune".to_string()).await.unwrap();
 
@@ -791,7 +800,7 @@ where
 async fn test_rewind_to_middle<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("rewind_to_middle".to_string()).await.unwrap();
 
@@ -830,7 +839,7 @@ where
 async fn test_rewind_to_zero<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("rewind_to_zero".to_string()).await.unwrap();
 
@@ -854,7 +863,7 @@ where
 async fn test_rewind_current_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("rewind_current_size".to_string()).await.unwrap();
 
@@ -873,7 +882,7 @@ where
 async fn test_rewind_invalid_forward<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("rewind_invalid_forward".to_string()).await.unwrap();
 
@@ -892,7 +901,7 @@ where
 async fn test_rewind_invalid_pruned<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("rewind_invalid_pruned".to_string()).await.unwrap();
 
@@ -915,7 +924,7 @@ where
 async fn test_rewind_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("rewind_then_append".to_string()).await.unwrap();
 
@@ -943,7 +952,7 @@ where
 async fn test_rewind_zero_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("rewind_zero_then_append".to_string())
         .await
@@ -975,7 +984,7 @@ where
 async fn test_rewind_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("rewind_after_prune".to_string()).await.unwrap();
 
@@ -1021,7 +1030,7 @@ where
 async fn test_section_boundary_behavior<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let mut journal = factory("section_boundary".to_string()).await.unwrap();
 
@@ -1076,7 +1085,7 @@ where
 async fn test_destroy_and_reinit<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous<Item = u64>,
+    J: PersistableContiguous,
 {
     let test_name = "destroy_and_reinit".to_string();
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -5,11 +5,12 @@
 
 use crate::{
     journal::{
-        contiguous::{fixed, Contiguous, MutableContiguous, PersistableContiguous},
+        contiguous::{fixed, Contiguous, MutableContiguous},
         segmented::variable,
         Error,
     },
     mmr::Location,
+    Persistable,
 };
 use commonware_codec::Codec;
 use commonware_runtime::{buffer::PoolRef, Metrics, Storage};
@@ -843,7 +844,9 @@ impl<E: Storage + Metrics, V: Codec> MutableContiguous for Journal<E, V> {
     }
 }
 
-impl<E: Storage + Metrics, V: Codec> PersistableContiguous for Journal<E, V> {
+impl<E: Storage + Metrics, V: Codec> Persistable for Journal<E, V> {
+    type Error = Error;
+
     async fn commit(&mut self) -> Result<(), Error> {
         Self::commit(self).await
     }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -32,3 +32,31 @@ cfg_if::cfg_if! {
         pub mod translator;
     }
 }
+
+/// A storage structure with capabilities to persist and recover state across restarts.
+#[cfg(feature = "std")]
+pub trait Persistable {
+    type Error;
+
+    /// Durably persist the structure, guaranteeing the current state will survive a crash.
+    ///
+    /// For a stronger guarantee that eliminates potential recovery, use [Self::sync] instead.
+    fn commit(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> {
+        self.sync()
+    }
+
+    /// Durably persist the structure, guaranteeing the current state will survive a crash, and that
+    /// no recovery will be needed on startup.
+    ///
+    /// This provides a stronger guarantee than [Self::commit] but may be slower.
+    fn sync(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>>;
+
+    /// Close the structure, syncing all pending writes and releasing resources.
+    fn close(self) -> impl std::future::Future<Output = Result<(), Self::Error>>;
+
+    /// Destroy the structure, removing all associated storage.
+    ///
+    /// This method consumes the structure and deletes all persisted data, leaving behind no storage
+    /// artifacts. This can be used to clean up disk resources in tests.
+    fn destroy(self) -> impl std::future::Future<Output = Result<(), Self::Error>>;
+}

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -442,10 +442,14 @@ impl<E: Storage + Metrics + Clock, V: CodecFixed<Cfg = ()>> crate::store::StoreM
     }
 }
 
-impl<E: Storage + Metrics + Clock, V: CodecFixed<Cfg = ()>> crate::store::StorePersistable
-    for Ordinal<E, V>
-{
-    async fn commit(&mut self) -> Result<(), Self::Error> {
+impl<E: Storage + Metrics + Clock, V: CodecFixed<Cfg = ()>> crate::Persistable for Ordinal<E, V> {
+    type Error = Error;
+
+    async fn close(self) -> Result<(), Self::Error> {
+        self.close().await
+    }
+
+    async fn sync(&mut self) -> Result<(), Self::Error> {
         self.sync().await
     }
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -6,7 +6,8 @@ use crate::{
     index::Unordered as UnorderedIndex,
     journal::{
         authenticated,
-        contiguous::{Contiguous, MutableContiguous, PersistableContiguous},
+        contiguous::{Contiguous, MutableContiguous},
+        Error as JournalError,
     },
     mmr::{
         mem::{Clean, Dirty, State},
@@ -19,7 +20,7 @@ use crate::{
         store::LogStore,
         Error, FloorHelper,
     },
-    AuthenticatedBitMap,
+    AuthenticatedBitMap, Persistable,
 };
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, DigestOf, Hasher};
@@ -307,7 +308,7 @@ where
     K: Array,
     V: ValueEncoding,
     U: Update<K, V>,
-    C: PersistableContiguous<Item = Operation<K, V, U>>,
+    C: MutableContiguous<Item = Operation<K, V, U>> + Persistable<Error = JournalError>,
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<K, V, U>: Codec,

--- a/storage/src/qmdb/any/ext.rs
+++ b/storage/src/qmdb/any/ext.rs
@@ -11,7 +11,8 @@ use crate::{
         store::{Batchable, CleanStore, DirtyStore, LogStore, LogStorePrunable},
         Error,
     },
-    store::{Store as StoreTrait, StoreDeletable, StoreMut, StorePersistable},
+    store::{Store as StoreTrait, StoreDeletable, StoreMut},
+    Persistable,
 };
 
 /// An extension wrapper for [CleanAny] databases that provides a traditional mutable key-value
@@ -106,15 +107,25 @@ where
     }
 }
 
-impl<A> StorePersistable for AnyExt<A>
+impl<A> Persistable for AnyExt<A>
 where
     A: CleanAny,
 {
+    type Error = Error;
+
+    async fn sync(&mut self) -> Result<(), Self::Error> {
+        self.ensure_clean().await?;
+        match self.inner.as_mut().expect("wrapper should never be empty") {
+            State::Clean(clean) => clean.sync().await,
+            _ => unreachable!("ensure_clean guarantees Clean state"),
+        }
+    }
+
     async fn commit(&mut self) -> Result<(), Self::Error> {
         // Merkleize before commit
         self.ensure_clean().await?;
         match self.inner.as_mut().expect("wrapper should never be empty") {
-            State::Clean(clean) => clean.commit(None).await.map(|_| ()),
+            State::Clean(clean) => CleanAny::commit(clean, None).await.map(|_| ()),
             _ => unreachable!("ensure_clean guarantees Clean state"),
         }
     }
@@ -126,6 +137,10 @@ where
             State::Clean(clean) => clean.destroy().await,
             _ => unreachable!("ensure_clean guarantees Clean state"),
         }
+    }
+
+    async fn close(self) -> Result<(), Self::Error> {
+        self.close().await
     }
 }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -14,6 +14,7 @@ use crate::{
         Error,
     },
     translator::Translator,
+    Persistable,
 };
 use commonware_codec::CodecFixed;
 use commonware_cryptography::{DigestOf, Hasher};
@@ -40,6 +41,7 @@ pub use ext::AnyExt;
 /// Extension trait for "Any" QMDBs in a clean (merkleized) state.
 pub trait CleanAny:
     CleanStore<Dirty: DirtyAny<Key = Self::Key, Value = Self::Value, Clean = Self>>
+    + Persistable<Error = Error>
 {
     /// The key type for this database.
     type Key: Array;
@@ -54,17 +56,8 @@ pub trait CleanAny:
         metadata: Option<Self::Value>,
     ) -> impl Future<Output = Result<Range<Location>, Error>>;
 
-    /// Sync all database state to disk.
-    fn sync(&mut self) -> impl Future<Output = Result<(), Error>>;
-
     /// Prune historical operations prior to `prune_loc`.
     fn prune(&mut self, prune_loc: Location) -> impl Future<Output = Result<(), Error>>;
-
-    /// Close the db. Uncommitted operations will be lost or rolled back on restart.
-    fn close(self) -> impl Future<Output = Result<(), Error>>;
-
-    /// Destroy the db, removing all data from disk.
-    fn destroy(self) -> impl Future<Output = Result<(), Error>>;
 }
 
 /// Extension trait for "Any" QMDBs in a dirty (deferred merkleization) state.

--- a/storage/src/qmdb/benches/variable/generate.rs
+++ b/storage/src/qmdb/benches/variable/generate.rs
@@ -2,10 +2,9 @@
 //! that supports variable-size values.
 
 use crate::variable::{
-    gen_random_kv, gen_random_kv_batched, get_any_ordered, get_any_unordered, get_store, Variant,
-    VARIANTS,
+    gen_random_kv, gen_random_kv_batched, get_any_ordered, get_any_unordered, get_store, Digest,
+    Variant, VARIANTS,
 };
-use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::{Config, Context},
@@ -15,7 +14,8 @@ use commonware_storage::{
         store::{Batchable, LogStorePrunable},
         Error,
     },
-    store::{StoreDeletable, StorePersistable},
+    store::StoreDeletable,
+    Persistable,
 };
 use criterion::{criterion_group, Criterion};
 use std::time::{Duration, Instant};
@@ -106,10 +106,10 @@ async fn test_db<A>(
     commit_frequency: u32,
 ) -> Result<Duration, Error>
 where
-    A: StorePersistable<Key = <Sha256 as Hasher>::Digest, Value = Vec<u8>>
+    A: Persistable<Error = Error>
         + Batchable
-        + StoreDeletable
-        + LogStorePrunable,
+        + StoreDeletable<Key = Digest, Value = Vec<u8>, Error = Error>
+        + LogStorePrunable<Value = Vec<u8>>,
 {
     let start = Instant::now();
     let db = if use_batch {

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -788,19 +788,35 @@ impl<
         self.commit(metadata).await
     }
 
-    async fn sync(&mut self) -> Result<(), Error> {
-        self.sync().await
-    }
-
     async fn prune(&mut self, prune_loc: Location) -> Result<(), Error> {
         self.prune(prune_loc).await
     }
+}
 
-    async fn close(self) -> Result<(), Error> {
+impl<
+        E: RStorage + Clock + Metrics,
+        K: Array,
+        V: FixedValue,
+        H: Hasher,
+        T: Translator,
+        const N: usize,
+    > crate::Persistable for Db<E, K, V, H, T, N, Clean<DigestOf<H>>>
+{
+    type Error = Error;
+
+    async fn commit(&mut self) -> Result<(), Self::Error> {
+        self.commit(None).await.map(|_| ())
+    }
+
+    async fn sync(&mut self) -> Result<(), Self::Error> {
+        self.sync().await
+    }
+
+    async fn close(self) -> Result<(), Self::Error> {
         self.close().await
     }
 
-    async fn destroy(self) -> Result<(), Error> {
+    async fn destroy(self) -> Result<(), Self::Error> {
         self.destroy().await
     }
 }

--- a/storage/src/qmdb/store/batch.rs
+++ b/storage/src/qmdb/store/batch.rs
@@ -176,7 +176,7 @@ pub trait Batchable: StoreDeletable<Key: Array, Value: Codec + Clone, Error = Er
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::store::StorePersistable;
+    use crate::Persistable;
     use commonware_cryptography::{blake3, sha256};
     use commonware_runtime::{
         deterministic::{self, Context},
@@ -200,7 +200,7 @@ pub mod tests {
     where
         F: FnMut(Context) -> Fut + Clone,
         Fut: Future<Output = D>,
-        D: Batchable + StorePersistable,
+        D: Batchable + Persistable<Error = Error>,
         D::Key: TestKey,
         D::Value: TestValue,
     {
@@ -231,7 +231,7 @@ pub mod tests {
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = D>,
-        D: Batchable + StorePersistable,
+        D: Batchable + Persistable<Error = Error>,
         D::Key: TestKey,
         D::Value: TestValue,
     {
@@ -249,7 +249,7 @@ pub mod tests {
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = D>,
-        D: Batchable + StorePersistable,
+        D: Batchable + Persistable<Error = Error>,
         D::Key: TestKey,
         D::Value: TestValue,
     {
@@ -271,7 +271,7 @@ pub mod tests {
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = D>,
-        D: Batchable + StorePersistable,
+        D: Batchable + Persistable<Error = Error>,
         D::Key: TestKey,
         D::Value: TestValue,
     {
@@ -302,7 +302,7 @@ pub mod tests {
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = D>,
-        D: Batchable + StorePersistable,
+        D: Batchable + Persistable<Error = Error>,
         D::Key: TestKey,
         D::Value: TestValue,
     {
@@ -331,7 +331,7 @@ pub mod tests {
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = D>,
-        D: Batchable + StorePersistable,
+        D: Batchable + Persistable<Error = Error>,
         D::Key: TestKey,
         D::Value: TestValue,
     {
@@ -358,7 +358,7 @@ pub mod tests {
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = D>,
-        D: Batchable + StorePersistable,
+        D: Batchable + Persistable<Error = Error>,
         D::Key: TestKey,
         D::Value: TestValue,
     {
@@ -431,7 +431,7 @@ pub mod tests {
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = D>,
-        D: Batchable + StorePersistable,
+        D: Batchable + Persistable<Error = Error>,
         D::Key: TestKey,
         D::Value: TestValue,
     {
@@ -495,7 +495,7 @@ pub mod tests {
     where
         F: FnMut() -> Fut,
         Fut: Future<Output = D>,
-        D: Batchable + StorePersistable,
+        D: Batchable + Persistable<Error = Error>,
         D::Key: TestKey,
         D::Value: TestValue,
     {

--- a/storage/src/qmdb/store/mod.rs
+++ b/storage/src/qmdb/store/mod.rs
@@ -100,6 +100,7 @@ use crate::{
         update_key, Error, FloorHelper,
     },
     translator::Translator,
+    Persistable,
 };
 use commonware_codec::{Codec, Read};
 use commonware_cryptography::Digest;
@@ -562,15 +563,25 @@ where
     }
 }
 
-impl<E, K, V, T> crate::store::StorePersistable for Store<E, K, V, T>
+impl<E, K, V, T> Persistable for Store<E, K, V, T>
 where
     E: Storage + Clock + Metrics,
     K: Array,
     V: VariableValue,
     T: Translator,
 {
+    type Error = Error;
+
     async fn commit(&mut self) -> Result<(), Error> {
         self.commit(None).await.map(|_| ())
+    }
+
+    async fn sync(&mut self) -> Result<(), Error> {
+        self.sync().await
+    }
+
+    async fn close(self) -> Result<(), Error> {
+        self.close().await
     }
 
     async fn destroy(self) -> Result<(), Error> {

--- a/storage/src/store.rs
+++ b/storage/src/store.rs
@@ -42,8 +42,8 @@ pub trait StoreMut: Store {
         }
     }
 
-    /// Creates a new key-value pair in the db.
-    /// Returns true if the key was created, false if it already existed.
+    /// Creates a new key-value pair in the db. Returns true if the key was created, false if it
+    /// already existed. The key is not modified if it already existed.
     fn create(
         &mut self,
         key: Self::Key,
@@ -66,13 +66,4 @@ pub trait StoreDeletable: StoreMut {
     ///
     /// Returns `true` if the key existed and was deleted, `false` if it did not exist.
     fn delete(&mut self, key: Self::Key) -> impl Future<Output = Result<bool, Self::Error>>;
-}
-
-/// A mutable key-value store that can be persisted.
-pub trait StorePersistable: StoreMut {
-    /// Commit the store to disk, ensuring all changes are durably persisted.
-    fn commit(&mut self) -> impl Future<Output = Result<(), Self::Error>>;
-
-    /// Destroy the store, removing all persisted data.
-    fn destroy(self) -> impl Future<Output = Result<(), Self::Error>>;
 }


### PR DESCRIPTION
Persistable is a trait that is useful more generally than for K/V stores and journals. This PR pulls it up a level to replace both `PersistentContiguous` (persistent journal) and `StorePersistent` (k/v stores), allowing it to be implemented by any Storage structure.