### PR TITLE
[runtime] Remove `AsRef` and `AsMut` impls for `Cell<T>`

### DIFF
--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -248,9 +248,12 @@ impl<
             buffer_pool: self.journal_buffer_pool.clone(),
             write_buffer: self.journal_write_buffer,
         };
-        let journal = Journal::init(self.context.with_label("journal").into(), journal_cfg)
-            .await
-            .expect("init failed");
+        let journal = Journal::init(
+            self.context.with_label("journal").into_present(),
+            journal_cfg,
+        )
+        .await
+        .expect("init failed");
         let unverified_indices = self.replay(&journal).await;
         self.journal = Some(journal);
 

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -1018,7 +1018,7 @@ impl<
             write_buffer: self.journal_write_buffer,
         };
         let journal = Journal::<_, Node<C::PublicKey, P::Scheme, D>>::init(
-            self.context.with_label("journal").into(),
+            self.context.with_label("journal").into_present(),
             cfg,
         )
         .await

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -618,7 +618,7 @@ impl<
 
         // Initialize journal
         let journal = Journal::<_, Artifact<S, D>>::init(
-            self.context.with_label("journal").into(),
+            self.context.with_label("journal").into_present(),
             JConfig {
                 partition: self.partition.clone(),
                 compression: None, // most of the data is not compressible

--- a/p2p/src/authenticated/discovery/actors/listener.rs
+++ b/p2p/src/authenticated/discovery/actors/listener.rs
@@ -232,7 +232,7 @@ impl<E: Spawner + Clock + Network + Rng + CryptoRng + Metrics, C: Signer> Actor<
                     let supervisor = supervisor.clone();
                     move |context| async move {
                         Self::handshake(
-                            context.into(),
+                            context.into_present(),
                             address,
                             stream_cfg,
                             sink,

--- a/p2p/src/authenticated/lookup/actors/listener.rs
+++ b/p2p/src/authenticated/lookup/actors/listener.rs
@@ -262,7 +262,7 @@ impl<E: Spawner + Clock + Network + Rng + CryptoRng + Metrics, C: Signer> Actor<
                     let supervisor = supervisor.clone();
                     move |context| async move {
                         Self::handshake(
-                            context.into(), address, stream_cfg, sink, stream, tracker, supervisor,
+                            context.into_present(), address, stream_cfg, sink, stream, tracker, supervisor,
                         )
                         .await;
 


### PR DESCRIPTION
## Overview

Removes the `AsRef<C>` and `AsMut<C>` impls from `Cell<T>` in favor of functions that document explicitly that they will panic under the condition that the context is `Missing`.

https://doc.rust-lang.org/stable/std/convert/trait.AsRef.html#relation-to-borrow / https://doc.rust-lang.org/stable/std/convert/trait.AsMut.html both state that implementations "must not fail."