### PR TITLE
[consensus] clarify simplex engine journal behavior

### DIFF
--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -121,7 +121,8 @@ impl<
 
     /// Start the `simplex` consensus engine.
     ///
-    /// This will also rebuild the state of the engine from provided `Journal`.
+    /// When started, the underlying voter actor replays its persistent journal
+    /// to rebuild in-memory consensus state before processing new traffic.
     ///
     /// # Network Channels
     ///


### PR DESCRIPTION
Previously the Engine::start docs claimed that it “rebuilds the state of the engine from provided Journal”, but the engine does not accept a journal parameter and never touches storage directly. Persistence and replay are implemented inside the voter::Actor, which opens and replays its own journal on startup.