### PR TITLE
chore: set msrv to 1.91.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ version = "0.0.64"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://commonware.xyz"
+rust-version = "1.91.0"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(full_bench)', 'cfg(generate_conformance_tests)'] }


### PR DESCRIPTION
Sets msrv to 1.91.0 because commonware started using very recently stabilized rust std features.

I recommend adding a job to your github workflows that checks that the msrv used by commonware still compiles with recent features.

Context: 45b0c9a62e8f643d8dc42a291a5c57631838293a introduced `std::time::Duration::from_hours` which only got stabilized as of rust 1.91.0 (corresponding commonware PR: https://github.com/commonwarexyz/monorepo/pull/2666).

This leads to errors like this in codebases using older rust versions:

```
    Checking commonware-p2p v0.0.64 (https://github.com/commonwarexyz/monorepo?rev=fcb1f0f7c0b66bc562066cfda46f12b56dedb4b7#fcb1f0f7)
error[E0658]: use of unstable library feature `duration_constructors_lite`
   --> /Users/janis/.cargo/git/checkouts/monorepo-9732103c47eb4665/fcb1f0f/p2p/src/authenticated/discovery/config.rs:164:29
    |
164 |             block_duration: Duration::from_hours(4),
    |                             ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #140881 <https://github.com/rust-lang/rust/issues/140881> for more information
```