### PR TITLE
Improve proofs malleability fuzz test

### DIFF
--- a/storage/fuzz/fuzz_targets/proofs_malleability.rs
+++ b/storage/fuzz/fuzz_targets/proofs_malleability.rs
@@ -119,11 +119,7 @@ where
 }
 
 fn fuzz(input: FuzzInput) {
-    let digests: Vec<Digest> = input
-        .elements
-        .iter()
-        .map(|&v| Sha256::hash(&[v]))
-        .collect();
+    let digests: Vec<Digest> = input.elements.iter().map(|&v| Sha256::hash(&[v])).collect();
 
     match input.proof {
         ProofType::Mmr => {


### PR DESCRIPTION
This PR adds `verify_range_inclusion` to the `proofs_malleability` fuzz test.