### PR TITLE
[p2p] `CheckedSender::Error: 'static`

### DIFF
--- a/collector/src/p2p/engine.rs
+++ b/collector/src/p2p/engine.rs
@@ -156,7 +156,7 @@ where
                                 }
                                 Err(err) => {
                                     error!(?err, ?commitment, "failed to send message");
-                                    let _ = responder.send(Err(Error::SendFailed(anyhow::anyhow!("{err:?}"))));
+                                    let _ = responder.send(Err(Error::SendFailed(err.into())));
                                 }
                             }
                         },

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -46,7 +46,7 @@ pub trait UnlimitedSender: Clone + Send + Sync + 'static {
     type PublicKey: PublicKey;
 
     /// Error that can occur when sending a message.
-    type Error: Debug + StdError + Send + Sync;
+    type Error: Debug + StdError + Send + Sync + 'static;
 
     /// Sends a message to a set of recipients.
     ///
@@ -107,7 +107,7 @@ pub trait CheckedSender: Send {
     type PublicKey: PublicKey;
 
     /// Error that can occur when sending a message.
-    type Error: Debug + StdError + Send + Sync;
+    type Error: Debug + StdError + Send + Sync + 'static;
 
     /// Sends a message to the pre-checked recipients.
     ///


### PR DESCRIPTION
## Overview

Fixes an issue where `CheckedSender::Error` was inferred to have the same lifetime as `LimitedSender::Checked<'_>` when using the `Sender` trait. In `main`, this makes it a pain to bubble up `CheckedSender::Error` with `?`, since the compiler infers the lifetime of the error to be tied to `CheckedSender`. In practice, it's unlikely that we'll want to return errors containing borrowed data.