### PR TITLE
[p2p/lookup] Fix `allow_unregistered_handshakes` (now `bypass_ip_check`)

### DIFF
--- a/p2p/src/authenticated/lookup/actors/listener.rs
+++ b/p2p/src/authenticated/lookup/actors/listener.rs
@@ -34,7 +34,7 @@ pub struct Config<C: Signer> {
     pub address: SocketAddr,
     pub stream_cfg: StreamConfig<C>,
     pub allow_private_ips: bool,
-    pub allow_unknown_ips: bool,
+    pub bypass_ip_check: bool,
     pub max_concurrent_handshakes: NonZeroU32,
     pub allowed_handshake_rate_per_ip: Quota,
     pub allowed_handshake_rate_per_subnet: Quota,
@@ -46,7 +46,7 @@ pub struct Actor<E: Spawner + Clock + Network + Rng + CryptoRng + Metrics, C: Si
     address: SocketAddr,
     stream_cfg: StreamConfig<C>,
     allow_private_ips: bool,
-    allow_unknown_ips: bool,
+    bypass_ip_check: bool,
     handshake_limiter: Limiter,
     allowed_handshake_rate_per_ip: Quota,
     allowed_handshake_rate_per_subnet: Quota,
@@ -92,7 +92,7 @@ impl<E: Spawner + Clock + Network + Rng + CryptoRng + Metrics, C: Signer> Actor<
             address: cfg.address,
             stream_cfg: cfg.stream_cfg,
             allow_private_ips: cfg.allow_private_ips,
-            allow_unknown_ips: cfg.allow_unknown_ips,
+            bypass_ip_check: cfg.bypass_ip_check,
             handshake_limiter: Limiter::new(cfg.max_concurrent_handshakes),
             allowed_handshake_rate_per_ip: cfg.allowed_handshake_rate_per_ip,
             allowed_handshake_rate_per_subnet: cfg.allowed_handshake_rate_per_subnet,
@@ -211,7 +211,7 @@ impl<E: Spawner + Clock + Network + Rng + CryptoRng + Metrics, C: Signer> Actor<
                 }
 
                 // Check whether the IP is registered
-                if !self.allow_unknown_ips && !self.registered_ips.contains(&ip) {
+                if !self.bypass_ip_check && !self.registered_ips.contains(&ip) {
                     self.handshakes_blocked.inc();
                     debug!(?address, "rejecting unregistered address");
                     continue;
@@ -316,7 +316,7 @@ mod tests {
                     stream_cfg,
                     allow_private_ips: true,
                     max_concurrent_handshakes: NZU32!(8),
-                    allow_unknown_ips: false,
+                    bypass_ip_check: false,
                     allowed_handshake_rate_per_ip,
                     allowed_handshake_rate_per_subnet,
                 },
@@ -483,7 +483,7 @@ mod tests {
                     address,
                     stream_cfg,
                     allow_private_ips: true,
-                    allow_unknown_ips: false,
+                    bypass_ip_check: false,
                     max_concurrent_handshakes: NZU32!(8),
                     allowed_handshake_rate_per_ip: Quota::per_hour(NZU32!(100)),
                     allowed_handshake_rate_per_subnet: Quota::per_hour(NZU32!(100)),
@@ -564,7 +564,7 @@ mod tests {
                     address,
                     stream_cfg,
                     allow_private_ips: true,
-                    allow_unknown_ips: true,
+                    bypass_ip_check: true,
                     max_concurrent_handshakes: NZU32!(8),
                     allowed_handshake_rate_per_ip: Quota::per_hour(NZU32!(100)),
                     allowed_handshake_rate_per_subnet: Quota::per_hour(NZU32!(100)),
@@ -645,7 +645,7 @@ mod tests {
                     address,
                     stream_cfg,
                     allow_private_ips: false,
-                    allow_unknown_ips: true,
+                    bypass_ip_check: true,
                     max_concurrent_handshakes: NZU32!(8),
                     allowed_handshake_rate_per_ip: Quota::per_hour(NZU32!(100)),
                     allowed_handshake_rate_per_subnet: Quota::per_hour(NZU32!(100)),

--- a/p2p/src/authenticated/lookup/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/directory.rs
@@ -29,7 +29,7 @@ pub struct Config {
     pub allow_dns: bool,
 
     /// Whether to skip IP verification for incoming connections (allows unknown IPs).
-    pub allow_unknown_ips: bool,
+    pub bypass_ip_check: bool,
 
     /// The maximum number of peer sets to track.
     pub max_sets: usize,
@@ -51,7 +51,7 @@ pub struct Directory<E: Rng + Clock + RuntimeMetrics, C: PublicKey> {
     allow_dns: bool,
 
     /// Whether to skip IP verification for incoming connections (allows unknown IPs).
-    allow_unknown_ips: bool,
+    bypass_ip_check: bool,
 
     // ---------- State ----------
     /// The records of all peers.
@@ -89,7 +89,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
             max_sets: cfg.max_sets,
             allow_private_ips: cfg.allow_private_ips,
             allow_dns: cfg.allow_dns,
-            allow_unknown_ips: cfg.allow_unknown_ips,
+            bypass_ip_check: cfg.bypass_ip_check,
             peers,
             sets: BTreeMap::new(),
             rate_limiter,
@@ -248,11 +248,11 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
 
     /// Returns true if this peer is acceptable (can accept an incoming connection from them).
     ///
-    /// Checks eligibility (peer set membership), egress IP match (if not allow_unknown_ips), and connection status.
+    /// Checks eligibility (peer set membership), egress IP match (if not bypass_ip_check), and connection status.
     pub fn acceptable(&self, peer: &C, source_ip: IpAddr) -> bool {
         self.peers
             .get(peer)
-            .is_some_and(|record| record.acceptable(source_ip, self.allow_unknown_ips))
+            .is_some_and(|record| record.acceptable(source_ip, self.bypass_ip_check))
     }
 
     /// Return egress IPs we should listen for (accept incoming connections from).
@@ -349,7 +349,7 @@ mod tests {
         let config = super::Config {
             allow_private_ips: true,
             allow_dns: true,
-            allow_unknown_ips: false,
+            bypass_ip_check: false,
             max_sets: 1,
             rate_limit: Quota::per_second(NZU32!(10)),
         };
@@ -411,7 +411,7 @@ mod tests {
         let config = super::Config {
             allow_private_ips: true,
             allow_dns: true,
-            allow_unknown_ips: false,
+            bypass_ip_check: false,
             max_sets: 3,
             rate_limit: Quota::per_second(NZU32!(10)),
         };
@@ -499,7 +499,7 @@ mod tests {
         let config = super::Config {
             allow_private_ips: true,
             allow_dns: true,
-            allow_unknown_ips: false,
+            bypass_ip_check: false,
             max_sets: 3,
             rate_limit: Quota::per_second(NZU32!(10)),
         };
@@ -545,7 +545,7 @@ mod tests {
         let config = super::Config {
             allow_private_ips: true,
             allow_dns: true,
-            allow_unknown_ips: false,
+            bypass_ip_check: false,
             max_sets: 3,
             rate_limit: Quota::per_second(NZU32!(10)),
         };
@@ -644,7 +644,7 @@ mod tests {
         let config = super::Config {
             allow_private_ips: true,
             allow_dns: false,
-            allow_unknown_ips: false,
+            bypass_ip_check: false,
             max_sets: 3,
             rate_limit: Quota::per_second(NZU32!(10)),
         };
@@ -709,7 +709,7 @@ mod tests {
         let config = super::Config {
             allow_private_ips: false,
             allow_dns: true,
-            allow_unknown_ips: false,
+            bypass_ip_check: false,
             max_sets: 3,
             rate_limit: Quota::per_second(NZU32!(10)),
         };

--- a/p2p/src/authenticated/lookup/actors/tracker/mod.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/mod.rs
@@ -25,6 +25,6 @@ pub struct Config<C: Signer> {
     pub allowed_connection_rate_per_peer: Quota,
     pub allow_private_ips: bool,
     pub allow_dns: bool,
-    pub allow_unknown_ips: bool,
+    pub bypass_ip_check: bool,
     pub listener: Mailbox<HashSet<IpAddr>>,
 }

--- a/p2p/src/authenticated/lookup/config.rs
+++ b/p2p/src/authenticated/lookup/config.rs
@@ -32,7 +32,7 @@ pub struct Config<C: Signer> {
 
     /// Whether or not to skip IP verification for incoming connections
     /// (allows known peers to connect from unknown IPs).
-    pub allow_unknown_ips: bool,
+    pub bypass_ip_check: bool,
 
     /// Maximum size allowed for messages over any connection.
     ///
@@ -113,7 +113,7 @@ impl<C: Signer> Config<C> {
 
             allow_private_ips: false,
             allow_dns: true,
-            allow_unknown_ips: false,
+            bypass_ip_check: false,
             max_message_size,
             mailbox_size: 1_000,
             synchrony_bound: Duration::from_secs(5),
@@ -144,7 +144,7 @@ impl<C: Signer> Config<C> {
 
             allow_private_ips: true,
             allow_dns: true,
-            allow_unknown_ips: false,
+            bypass_ip_check: false,
             max_message_size,
             mailbox_size: 1_000,
             synchrony_bound: Duration::from_secs(5),
@@ -170,7 +170,7 @@ impl<C: Signer> Config<C> {
 
             allow_private_ips: true,
             allow_dns: true,
-            allow_unknown_ips: false,
+            bypass_ip_check: false,
             max_message_size,
             mailbox_size: 1_000,
             synchrony_bound: Duration::from_secs(5),

--- a/p2p/src/authenticated/lookup/network.rs
+++ b/p2p/src/authenticated/lookup/network.rs
@@ -61,7 +61,7 @@ impl<E: Spawner + Clock + Rng + CryptoRng + RNetwork + Resolver + Metrics, C: Si
                 allowed_connection_rate_per_peer: cfg.allowed_connection_rate_per_peer,
                 allow_private_ips: cfg.allow_private_ips,
                 allow_dns: cfg.allow_dns,
-                allow_unknown_ips: cfg.allow_unknown_ips,
+                bypass_ip_check: cfg.bypass_ip_check,
                 listener: listener_mailbox,
             },
         );
@@ -162,7 +162,7 @@ impl<E: Spawner + Clock + Rng + CryptoRng + RNetwork + Resolver + Metrics, C: Si
                 address: self.cfg.listen,
                 stream_cfg: stream_cfg.clone(),
                 allow_private_ips: self.cfg.allow_private_ips,
-                allow_unknown_ips: self.cfg.allow_unknown_ips,
+                bypass_ip_check: self.cfg.bypass_ip_check,
                 max_concurrent_handshakes: self.cfg.max_concurrent_handshakes,
                 allowed_handshake_rate_per_ip: self.cfg.allowed_handshake_rate_per_ip,
                 allowed_handshake_rate_per_subnet: self.cfg.allowed_handshake_rate_per_subnet,


### PR DESCRIPTION
In a previous PR (#2534), we broke `allow_unregistered_handshakes` (when ensuring a peer is dialing from their IP rather than any allowed IP).

This PR fixes that regression and adds regression tests.