### PR TITLE
Fix double-counting bug in DKG test harness reveal calculation

### DIFF
--- a/cryptography/src/bls12381/dkg.rs
+++ b/cryptography/src/bls12381/dkg.rs
@@ -2151,10 +2151,12 @@ mod test_plan {
                     .expect("players are unique");
 
                 // Compute expected reveals
+                //
+                // Note: We use union of no_acks and bad_shares since each (dealer, player) pair
+                // results in at most one reveal in the protocol, regardless of whether the player
+                // didn't ack, got a bad share, or both.
                 let mut expected_reveals: BTreeMap<ed25519::PublicKey, u32> = BTreeMap::new();
-                for &(dealer_idx, player_key_idx) in
-                    round.no_acks.iter().chain(round.bad_shares.iter())
-                {
+                for &(dealer_idx, player_key_idx) in round.no_acks.union(&round.bad_shares) {
                     if !selected_dealers.contains(&dealer_idx) {
                         continue;
                     }
@@ -2528,6 +2530,19 @@ mod test {
                         },
                     ),
             )
+            .run::<MinPk>(0)
+    }
+
+    #[test]
+    fn issue_2745_regression() -> anyhow::Result<()> {
+        Plan::new(NonZeroU32::new(6).unwrap())
+            .with(
+                Round::new(vec![0], vec![5, 1, 3, 0, 4])
+                    .no_ack(0, 5)
+                    .bad_share(0, 5),
+            )
+            .with(Round::new(vec![0, 1, 3, 4], vec![0]))
+            .with(Round::new(vec![0], vec![0]))
             .run::<MinPk>(0)
     }
 


### PR DESCRIPTION
## Summary
- Fix bug where `expected_reveals` calculation double-counted `(dealer, player)` pairs present in both `no_acks` and `bad_shares`
- Changed from `chain()` to `union()` to deduplicate pairs before counting
- Added regression test for issue #2745

## Test plan
- [x] Added `issue_2745_regression` test that reproduces the original bug
- [x] All 14 DKG tests pass
- [x] Clippy passes

Fixes #2745

🤖 Generated with [Claude Code](https://claude.ai/code)