### PR TITLE
chore: annual license year update

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -2,7 +2,7 @@
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
-   Copyright (c) 2025 Commonware, Inc.
+   Copyright (c) 2026 Commonware, Inc.
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Commonware, Inc.
+Copyright (c) 2026 Commonware, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Happy New Year!

## Changes
Updates the copyright year in license files from 2025 to 2026.

This is a routine annual update to keep the copyright notices current.