### PR TITLE
fix(storage): handle qmdb cursor insert after collisions

### DIFF
--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -233,6 +233,7 @@ where
     }
 
     // The key wasn't in the snapshot, so add it to the cursor.
+    cursor.next();
     cursor.insert(new_loc);
 
     Ok(None)
@@ -262,6 +263,7 @@ where
     }
 
     // The key doesn't exist, so add it to the cursor.
+    cursor.next();
     cursor.insert(new_loc);
 
     Ok(true)


### PR DESCRIPTION
fixes https://github.com/commonwarexyz/monorepo/issues/2823

## Summary
- call `cursor.next()` before insert when adding a new key after translated-key collisions
- add regression test for collision updates in QMDB unordered fixed

## Testing
- cargo test -p commonware-storage test_update_handles_translator_collisions