### PR TITLE
[consensus/ordered-broadcast] Remove `epoch` from signed over data

### DIFF
--- a/consensus/src/ordered_broadcast/ack_manager.rs
+++ b/consensus/src/ordered_broadcast/ack_manager.rs
@@ -196,10 +196,7 @@ mod tests {
         where
             S: Scheme<PublicKey, Sha256Digest>,
         {
-            let context = AckSubject {
-                chunk: &chunk,
-                epoch,
-            };
+            let context = AckSubject { chunk: &chunk };
             let attestation = scheme
                 .sign::<Sha256Digest>(context)
                 .expect("Failed to sign vote");

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{Epoch, Height},
     Heightable,
 };
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes};
 use commonware_codec::{Encode, EncodeSize, Error as CodecError, Read, ReadExt, Write};
 use commonware_cryptography::{
     certificate::{self, Attestation, Namespace, Provider, Scheme},
@@ -803,9 +803,7 @@ impl<P: PublicKey, S: Scheme, D: Digest> Ack<P, S, D> {
         R: CryptoRngCore,
         S: scheme::Scheme<P, D>,
     {
-        let ctx = AckSubject {
-            chunk: &self.chunk,
-        };
+        let ctx = AckSubject { chunk: &self.chunk };
         scheme.verify_attestation::<_, D>(rng, ctx, &self.attestation, strategy)
     }
 
@@ -1074,9 +1072,7 @@ impl<P: PublicKey, S: Scheme, D: Digest> Lock<P, S, D> {
         R: CryptoRngCore,
         S: scheme::Scheme<P, D>,
     {
-        let ctx = AckSubject {
-            chunk: &self.chunk,
-        };
+        let ctx = AckSubject { chunk: &self.chunk };
         scheme.verify_certificate::<R, D, N3f1>(rng, ctx, &self.certificate, strategy)
     }
 }
@@ -1878,7 +1874,11 @@ mod tests {
 
         // Now create a parent with invalid certificate
         // Generate certificate for a different chunk (wrong payload)
-        let wrong_chunk = Chunk::new(public_key, 0, sample_digest(99));
+        let wrong_chunk = Chunk::new(
+            parent_chunk.sequencer.clone(),
+            Height::zero(),
+            sample_digest(99),
+        );
         let wrong_ctx = AckSubject {
             chunk: &wrong_chunk,
         };
@@ -2110,7 +2110,6 @@ mod tests {
 
         // Create a parent with a dummy certificate (content doesn't matter for this test)
         let dummy_chunk = Chunk::new(public_key, Height::zero(), sample_digest(0));
-        let dummy_epoch = Epoch::new(5);
         let ctx = AckSubject {
             chunk: &dummy_chunk,
         };

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -372,6 +372,10 @@ impl Namespace for AckNamespace {
 /// Note: epoch is NOT included here because the p2p channel is already muxed by epoch,
 /// so including it in the signature is redundant. Not signing over epoch allows
 /// certificates to be verified without knowing the epoch.
+///
+/// Replay resistance still holds for the signed statement: signatures are domain
+/// separated with the ack namespace and bind the chunk `(sequencer, height, payload)`.
+/// The protocol also validates sender identity and epoch routing before accepting an ack.
 #[derive(Debug, Clone)]
 pub struct AckSubject<'a, P: PublicKey, D: Digest> {
     /// The chunk being acknowledged.
@@ -766,7 +770,9 @@ where
 ///
 /// Note: The epoch is included in the message for routing purposes but is NOT
 /// signed over. The p2p channel is already muxed by epoch, making it redundant
-/// to include in the signature.
+/// to include in the signature. Replay resistance comes from signing the
+/// domain-separated chunk statement and from sender/epoch validation during
+/// ack processing.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Ack<P: PublicKey, S: Scheme, D: Digest> {
     /// Chunk that is being acknowledged.

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -393,7 +393,7 @@ impl<P: PublicKey, D: Digest> certificate::Subject for AckSubject<'_, P, D> {
         // Note: epoch is NOT included in signed data. The p2p channel is already
         // muxed by epoch, so including it in the signature is redundant. Not signing
         // over epoch allows certificates to be verified without knowing the epoch.
-        self.chunk.encode().into()
+        self.chunk.encode()
     }
 }
 

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -388,8 +388,6 @@ impl<P: PublicKey, D: Digest> certificate::Subject for AckSubject<'_, P, D> {
     }
 
     fn message(&self) -> Bytes {
-        // Epoch is NOT included in signed data. Not signing over epoch allows
-        // certificates to be verified without knowing the epoch.
         self.chunk.encode()
     }
 }

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -367,13 +367,15 @@ impl Namespace for AckNamespace {
 /// Context for signing/verifying validator acknowledgments.
 ///
 /// This is used as the context type for `Scheme` implementations for validators.
-/// It contains the chunk being acknowledged and the epoch of the validator set.
+/// It contains the chunk being acknowledged.
+///
+/// Note: epoch is NOT included here because the p2p channel is already muxed by epoch,
+/// so including it in the signature is redundant. Not signing over epoch allows
+/// certificates to be verified without knowing the epoch.
 #[derive(Debug, Clone)]
 pub struct AckSubject<'a, P: PublicKey, D: Digest> {
     /// The chunk being acknowledged.
     pub chunk: &'a Chunk<P, D>,
-    /// The epoch of the validator set.
-    pub epoch: Epoch,
 }
 
 impl<P: PublicKey, D: Digest> certificate::Subject for AckSubject<'_, P, D> {
@@ -384,11 +386,10 @@ impl<P: PublicKey, D: Digest> certificate::Subject for AckSubject<'_, P, D> {
     }
 
     fn message(&self) -> Bytes {
-        let mut message =
-            BytesMut::with_capacity(self.chunk.encode_size() + self.epoch.encode_size());
-        self.chunk.write(&mut message);
-        self.epoch.write(&mut message);
-        message.freeze()
+        // Note: epoch is NOT included in signed data. The p2p channel is already
+        // muxed by epoch, so including it in the signature is redundant. Not signing
+        // over epoch allows certificates to be verified without knowing the epoch.
+        self.chunk.encode().into()
     }
 }
 
@@ -661,7 +662,6 @@ impl<P: PublicKey, S: Scheme, D: Digest> Node<P, S, D> {
             .ok_or(Error::UnknownScheme(parent.epoch))?;
         let ctx = AckSubject {
             chunk: &parent_chunk,
-            epoch: parent.epoch,
         };
         if !parent_scheme.verify_certificate::<R, D, N3f1>(rng, ctx, &parent.certificate, strategy)
         {
@@ -757,12 +757,16 @@ where
 ///
 /// When a validator receives and validates a chunk, it sends an Ack containing:
 /// 1. The chunk being acknowledged
-/// 2. The current epoch
-/// 3. An attestation over the chunk and epoch
+/// 2. The current epoch (for routing, not signed over)
+/// 3. An attestation over the chunk
 ///
 /// These attestations from validators can be aggregated to form a certificate
 /// once enough validators (a quorum) have acknowledged the chunk. This certificate
 /// serves as proof that the chunk was reliably broadcast.
+///
+/// Note: The epoch is included in the message for routing purposes but is NOT
+/// signed over. The p2p channel is already muxed by epoch, making it redundant
+/// to include in the signature.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Ack<P: PublicKey, S: Scheme, D: Digest> {
     /// Chunk that is being acknowledged.
@@ -801,7 +805,6 @@ impl<P: PublicKey, S: Scheme, D: Digest> Ack<P, S, D> {
     {
         let ctx = AckSubject {
             chunk: &self.chunk,
-            epoch: self.epoch,
         };
         scheme.verify_attestation::<_, D>(rng, ctx, &self.attestation, strategy)
     }
@@ -814,10 +817,7 @@ impl<P: PublicKey, S: Scheme, D: Digest> Ack<P, S, D> {
     where
         S: scheme::Scheme<P, D>,
     {
-        let ctx = AckSubject {
-            chunk: &chunk,
-            epoch,
-        };
+        let ctx = AckSubject { chunk: &chunk };
         let attestation = scheme.sign::<D>(ctx)?;
         Some(Self::new(chunk, epoch, attestation))
     }
@@ -1062,8 +1062,11 @@ impl<P: PublicKey, S: Scheme, D: Digest> Lock<P, S, D> {
 
     /// Verify the Lock.
     ///
-    /// This ensures that the certificate is valid for the given chunk and epoch,
-    /// using the provided scheme.
+    /// This ensures that the certificate is valid for the given chunk, using
+    /// the provided scheme.
+    ///
+    /// Note: The epoch field is used for routing but is NOT verified as part
+    /// of the certificate signature.
     ///
     /// Returns true if the signature is valid, false otherwise.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
@@ -1073,7 +1076,6 @@ impl<P: PublicKey, S: Scheme, D: Digest> Lock<P, S, D> {
     {
         let ctx = AckSubject {
             chunk: &self.chunk,
-            epoch: self.epoch,
         };
         scheme.verify_certificate::<R, D, N3f1>(rng, ctx, &self.certificate, strategy)
     }
@@ -1201,10 +1203,7 @@ mod tests {
         let quorum = N3f1::quorum(fixture.schemes.len() as u32) as usize;
 
         // Generate acks from quorum validators
-        let ctx = AckSubject {
-            chunk: &chunk,
-            epoch,
-        };
+        let ctx = AckSubject { chunk: &chunk };
         let attestations: Vec<_> = fixture.schemes[..quorum]
             .iter()
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
@@ -1265,7 +1264,6 @@ mod tests {
         // Generate parent certificate
         let parent_ctx = AckSubject {
             chunk: &parent_chunk,
-            epoch: parent_epoch,
         };
         let parent_attestations: Vec<_> = fixture.schemes[..quorum]
             .iter()
@@ -1346,7 +1344,6 @@ mod tests {
         let parent_epoch = Epoch::new(5);
         let parent_ctx = AckSubject {
             chunk: &genesis_chunk,
-            epoch: parent_epoch,
         };
 
         // Collect signatures from a quorum of validators to form the parent certificate.
@@ -1419,10 +1416,7 @@ mod tests {
         );
         let epoch = Epoch::new(5);
 
-        let ctx = AckSubject {
-            chunk: &chunk,
-            epoch,
-        };
+        let ctx = AckSubject { chunk: &chunk };
         let attestation = fixture.schemes[0]
             .sign::<Sha256Digest>(ctx)
             .expect("Should sign vote");
@@ -1486,10 +1480,7 @@ mod tests {
         let epoch = Epoch::new(5);
 
         // Generate votes from quorum validators
-        let ctx = AckSubject {
-            chunk: &chunk,
-            epoch,
-        };
+        let ctx = AckSubject { chunk: &chunk };
         let attestations: Vec<_> = fixture.schemes[..quorum]
             .iter()
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
@@ -1568,10 +1559,7 @@ mod tests {
         let quorum = N3f1::quorum(fixture.schemes.len() as u32) as usize;
 
         // Generate votes from quorum validators
-        let ctx = AckSubject {
-            chunk: &chunk,
-            epoch,
-        };
+        let ctx = AckSubject { chunk: &chunk };
         let attestations: Vec<_> = fixture.schemes[..quorum]
             .iter()
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
@@ -1634,7 +1622,6 @@ mod tests {
         // Create certificate for parent
         let parent_ctx = AckSubject {
             chunk: &parent_chunk,
-            epoch: parent_epoch,
         };
         let parent_attestations: Vec<_> = fixture.schemes[..quorum]
             .iter()
@@ -1705,10 +1692,7 @@ mod tests {
         let quorum = N3f1::quorum(fixture.schemes.len() as u32) as usize;
 
         // Create quorum votes
-        let ctx = AckSubject {
-            chunk: &chunk,
-            epoch,
-        };
+        let ctx = AckSubject { chunk: &chunk };
         let attestations: Vec<_> = fixture.schemes[..quorum]
             .iter()
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
@@ -1749,10 +1733,7 @@ mod tests {
         let quorum = N3f1::quorum(fixture.schemes.len() as u32) as usize;
 
         // Create certificate
-        let ctx = AckSubject {
-            chunk: &chunk,
-            epoch,
-        };
+        let ctx = AckSubject { chunk: &chunk };
         let attestations: Vec<_> = fixture.schemes[..quorum]
             .iter()
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
@@ -1866,7 +1847,6 @@ mod tests {
         // Generate a valid certificate for the parent
         let parent_ctx = AckSubject {
             chunk: &parent_chunk,
-            epoch,
         };
         let parent_attestations: Vec<_> = fixture.schemes[..quorum]
             .iter()
@@ -1897,10 +1877,10 @@ mod tests {
             .is_ok());
 
         // Now create a parent with invalid certificate
-        // Generate certificate with the wrong keys (sign with schemes[1..] but pretend it's from schemes[0..])
+        // Generate certificate for a different chunk (wrong payload)
+        let wrong_chunk = Chunk::new(public_key, 0, sample_digest(99));
         let wrong_ctx = AckSubject {
-            chunk: &parent_chunk,
-            epoch: Epoch::new(99), // Different epoch to get different signatures
+            chunk: &wrong_chunk,
         };
         let wrong_attestations: Vec<_> = fixture.schemes[..quorum]
             .iter()
@@ -1910,7 +1890,7 @@ mod tests {
             .assemble::<_, N3f1>(wrong_attestations, &Sequential)
             .expect("Should assemble certificate");
 
-        // Create parent with certificate signed for wrong context (wrong epoch)
+        // Create parent with certificate signed for wrong chunk (wrong payload)
         let wrong_parent =
             Parent::<S, Sha256Digest>::new(parent_chunk.payload, epoch, wrong_certificate);
 
@@ -1921,7 +1901,7 @@ mod tests {
             Some(wrong_parent),
         );
 
-        // Verification should fail because the parent certificate was signed for different epoch
+        // Verification should fail because the parent certificate was signed for different chunk
         assert!(matches!(
             node.verify(&mut rng, &verifier, &provider, &Sequential),
             Err(Error::InvalidCertificate)
@@ -1959,10 +1939,7 @@ mod tests {
         assert!(ack.verify(&mut rng, &fixture.verifier, &Sequential));
 
         // Create an ack with tampered signature by signing with a different scheme
-        let ctx = AckSubject {
-            chunk: &chunk,
-            epoch,
-        };
+        let ctx = AckSubject { chunk: &chunk };
         let mut tampered_vote = fixture.schemes[1]
             .sign::<Sha256Digest>(ctx)
             .expect("Should sign vote");
@@ -2033,10 +2010,7 @@ mod tests {
         let quorum_size = N3f1::quorum(fixture.schemes.len() as u32) as usize;
 
         // Generate certificate
-        let ctx = AckSubject {
-            chunk: &chunk,
-            epoch,
-        };
+        let ctx = AckSubject { chunk: &chunk };
         let attestations: Vec<_> = fixture.schemes[..quorum_size]
             .iter()
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
@@ -2139,7 +2113,6 @@ mod tests {
         let dummy_epoch = Epoch::new(5);
         let ctx = AckSubject {
             chunk: &dummy_chunk,
-            epoch: dummy_epoch,
         };
         let attestations: Vec<_> = fixture.schemes[..quorum_size]
             .iter()
@@ -2224,7 +2197,6 @@ mod tests {
         let parent_epoch = Epoch::new(5);
         let parent_ctx = AckSubject {
             chunk: &parent_chunk,
-            epoch: parent_epoch,
         };
         let parent_attestations: Vec<_> = fixture.schemes[..N3f1::quorum(4) as usize]
             .iter()


### PR DESCRIPTION
Removes `epoch` from the signed data in ordered broadcast ack/certificate signatures. This allows certificates to be verified with just the chunk and scheme, without needing to know which epoch produced them.

`epoch` remains in the wire format for routing but is no longer part of the signed message. Replay resistance is maintained by domain-separated namespaces, the chunk binding `(sequencer, height, payload)`, and protocol-level sender/epoch validation.

Existing sign/verify tests are sufficient since verification has always been determined by the scheme (validator set + keys), not the epoch. The epoch was just a lookup key to find the right scheme. Removing it from the signed data doesn't change any verification path that tests exercise.

Fixes #969