### PR TITLE
[storage/kv] implement kv traits for Batchable

### DIFF
--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -4,7 +4,7 @@ use arbitrary::Arbitrary;
 use commonware_cryptography::Sha256;
 use commonware_runtime::{buffer::PoolRef, deterministic, Runner};
 use commonware_storage::{
-    kv::Batchable as _,
+    kv::{Batchable as _, Deletable as _, Gettable as _, Updatable as _},
     qmdb::any::{ordered::fixed::Db, FixedConfig as Config},
     translator::EightCap,
 };

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -999,6 +999,7 @@ where
 mod test {
     use super::*;
     use crate::{
+        kv::{Deletable as _, Updatable as _},
         qmdb::{
             any::test::{fixed_db_config, variable_db_config},
             store::{DirtyStore as _, LogStore as _},

--- a/storage/src/qmdb/benches/fixed/mod.rs
+++ b/storage/src/qmdb/benches/fixed/mod.rs
@@ -7,7 +7,7 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{buffer::PoolRef, create_pool, tokio::Context, ThreadPool};
 use commonware_storage::{
-    kv::{Batchable, Deletable},
+    kv::{Batchable, Deletable, Updatable as _},
     qmdb::{
         any::{
             ordered::{fixed::Db as OFixed, variable::Db as OVariable},

--- a/storage/src/qmdb/benches/variable/mod.rs
+++ b/storage/src/qmdb/benches/variable/mod.rs
@@ -3,7 +3,7 @@
 use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{buffer::PoolRef, create_pool, tokio::Context, ThreadPool};
 use commonware_storage::{
-    kv::{Batchable, Deletable},
+    kv::{Batchable, Deletable, Updatable as _},
     qmdb::{
         any::{
             ordered::variable::Db as OVariable, unordered::variable::Db as UVariable,

--- a/storage/src/qmdb/store/batch.rs
+++ b/storage/src/qmdb/store/batch.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 pub mod tests {
     use crate::{
-        kv::{self, Batchable},
+        kv::{self, Batchable, Deletable as _, Gettable as _, Updatable as _},
         qmdb::Error,
         Persistable,
     };


### PR DESCRIPTION
Allows treating a `Batch` identically to any other key/value store.