### PR TITLE
Set MSRV to 1.91.1

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -282,3 +282,39 @@ jobs:
         run: zepter format features
       - name: Lint feature propagation
         run: zepter run check
+
+  build:
+    name: "Build (toolchain: ${{ matrix.toolchain }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        toolchain:
+          - msrv
+          - stable
+          - nightly
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - name: Determine toolchain version
+        id: toolchain
+        run: |
+          if [ "${{ matrix.toolchain }}" = "msrv" ]; then
+            echo "version=$(yq -oy '.workspace.package.rust-version' Cargo.toml)" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ matrix.toolchain }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run setup
+        uses: ./.github/actions/setup
+        with:
+          additional-cache-key: toolchain-${{ matrix.toolchain }}
+      - name: Clear disk space
+        uses: ./.github/actions/disk
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+        with:
+          toolchain: ${{ steps.toolchain.outputs.version }}
+      - name: Print Rust version
+        run: rustc --version
+      - name: Build workspace
+        run: cargo build --workspace --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ version = "0.0.64"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://commonware.xyz"
+rust-version = "1.91.1"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(full_bench)', 'cfg(generate_conformance_tests)'] }


### PR DESCRIPTION
## Overview

Sets the MSRV of the workspace to `1.91.1` and adds a job to build the workspace with all features enabled on the MSRV, stable, and nightly.

supersedes #2716 