### PR TITLE
fix(broadcast): use correct metric for dropped subscribe waiters

### DIFF
--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -448,7 +448,7 @@ impl<E: Clock + Spawner + Metrics, P: PublicKey, M: Committable + Digestible + C
 
             // Increment metrics for each dropped waiter
             for _ in 0..dropped_count {
-                self.metrics.get.inc(Status::Dropped);
+                self.metrics.subscribe.inc(Status::Dropped);
             }
 
             !waiters.is_empty()


### PR DESCRIPTION
The cleanup_waiters function was incrementing the `get` metric for dropped waiters, but waiters are only created by `subscribe` requests (handle_get responds immediately without creating waiters). Fixed to use `subscribe` metric instead.