### PR TITLE
[docs] Add sitemap and LLMs to header

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
 
     <link rel="canonical" href="https://commonware.xyz/" />
     <link rel="sitemap" type="application/xml" href="/sitemap.xml">
-    <link rel="alternate" type="text/plain" href="/llms.txt" title="LLM-friendly documentation">
+    <link rel="alternate" type="text/plain" href="/llms.txt" title="LLM-focused documentation">
 
     <meta property="og:url" content="https://commonware.xyz/" />
     <meta property="og:type" content="website" />


### PR DESCRIPTION
Add a link to /llms.txt in the site footer for easy access to
LLM-friendly documentation.