### PR TITLE
[storage/index] allow Translator capping at sizes that are not equal to some int type

### DIFF
--- a/storage/src/index/benches/insert.rs
+++ b/storage/src/index/benches/insert.rs
@@ -120,7 +120,7 @@ fn bench_insert(c: &mut Criterion) {
                             Variant::PartitionedOrdered2 => {
                                 let mut index = partitioned::ordered::Index::<_, _, 2>::new(
                                     DummyMetrics,
-                                    TwoCap,
+                                    Cap::<2>::new(),
                                 );
                                 total += run_benchmark(&mut index, &kvs_data);
                             }


### PR DESCRIPTION
The current "*Cap" translators only support sizes equivalent to some int type.  This PR allows capping at arbitrary sizes from [1-8].  Thus we can create an effective "9 byte cap" using a 2-byte partitioned index with a 7-byte translator to match the parameters used in the QMDB whitepaper.