### PR TITLE
feat(storage,consensus): add index_for_key to Archive trait

### DIFF
--- a/consensus/src/marshal/actor.rs
+++ b/consensus/src/marshal/actor.rs
@@ -342,16 +342,13 @@ where
                     match message {
                         Message::GetInfo { identifier, response } => {
                             let info = match identifier {
-                                // TODO: Instead of pulling out the entire block, determine the
-                                // height directly from the archive by mapping the commitment to
-                                // the index, which is the same as the height.
                                 BlockID::Commitment(commitment) => self
                                     .finalized_blocks
-                                    .get(ArchiveID::Key(&commitment))
+                                    .get_height(&commitment)
                                     .await
                                     .ok()
                                     .flatten()
-                                    .map(|b| (b.height(), commitment)),
+                                    .map(|height| (height, commitment)),
                                 BlockID::Height(height) => self
                                     .finalizations_by_height
                                     .get(ArchiveID::Index(height))

--- a/storage/src/archive/immutable/storage.rs
+++ b/storage/src/archive/immutable/storage.rs
@@ -287,6 +287,14 @@ impl<E: Storage + Metrics + Clock, K: Array, V: Codec> crate::archive::Archive
         }
     }
 
+    async fn index_for_key(&self, _key: &K) -> Result<Option<u64>, Error> {
+        // Immutable archive does not maintain a direct key -> index mapping.
+        // The structure stores: key -> cursor (in Freezer) and index -> cursor (in Ordinal).
+        // There is no efficient reverse lookup from key to index without scanning.
+        // Callers should use `get` and extract the index from the value if needed.
+        Ok(None)
+    }
+
     async fn sync(&mut self) -> Result<(), Error> {
         self.syncs.inc();
 

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -80,6 +80,12 @@ pub trait Archive {
         identifier: Identifier<'_, Self::Key>,
     ) -> impl Future<Output = Result<bool, Error>>;
 
+    /// Retrieve the index associated with a key without fetching the value.
+    ///
+    /// This is more efficient than [Archive::get] when only the index is needed,
+    /// as it avoids deserializing the value.
+    fn index_for_key(&self, key: &Self::Key) -> impl Future<Output = Result<Option<u64>, Error>>;
+
     /// Retrieve the end of the current range including `index` (inclusive) and
     /// the start of the next range after `index` (if it exists).
     ///


### PR DESCRIPTION
Add index_for_key method to Archive trait and get_height to Blocks trait for retrieving block height from commitment without deserializing the full block.
**Note** : Optimization applies to prunable archive only. Immutable archive falls back to full block fetch.