### PR TITLE
[utils] update test for array intersection and difference

### DIFF
--- a/utils/src/bitmap/roaring/container/array.rs
+++ b/utils/src/bitmap/roaring/container/array.rs
@@ -343,7 +343,6 @@ impl Array {
         }
 
         // Limited case: need to check limit
-        // let mut result = Vec::with_capacity(min_size.min(limit));
         let mut result = Vec::with_capacity(limit);
         let mut i = 0;
         let mut j = 0;
@@ -401,7 +400,7 @@ impl Array {
                         result.push(av);
                         i += 1;
                     }
-                    core::cmp::Ordering::Greater => { // possible and check for i=j
+                    core::cmp::Ordering::Greater => {
                         j += 1;
                     }
                     core::cmp::Ordering::Equal => {


### PR DESCRIPTION
This PR also removes the needless call to `min()` as `limit` is already restrained by prior `if` checks.