### PR TITLE
[ci] Don't require `breaking-format` label for new conformance tests

### DIFF
--- a/.github/scripts/check_conformance_label.sh
+++ b/.github/scripts/check_conformance_label.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Labels that allow conformance.toml changes (at least one required)
+# Labels that allow conformance.toml changes (at least one required for changes to existing cases)
 required_labels=(
   breaking-format
   breaking-api
@@ -22,6 +22,29 @@ echo "Conformance files changed:"
 echo "$changed"
 echo ""
 
+# Check if any conformance.toml changes include deletions
+has_deletions=false
+current_file=""
+while IFS= read -r line; do
+  # Track which file we're in
+  if [[ "$line" =~ ^diff\ --git\ a/(.*)\ b/ ]]; then
+    current_file="${BASH_REMATCH[1]}"
+  fi
+  # If we're in a conformance.toml file and see a deletion line (starts with - but not ---)
+  if [[ "$current_file" == *conformance.toml ]] && [[ "$line" =~ ^-[^-] ]]; then
+    has_deletions=true
+    echo "Deletion/modification found in: $current_file"
+    break
+  fi
+done < <(gh pr diff "$PR_NUMBER")
+
+if [ "$has_deletions" = "false" ]; then
+  echo "All conformance.toml changes are additive, no label required"
+  exit 0
+fi
+
+echo ""
+
 # Get PR labels
 labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
 
@@ -35,7 +58,8 @@ done
 
 echo "ERROR: conformance.toml file(s) changed but no required label found."
 echo ""
-echo "Changing conformance.toml files is a BREAKING CHANGE."
+echo "Modifying or removing entries in conformance.toml files is a BREAKING CHANGE."
+echo "Adding new entries is allowed without a label."
 echo ""
 echo "Required labels (at least one):"
 printf "  - %s\n" "${required_labels[@]}"


### PR DESCRIPTION
## Overview

Updates the conformance label check to not throw an error if the changes to `conformance.toml` files are purely additive.