### PR TITLE
[docs] Add _headers for explicit sitemap Content-Type charset

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,6 +1,7 @@
 # Cloudflare Pages custom headers
 # https://developers.cloudflare.com/pages/configuration/headers/
 
+# Metadata files
 /sitemap.xml
   Content-Type: application/xml; charset=utf-8
 
@@ -9,3 +10,20 @@
 
 /llms.txt
   Content-Type: text/plain; charset=utf-8
+
+# Source code files
+/code/*.rs
+  Content-Type: text/plain; charset=utf-8
+
+/code/*.md
+  Content-Type: text/plain; charset=utf-8
+
+/code/*.toml
+  Content-Type: text/plain; charset=utf-8
+
+# Static assets
+/*.css
+  Content-Type: text/css; charset=utf-8
+
+/*.js
+  Content-Type: text/javascript; charset=utf-8


### PR DESCRIPTION
Set Content-Type: application/xml; charset=utf-8 for sitemap.xml to
ensure proper encoding detection by crawlers and tools. Also set
explicit charset for robots.txt and llms.txt.