### PR TITLE
[consensus/simplex] Fix `Seedable` impl for `bls12381_threshold` scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,7 @@ dependencies = [
  "commonware-macros",
  "commonware-math",
  "commonware-p2p",
+ "commonware-parallel",
  "commonware-runtime",
  "commonware-utils",
  "futures",

--- a/consensus/fuzz/Cargo.toml
+++ b/consensus/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ commonware-cryptography.workspace = true
 commonware-macros.workspace = true
 commonware-math.workspace = true
 commonware-p2p.workspace = true
+commonware-parallel.workspace = true
 commonware-runtime.workspace = true
 commonware-utils.workspace = true
 futures.workspace = true

--- a/consensus/fuzz/fuzz_targets/simplex_bls12381_threshold_minpk.rs
+++ b/consensus/fuzz/fuzz_targets/simplex_bls12381_threshold_minpk.rs
@@ -6,13 +6,14 @@ use commonware_cryptography::{
     bls12381::primitives::variant::MinPk, certificate::mocks::Fixture,
     ed25519::PublicKey as Ed25519PublicKey,
 };
+use commonware_parallel::Sequential;
 use commonware_runtime::deterministic;
 use libfuzzer_sys::fuzz_target;
 
 struct SimplexBls12381MinPk;
 
 impl Simplex for SimplexBls12381MinPk {
-    type Scheme = bls12381_threshold::Scheme<Ed25519PublicKey, MinPk>;
+    type Scheme = bls12381_threshold::Scheme<Ed25519PublicKey, MinPk, Sequential>;
     type Elector = Random;
 
     fn fixture(

--- a/consensus/fuzz/fuzz_targets/simplex_bls12381_threshold_minsig.rs
+++ b/consensus/fuzz/fuzz_targets/simplex_bls12381_threshold_minsig.rs
@@ -6,13 +6,14 @@ use commonware_cryptography::{
     bls12381::primitives::variant::MinSig, certificate::mocks::Fixture,
     ed25519::PublicKey as Ed25519PublicKey,
 };
+use commonware_parallel::Sequential;
 use commonware_runtime::deterministic;
 use libfuzzer_sys::fuzz_target;
 
 struct SimplexBls12381MinSig;
 
 impl Simplex for SimplexBls12381MinSig {
-    type Scheme = bls12381_threshold::Scheme<Ed25519PublicKey, MinSig>;
+    type Scheme = bls12381_threshold::Scheme<Ed25519PublicKey, MinSig, Sequential>;
     type Elector = Random;
 
     fn fixture(

--- a/consensus/fuzz/fuzz_targets/simplex_elector.rs
+++ b/consensus/fuzz/fuzz_targets/simplex_elector.rs
@@ -15,6 +15,7 @@ use commonware_cryptography::{
     Sha256, Signer,
 };
 use commonware_math::algebra::Random as _;
+use commonware_parallel::Sequential;
 use commonware_utils::{ordered::Set, TryCollect};
 use libfuzzer_sys::fuzz_target;
 use rand::{rngs::StdRng, SeedableRng};
@@ -76,10 +77,18 @@ fuzz_target!(|input: FuzzInput| {
             fuzz::<ed25519::Scheme, _>(&input, RoundRobin::<Sha256>::shuffled(seed), None);
         }
         FuzzElector::RandomMinPk(certificate) => {
-            fuzz::<bls12381_threshold::Scheme<_, MinPk>, _>(&input, Random, Some(certificate));
+            fuzz::<bls12381_threshold::Scheme<_, MinPk, Sequential>, _>(
+                &input,
+                Random,
+                Some(certificate),
+            );
         }
         FuzzElector::RandomMinSig(certificate) => {
-            fuzz::<bls12381_threshold::Scheme<_, MinSig>, _>(&input, Random, Some(certificate));
+            fuzz::<bls12381_threshold::Scheme<_, MinSig, Sequential>, _>(
+                &input,
+                Random,
+                Some(certificate),
+            );
         }
     }
 });

--- a/consensus/fuzz/fuzz_targets/simplex_messages.rs
+++ b/consensus/fuzz/fuzz_targets/simplex_messages.rs
@@ -15,13 +15,14 @@ use commonware_cryptography::{
     ed25519::PublicKey,
     sha256,
 };
+use commonware_parallel::Sequential;
 use libfuzzer_sys::fuzz_target;
 
 type Ed25519Scheme = ed25519::Scheme;
 type Bls12381MultisigMinPk = bls12381_multisig::Scheme<PublicKey, MinPk>;
 type Bls12381MultisigMinSig = bls12381_multisig::Scheme<PublicKey, MinSig>;
-type ThresholdSchemeMinPk = bls12381_threshold::Scheme<PublicKey, MinPk>;
-type ThresholdSchemeMinSig = bls12381_threshold::Scheme<PublicKey, MinSig>;
+type ThresholdSchemeMinPk = bls12381_threshold::Scheme<PublicKey, MinPk, Sequential>;
+type ThresholdSchemeMinSig = bls12381_threshold::Scheme<PublicKey, MinSig, Sequential>;
 
 #[derive(Arbitrary, Debug)]
 enum FuzzInput {

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -128,6 +128,7 @@ mod tests {
         simulated::{self, Link, Network, Oracle},
         Manager,
     };
+    use commonware_parallel::Sequential;
     use commonware_runtime::{buffer::PoolRef, deterministic, Clock, Metrics, Quota, Runner};
     use commonware_storage::archive::immutable;
     use commonware_utils::{vec::NonEmptyVec, NZUsize, NZU16, NZU64};
@@ -147,7 +148,7 @@ mod tests {
     type B = Block<D>;
     type K = PublicKey;
     type V = MinPk;
-    type S = bls12381_threshold::Scheme<K, V>;
+    type S = bls12381_threshold::Scheme<K, V, Sequential>;
     type P = ConstantProvider<S, Epoch>;
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(1024);

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -233,13 +233,14 @@ mod tests {
         bls12381::primitives::variant::MinPk, certificate::mocks::Fixture,
         sha256::Digest as Sha256Digest, Sha256,
     };
+    use commonware_parallel::Sequential;
     use commonware_utils::{quorum_from_slice, TryFromIterator};
     use rand::{rngs::StdRng, SeedableRng};
 
     const NAMESPACE: &[u8] = b"test";
 
     type ThresholdScheme =
-        bls12381_threshold::Scheme<commonware_cryptography::ed25519::PublicKey, MinPk>;
+        bls12381_threshold::Scheme<commonware_cryptography::ed25519::PublicKey, MinPk, Sequential>;
 
     #[test]
     fn round_robin_rotates_through_participants() {

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -317,6 +317,7 @@ mod tests {
         simulated::{Config, Link, Network, Oracle, Receiver, Sender, SplitOrigin, SplitTarget},
         Recipients, Sender as _,
     };
+    use commonware_parallel::Sequential;
     use commonware_runtime::{
         buffer::PoolRef, count_running_tasks, deterministic, Clock, Metrics, Quota, Runner, Spawner,
     };
@@ -4763,7 +4764,7 @@ mod tests {
     fn tle<V, L>()
     where
         V: Variant,
-        L: Elector<bls12381_threshold::Scheme<PublicKey, V>>,
+        L: Elector<bls12381_threshold::Scheme<PublicKey, V, Sequential>>,
     {
         // Create context
         let n = 4;

--- a/consensus/src/simplex/scheme/reporter.rs
+++ b/consensus/src/simplex/scheme/reporter.rs
@@ -123,6 +123,7 @@ mod tests {
         sha256::Digest as Sha256Digest,
         Hasher, Sha256,
     };
+    use commonware_parallel::Sequential;
     use futures::executor::block_on;
     use rand::{rngs::StdRng, SeedableRng};
     use std::sync::{Arc, Mutex};
@@ -260,7 +261,7 @@ mod tests {
         } = bls12381_threshold::fixture::<MinPk, _>(&mut rng, NAMESPACE, 4);
 
         assert!(
-            !bls12381_threshold::Scheme::<Ed25519PublicKey, MinPk>::is_attributable(),
+            !bls12381_threshold::Scheme::<Ed25519PublicKey, MinPk, Sequential>::is_attributable(),
             "BLS threshold must be non-attributable"
         );
 
@@ -307,7 +308,7 @@ mod tests {
         } = bls12381_threshold::fixture::<MinPk, _>(&mut rng, NAMESPACE, 4);
 
         assert!(
-            !bls12381_threshold::Scheme::<Ed25519PublicKey, MinPk>::is_attributable(),
+            !bls12381_threshold::Scheme::<Ed25519PublicKey, MinPk, Sequential>::is_attributable(),
             "BLS threshold must be non-attributable"
         );
 

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -3241,8 +3241,9 @@ mod tests {
         use crate::simplex::scheme::bls12381_threshold;
         use commonware_codec::conformance::CodecConformance;
         use commonware_cryptography::{ed25519::PublicKey, sha256::Digest as Sha256Digest};
+        use commonware_parallel::Sequential;
 
-        type Scheme = bls12381_threshold::Scheme<PublicKey, MinSig>;
+        type Scheme = bls12381_threshold::Scheme<PublicKey, MinSig, Sequential>;
 
         commonware_conformance::conformance_tests! {
             CodecConformance<Vote<Scheme, Sha256Digest>>,


### PR DESCRIPTION
## Overview

Fixes the `Seedable` implementation for `bls12381_threshold::Scheme` in simplex. API blunder from https://github.com/commonwarexyz/monorepo/pull/2621
