### PR TITLE
[runtime] Release lock before notifying in Blocker

### DIFF
--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -216,10 +216,11 @@ impl Blocker {
 
 impl ArcWake for Blocker {
     fn wake_by_ref(arc_self: &Arc<Self>) {
+        // Mark as signaled (and release lock before notifying).
         {
             let mut signaled = arc_self.state.lock().unwrap();
             *signaled = true;
-        } // Release lock before notifying to avoid unnecessary contention
+        }
 
         // Notify a single waiter so the blocked thread re-checks the flag.
         arc_self.cv.notify_one();


### PR DESCRIPTION
Found that we were notifying while holding the lock in Blocker, which defeats the point since the woken thread can't grab it anyway. Quick fix to drop the lock before the notify.