### PR TITLE
[CI] Extend breaking changes timeout

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -183,7 +183,7 @@ jobs:
   conformance:
     name: Breaking Changes
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
     - name: Checkout repository
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4


### PR DESCRIPTION
Breaking changes is now running at ~57-60 minutes (and failed on `main`).