### PR TITLE
[docs] Add `parallel` to homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -98,6 +98,8 @@
         <p>Create and manipulate mathematical objects.</p>
         <h3><a href="https://docs.rs/commonware-p2p">p2p</a></h3>
         <p>Communicate with authenticated peers over encrypted connections.</p>
+        <h3><a href="https://docs.rs/commonware-parallel">p2p</a></h3>
+        <p>Parallelize fold operations with pluggable execution strategies.</p>
         <h3><a href="https://docs.rs/commonware-resolver">resolver</a></h3>
         <p>Resolve data identified by a fixed-length key.</p>
         <h3><a href="https://docs.rs/commonware-runtime">runtime</a></h3>


### PR DESCRIPTION
## Overview

Adds `commonware-parallel` to the homepage.