### PR TITLE
[consensus/simplex] Cleanup Notarize/Notarization Check Prior to Finalize

### DIFF
--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -1032,4 +1032,48 @@ mod tests {
         // This should not panic - the result is simply ignored.
         round.certified(true);
     }
+
+    #[test]
+    fn construct_finalize_requires_notarization() {
+        let mut rng = test_rng();
+        let namespace = b"ns";
+        let Fixture {
+            schemes, verifier, ..
+        } = ed25519::fixture(&mut rng, namespace, 4);
+        let local_scheme = schemes[0].clone();
+
+        let now = SystemTime::UNIX_EPOCH;
+        let round_info = Rnd::new(Epoch::new(1), View::new(1));
+        let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([1u8; 32]));
+
+        let mut round = Round::new(local_scheme, round_info, now);
+        round.set_leader(Participant::new(0));
+        assert!(round.set_proposal(proposal.clone()));
+        assert!(round.verified());
+
+        // Construct notarize succeeds
+        assert!(round.construct_notarize().is_some());
+
+        // Certify the proposal before notarization. This should never happen in
+        // practice (we only call certify after notarization) but ensures the
+        // notarization check is functional.
+        round.certified(true);
+
+        // Construct finalize fails without notarization (even though certified)
+        assert!(round.construct_finalize().is_none());
+
+        // Add notarization
+        let notarization_votes: Vec<_> = schemes
+            .iter()
+            .map(|scheme| Notarize::sign(scheme, proposal.clone()).unwrap())
+            .collect();
+        let notarization =
+            Notarization::from_notarizes(&verifier, notarization_votes.iter(), &Sequential)
+                .unwrap();
+        let (added, _) = round.add_notarization(notarization);
+        assert!(added);
+
+        // Now construct finalize succeeds
+        assert!(round.construct_finalize().is_some());
+    }
 }


### PR DESCRIPTION
Fixes #2692 

Remove some historical vote construction/broadcast checks that aren't functional (and just add confusion).