### PR TITLE
[runtime/network/tokio] Use `BufReader` for read buffering

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -471,6 +471,10 @@ pub trait Listener: Sync + Send + 'static {
 /// messages over a network connection.
 pub trait Sink: Sync + Send + 'static {
     /// Send a message to the sink.
+    ///
+    /// # Warning
+    ///
+    /// If the sink returns an error, part of the message may still be delivered.
     fn send(
         &mut self,
         msg: impl Into<StableBuf> + Send,
@@ -482,6 +486,10 @@ pub trait Sink: Sync + Send + 'static {
 pub trait Stream: Sync + Send + 'static {
     /// Receive a message from the stream, storing it in the given buffer.
     /// Reads exactly the number of bytes that fit in the buffer.
+    ///
+    /// # Warning
+    ///
+    /// If the stream returns an error, partially read data may be discarded.
     fn recv(
         &mut self,
         buf: impl Into<StableBuf> + Send,

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -244,7 +244,6 @@ mod tests {
     };
     use commonware_macros::test_group;
     use std::time::{Duration, Instant};
-    use tokio::sync::oneshot;
 
     #[tokio::test]
     async fn test_trait() {
@@ -350,72 +349,5 @@ mod tests {
         assert!(elapsed >= read_timeout);
         // Allow some margin for timing variance
         assert!(elapsed < read_timeout * 2);
-    }
-
-    #[tokio::test]
-    async fn test_timeout_discards_partial_read() {
-        let read_timeout = Duration::from_millis(50);
-        let network = TokioNetwork::Network::from(
-            TokioNetwork::Config::default()
-                .with_read_timeout(read_timeout)
-                .with_write_timeout(Duration::from_secs(5)),
-        );
-
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        // Channel to coordinate between sender and receiver
-        let (first_msg_sent_tx, first_msg_sent_rx) = oneshot::channel::<()>();
-        let (timeout_occurred_tx, timeout_occurred_rx) = oneshot::channel::<()>();
-
-        let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
-
-            // Wait for first message to be sent
-            first_msg_sent_rx.await.unwrap();
-
-            // Give time for the data to arrive and be buffered
-            tokio::time::sleep(Duration::from_millis(10)).await;
-
-            // Try to read 100 bytes, but only 5 were sent - this will timeout.
-            // The 5 bytes that were partially read are discarded.
-            let result = stream.recv(vec![0u8; 100]).await;
-            assert!(result.is_err()); // Should timeout
-
-            // Signal that timeout occurred
-            timeout_occurred_tx.send(()).unwrap();
-
-            // Read the second message - the first message's bytes are gone
-            let result = stream.recv(vec![0u8; 5]).await;
-
-            (stream, result)
-        });
-
-        // Connect and send first message
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
-        let first_msg = vec![b'A'; 5];
-        sink.send(first_msg.clone()).await.unwrap();
-        first_msg_sent_tx.send(()).unwrap();
-
-        // Wait for the timeout to occur
-        timeout_occurred_rx.await.unwrap();
-
-        // Send second message
-        let second_msg = vec![b'B'; 5];
-        sink.send(second_msg.clone()).await.unwrap();
-
-        // Get results
-        let (_stream, result) = reader.await.unwrap();
-        let received = result.expect("second read should succeed");
-
-        // The first message was discarded due to timeout - we get the second.
-        // This is correct: after a timeout, the stream is in an undefined state
-        // and should be closed. Continuing to read is undefined behavior.
-        assert_eq!(received.as_ref(), &second_msg[..], "Should have lost data");
-        assert_ne!(
-            received.as_ref(),
-            &first_msg[..],
-            "Should not have received the first message"
-        );
     }
 }


### PR DESCRIPTION
Closes: #786 

## Overview

Alternative for #2593, but using `tokio`'s `BufReader` rather than implementing our own read buffering.