### PR TITLE
[cryptography/certificate] cleanup unnecessary bounds

### DIFF
--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -183,7 +183,7 @@ impl Random {
 impl<P, V> Config<bls12381_threshold::Scheme<P, V>> for Random
 where
     P: PublicKey,
-    V: Variant + Send + Sync + 'static,
+    V: Variant,
 {
     type Elector = RandomElector<bls12381_threshold::Scheme<P, V>>;
 
@@ -209,7 +209,7 @@ impl<P, V> Elector<bls12381_threshold::Scheme<P, V>>
     for RandomElector<bls12381_threshold::Scheme<P, V>>
 where
     P: PublicKey,
-    V: Variant + Send + Sync + 'static,
+    V: Variant,
 {
     fn elect(&self, round: Round, certificate: Option<&bls12381_threshold::Signature<V>>) -> u32 {
         Random::select_leader::<V>(round, self.n, certificate.map(|c| c.seed_signature))

--- a/consensus/src/simplex/scheme/bls12381_threshold.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold.rs
@@ -393,7 +393,7 @@ impl<P: PublicKey, V: Variant, D: Digest> Seedable<V> for Finalization<Scheme<P,
     }
 }
 
-impl<P: PublicKey, V: Variant + Send + Sync> certificate::Scheme for Scheme<P, V> {
+impl<P: PublicKey, V: Variant> certificate::Scheme for Scheme<P, V> {
     type Subject<'a, D: Digest> = Subject<'a, D>;
     type PublicKey = P;
     type Signature = Signature<V>;
@@ -806,6 +806,18 @@ mod tests {
     #[should_panic(expected = "polynomial total must equal participant len")]
     fn test_verifier_polynomial_threshold_must_equal_quorum_min_sig() {
         verifier_polynomial_threshold_must_equal_quorum::<MinSig>();
+    }
+
+    #[test]
+    fn test_is_not_attributable() {
+        assert!(!Scheme::<MinPk>::is_attributable());
+        assert!(!Scheme::<MinSig>::is_attributable());
+    }
+
+    #[test]
+    fn test_is_batchable() {
+        assert!(Scheme::<MinPk>::is_batchable());
+        assert!(Scheme::<MinSig>::is_batchable());
     }
 
     fn sign_vote_roundtrip_for_each_context<V: Variant>() {


### PR DESCRIPTION
This PR removes a bunch of `Send + Sync` around BLS `Variant` that were unneeded.
Also adds missing tests for `is_attributable` and `is_batchable` and some more missing tests to make the test suites uniform.