### PR TITLE
fix(storage): correct element indices in MMR documentation example

### DIFF
--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -55,15 +55,15 @@
 //!   Hash(14,                                                  // first peak
 //!     Hash(6,
 //!       Hash(2, Hash(0, element_0), Hash(1, element_1)),
-//!       Hash(5, Hash(3, element_2), Hash(4, element_4))
+//!       Hash(5, Hash(3, element_2), Hash(4, element_3))
 //!     )
 //!     Hash(13,
-//!       Hash(9, Hash(7, element_7), Hash(8, element_8)),
-//!       Hash(12, Hash(10, element_10), Hash(11, element_11))
+//!       Hash(9, Hash(7, element_4), Hash(8, element_5)),
+//!       Hash(12, Hash(10, element_6), Hash(11, element_7))
 //!     )
 //!   )
-//!   Hash(17, Hash(15, element_15), Hash(16, element_16))      // second peak
-//!   Hash(18, element_18)                                      // third peak
+//!   Hash(17, Hash(15, element_8), Hash(16, element_9))        // second peak
+//!   Hash(18, element_10)                                      // third peak
 //! )
 //! ```
 


### PR DESCRIPTION
The MMR module documentation had incorrect element indices in the hash computation example. The example showed element_4, element_7, element_8, etc. but these didn't match the location-to-position mapping shown in the diagram above. Fixed to use correct indices: element_3 at position 4, element_4 at position 7, and so on through element_10 at position 18.