### PR TITLE
[cryptography] Remove Hash from PrivateKey types

### DIFF
--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -87,14 +87,6 @@ impl FixedSize for PrivateKey {
     const SIZE: usize = group::PRIVATE_KEY_LENGTH;
 }
 
-impl Span for PrivateKey {}
-
-impl Hash for PrivateKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.raw.expose(|raw| raw.hash(state));
-    }
-}
-
 impl Ord for PrivateKey {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.raw.cmp(&other.raw)

--- a/cryptography/src/ed25519/certificate/mocks.rs
+++ b/cryptography/src/ed25519/certificate/mocks.rs
@@ -6,11 +6,11 @@ use crate::{
     Signer as _,
 };
 use commonware_math::algebra::Random;
-use commonware_utils::{ordered::BiMap, TryCollect as _};
+use commonware_utils::{ordered::Map, TryCollect as _};
 use rand::{CryptoRng, RngCore};
 
 /// Generates ed25519 identity participants.
-pub fn participants<R>(rng: &mut R, n: u32) -> BiMap<PublicKey, PrivateKey>
+pub fn participants<R>(rng: &mut R, n: u32) -> Map<PublicKey, PrivateKey>
 where
     R: RngCore + CryptoRng,
 {

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -95,15 +95,7 @@ impl FixedSize for PrivateKey {
     const SIZE: usize = PRIVATE_KEY_LENGTH;
 }
 
-impl Span for PrivateKey {}
-
 impl Eq for PrivateKey {}
-
-impl Hash for PrivateKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.raw.expose(|raw| raw.hash(state));
-    }
-}
 
 impl PartialEq for PrivateKey {
     fn eq(&self, other: &Self) -> bool {

--- a/cryptography/src/secp256r1/common.rs
+++ b/cryptography/src/secp256r1/common.rs
@@ -76,14 +76,6 @@ impl FixedSize for PrivateKeyInner {
     const SIZE: usize = PRIVATE_KEY_LENGTH;
 }
 
-impl Span for PrivateKeyInner {}
-
-impl Hash for PrivateKeyInner {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.raw.expose(|raw| raw.hash(state));
-    }
-}
-
 impl Ord for PrivateKeyInner {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.raw.cmp(&other.raw)
@@ -242,14 +234,6 @@ macro_rules! impl_private_key_wrapper {
 
         impl commonware_codec::FixedSize for $name {
             const SIZE: usize = PRIVATE_KEY_LENGTH;
-        }
-
-        impl commonware_utils::Span for $name {}
-
-        impl core::hash::Hash for $name {
-            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-                self.0.hash(state);
-            }
         }
 
         impl Ord for $name {


### PR DESCRIPTION
Remove Hash implementation from all private key types to eliminate timing side-channel vulnerabilities. Standard hashers are not constant-time, so an attacker observing hash computation could potentially learn information about key material.

Changes:
- Remove Hash impl from bls12381::PrivateKey
- Remove Hash impl from ed25519::PrivateKey
- Remove Hash impl from secp256r1::PrivateKeyInner and wrapper types
- Remove Span impl from all PrivateKey types (Span requires Hash)
- Change ed25519/certificate/mocks to use Map instead of BiMap