### PR TITLE
[cryptography] 2701, document RecvCipher::recv caveats

### DIFF
--- a/cryptography/src/handshake/cipher.rs
+++ b/cryptography/src/handshake/cipher.rs
@@ -80,15 +80,15 @@ impl RecvCipher {
     ///
     /// # Errors
     ///
-    /// This will return an error in the following situations:
+    /// This function will return an error in the following situations:
     ///
     /// - Too many messages have been received with this cipher.
     /// - The ciphertext was corrupted in some way.
     ///
     /// In *both* cases, the `RecvCipher` will no longer be able to return
     /// valid ciphertexts, and will always return an error on subsequent calls
-    /// to [`Self::recv`]. Terminating, and potentially reëstablishing,
-    /// the connection is a simple way to handle this case.
+    /// to [`Self::recv`]. Terminating (and optionally reestablishing) the connection
+    /// is a simple (and safe) way to handle this scenario.
     pub fn recv(&mut self, encrypted_data: &[u8]) -> Result<Vec<u8>, Error> {
         let nonce = self.nonce.inc()?;
         self.inner


### PR DESCRIPTION
Closes #2701.

Documents the behavior of `RecvCipher::recv` after a ciphertext fails to authenticate.