### PR TITLE
[storage/kv] move Batchable to kv module

### DIFF
--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -4,10 +4,8 @@ use arbitrary::Arbitrary;
 use commonware_cryptography::Sha256;
 use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
 use commonware_storage::{
-    qmdb::{
-        any::{ordered::fixed::Db, FixedConfig as Config},
-        store::Batchable as _,
-    },
+    kv::Batchable as _,
+    qmdb::any::{ordered::fixed::Db, FixedConfig as Config},
     translator::EightCap,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU64};

--- a/storage/src/kv/mod.rs
+++ b/storage/src/kv/mod.rs
@@ -1,5 +1,7 @@
 //! Traits for interacting with a key/value store.
 
+mod batch;
+pub use batch::{Batch, Batchable};
 use std::future::Future;
 
 /// A readable key-value store.

--- a/storage/src/qmdb/any/ext.rs
+++ b/storage/src/qmdb/any/ext.rs
@@ -6,10 +6,10 @@
 
 use super::{CleanAny, DirtyAny};
 use crate::{
-    kv,
+    kv::{self, Batchable},
     mmr::Location,
     qmdb::{
-        store::{Batchable, CleanStore, DirtyStore, LogStore, LogStorePrunable},
+        store::{CleanStore, DirtyStore, LogStore, LogStorePrunable},
         Error,
     },
     Persistable,

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -4,7 +4,7 @@ use crate::{
         contiguous::{Contiguous, MutableContiguous},
         Error as JournalError,
     },
-    kv,
+    kv::{self, Batchable},
     mmr::{
         mem::{Dirty, State},
         Location,
@@ -16,7 +16,6 @@ use crate::{
         },
         delete_known_loc,
         operation::Operation as OperationTrait,
-        store::Batchable,
         update_known_loc, Error,
     },
     Persistable,

--- a/storage/src/qmdb/any/unordered/mod.rs
+++ b/storage/src/qmdb/any/unordered/mod.rs
@@ -3,7 +3,7 @@ use crate::{
         contiguous::{Contiguous, MutableContiguous},
         Error as JournalError,
     },
-    kv,
+    kv::{self, Batchable},
     mmr::{
         mem::{Dirty, State},
         Location,
@@ -15,7 +15,6 @@ use crate::{
         },
         build_snapshot_from_log, create_key, delete_key, delete_known_loc,
         operation::{Committable as _, Operation as OperationTrait},
-        store::Batchable,
         update_key, update_known_loc, Error, Index,
     },
     Persistable,

--- a/storage/src/qmdb/benches/fixed/generate.rs
+++ b/storage/src/qmdb/benches/fixed/generate.rs
@@ -12,11 +12,8 @@ use commonware_runtime::{
     tokio::{Config, Context},
 };
 use commonware_storage::{
-    qmdb::{
-        any::AnyExt,
-        store::{Batchable, LogStorePrunable},
-        Error,
-    },
+    kv::Batchable,
+    qmdb::{any::AnyExt, store::LogStorePrunable, Error},
     Persistable,
 };
 use criterion::{criterion_group, Criterion};

--- a/storage/src/qmdb/benches/fixed/mod.rs
+++ b/storage/src/qmdb/benches/fixed/mod.rs
@@ -7,7 +7,7 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{buffer::PoolRef, create_pool, tokio::Context, ThreadPool};
 use commonware_storage::{
-    kv::Deletable,
+    kv::{Batchable, Deletable},
     qmdb::{
         any::{
             ordered::{fixed::Db as OFixed, variable::Db as OVariable},
@@ -18,7 +18,7 @@ use commonware_storage::{
             ordered::fixed::Db as OCurrent, unordered::fixed::Db as UCurrent,
             FixedConfig as CConfig,
         },
-        store::{Batchable, Config as SConfig, Store},
+        store::{Config as SConfig, Store},
         Error,
     },
     translator::EightCap,

--- a/storage/src/qmdb/benches/variable/generate.rs
+++ b/storage/src/qmdb/benches/variable/generate.rs
@@ -11,11 +11,8 @@ use commonware_runtime::{
     tokio::{Config, Context},
 };
 use commonware_storage::{
-    kv::Deletable,
-    qmdb::{
-        store::{Batchable, LogStorePrunable},
-        Error,
-    },
+    kv::{Batchable, Deletable},
+    qmdb::{store::LogStorePrunable, Error},
     Persistable,
 };
 use criterion::{criterion_group, Criterion};

--- a/storage/src/qmdb/benches/variable/mod.rs
+++ b/storage/src/qmdb/benches/variable/mod.rs
@@ -3,13 +3,13 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{buffer::PoolRef, create_pool, tokio::Context, ThreadPool};
 use commonware_storage::{
-    kv::Deletable,
+    kv::{Batchable, Deletable},
     qmdb::{
         any::{
             ordered::variable::Db as OVariable, unordered::variable::Db as UVariable,
             VariableConfig as AConfig,
         },
-        store::{Batchable, Config as SConfig, LogStorePrunable, Store},
+        store::{Config as SConfig, LogStorePrunable, Store},
         Error,
     },
     translator::EightCap,

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     bitmap::{CleanBitMap, DirtyBitMap},
-    kv,
+    kv::{self, Batchable},
     mmr::{
         grafting::Storage as GraftingStorage,
         mem::{Clean, Dirty, State},
@@ -26,7 +26,7 @@ use crate::{
             proof::{OperationProof, RangeProof},
             root, FixedConfig as Config,
         },
-        store::{Batchable, CleanStore, DirtyStore, LogStore},
+        store::{CleanStore, DirtyStore, LogStore},
         Error,
     },
     translator::Translator,

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     bitmap::{CleanBitMap, DirtyBitMap},
-    kv,
+    kv::{self, Batchable},
     mmr::{
         mem::{Clean, Dirty, State},
         Location, Proof, StandardHasher,
@@ -26,7 +26,7 @@ use crate::{
             proof::{OperationProof, RangeProof},
             root, FixedConfig as Config,
         },
-        store::{Batchable, CleanStore, DirtyStore, LogStore},
+        store::{CleanStore, DirtyStore, LogStore},
         Error,
     },
     translator::Translator,

--- a/storage/src/qmdb/store/batch.rs
+++ b/storage/src/qmdb/store/batch.rs
@@ -1,184 +1,19 @@
-//! Support for batching changes to an underlying database.
-
-use crate::{kv, qmdb::Error};
-use commonware_codec::Codec;
-use commonware_utils::Array;
-use core::future::Future;
-use std::collections::BTreeMap;
-
-/// A trait for getting values from a keyed database.
-pub trait Getter<K, V> {
-    /// Get the value of `key` from the database.
-    fn get(&self, key: &K) -> impl Future<Output = Result<Option<V>, Error>>;
-}
-
-/// All databases implement the [Getter] trait.
-impl<D> Getter<D::Key, D::Value> for D
-where
-    D: kv::Gettable<Error = Error>,
-    D::Key: Array,
-    D::Value: Codec + Clone,
-{
-    async fn get(&self, key: &D::Key) -> Result<Option<D::Value>, Error> {
-        kv::Gettable::get(self, key).await
-    }
-}
-
-/// A batch of changes which may be written to an underlying database with [Batchable::write_batch].
-/// Writes and deletes to a batch are not applied to the database until the batch is written but
-/// will be reflected in reads from the batch.
-pub struct Batch<'a, K, V, D>
-where
-    K: Array,
-    V: Codec + Clone,
-    D: Getter<K, V>,
-{
-    /// The underlying database.
-    db: &'a D,
-    /// The diff of changes to the database.
-    ///
-    /// If the value is Some, the key is being created or updated.
-    /// If the value is None, the key is being deleted.
-    ///
-    /// We use a BTreeMap instead of HashMap to allow for a deterministic iteration order.
-    diff: BTreeMap<K, Option<V>>,
-}
-
-impl<'a, K, V, D> Batch<'a, K, V, D>
-where
-    K: Array,
-    V: Codec + Clone,
-    D: Getter<K, V>,
-{
-    /// Returns a new batch of changes that may be written to the database.
-    pub const fn new(db: &'a D) -> Self {
-        Self {
-            db,
-            diff: BTreeMap::new(),
-        }
-    }
-
-    /// Returns the value of `key` in the batch, or the value in the database if it is not present
-    /// in the batch.
-    pub async fn get(&self, key: &K) -> Result<Option<V>, Error> {
-        if let Some(value) = self.diff.get(key) {
-            return Ok(value.clone());
-        }
-
-        self.db.get(key).await
-    }
-
-    /// Creates a new key-value pair in the batch if it isn't present in the batch or database.
-    /// Returns true if the key was created, false if it already existed.
-    pub async fn create(&mut self, key: K, value: V) -> Result<bool, Error> {
-        if let Some(value_opt) = self.diff.get_mut(&key) {
-            match value_opt {
-                Some(_) => return Ok(false),
-                None => {
-                    *value_opt = Some(value);
-                    return Ok(true);
-                }
-            }
-        }
-
-        if self.db.get(&key).await?.is_some() {
-            return Ok(false);
-        }
-
-        self.diff.insert(key, Some(value));
-        Ok(true)
-    }
-
-    /// Updates the value of `key` to `value` in the batch.
-    pub async fn update(&mut self, key: K, value: V) -> Result<(), Error> {
-        self.diff.insert(key, Some(value));
-
-        Ok(())
-    }
-
-    /// Deletes `key` from the batch.
-    /// Returns true if the key was in the batch or database, false otherwise.
-    pub async fn delete(&mut self, key: K) -> Result<bool, Error> {
-        if let Some(entry) = self.diff.get_mut(&key) {
-            match entry {
-                Some(_) => {
-                    *entry = None;
-                    return Ok(true);
-                }
-                None => return Ok(false),
-            }
-        }
-
-        if self.db.get(&key).await?.is_some() {
-            self.diff.insert(key, None);
-            return Ok(true);
-        }
-
-        Ok(false)
-    }
-
-    /// Deletes `key` from the batch without checking if it is present in the batch or database.
-    pub async fn delete_unchecked(&mut self, key: K) -> Result<(), Error> {
-        self.diff.insert(key, None);
-
-        Ok(())
-    }
-}
-
-impl<'a, K, V, D> IntoIterator for Batch<'a, K, V, D>
-where
-    K: Array,
-    V: Codec + Clone,
-    D: Getter<K, V>,
-{
-    type Item = (K, Option<V>);
-    type IntoIter = std::collections::btree_map::IntoIter<K, Option<V>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.diff.into_iter()
-    }
-}
-
-/// A database that supports making batched changes.
-pub trait Batchable: kv::Deletable<Key: Array, Value: Codec + Clone, Error = Error> {
-    /// Returns a new empty batch of changes.
-    fn start_batch(&self) -> Batch<'_, Self::Key, Self::Value, Self>
-    where
-        Self: Sized,
-    {
-        Batch {
-            db: self,
-            diff: BTreeMap::new(),
-        }
-    }
-
-    /// Writes a batch of changes to the database.
-    fn write_batch(
-        &mut self,
-        iter: impl Iterator<Item = (Self::Key, Option<Self::Value>)>,
-    ) -> impl Future<Output = Result<(), Error>> {
-        async {
-            for (key, value) in iter {
-                if let Some(value) = value {
-                    self.update(key, value).await?;
-                } else {
-                    self.delete(key).await?;
-                }
-            }
-            Ok(())
-        }
-    }
-}
+//! Test utilities for batch operations on qmdb databases.
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
-    use crate::Persistable;
+    use crate::{
+        kv::{self, Batchable},
+        qmdb::Error,
+        Persistable,
+    };
+    use commonware_codec::Codec;
     use commonware_cryptography::{blake3, sha256};
     use commonware_runtime::{
         deterministic::{self, Context},
         Runner as _,
     };
+    use commonware_utils::Array;
     use core::{fmt::Debug, future::Future};
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use std::collections::HashSet;

--- a/storage/src/qmdb/store/mod.rs
+++ b/storage/src/qmdb/store/mod.rs
@@ -113,7 +113,6 @@ use tracing::{debug, warn};
 mod batch;
 #[cfg(test)]
 pub use batch::tests as batch_tests;
-pub use batch::{Batch, Batchable, Getter};
 
 /// Configuration for initializing a [Store] database.
 #[derive(Clone)]
@@ -655,7 +654,7 @@ where
     }
 }
 
-impl<E, K, V, T> Batchable for Store<E, K, V, T>
+impl<E, K, V, T> kv::Batchable for Store<E, K, V, T>
 where
     E: Storage + Clock + Metrics,
     K: Array,


### PR DESCRIPTION
Batchable is a trait for batch-updating kv stores, so it belongs in the kv module.