### PR TITLE
[storage/journal/contiguous] allow concurrent reads during Persistable::sync()

### DIFF
--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -801,7 +801,7 @@ impl<
         let mut certified = Vec::new();
         let mut acks = Vec::new();
         let stream = journal
-            .replay(0, 0, self.journal_replay_buffer)
+            .replay(self.journal_replay_buffer, 0, 0)
             .await
             .expect("replay failed");
         pin_mut!(stream);

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -1045,7 +1045,7 @@ impl<
 
             // Prepare the stream
             let stream = journal
-                .replay(0, 0, self.journal_replay_buffer)
+                .replay(self.journal_replay_buffer, 0, 0)
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -698,7 +698,7 @@ impl<
         let start = self.context.current();
         {
             let stream = journal
-                .replay(0, 0, self.replay_buffer)
+                .replay(self.replay_buffer, 0, 0)
                 .await
                 .expect("unable to replay journal");
             pin_mut!(stream);

--- a/examples/reshare/src/dkg/state.rs
+++ b/examples/reshare/src/dkg/state.rs
@@ -219,7 +219,7 @@ impl<E: Clock + RuntimeStorage + Metrics, V: Variant, P: PublicKey> Storage<E, V
         let mut epochs = BTreeMap::<EpochNum, EpochCache<V, P>>::new();
         {
             let replay = msgs
-                .replay(0, 0, READ_BUFFER)
+                .replay(READ_BUFFER, 0, 0)
                 .await
                 .expect("should be able to replay msgs");
             futures::pin_mut!(replay);

--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -152,7 +152,7 @@ where
             };
 
         let database: any::Database<_> = sync::sync(sync_config).await?;
-        let got_root = database.root();
+        let got_root = database.root().await;
         info!(
             sync_iteration = iteration,
             root = %got_root,
@@ -212,7 +212,7 @@ where
             };
 
         let database: immutable::Database<_> = sync::sync(sync_config).await?;
-        let got_root = database.root();
+        let got_root = database.root().await;
         info!(
             sync_iteration = iteration,
             root = %got_root,

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -19,7 +19,7 @@ use commonware_storage::{
     },
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
-use std::{future::Future, num::NonZeroU64};
+use std::num::NonZeroU64;
 use tracing::error;
 
 /// Database type alias for the Clean state.
@@ -112,25 +112,25 @@ where
         panic!("operations should end with a commit");
     }
 
-    fn root(&self) -> Key {
-        self.root()
+    async fn root(&self) -> Key {
+        self.root().await
     }
 
-    fn size(&self) -> Location {
-        LogStore::bounds(self).end
+    async fn size(&self) -> Location {
+        LogStore::bounds(self).await.end
     }
 
-    fn inactivity_floor(&self) -> Location {
+    async fn inactivity_floor(&self) -> Location {
         self.inactivity_floor_loc()
     }
 
-    fn historical_proof(
+    async fn historical_proof(
         &self,
         op_count: Location,
         start_loc: Location,
         max_ops: NonZeroU64,
-    ) -> impl Future<Output = Result<(Proof<Key>, Vec<Self::Operation>), qmdb::Error>> + Send {
-        self.historical_proof(op_count, start_loc, max_ops)
+    ) -> Result<(Proof<Key>, Vec<Self::Operation>), qmdb::Error> {
+        self.historical_proof(op_count, start_loc, max_ops).await
     }
 
     fn name() -> &'static str {

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -13,7 +13,7 @@ use commonware_storage::{
     },
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
-use std::{future::Future, num::NonZeroU64};
+use std::num::NonZeroU64;
 use tracing::error;
 
 /// Database type alias for the clean (merkleized, durable) state.
@@ -113,27 +113,27 @@ where
         unreachable!("operations must end with a commit");
     }
 
-    fn root(&self) -> Key {
-        self.root()
+    async fn root(&self) -> Key {
+        self.root().await
     }
 
-    fn size(&self) -> Location {
-        LogStore::bounds(self).end
+    async fn size(&self) -> Location {
+        LogStore::bounds(self).await.end
     }
 
-    fn inactivity_floor(&self) -> Location {
+    async fn inactivity_floor(&self) -> Location {
         // For Immutable databases, all retained operations are active,
         // so the inactivity floor equals the pruning boundary.
-        LogStore::bounds(self).start
+        LogStore::bounds(self).await.start
     }
 
-    fn historical_proof(
+    async fn historical_proof(
         &self,
         op_count: Location,
         start_loc: Location,
         max_ops: NonZeroU64,
-    ) -> impl Future<Output = Result<(Proof<Key>, Vec<Self::Operation>), qmdb::Error>> + Send {
-        self.historical_proof(op_count, start_loc, max_ops)
+    ) -> Result<(Proof<Key>, Vec<Self::Operation>), qmdb::Error> {
+        self.historical_proof(op_count, start_loc, max_ops).await
     }
 
     fn name() -> &'static str {

--- a/examples/sync/src/databases/mod.rs
+++ b/examples/sync/src/databases/mod.rs
@@ -58,13 +58,13 @@ pub trait Syncable: Sized {
     ) -> impl Future<Output = Result<Self, qmdb::Error>>;
 
     /// Get the database's root digest.
-    fn root(&self) -> Key;
+    fn root(&self) -> impl Future<Output = Key> + Send;
 
     /// Get the total number of operations in the database (including pruned operations).
-    fn size(&self) -> Location;
+    fn size(&self) -> impl Future<Output = Location> + Send;
 
     /// Get the inactivity floor, the location below which all operations are inactive.
-    fn inactivity_floor(&self) -> Location;
+    fn inactivity_floor(&self) -> impl Future<Output = Location> + Send;
 
     /// Get historical proof and operations.
     fn historical_proof(

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -126,7 +126,7 @@ fn fuzz(data: FuzzInput) {
                         // Account for the previous key update
                         uncommitted_ops += 1;
                     }
-                    let actual_count = db.bounds().end;
+                    let actual_count = db.bounds().await.end;
                     let expected_count = last_committed_op_count + uncommitted_ops;
                     assert_eq!(actual_count, expected_count,
                         "Operation count mismatch: expected {expected_count} (last_known={last_committed_op_count} + uncommitted={uncommitted_ops}), got {actual_count}");
@@ -175,7 +175,7 @@ fn fuzz(data: FuzzInput) {
                 }
 
                 CurrentOperation::OpCount => {
-                    let actual_count = db.bounds().end;
+                    let actual_count = db.bounds().await.end;
                     let expected_count = last_committed_op_count + uncommitted_ops;
                     assert_eq!(actual_count, expected_count,
                         "Operation count mismatch: expected {expected_count}, got {actual_count}");
@@ -184,7 +184,7 @@ fn fuzz(data: FuzzInput) {
                 CurrentOperation::Commit => {
                     let (durable_db, _) = db.commit(None).await.expect("Commit should not fail");
                     let clean_db = durable_db.into_merkleized().await.expect("into_merkleized should not fail");
-                    last_committed_op_count = clean_db.bounds().end;
+                    last_committed_op_count = clean_db.bounds().await.end;
                     uncommitted_ops = 0;
                     db = clean_db.into_mutable();
                 }
@@ -202,7 +202,7 @@ fn fuzz(data: FuzzInput) {
                 }
 
                 CurrentOperation::RangeProof { start_loc, max_ops } => {
-                    let current_op_count = db.bounds().end;
+                    let current_op_count = db.bounds().await.end;
 
                     if current_op_count > 0 {
                         let merkleized_db = db.into_merkleized().await.expect("into_merkleized should not fail");
@@ -235,7 +235,7 @@ fn fuzz(data: FuzzInput) {
                 }
 
                 CurrentOperation::ArbitraryProof {start_loc, bad_digests, max_ops, bad_chunks} => {
-                    let current_op_count = db.bounds().end;
+                    let current_op_count = db.bounds().await.end;
                     if current_op_count == 0 {
                         continue;
                     }

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -153,7 +153,7 @@ fn fuzz(data: FuzzInput) {
                 }
 
                 CurrentOperation::OpCount => {
-                    let actual_count = db.bounds().end;
+                    let actual_count = db.bounds().await.end;
                     let expected_count = last_committed_op_count + uncommitted_ops;
                     assert_eq!(actual_count, expected_count,
                         "Operation count mismatch: expected {expected_count}, got {actual_count}");
@@ -162,7 +162,7 @@ fn fuzz(data: FuzzInput) {
                 CurrentOperation::Commit => {
                     let (durable_db, _) = db.commit(None).await.expect("Commit should not fail");
                     let clean_db = durable_db.into_merkleized().await.expect("into_merkleized should not fail");
-                    last_committed_op_count = clean_db.bounds().end;
+                    last_committed_op_count = clean_db.bounds().await.end;
                     uncommitted_ops = 0;
                     db = clean_db.into_mutable();
                 }
@@ -180,7 +180,7 @@ fn fuzz(data: FuzzInput) {
                 }
 
                 CurrentOperation::RangeProof { start_loc, max_ops } => {
-                    let current_op_count = db.bounds().end;
+                    let current_op_count = db.bounds().await.end;
                     if current_op_count == 0 {
                         continue;
                     }
@@ -213,7 +213,7 @@ fn fuzz(data: FuzzInput) {
                 }
 
                 CurrentOperation::ArbitraryProof {start_loc, bad_digests, max_ops, bad_chunks} => {
-                    let current_op_count = db.bounds().end;
+                    let current_op_count = db.bounds().await.end;
                     if current_op_count == 0 {
                         continue;
                     }

--- a/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
@@ -99,7 +99,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 JournalOperation::Size => {
-                    let size = journal.size();
+                    let size = journal.size().await;
                     assert_eq!(journal_size, size, "unexpected size");
                 }
 
@@ -116,7 +116,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 JournalOperation::Bounds => {
-                    let _bounds = journal.bounds();
+                    let _bounds = journal.bounds().await;
                 }
 
                 JournalOperation::Prune { min_pos } => {
@@ -163,8 +163,8 @@ fn fuzz(input: FuzzInput) {
                     .unwrap();
                     restarts += 1;
                     // Reset tracking variables to match recovered state
-                    journal_size = journal.size();
-                    let bounds = journal.bounds();
+                    journal_size = journal.size().await;
+                    let bounds = journal.bounds().await;
                     oldest_retained_pos = if bounds.is_empty() { 0 } else { bounds.start };
                 }
 

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -160,8 +160,8 @@ trait FuzzJournal: Sized {
         cfg: Self::Config,
     ) -> impl std::future::Future<Output = Result<Self, commonware_storage::journal::Error>> + Send;
 
-    fn size(&self) -> u64;
-    fn bounds(&self) -> Range<u64>;
+    async fn size(&self) -> u64;
+    async fn bounds(&self) -> Range<u64>;
 
     fn append(
         &mut self,
@@ -229,12 +229,12 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::init(ctx, cfg).await
     }
 
-    fn size(&self) -> u64 {
-        FixedJournal::size(self)
+    async fn size(&self) -> u64 {
+        <FixedJournal<deterministic::Context, Item>>::size(self).await
     }
 
-    fn bounds(&self) -> Range<u64> {
-        FixedJournal::bounds(self)
+    async fn bounds(&self) -> Range<u64> {
+        <FixedJournal<deterministic::Context, Item>>::bounds(self).await
     }
 
     async fn append(&mut self, item: Item) -> Result<u64, commonware_storage::journal::Error> {
@@ -302,12 +302,14 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::init(ctx, cfg).await
     }
 
-    fn size(&self) -> u64 {
-        VariableJournal::size(self)
+    async fn size(&self) -> u64 {
+        <VariableJournal<deterministic::Context, Item>>::bounds(self)
+            .await
+            .end
     }
 
-    fn bounds(&self) -> Range<u64> {
-        VariableJournal::bounds(self)
+    async fn bounds(&self) -> Range<u64> {
+        <VariableJournal<deterministic::Context, Item>>::bounds(self).await
     }
 
     async fn append(&mut self, item: Item) -> Result<u64, commonware_storage::journal::Error> {
@@ -335,7 +337,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<(), commonware_storage::journal::Error> {
-        let _ = VariableJournal::replay(self, start_pos, buffer).await?;
+        let _ = VariableJournal::replay(self, buffer, start_pos).await?;
         Ok(())
     }
 
@@ -353,19 +355,19 @@ async fn run_operations<J: FuzzJournal>(
     operations: &[JournalOperation],
 ) -> (u64, u64, u64, u64) {
     let mut min_expected_size = 0u64;
-    let mut max_expected_size = journal.size();
+    let mut max_expected_size = journal.size().await;
     let mut min_expected_oldest = 0u64;
-    let mut max_expected_oldest = journal.bounds().start;
+    let mut max_expected_oldest = journal.bounds().await.start;
 
     for op in operations.iter() {
         let step_result: Result<(), ()> = match op {
             JournalOperation::Append { value } => {
-                let size_before = journal.size();
+                let size_before = journal.size().await;
                 if journal.append(Item::from(*value)).await.is_err() {
                     max_expected_size = max_expected_size.max(size_before + 1);
                     Err(())
                 } else {
-                    max_expected_size = max_expected_size.max(journal.size());
+                    max_expected_size = max_expected_size.max(journal.size().await);
                     Ok(())
                 }
             }
@@ -379,10 +381,10 @@ async fn run_operations<J: FuzzJournal>(
                 if journal.sync().await.is_err() {
                     Err(())
                 } else {
-                    let size = journal.size();
+                    let size = journal.size().await;
                     min_expected_size = size;
                     max_expected_size = max_expected_size.max(size);
-                    let oldest = journal.bounds().start;
+                    let oldest = journal.bounds().await.start;
                     min_expected_oldest = oldest;
                     max_expected_oldest = max_expected_oldest.max(oldest);
                     Ok(())
@@ -390,7 +392,7 @@ async fn run_operations<J: FuzzJournal>(
             }
 
             JournalOperation::Rewind { size } => {
-                let prev_size = journal.size();
+                let prev_size = journal.size().await;
                 if *size >= prev_size {
                     Ok(())
                 } else if journal.rewind(*size).await.is_err() {
@@ -404,12 +406,13 @@ async fn run_operations<J: FuzzJournal>(
 
             JournalOperation::Prune { min_pos } => match journal.prune(*min_pos).await {
                 Err(_) => {
-                    max_expected_oldest = max_expected_oldest.max((*min_pos).min(journal.size()));
+                    max_expected_oldest =
+                        max_expected_oldest.max((*min_pos).min(journal.size().await));
                     Err(())
                 }
                 Ok(false) => Ok(()),
                 Ok(true) => {
-                    let new_oldest = journal.bounds().start;
+                    let new_oldest = journal.bounds().await.start;
                     min_expected_oldest = new_oldest;
                     max_expected_oldest = new_oldest;
                     Ok(())
@@ -429,10 +432,10 @@ async fn run_operations<J: FuzzJournal>(
                 if journal.commit().await.is_err() {
                     Err(())
                 } else {
-                    let size = journal.size();
+                    let size = journal.size().await;
                     min_expected_size = size;
                     max_expected_size = size;
-                    let oldest = journal.bounds().start;
+                    let oldest = journal.bounds().await.start;
                     min_expected_oldest = oldest;
                     max_expected_oldest = oldest;
                     Ok(())
@@ -460,8 +463,8 @@ async fn verify_recovery<J: FuzzJournal>(
     min_expected_oldest: u64,
     max_expected_oldest: u64,
 ) {
-    let size = journal.size();
-    let oldest = journal.bounds().start;
+    let size = journal.size().await;
+    let oldest = journal.bounds().await.start;
     assert!(size >= oldest);
 
     assert!(

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -7,6 +7,7 @@ use commonware_runtime::{deterministic, Metrics as _, Runner};
 use commonware_storage::journal::contiguous::{
     fixed::{Config as FixedConfig, Journal as FixedJournal},
     variable::{Config as VariableConfig, Journal as VariableJournal},
+    ContiguousReader as _,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU64};
 use libfuzzer_sys::fuzz_target;
@@ -262,7 +263,8 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<(), commonware_storage::journal::Error> {
-        let _ = FixedJournal::replay(self, buffer, start_pos).await?;
+        let reader = FixedJournal::reader(self).await;
+        let _ = reader.replay(buffer, start_pos).await?;
         Ok(())
     }
 
@@ -337,7 +339,8 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<(), commonware_storage::journal::Error> {
-        let _ = VariableJournal::replay(self, buffer, start_pos).await?;
+        let reader = VariableJournal::reader(self).await;
+        let _ = reader.replay(buffer, start_pos).await?;
         Ok(())
     }
 

--- a/storage/fuzz/fuzz_targets/mmr_journaled.rs
+++ b/storage/fuzz/fuzz_targets/mmr_journaled.rs
@@ -138,12 +138,12 @@ fn fuzz(input: FuzzInput) {
                         MmrState::Dirty(m) => m,
                     };
 
-                    let size_before = mmr.size();
+                    let size_before = mmr.size().await;
                     let pos = mmr.add(&mut hasher, limited_data).await.unwrap();
                     leaves.push(limited_data.to_vec());
-                    historical_sizes.push(mmr.size());
-                    assert!(mmr.size() > size_before);
-                    assert_eq!(mmr.last_leaf_pos(), Some(pos));
+                    historical_sizes.push(mmr.size().await);
+                    assert!(mmr.size().await > size_before);
+                    assert_eq!(mmr.last_leaf_pos().await, Some(pos));
 
                     MmrState::Dirty(mmr)
                 }
@@ -164,13 +164,13 @@ fn fuzz(input: FuzzInput) {
                         MmrState::Dirty(m) => m,
                     };
 
-                    let size_before = mmr.size();
+                    let size_before = mmr.size().await;
                     let pos = mmr.add(&mut hasher, limited_data).await.unwrap();
-                    assert!(mmr.size() > size_before);
+                    assert!(mmr.size().await > size_before);
 
                     leaves.push(limited_data.to_vec());
-                    historical_sizes.push(mmr.size());
-                    assert_eq!(mmr.last_leaf_pos(), Some(pos));
+                    historical_sizes.push(mmr.size().await);
+                    assert_eq!(mmr.last_leaf_pos().await, Some(pos));
 
                     MmrState::Dirty(mmr)
                 }
@@ -182,9 +182,9 @@ fn fuzz(input: FuzzInput) {
                         MmrState::Dirty(m) => m,
                     };
 
-                    if count as u64 <= mmr.leaves() {
+                    if count as u64 <= mmr.leaves().await {
                         let _ = mmr.pop(count as usize).await;
-                        let new_len = mmr.leaves();
+                        let new_len = mmr.leaves().await;
                         leaves.truncate(new_len.as_u64() as usize);
                     }
                     MmrState::Dirty(mmr)
@@ -206,16 +206,17 @@ fn fuzz(input: FuzzInput) {
                         MmrState::Dirty(m) => m.merkleize(&mut hasher),
                     };
 
-                    if mmr.leaves() > 0 {
-                        let location = location % mmr.leaves().as_u64();
+                    let leaves_count = mmr.leaves().await;
+                    if leaves_count > 0 {
+                        let location = location % leaves_count.as_u64();
                         let location = Location::new(location).unwrap();
                         let position = Position::try_from(location).unwrap();
-                        let bounds = mmr.bounds();
+                        let bounds = mmr.bounds().await;
                         if bounds.contains(&position) {
                             let element = leaves.get(location.as_u64() as usize).unwrap();
 
                             if let Ok(proof) = mmr.proof(location).await {
-                                let root = mmr.root();
+                                let root = mmr.root().await;
                                 assert!(proof.verify_element_inclusion(
                                     &mut hasher,
                                     element,
@@ -240,17 +241,18 @@ fn fuzz(input: FuzzInput) {
                         MmrState::Dirty(m) => m.merkleize(&mut hasher),
                     };
 
-                    if mmr.leaves() > 0 {
+                    let leaves_count = mmr.leaves().await;
+                    if leaves_count > 0 {
                         let range =
                             Location::new(start_loc).unwrap()..Location::new(end_loc).unwrap();
                         let start_pos = Position::try_from(range.start).unwrap();
 
-                        if start_loc < mmr.leaves()
-                            && end_loc < mmr.leaves()
-                            && mmr.bounds().contains(&start_pos)
+                        if start_loc < mmr.leaves().await
+                            && end_loc < mmr.leaves().await
+                            && mmr.bounds().await.contains(&start_pos)
                         {
                             if let Ok(proof) = mmr.range_proof(range.clone()).await {
-                                let root = mmr.root();
+                                let root = mmr.root().await;
                                 assert!(proof.verify_range_inclusion(
                                     &mut hasher,
                                     &leaves[range.to_usize_range()],
@@ -275,21 +277,22 @@ fn fuzz(input: FuzzInput) {
                         MmrState::Dirty(m) => m.merkleize(&mut hasher),
                     };
 
-                    if mmr.leaves() > 0 {
+                    let leaves_count = mmr.leaves().await;
+                    if leaves_count > 0 {
                         // Ensure the size represents a valid MMR structure
                         let start_pos = Position::from(start_loc);
-                        if start_loc < mmr.leaves()
-                            && end_loc < mmr.leaves()
-                            && mmr.bounds().contains(&start_pos)
+                        if start_loc < mmr.leaves().await
+                            && end_loc < mmr.leaves().await
+                            && mmr.bounds().await.contains(&start_pos)
                         {
                             let range =
                                 Location::new(start_loc).unwrap()..Location::new(end_loc).unwrap();
 
                             if let Ok(historical_proof) = mmr
-                                .historical_range_proof(mmr.leaves(), range.clone())
+                                .historical_range_proof(leaves_count, range.clone())
                                 .await
                             {
-                                let root = mmr.root();
+                                let root = mmr.root().await;
                                 assert!(historical_proof.verify_range_inclusion(
                                     &mut hasher,
                                     &leaves[range.to_usize_range()],
@@ -303,7 +306,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 MmrJournaledOperation::Sync => {
-                    let mut mmr = match mmr {
+                    let mmr = match mmr {
                         MmrState::Clean(m) => m,
                         MmrState::Dirty(m) => m.merkleize(&mut hasher),
                     };
@@ -336,10 +339,11 @@ fn fuzz(input: FuzzInput) {
                         MmrState::Clean(m) => m,
                         MmrState::Dirty(m) => m.merkleize(&mut hasher),
                     };
-                    if mmr.size() > 0 {
-                        let safe_pos = pos % (mmr.size() + 1).as_u64();
+                    let size = mmr.size().await;
+                    if size > 0 {
+                        let safe_pos = pos % (size + 1).as_u64();
                         mmr.prune_to_pos(safe_pos.into()).await.unwrap();
-                        assert!(mmr.bounds().start <= mmr.size());
+                        assert!(mmr.bounds().await.start <= mmr.size().await);
                     }
                     MmrState::Clean(mmr)
                 }
@@ -350,42 +354,42 @@ fn fuzz(input: FuzzInput) {
                         MmrState::Clean(m) => m,
                         MmrState::Dirty(m) => m.merkleize(&mut hasher),
                     };
-                    let _ = mmr.root();
+                    let _ = mmr.root().await;
                     MmrState::Clean(mmr)
                 }
 
                 MmrJournaledOperation::GetSize => {
                     match &mmr {
                         MmrState::Clean(m) => {
-                            let _ = m.size();
+                            let _ = m.size().await;
                         }
                         MmrState::Dirty(m) => {
-                            let _ = m.size();
+                            let _ = m.size().await;
                         }
                     }
                     mmr
                 }
 
                 MmrJournaledOperation::GetLeaves => {
-                    let (leaves, size) = match &mmr {
-                        MmrState::Clean(m) => (m.leaves().as_u64(), m.size().as_u64()),
-                        MmrState::Dirty(m) => (m.leaves().as_u64(), m.size().as_u64()),
+                    let (leaves_count, size_val) = match &mmr {
+                        MmrState::Clean(m) => (m.leaves().await.as_u64(), m.size().await.as_u64()),
+                        MmrState::Dirty(m) => (m.leaves().await.as_u64(), m.size().await.as_u64()),
                     };
-                    assert!(leaves <= size);
+                    assert!(leaves_count <= size_val);
                     mmr
                 }
 
                 MmrJournaledOperation::GetLastLeafPos => {
                     match &mmr {
                         MmrState::Clean(m) => {
-                            let last_pos = m.last_leaf_pos();
-                            if m.size() > 0 && m.leaves() > 0 {
+                            let last_pos = m.last_leaf_pos().await;
+                            if m.size().await > 0 && m.leaves().await > 0 {
                                 assert!(last_pos.is_some());
                             }
                         }
                         MmrState::Dirty(m) => {
-                            let last_pos = m.last_leaf_pos();
-                            if m.size() > 0 && m.leaves() > 0 {
+                            let last_pos = m.last_leaf_pos().await;
+                            if m.size().await > 0 && m.leaves().await > 0 {
                                 assert!(last_pos.is_some());
                             }
                         }
@@ -396,12 +400,12 @@ fn fuzz(input: FuzzInput) {
                 MmrJournaledOperation::GetPrunedToPos => {
                     match &mmr {
                         MmrState::Clean(m) => {
-                            let pruned_pos = m.bounds().start;
-                            assert!(pruned_pos <= m.size());
+                            let pruned_pos = m.bounds().await.start;
+                            assert!(pruned_pos <= m.size().await);
                         }
                         MmrState::Dirty(m) => {
-                            let pruned_pos = m.bounds().start;
-                            assert!(pruned_pos <= m.size());
+                            let pruned_pos = m.bounds().await.start;
+                            assert!(pruned_pos <= m.size().await);
                         }
                     }
                     mmr
@@ -410,15 +414,15 @@ fn fuzz(input: FuzzInput) {
                 MmrJournaledOperation::GetOldestRetainedPos => {
                     match &mmr {
                         MmrState::Clean(m) => {
-                            let bounds = m.bounds();
+                            let bounds = m.bounds().await;
                             if !bounds.is_empty() {
-                                assert!(bounds.start < m.size());
+                                assert!(bounds.start < m.size().await);
                             }
                         }
                         MmrState::Dirty(m) => {
-                            let bounds = m.bounds();
+                            let bounds = m.bounds().await;
                             if !bounds.is_empty() {
-                                assert!(bounds.start < m.size());
+                                assert!(bounds.start < m.size().await);
                             }
                         }
                     }
@@ -440,7 +444,7 @@ fn fuzz(input: FuzzInput) {
                     restarts += 1;
 
                     // Truncate tracking variables to match recovered state
-                    let recovered_leaves = new_mmr.leaves().as_u64() as usize;
+                    let recovered_leaves = new_mmr.leaves().await.as_u64() as usize;
                     leaves.truncate(recovered_leaves);
                     historical_sizes.truncate(recovered_leaves);
                     MmrState::Clean(new_mmr)
@@ -473,8 +477,8 @@ fn fuzz(input: FuzzInput) {
                     )
                     .await
                     {
-                        assert!(sync_mmr.size() <= upper_bound_pos);
-                        assert_eq!(sync_mmr.bounds().start, lower_bound_pos);
+                        assert!(sync_mmr.size().await <= upper_bound_pos);
+                        assert_eq!(sync_mmr.bounds().await.start, lower_bound_pos);
                         sync_mmr.destroy().await.unwrap();
                     }
                     restarts += 1;

--- a/storage/fuzz/fuzz_targets/mmr_journaled.rs
+++ b/storage/fuzz/fuzz_targets/mmr_journaled.rs
@@ -247,8 +247,8 @@ fn fuzz(input: FuzzInput) {
                             Location::new(start_loc).unwrap()..Location::new(end_loc).unwrap();
                         let start_pos = Position::try_from(range.start).unwrap();
 
-                        if start_loc < mmr.leaves().await
-                            && end_loc < mmr.leaves().await
+                        if start_loc < leaves_count
+                            && end_loc < leaves_count
                             && mmr.bounds().await.contains(&start_pos)
                         {
                             if let Ok(proof) = mmr.range_proof(range.clone()).await {
@@ -281,8 +281,8 @@ fn fuzz(input: FuzzInput) {
                     if leaves_count > 0 {
                         // Ensure the size represents a valid MMR structure
                         let start_pos = Position::from(start_loc);
-                        if start_loc < mmr.leaves().await
-                            && end_loc < mmr.leaves().await
+                        if start_loc < leaves_count
+                            && end_loc < leaves_count
                             && mmr.bounds().await.contains(&start_pos)
                         {
                             let range =

--- a/storage/fuzz/fuzz_targets/mmr_journaled_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/mmr_journaled_crash_recovery.rs
@@ -118,16 +118,16 @@ async fn run_operations(
     operations: &[MmrOperation],
 ) -> ExpectedBounds {
     let mut min_size = 0u64;
-    let mut max_size = mmr.size().as_u64();
+    let mut max_size = mmr.size().await.as_u64();
     let mut min_leaves = 0u64;
-    let mut max_leaves = mmr.leaves().as_u64();
+    let mut max_leaves = mmr.leaves().await.as_u64();
     let mut min_pruned = 0u64;
-    let mut max_pruned = mmr.bounds().start.as_u64();
+    let mut max_pruned = mmr.bounds().await.start.as_u64();
 
     for op in operations.iter() {
         let step_result: Result<UnmerkleizedMmr, ()> = match op {
             MmrOperation::Add { data } => {
-                let leaves_before = mmr.leaves().as_u64();
+                let leaves_before = mmr.leaves().await.as_u64();
 
                 if mmr.add(hasher, data).await.is_err() {
                     // Partial write possible: max is size after one leaf added
@@ -139,18 +139,18 @@ async fn run_operations(
                     max_leaves = max_leaves.max(leaves_before + 1);
                     Err(())
                 } else {
-                    max_size = max_size.max(mmr.size().as_u64());
-                    max_leaves = max_leaves.max(mmr.leaves().as_u64());
+                    max_size = max_size.max(mmr.size().await.as_u64());
+                    max_leaves = max_leaves.max(mmr.leaves().await.as_u64());
                     Ok(mmr)
                 }
             }
 
             MmrOperation::Pop { count } => {
                 let count = *count as usize;
-                if count == 0 || count as u64 > mmr.leaves().as_u64() {
+                if count == 0 || count as u64 > mmr.leaves().await.as_u64() {
                     Ok(mmr)
                 } else {
-                    let target_leaves = mmr.leaves().as_u64() - count as u64;
+                    let target_leaves = mmr.leaves().await.as_u64() - count as u64;
 
                     if mmr.pop(count).await.is_err() {
                         // Partial pop possible: min could be target
@@ -167,22 +167,22 @@ async fn run_operations(
                         Err(())
                     } else {
                         // Pop decreases size: update min bounds
-                        min_size = min_size.min(mmr.size().as_u64());
-                        min_leaves = min_leaves.min(mmr.leaves().as_u64());
+                        min_size = min_size.min(mmr.size().await.as_u64());
+                        min_leaves = min_leaves.min(mmr.leaves().await.as_u64());
                         Ok(mmr)
                     }
                 }
             }
 
             MmrOperation::Sync => {
-                let mut clean_mmr = mmr.merkleize(hasher);
+                let clean_mmr = mmr.merkleize(hasher);
                 if clean_mmr.sync().await.is_err() {
                     Err(())
                 } else {
                     // Sync commits state: update all bounds to current values
-                    let size = clean_mmr.size().as_u64();
-                    let leaves = clean_mmr.leaves().as_u64();
-                    let pruned = clean_mmr.bounds().start.as_u64();
+                    let size = clean_mmr.size().await.as_u64();
+                    let leaves = clean_mmr.leaves().await.as_u64();
+                    let pruned = clean_mmr.bounds().await.start.as_u64();
                     min_size = size;
                     max_size = max_size.max(size);
                     min_leaves = leaves;
@@ -194,8 +194,8 @@ async fn run_operations(
             }
 
             MmrOperation::PruneToPos { pos } => {
-                let size = mmr.size().as_u64();
-                let current_pruned = mmr.bounds().start.as_u64();
+                let size = mmr.size().await.as_u64();
+                let current_pruned = mmr.bounds().await.start.as_u64();
                 let safe_pos = (*pos).min(size);
 
                 if safe_pos <= current_pruned {
@@ -211,7 +211,7 @@ async fn run_operations(
                         }
                         Ok(_) => {
                             // Prune commits: update both bounds to actual value
-                            let pruned = clean_mmr.bounds().start.as_u64();
+                            let pruned = clean_mmr.bounds().await.start.as_u64();
                             min_pruned = pruned;
                             max_pruned = pruned;
                             Ok(clean_mmr.into_dirty())
@@ -221,8 +221,8 @@ async fn run_operations(
             }
 
             MmrOperation::PruneAll => {
-                let size = mmr.size().as_u64();
-                let current_pruned = mmr.bounds().start.as_u64();
+                let size = mmr.size().await.as_u64();
+                let current_pruned = mmr.bounds().await.start.as_u64();
 
                 if size == 0 || current_pruned >= size {
                     // No-op: nothing to prune
@@ -237,7 +237,7 @@ async fn run_operations(
                         }
                         Ok(_) => {
                             // Prune commits: update both bounds to actual value
-                            let pruned = clean_mmr.bounds().start.as_u64();
+                            let pruned = clean_mmr.bounds().await.start.as_u64();
                             min_pruned = pruned;
                             max_pruned = pruned;
                             Ok(clean_mmr.into_dirty())
@@ -331,9 +331,9 @@ fn fuzz(input: FuzzInput) {
         .expect("MMR recovery should succeed");
 
         // Verify recovered state is within expected bounds
-        let size = mmr.size().as_u64();
-        let leaves = mmr.leaves().as_u64();
-        let pruned = mmr.bounds().start.as_u64();
+        let size = mmr.size().await.as_u64();
+        let leaves = mmr.leaves().await.as_u64();
+        let pruned = mmr.bounds().await.start.as_u64();
 
         assert!(
             size <= bounds.max_size,

--- a/storage/fuzz/fuzz_targets/ordinal_operations.rs
+++ b/storage/fuzz/fuzz_targets/ordinal_operations.rs
@@ -242,7 +242,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 OrdinalOperation::ReopenAfterOperations => {
-                    if let Some(mut o) = store.take() {
+                    if let Some(o) = store.take() {
                         // Sync and drop the current ordinal
                         o.sync().await.expect("failed to sync store before reopen failed");
                         drop(o);

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -132,7 +132,7 @@ async fn test_sync<
     };
 
     if let Ok(synced) = sync::sync(sync_config).await {
-        let actual_root = synced.root();
+        let actual_root = synced.root().await;
         assert_eq!(
             actual_root, expected_root,
             "Synced root must match target root"
@@ -202,7 +202,7 @@ fn fuzz(mut input: FuzzInput) {
                 }
 
                 Operation::SyncFull { fetch_batch_size } => {
-                    if db.bounds().end == 0 {
+                    if db.bounds().await.end == 0 {
                         continue;
                     }
                     input.commit_counter += 1;
@@ -215,8 +215,8 @@ fn fuzz(mut input: FuzzInput) {
                     let clean_db = durable_db.into_merkleized();
 
                     let target = sync::Target {
-                        root: clean_db.root(),
-                        range: clean_db.inactivity_floor_loc()..clean_db.bounds().end,
+                        root: clean_db.root().await,
+                        range: clean_db.inactivity_floor_loc()..clean_db.bounds().await.end,
                     };
 
                     let wrapped_src = Arc::new(RwLock::new(clean_db));

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -137,7 +137,7 @@ fn fuzz(input: FuzzInput) {
                     let value = generate_value(&mut rng, value_size);
 
                     if !keys_set.iter().any(|(k, _)| k == &key) {
-                        let loc = db.bounds().end;
+                        let loc = db.bounds().await.end;
                         if let Ok(()) = db.set(key, value.clone()).await {
                             keys_set.push((key, loc));
                             set_locations.push((key, loc));
@@ -162,7 +162,7 @@ fn fuzz(input: FuzzInput) {
                     };
 
                     let (durable_db, _) = db.commit(metadata).await.unwrap();
-                    last_commit_loc = Some(durable_db.bounds().end - 1);
+                    last_commit_loc = Some(durable_db.bounds().await.end - 1);
                     uncommitted_ops.clear();
                     db = durable_db.into_mutable();
                 }
@@ -176,7 +176,7 @@ fn fuzz(input: FuzzInput) {
                             .prune(safe_loc)
                             .await
                             .expect("prune should not fail");
-                        let oldest = merkleized_db.bounds().start;
+                        let oldest = merkleized_db.bounds().await.start;
                         set_locations.retain(|(_, l)| *l >= oldest);
                         keys_set.retain(|(_, l)| *l >= oldest);
                         db = merkleized_db.into_mutable();
@@ -187,7 +187,7 @@ fn fuzz(input: FuzzInput) {
                     start_index,
                     max_ops,
                 } => {
-                    let op_count = db.bounds().end;
+                    let op_count = db.bounds().await.end;
                     if op_count > 0 && uncommitted_ops.is_empty() {
                         let safe_start = start_index % op_count.as_u64();
                         let safe_start = Location::new(safe_start).unwrap();
@@ -197,7 +197,7 @@ fn fuzz(input: FuzzInput) {
                         if let Ok((proof, ops)) =
                             merkleized_db.proof(safe_start, safe_max_ops).await
                         {
-                            let root = merkleized_db.root();
+                            let root = merkleized_db.root().await;
                             let _ = verify_proof(&mut hasher, &proof, safe_start, &ops, &root);
                         }
                         db = merkleized_db.into_mutable();
@@ -209,7 +209,7 @@ fn fuzz(input: FuzzInput) {
                     start_loc,
                     max_ops,
                 } => {
-                    let op_count = db.bounds().end;
+                    let op_count = db.bounds().await.end;
                     if op_count > 0 && uncommitted_ops.is_empty() {
                         let safe_size = (size % op_count.as_u64()).max(1);
                         let safe_size = Location::new(safe_size).unwrap();
@@ -219,7 +219,7 @@ fn fuzz(input: FuzzInput) {
                             NonZeroU64::new((max_ops % MAX_PROOF_OPS).max(1)).unwrap();
 
                         let merkleized_db = db.into_merkleized();
-                        if safe_start >= merkleized_db.bounds().start {
+                        if safe_start >= merkleized_db.bounds().await.start {
                             let _ = merkleized_db
                                 .historical_proof(safe_size, safe_start, safe_max_ops)
                                 .await;
@@ -233,16 +233,16 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 ImmutableOperation::OpCount => {
-                    let _ = db.bounds().end;
+                    let _ = db.bounds().await.end;
                 }
 
                 ImmutableOperation::OldestRetainedLoc => {
-                    let _ = db.bounds().start;
+                    let _ = db.bounds().await.start;
                 }
 
                 ImmutableOperation::Root => {
                     let clean_db = db.into_merkleized();
-                    let _ = clean_db.root();
+                    let _ = clean_db.root().await;
                     db = clean_db.into_mutable();
                 }
             }

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -106,7 +106,7 @@ fn fuzz(data: FuzzInput) {
                         // Account for the previous key update
                         uncommitted_ops += 1;
                     }
-                    let actual_count = db.bounds().end;
+                    let actual_count = db.bounds().await.end;
                     let expected_count = last_known_op_count + uncommitted_ops;
                     assert_eq!(actual_count, expected_count,
                         "Operation count mismatch: expected {expected_count} (last_known={last_known_op_count} + uncommitted={uncommitted_ops}), got {actual_count}");
@@ -124,7 +124,7 @@ fn fuzz(data: FuzzInput) {
                 }
 
                 QmdbOperation::OpCount => {
-                    let actual_count = db.bounds().end;
+                    let actual_count = db.bounds().await.end;
                     // The count should have increased by the number of uncommitted operations
                     let expected_count = last_known_op_count + uncommitted_ops;
                     assert_eq!(actual_count, expected_count,
@@ -134,7 +134,7 @@ fn fuzz(data: FuzzInput) {
                 QmdbOperation::Commit => {
                     let (durable_db, _) = db.commit(None).await.expect("commit should not fail");
                     // After commit, update our last known count since commit may add more operations
-                    last_known_op_count = durable_db.bounds().end;
+                    last_known_op_count = durable_db.bounds().await.end;
                     uncommitted_ops = 0; // Reset uncommitted operations counter
                     db = durable_db.into_mutable();
                 }
@@ -142,17 +142,17 @@ fn fuzz(data: FuzzInput) {
                 QmdbOperation::Root => {
                     // root requires merkleization but not commit
                     let clean_db = db.into_merkleized();
-                    clean_db.root();
+                    clean_db.root().await;
                     db = clean_db.into_mutable();
                 }
 
                 QmdbOperation::Proof { start_loc, max_ops } => {
-                    let actual_op_count = db.bounds().end;
+                    let actual_op_count = db.bounds().await.end;
 
                     // Only generate proof if QMDB has operations and valid parameters
                     if actual_op_count > 0 {
                         let clean_db = db.into_merkleized();
-                        let current_root = clean_db.root();
+                        let current_root = clean_db.root().await;
                         // Adjust start_loc to be within valid range
                         // Locations are 0-indexed (first operation is at location 0)
                         let adjusted_start = Location::new(*start_loc % *actual_op_count).unwrap();
@@ -176,7 +176,7 @@ fn fuzz(data: FuzzInput) {
                 }
 
                 QmdbOperation::ArbitraryProof { start_loc, max_ops , proof_leaves, digests} => {
-                    let actual_op_count = db.bounds().end;
+                    let actual_op_count = db.bounds().await.end;
 
                     let proof = Proof {
                         leaves: *proof_leaves,
@@ -186,7 +186,7 @@ fn fuzz(data: FuzzInput) {
                     // Only generate proof if QMDB has operations and valid parameters
                     if actual_op_count > 0 {
                         let clean_db = db.into_merkleized();
-                        let current_root = clean_db.root();
+                        let current_root = clean_db.root().await;
                         let adjusted_start = Location::new(*start_loc % *actual_op_count).unwrap();
 
                         if let Ok(res) = clean_db

--- a/storage/fuzz/fuzz_targets/store_operations.rs
+++ b/storage/fuzz/fuzz_targets/store_operations.rs
@@ -143,7 +143,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 Operation::Sync => {
-                    let (mut clean_db, _) = db.commit(None).await.expect("Commit should not fail");
+                    let (clean_db, _) = db.commit(None).await.expect("Commit should not fail");
                     clean_db.sync().await.expect("Sync should not fail");
                     db = clean_db.into_dirty();
                 }
@@ -155,7 +155,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 Operation::OpCount => {
-                    let _ = db.bounds().end;
+                    let _ = db.bounds().await.end;
                 }
 
                 Operation::InactivityFloorLoc => {

--- a/storage/src/bitmap/authenticated.rs
+++ b/storage/src/bitmap/authenticated.rs
@@ -612,7 +612,7 @@ impl<E: Clock + RStorage + Metrics, D: Digest, const N: usize> UnmerkleizedBitMa
 impl<E: Clock + RStorage + Metrics, D: Digest, const N: usize> Storage<D>
     for MerkleizedBitMap<E, D, N>
 {
-    fn size(&self) -> Position {
+    async fn size(&self) -> Position {
         self.size()
     }
 

--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -103,7 +103,7 @@ impl<E: Storage + Metrics, V: CodecShared> Cache<E, V> {
         let mut intervals = RMap::new();
         {
             debug!("initializing cache");
-            let stream = journal.replay(0, 0, cfg.replay_buffer).await?;
+            let stream = journal.replay(cfg.replay_buffer, 0, 0).await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 // Extract key from record

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -3,7 +3,7 @@ use crate::{
     journal::segmented::oversized::{
         Config as OversizedConfig, Oversized, Record as OversizedRecord,
     },
-    kv, Persistable,
+    kv,
 };
 use commonware_codec::{CodecShared, Encode, FixedSize, Read, ReadExt, Write as CodecWrite};
 use commonware_cryptography::{crc32, Crc32, Hasher};
@@ -1166,25 +1166,6 @@ impl<E: Storage + Metrics + Clock, K: Array, V: CodecShared> kv::Gettable for Fr
 impl<E: Storage + Metrics + Clock, K: Array, V: CodecShared> kv::Updatable for Freezer<E, K, V> {
     async fn update(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
         self.put(key, value).await?;
-        Ok(())
-    }
-}
-
-impl<E: Storage + Metrics + Clock, K: Array, V: CodecShared> Persistable for Freezer<E, K, V> {
-    type Error = Error;
-
-    async fn commit(&mut self) -> Result<(), Self::Error> {
-        self.sync().await?;
-        Ok(())
-    }
-
-    async fn sync(&mut self) -> Result<(), Self::Error> {
-        self.sync().await?;
-        Ok(())
-    }
-
-    async fn destroy(self) -> Result<(), Self::Error> {
-        self.destroy().await?;
         Ok(())
     }
 }

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -462,6 +462,11 @@ where
     S: State<DigestOf<H>> + Send + Sync,
 {
     type Item = C::Item;
+    type Reader<'a> = C::Reader<'a> where Self: 'a;
+
+    async fn reader(&self) -> Self::Reader<'_> {
+        self.journal.reader().await
+    }
 
     async fn bounds(&self) -> std::ops::Range<u64> {
         self.journal.bounds().await

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -64,14 +64,14 @@ where
 {
     /// Returns [start, end) where `start` and `end - 1` are the Locations of the oldest and newest
     /// retained operations respectively.
-    pub fn bounds(&self) -> std::ops::Range<Location> {
-        let inner = self.journal.bounds();
+    pub async fn bounds(&self) -> std::ops::Range<Location> {
+        let inner = self.journal.bounds().await;
         Location::new_unchecked(inner.start)..Location::new_unchecked(inner.end)
     }
 
     /// Returns the Location of the next item appended to the journal.
-    pub fn size(&self) -> Location {
-        Location::new_unchecked(self.journal.bounds().end)
+    pub async fn size(&self) -> Location {
+        Location::new_unchecked(self.journal.bounds().await.end)
     }
 
     /// Read an item from the journal at the given location.
@@ -107,8 +107,7 @@ where
         mut hasher: StandardHasher<H>,
         apply_batch_size: u64,
     ) -> Result<Self, Error> {
-        let mut mmr =
-            Self::align(mmr.into_dirty(), &journal, &mut hasher, apply_batch_size).await?;
+        let mmr = Self::align(mmr.into_dirty(), &journal, &mut hasher, apply_batch_size).await?;
 
         // Sync the MMR to disk to avoid having to repeat any recovery that may have been performed
         // on next startup.
@@ -132,8 +131,8 @@ where
     ) -> Result<CleanMmr<E, H::Digest>, Error> {
         // Pop any MMR elements that are ahead of the journal.
         // Note mmr_size is the size of the MMR in leaves, not positions.
-        let journal_size = journal.size();
-        let mut mmr_size = mmr.leaves();
+        let journal_size = journal.size().await;
+        let mut mmr_size = mmr.leaves().await;
         if mmr_size > journal_size {
             let pop_count = mmr_size - journal_size;
             warn!(journal_size, ?pop_count, "popping MMR items");
@@ -145,7 +144,7 @@ where
         if mmr_size < journal_size {
             let replay_count = journal_size - *mmr_size;
             warn!(
-                journal_size,
+                ?journal_size,
                 replay_count, "MMR lags behind journal, replaying journal to catch up"
             );
 
@@ -164,7 +163,7 @@ where
         }
 
         // At this point the MMR and journal should be consistent.
-        assert_eq!(journal.size(), mmr.leaves());
+        assert_eq!(journal.size().await, *mmr.leaves().await);
 
         Ok(mmr.merkleize(hasher))
     }
@@ -174,9 +173,9 @@ where
     /// # Returns
     /// The new pruning boundary, which may be less than the requested `prune_loc`.
     pub async fn prune(&mut self, prune_loc: Location) -> Result<Location, Error> {
-        if self.mmr.size() == 0 {
+        if self.mmr.size().await == 0 {
             // DB is empty, nothing to prune.
-            return Ok(self.bounds().start);
+            return Ok(self.bounds().await.start);
         }
 
         // Sync the MMR before pruning the journal, otherwise the MMR's last element could end up
@@ -186,10 +185,10 @@ where
 
         // Prune the journal and check if anything was actually pruned
         if !self.journal.prune(*prune_loc).await? {
-            return Ok(self.bounds().start);
+            return Ok(self.bounds().await.start);
         }
 
-        let bounds = self.bounds();
+        let bounds = self.bounds().await;
         debug!(size = ?bounds.end, ?prune_loc, boundary = ?bounds.start, "pruned inactive ops");
 
         // Prune MMR to match the journal's actual boundary
@@ -225,7 +224,8 @@ where
         start_loc: Location,
         max_ops: NonZeroU64,
     ) -> Result<(Proof<H::Digest>, Vec<C::Item>), Error> {
-        self.historical_proof(self.size(), start_loc, max_ops).await
+        self.historical_proof(self.size().await, start_loc, max_ops)
+            .await
     }
 
     /// Generate a historical proof with respect to the state of the MMR when it had
@@ -246,7 +246,7 @@ where
         start_loc: Location,
         max_ops: NonZeroU64,
     ) -> Result<(Proof<H::Digest>, Vec<C::Item>), Error> {
-        let leaves = self.size();
+        let leaves = self.size().await;
         if historical_leaves > leaves {
             return Err(crate::mmr::Error::RangeOutOfBounds(leaves).into());
         }
@@ -273,8 +273,8 @@ where
     }
 
     /// Return the root of the MMR.
-    pub const fn root(&self) -> H::Digest {
-        self.mmr.root()
+    pub async fn root(&self) -> H::Digest {
+        self.mmr.root().await
     }
 
     /// Convert this journal into its dirty counterpart for batched updates.
@@ -303,7 +303,7 @@ where
     }
 
     /// Durably persist the journal, ensuring no recovery is required on startup.
-    pub async fn sync(&mut self) -> Result<(), Error> {
+    pub async fn sync(&self) -> Result<(), Error> {
         try_join!(
             self.journal.sync().map_err(Error::Journal),
             self.mmr.sync().map_err(Into::into)
@@ -399,8 +399,7 @@ where
         // Align the MMR and journal.
         let mut hasher = StandardHasher::<H>::new();
         let mmr = Mmr::init(context.with_label("mmr"), &mut hasher, mmr_cfg).await?;
-        let mut mmr =
-            Self::align(mmr.into_dirty(), &journal, &mut hasher, APPLY_BATCH_SIZE).await?;
+        let mmr = Self::align(mmr.into_dirty(), &journal, &mut hasher, APPLY_BATCH_SIZE).await?;
 
         // Sync the journal and MMR to disk to avoid having to repeat any recovery that may have
         // been performed on next startup.
@@ -440,8 +439,7 @@ where
         journal.rewind_to(rewind_predicate).await?;
 
         // Align the MMR and journal.
-        let mut mmr =
-            Self::align(mmr.into_dirty(), &journal, &mut hasher, APPLY_BATCH_SIZE).await?;
+        let mmr = Self::align(mmr.into_dirty(), &journal, &mut hasher, APPLY_BATCH_SIZE).await?;
 
         // Sync the journal and MMR to disk to avoid having to repeat any recovery that may have
         // been performed on next startup.
@@ -465,19 +463,19 @@ where
 {
     type Item = C::Item;
 
-    fn bounds(&self) -> std::ops::Range<u64> {
-        self.journal.bounds()
+    async fn bounds(&self) -> std::ops::Range<u64> {
+        self.journal.bounds().await
     }
 
     async fn replay(
         &self,
-        start_pos: u64,
         buffer: NonZeroUsize,
+        start_pos: u64,
     ) -> Result<
         impl futures::Stream<Item = Result<(u64, Self::Item), JournalError>> + '_,
         JournalError,
     > {
-        self.journal.replay(start_pos, buffer).await
+        self.journal.replay(buffer, start_pos).await
     }
 
     async fn read(&self, position: u64) -> Result<Self::Item, JournalError> {
@@ -507,7 +505,7 @@ where
     async fn rewind(&mut self, size: u64) -> Result<(), JournalError> {
         self.journal.rewind(size).await?;
 
-        let leaves = *self.mmr.leaves();
+        let leaves = *self.mmr.leaves().await;
         if leaves > size {
             self.mmr
                 .pop((leaves - size) as usize)
@@ -534,8 +532,8 @@ where
         })
     }
 
-    async fn sync(&mut self) -> Result<(), JournalError> {
-        self.sync().await.map_err(|e| match e {
+    async fn sync(&self) -> Result<(), JournalError> {
+        Self::sync(self).await.map_err(|e| match e {
             Error::Journal(inner) => inner,
             Error::Mmr(inner) => JournalError::Mmr(anyhow::Error::from(inner)),
         })
@@ -643,7 +641,7 @@ mod tests {
             assert_eq!(loc, Location::new_unchecked(i as u64));
         }
 
-        let mut journal = journal.merkleize();
+        let journal = journal.merkleize();
         journal.sync().await.unwrap();
         journal
     }
@@ -690,7 +688,7 @@ mod tests {
         executor.start(|context| async move {
             let journal = create_empty_journal(context, "new_empty").await;
 
-            let bounds = journal.bounds();
+            let bounds = journal.bounds().await;
             assert_eq!(bounds.end, Location::new_unchecked(0));
             assert_eq!(bounds.start, Location::new_unchecked(0));
             assert!(bounds.is_empty());
@@ -708,8 +706,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(mmr.leaves(), Location::new_unchecked(0));
-            assert_eq!(journal.size(), Location::new_unchecked(0));
+            assert_eq!(mmr.leaves().await, Location::new_unchecked(0));
+            assert_eq!(journal.size().await, 0);
         });
     }
 
@@ -718,7 +716,7 @@ mod tests {
     fn test_align_when_mmr_ahead() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (mmr, mut journal, mut hasher) = create_components(context, "mmr_ahead").await;
+            let (mmr, journal, mut hasher) = create_components(context, "mmr_ahead").await;
 
             // Add 20 operations to both MMR and journal
             let mut mmr = mmr.into_dirty();
@@ -741,8 +739,8 @@ mod tests {
                 .unwrap();
 
             // MMR should have been popped to match journal
-            assert_eq!(mmr.leaves(), Location::new_unchecked(21));
-            assert_eq!(journal.size(), Location::new_unchecked(21));
+            assert_eq!(mmr.leaves().await, Location::new_unchecked(21));
+            assert_eq!(journal.size().await, 21);
         });
     }
 
@@ -751,7 +749,7 @@ mod tests {
     fn test_align_when_journal_ahead() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (mmr, mut journal, mut hasher) = create_components(context, "journal_ahead").await;
+            let (mmr, journal, mut hasher) = create_components(context, "journal_ahead").await;
 
             // Add 20 operations to journal only
             for i in 0..20 {
@@ -770,8 +768,8 @@ mod tests {
                 .unwrap();
 
             // MMR should have been replayed to match journal
-            assert_eq!(mmr.leaves(), Location::new_unchecked(21));
-            assert_eq!(journal.size(), Location::new_unchecked(21));
+            assert_eq!(mmr.leaves().await, Location::new_unchecked(21));
+            assert_eq!(journal.size().await, 21);
         });
     }
 
@@ -789,11 +787,11 @@ mod tests {
                 let loc = journal.append(create_operation(i as u8)).await.unwrap();
                 assert_eq!(loc, Location::new_unchecked(i as u64));
             }
-            let mut journal = journal.merkleize();
+            let journal = journal.merkleize();
 
             // Don't sync - these are uncommitted
             // After alignment, they should be discarded
-            let size_before = journal.size();
+            let size_before = journal.size().await;
             assert_eq!(size_before, 20);
 
             // Drop and recreate to simulate restart (which calls align internally)
@@ -802,7 +800,7 @@ mod tests {
             let journal = create_empty_journal(context.with_label("second"), "mismatched").await;
 
             // Uncommitted operations should be gone
-            assert_eq!(journal.size(), 0);
+            assert_eq!(journal.size().await, 0);
         });
     }
 
@@ -834,7 +832,7 @@ mod tests {
                 // Rewind to last commit
                 let final_size = journal.rewind_to(|op| op.is_commit()).await.unwrap();
                 assert_eq!(final_size, 4);
-                assert_eq!(journal.size(), 4);
+                assert_eq!(journal.size().await, 4);
 
                 // Verify the commit operation is still there
                 let op = journal.read(3).await.unwrap();
@@ -892,7 +890,7 @@ mod tests {
                 // Rewind should go to pruning boundary (0 for unpruned)
                 let final_size = journal.rewind_to(|op| op.is_commit()).await.unwrap();
                 assert_eq!(final_size, 0, "Should rewind to pruning boundary (0)");
-                assert_eq!(journal.size(), 0);
+                assert_eq!(journal.size().await, 0);
             }
 
             // Test 4: Rewind with existing pruning boundary
@@ -919,7 +917,7 @@ mod tests {
 
                 // Prune up to position 8 (this will prune section 0, items 0-6, keeping 7+)
                 journal.prune(8).await.unwrap();
-                assert_eq!(journal.bounds().start, Location::new_unchecked(7));
+                assert_eq!(journal.bounds().await.start, Location::new_unchecked(7));
 
                 // Add more uncommitted operations
                 for i in 15..20 {
@@ -960,7 +958,7 @@ mod tests {
                 // Prune up to position 8 (this prunes section 0, including the commit at pos 5)
                 // Pruning boundary will be at position 7 (start of section 1)
                 journal.prune(8).await.unwrap();
-                assert_eq!(journal.bounds().start, Location::new_unchecked(7));
+                assert_eq!(journal.bounds().await.start, Location::new_unchecked(7));
 
                 // Add uncommitted operations with no commits (in section 1: 7-13)
                 for i in 10..14 {
@@ -988,7 +986,7 @@ mod tests {
                     .await
                     .unwrap();
                 assert_eq!(final_size, 0);
-                assert_eq!(journal.size(), 0);
+                assert_eq!(journal.size().await, 0);
             }
 
             // Test 7: Position based authenticated journal rewind.
@@ -1015,14 +1013,14 @@ mod tests {
                     journal.append(create_operation(i)).await.unwrap();
                 }
                 let journal = journal.merkleize();
-                assert_eq!(journal.size(), 10);
+                assert_eq!(journal.size().await, 10);
 
                 let mut journal = journal.into_dirty();
                 journal.rewind(2).await.unwrap();
-                assert_eq!(journal.size(), 2);
-                assert_eq!(journal.mmr.leaves(), 2);
-                assert_eq!(journal.mmr.size(), 3);
-                let bounds = journal.bounds();
+                assert_eq!(journal.size().await, 2);
+                assert_eq!(journal.mmr.leaves().await, 2);
+                assert_eq!(journal.mmr.size().await, 3);
+                let bounds = journal.bounds().await;
                 assert_eq!(bounds.start, Location::new_unchecked(0));
                 assert!(!bounds.is_empty());
 
@@ -1033,10 +1031,10 @@ mod tests {
 
                 journal.rewind(0).await.unwrap();
                 let journal = journal.merkleize();
-                assert_eq!(journal.size(), 0);
-                assert_eq!(journal.mmr.leaves(), 0);
-                assert_eq!(journal.mmr.size(), 0);
-                let bounds = journal.bounds();
+                assert_eq!(journal.size().await, 0);
+                assert_eq!(journal.mmr.leaves().await, 0);
+                assert_eq!(journal.mmr.size().await, 0);
+                let bounds = journal.bounds().await;
                 assert_eq!(bounds.start, Location::new_unchecked(0));
                 assert!(bounds.is_empty());
 
@@ -1045,17 +1043,16 @@ mod tests {
                 for i in 0..255 {
                     journal.append(create_operation(i)).await.unwrap();
                 }
-
                 let mut journal = journal.merkleize();
                 journal.prune(Location::new_unchecked(100)).await.unwrap();
-                assert_eq!(journal.bounds().start, Location::new_unchecked(98));
+                assert_eq!(journal.bounds().await.start, Location::new_unchecked(98));
                 let mut journal = journal.into_dirty();
                 let res = journal.rewind(97).await;
                 assert!(matches!(res, Err(JournalError::InvalidRewind(97))));
                 journal.rewind(98).await.unwrap();
-                let bounds = journal.bounds();
+                let bounds = journal.bounds().await;
                 assert_eq!(bounds.end, Location::new_unchecked(98));
-                assert_eq!(journal.mmr.leaves(), 98);
+                assert_eq!(journal.mmr.leaves().await, 98);
                 assert_eq!(bounds.start, Location::new_unchecked(98));
                 assert!(bounds.is_empty());
             }
@@ -1070,18 +1067,18 @@ mod tests {
         executor.start(|context| async move {
             let mut journal = create_empty_journal(context, "apply_op").await.into_dirty();
 
-            assert_eq!(journal.size(), 0);
+            assert_eq!(journal.size().await, 0);
 
             // Add 50 operations
             let expected_ops: Vec<_> = (0..50).map(|i| create_operation(i as u8)).collect();
             for (i, op) in expected_ops.iter().enumerate() {
                 let loc = journal.append(op.clone()).await.unwrap();
                 assert_eq!(loc, Location::new_unchecked(i as u64));
-                assert_eq!(journal.size(), (i + 1) as u64);
+                assert_eq!(journal.size().await, (i + 1) as u64);
             }
-            let mut journal = journal.merkleize();
+            let journal = journal.merkleize();
 
-            assert_eq!(journal.size(), 50);
+            assert_eq!(journal.size().await, 50);
 
             // Verify all operations can be read back correctly
             journal.sync().await.unwrap();
@@ -1175,7 +1172,7 @@ mod tests {
         executor.start(|context| async move {
             let journal = create_journal_with_ops(context, "read_all", 50).await;
 
-            assert_eq!(journal.size(), 50);
+            assert_eq!(journal.size().await, 50);
 
             // Verify all operations can be read back and match expected values
             for i in 0..50 {
@@ -1206,7 +1203,7 @@ mod tests {
                 .append(Operation::CommitFloor(None, Location::new_unchecked(0)))
                 .await
                 .unwrap();
-            let mut journal = journal.merkleize();
+            let journal = journal.merkleize();
             assert_eq!(
                 commit_loc,
                 Location::new_unchecked(20),
@@ -1217,7 +1214,7 @@ mod tests {
             // Reopen and verify the operations persisted
             drop(journal);
             let journal = create_empty_journal(context.with_label("second"), "close_pending").await;
-            assert_eq!(journal.size(), 21);
+            assert_eq!(journal.size().await, 21);
 
             // Verify all operations can be read back
             for (i, expected_op) in expected_ops.iter().enumerate() {
@@ -1287,7 +1284,7 @@ mod tests {
             let actual = journal.prune(requested).await.unwrap();
 
             // Actual boundary should match bounds.start
-            let bounds = journal.bounds();
+            let bounds = journal.bounds().await;
             assert!(!bounds.is_empty());
             assert_eq!(actual, bounds.start);
 
@@ -1312,9 +1309,9 @@ mod tests {
             let mut journal = journal.merkleize();
             journal.sync().await.unwrap();
 
-            let count_before = journal.size();
+            let count_before = journal.size().await;
             journal.prune(Location::new_unchecked(50)).await.unwrap();
-            let count_after = journal.size();
+            let count_after = journal.size().await;
 
             assert_eq!(count_before, count_after);
         });
@@ -1327,13 +1324,13 @@ mod tests {
         executor.start(|context| async move {
             // Test empty journal
             let journal = create_empty_journal(context.with_label("empty"), "oldest").await;
-            assert!(journal.bounds().is_empty());
+            assert!(journal.bounds().await.is_empty());
             journal.destroy().await.unwrap();
 
             // Test no pruning
             let journal =
                 create_journal_with_ops(context.with_label("no_prune"), "oldest", 100).await;
-            let bounds = journal.bounds();
+            let bounds = journal.bounds().await;
             assert!(!bounds.is_empty());
             assert_eq!(bounds.start, Location::new_unchecked(0));
             journal.destroy().await.unwrap();
@@ -1352,7 +1349,7 @@ mod tests {
             let pruned_boundary = journal.prune(Location::new_unchecked(50)).await.unwrap();
 
             // Should match the pruned boundary (may be <= 50 due to section alignment)
-            let bounds = journal.bounds();
+            let bounds = journal.bounds().await;
             assert!(!bounds.is_empty());
             assert_eq!(bounds.start, pruned_boundary);
             // Should be <= requested location (50)
@@ -1368,12 +1365,12 @@ mod tests {
         executor.start(|context| async move {
             // Test empty journal
             let journal = create_empty_journal(context.with_label("empty"), "boundary").await;
-            assert_eq!(journal.bounds().start, Location::new_unchecked(0));
+            assert_eq!(journal.bounds().await.start, Location::new_unchecked(0));
 
             // Test no pruning
             let journal =
                 create_journal_with_ops(context.with_label("no_prune"), "boundary", 100).await;
-            assert_eq!(journal.bounds().start, Location::new_unchecked(0));
+            assert_eq!(journal.bounds().await.start, Location::new_unchecked(0));
 
             // Test after pruning
             let mut journal =
@@ -1389,7 +1386,7 @@ mod tests {
 
             let pruned_boundary = journal.prune(Location::new_unchecked(50)).await.unwrap();
 
-            assert_eq!(journal.bounds().start, pruned_boundary);
+            assert_eq!(journal.bounds().await.start, pruned_boundary);
         });
     }
 
@@ -1412,14 +1409,14 @@ mod tests {
             let pruned_boundary = journal.prune(Location::new_unchecked(25)).await.unwrap();
 
             // Verify MMR and journal remain in sync
-            assert!(!journal.bounds().is_empty());
-            assert_eq!(pruned_boundary, journal.bounds().start);
+            assert!(!journal.bounds().await.is_empty());
+            assert_eq!(pruned_boundary, journal.bounds().await.start);
 
             // Verify boundary is at or before requested (due to section alignment)
             assert!(pruned_boundary <= Location::new_unchecked(25));
 
             // Verify operation count is unchanged
-            assert_eq!(journal.size(), 51);
+            assert_eq!(journal.size().await, 51);
         });
     }
 
@@ -1442,7 +1439,7 @@ mod tests {
 
             // Verify the proof is valid
             let mut hasher = StandardHasher::new();
-            let root = journal.root();
+            let root = journal.root().await;
             assert!(verify_proof(
                 &proof,
                 &ops,
@@ -1460,7 +1457,7 @@ mod tests {
         executor.start(|context| async move {
             let journal = create_journal_with_ops(context, "proof_limit", 50).await;
 
-            let size = journal.size();
+            let size = journal.size().await;
             let (proof, ops) = journal
                 .historical_proof(size, Location::new_unchecked(0), NZU64!(20))
                 .await
@@ -1474,7 +1471,7 @@ mod tests {
 
             // Verify the proof is valid
             let mut hasher = StandardHasher::new();
-            let root = journal.root();
+            let root = journal.root().await;
             assert!(verify_proof(
                 &proof,
                 &ops,
@@ -1492,7 +1489,7 @@ mod tests {
         executor.start(|context| async move {
             let journal = create_journal_with_ops(context, "proof_end", 50).await;
 
-            let size = journal.size();
+            let size = journal.size().await;
             // Request proof starting near the end
             let (proof, ops) = journal
                 .historical_proof(size, Location::new_unchecked(40), NZU64!(20))
@@ -1507,7 +1504,7 @@ mod tests {
 
             // Verify the proof is valid
             let mut hasher = StandardHasher::new();
-            let root = journal.root();
+            let root = journal.root().await;
             assert!(verify_proof(
                 &proof,
                 &ops,
@@ -1548,7 +1545,7 @@ mod tests {
         executor.start(|context| async move {
             let journal = create_journal_with_ops(context, "proof_start_oob", 5).await;
 
-            let size = journal.size();
+            let size = journal.size().await;
             // Request proof starting at size (should fail)
             let result = journal.historical_proof(size, size, NZU64!(1)).await;
 
@@ -1569,15 +1566,15 @@ mod tests {
 
             // Capture root at historical state
             let mut hasher = StandardHasher::new();
-            let historical_root = journal.root();
-            let historical_size = journal.size();
+            let historical_root = journal.root().await;
+            let historical_size = journal.size().await;
 
             // Add more operations after the historical state
             let mut journal = journal.into_dirty();
             for i in 50..100 {
                 journal.append(create_operation(i as u8)).await.unwrap();
             }
-            let mut journal = journal.merkleize();
+            let journal = journal.merkleize();
             journal.sync().await.unwrap();
 
             // Generate proof for the historical state
@@ -1620,7 +1617,7 @@ mod tests {
             let pruned_boundary = journal.prune(Location::new_unchecked(25)).await.unwrap();
 
             // Try to get proof starting at a location before the pruned boundary
-            let size = journal.size();
+            let size = journal.size().await;
             let start_loc = Location::new_unchecked(0);
             if start_loc < pruned_boundary {
                 let result = journal.historical_proof(size, start_loc, NZU64!(1)).await;
@@ -1638,14 +1635,14 @@ mod tests {
         executor.start(|context| async move {
             // Test empty journal
             let journal = create_empty_journal(context.with_label("empty"), "replay").await;
-            let stream = journal.replay(0, NZUsize!(10)).await.unwrap();
+            let stream = journal.replay(NZUsize!(10), 0).await.unwrap();
             futures::pin_mut!(stream);
             assert!(stream.next().await.is_none());
 
             // Test replaying all operations
             let journal =
                 create_journal_with_ops(context.with_label("with_ops"), "replay", 50).await;
-            let stream = journal.replay(0, NZUsize!(100)).await.unwrap();
+            let stream = journal.replay(NZUsize!(100), 0).await.unwrap();
             futures::pin_mut!(stream);
 
             for i in 0..50 {
@@ -1664,7 +1661,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let journal = create_journal_with_ops(context, "replay_middle", 50).await;
-            let stream = journal.replay(25, NZUsize!(100)).await.unwrap();
+            let stream = journal.replay(NZUsize!(100), 25).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut count = 0;

--- a/storage/src/journal/benches/fixed_read_sequential.rs
+++ b/storage/src/journal/benches/fixed_read_sequential.rs
@@ -42,7 +42,7 @@ fn bench_fixed_read_sequential(c: &mut Criterion) {
                     let mut j =
                         get_fixed_journal::<ITEM_SIZE>(ctx, PARTITION, ITEMS_PER_BLOB).await;
                     append_fixed_random_data::<_, ITEM_SIZE>(&mut j, items).await;
-                    let sz = j.size();
+                    let sz = j.size().await;
                     assert_eq!(sz, items);
 
                     // Run the benchmark

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -4,7 +4,7 @@ use commonware_runtime::{
     tokio::{Config, Context, Runner},
     Runner as _,
 };
-use commonware_storage::journal::contiguous::fixed::Journal;
+use commonware_storage::journal::contiguous::{fixed::Journal, ContiguousReader as _};
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use criterion::{criterion_group, Criterion};
 use futures::{pin_mut, StreamExt};
@@ -18,7 +18,8 @@ const PARTITION: &str = "test_partition";
 
 /// Replay all items in the given `journal`.
 async fn bench_run(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: usize) {
-    let stream = journal
+    let reader = journal.reader().await;
+    let stream = reader
         .replay(NZUsize!(buffer), 0)
         .await
         .expect("failed to replay journal");

--- a/storage/src/journal/benches/variable_replay.rs
+++ b/storage/src/journal/benches/variable_replay.rs
@@ -19,7 +19,7 @@ const PARTITION: &str = "variable_test_partition";
 /// Replay all items in the given `journal`.
 async fn bench_run(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: usize) {
     let stream = journal
-        .replay(0, NZUsize!(buffer))
+        .replay(NZUsize!(buffer), 0)
         .await
         .expect("failed to replay journal");
     pin_mut!(stream);

--- a/storage/src/journal/benches/variable_replay.rs
+++ b/storage/src/journal/benches/variable_replay.rs
@@ -4,7 +4,7 @@ use commonware_runtime::{
     tokio::{Config, Context, Runner},
     Runner as _,
 };
-use commonware_storage::journal::contiguous::variable::Journal;
+use commonware_storage::journal::contiguous::{variable::Journal, ContiguousReader as _};
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use criterion::{criterion_group, Criterion};
 use futures::{pin_mut, StreamExt};
@@ -18,7 +18,8 @@ const PARTITION: &str = "variable_test_partition";
 
 /// Replay all items in the given `journal`.
 async fn bench_run(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: usize) {
-    let stream = journal
+    let reader = journal.reader().await;
+    let stream = reader
         .replay(NZUsize!(buffer), 0)
         .await
         .expect("failed to replay journal");

--- a/storage/src/journal/conformance.rs
+++ b/storage/src/journal/conformance.rs
@@ -29,7 +29,7 @@ impl Conformance for ContiguousFixed {
                 page_cache: CacheRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
                 write_buffer: WRITE_BUFFER,
             };
-            let mut journal = fixed::Journal::<_, u64>::init(context.with_label("journal"), config)
+            let journal = fixed::Journal::<_, u64>::init(context.with_label("journal"), config)
                 .await
                 .unwrap();
 
@@ -62,7 +62,7 @@ impl Conformance for ContiguousVariable {
                 compression: None,
                 codec_config: (RangeCfg::new(0..256), ()),
             };
-            let mut journal =
+            let journal =
                 variable::Journal::<_, Vec<u8>>::init(context.with_label("journal"), config)
                     .await
                     .unwrap();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -63,8 +63,8 @@ use crate::{
     Persistable,
 };
 use commonware_codec::CodecFixedShared;
-use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, Storage};
-use futures::{stream::Stream, StreamExt};
+use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, RwLock, Storage};
+use futures::{lock::Mutex, stream::Stream, StreamExt};
 use std::num::{NonZeroU64, NonZeroUsize};
 use tracing::warn;
 
@@ -93,25 +93,10 @@ pub struct Config {
     pub write_buffer: NonZeroUsize,
 }
 
-/// Implementation of `Journal` storage.
-///
-/// This is implemented as a wrapper around [SegmentedJournal] that provides position-based access
-/// where positions are automatically mapped to (section, position_in_section) pairs.
-///
-/// # Repair
-///
-/// Like
-/// [sqlite](https://github.com/sqlite/sqlite/blob/8658a8df59f00ec8fcfea336a2a6a4b5ef79d2ee/src/wal.c#L1504-L1505)
-/// and
-/// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
-/// the first invalid data read will be considered the new end of the journal (and the
-/// underlying blob will be truncated to the last valid item). Repair is performed
-/// by the underlying [SegmentedJournal] during init.
-pub struct Journal<E: Clock + Storage + Metrics, A: CodecFixedShared> {
-    inner: SegmentedJournal<E, A>,
-
-    /// The maximum number of items per blob (section).
-    items_per_blob: u64,
+/// Inner state protected by a single RwLock.
+struct Inner<E: Clock + Storage + Metrics, A: CodecFixedShared> {
+    /// The underlying segmented journal.
+    journal: SegmentedJournal<E, A>,
 
     /// Total number of items appended (not affected by pruning).
     size: u64,
@@ -127,6 +112,32 @@ pub struct Journal<E: Clock + Storage + Metrics, A: CodecFixedShared> {
 
     /// The position before which all items have been pruned.
     pruning_boundary: u64,
+}
+
+/// Implementation of `Journal` storage.
+///
+/// This is implemented as a wrapper around [SegmentedJournal] that provides position-based access
+/// where positions are automatically mapped to (section, position_in_section) pairs.
+///
+/// # Repair
+///
+/// Like
+/// [sqlite](https://github.com/sqlite/sqlite/blob/8658a8df59f00ec8fcfea336a2a6a4b5ef79d2ee/src/wal.c#L1504-L1505)
+/// and
+/// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
+/// the first invalid data read will be considered the new end of the journal (and the
+/// underlying blob will be truncated to the last valid item). Repair is performed
+/// by the underlying [SegmentedJournal] during init.
+pub struct Journal<E: Clock + Storage + Metrics, A: CodecFixedShared> {
+    /// Inner state with segmented journal and size.
+    inner: RwLock<Inner<E, A>>,
+
+    /// Serializes write operations to prevent race conditions.
+    /// This allows sync to use a read lock, enabling concurrent reads during sync.
+    write_lock: Mutex<()>,
+
+    /// The maximum number of items per blob (section).
+    items_per_blob: u64,
 }
 
 impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
@@ -185,13 +196,15 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
             write_buffer: cfg.write_buffer,
         };
 
-        let mut inner = SegmentedJournal::init(context.with_label("blobs"), segmented_cfg).await?;
+        let mut journal =
+            SegmentedJournal::init(context.with_label("blobs"), segmented_cfg).await?;
 
         // Initialize metadata store
         let meta_cfg = MetadataConfig {
             partition: format!("{}-metadata", cfg.partition),
             codec_config: ((0..).into(), ()),
         };
+
         let mut metadata =
             Metadata::<_, u64, Vec<u8>>::init(context.with_label("meta"), meta_cfg).await?;
 
@@ -205,7 +218,7 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
 
         // Recover bounds from metadata and/or blobs
         let (pruning_boundary, size, needs_metadata_update) =
-            Self::recover_bounds(&inner, items_per_blob, meta_pruning_boundary).await?;
+            Self::recover_bounds(&journal, items_per_blob, meta_pruning_boundary).await?;
 
         // Persist metadata if needed
         if needs_metadata_update {
@@ -224,14 +237,17 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         // reopen even after pruning all items. The tail blob is at `size / items_per_blob` (where
         // the next append would go).
         let tail_section = size / items_per_blob;
-        inner.ensure_section_exists(tail_section).await?;
+        journal.ensure_section_exists(tail_section).await?;
 
         Ok(Self {
-            inner,
+            inner: RwLock::new(Inner {
+                journal,
+                size,
+                metadata,
+                pruning_boundary,
+            }),
+            write_lock: Mutex::new(()),
             items_per_blob,
-            size,
-            pruning_boundary,
-            metadata,
         })
     }
 
@@ -414,15 +430,16 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         };
         let mut metadata =
             Metadata::<_, u64, Vec<u8>>::init(context.with_label("meta"), meta_cfg).await?;
-        let mut inner = SegmentedJournal::init(context.with_label("blobs"), segmented_cfg).await?;
+        let mut journal =
+            SegmentedJournal::init(context.with_label("blobs"), segmented_cfg).await?;
 
         // Clear blobs before updating metadata.
         // This ordering is critical for crash safety:
         // - Crash after clear: no blobs, recovery returns (0, 0), metadata ignored
         // - Crash after create: old metadata triggers "metadata ahead" warning,
         //   recovery falls back to blob state.
-        inner.clear().await?;
-        inner.ensure_section_exists(tail_section).await?;
+        journal.clear().await?;
+        journal.ensure_section_exists(tail_section).await?;
 
         // Persist metadata if pruning_boundary is mid-section.
         if !size.is_multiple_of(items_per_blob) {
@@ -434,11 +451,14 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         }
 
         Ok(Self {
-            inner,
+            inner: RwLock::new(Inner {
+                journal,
+                size,
+                metadata,
+                pruning_boundary: size, // No data exists yet
+            }),
+            write_lock: Mutex::new(()),
             items_per_blob,
-            size,
-            pruning_boundary: size, // No data exists yet
-            metadata,
         })
     }
 
@@ -454,27 +474,42 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     ///
     /// Only the tail section can have pending updates since historical sections are synced
     /// when they become full.
-    pub async fn sync(&mut self) -> Result<(), Error> {
-        // Sync inner journal
-        let tail_section = self.size / self.items_per_blob;
-        self.inner.sync(tail_section).await?;
+    pub async fn sync(&self) -> Result<(), Error> {
+        let _write_guard = self.write_lock.lock().await; // avoid race conditions due to metadata
+
+        let (pruning_boundary, pruning_boundary_from_metadata) = {
+            let inner = self.inner.read().await;
+
+            // Sync the tail section
+            let tail_section = inner.size / self.items_per_blob;
+
+            // The tail section may not exist yet if the previous section was just filled, but syncing a
+            // non-existent section is safe (returns Ok).
+            inner.journal.sync(tail_section).await?;
+
+            let pruning_boundary = inner.pruning_boundary;
+            let pruning_boundary_from_metadata = inner.metadata.get(&PRUNING_BOUNDARY_KEY).cloned();
+
+            (pruning_boundary, pruning_boundary_from_metadata)
+        };
 
         // Persist metadata only when pruning_boundary is mid-section.
-        if !self.pruning_boundary.is_multiple_of(self.items_per_blob) {
-            let needs_update = self
-                .metadata
-                .get(&PRUNING_BOUNDARY_KEY)
-                .is_none_or(|bytes| bytes.as_slice() != self.pruning_boundary.to_be_bytes());
+        if !pruning_boundary.is_multiple_of(self.items_per_blob) {
+            let needs_update = pruning_boundary_from_metadata
+                .is_none_or(|bytes| bytes.as_slice() != pruning_boundary.to_be_bytes());
+
             if needs_update {
-                self.metadata.put(
+                let mut inner = self.inner.write().await;
+                inner.metadata.put(
                     PRUNING_BOUNDARY_KEY,
-                    self.pruning_boundary.to_be_bytes().to_vec(),
+                    pruning_boundary.to_be_bytes().to_vec(),
                 );
-                self.metadata.sync().await?;
+                inner.metadata.sync().await?;
             }
-        } else if self.metadata.get(&PRUNING_BOUNDARY_KEY).is_some() {
-            self.metadata.remove(&PRUNING_BOUNDARY_KEY);
-            self.metadata.sync().await?;
+        } else if pruning_boundary_from_metadata.is_some() {
+            let mut inner = self.inner.write().await;
+            inner.metadata.remove(&PRUNING_BOUNDARY_KEY);
+            inner.metadata.sync().await?;
         }
 
         Ok(())
@@ -482,31 +517,54 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
 
     /// Return the total number of items in the journal, irrespective of pruning. The next value
     /// appended to the journal will be at this position.
-    pub const fn size(&self) -> u64 {
-        self.size
+    pub async fn size(&self) -> u64 {
+        self.inner.read().await.size
     }
 
     /// Returns [start, end) where `start` and `end - 1` are the indices of the oldest and newest
     /// retained operations respectively.
-    pub const fn bounds(&self) -> std::ops::Range<u64> {
-        self.pruning_boundary..self.size
+    pub async fn bounds(&self) -> std::ops::Range<u64> {
+        let inner = self.inner.read().await;
+        inner.pruning_boundary..inner.size
     }
 
     /// Append a new item to the journal. Return the item's position in the journal, or error if the
     /// operation fails.
-    pub async fn append(&mut self, item: A) -> Result<u64, Error> {
-        let position = self.size;
-        let (section, _pos_in_section) = self.position_to_section(position);
+    pub async fn append(&self, item: A) -> Result<u64, Error> {
+        // Serialize appends to prevent race conditions when sections fill up.
+        let _append_guard = self.write_lock.lock().await;
 
-        self.inner.append(section, item).await?;
-        self.size += 1;
+        // Append the item (requires write lock)
+        let (position, section) = {
+            let mut inner = self.inner.write().await;
+            let position = inner.size;
+            let (section, _pos_in_section) = self.position_to_section(position);
 
-        // If we just filled up a section, sync it and create the next tail blob. This maintains the
-        // invariant that the tail blob always exists.
-        if self.size.is_multiple_of(self.items_per_blob) {
-            self.inner.sync(section).await?;
-            // Create the new tail blob.
-            self.inner.ensure_section_exists(section + 1).await?;
+            inner.journal.append(section, item).await?;
+            inner.size += 1;
+
+            // Return early if no sync is needed (section not full).
+            if !inner.size.is_multiple_of(self.items_per_blob) {
+                return Ok(position);
+            }
+
+            (position, section)
+        };
+
+        // If we get here the section was filled and we need to sync it. We sync while only holding
+        // a read lock on self.inner to avoid blocking concurrent reads. We must however continue to
+        // hold the outer write_lock since we don't want to start writing to the new section until
+        // this completes.
+        {
+            let inner = self.inner.read().await;
+            inner.journal.sync(section).await?;
+        }
+
+        // Ensure the new tail section exists, as required to maintain the invariant. This must
+        // happen after the previous section is synced.
+        {
+            let mut inner = self.inner.write().await;
+            inner.journal.ensure_section_exists(section + 1).await?;
         }
 
         Ok(position)
@@ -520,14 +578,17 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     /// * This operation is not guaranteed to survive restarts until sync is called.
     /// * This operation is not atomic, but it will always leave the journal in a consistent state
     ///   in the event of failure since blobs are always removed from newest to oldest.
-    pub async fn rewind(&mut self, size: u64) -> Result<(), Error> {
-        match size.cmp(&self.size) {
+    pub async fn rewind(&self, size: u64) -> Result<(), Error> {
+        let _write_guard = self.write_lock.lock().await;
+        let mut inner = self.inner.write().await;
+
+        match size.cmp(&inner.size) {
             std::cmp::Ordering::Greater => return Err(Error::InvalidRewind(size)),
             std::cmp::Ordering::Equal => return Ok(()),
             std::cmp::Ordering::Less => {}
         }
 
-        if size < self.pruning_boundary {
+        if size < inner.pruning_boundary {
             return Err(Error::InvalidRewind(size));
         }
 
@@ -535,14 +596,34 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         let section_start = section * self.items_per_blob;
 
         // Calculate offset within section for rewind
-        let first_in_section = self.pruning_boundary.max(section_start);
+        let first_in_section = inner.pruning_boundary.max(section_start);
         let pos_in_section = size - first_in_section;
         let byte_offset = pos_in_section * Self::CHUNK_SIZE_U64;
 
-        self.inner.rewind(section, byte_offset).await?;
-        self.size = size;
+        inner.journal.rewind(section, byte_offset).await?;
+        inner.size = size;
 
         Ok(())
+    }
+
+    /// Return the position of the oldest item in the journal that remains readable.
+    ///
+    /// Returns `None` if no data exists (fully pruned state or after `init_at_size`).
+    ///
+    /// Note that this value could be older than the `min_item_pos` last passed to prune.
+    pub async fn oldest_retained_pos(&self) -> Option<u64> {
+        let inner = self.inner.read().await;
+        if inner.pruning_boundary >= inner.size {
+            None
+        } else {
+            Some(inner.pruning_boundary)
+        }
+    }
+
+    /// Return the location before which all items have been pruned.
+    pub async fn pruning_boundary(&self) -> u64 {
+        let inner = self.inner.read().await;
+        inner.pruning_boundary
     }
 
     /// Read the item at position `pos` in the journal.
@@ -552,11 +633,11 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     ///  - [Error::ItemPruned] if the item at position `pos` is pruned.
     ///  - [Error::ItemOutOfRange] if the item at position `pos` does not exist.
     pub async fn read(&self, pos: u64) -> Result<A, Error> {
-        let bounds = self.bounds();
-        if pos >= bounds.end {
+        let inner = self.inner.read().await;
+        if pos >= inner.size {
             return Err(Error::ItemOutOfRange(pos));
         }
-        if pos < bounds.start {
+        if pos < inner.pruning_boundary {
             return Err(Error::ItemPruned(pos));
         }
 
@@ -564,21 +645,25 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         let section_start = section * self.items_per_blob;
 
         // Calculate position within the blob.
-        // This accounts for sections that begin mid-section (bounds.start > section_start).
-        let first_in_section = bounds.start.max(section_start);
+        // This accounts for sections that begin mid-section (pruning_boundary > section_start).
+        let first_in_section = inner.pruning_boundary.max(section_start);
         let pos_in_section = pos - first_in_section;
 
-        self.inner.get(section, pos_in_section).await.map_err(|e| {
-            // Since we check bounds above, any failure here is unexpected.
-            match e {
-                Error::SectionOutOfRange(e)
-                | Error::AlreadyPrunedToSection(e)
-                | Error::ItemOutOfRange(e) => {
-                    Error::Corruption(format!("section/item should be found, but got: {e}"))
+        inner
+            .journal
+            .get(section, pos_in_section)
+            .await
+            .map_err(|e| {
+                // Since we check bounds above, any failure here is unexpected.
+                match e {
+                    Error::SectionOutOfRange(e)
+                    | Error::AlreadyPrunedToSection(e)
+                    | Error::ItemOutOfRange(e) => {
+                        Error::Corruption(format!("section/item should be found, but got: {e}"))
+                    }
+                    other => other,
                 }
-                other => other,
-            }
-        })
+            })
     }
 
     /// Returns an ordered stream of all items in the journal with position >= `start_pos`.
@@ -592,47 +677,57 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         &self,
         buffer: NonZeroUsize,
         start_pos: u64,
-    ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + '_, Error> {
-        let bounds = self.bounds();
-        if start_pos > bounds.end {
-            return Err(Error::ItemOutOfRange(start_pos));
-        }
-        if start_pos < bounds.start {
-            return Err(Error::ItemPruned(start_pos));
-        }
-
-        let start_section = start_pos / self.items_per_blob;
-        let section_start = start_section * self.items_per_blob;
-
-        // Calculate start position within the section
-        let first_in_section = bounds.start.max(section_start);
-        let start_pos_in_section = start_pos - first_in_section;
-
+    ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
         let items_per_blob = self.items_per_blob;
-        let pruning_boundary = bounds.start;
 
-        // Check all middle sections (not oldest, not tail) in range are complete.
-        // The oldest section may be partial due to mid-section pruning boundary.
-        // The tail section may be partial because it's not been fully filled yet.
-        if let (Some(oldest), Some(newest)) =
-            (self.inner.oldest_section(), self.inner.newest_section())
-        {
-            // Start from max(start_section, oldest+1) to skip oldest which may be partial
-            let first_to_check = start_section.max(oldest + 1);
-            for section in first_to_check..newest {
-                let len = self.inner.section_len(section).await?;
-                if len < items_per_blob {
-                    return Err(Error::Corruption(format!(
+        // Validate inputs and get inner stream.
+        let (inner_stream, pruning_boundary) = {
+            let inner = self.inner.read().await;
+
+            // Validate bounds.
+            if start_pos > inner.size {
+                return Err(Error::ItemOutOfRange(start_pos));
+            }
+
+            // Make sure we aren't trying to read pruned items.
+            if start_pos < inner.pruning_boundary {
+                return Err(Error::ItemPruned(start_pos));
+            }
+
+            let start_section = start_pos / self.items_per_blob;
+            let section_start = start_section * self.items_per_blob;
+
+            // Calculate start position within the section
+            let first_in_section = inner.pruning_boundary.max(section_start);
+            let start_pos_in_section = start_pos - first_in_section;
+
+            let items_per_blob = self.items_per_blob;
+
+            // Check all middle sections (not oldest, not tail) in range are complete.
+            // The oldest section may be partial due to mid-section pruning boundary.
+            // The tail section may be partial because it's not been fully filled yet.
+            let journal = &inner.journal;
+            if let (Some(oldest), Some(newest)) =
+                (journal.oldest_section(), journal.newest_section())
+            {
+                // Start from max(start_section, oldest+1) to skip oldest which may be partial
+                let first_to_check = start_section.max(oldest + 1);
+                for section in first_to_check..newest {
+                    let len = journal.section_len(section).await?;
+                    if len < items_per_blob {
+                        return Err(Error::Corruption(format!(
                         "section {section} incomplete: expected {items_per_blob} items, got {len}"
                     )));
+                    }
                 }
             }
-        }
 
-        let inner_stream = self
-            .inner
-            .replay(start_section, start_pos_in_section, buffer)
-            .await?;
+            let inner_stream = journal
+                .replay(start_section, start_pos_in_section, buffer)
+                .await?;
+            // Return inner stream.
+            (inner_stream, inner.pruning_boundary)
+        };
 
         // Transform (section, pos_in_section, item) to (global_pos, item).
         let stream = inner_stream.map(move |result| {
@@ -653,27 +748,31 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     ///
     /// Note that this operation may NOT be atomic, however it's guaranteed not to leave gaps in the
     /// event of failure as items are always pruned in order from oldest to newest.
-    pub async fn prune(&mut self, min_item_pos: u64) -> Result<bool, Error> {
+    pub async fn prune(&self, min_item_pos: u64) -> Result<bool, Error> {
+        let _write_guard = self.write_lock.lock().await;
+
+        let mut inner = self.inner.write().await;
+
         // Calculate the section that would contain min_item_pos
         let target_section = min_item_pos / self.items_per_blob;
 
         // Calculate the tail section.
-        let tail_section = self.size / self.items_per_blob;
+        let tail_section = inner.size / self.items_per_blob;
 
         // Cap to tail section. The tail section is guaranteed to exist by our invariant.
         let min_section = std::cmp::min(target_section, tail_section);
 
-        let pruned = self.inner.prune(min_section).await?;
+        let pruned = inner.journal.prune(min_section).await?;
 
         // After pruning, update pruning_boundary to the start of the oldest remaining section
         if pruned {
-            let new_oldest = self
-                .inner
+            let new_oldest = inner
+                .journal
                 .oldest_section()
                 .expect("all sections pruned - violates tail section invariant");
             // Pruning boundary only moves forward
-            assert!(self.pruning_boundary < new_oldest * self.items_per_blob);
-            self.pruning_boundary = new_oldest * self.items_per_blob;
+            assert!(inner.pruning_boundary < new_oldest * self.items_per_blob);
+            inner.pruning_boundary = new_oldest * self.items_per_blob;
         }
 
         Ok(pruned)
@@ -682,10 +781,11 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     /// Remove any persisted data created by the journal.
     pub async fn destroy(self) -> Result<(), Error> {
         // Destroy inner journal
-        self.inner.destroy().await?;
+        let inner = self.inner.into_inner();
+        inner.journal.destroy().await?;
 
         // Destroy metadata
-        self.metadata.destroy().await?;
+        inner.metadata.destroy().await?;
 
         Ok(())
     }
@@ -704,26 +804,40 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         // - Crash after clear: no blobs, recovery returns (0, 0), metadata ignored
         // - Crash after create: old metadata triggers "metadata ahead" warning,
         //   recovery falls back to blob state
-        self.inner.clear().await?;
+        let _write_guard = self.write_lock.lock().await;
+        let mut inner = self.inner.write().await;
+        inner.journal.clear().await?;
         let tail_section = new_size / self.items_per_blob;
-        self.inner.ensure_section_exists(tail_section).await?;
+        inner.journal.ensure_section_exists(tail_section).await?;
 
-        self.size = new_size;
-        self.pruning_boundary = new_size; // No data exists
+        inner.size = new_size;
+        inner.pruning_boundary = new_size; // No data exists
 
         // Persist metadata only when pruning_boundary is mid-section.
-        if !self.pruning_boundary.is_multiple_of(self.items_per_blob) {
-            self.metadata.put(
-                PRUNING_BOUNDARY_KEY,
-                self.pruning_boundary.to_be_bytes().to_vec(),
-            );
-            self.metadata.sync().await?;
-        } else if self.metadata.get(&PRUNING_BOUNDARY_KEY).is_some() {
-            self.metadata.remove(&PRUNING_BOUNDARY_KEY);
-            self.metadata.sync().await?;
+        if !inner.pruning_boundary.is_multiple_of(self.items_per_blob) {
+            let value = inner.pruning_boundary.to_be_bytes().to_vec();
+            inner.metadata.put(PRUNING_BOUNDARY_KEY, value);
+            inner.metadata.sync().await?;
+        } else if inner.metadata.get(&PRUNING_BOUNDARY_KEY).is_some() {
+            inner.metadata.remove(&PRUNING_BOUNDARY_KEY);
+            inner.metadata.sync().await?;
         }
 
         Ok(())
+    }
+
+    /// Test helper: Get the oldest section from the internal segmented journal.
+    #[cfg(test)]
+    pub(crate) async fn test_oldest_section(&self) -> Option<u64> {
+        let inner = self.inner.read().await;
+        inner.journal.oldest_section()
+    }
+
+    /// Test helper: Get the newest section from the internal segmented journal.
+    #[cfg(test)]
+    pub(crate) async fn test_newest_section(&self) -> Option<u64> {
+        let inner = self.inner.read().await;
+        inner.journal.newest_section()
     }
 }
 
@@ -731,15 +845,15 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
 impl<E: Clock + Storage + Metrics, A: CodecFixedShared> super::Contiguous for Journal<E, A> {
     type Item = A;
 
-    fn bounds(&self) -> std::ops::Range<u64> {
-        Self::bounds(self)
+    async fn bounds(&self) -> std::ops::Range<u64> {
+        Self::bounds(self).await
     }
 
     async fn replay(
         &self,
-        start_pos: u64,
         buffer: NonZeroUsize,
-    ) -> Result<impl Stream<Item = Result<(u64, Self::Item), Error>> + '_, Error> {
+        start_pos: u64,
+    ) -> Result<impl Stream<Item = Result<(u64, Self::Item), Error>> + Send + '_, Error> {
         Self::replay(self, buffer, start_pos).await
     }
 
@@ -766,15 +880,15 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Persistable for Journal<
     type Error = Error;
 
     async fn commit(&mut self) -> Result<(), Error> {
-        Self::sync(self).await
+        self.sync().await
     }
 
-    async fn sync(&mut self) -> Result<(), Error> {
-        Self::sync(self).await
+    async fn sync(&self) -> Result<(), Error> {
+        self.sync().await
     }
 
     async fn destroy(self) -> Result<(), Error> {
-        Self::destroy(self).await
+        self.destroy().await
     }
 }
 
@@ -879,7 +993,7 @@ mod tests {
                 .await
                 .expect("Failed to sync legacy blob");
 
-            let mut journal = Journal::<_, Digest>::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::<_, Digest>::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
             journal.append(test_digest(1)).await.unwrap();
@@ -901,7 +1015,7 @@ mod tests {
             let legacy_partition = cfg.partition.clone();
             let blobs_partition = blob_partition(&cfg);
 
-            let mut journal = Journal::<_, Digest>::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::<_, Digest>::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
             journal.append(test_digest(1)).await.unwrap();
@@ -924,7 +1038,7 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 2 items per blob.
             let cfg = test_cfg(NZU64!(2));
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
@@ -940,10 +1054,10 @@ mod tests {
             drop(journal);
 
             let cfg = test_cfg(NZU64!(2));
-            let mut journal = Journal::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::init(context.with_label("second"), cfg.clone())
                 .await
                 .expect("failed to re-initialize journal");
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
 
             // Append two more items to the journal to trigger a new blob creation
             pos = journal
@@ -975,7 +1089,7 @@ mod tests {
 
             // Pruning to 2 should allow the first blob to be pruned.
             journal.prune(2).await.expect("failed to prune journal 2");
-            assert_eq!(journal.bounds().start, 2);
+            assert_eq!(journal.bounds().await.start, 2);
 
             // Reading from the first blob should fail since it's now pruned
             let result0 = journal.read(0).await;
@@ -998,33 +1112,33 @@ mod tests {
 
             // Check no-op pruning
             journal.prune(0).await.expect("no-op pruning failed");
-            assert_eq!(journal.inner.oldest_section(), Some(1));
-            assert_eq!(journal.inner.newest_section(), Some(5));
-            assert_eq!(journal.bounds().start, 2);
+            assert_eq!(journal.inner.read().await.journal.oldest_section(), Some(1));
+            assert_eq!(journal.inner.read().await.journal.newest_section(), Some(5));
+            assert_eq!(journal.bounds().await.start, 2);
 
             // Prune first 3 blobs (6 items)
             journal
                 .prune(3 * cfg.items_per_blob.get())
                 .await
                 .expect("failed to prune journal 2");
-            assert_eq!(journal.inner.oldest_section(), Some(3));
-            assert_eq!(journal.inner.newest_section(), Some(5));
-            assert_eq!(journal.bounds().start, 6);
+            assert_eq!(journal.inner.read().await.journal.oldest_section(), Some(3));
+            assert_eq!(journal.inner.read().await.journal.newest_section(), Some(5));
+            assert_eq!(journal.bounds().await.start, 6);
 
             // Try pruning (more than) everything in the journal.
             journal
                 .prune(10000)
                 .await
                 .expect("failed to max-prune journal");
-            let size = journal.size();
+            let size = journal.size().await;
             assert_eq!(size, 10);
-            assert_eq!(journal.inner.oldest_section(), Some(5));
-            assert_eq!(journal.inner.newest_section(), Some(5));
+            assert_eq!(journal.test_oldest_section().await, Some(5));
+            assert_eq!(journal.test_newest_section().await, Some(5));
             // Since the size of the journal is currently a multiple of items_per_blob, the newest blob
             // will be empty, and there will be no retained items.
-            assert!(journal.bounds().is_empty());
+            assert!(journal.bounds().await.is_empty());
             // bounds.start should equal bounds.end when empty.
-            assert_eq!(journal.bounds().start, size);
+            assert_eq!(journal.bounds().await.start, size);
 
             // Replaying from 0 should fail since all items before bounds.start are pruned
             {
@@ -1034,8 +1148,11 @@ mod tests {
 
             // Replaying from pruning_boundary should return empty stream
             {
+                let res = journal.replay(NZUsize!(1024), 0).await;
+                assert!(matches!(res, Err(Error::ItemPruned(_))));
+
                 let stream = journal
-                    .replay(NZUsize!(1024), journal.bounds().start)
+                    .replay(NZUsize!(1024), journal.bounds().await.start)
                     .await
                     .expect("failed to replay journal from pruning boundary");
                 pin_mut!(stream);
@@ -1064,7 +1181,7 @@ mod tests {
         const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(10000);
         executor.start(|context| async move {
             let cfg = test_cfg(ITEMS_PER_BLOB);
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
             // Append 2 blobs worth of items.
@@ -1098,7 +1215,7 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 7 items per blob.
             let cfg = test_cfg(ITEMS_PER_BLOB);
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
@@ -1209,7 +1326,7 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 7 items per blob.
             let cfg = test_cfg(ITEMS_PER_BLOB);
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
@@ -1244,7 +1361,7 @@ mod tests {
             // Journal size is computed from the tail section, so it's unchanged
             // despite the corruption in section 40.
             let expected_size = ITEMS_PER_BLOB.get() * 100 + ITEMS_PER_BLOB.get() / 2;
-            assert_eq!(journal.size(), expected_size);
+            assert_eq!(journal.size().await, expected_size);
 
             // Replay should detect corruption (incomplete section) in section 40
             match journal.replay(NZUsize!(1024), 0).await {
@@ -1265,7 +1382,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(NZU64!(2));
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
             for i in 0u64..5 {
@@ -1312,7 +1429,7 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 7 items per blob.
             let cfg = test_cfg(ITEMS_PER_BLOB);
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
@@ -1324,7 +1441,7 @@ mod tests {
                     .await
                     .expect("failed to append data");
             }
-            assert_eq!(journal.size(), item_count);
+            assert_eq!(journal.size().await, item_count);
             journal.sync().await.expect("Failed to sync journal");
             drop(journal);
 
@@ -1343,7 +1460,7 @@ mod tests {
 
             // The truncation invalidates the last page (bad checksum), which is removed.
             // This loses one item.
-            assert_eq!(journal.size(), item_count - 1);
+            assert_eq!(journal.size().await, item_count - 1);
 
             // Cleanup.
             journal.destroy().await.expect("Failed to destroy journal");
@@ -1363,7 +1480,7 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 7 items per blob.
             let cfg = test_cfg(ITEMS_PER_BLOB);
-            let mut journal = Journal::init(context.clone(), cfg.clone())
+            let journal = Journal::init(context.clone(), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
@@ -1424,7 +1541,7 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 3 items per blob.
             let cfg = test_cfg(NZU64!(3));
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
             for i in 0..5 {
@@ -1433,7 +1550,7 @@ mod tests {
                     .await
                     .expect("failed to append data");
             }
-            assert_eq!(journal.size(), 5);
+            assert_eq!(journal.size().await, 5);
             journal.sync().await.expect("Failed to sync journal");
             drop(journal);
 
@@ -1451,8 +1568,8 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             // The truncation invalidates the last page, which is removed. This loses one item.
-            assert_eq!(journal.pruning_boundary, 0);
-            assert_eq!(journal.size(), 4);
+            assert_eq!(journal.pruning_boundary().await, 0);
+            assert_eq!(journal.size().await, 4);
             drop(journal);
 
             // Delete the second blob and re-init
@@ -1465,7 +1582,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             // Only the first blob remains
-            assert_eq!(journal.size(), 3);
+            assert_eq!(journal.size().await, 3);
 
             journal.destroy().await.unwrap();
         });
@@ -1476,7 +1593,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(NZU64!(5));
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .expect("failed to initialize journal at size");
@@ -1489,8 +1606,8 @@ mod tests {
                     .expect("failed to append data");
             }
             journal.sync().await.expect("failed to sync journal");
-            assert_eq!(journal.pruning_boundary, 7);
-            assert_eq!(journal.size(), 15);
+            assert_eq!(journal.pruning_boundary().await, 7);
+            assert_eq!(journal.size().await, 15);
             drop(journal);
 
             // Corrupt the oldest section by truncating one byte (drops one item on recovery).
@@ -1513,7 +1630,7 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 10 items per blob.
             let cfg = test_cfg(NZU64!(10));
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
             // Add only a single item
@@ -1521,7 +1638,7 @@ mod tests {
                 .append(test_digest(0))
                 .await
                 .expect("failed to append data");
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
             journal.sync().await.expect("Failed to sync journal");
             drop(journal);
 
@@ -1535,20 +1652,20 @@ mod tests {
             blob.sync().await.expect("Failed to sync blob");
 
             // Re-initialize the journal to simulate a restart
-            let mut journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
                 .await
                 .expect("Failed to re-initialize journal");
 
             // Since there was only a single item appended which we then corrupted, recovery should
             // leave us in the state of an empty journal.
-            assert_eq!(journal.bounds().end, 0);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 0);
+            assert!(journal.bounds().await.is_empty());
             // Make sure journal still works for appending.
             journal
                 .append(test_digest(0))
                 .await
                 .expect("failed to append data");
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
 
             journal.destroy().await.unwrap();
         });
@@ -1560,7 +1677,7 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 10 items per blob.
             let cfg = test_cfg(NZU64!(10));
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
@@ -1569,7 +1686,7 @@ mod tests {
                 .append(test_digest(0))
                 .await
                 .expect("failed to append data");
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
             journal.sync().await.expect("Failed to sync journal");
             drop(journal);
 
@@ -1585,13 +1702,13 @@ mod tests {
             blob.sync().await.expect("Failed to sync blob");
 
             // Re-initialize the journal to simulate a restart
-            let mut journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
                 .await
                 .expect("Failed to re-initialize journal");
 
             // The zero-filled pages are detected as invalid (bad checksum) and truncated.
             // No items should be lost since we called sync before the corruption.
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
 
             // Make sure journal still works for appending.
             journal
@@ -1609,7 +1726,7 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 2 items per blob.
             let cfg = test_cfg(NZU64!(2));
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
             assert!(matches!(journal.rewind(0).await, Ok(())));
@@ -1623,10 +1740,10 @@ mod tests {
                 .append(test_digest(0))
                 .await
                 .expect("failed to append data 0");
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
             assert!(matches!(journal.rewind(1).await, Ok(()))); // should be no-op
             assert!(matches!(journal.rewind(0).await, Ok(())));
-            assert_eq!(journal.size(), 0);
+            assert_eq!(journal.size().await, 0);
 
             // append 7 items
             for i in 0..7 {
@@ -1636,15 +1753,15 @@ mod tests {
                     .expect("failed to append data");
                 assert_eq!(pos, i);
             }
-            assert_eq!(journal.size(), 7);
+            assert_eq!(journal.size().await, 7);
 
             // rewind back to item #4, which should prune 2 blobs
             assert!(matches!(journal.rewind(4).await, Ok(())));
-            assert_eq!(journal.size(), 4);
+            assert_eq!(journal.size().await, 4);
 
             // rewind back to empty and ensure all blobs are rewound over
             assert!(matches!(journal.rewind(0).await, Ok(())));
-            assert_eq!(journal.size(), 0);
+            assert_eq!(journal.size().await, 0);
 
             // stress test: add 100 items, rewind 49, repeat x10.
             for _ in 0..10 {
@@ -1654,10 +1771,10 @@ mod tests {
                         .await
                         .expect("failed to append data");
                 }
-                journal.rewind(journal.size() - 49).await.unwrap();
+                journal.rewind(journal.size().await - 49).await.unwrap();
             }
             const ITEMS_REMAINING: u64 = 10 * (100 - 49);
-            assert_eq!(journal.size(), ITEMS_REMAINING);
+            assert_eq!(journal.size().await, ITEMS_REMAINING);
 
             journal.sync().await.expect("Failed to sync journal");
             drop(journal);
@@ -1665,7 +1782,7 @@ mod tests {
             // Repeat with a different blob size (3 items per blob)
             let mut cfg = test_cfg(NZU64!(3));
             cfg.partition = "test_partition_2".into();
-            let mut journal = Journal::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::init(context.with_label("second"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
             for _ in 0..10 {
@@ -1675,23 +1792,23 @@ mod tests {
                         .await
                         .expect("failed to append data");
                 }
-                journal.rewind(journal.size() - 49).await.unwrap();
+                journal.rewind(journal.size().await - 49).await.unwrap();
             }
-            assert_eq!(journal.size(), ITEMS_REMAINING);
+            assert_eq!(journal.size().await, ITEMS_REMAINING);
 
             journal.sync().await.expect("Failed to sync journal");
             drop(journal);
 
             // Make sure re-opened journal is as expected
-            let mut journal: Journal<_, Digest> =
+            let journal: Journal<_, Digest> =
                 Journal::init(context.with_label("third"), cfg.clone())
                     .await
                     .expect("failed to re-initialize journal");
-            assert_eq!(journal.size(), 10 * (100 - 49));
+            assert_eq!(journal.size().await, 10 * (100 - 49));
 
             // Make sure rewinding works after pruning
             journal.prune(300).await.expect("pruning failed");
-            assert_eq!(journal.size(), ITEMS_REMAINING);
+            assert_eq!(journal.size().await, ITEMS_REMAINING);
             // Rewinding prior to our prune point should fail.
             assert!(matches!(
                 journal.rewind(299).await,
@@ -1700,8 +1817,8 @@ mod tests {
             // Rewinding to the prune point should work.
             // always remain in the journal.
             assert!(matches!(journal.rewind(300).await, Ok(())));
-            assert_eq!(journal.bounds().end, 300);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 300);
+            assert!(journal.bounds().await.is_empty());
 
             journal.destroy().await.unwrap();
         });
@@ -1720,7 +1837,7 @@ mod tests {
         executor.start(|context: Context| async move {
             // Use a small items_per_blob to keep the test focused on a single blob
             let cfg = test_cfg(NZU64!(100));
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
@@ -1737,7 +1854,7 @@ mod tests {
                     .await
                     .expect("failed to append data");
             }
-            assert_eq!(journal.size(), 10);
+            assert_eq!(journal.size().await, 10);
             journal.sync().await.expect("Failed to sync journal");
             drop(journal);
 
@@ -1771,7 +1888,7 @@ mod tests {
             let remaining_logical_bytes = (full_pages - 1) * PAGE_SIZE.get() as u64;
             let expected_items = remaining_logical_bytes / 32; // 32 = Digest::SIZE
             assert_eq!(
-                journal.size(),
+                journal.size().await,
                 expected_items,
                 "Journal should recover to {} items after truncation",
                 expected_items
@@ -1807,13 +1924,13 @@ mod tests {
             };
 
             // === Test 1: Basic single item operation ===
-            let mut journal = Journal::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::init(context.with_label("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
             // Verify empty state
-            assert_eq!(journal.bounds().end, 0);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 0);
+            assert!(journal.bounds().await.is_empty());
 
             // Append 1 item
             let pos = journal
@@ -1821,14 +1938,14 @@ mod tests {
                 .await
                 .expect("failed to append");
             assert_eq!(pos, 0);
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
 
             // Sync
             journal.sync().await.expect("failed to sync");
 
             // Read from size() - 1
             let value = journal
-                .read(journal.size() - 1)
+                .read(journal.size().await - 1)
                 .await
                 .expect("failed to read");
             assert_eq!(value, test_digest(0));
@@ -1840,11 +1957,11 @@ mod tests {
                     .await
                     .expect("failed to append");
                 assert_eq!(pos, i);
-                assert_eq!(journal.size(), i + 1);
+                assert_eq!(journal.size().await, i + 1);
 
                 // Verify we can read the just-appended item at size() - 1
                 let value = journal
-                    .read(journal.size() - 1)
+                    .read(journal.size().await - 1)
                     .await
                     .expect("failed to read");
                 assert_eq!(value, test_digest(i));
@@ -1862,14 +1979,14 @@ mod tests {
             journal.prune(5).await.expect("failed to prune");
 
             // Size should still be 10
-            assert_eq!(journal.size(), 10);
+            assert_eq!(journal.size().await, 10);
 
             // bounds.start should be 5
-            assert_eq!(journal.bounds().start, 5);
+            assert_eq!(journal.bounds().await.start, 5);
 
             // Reading from size() - 1 (position 9) should still work
             let value = journal
-                .read(journal.size() - 1)
+                .read(journal.size().await - 1)
                 .await
                 .expect("failed to read");
             assert_eq!(value, test_digest(9));
@@ -1894,7 +2011,7 @@ mod tests {
 
                 // Verify we can read from size() - 1
                 let value = journal
-                    .read(journal.size() - 1)
+                    .read(journal.size().await - 1)
                     .await
                     .expect("failed to read");
                 assert_eq!(value, test_digest(i));
@@ -1909,14 +2026,14 @@ mod tests {
                 .expect("failed to re-initialize journal");
 
             // Verify size is preserved
-            assert_eq!(journal.size(), 15);
+            assert_eq!(journal.size().await, 15);
 
             // Verify bounds.start is preserved
-            assert_eq!(journal.bounds().start, 5);
+            assert_eq!(journal.bounds().await.start, 5);
 
             // Reading from size() - 1 should work after restart
             let value = journal
-                .read(journal.size() - 1)
+                .read(journal.size().await - 1)
                 .await
                 .expect("failed to read");
             assert_eq!(value, test_digest(14));
@@ -1930,7 +2047,7 @@ mod tests {
 
             // === Test 5: Restart after pruning with non-zero index ===
             // Fresh journal for this test
-            let mut journal = Journal::init(context.with_label("third"), cfg.clone())
+            let journal = Journal::init(context.with_label("third"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
@@ -1941,8 +2058,8 @@ mod tests {
 
             // Prune to position 5 (removes positions 0-4)
             journal.prune(5).await.unwrap();
-            assert_eq!(journal.bounds().end, 10);
-            assert_eq!(journal.bounds().start, 5);
+            assert_eq!(journal.bounds().await.end, 10);
+            assert_eq!(journal.bounds().await.start, 5);
 
             // Sync and restart
             journal.sync().await.unwrap();
@@ -1954,11 +2071,11 @@ mod tests {
                 .expect("failed to re-initialize journal");
 
             // Verify state after restart
-            assert_eq!(journal.bounds().end, 10);
-            assert_eq!(journal.bounds().start, 5);
+            assert_eq!(journal.bounds().await.end, 10);
+            assert_eq!(journal.bounds().await.start, 5);
 
             // Reading from size() - 1 (position 9) should work
-            let value = journal.read(journal.size() - 1).await.unwrap();
+            let value = journal.read(journal.size().await - 1).await.unwrap();
             assert_eq!(value, test_digest(109));
 
             // Verify all retained positions (5-9) work
@@ -1969,7 +2086,7 @@ mod tests {
             journal.destroy().await.expect("failed to destroy journal");
 
             // === Test 6: Prune all items (edge case) ===
-            let mut journal = Journal::init(context.clone(), cfg.clone())
+            let journal = Journal::init(context.clone(), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
 
@@ -1980,18 +2097,18 @@ mod tests {
 
             // Prune all items
             journal.prune(5).await.unwrap();
-            assert_eq!(journal.bounds().end, 5); // Size unchanged
-            assert!(journal.bounds().is_empty()); // All pruned
+            assert_eq!(journal.bounds().await.end, 5); // Size unchanged
+            assert!(journal.bounds().await.is_empty()); // All pruned
 
             // size() - 1 = 4, but position 4 is pruned
-            let result = journal.read(journal.size() - 1).await;
+            let result = journal.read(journal.size().await - 1).await;
             assert!(matches!(result, Err(Error::ItemPruned(4))));
 
             // After appending, reading works again
             journal.append(test_digest(205)).await.unwrap();
-            assert_eq!(journal.bounds().start, 5);
+            assert_eq!(journal.bounds().await.start, 5);
             assert_eq!(
-                journal.read(journal.size() - 1).await.unwrap(),
+                journal.read(journal.size().await - 1).await.unwrap(),
                 test_digest(205)
             );
 
@@ -2004,17 +2121,17 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(NZU64!(5));
-            let mut journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 0)
+            let journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 0)
                 .await
                 .unwrap();
 
-            assert_eq!(journal.bounds().end, 0);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 0);
+            assert!(journal.bounds().await.is_empty());
 
             // Next append should get position 0
             let pos = journal.append(test_digest(100)).await.unwrap();
             assert_eq!(pos, 0);
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
             assert_eq!(journal.read(0).await.unwrap(), test_digest(100));
 
             journal.destroy().await.unwrap();
@@ -2028,17 +2145,17 @@ mod tests {
             let cfg = test_cfg(NZU64!(5));
 
             // Initialize at position 10 (exactly at section 2 boundary with items_per_blob=5)
-            let mut journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 10)
+            let journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 10)
                 .await
                 .unwrap();
 
-            assert_eq!(journal.bounds().end, 10);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 10);
+            assert!(journal.bounds().await.is_empty());
 
             // Next append should get position 10
             let pos = journal.append(test_digest(1000)).await.unwrap();
             assert_eq!(pos, 10);
-            assert_eq!(journal.size(), 11);
+            assert_eq!(journal.size().await, 11);
             assert_eq!(journal.read(10).await.unwrap(), test_digest(1000));
 
             // Can continue appending
@@ -2058,13 +2175,13 @@ mod tests {
 
             // Initialize at position 7 (middle of section 1 with items_per_blob=5)
             // No data exists yet, so oldest_retained_pos is None
-            let mut journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 7)
+            let journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 7)
                 .await
                 .unwrap();
 
-            assert_eq!(journal.bounds().end, 7);
+            assert_eq!(journal.bounds().await.end, 7);
             // No data exists yet after init_at_size
-            assert!(journal.bounds().is_empty());
+            assert!(journal.bounds().await.is_empty());
 
             // Reading before bounds.start should return ItemPruned
             assert!(matches!(journal.read(5).await, Err(Error::ItemPruned(5))));
@@ -2073,10 +2190,10 @@ mod tests {
             // Next append should get position 7
             let pos = journal.append(test_digest(700)).await.unwrap();
             assert_eq!(pos, 7);
-            assert_eq!(journal.size(), 8);
+            assert_eq!(journal.size().await, 8);
             assert_eq!(journal.read(7).await.unwrap(), test_digest(700));
             // Now bounds.start should be 7 (first data position)
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.start, 7);
 
             journal.destroy().await.unwrap();
         });
@@ -2089,7 +2206,7 @@ mod tests {
             let cfg = test_cfg(NZU64!(5));
 
             // Initialize at position 15
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init_at_size(context.with_label("first"), cfg.clone(), 15)
                     .await
                     .unwrap();
@@ -2100,19 +2217,19 @@ mod tests {
                 assert_eq!(pos, 15 + i);
             }
 
-            assert_eq!(journal.size(), 20);
+            assert_eq!(journal.size().await, 20);
 
             // Sync and reopen
             journal.sync().await.unwrap();
             drop(journal);
 
-            let mut journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
 
             // Size and data should be preserved
-            assert_eq!(journal.bounds().end, 20);
-            assert_eq!(journal.bounds().start, 15);
+            assert_eq!(journal.bounds().await.end, 20);
+            assert_eq!(journal.bounds().await.start, 15);
 
             // Verify data
             for i in 0..5u64 {
@@ -2140,19 +2257,19 @@ mod tests {
                     .await
                     .unwrap();
 
-            assert_eq!(journal.bounds().end, 15);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 15);
+            assert!(journal.bounds().await.is_empty());
 
             // Drop without writing any data
             drop(journal);
 
             // Reopen and verify size persisted
-            let mut journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
 
-            assert_eq!(journal.bounds().end, 15);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 15);
+            assert!(journal.bounds().await.is_empty());
 
             // Can append starting at position 15
             let pos = journal.append(test_digest(1500)).await.unwrap();
@@ -2170,13 +2287,12 @@ mod tests {
             let cfg = test_cfg(NZU64!(5));
 
             // Initialize at a large position (position 1000)
-            let mut journal =
-                Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 1000)
-                    .await
-                    .unwrap();
+            let journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 1000)
+                .await
+                .unwrap();
 
-            assert_eq!(journal.bounds().end, 1000);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 1000);
+            assert!(journal.bounds().await.is_empty());
 
             // Next append should get position 1000
             let pos = journal.append(test_digest(100000)).await.unwrap();
@@ -2194,7 +2310,7 @@ mod tests {
             let cfg = test_cfg(NZU64!(5));
 
             // Initialize at position 20
-            let mut journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 20)
+            let journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 20)
                 .await
                 .unwrap();
 
@@ -2203,13 +2319,13 @@ mod tests {
                 journal.append(test_digest(2000 + i)).await.unwrap();
             }
 
-            assert_eq!(journal.size(), 30);
+            assert_eq!(journal.size().await, 30);
 
             // Prune to position 25
             journal.prune(25).await.unwrap();
 
-            assert_eq!(journal.bounds().end, 30);
-            assert_eq!(journal.bounds().start, 25);
+            assert_eq!(journal.bounds().await.end, 30);
+            assert_eq!(journal.bounds().await.start, 25);
 
             // Verify remaining items are readable
             for i in 25..30u64 {
@@ -2237,12 +2353,12 @@ mod tests {
             for i in 0..25u64 {
                 journal.append(test_digest(i)).await.unwrap();
             }
-            assert_eq!(journal.size(), 25);
+            assert_eq!(journal.size().await, 25);
             journal.sync().await.unwrap();
 
             // Clear to position 100, effectively resetting the journal
             journal.clear_to_size(100).await.unwrap();
-            assert_eq!(journal.size(), 100);
+            assert_eq!(journal.size().await, 100);
 
             // Old positions should fail
             for i in 0..25 {
@@ -2251,18 +2367,18 @@ mod tests {
 
             // Verify size persists after restart without writing any data
             drop(journal);
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init(context.with_label("journal_after_clear"), cfg.clone())
                     .await
                     .expect("failed to re-initialize journal after clear");
-            assert_eq!(journal.size(), 100);
+            assert_eq!(journal.size().await, 100);
 
             // Append new data starting at position 100
             for i in 100..105u64 {
                 let pos = journal.append(test_digest(i)).await.unwrap();
                 assert_eq!(pos, i);
             }
-            assert_eq!(journal.size(), 105);
+            assert_eq!(journal.size().await, 105);
 
             // New positions should be readable
             for i in 100..105u64 {
@@ -2277,7 +2393,7 @@ mod tests {
                 .await
                 .expect("failed to re-initialize journal");
 
-            assert_eq!(journal.size(), 105);
+            assert_eq!(journal.size().await, 105);
             for i in 100..105u64 {
                 assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
             }
@@ -2292,22 +2408,24 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(NZU64!(5));
-            let mut journal = Journal::<_, Digest>::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::<_, Digest>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
             for i in 0..5u64 {
                 journal.append(test_digest(i)).await.unwrap();
             }
-            let tail_section = journal.size / journal.items_per_blob;
-            journal.inner.sync(tail_section).await.unwrap();
+            let inner = journal.inner.read().await;
+            let tail_section = inner.size / journal.items_per_blob;
+            inner.journal.sync(tail_section).await.unwrap();
+            drop(inner);
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(journal.bounds().start, 0);
-            assert_eq!(journal.bounds().end, 5);
+            assert_eq!(journal.bounds().await.start, 0);
+            assert_eq!(journal.bounds().await.end, 5);
             journal.destroy().await.unwrap();
         });
     }
@@ -2318,19 +2436,21 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(NZU64!(5));
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
             for i in 0..3u64 {
                 journal.append(test_digest(i)).await.unwrap();
             }
-            assert_eq!(journal.inner.newest_section(), Some(2));
+            assert_eq!(journal.inner.read().await.journal.newest_section(), Some(2));
             journal.sync().await.unwrap();
 
             // Simulate metadata deletion (corruption).
-            journal.metadata.clear();
-            journal.metadata.sync().await.unwrap();
+            let mut inner = journal.inner.write().await;
+            inner.metadata.clear();
+            inner.metadata.sync().await.unwrap();
+            drop(inner);
             drop(journal);
 
             // Section 1 has items 7,8,9 but metadata is missing, so falls back to blob-based boundary.
@@ -2353,22 +2473,24 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(NZU64!(5));
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
             for i in 0..3u64 {
                 journal.append(test_digest(i)).await.unwrap();
             }
-            let tail_section = journal.size / journal.items_per_blob;
-            journal.inner.sync(tail_section).await.unwrap();
+            let inner = journal.inner.read().await;
+            let tail_section = inner.size / journal.items_per_blob;
+            inner.journal.sync(tail_section).await.unwrap();
+            drop(inner);
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(journal.bounds().start, 7);
-            assert_eq!(journal.bounds().end, 10);
+            assert_eq!(journal.bounds().await.start, 7);
+            assert_eq!(journal.bounds().await.end, 10);
             journal.destroy().await.unwrap();
         });
     }
@@ -2378,25 +2500,27 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(NZU64!(5));
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
             for i in 0..10u64 {
                 journal.append(test_digest(i)).await.unwrap();
             }
-            assert_eq!(journal.size(), 17);
+            assert_eq!(journal.size().await, 17);
             journal.prune(10).await.unwrap();
 
-            let tail_section = journal.size / journal.items_per_blob;
-            journal.inner.sync(tail_section).await.unwrap();
+            let inner = journal.inner.read().await;
+            let tail_section = inner.size / journal.items_per_blob;
+            inner.journal.sync(tail_section).await.unwrap();
+            drop(inner);
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(journal.bounds().start, 10);
-            assert_eq!(journal.bounds().end, 17);
+            assert_eq!(journal.bounds().await.start, 10);
+            assert_eq!(journal.bounds().await.end, 17);
             journal.destroy().await.unwrap();
         });
     }
@@ -2409,7 +2533,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(NZU64!(5));
             // init_at_size(7) sets pruning_boundary = 7 (mid-section in section 1)
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
@@ -2419,7 +2543,7 @@ mod tests {
             }
             // Prune to position 5 (section 1 start) should NOT move boundary back from 7 to 5
             journal.prune(5).await.unwrap();
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.start, 7);
             journal.destroy().await.unwrap();
         });
     }
@@ -2434,7 +2558,7 @@ mod tests {
 
             // Initialize at position 7 (mid-section with items_per_blob=5)
             // Section 1 (positions 5-9) begins mid-section: only positions 7, 8, 9 have data
-            let mut journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 7)
+            let journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 7)
                 .await
                 .unwrap();
 
@@ -2443,7 +2567,7 @@ mod tests {
                 let pos = journal.append(test_digest(100 + i)).await.unwrap();
                 assert_eq!(pos, 7 + i);
             }
-            assert_eq!(journal.size(), 20);
+            assert_eq!(journal.size().await, 20);
             journal.sync().await.unwrap();
 
             // Replay from pruning_boundary
@@ -2497,7 +2621,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(NZU64!(5));
 
-            let mut journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 10)
+            let journal = Journal::<_, Digest>::init_at_size(context.clone(), cfg.clone(), 10)
                 .await
                 .unwrap();
 
@@ -2505,15 +2629,15 @@ mod tests {
             for i in 0..3u64 {
                 journal.append(test_digest(i)).await.unwrap();
             }
-            assert_eq!(journal.size(), 13);
+            assert_eq!(journal.size().await, 13);
 
             // Rewind to position 11 should work
             journal.rewind(11).await.unwrap();
-            assert_eq!(journal.size(), 11);
+            assert_eq!(journal.size().await, 11);
 
             // Rewind to position 10 (pruning_boundary) should work
             journal.rewind(10).await.unwrap();
-            assert_eq!(journal.size(), 10);
+            assert_eq!(journal.size().await, 10);
 
             // Rewind to before pruning_boundary should fail
             let result = journal.rewind(9).await;
@@ -2530,7 +2654,7 @@ mod tests {
             let cfg = test_cfg(NZU64!(5));
 
             // Setup: Create a journal with some data and mid-section metadata
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
@@ -2549,8 +2673,8 @@ mod tests {
             let journal = Journal::<_, Digest>::init(context.with_label("crash1"), cfg.clone())
                 .await
                 .expect("init failed after clear crash");
-            assert_eq!(journal.bounds().end, 0);
-            assert_eq!(journal.bounds().start, 0);
+            assert_eq!(journal.bounds().await.end, 0);
+            assert_eq!(journal.bounds().await.start, 0);
             drop(journal);
 
             // Restore metadata for next scenario (it might have been removed by init)
@@ -2588,9 +2712,9 @@ mod tests {
                 .expect("init failed after create crash");
 
             // Should recover to blob state (section 0 aligned)
-            assert_eq!(journal.bounds().start, 0);
+            assert_eq!(journal.bounds().await.start, 0);
             // Size is 0 because blob is empty
-            assert_eq!(journal.bounds().end, 0);
+            assert_eq!(journal.bounds().await.end, 0);
             journal.destroy().await.unwrap();
         });
     }
@@ -2603,7 +2727,7 @@ mod tests {
 
             // Setup: Init at 12 (Section 2, offset 2)
             // Metadata = 12
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init_at_size(context.with_label("first"), cfg.clone(), 12)
                     .await
                     .unwrap();
@@ -2631,8 +2755,8 @@ mod tests {
                     .expect("init failed after clear_to_size crash");
 
             // Should fallback to blobs
-            assert_eq!(journal.bounds().start, 0);
-            assert_eq!(journal.bounds().end, 0);
+            assert_eq!(journal.bounds().await.start, 0);
+            assert_eq!(journal.bounds().await.end, 0);
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -1,6 +1,6 @@
 //! Generic test suite for [Contiguous] trait implementations.
 
-use super::Contiguous;
+use super::{Contiguous, ContiguousReader as _};
 use crate::{
     journal::{contiguous::MutableContiguous, Error},
     Persistable,
@@ -222,7 +222,8 @@ where
     }
 
     {
-        let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
+        let reader = journal.reader().await;
+        let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -253,7 +254,8 @@ where
     }
 
     {
-        let stream = journal.replay(NZUsize!(1024), 7).await.unwrap();
+        let reader = journal.reader().await;
+        let stream = reader.replay(NZUsize!(1024), 7).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -341,7 +343,8 @@ where
     {
         // Replay from a position that may or may not be pruned (section-aligned)
         // We replay from position 10 which should be safe
-        let stream = journal.replay(NZUsize!(1024), 10).await.unwrap();
+        let reader = journal.reader().await;
+        let stream = reader.replay(NZUsize!(1024), 10).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -418,7 +421,8 @@ where
 
     {
         // Replay from position 10 and verify positions
-        let stream = journal.replay(NZUsize!(1024), 10).await.unwrap();
+        let reader = journal.reader().await;
+        let stream = reader.replay(NZUsize!(1024), 10).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -471,7 +475,8 @@ where
     let journal = factory("replay_on_empty".to_string()).await.unwrap();
 
     {
-        let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
+        let reader = journal.reader().await;
+        let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -500,7 +505,8 @@ where
     let bounds = journal.bounds().await;
 
     {
-        let stream = journal.replay(NZUsize!(1024), bounds.end).await.unwrap();
+        let reader = journal.reader().await;
+        let stream = reader.replay(NZUsize!(1024), bounds.end).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -599,7 +605,8 @@ where
 
         // Replay and verify all items
         {
-            let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
+            let reader = journal.reader().await;
+            let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut items = Vec::new();
@@ -662,7 +669,8 @@ where
 
         // Replay from position 10 (first non-pruned position)
         {
-            let stream = journal.replay(NZUsize!(1024), 10).await.unwrap();
+            let reader = journal.reader().await;
+            let stream = reader.replay(NZUsize!(1024), 10).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut items = Vec::new();
@@ -1072,7 +1080,8 @@ where
 
         // Replay should yield no items
         {
-            let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
+            let reader = journal.reader().await;
+            let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut items = Vec::new();

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -83,7 +83,7 @@ where
     J: PersistableContiguous<u64>,
 {
     let journal = factory("empty".to_string()).await.unwrap();
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.start, 0);
     assert_eq!(bounds.end, 0);
     assert!(bounds.is_empty());
@@ -103,7 +103,7 @@ where
         journal.append(i * 100).await.unwrap();
     }
 
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.start, 0);
     assert_eq!(bounds.end, 10);
     assert!(!bounds.is_empty());
@@ -126,7 +126,7 @@ where
     }
 
     // Initially bounds should be 0..30
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.start, 0);
     assert_eq!(bounds.end, 30);
 
@@ -134,7 +134,7 @@ where
     journal.prune(10).await.unwrap();
 
     // Assumed section-aligned pruning and items_per_section = 10
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.start, 10);
     assert_eq!(bounds.end, 30);
 
@@ -142,13 +142,13 @@ where
     journal.prune(25).await.unwrap();
 
     // bounds.start should have advanced to 20 (section-aligned)
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.start, 20);
     assert_eq!(bounds.end, 30);
 
     // Prune all
     journal.prune(30).await.unwrap();
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.start, 30);
     assert_eq!(bounds.end, 30);
     assert!(bounds.is_empty());
@@ -157,9 +157,8 @@ where
     journal.sync().await.unwrap();
     drop(journal);
     let journal = factory("bounds_after_prune".to_string()).await.unwrap();
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert!(bounds.is_empty());
-
     journal.destroy().await.unwrap();
 }
 
@@ -178,7 +177,7 @@ where
     assert_eq!(pos1, 0);
     assert_eq!(pos2, 1);
     assert_eq!(pos3, 2);
-    assert_eq!(journal.bounds().end, 3);
+    assert_eq!(journal.bounds().await.end, 3);
 
     // Verify values can be read back
     assert_eq!(journal.read(0).await.unwrap(), 100);
@@ -201,7 +200,7 @@ where
         assert_eq!(pos, i);
     }
 
-    assert_eq!(journal.bounds().end, 25);
+    assert_eq!(journal.bounds().await.end, 25);
 
     for i in 0..25u64 {
         assert_eq!(journal.read(i).await.unwrap(), i * 10);
@@ -223,7 +222,7 @@ where
     }
 
     {
-        let stream = journal.replay(0, NZUsize!(1024)).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -254,7 +253,7 @@ where
     }
 
     {
-        let stream = journal.replay(7, NZUsize!(1024)).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 7).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -284,22 +283,22 @@ where
         journal.append(i).await.unwrap();
     }
 
-    let size_before = journal.bounds().end;
+    let size_before = journal.bounds().await.end;
     journal.prune(10).await.unwrap();
-    let size_after = journal.bounds().end;
+    let size_after = journal.bounds().await.end;
 
     assert_eq!(size_before, size_after);
     assert_eq!(size_after, 20);
 
     journal.prune(20).await.unwrap();
-    let size_after_all = journal.bounds().end;
+    let size_after_all = journal.bounds().await.end;
     assert_eq!(size_after, size_after_all);
 
     journal.sync().await.unwrap();
     drop(journal);
 
     let journal = factory("prune_retains_size".to_string()).await.unwrap();
-    let size_after_close = journal.bounds().end;
+    let size_after_close = journal.bounds().await.end;
     assert_eq!(size_after_close, size_after_all);
 
     journal.destroy().await.unwrap();
@@ -319,7 +318,7 @@ where
     assert_eq!(pos1, 0);
     assert_eq!(pos2, 1);
 
-    let bounds = Contiguous::bounds(&journal);
+    let bounds = Contiguous::bounds(&journal).await;
     assert_eq!(bounds.end, 2);
 
     journal.destroy().await.unwrap();
@@ -342,7 +341,7 @@ where
     {
         // Replay from a position that may or may not be pruned (section-aligned)
         // We replay from position 10 which should be safe
-        let stream = journal.replay(10, NZUsize!(1024)).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 10).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -378,13 +377,13 @@ where
 
     // Prune all items (prune at section boundary)
     journal.prune(10).await.unwrap();
-    assert!(journal.bounds().is_empty());
+    assert!(journal.bounds().await.is_empty());
 
     // Append new items after pruning - position should continue from 10
     let pos = journal.append(999).await.unwrap();
     assert_eq!(pos, 10);
 
-    assert_eq!(journal.bounds().end, 11);
+    assert_eq!(journal.bounds().await.end, 11);
 
     journal.destroy().await.unwrap();
 }
@@ -419,7 +418,7 @@ where
 
     {
         // Replay from position 10 and verify positions
-        let stream = journal.replay(10, NZUsize!(1024)).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 10).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -458,7 +457,7 @@ where
     assert_eq!(pos, 5);
     assert_eq!(journal.read(5).await.unwrap(), 100);
 
-    assert_eq!(journal.bounds().end, 6);
+    assert_eq!(journal.bounds().await.end, 6);
 
     journal.destroy().await.unwrap();
 }
@@ -472,7 +471,7 @@ where
     let journal = factory("replay_on_empty".to_string()).await.unwrap();
 
     {
-        let stream = journal.replay(0, NZUsize!(1024)).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -498,10 +497,10 @@ where
         journal.append(i).await.unwrap();
     }
 
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
 
     {
-        let stream = journal.replay(bounds.end, NZUsize!(1024)).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), bounds.end).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -533,7 +532,7 @@ where
     assert!(pruned1);
     assert!(!pruned2); // Second prune should return false (nothing to prune)
 
-    assert_eq!(journal.bounds().end, 20);
+    assert_eq!(journal.bounds().await.end, 20);
     assert_eq!(journal.read(10).await.unwrap(), 10);
     assert_eq!(journal.read(19).await.unwrap(), 19);
 
@@ -556,7 +555,7 @@ where
     journal.prune(100).await.unwrap();
 
     // Verify journal still works
-    assert_eq!(journal.bounds().end, 10);
+    assert_eq!(journal.bounds().await.end, 10);
 
     let pos = journal.append(999).await.unwrap();
     assert_eq!(pos, 10);
@@ -582,7 +581,7 @@ where
             assert_eq!(pos, i);
         }
 
-        assert_eq!(journal.bounds().end, 15);
+        assert_eq!(journal.bounds().await.end, 15);
 
         journal.sync().await.unwrap();
     }
@@ -591,7 +590,7 @@ where
     {
         let journal = factory(test_name.clone()).await.unwrap();
 
-        assert_eq!(journal.bounds().end, 15);
+        assert_eq!(journal.bounds().await.end, 15);
 
         // Verify reads work after persistence
         for i in 0..15u64 {
@@ -600,7 +599,7 @@ where
 
         // Replay and verify all items
         {
-            let stream = journal.replay(0, NZUsize!(1024)).await.unwrap();
+            let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut items = Vec::new();
@@ -639,7 +638,7 @@ where
         let pruned = journal.prune(10).await.unwrap();
         assert!(pruned);
 
-        assert_eq!(journal.bounds().end, 25);
+        assert_eq!(journal.bounds().await.end, 25);
 
         journal.sync().await.unwrap();
     }
@@ -649,7 +648,7 @@ where
         let mut journal = factory(test_name.clone()).await.unwrap();
 
         // size should still be 25
-        assert_eq!(journal.bounds().end, 25);
+        assert_eq!(journal.bounds().await.end, 25);
 
         // Verify pruned positions cannot be read
         for i in 0..10u64 {
@@ -663,7 +662,7 @@ where
 
         // Replay from position 10 (first non-pruned position)
         {
-            let stream = journal.replay(10, NZUsize!(1024)).await.unwrap();
+            let stream = journal.replay(NZUsize!(1024), 10).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut items = Vec::new();
@@ -742,7 +741,7 @@ where
 
     journal.prune(10).await.unwrap();
 
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     let result = journal.read(bounds.start - 1).await;
     assert!(matches!(result, Err(Error::ItemPruned(_))));
 
@@ -765,7 +764,7 @@ where
     // Rewind to 12 items
     journal.rewind(12).await.unwrap();
 
-    assert_eq!(journal.bounds().end, 12);
+    assert_eq!(journal.bounds().await.end, 12);
 
     // Verify first 12 items are still readable
     for i in 0..12u64 {
@@ -802,7 +801,7 @@ where
 
     journal.rewind(0).await.unwrap();
 
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.end, 0);
     assert!(bounds.is_empty());
 
@@ -827,7 +826,7 @@ where
 
     // Rewind to current size should be no-op
     journal.rewind(10).await.unwrap();
-    assert_eq!(journal.bounds().end, 10);
+    assert_eq!(journal.bounds().await.end, 10);
 
     journal.destroy().await.unwrap();
 }
@@ -921,14 +920,14 @@ where
     journal.rewind(0).await.unwrap();
 
     // Verify journal is empty
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.end, 0);
     assert!(bounds.is_empty());
 
     // Append should work
     let pos = journal.append(42).await.unwrap();
     assert_eq!(pos, 0);
-    assert_eq!(journal.bounds().end, 1);
+    assert_eq!(journal.bounds().await.end, 1);
     assert_eq!(journal.read(0).await.unwrap(), 42);
 
     journal.destroy().await.unwrap();
@@ -950,12 +949,12 @@ where
 
     // Prune first section (items 0-9)
     journal.prune(10).await.unwrap();
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.start, 10);
 
     // Rewind to position 20 (still in retained range)
     journal.rewind(20).await.unwrap();
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.end, 20);
     assert_eq!(bounds.start, 10);
 
@@ -969,7 +968,7 @@ where
     assert!(matches!(result, Err(Error::ItemPruned(5))));
 
     // Verify journal state is unchanged after failed rewind
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.end, 20);
     assert_eq!(bounds.start, 10);
 
@@ -977,7 +976,7 @@ where
     let pos = journal.append(999).await.unwrap();
     assert_eq!(pos, 20);
     assert_eq!(journal.read(20).await.unwrap(), 999);
-    assert_eq!(journal.bounds().start, 10);
+    assert_eq!(journal.bounds().await.start, 10);
 
     journal.destroy().await.unwrap();
 }
@@ -998,16 +997,16 @@ where
     }
 
     // Verify we're at a section boundary
-    assert_eq!(journal.bounds().end, 10);
+    assert_eq!(journal.bounds().await.end, 10);
 
     // Append one more item to cross the boundary
     let pos = journal.append(999).await.unwrap();
     assert_eq!(pos, 10);
-    assert_eq!(journal.bounds().end, 11);
+    assert_eq!(journal.bounds().await.end, 11);
 
     // Prune exactly at the section boundary
     journal.prune(10).await.unwrap();
-    assert_eq!(journal.bounds().start, 10);
+    assert_eq!(journal.bounds().await.start, 10);
 
     // Verify only the item after the boundary is readable
     assert!(matches!(journal.read(9).await, Err(Error::ItemPruned(_))));
@@ -1016,21 +1015,21 @@ where
     // Append another item to move past the boundary
     let pos = journal.append(888).await.unwrap();
     assert_eq!(pos, 11);
-    assert_eq!(journal.bounds().end, 12);
+    assert_eq!(journal.bounds().await.end, 12);
 
     // Rewind to exactly the section boundary (position 10)
     // This leaves bounds.end=10, bounds.start=10, making the journal fully pruned
     journal.rewind(10).await.unwrap();
-    let bounds = journal.bounds();
+    let bounds = journal.bounds().await;
     assert_eq!(bounds.end, 10);
     assert!(bounds.is_empty());
 
     // Append after rewinding to boundary should continue from position 10
     let pos = journal.append(777).await.unwrap();
     assert_eq!(pos, 10);
-    assert_eq!(journal.bounds().end, 11);
+    assert_eq!(journal.bounds().await.end, 11);
     assert_eq!(journal.read(10).await.unwrap(), 777);
-    assert_eq!(journal.bounds().start, 10);
+    assert_eq!(journal.bounds().await.start, 10);
 
     journal.destroy().await.unwrap();
 }
@@ -1055,8 +1054,8 @@ where
         }
 
         journal.prune(10).await.unwrap();
-        assert_eq!(journal.bounds().end, 20);
-        assert!(!journal.bounds().is_empty());
+        assert_eq!(journal.bounds().await.end, 20);
+        assert!(!journal.bounds().await.is_empty());
 
         // Explicitly destroy the journal
         journal.destroy().await.unwrap();
@@ -1067,13 +1066,13 @@ where
         let journal = factory(test_name.clone()).await.unwrap();
 
         // Journal should be completely empty, not contain previous data
-        let bounds = journal.bounds();
+        let bounds = journal.bounds().await;
         assert_eq!(bounds.end, 0);
         assert!(bounds.is_empty());
 
         // Replay should yield no items
         {
-            let stream = journal.replay(0, NZUsize!(1024)).await.unwrap();
+            let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut items = Vec::new();

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -12,11 +12,11 @@ use crate::{
     Persistable,
 };
 use commonware_codec::{Codec, CodecShared};
-use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, Storage};
+use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, RwLock, Storage};
 use commonware_utils::NZUsize;
 #[commonware_macros::stability(ALPHA)]
 use core::ops::Range;
-use futures::{future::Either, stream, Stream, StreamExt as _};
+use futures::{lock::Mutex, stream, Stream, StreamExt as _};
 use std::num::{NonZeroU64, NonZeroUsize};
 #[commonware_macros::stability(ALPHA)]
 use tracing::debug;
@@ -92,6 +92,33 @@ impl<C> Config<C> {
     }
 }
 
+/// Inner jounal state protected by a lock for interior mutability.
+struct Inner<E: Clock + Storage + Metrics, V: Codec> {
+    /// The underlying variable-length data journal.
+    data: variable::Journal<E, V>,
+
+    /// Index mapping positions to byte offsets within the data journal.
+    /// The section can be calculated from the position using items_per_section.
+    offsets: fixed::Journal<E, u64>,
+
+    /// The next position to be assigned on append (total items appended).
+    ///
+    /// # Invariant
+    ///
+    /// Always >= `pruning_boundary`. Equal when data journal is empty or fully pruned.
+    size: u64,
+
+    /// The position before which all items have been pruned.
+    ///
+    /// After normal operation and pruning, the value is section-aligned.
+    /// After `init_at_size(N)`, the value may be mid-section.
+    ///
+    /// # Invariant
+    ///
+    /// Never decreases (pruning only moves forward).
+    pruning_boundary: u64,
+}
+
 /// A contiguous journal with variable-size entries.
 ///
 /// This journal manages section assignment automatically, allowing callers to append items
@@ -130,12 +157,11 @@ impl<C> Config<C> {
 /// data.bounds().start. This should never occur because we always prune the data journal
 /// before the offsets journal.
 pub struct Journal<E: Clock + Storage + Metrics, V: Codec> {
-    /// The underlying variable-length data journal.
-    data: variable::Journal<E, V>,
+    inner: RwLock<Inner<E, V>>,
 
-    /// Index mapping positions to byte offsets within the data journal.
-    /// The section can be calculated from the position using items_per_section.
-    offsets: fixed::Journal<E, u64>,
+    /// Serializes write operations to prevent race conditions.
+    /// This allows sync to use a read lock, enabling concurrent reads during sync.
+    write_lock: Mutex<()>,
 
     /// The number of items per section.
     ///
@@ -144,23 +170,6 @@ pub struct Journal<E: Clock + Storage + Metrics, V: Codec> {
     /// This value is immutable after initialization and must remain consistent
     /// across restarts. Changing this value will result in data loss or corruption.
     items_per_section: u64,
-
-    /// The next position to be assigned on append (total items appended).
-    ///
-    /// # Invariant
-    ///
-    /// Always >= `oldest_retained_pos`. Equal when data journal is empty or fully pruned.
-    size: u64,
-
-    /// The position of the first item that remains after pruning.
-    ///
-    /// After normal operation and pruning, `oldest_retained_pos` is section-aligned.
-    /// After `init_at_size(N)`, `oldest_retained_pos` may be mid-section.
-    ///
-    /// # Invariant
-    ///
-    /// Never decreases (pruning only moves forward).
-    oldest_retained_pos: u64,
 }
 
 impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
@@ -201,15 +210,18 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         .await?;
 
         // Validate and align offsets journal to match data journal
-        let (oldest_retained_pos, size) =
+        let (pruning_boundary, size) =
             Self::align_journals(&mut data, &mut offsets, items_per_section).await?;
 
         Ok(Self {
-            data,
-            offsets,
+            inner: RwLock::new(Inner {
+                data,
+                offsets,
+                size,
+                pruning_boundary,
+            }),
+            write_lock: Mutex::new(()),
             items_per_section,
-            size,
-            oldest_retained_pos,
         })
     }
 
@@ -246,11 +258,14 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         .await?;
 
         Ok(Self {
-            data,
-            offsets,
+            inner: RwLock::new(Inner {
+                data,
+                offsets,
+                size,
+                pruning_boundary: size,
+            }),
+            write_lock: Mutex::new(()),
             items_per_section: cfg.items_per_section.get(),
-            size,
-            oldest_retained_pos: size,
         })
     }
 
@@ -295,9 +310,9 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         );
 
         // Initialize contiguous journal
-        let mut journal = Self::init(context.with_label("journal"), cfg.clone()).await?;
+        let journal = Self::init(context.with_label("journal"), cfg.clone()).await?;
 
-        let size = journal.size();
+        let size = journal.size().await;
 
         // No existing data - initialize at the start of the sync range if needed
         if size == 0 {
@@ -331,7 +346,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         }
 
         // Prune to lower bound if needed
-        let bounds = journal.bounds();
+        let bounds = journal.bounds().await;
         if !bounds.is_empty() && bounds.start < range.start {
             debug!(
                 oldest_pos = bounds.start,
@@ -350,35 +365,40 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
     ///
     /// # Errors
     ///
-    /// Returns [Error::InvalidRewind] if size is invalid (too large or points to pruned data).
+    /// Returns [Error::InvalidRewind] if `size` is larger than current size.
+    /// Returns [Error::ItemPruned] if `size` is smaller than the pruning boundary.
     ///
     /// # Warning
     ///
     /// - This operation is not guaranteed to survive restarts until `commit` or `sync` is called.
-    pub async fn rewind(&mut self, size: u64) -> Result<(), Error> {
+    pub async fn rewind(&self, size: u64) -> Result<(), Error> {
+        let _write_guard = self.write_lock.lock().await;
+        let mut inner = self.inner.write().await;
+
         // Validate rewind target
-        match size.cmp(&self.size) {
+        match size.cmp(&inner.size) {
             std::cmp::Ordering::Greater => return Err(Error::InvalidRewind(size)),
             std::cmp::Ordering::Equal => return Ok(()), // No-op
             std::cmp::Ordering::Less => {}
         }
 
-        // Rewind never updates oldest_retained_pos.
-        if size < self.oldest_retained_pos {
+        // Rewind never updates the pruning boundary.
+        if size < inner.pruning_boundary {
             return Err(Error::ItemPruned(size));
         }
 
         // Read the offset of the first item to discard (at position 'size').
-        let discard_offset = self.offsets.read(size).await?;
+        let discard_offset = inner.offsets.read(size).await?;
         let discard_section = position_to_section(size, self.items_per_section);
 
-        self.data
+        inner
+            .data
             .rewind_to_offset(discard_section, discard_offset)
             .await?;
-        self.offsets.rewind(size).await?;
+        inner.offsets.rewind(size).await?;
 
         // Update our size
-        self.size = size;
+        inner.size = size;
 
         Ok(())
     }
@@ -398,24 +418,42 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
     ///
     /// Errors may leave the journal in an inconsistent state. The journal should be closed and
     /// reopened to trigger alignment in [Journal::init].
-    pub async fn append(&mut self, item: V) -> Result<u64, Error> {
-        // Calculate which section this position belongs to
-        let section = self.current_section();
+    pub async fn append(&self, item: V) -> Result<u64, Error> {
+        // Serialize write operations to prevent race conditions when sections fill up.
+        let _write_guard = self.write_lock.lock().await;
 
-        // Append to data journal, get offset
-        let (offset, _size) = self.data.append(section, item).await?;
+        let (position, section) = {
+            let mut inner = self.inner.write().await;
 
-        // Append offset to offsets journal
-        let offsets_pos = self.offsets.append(offset).await?;
-        assert_eq!(offsets_pos, self.size);
+            // Calculate which section this position belongs to
+            let section = position_to_section(inner.size, self.items_per_section);
 
-        // Return the current position
-        let position = self.size;
-        self.size += 1;
+            // Append to data journal, get offset
+            let (offset, _size) = inner.data.append(section, item).await?;
 
-        // Maintain invariant that all full sections are persisted.
-        if self.size.is_multiple_of(self.items_per_section) {
-            futures::try_join!(self.data.sync(section), self.offsets.sync())?;
+            // Append offset to offsets journal
+            let offsets_pos = inner.offsets.append(offset).await?;
+            assert_eq!(offsets_pos, inner.size);
+
+            // Return the current position
+            let position = inner.size;
+            inner.size += 1;
+
+            // Return early if no sync is needed (section not full).
+            if !inner.size.is_multiple_of(self.items_per_section) {
+                return Ok(position);
+            }
+
+            (position, section)
+        };
+
+        // If we get here the section was filled and we need to sync it. We sync while only holding
+        // a read lock on self.inner to avoid blocking concurrent reads. We must however continue to
+        // hold the outer write_lock since we don't want to start writing to the new section until
+        // this completes.
+        {
+            let inner = self.inner.read().await;
+            futures::try_join!(inner.data.sync(section), inner.offsets.sync())?;
         }
 
         Ok(position)
@@ -423,16 +461,9 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
 
     /// Returns [start, end) where `start` and `end - 1` are the positions of the oldest and newest
     /// retained items respectively.
-    pub const fn bounds(&self) -> std::ops::Range<u64> {
-        self.oldest_retained_pos..self.size
-    }
-
-    /// Return the total number of items that have been appended to the journal.
-    ///
-    /// This count is NOT affected by pruning. The next appended item will receive this
-    /// position as its value.
-    pub const fn size(&self) -> u64 {
-        self.size
+    pub async fn bounds(&self) -> std::ops::Range<u64> {
+        let inner = self.inner.read().await;
+        inner.pruning_boundary..inner.size
     }
 
     /// Prune items at positions strictly less than `min_position`.
@@ -445,72 +476,81 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
     ///
     /// Errors may leave the journal in an inconsistent state. The journal should be closed and
     /// reopened to trigger alignment in [Journal::init].
-    pub async fn prune(&mut self, min_position: u64) -> Result<bool, Error> {
-        if min_position <= self.oldest_retained_pos {
+    pub async fn prune(&self, min_position: u64) -> Result<bool, Error> {
+        let _write_guard = self.write_lock.lock().await;
+        let mut inner = self.inner.write().await;
+
+        if min_position <= inner.pruning_boundary {
             return Ok(false);
         }
 
         // Cap min_position to size to maintain the invariant oldest_retained_pos <= size
-        let min_position = min_position.min(self.size);
+        let min_position = min_position.min(inner.size);
 
         // Calculate section number
         let min_section = position_to_section(min_position, self.items_per_section);
 
-        let pruned = self.data.prune(min_section).await?;
+        let pruned = inner.data.prune(min_section).await?;
         if pruned {
-            let new_oldest = (min_section * self.items_per_section).max(self.oldest_retained_pos);
-            self.oldest_retained_pos = new_oldest;
-            self.offsets.prune(new_oldest).await?;
+            let new_oldest = (min_section * self.items_per_section).max(inner.pruning_boundary);
+            inner.pruning_boundary = new_oldest;
+            inner.offsets.prune(new_oldest).await?;
         }
         Ok(pruned)
     }
 
     /// Return a stream of all items in the journal starting from `start_pos`.
     ///
-    /// Each item is yielded as a tuple `(position, item)` where position is the item's
-    /// position in the journal.
+    /// Each item is yielded as a tuple `(position, item)` where position is the item's position in
+    /// the journal.
     ///
     /// # Errors
     ///
-    /// Returns an error if `start_pos` exceeds the journal size or if any storage/decoding
-    /// errors occur during replay.
+    ///  - [Error::ItemPruned] if any of the requested items are pruned.
+    ///  - [Error::ItemOutOfRange] if `start_pos` exceeds the journal size.
     pub async fn replay(
         &self,
-        start_pos: u64,
         buffer_size: NonZeroUsize,
-    ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + '_, Error> {
-        // Validate start position is within bounds.
-        let bounds = self.bounds();
-        if start_pos < bounds.start {
-            return Err(Error::ItemPruned(start_pos));
-        }
-        if start_pos > bounds.end {
-            return Err(Error::ItemOutOfRange(start_pos));
-        }
+        start_pos: u64,
+    ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
+        let items_per_section = self.items_per_section;
 
-        // If replaying at exactly size, return empty stream
-        if start_pos == bounds.end {
-            return Ok(Either::Left(stream::empty()));
-        }
+        // Validate inputs and get inner stream.
+        let inner_stream = {
+            let inner = self.inner.read().await;
 
-        // Use offsets index to find offset to start from, calculate section from position
-        let start_offset = self.offsets.read(start_pos).await?;
-        let start_section = position_to_section(start_pos, self.items_per_section);
-        let data_stream = self
-            .data
-            .replay(start_section, start_offset, buffer_size)
-            .await?;
+            // Validate bounds.
+            if start_pos < inner.pruning_boundary {
+                return Err(Error::ItemPruned(start_pos));
+            }
+            if start_pos > inner.size {
+                return Err(Error::ItemOutOfRange(start_pos));
+            }
 
-        // Transform the stream to include position information
-        let transformed = data_stream.enumerate().map(move |(idx, result)| {
-            result.map(|(_section, _offset, _size, item)| {
-                // Calculate position: start_pos + items read
-                let pos = start_pos + idx as u64;
-                (pos, item)
-            })
-        });
+            // Get the starting offset and section. For empty range (start_pos == size),
+            // use a section beyond existing data so data.replay returns empty naturally.
+            let (start_section, start_offset) = if start_pos < inner.size {
+                let offset = inner.offsets.read(start_pos).await?;
+                let section = position_to_section(start_pos, items_per_section);
+                (section, offset)
+            } else {
+                (u64::MAX, 0)
+            };
 
-        Ok(Either::Right(transformed))
+            // Return the inner stream.
+            inner
+                .data
+                .replay(buffer_size, start_section, start_offset)
+                .await?
+        };
+
+        // Map the stream to add positions. The data journal yields (section, offset, size, item),
+        // but we need (position, item). Zip with position counter starting from start_pos.
+        let stream = inner_stream
+            .zip(stream::iter(start_pos..))
+            .map(|(result, pos)| result.map(|(_section, _offset, _size, item)| (pos, item)));
+
+        Ok(stream)
     }
 
     /// Read the item at the given position.
@@ -521,43 +561,47 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// - Returns [Error::ItemOutOfRange] if `position` is beyond the journal size.
     /// - Returns other errors if storage or decoding fails.
     pub async fn read(&self, position: u64) -> Result<V, Error> {
+        let inner = self.inner.read().await;
+
         // Check bounds
-        let bounds = self.bounds();
-        if position >= bounds.end {
+        if position >= inner.size {
             return Err(Error::ItemOutOfRange(position));
         }
 
-        if position < bounds.start {
+        if position < inner.pruning_boundary {
             return Err(Error::ItemPruned(position));
         }
 
         // Read offset from journal and calculate section from position
-        let offset = self.offsets.read(position).await?;
+        let offset = inner.offsets.read(position).await?;
         let section = position_to_section(position, self.items_per_section);
 
         // Read item from data journal
-        self.data.get(section, offset).await
+        inner.data.get(section, offset).await
     }
 
     /// Durably persist the journal.
     ///
     /// This is faster than `sync()` but recovery will be required on startup if a crash occurs
     /// before the next call to `sync()`.
-    pub async fn commit(&mut self) -> Result<(), Error> {
-        let section = self.current_section();
-        self.data.sync(section).await
+    pub async fn commit(&self) -> Result<(), Error> {
+        let inner = self.inner.read().await;
+        let section = position_to_section(inner.size, self.items_per_section);
+        inner.data.sync(section).await
     }
 
     /// Durably persist the journal and ensure recovery is not required on startup.
     ///
     /// This is slower than `commit()` but ensures the journal doesn't require recovery on startup.
-    pub async fn sync(&mut self) -> Result<(), Error> {
+    pub async fn sync(&self) -> Result<(), Error> {
+        let inner = self.inner.read().await;
         // Persist only the current (final) section of the data journal.
         // All non-final sections are already persisted per Invariant #1.
-        let section = self.current_section();
+        let section = position_to_section(inner.size, self.items_per_section);
 
-        // Persist both journals concurrently
-        futures::try_join!(self.data.sync(section), self.offsets.sync())?;
+        // Persist both journals concurrently. These journals may not exist yet if the
+        // previous section was just filled. This is checked internally.
+        futures::try_join!(inner.data.sync(section), inner.offsets.sync())?;
 
         Ok(())
     }
@@ -566,8 +610,9 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
     ///
     /// This destroys both the data journal and the offsets journal.
     pub async fn destroy(self) -> Result<(), Error> {
-        self.data.destroy().await?;
-        self.offsets.destroy().await
+        let inner = self.inner.into_inner();
+        inner.data.destroy().await?;
+        inner.offsets.destroy().await
     }
 
     /// Clear all data and reset the journal to a new starting position.
@@ -575,18 +620,15 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// Unlike `destroy`, this keeps the journal alive so it can be reused.
     /// After clearing, the journal will behave as if initialized with `init_at_size(new_size)`.
     #[commonware_macros::stability(ALPHA)]
-    pub(crate) async fn clear_to_size(&mut self, new_size: u64) -> Result<(), Error> {
-        self.data.clear().await?;
+    pub(crate) async fn clear_to_size(&self, new_size: u64) -> Result<(), Error> {
+        let _write_guard = self.write_lock.lock().await;
+        let mut inner = self.inner.write().await;
+        inner.data.clear().await?;
 
-        self.offsets.clear_to_size(new_size).await?;
-        self.size = new_size;
-        self.oldest_retained_pos = new_size;
+        inner.offsets.clear_to_size(new_size).await?;
+        inner.size = new_size;
+        inner.pruning_boundary = new_size;
         Ok(())
-    }
-
-    /// Return the section number where the next append will write.
-    const fn current_section(&self) -> u64 {
-        position_to_section(self.size, self.items_per_section)
     }
 
     /// Align the offsets journal and data journal to be consistent in case a crash occurred
@@ -606,7 +648,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         // === Handle empty data journal case ===
         let items_in_last_section = match data.newest_section() {
             Some(last_section) => {
-                let stream = data.replay(last_section, 0, REPLAY_BUFFER_SIZE).await?;
+                let stream = data.replay(REPLAY_BUFFER_SIZE, last_section, 0).await?;
                 futures::pin_mut!(stream);
                 let mut count = 0u64;
                 while let Some(result) = stream.next().await {
@@ -624,7 +666,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         let data_empty =
             data.is_empty() || (data.num_sections() == 1 && items_in_last_section == 0);
         if data_empty {
-            let size = offsets.size();
+            let size = offsets.bounds().await.end;
 
             if !data.is_empty() {
                 // A section exists but contains 0 items. This can happen in two cases:
@@ -634,7 +676,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
                 // SAFETY: data is non-empty (checked above)
                 let data_first_section = data.oldest_section().unwrap();
                 let data_section_start = data_first_section * items_per_section;
-                let target_pos = data_section_start.max(offsets.bounds().start);
+                let target_pos = data_section_start.max(offsets.bounds().await.start);
 
                 warn!("crash repair: clearing offsets to {target_pos} (empty section crash)");
                 offsets.clear_to_size(target_pos).await?;
@@ -645,7 +687,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
             // 1. We completely pruned the data journal but crashed before pruning
             //    the offsets journal.
             // 2. The data journal was never opened.
-            let offsets_bounds = offsets.bounds();
+            let offsets_bounds = offsets.bounds().await;
             if !offsets_bounds.is_empty() && offsets_bounds.start < size {
                 // Offsets has unpruned entries but data is gone - clear to match empty state.
                 // We use clear_to_size (not prune) to ensure bounds.start == bounds.end,
@@ -667,7 +709,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
 
         // Align pruning state
         // We always prune data before offsets, so offsets should never be "ahead" by a section.
-        let offsets_bounds = offsets.bounds();
+        let offsets_bounds = offsets.bounds().await;
         match (
             offsets_bounds.is_empty(),
             offsets_bounds.start.cmp(&data_oldest_pos),
@@ -712,7 +754,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         // Note: Corruption checks above ensure bounds.start is in data_first_section,
         // so the subtraction in oldest_items cannot underflow.
         // Re-fetch bounds since prune may have been called above.
-        let offsets_bounds = offsets.bounds();
+        let offsets_bounds = offsets.bounds().await;
         let data_size = if data_first_section == data_last_section {
             offsets_bounds.start + items_in_last_section
         } else {
@@ -733,11 +775,11 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         }
 
         // Final invariant checks
-        assert_eq!(offsets.bounds().end, data_size);
+        assert_eq!(offsets.bounds().await.end, data_size);
 
         // After alignment, offsets and data must be in the same section.
         // We return bounds.start from offsets as the true boundary.
-        let offsets_bounds = offsets.bounds();
+        let offsets_bounds = offsets.bounds().await;
         assert!(
             !offsets_bounds.is_empty(),
             "offsets should have data after alignment"
@@ -774,7 +816,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         );
 
         // Find where to start replaying
-        let offsets_bounds = offsets.bounds();
+        let offsets_bounds = offsets.bounds().await;
         let (start_section, resume_offset, skip_first) = if offsets_bounds.is_empty() {
             // Offsets empty -- start from first data section
             // SAFETY: data is non-empty (checked above)
@@ -796,7 +838,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
         // The data journal is the source of truth, so we consume the entire stream.
         // (replay streams from start_section onwards through all subsequent sections)
         let stream = data
-            .replay(start_section, resume_offset, REPLAY_BUFFER_SIZE)
+            .replay(REPLAY_BUFFER_SIZE, start_section, resume_offset)
             .await?;
         futures::pin_mut!(stream);
 
@@ -821,16 +863,16 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
 impl<E: Clock + Storage + Metrics, V: CodecShared> Contiguous for Journal<E, V> {
     type Item = V;
 
-    fn bounds(&self) -> std::ops::Range<u64> {
-        Self::bounds(self)
+    async fn bounds(&self) -> std::ops::Range<u64> {
+        Self::bounds(self).await
     }
 
     async fn replay(
         &self,
-        start_pos: u64,
         buffer: NonZeroUsize,
-    ) -> Result<impl Stream<Item = Result<(u64, Self::Item), Error>> + '_, Error> {
-        Self::replay(self, start_pos, buffer).await
+        start_pos: u64,
+    ) -> Result<impl Stream<Item = Result<(u64, Self::Item), Error>> + Send + '_, Error> {
+        Self::replay(self, buffer, start_pos).await
     }
 
     async fn read(&self, position: u64) -> Result<Self::Item, Error> {
@@ -859,14 +901,61 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Persistable for Journal<E, V>
         Self::commit(self).await
     }
 
-    async fn sync(&mut self) -> Result<(), Error> {
-        Self::sync(self).await
+    async fn sync(&self) -> Result<(), Error> {
+        self.sync().await
     }
 
     async fn destroy(self) -> Result<(), Error> {
-        Self::destroy(self).await
+        self.destroy().await
     }
 }
+
+#[cfg(test)]
+impl<E: Clock + Storage + Metrics, V: CodecShared> Journal<E, V> {
+    /// Test helper: Prune the internal data journal directly (simulates crash scenario).
+    pub(crate) async fn test_prune_data(&self, section: u64) -> Result<bool, Error> {
+        let mut inner = self.inner.write().await;
+        inner.data.prune(section).await
+    }
+
+    /// Test helper: Prune the internal offsets journal directly (simulates crash scenario).
+    pub(crate) async fn test_prune_offsets(&self, position: u64) -> Result<bool, Error> {
+        let inner = self.inner.write().await;
+        inner.offsets.prune(position).await
+    }
+
+    /// Test helper: Rewind the internal offsets journal directly (simulates crash scenario).
+    pub(crate) async fn test_rewind_offsets(&self, position: u64) -> Result<(), Error> {
+        let inner = self.inner.write().await;
+        inner.offsets.rewind(position).await
+    }
+
+    /// Test helper: Get the size of the internal offsets journal.
+    pub(crate) async fn test_offsets_size(&self) -> u64 {
+        let inner = self.inner.read().await;
+        inner.offsets.size().await
+    }
+
+    /// Test helper: Append directly to the internal data journal (simulates crash scenario).
+    pub(crate) async fn test_append_data(
+        &self,
+        section: u64,
+        item: V,
+    ) -> Result<(u64, u32), Error> {
+        let mut inner = self.inner.write().await;
+        inner.data.append(section, item).await
+    }
+
+    /// Test helper: Sync the internal data journal.
+    pub(crate) async fn test_sync_data(&self) -> Result<(), Error> {
+        let inner = self.inner.read().await;
+        inner
+            .data
+            .sync(inner.data.newest_section().unwrap_or(0))
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -903,7 +992,7 @@ mod tests {
             };
 
             // === Phase 1: Create journal with data and prune ===
-            let mut journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -914,8 +1003,8 @@ mod tests {
 
             // Prune to position 20 (removes sections 0-1, keeps sections 2-3)
             journal.prune(20).await.unwrap();
-            assert_eq!(journal.bounds().start, 20);
-            assert_eq!(journal.bounds().end, 40);
+            assert_eq!(journal.bounds().await.start, 20);
+            assert_eq!(journal.bounds().await.end, 40);
 
             journal.sync().await.unwrap();
             drop(journal);
@@ -958,7 +1047,7 @@ mod tests {
             };
 
             // === Setup: Create journal with data ===
-            let mut variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -977,15 +1066,15 @@ mod tests {
                 .expect("Failed to remove data partition");
 
             // === Verify init aligns the mismatch ===
-            let mut journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
                 .await
                 .expect("Should align offsets to match empty data");
 
             // Size should be preserved
-            assert_eq!(journal.size(), 20);
+            assert_eq!(journal.size().await, 20);
 
             // But no items remain (both journals pruned)
-            assert!(journal.bounds().is_empty());
+            assert!(journal.bounds().await.is_empty());
 
             // All reads should fail with ItemPruned
             for i in 0..20 {
@@ -999,6 +1088,107 @@ mod tests {
             let pos = journal.append(999).await.unwrap();
             assert_eq!(pos, 20);
             assert_eq!(journal.read(20).await.unwrap(), 999);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Test replay behavior for variable-length items.
+    #[test_traced]
+    fn test_variable_replay() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "replay".to_string(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::new(LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            // Initialize journal
+            let journal = Journal::<_, u64>::init(context, cfg).await.unwrap();
+
+            // Append 40 items across 4 sections (0-3)
+            for i in 0..40u64 {
+                journal.append(i * 100).await.unwrap();
+            }
+
+            // Test 1: Full replay
+            {
+                let stream = journal.replay(NZUsize!(20), 0).await.unwrap();
+                futures::pin_mut!(stream);
+                for i in 0..40u64 {
+                    let (pos, item) = stream.next().await.unwrap().unwrap();
+                    assert_eq!(pos, i);
+                    assert_eq!(item, i * 100);
+                }
+                assert!(stream.next().await.is_none());
+            }
+
+            // Test 2: Partial replay from middle of section
+            {
+                let stream = journal.replay(NZUsize!(20), 15).await.unwrap();
+                futures::pin_mut!(stream);
+                for i in 15..40u64 {
+                    let (pos, item) = stream.next().await.unwrap().unwrap();
+                    assert_eq!(pos, i);
+                    assert_eq!(item, i * 100);
+                }
+                assert!(stream.next().await.is_none());
+            }
+
+            // Test 3: Partial replay from section boundary
+            {
+                let stream = journal.replay(NZUsize!(20), 20).await.unwrap();
+                futures::pin_mut!(stream);
+                for i in 20..40u64 {
+                    let (pos, item) = stream.next().await.unwrap().unwrap();
+                    assert_eq!(pos, i);
+                    assert_eq!(item, i * 100);
+                }
+                assert!(stream.next().await.is_none());
+            }
+
+            // Test 4: Prune and verify replay from pruned
+            journal.prune(20).await.unwrap();
+            {
+                let res = journal.replay(NZUsize!(20), 0).await;
+                assert!(matches!(res, Err(crate::journal::Error::ItemPruned(_))));
+            }
+            {
+                let res = journal.replay(NZUsize!(20), 19).await;
+                assert!(matches!(res, Err(crate::journal::Error::ItemPruned(_))));
+            }
+
+            // Test 5: Replay from exactly at pruning boundary after prune
+            {
+                let stream = journal.replay(NZUsize!(20), 20).await.unwrap();
+                futures::pin_mut!(stream);
+                for i in 20..40u64 {
+                    let (pos, item) = stream.next().await.unwrap().unwrap();
+                    assert_eq!(pos, i);
+                    assert_eq!(item, i * 100);
+                }
+                assert!(stream.next().await.is_none());
+            }
+
+            // Test 6: Replay from the end
+            {
+                let stream = journal.replay(NZUsize!(20), 40).await.unwrap();
+                futures::pin_mut!(stream);
+                assert!(stream.next().await.is_none());
+            }
+
+            // Test 7: Replay beyond the end (should error)
+            {
+                let res = journal.replay(NZUsize!(20), 41).await;
+                assert!(matches!(
+                    res,
+                    Err(crate::journal::Error::ItemOutOfRange(41))
+                ));
+            }
 
             journal.destroy().await.unwrap();
         });
@@ -1044,7 +1234,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut journal = Journal::<_, u64>::init(context, cfg).await.unwrap();
+            let journal = Journal::<_, u64>::init(context, cfg).await.unwrap();
 
             // Append items across 4 sections: [0-9], [10-19], [20-29], [30-39]
             for i in 0..40u64 {
@@ -1052,15 +1242,15 @@ mod tests {
             }
 
             // Initial state: all items accessible
-            assert_eq!(journal.bounds().start, 0);
-            assert_eq!(journal.bounds().end, 40);
+            assert_eq!(journal.bounds().await.start, 0);
+            assert_eq!(journal.bounds().await.end, 40);
 
             // First prune: remove section 0 (positions 0-9)
             let pruned = journal.prune(10).await.unwrap();
             assert!(pruned);
 
             // Variable-specific guarantee: oldest is EXACTLY at section boundary
-            assert_eq!(journal.bounds().start, 10);
+            assert_eq!(journal.bounds().await.start, 10);
 
             // Items 0-9 should be pruned, 10+ should be accessible
             assert!(matches!(
@@ -1075,7 +1265,7 @@ mod tests {
             assert!(pruned);
 
             // Variable-specific guarantee: oldest is EXACTLY at section boundary
-            assert_eq!(journal.bounds().start, 20);
+            assert_eq!(journal.bounds().await.start, 20);
 
             // Items 0-19 should be pruned, 20+ should be accessible
             assert!(matches!(
@@ -1094,7 +1284,7 @@ mod tests {
             assert!(pruned);
 
             // Variable-specific guarantee: oldest is EXACTLY at section boundary
-            assert_eq!(journal.bounds().start, 30);
+            assert_eq!(journal.bounds().await.start, 30);
 
             // Items 0-29 should be pruned, 30+ should be accessible
             assert!(matches!(
@@ -1109,7 +1299,7 @@ mod tests {
             assert_eq!(journal.read(39).await.unwrap(), 3900);
 
             // Size should still be 40 (pruning doesn't affect size)
-            assert_eq!(journal.size(), 40);
+            assert_eq!(journal.size().await, 40);
 
             journal.destroy().await.unwrap();
         });
@@ -1130,7 +1320,7 @@ mod tests {
             };
 
             // === Phase 1: Create journal and append data ===
-            let mut journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -1138,16 +1328,16 @@ mod tests {
                 journal.append(i * 100).await.unwrap();
             }
 
-            assert_eq!(journal.bounds().end, 100);
-            assert_eq!(journal.bounds().start, 0);
+            assert_eq!(journal.bounds().await.end, 100);
+            assert_eq!(journal.bounds().await.start, 0);
 
             // === Phase 2: Prune all data ===
             let pruned = journal.prune(100).await.unwrap();
             assert!(pruned);
 
             // All data is pruned - no items remain
-            assert_eq!(journal.bounds().end, 100);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 100);
+            assert!(journal.bounds().await.is_empty());
 
             // All reads should fail with ItemPruned
             for i in 0..100 {
@@ -1161,13 +1351,13 @@ mod tests {
             drop(journal);
 
             // === Phase 3: Re-init and verify position preserved ===
-            let mut journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
 
             // Size should be preserved, but no items remain
-            assert_eq!(journal.bounds().end, 100);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 100);
+            assert!(journal.bounds().await.is_empty());
 
             // All reads should still fail
             for i in 0..100 {
@@ -1180,9 +1370,9 @@ mod tests {
             // === Phase 4: Append new data ===
             // Next append should get position 100
             journal.append(10000).await.unwrap();
-            assert_eq!(journal.bounds().end, 101);
+            assert_eq!(journal.bounds().await.end, 101);
             // Now we have one item at position 100
-            assert_eq!(journal.bounds().start, 100);
+            assert_eq!(journal.bounds().await.start, 100);
 
             // Can read the new item
             assert_eq!(journal.read(100).await.unwrap(), 10000);
@@ -1212,7 +1402,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -1223,11 +1413,11 @@ mod tests {
 
             // Prune to position 10 normally (both data and offsets journals pruned)
             variable.prune(10).await.unwrap();
-            assert_eq!(variable.bounds().start, 10);
+            assert_eq!(variable.bounds().await.start, 10);
 
             // === Simulate crash: Prune data journal but not offsets journal ===
             // Manually prune data journal to section 2 (position 20)
-            variable.data.prune(2).await.unwrap();
+            variable.test_prune_data(2).await.unwrap();
             // Offsets journal still has data from position 10-19
 
             variable.sync().await.unwrap();
@@ -1239,8 +1429,8 @@ mod tests {
                 .unwrap();
 
             // Init should auto-repair: offsets journal pruned to match data journal
-            assert_eq!(variable.bounds().start, 20);
-            assert_eq!(variable.bounds().end, 40);
+            assert_eq!(variable.bounds().await.start, 20);
+            assert_eq!(variable.bounds().await.end, 40);
 
             // Reads before position 20 should fail (pruned from both journals)
             assert!(matches!(
@@ -1274,7 +1464,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -1284,8 +1474,8 @@ mod tests {
             }
 
             // Prune offsets journal ahead of data journal (impossible state)
-            variable.offsets.prune(20).await.unwrap(); // Prune to position 20
-            variable.data.prune(1).await.unwrap(); // Only prune data journal to section 1 (position 10)
+            variable.test_prune_offsets(20).await.unwrap(); // Prune to position 20
+            variable.test_prune_data(1).await.unwrap(); // Only prune data journal to section 1 (position 10)
 
             variable.sync().await.unwrap();
             drop(variable);
@@ -1311,7 +1501,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -1320,11 +1510,11 @@ mod tests {
                 variable.append(i * 100).await.unwrap();
             }
 
-            assert_eq!(variable.size(), 15);
+            assert_eq!(variable.size().await, 15);
 
             // Manually append 5 more items directly to data journal only
             for i in 15..20u64 {
-                variable.data.append(1, i * 100).await.unwrap();
+                variable.test_append_data(1, i * 100).await.unwrap();
             }
             // Offsets journal still has only 15 entries
 
@@ -1337,8 +1527,8 @@ mod tests {
                 .unwrap();
 
             // Init should rebuild offsets journal from data journal replay
-            assert_eq!(variable.bounds().end, 20);
-            assert_eq!(variable.bounds().start, 0);
+            assert_eq!(variable.bounds().await.end, 20);
+            assert_eq!(variable.bounds().await.start, 0);
 
             // All items should be readable from both journals
             for i in 0..20u64 {
@@ -1346,7 +1536,7 @@ mod tests {
             }
 
             // Offsets journal should be fully rebuilt to match data journal
-            assert_eq!(variable.offsets.size(), 20);
+            assert_eq!(variable.test_offsets_size().await, 20);
 
             variable.destroy().await.unwrap();
         });
@@ -1367,7 +1557,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -1378,11 +1568,11 @@ mod tests {
 
             // Prune to position 10 normally (both data and offsets journals pruned)
             variable.prune(10).await.unwrap();
-            assert_eq!(variable.bounds().start, 10);
+            assert_eq!(variable.bounds().await.start, 10);
 
             // === Simulate crash: Multiple prunes on data journal, not on offsets journal ===
             // Manually prune data journal to section 3 (position 30)
-            variable.data.prune(3).await.unwrap();
+            variable.test_prune_data(3).await.unwrap();
             // Offsets journal still thinks oldest is position 10
 
             variable.sync().await.unwrap();
@@ -1394,8 +1584,8 @@ mod tests {
                 .unwrap();
 
             // Init should auto-repair: offsets journal pruned to match data journal
-            assert_eq!(variable.bounds().start, 30);
-            assert_eq!(variable.bounds().end, 50);
+            assert_eq!(variable.bounds().await.start, 30);
+            assert_eq!(variable.bounds().await.end, 50);
 
             // Reads before position 30 should fail (pruned from both journals)
             assert!(matches!(
@@ -1435,7 +1625,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let variable = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -1444,24 +1634,24 @@ mod tests {
                 variable.append(i * 100).await.unwrap();
             }
 
-            assert_eq!(variable.size(), 25);
+            assert_eq!(variable.size().await, 25);
 
             // === Simulate crash during rewind(5) ===
             // Rewind offsets journal to size 5 (keeps positions 0-4)
-            variable.offsets.rewind(5).await.unwrap();
+            variable.test_rewind_offsets(5).await.unwrap();
             // CRASH before data.rewind() completes - data still has all 3 sections
 
             variable.sync().await.unwrap();
             drop(variable);
 
             // === Verify recovery ===
-            let mut variable = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
+            let variable = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
 
             // Init should rebuild offsets[5-24] from data journal across all 3 sections
-            assert_eq!(variable.bounds().end, 25);
-            assert_eq!(variable.bounds().start, 0);
+            assert_eq!(variable.bounds().await.end, 25);
+            assert_eq!(variable.bounds().await.start, 0);
 
             // All items should be readable - offsets rebuilt correctly across all sections
             for i in 0..25u64 {
@@ -1469,7 +1659,7 @@ mod tests {
             }
 
             // Verify offsets journal fully rebuilt
-            assert_eq!(variable.offsets.size(), 25);
+            assert_eq!(variable.test_offsets_size().await, 25);
 
             // Verify next append gets position 25
             let pos = variable.append(2500).await.unwrap();
@@ -1496,7 +1686,7 @@ mod tests {
             };
 
             // === Phase 1: Create journal with one full section ===
-            let mut journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -1504,22 +1694,22 @@ mod tests {
             for i in 0..10u64 {
                 journal.append(i * 100).await.unwrap();
             }
-            assert_eq!(journal.bounds().end, 10);
-            assert_eq!(journal.bounds().start, 0);
+            assert_eq!(journal.bounds().await.end, 10);
+            assert_eq!(journal.bounds().await.start, 0);
 
             // === Phase 2: Prune to create empty journal ===
             journal.prune(10).await.unwrap();
-            assert_eq!(journal.bounds().end, 10);
-            assert!(journal.bounds().is_empty()); // Empty!
+            assert_eq!(journal.bounds().await.end, 10);
+            assert!(journal.bounds().await.is_empty()); // Empty!
 
             // === Phase 3: Append directly to data journal to simulate crash ===
             // Manually append to data journal only (bypassing Variable's append logic)
             // This simulates the case where data was synced but offsets wasn't
             for i in 10..20u64 {
-                journal.data.append(1, i * 100).await.unwrap();
+                journal.test_append_data(1, i * 100).await.unwrap();
             }
             // Sync the data journal (section 1)
-            journal.data.sync(1).await.unwrap();
+            journal.test_sync_data().await.unwrap();
             // Do NOT sync offsets journal - simulates crash before offsets.sync()
 
             // Close without syncing offsets
@@ -1531,8 +1721,8 @@ mod tests {
                 .expect("Should recover from crash after data sync but before offsets sync");
 
             // All data should be recovered
-            assert_eq!(journal.bounds().end, 20);
-            assert_eq!(journal.bounds().start, 10);
+            assert_eq!(journal.bounds().await.end, 20);
+            assert_eq!(journal.bounds().await.start, 10);
 
             // All items from position 10-19 should be readable
             for i in 10..20u64 {
@@ -1562,7 +1752,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -1582,7 +1772,7 @@ mod tests {
                 .unwrap();
 
             // Data should be intact and offsets rebuilt
-            assert_eq!(journal.size(), 15);
+            assert_eq!(journal.size().await, 15);
             for i in 0..15u64 {
                 assert_eq!(journal.read(i).await.unwrap(), i * 100);
             }
@@ -1604,20 +1794,20 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 0)
+            let journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 0)
                 .await
                 .unwrap();
 
             // Size should be 0
-            assert_eq!(journal.size(), 0);
+            assert_eq!(journal.size().await, 0);
 
             // No oldest retained position (empty journal)
-            assert!(journal.bounds().is_empty());
+            assert!(journal.bounds().await.is_empty());
 
             // Next append should get position 0
             let pos = journal.append(100).await.unwrap();
             assert_eq!(pos, 0);
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
             assert_eq!(journal.read(0).await.unwrap(), 100);
 
             journal.destroy().await.unwrap();
@@ -1638,20 +1828,20 @@ mod tests {
             };
 
             // Initialize at position 10 (exactly at section 1 boundary with items_per_section=5)
-            let mut journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 10)
+            let journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 10)
                 .await
                 .unwrap();
 
             // Size should be 10
-            assert_eq!(journal.bounds().end, 10);
+            assert_eq!(journal.bounds().await.end, 10);
 
             // No data yet, so no oldest retained position
-            assert!(journal.bounds().is_empty());
+            assert!(journal.bounds().await.is_empty());
 
             // Next append should get position 10
             let pos = journal.append(1000).await.unwrap();
             assert_eq!(pos, 10);
-            assert_eq!(journal.size(), 11);
+            assert_eq!(journal.size().await, 11);
             assert_eq!(journal.read(10).await.unwrap(), 1000);
 
             // Can continue appending
@@ -1677,20 +1867,20 @@ mod tests {
             };
 
             // Initialize at position 7 (middle of section 1 with items_per_section=5)
-            let mut journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 7)
+            let journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 7)
                 .await
                 .unwrap();
 
             // Size should be 7
-            assert_eq!(journal.bounds().end, 7);
+            assert_eq!(journal.bounds().await.end, 7);
 
             // No data yet, so no oldest retained position
-            assert!(journal.bounds().is_empty());
+            assert!(journal.bounds().await.is_empty());
 
             // Next append should get position 7
             let pos = journal.append(700).await.unwrap();
             assert_eq!(pos, 7);
-            assert_eq!(journal.size(), 8);
+            assert_eq!(journal.size().await, 8);
             assert_eq!(journal.read(7).await.unwrap(), 700);
 
             journal.destroy().await.unwrap();
@@ -1711,7 +1901,7 @@ mod tests {
             };
 
             // Initialize at position 15
-            let mut journal =
+            let journal =
                 Journal::<_, u64>::init_at_size(context.with_label("first"), cfg.clone(), 15)
                     .await
                     .unwrap();
@@ -1722,19 +1912,19 @@ mod tests {
                 assert_eq!(pos, 15 + i);
             }
 
-            assert_eq!(journal.size(), 20);
+            assert_eq!(journal.size().await, 20);
 
             // Sync and reopen
             journal.sync().await.unwrap();
             drop(journal);
 
-            let mut journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
 
             // Size and data should be preserved
-            assert_eq!(journal.bounds().end, 20);
-            assert_eq!(journal.bounds().start, 15);
+            assert_eq!(journal.bounds().await.end, 20);
+            assert_eq!(journal.bounds().await.start, 15);
 
             // Verify data
             for i in 0..5u64 {
@@ -1769,19 +1959,19 @@ mod tests {
                     .await
                     .unwrap();
 
-            assert_eq!(journal.bounds().end, 15);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 15);
+            assert!(journal.bounds().await.is_empty());
 
             // Drop without writing any data
             drop(journal);
 
             // Reopen and verify size persisted
-            let mut journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
 
-            assert_eq!(journal.bounds().end, 15);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 15);
+            assert!(journal.bounds().await.is_empty());
 
             // Can append starting at position 15
             let pos = journal.append(1500).await.unwrap();
@@ -1807,7 +1997,7 @@ mod tests {
             };
 
             // Initialize at position 7 (mid-section, 7 % 5 = 2)
-            let mut journal =
+            let journal =
                 Journal::<_, u64>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
@@ -1818,8 +2008,8 @@ mod tests {
                 assert_eq!(pos, 7 + i);
             }
 
-            assert_eq!(journal.bounds().end, 10);
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.end, 10);
+            assert_eq!(journal.bounds().await.start, 7);
 
             // Sync and reopen
             journal.sync().await.unwrap();
@@ -1831,8 +2021,8 @@ mod tests {
                 .unwrap();
 
             // Size and bounds.start should be preserved correctly
-            assert_eq!(journal.bounds().end, 10);
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.end, 10);
+            assert_eq!(journal.bounds().await.start, 7);
 
             // Verify data
             for i in 0..3u64 {
@@ -1861,7 +2051,7 @@ mod tests {
             };
 
             // Initialize at position 7 (mid-section)
-            let mut journal =
+            let journal =
                 Journal::<_, u64>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
@@ -1872,8 +2062,8 @@ mod tests {
                 assert_eq!(pos, 7 + i);
             }
 
-            assert_eq!(journal.bounds().end, 15);
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.end, 15);
+            assert_eq!(journal.bounds().await.start, 7);
 
             // Sync and reopen
             journal.sync().await.unwrap();
@@ -1885,8 +2075,8 @@ mod tests {
                 .unwrap();
 
             // Verify state preserved
-            assert_eq!(journal.bounds().end, 15);
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.end, 15);
+            assert_eq!(journal.bounds().await.start, 7);
 
             // Verify all data
             for i in 0..8u64 {
@@ -1912,7 +2102,7 @@ mod tests {
             };
 
             // Phase 1: Create data and offsets, then simulate data-only pruning crash.
-            let mut journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
             for i in 0..7u64 {
@@ -1921,33 +2111,40 @@ mod tests {
             journal.sync().await.unwrap();
 
             // Simulate crash after data was cleared but before offsets were pruned.
-            journal.data.clear().await.unwrap();
+            journal.inner.write().await.data.clear().await.unwrap();
             drop(journal);
 
             // Phase 2: Init triggers data-empty repair and should treat journal as fully pruned at size 7.
-            let mut journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("second"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(journal.bounds().end, 7);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 7);
+            assert!(journal.bounds().await.is_empty());
 
             // Append one item at position 7.
             let pos = journal.append(777).await.unwrap();
             assert_eq!(pos, 7);
-            assert_eq!(journal.size(), 8);
+            assert_eq!(journal.size().await, 8);
             assert_eq!(journal.read(7).await.unwrap(), 777);
 
             // Sync only the data journal to simulate a crash before offsets are synced.
             let section = 7 / cfg.items_per_section.get();
-            journal.data.sync(section).await.unwrap();
+            journal
+                .inner
+                .write()
+                .await
+                .data
+                .sync(section)
+                .await
+                .unwrap();
             drop(journal);
 
             // Phase 3: Reopen and verify we did not lose the appended item.
             let journal = Journal::<_, u64>::init(context.with_label("third"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(journal.bounds().end, 8);
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.end, 8);
+            assert_eq!(journal.bounds().await.start, 7);
             assert_eq!(journal.read(7).await.unwrap(), 777);
 
             journal.destroy().await.unwrap();
@@ -1969,7 +2166,7 @@ mod tests {
             };
 
             // Initialize at position 7 (mid-section)
-            let mut journal =
+            let journal =
                 Journal::<_, u64>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
@@ -1980,7 +2177,7 @@ mod tests {
             }
 
             // Sync only the data journal, not offsets (simulate crash)
-            journal.data.sync(1).await.unwrap();
+            journal.inner.write().await.data.sync(1).await.unwrap();
             // Don't sync offsets - simulates crash after data write but before offsets write
             drop(journal);
 
@@ -1990,8 +2187,8 @@ mod tests {
                 .unwrap();
 
             // Verify recovery
-            assert_eq!(journal.bounds().end, 10);
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.end, 10);
+            assert_eq!(journal.bounds().await.start, 7);
 
             // Verify data is accessible
             for i in 0..3u64 {
@@ -2015,7 +2212,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut journal =
+            let journal =
                 Journal::<_, u64>::init_at_size(context.with_label("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
@@ -2025,11 +2222,11 @@ mod tests {
                 let pos = journal.append(700 + i).await.unwrap();
                 assert_eq!(pos, 7 + i);
             }
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.start, 7);
 
             // Prune to a position within the same section should not move bounds.start backwards.
             journal.prune(8).await.unwrap();
-            assert_eq!(journal.bounds().start, 7);
+            assert_eq!(journal.bounds().await.start, 7);
             assert!(matches!(journal.read(6).await, Err(Error::ItemPruned(6))));
             assert_eq!(journal.read(7).await.unwrap(), 700);
 
@@ -2051,13 +2248,13 @@ mod tests {
             };
 
             // Initialize at a large position (position 1000)
-            let mut journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 1000)
+            let journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 1000)
                 .await
                 .unwrap();
 
-            assert_eq!(journal.bounds().end, 1000);
+            assert_eq!(journal.bounds().await.end, 1000);
             // No data yet, so no oldest retained position
-            assert!(journal.bounds().is_empty());
+            assert!(journal.bounds().await.is_empty());
 
             // Next append should get position 1000
             let pos = journal.append(100000).await.unwrap();
@@ -2082,7 +2279,7 @@ mod tests {
             };
 
             // Initialize at position 20
-            let mut journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 20)
+            let journal = Journal::<_, u64>::init_at_size(context.clone(), cfg.clone(), 20)
                 .await
                 .unwrap();
 
@@ -2091,13 +2288,13 @@ mod tests {
                 journal.append(2000 + i).await.unwrap();
             }
 
-            assert_eq!(journal.size(), 30);
+            assert_eq!(journal.size().await, 30);
 
             // Prune to position 25
             journal.prune(25).await.unwrap();
 
-            assert_eq!(journal.bounds().end, 30);
-            assert_eq!(journal.bounds().start, 25);
+            assert_eq!(journal.bounds().await.end, 30);
+            assert_eq!(journal.bounds().await.start, 25);
 
             // Verify remaining items are readable
             for i in 25..30u64 {
@@ -2129,13 +2326,13 @@ mod tests {
             // Initialize journal with sync boundaries when no existing data exists
             let lower_bound = 10;
             let upper_bound = 26;
-            let mut journal =
+            let journal =
                 Journal::init_sync(context.clone(), cfg.clone(), lower_bound..upper_bound)
                     .await
                     .expect("Failed to initialize journal with sync boundaries");
 
-            assert_eq!(journal.bounds().end, lower_bound);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, lower_bound);
+            assert!(journal.bounds().await.is_empty());
 
             // Append items using the contiguous API
             let pos1 = journal.append(42u64).await.unwrap();
@@ -2165,7 +2362,7 @@ mod tests {
             };
 
             // Create initial journal with data in multiple sections
-            let mut journal =
+            let journal =
                 Journal::<deterministic::Context, u64>::init(context.clone(), cfg.clone())
                     .await
                     .expect("Failed to create initial journal");
@@ -2181,7 +2378,7 @@ mod tests {
             // lower_bound: 8 (section 1), upper_bound: 31 (last location 30, section 6)
             let lower_bound = 8;
             let upper_bound = 31;
-            let mut journal = Journal::<deterministic::Context, u64>::init_sync(
+            let journal = Journal::<deterministic::Context, u64>::init_sync(
                 context.clone(),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -2189,10 +2386,10 @@ mod tests {
             .await
             .expect("Failed to initialize journal with overlap");
 
-            assert_eq!(journal.size(), 20);
+            assert_eq!(journal.size().await, 20);
 
             // Verify oldest retained is pruned to lower_bound's section boundary (5)
-            assert_eq!(journal.bounds().start, 5); // Section 1 starts at position 5
+            assert_eq!(journal.bounds().await.start, 5); // Section 1 starts at position 5
 
             // Verify data integrity: positions before 5 are pruned
             assert!(matches!(journal.read(0).await, Err(Error::ItemPruned(_))));
@@ -2259,7 +2456,7 @@ mod tests {
             };
 
             // Create initial journal with data exactly matching sync range
-            let mut journal =
+            let journal =
                 Journal::<deterministic::Context, u64>::init(context.clone(), cfg.clone())
                     .await
                     .expect("Failed to create initial journal");
@@ -2274,7 +2471,7 @@ mod tests {
             // Initialize with sync boundaries that exactly match existing data
             let lower_bound = 5; // section 1
             let upper_bound = 20; // section 3
-            let mut journal = Journal::<deterministic::Context, u64>::init_sync(
+            let journal = Journal::<deterministic::Context, u64>::init_sync(
                 context.clone(),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -2282,10 +2479,10 @@ mod tests {
             .await
             .expect("Failed to initialize journal with exact match");
 
-            assert_eq!(journal.size(), 20);
+            assert_eq!(journal.size().await, 20);
 
             // Verify pruning to lower bound (section 1 boundary = position 5)
-            assert_eq!(journal.bounds().start, 5); // Section 1 starts at position 5
+            assert_eq!(journal.bounds().await.start, 5); // Section 1 starts at position 5
 
             // Verify positions before 5 are pruned
             assert!(matches!(journal.read(0).await, Err(Error::ItemPruned(_))));
@@ -2328,7 +2525,7 @@ mod tests {
             };
 
             // Create initial journal with data beyond sync range
-            let mut journal = Journal::<deterministic::Context, u64>::init(
+            let journal = Journal::<deterministic::Context, u64>::init(
                 context.with_label("initial"),
                 cfg.clone(),
             )
@@ -2374,7 +2571,7 @@ mod tests {
             };
 
             // Create initial journal with stale data
-            let mut journal = Journal::<deterministic::Context, u64>::init(
+            let journal = Journal::<deterministic::Context, u64>::init(
                 context.with_label("first"),
                 cfg.clone(),
             )
@@ -2399,10 +2596,10 @@ mod tests {
             .await
             .expect("Failed to initialize journal with stale data");
 
-            assert_eq!(journal.size(), 15);
+            assert_eq!(journal.size().await, 15);
 
             // Verify fresh journal (all old data destroyed, starts at position 15)
-            assert!(journal.bounds().is_empty());
+            assert!(journal.bounds().await.is_empty());
 
             // Verify old positions don't exist
             assert!(matches!(journal.read(0).await, Err(Error::ItemPruned(_))));
@@ -2429,7 +2626,7 @@ mod tests {
             };
 
             // Create journal with data at section boundaries
-            let mut journal =
+            let journal =
                 Journal::<deterministic::Context, u64>::init(context.clone(), cfg.clone())
                     .await
                     .expect("Failed to create initial journal");
@@ -2444,7 +2641,7 @@ mod tests {
             // Test sync boundaries exactly at section boundaries
             let lower_bound = 15; // Exactly at section boundary (15/5 = 3)
             let upper_bound = 25; // Last element exactly at section boundary (24/5 = 4)
-            let mut journal = Journal::<deterministic::Context, u64>::init_sync(
+            let journal = Journal::<deterministic::Context, u64>::init_sync(
                 context.clone(),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -2452,10 +2649,10 @@ mod tests {
             .await
             .expect("Failed to initialize journal at boundaries");
 
-            assert_eq!(journal.size(), 25);
+            assert_eq!(journal.size().await, 25);
 
             // Verify oldest retained is at section 3 boundary (position 15)
-            assert_eq!(journal.bounds().start, 15);
+            assert_eq!(journal.bounds().await.start, 15);
 
             // Verify positions before 15 are pruned
             assert!(matches!(journal.read(0).await, Err(Error::ItemPruned(_))));
@@ -2497,7 +2694,7 @@ mod tests {
             };
 
             // Create journal with data in multiple sections
-            let mut journal =
+            let journal =
                 Journal::<deterministic::Context, u64>::init(context.clone(), cfg.clone())
                     .await
                     .expect("Failed to create initial journal");
@@ -2512,7 +2709,7 @@ mod tests {
             // Test sync boundaries within the same section
             let lower_bound = 10; // operation 10 (section 2: 10/5 = 2)
             let upper_bound = 15; // Last operation 14 (section 2: 14/5 = 2)
-            let mut journal = Journal::<deterministic::Context, u64>::init_sync(
+            let journal = Journal::<deterministic::Context, u64>::init_sync(
                 context.clone(),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -2520,11 +2717,11 @@ mod tests {
             .await
             .expect("Failed to initialize journal with same-section bounds");
 
-            assert_eq!(journal.size(), 15);
+            assert_eq!(journal.size().await, 15);
 
             // Both operations are in section 2, so sections 0, 1 should be pruned, section 2 retained
             // Oldest retained position should be at section 2 boundary (position 10)
-            assert_eq!(journal.bounds().start, 10);
+            assert_eq!(journal.bounds().await.start, 10);
 
             // Verify positions before 10 are pruned
             assert!(matches!(journal.read(0).await, Err(Error::ItemPruned(_))));
@@ -2568,34 +2765,34 @@ mod tests {
             };
 
             // === Test 1: Basic single item operation ===
-            let mut journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("first"), cfg.clone())
                 .await
                 .unwrap();
 
             // Verify empty state
-            assert_eq!(journal.bounds().end, 0);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 0);
+            assert!(journal.bounds().await.is_empty());
 
             // Append 1 item (value = position * 100, so position 0 has value 0)
             let pos = journal.append(0).await.unwrap();
             assert_eq!(pos, 0);
-            assert_eq!(journal.size(), 1);
+            assert_eq!(journal.size().await, 1);
 
             // Sync
             journal.sync().await.unwrap();
 
             // Read from size() - 1
-            let value = journal.read(journal.size() - 1).await.unwrap();
+            let value = journal.read(journal.size().await - 1).await.unwrap();
             assert_eq!(value, 0);
 
             // === Test 2: Multiple items with single item per section ===
             for i in 1..10u64 {
                 let pos = journal.append(i * 100).await.unwrap();
                 assert_eq!(pos, i);
-                assert_eq!(journal.size(), i + 1);
+                assert_eq!(journal.size().await, i + 1);
 
                 // Verify we can read the just-appended item at size() - 1
-                let value = journal.read(journal.size() - 1).await.unwrap();
+                let value = journal.read(journal.size().await - 1).await.unwrap();
                 assert_eq!(value, i * 100);
             }
 
@@ -2612,13 +2809,13 @@ mod tests {
             assert!(pruned);
 
             // Size should still be 10
-            assert_eq!(journal.size(), 10);
+            assert_eq!(journal.size().await, 10);
 
             // bounds.start should be 5
-            assert_eq!(journal.bounds().start, 5);
+            assert_eq!(journal.bounds().await.start, 5);
 
             // Reading from bounds.end - 1 (position 9) should still work
-            let value = journal.read(journal.size() - 1).await.unwrap();
+            let value = journal.read(journal.size().await - 1).await.unwrap();
             assert_eq!(value, 900);
 
             // Reading from pruned positions should return ItemPruned
@@ -2640,7 +2837,7 @@ mod tests {
                 assert_eq!(pos, i);
 
                 // Verify we can read from size() - 1
-                let value = journal.read(journal.size() - 1).await.unwrap();
+                let value = journal.read(journal.size().await - 1).await.unwrap();
                 assert_eq!(value, i * 100);
             }
 
@@ -2653,13 +2850,13 @@ mod tests {
                 .unwrap();
 
             // Verify size is preserved
-            assert_eq!(journal.size(), 15);
+            assert_eq!(journal.size().await, 15);
 
             // Verify bounds.start is preserved
-            assert_eq!(journal.bounds().start, 5);
+            assert_eq!(journal.bounds().await.start, 5);
 
             // Reading from bounds.end - 1 should work after restart
-            let value = journal.read(journal.size() - 1).await.unwrap();
+            let value = journal.read(journal.size().await - 1).await.unwrap();
             assert_eq!(value, 1400);
 
             // Reading all retained positions should work
@@ -2671,7 +2868,7 @@ mod tests {
 
             // === Test 5: Restart after pruning with non-zero index (KEY SCENARIO) ===
             // Fresh journal for this test
-            let mut journal = Journal::<_, u64>::init(context.with_label("third"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("third"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -2682,8 +2879,8 @@ mod tests {
 
             // Prune to position 5 (removes positions 0-4)
             journal.prune(5).await.unwrap();
-            assert_eq!(journal.bounds().end, 10);
-            assert_eq!(journal.bounds().start, 5);
+            assert_eq!(journal.bounds().await.end, 10);
+            assert_eq!(journal.bounds().await.start, 5);
 
             // Sync and restart
             journal.sync().await.unwrap();
@@ -2695,11 +2892,11 @@ mod tests {
                 .unwrap();
 
             // Verify state after restart
-            assert_eq!(journal.bounds().end, 10);
-            assert_eq!(journal.bounds().start, 5);
+            assert_eq!(journal.bounds().await.end, 10);
+            assert_eq!(journal.bounds().await.start, 5);
 
             // KEY TEST: Reading from bounds.end - 1 (position 9) should work
-            let value = journal.read(journal.size() - 1).await.unwrap();
+            let value = journal.read(journal.size().await - 1).await.unwrap();
             assert_eq!(value, 9000);
 
             // Verify all retained positions (5-9) work
@@ -2712,7 +2909,7 @@ mod tests {
             // === Test 6: Prune all items (edge case) ===
             // This tests the scenario where prune removes everything.
             // Callers must check bounds().is_empty() before reading.
-            let mut journal = Journal::<_, u64>::init(context.with_label("fifth"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("fifth"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -2723,17 +2920,20 @@ mod tests {
 
             // Prune all items
             journal.prune(5).await.unwrap();
-            assert_eq!(journal.bounds().end, 5); // Size unchanged
-            assert!(journal.bounds().is_empty()); // All pruned
+            assert_eq!(journal.bounds().await.end, 5); // Size unchanged
+            assert!(journal.bounds().await.is_empty()); // All pruned
 
             // bounds.end - 1 = 4, but position 4 is pruned
-            let result = journal.read(journal.size() - 1).await;
+            let result = journal.read(journal.size().await - 1).await;
             assert!(matches!(result, Err(crate::journal::Error::ItemPruned(4))));
 
             // After appending, reading works again
             journal.append(500).await.unwrap();
-            assert_eq!(journal.bounds().start, 5);
-            assert_eq!(journal.read(journal.bounds().end - 1).await.unwrap(), 500);
+            assert_eq!(journal.bounds().await.start, 5);
+            assert_eq!(
+                journal.read(journal.bounds().await.end - 1).await.unwrap(),
+                500
+            );
 
             journal.destroy().await.unwrap();
         });
@@ -2752,7 +2952,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut journal = Journal::<_, u64>::init(context.with_label("journal"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.with_label("journal"), cfg.clone())
                 .await
                 .unwrap();
 
@@ -2760,14 +2960,14 @@ mod tests {
             for i in 0..25u64 {
                 journal.append(i * 100).await.unwrap();
             }
-            assert_eq!(journal.bounds().end, 25);
-            assert_eq!(journal.bounds().start, 0);
+            assert_eq!(journal.bounds().await.end, 25);
+            assert_eq!(journal.bounds().await.start, 0);
             journal.sync().await.unwrap();
 
             // Clear to position 100, effectively resetting the journal
             journal.clear_to_size(100).await.unwrap();
-            assert_eq!(journal.bounds().end, 100);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 100);
+            assert!(journal.bounds().await.is_empty());
 
             // Old positions should fail
             for i in 0..25 {
@@ -2779,20 +2979,20 @@ mod tests {
 
             // Verify size persists after restart without writing any data
             drop(journal);
-            let mut journal =
+            let journal =
                 Journal::<_, u64>::init(context.with_label("journal_after_clear"), cfg.clone())
                     .await
                     .unwrap();
-            assert_eq!(journal.bounds().end, 100);
-            assert!(journal.bounds().is_empty());
+            assert_eq!(journal.bounds().await.end, 100);
+            assert!(journal.bounds().await.is_empty());
 
             // Append new data starting at position 100
             for i in 100..105u64 {
                 let pos = journal.append(i * 100).await.unwrap();
                 assert_eq!(pos, i);
             }
-            assert_eq!(journal.bounds().end, 105);
-            assert_eq!(journal.bounds().start, 100);
+            assert_eq!(journal.bounds().await.end, 105);
+            assert_eq!(journal.bounds().await.start, 100);
 
             // New positions should be readable
             for i in 100..105u64 {
@@ -2807,13 +3007,63 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(journal.bounds().end, 105);
-            assert_eq!(journal.bounds().start, 100);
+            assert_eq!(journal.bounds().await.end, 105);
+            assert_eq!(journal.bounds().await.start, 100);
             for i in 100..105u64 {
                 assert_eq!(journal.read(i).await.unwrap(), i * 100);
             }
 
             journal.destroy().await.unwrap();
+        });
+    }
+}
+
+#[cfg(test)]
+mod repro_tests {
+    use super::*;
+    use commonware_macros::test_traced;
+    use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner};
+    use commonware_utils::{NZUsize, NZU16, NZU64};
+
+    #[test_traced]
+    fn test_variable_replay_mid_section_bug() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "repro_bug".to_string(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::new(NZU16!(1024), NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context, cfg).await.unwrap();
+
+            // Append 5 items (middle of first section)
+            for i in 0..5 {
+                journal.append(i as u64).await.unwrap();
+            }
+
+            let size = journal.size().await;
+            assert_eq!(size, 5);
+
+            // Replay from size (should be empty)
+            let stream = journal.replay(NZUsize!(1024), size).await.unwrap();
+            futures::pin_mut!(stream);
+
+            let mut items = Vec::new();
+            while let Some(result) = stream.next().await {
+                items.push(result.unwrap());
+            }
+
+            assert_eq!(
+                items.len(),
+                0,
+                "Replay from size should be empty, but got {} items: {:?}",
+                items.len(),
+                items
+            );
         });
     }
 }

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -187,7 +187,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         start_section: u64,
         start_position: u64,
         buffer: NonZeroUsize,
-    ) -> Result<impl Stream<Item = Result<(u64, u64, A), Error>> + Send + '_, Error> {
+    ) -> Result<impl Stream<Item = Result<(u64, u64, A), Error>> + Send, Error> {
         // Pre-create readers from blobs (async operation)
         let mut blob_info = Vec::new();
         for (&section, blob) in self.manager.sections_from(start_section) {

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -296,10 +296,10 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// (section, offset, size, item).
     pub async fn replay(
         &self,
+        buffer: NonZeroUsize,
         start_section: u64,
         mut start_offset: u64,
-        buffer: NonZeroUsize,
-    ) -> Result<impl Stream<Item = Result<(u64, u64, u32, V), Error>> + Send + '_, Error> {
+    ) -> Result<impl Stream<Item = Result<(u64, u64, u32, V), Error>> + Send, Error> {
         // Collect all blobs to replay (keeping blob reference for potential resize)
         let codec_config = self.codec_config.clone();
         let compressed = self.compression.is_some();
@@ -711,7 +711,7 @@ mod tests {
             // Replay the journal and collect items
             let mut items = Vec::new();
             let stream = journal
-                .replay(0, 0, NZUsize!(1024))
+                .replay(NZUsize!(1024), 0, 0)
                 .await
                 .expect("unable to setup replay");
             pin_mut!(stream);
@@ -779,7 +779,7 @@ mod tests {
             let mut items = Vec::<(u64, u32)>::new();
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("unable to setup replay");
                 pin_mut!(stream);
@@ -865,7 +865,7 @@ mod tests {
             let mut items = Vec::<(u64, u64)>::new();
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("unable to setup replay");
                 pin_mut!(stream);
@@ -1134,7 +1134,7 @@ mod tests {
 
             // Attempt to replay the journal
             let stream = journal
-                .replay(0, 0, NZUsize!(1024))
+                .replay(NZUsize!(1024), 0, 0)
                 .await
                 .expect("unable to setup replay");
             pin_mut!(stream);
@@ -1191,7 +1191,7 @@ mod tests {
 
             // Attempt to replay the journal
             let stream = journal
-                .replay(0, 0, NZUsize!(1024))
+                .replay(NZUsize!(1024), 0, 0)
                 .await
                 .expect("unable to setup replay");
             pin_mut!(stream);
@@ -1253,7 +1253,7 @@ mod tests {
             //
             // This will truncate the leftover bytes from our manual write.
             let stream = journal
-                .replay(0, 0, NZUsize!(1024))
+                .replay(NZUsize!(1024), 0, 0)
                 .await
                 .expect("unable to setup replay");
             pin_mut!(stream);
@@ -1316,7 +1316,7 @@ mod tests {
             // Attempt to replay the journal
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("unable to setup replay");
                 pin_mut!(stream);
@@ -1397,7 +1397,7 @@ mod tests {
             let mut items = Vec::<(u64, u32)>::new();
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("unable to setup replay");
                 pin_mut!(stream);
@@ -1431,7 +1431,7 @@ mod tests {
             let mut items = Vec::<(u64, u32)>::new();
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("unable to setup replay");
                 pin_mut!(stream);
@@ -1468,7 +1468,7 @@ mod tests {
             let mut items = Vec::<(u64, u32)>::new();
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("unable to setup replay");
                 pin_mut!(stream);
@@ -1545,7 +1545,7 @@ mod tests {
             // Attempt to replay the journal
             let mut items = Vec::<(u64, i32)>::new();
             let stream = journal
-                .replay(0, 0, NZUsize!(1024))
+                .replay(NZUsize!(1024), 0, 0)
                 .await
                 .expect("unable to setup replay");
             pin_mut!(stream);
@@ -1711,7 +1711,7 @@ mod tests {
 
             // Replay and verify all items
             let stream = journal
-                .replay(0, 0, NZUsize!(1024))
+                .replay(NZUsize!(1024), 0, 0)
                 .await
                 .expect("Failed to setup replay");
             pin_mut!(stream);
@@ -1774,7 +1774,7 @@ mod tests {
 
             // Verify data integrity via replay
             {
-                let stream = journal.replay(0, 0, NZUsize!(1024)).await.unwrap();
+                let stream = journal.replay(NZUsize!(1024), 0, 0).await.unwrap();
                 pin_mut!(stream);
                 let mut items = Vec::new();
                 while let Some(result) = stream.next().await {
@@ -1823,7 +1823,7 @@ mod tests {
 
             // Verify first 3 items via replay
             {
-                let stream = journal.replay(0, 0, NZUsize!(1024)).await.unwrap();
+                let stream = journal.replay(NZUsize!(1024), 0, 0).await.unwrap();
                 pin_mut!(stream);
                 let mut items = Vec::new();
                 while let Some(result) = stream.next().await {
@@ -1870,7 +1870,7 @@ mod tests {
 
             // Verify replay returns nothing
             {
-                let stream = journal.replay(0, 0, NZUsize!(1024)).await.unwrap();
+                let stream = journal.replay(NZUsize!(1024), 0, 0).await.unwrap();
                 pin_mut!(stream);
                 let items: Vec<_> = stream.collect().await;
                 assert!(items.is_empty());
@@ -1926,7 +1926,7 @@ mod tests {
 
             // Verify data integrity via replay
             {
-                let stream = journal.replay(0, 0, NZUsize!(1024)).await.unwrap();
+                let stream = journal.replay(NZUsize!(1024), 0, 0).await.unwrap();
                 pin_mut!(stream);
                 let mut items = Vec::new();
                 while let Some(result) = stream.next().await {
@@ -1976,7 +1976,7 @@ mod tests {
 
             // Verify replay returns nothing
             {
-                let stream = journal.replay(0, 0, NZUsize!(1024)).await.unwrap();
+                let stream = journal.replay(NZUsize!(1024), 0, 0).await.unwrap();
                 pin_mut!(stream);
                 let items: Vec<_> = stream.collect().await;
                 assert!(items.is_empty());
@@ -2033,7 +2033,7 @@ mod tests {
                     .unwrap();
 
                 let stream = journal
-                    .replay(1, start_offset, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 1, start_offset)
                     .await
                     .unwrap();
                 pin_mut!(stream);
@@ -2112,7 +2112,7 @@ mod tests {
             // Replay and verify the large item
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("Failed to setup replay");
                 pin_mut!(stream);
@@ -2194,7 +2194,7 @@ mod tests {
             // Replay and verify all items in order
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("Failed to setup replay");
                 pin_mut!(stream);
@@ -2214,7 +2214,7 @@ mod tests {
             // Test replay starting from middle section (5)
             {
                 let stream = journal
-                    .replay(5, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 5, 0)
                     .await
                     .expect("Failed to setup replay from section 5");
                 pin_mut!(stream);
@@ -2233,7 +2233,7 @@ mod tests {
             // Test replay starting from non-existent section (should skip to next)
             {
                 let stream = journal
-                    .replay(3, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 3, 0)
                     .await
                     .expect("Failed to setup replay from section 3");
                 pin_mut!(stream);
@@ -2302,7 +2302,7 @@ mod tests {
             // Replay all - should get items from sections 1 and 3, skipping empty section 2
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("Failed to setup replay");
                 pin_mut!(stream);
@@ -2325,7 +2325,7 @@ mod tests {
             // Replay starting from empty section 2 - should get only section 3
             {
                 let stream = journal
-                    .replay(2, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 2, 0)
                     .await
                     .expect("Failed to setup replay from section 2");
                 pin_mut!(stream);
@@ -2394,7 +2394,7 @@ mod tests {
             // Replay and verify
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(1024))
+                    .replay(NZUsize!(1024), 0, 0)
                     .await
                     .expect("Failed to setup replay");
                 pin_mut!(stream);
@@ -2473,7 +2473,7 @@ mod tests {
             // Replay and verify all items
             {
                 let stream = journal
-                    .replay(0, 0, NZUsize!(64))
+                    .replay(NZUsize!(64), 0, 0)
                     .await
                     .expect("Failed to setup replay");
                 pin_mut!(stream);

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -49,7 +49,7 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
         /// no recovery will be needed on startup.
         ///
         /// This provides a stronger guarantee than [Self::commit] but may be slower.
-        fn sync(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
+        fn sync(&self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 
         /// Destroy the structure, removing all associated storage.
         ///

--- a/storage/src/mmr/storage.rs
+++ b/storage/src/mmr/storage.rs
@@ -8,7 +8,7 @@ use std::future::Future;
 /// A trait for accessing MMR digests from storage.
 pub trait Storage<D: Digest>: Send + Sync {
     /// Return the number of elements in the MMR.
-    fn size(&self) -> Position;
+    fn size(&self) -> impl Future<Output = Position> + Send;
 
     /// Return the specified node of the MMR if it exists & hasn't been pruned.
     fn get_node(&self, position: Position)
@@ -19,7 +19,7 @@ impl<D> Storage<D> for CleanMmr<D>
 where
     D: Digest,
 {
-    fn size(&self) -> Position {
+    async fn size(&self) -> Position {
         self.size()
     }
 

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -71,7 +71,7 @@ impl<D: Digest> Storage<D> for ProofStore<D> {
         Ok(self.digests.get(&pos).cloned())
     }
 
-    fn size(&self) -> Position {
+    async fn size(&self) -> Position {
         self.size
     }
 }
@@ -88,7 +88,7 @@ pub async fn range_proof<D: Digest, S: Storage<D>>(
     mmr: &S,
     range: Range<Location>,
 ) -> Result<Proof<D>, Error> {
-    let leaves = Location::try_from(mmr.size())?;
+    let leaves = Location::try_from(mmr.size().await)?;
     historical_range_proof(mmr, leaves, range).await
 }
 
@@ -145,7 +145,7 @@ pub async fn multi_proof<D: Digest, S: Storage<D>>(
     }
 
     // Collect all required node positions
-    let size = mmr.size();
+    let size = mmr.size().await;
     let leaves = Location::try_from(size)?;
     let node_positions: BTreeSet<_> = proof::nodes_required_for_multi_proof(leaves, locations)?;
 

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -86,7 +86,7 @@ where
     ) -> Result<LocatedKey<K, V>, Error> {
         let mut last_key: LocatedKey<K, V> = None;
         for loc in locs {
-            if loc >= self.log.bounds().end {
+            if loc >= self.log.bounds().await.end {
                 // Don't try to look up operations that don't yet exist in the log. This can happen
                 // when there are translated key conflicts between a created key and its
                 // previous-key.
@@ -396,7 +396,7 @@ where
         value: V::Value,
         mut callback: impl FnMut(Option<Location>),
     ) -> Result<(), Error> {
-        let next_loc = self.log.bounds().end;
+        let next_loc = self.log.bounds().await.end;
         if self.is_empty() {
             // We're inserting the very first key. For this special case, the next-key value is the
             // same as the key.
@@ -453,7 +453,7 @@ where
         value: V::Value,
         mut callback: impl FnMut(Option<Location>),
     ) -> Result<bool, Error> {
-        let next_loc = self.log.bounds().end;
+        let next_loc = self.log.bounds().await.end;
         if self.is_empty() {
             // We're inserting the very first key. For this special case, the next-key value is the
             // same as the key.
@@ -566,7 +566,7 @@ where
 
         let prev_key = prev_key.expect("prev_key should have been found");
 
-        let loc = self.log.bounds().end;
+        let loc = self.log.bounds().await.end;
         callback(true, Some(prev_key.0));
         update_known_loc(&mut self.snapshot, &prev_key.1, prev_key.0, loc);
 
@@ -721,7 +721,7 @@ where
         // Apply the updates of existing keys.
         let mut already_updated = BTreeSet::new();
         for (key, (value, loc)) in updated {
-            let new_loc = self.log.bounds().end;
+            let new_loc = self.log.bounds().await.end;
             update_known_loc(&mut self.snapshot, &key, loc, new_loc);
 
             let next_key = find_next_key(&key, &possible_next);
@@ -740,7 +740,7 @@ where
 
         // Create each new key, and update its previous key if it hasn't already been updated.
         for (key, value) in created {
-            let new_loc = self.log.bounds().end;
+            let new_loc = self.log.bounds().await.end;
             self.snapshot.insert(&key, new_loc);
             let next_key = find_next_key(&key, &possible_next);
             let op = Operation::Update(Update {
@@ -764,7 +764,7 @@ where
             }
             already_updated.insert(prev_key.clone());
 
-            let new_loc = self.log.bounds().end;
+            let new_loc = self.log.bounds().await.end;
             update_known_loc(&mut self.snapshot, prev_key, *prev_loc, new_loc);
             let next_key = find_next_key(prev_key, &possible_next);
             let op = Operation::Update(Update {
@@ -791,7 +791,7 @@ where
             }
             already_updated.insert(prev_key.clone());
 
-            let new_loc = self.log.bounds().end;
+            let new_loc = self.log.bounds().await.end;
             update_known_loc(&mut self.snapshot, prev_key, *prev_loc, new_loc);
             let next_key = find_next_key(prev_key, &possible_next);
             let op = Operation::Update(Update {
@@ -860,6 +860,10 @@ where
 {
     async fn update(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
         self.update(key, value).await
+    }
+
+    async fn create(&mut self, key: Self::Key, value: Self::Value) -> Result<bool, Self::Error> {
+        self.create(key, value).await
     }
 }
 
@@ -1078,20 +1082,23 @@ mod test {
         mut db: D,
         reopen_db: impl Fn(Context) -> Pin<Box<dyn Future<Output = D> + Send>>,
     ) {
-        assert_eq!(db.size(), 1);
+        assert_eq!(db.size().await, 1);
         assert!(db.get_metadata().await.unwrap().is_none());
-        assert!(matches!(db.prune(db.inactivity_floor_loc()).await, Ok(())));
+        assert!(matches!(
+            db.prune(db.inactivity_floor_loc().await).await,
+            Ok(())
+        ));
 
         // Make sure closing/reopening gets us back to the same state, even after adding an
         // uncommitted op, and even without a clean shutdown.
         let d1 = Sha256::fill(1u8);
         let d2 = Sha256::fill(2u8);
-        let root = db.root();
+        let root = db.root().await;
         let mut db = db.into_mutable();
         db.update(d1, d2).await.unwrap();
         let db = reopen_db(context.with_label("reopen1")).await;
-        assert_eq!(db.root(), root);
-        assert_eq!(db.size(), 1);
+        assert_eq!(db.root().await, root);
+        assert_eq!(db.size().await, 1);
 
         // Test calling commit on an empty db.
         let metadata = Sha256::fill(3u8);
@@ -1100,22 +1107,28 @@ mod test {
         let mut db = db.into_merkleized().await.unwrap();
         assert_eq!(range.start, Location::new_unchecked(1));
         assert_eq!(range.end, Location::new_unchecked(2));
-        assert_eq!(db.size(), 2); // floor op added
+        assert_eq!(db.size().await, 2); // floor op added
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
-        let root = db.root();
-        assert!(matches!(db.prune(db.inactivity_floor_loc()).await, Ok(())));
+        let root = db.root().await;
+        assert!(matches!(
+            db.prune(db.inactivity_floor_loc().await).await,
+            Ok(())
+        ));
 
         // Re-opening the DB without a clean shutdown should still recover the correct state.
         let db = reopen_db(context.with_label("reopen2")).await;
-        assert_eq!(db.size(), 2);
+        assert_eq!(db.size().await, 2);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
-        assert_eq!(db.root(), root);
+        assert_eq!(db.root().await, root);
 
         // Confirm the inactivity floor doesn't fall endlessly behind with multiple commits.
         let mut mutable_db = db.into_mutable();
         for _ in 1..100 {
             let (durable_db, _) = mutable_db.commit(None).await.unwrap();
-            assert_eq!(durable_db.size() - 1, durable_db.inactivity_floor_loc());
+            assert_eq!(
+                durable_db.size().await - 1,
+                durable_db.inactivity_floor_loc().await
+            );
             mutable_db = durable_db.into_mutable();
         }
         let db = mutable_db.commit(None).await.unwrap().0;
@@ -1161,8 +1174,8 @@ mod test {
         assert_eq!(db.get(&key2).await.unwrap().unwrap(), new_val);
 
         // 2 new keys (4 ops), 2 updates (2 ops), 1 deletion (2 ops) + 1 initial commit = 9 ops
-        assert_eq!(db.size(), 9);
-        assert_eq!(db.inactivity_floor_loc(), Location::new_unchecked(0));
+        assert_eq!(db.size().await, 9);
+        assert_eq!(db.inactivity_floor_loc().await, Location::new_unchecked(0));
         let (durable_db, _) = db.commit(None).await.unwrap();
         let mut db = durable_db.into_merkleized().await.unwrap().into_mutable();
 
@@ -1186,25 +1199,25 @@ mod test {
             .unwrap();
 
         // Multiple deletions of the same key should be a no-op.
-        let prev_op_count = db.size();
+        let prev_op_count = db.size().await;
         let mut db = db.into_mutable();
         // Note: commit always adds a floor op, so op_count will increase by 1 after commit.
         assert!(!db.delete(key1).await.unwrap());
-        assert_eq!(db.size(), prev_op_count);
+        assert_eq!(db.size().await, prev_op_count);
 
         // Deletions of non-existent keys should be a no-op.
         let key3 = Sha256::fill(6u8);
         assert!(!db.delete(key3).await.unwrap());
-        assert_eq!(db.size(), prev_op_count);
+        assert_eq!(db.size().await, prev_op_count);
 
         // Make sure closing/reopening gets us back to the same state.
         let db = db.commit(None).await.unwrap().0;
         let db = db.into_merkleized().await.unwrap();
-        let op_count = db.size();
-        let root = db.root();
+        let op_count = db.size().await;
+        let root = db.root().await;
         let db = reopen_db(context.with_label("reopen1")).await;
-        assert_eq!(db.size(), op_count);
-        assert_eq!(db.root(), root);
+        assert_eq!(db.size().await, op_count);
+        assert_eq!(db.root().await, root);
         let mut db = db.into_mutable();
 
         // Re-activate the keys by updating them.
@@ -1224,12 +1237,12 @@ mod test {
             .unwrap();
 
         // Confirm close/reopen gets us back to the same state.
-        let op_count = db.size();
-        let root = db.root();
+        let op_count = db.size().await;
+        let root = db.root().await;
         let db = reopen_db(context.with_label("reopen2")).await;
 
-        assert_eq!(db.root(), root);
-        assert_eq!(db.size(), op_count);
+        assert_eq!(db.root().await, root);
+        assert_eq!(db.size().await, op_count);
 
         // Commit will raise the inactivity floor, which won't affect state but will affect the
         // root.
@@ -1243,12 +1256,12 @@ mod test {
             .await
             .unwrap();
 
-        assert!(db.root() != root);
+        assert!(db.root().await != root);
 
         // Pruning inactive ops should not affect current state or root.
-        let root = db.root();
-        db.prune(db.inactivity_floor_loc()).await.unwrap();
-        assert_eq!(db.root(), root);
+        let root = db.root().await;
+        db.prune(db.inactivity_floor_loc().await).await.unwrap();
+        assert_eq!(db.root().await, root);
 
         db.destroy().await.unwrap();
     }
@@ -1258,20 +1271,23 @@ mod test {
         mut db: D,
         reopen_db: impl Fn(Context) -> Pin<Box<dyn Future<Output = D> + Send>>,
     ) {
-        assert_eq!(db.bounds().end, 1);
+        assert_eq!(db.bounds().await.end, 1);
         assert!(db.get_metadata().await.unwrap().is_none());
-        assert!(matches!(db.prune(db.inactivity_floor_loc()).await, Ok(())));
+        assert!(matches!(
+            db.prune(db.inactivity_floor_loc().await).await,
+            Ok(())
+        ));
 
         // Make sure closing/reopening gets us back to the same state, even after adding an
         // uncommitted op, and even without a clean shutdown.
         let d1 = FixedBytes::from([1u8; 4]);
         let d2 = Sha256::fill(2u8);
-        let root = db.root();
+        let root = db.root().await;
         let mut db = db.into_mutable();
         db.update(d1, d2).await.unwrap();
         let db = reopen_db(context.with_label("reopen1")).await;
-        assert_eq!(db.root(), root);
-        assert_eq!(db.bounds().end, 1);
+        assert_eq!(db.root().await, root);
+        assert_eq!(db.bounds().await.end, 1);
 
         // Test calling commit on an empty db.
         let metadata = Sha256::fill(3u8);
@@ -1280,24 +1296,27 @@ mod test {
         let mut db = db.into_merkleized().await.unwrap();
         assert_eq!(range.start, Location::new_unchecked(1));
         assert_eq!(range.end, Location::new_unchecked(2));
-        assert_eq!(db.bounds().end, 2); // floor op added
+        assert_eq!(db.bounds().await.end, 2); // floor op added
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
-        let root = db.root();
-        assert!(matches!(db.prune(db.inactivity_floor_loc()).await, Ok(())));
+        let root = db.root().await;
+        assert!(matches!(
+            db.prune(db.inactivity_floor_loc().await).await,
+            Ok(())
+        ));
 
         // Re-opening the DB without a clean shutdown should still recover the correct state.
         let db = reopen_db(context.with_label("reopen2")).await;
-        assert_eq!(db.bounds().end, 2);
+        assert_eq!(db.bounds().await.end, 2);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
-        assert_eq!(db.root(), root);
+        assert_eq!(db.root().await, root);
 
         // Confirm the inactivity floor doesn't fall endlessly behind with multiple commits.
         let mut mutable_db = db.into_mutable();
         for _ in 1..100 {
             let (durable_db, _) = mutable_db.commit(None).await.unwrap();
             assert_eq!(
-                durable_db.bounds().end - 1,
-                durable_db.inactivity_floor_loc()
+                durable_db.bounds().await.end - 1,
+                durable_db.inactivity_floor_loc().await
             );
             mutable_db = durable_db.into_mutable();
         }
@@ -1341,8 +1360,8 @@ mod test {
         assert_eq!(db.get(&key2).await.unwrap().unwrap(), new_val);
 
         // 2 new keys (4 ops), 2 updates (2 ops), 1 deletion (2 ops) + 1 initial commit = 9 ops
-        assert_eq!(db.bounds().end, 9);
-        assert_eq!(db.inactivity_floor_loc(), Location::new_unchecked(0));
+        assert_eq!(db.bounds().await.end, 9);
+        assert_eq!(db.inactivity_floor_loc().await, Location::new_unchecked(0));
         let (durable_db, _) = db.commit(None).await.unwrap();
         let mut db = durable_db.into_merkleized().await.unwrap().into_mutable();
 
@@ -1360,25 +1379,31 @@ mod test {
         let db = db.into_merkleized().await.unwrap();
 
         // Multiple deletions of the same key should be a no-op.
-        let prev_op_count = db.bounds().end;
+        let prev_op_count = db.bounds().await.end;
         let mut db = db.into_mutable();
         // Note: commit always adds a floor op, so op_count will increase by 1 after commit.
         assert!(!db.delete(key1.clone()).await.unwrap());
-        assert_eq!(db.bounds().end, prev_op_count);
+        assert_eq!(db.bounds().await.end, prev_op_count);
 
         // Deletions of non-existent keys should be a no-op.
         let key3 = FixedBytes::from([6u8; 4]);
         assert!(!db.delete(key3).await.unwrap());
-        assert_eq!(db.bounds().end, prev_op_count);
+        assert_eq!(db.bounds().await.end, prev_op_count);
 
         // Make sure closing/reopening gets us back to the same state.
-        let db = db.commit(None).await.unwrap().0;
-        let db = db.into_merkleized().await.unwrap();
-        let op_count = db.bounds().end;
-        let root = db.root();
+        let db = db
+            .commit(None)
+            .await
+            .unwrap()
+            .0
+            .into_merkleized()
+            .await
+            .unwrap();
+        let op_count = db.bounds().await.end;
+        let root = db.root().await;
         let db = reopen_db(context.with_label("reopen1")).await;
-        assert_eq!(db.bounds().end, op_count);
-        assert_eq!(db.root(), root);
+        assert_eq!(db.bounds().await.end, op_count);
+        assert_eq!(db.root().await, root);
         let mut db = db.into_mutable();
 
         // Re-activate the keys by updating them.
@@ -1392,12 +1417,12 @@ mod test {
         let db = db.into_merkleized().await.unwrap();
 
         // Confirm close/reopen gets us back to the same state.
-        let op_count = db.bounds().end;
-        let root = db.root();
+        let op_count = db.bounds().await.end;
+        let root = db.root().await;
         let db = reopen_db(context.with_label("reopen2")).await;
 
-        assert_eq!(db.root(), root);
-        assert_eq!(db.bounds().end, op_count);
+        assert_eq!(db.root().await, root);
+        assert_eq!(db.bounds().await.end, op_count);
 
         // Commit will raise the inactivity floor, which won't affect state but will affect the
         // root.
@@ -1405,12 +1430,12 @@ mod test {
         let db = db.commit(None).await.unwrap().0;
         let mut db = db.into_merkleized().await.unwrap();
 
-        assert!(db.root() != root);
+        assert!(db.root().await != root);
 
         // Pruning inactive ops should not affect current state or root.
-        let root = db.root();
-        db.prune(db.inactivity_floor_loc()).await.unwrap();
-        assert_eq!(db.root(), root);
+        let root = db.root().await;
+        db.prune(db.inactivity_floor_loc().await).await.unwrap();
+        assert_eq!(db.root().await, root);
 
         db.destroy().await.unwrap();
     }

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -553,8 +553,8 @@ pub(crate) mod test {
                     .collect()
             }
 
-            fn pinned_nodes_from_map(&self, pos: Position) -> Vec<Digest> {
-                let map = self.log.mmr.get_pinned_nodes();
+            async fn pinned_nodes_from_map(&self, pos: Position) -> Vec<Digest> {
+                let map = self.log.mmr.get_pinned_nodes().await;
                 nodes_to_pin(pos).map(|p| *map.get(&p).unwrap()).collect()
             }
         }

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -152,8 +152,8 @@ where
         .await
     }
 
-    fn root(&self) -> Self::Digest {
-        self.log.root()
+    async fn root(&self) -> Self::Digest {
+        self.log.root().await
     }
 }
 
@@ -195,8 +195,8 @@ where
         .await
     }
 
-    fn root(&self) -> Self::Digest {
-        self.log.root()
+    async fn root(&self) -> Self::Digest {
+        self.log.root().await
     }
 }
 
@@ -237,8 +237,8 @@ where
         .await
     }
 
-    fn root(&self) -> Self::Digest {
-        self.log.root()
+    async fn root(&self) -> Self::Digest {
+        self.log.root().await
     }
 }
 
@@ -280,7 +280,7 @@ where
         .await
     }
 
-    fn root(&self) -> Self::Digest {
-        self.log.root()
+    async fn root(&self) -> Self::Digest {
+        self.log.root().await
     }
 }

--- a/storage/src/qmdb/benches/fixed/generate.rs
+++ b/storage/src/qmdb/benches/fixed/generate.rs
@@ -188,7 +188,7 @@ where
 
     // Convert durable → provable (clean) for pruning
     let mut clean = durable.into_merkleized().await?;
-    clean.prune(clean.inactivity_floor_loc()).await?;
+    clean.prune(clean.inactivity_floor_loc().await).await?;
     clean.sync().await?;
 
     let res = start.elapsed();

--- a/storage/src/qmdb/benches/fixed/init.rs
+++ b/storage/src/qmdb/benches/fixed/init.rs
@@ -45,7 +45,10 @@ where
     let mutable = db.into_mutable();
     let durable = gen_random_kv(mutable, elements, operations, Some(COMMIT_FREQUENCY)).await;
     let mut clean = durable.into_merkleized().await.unwrap();
-    clean.prune(clean.inactivity_floor_loc()).await.unwrap();
+    clean
+        .prune(clean.inactivity_floor_loc().await)
+        .await
+        .unwrap();
     clean.sync().await.unwrap();
     drop(clean);
 }
@@ -120,39 +123,39 @@ fn bench_fixed_init(c: &mut Criterion) {
                                         let db = UFixedDb::init(ctx.clone(), any_cfg.clone())
                                             .await
                                             .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::AnyOrderedFixed => {
                                         let db = OFixedDb::init(ctx.clone(), any_cfg.clone())
                                             .await
                                             .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::CurrentUnorderedFixed => {
                                         let db = UCurrentDb::init(ctx.clone(), current_cfg.clone())
                                             .await
                                             .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::CurrentOrderedFixed => {
                                         let db = OCurrentDb::init(ctx.clone(), current_cfg.clone())
                                             .await
                                             .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::AnyUnorderedVariable => {
                                         let db =
                                             UVAnyDb::init(ctx.clone(), variable_any_cfg.clone())
                                                 .await
                                                 .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::AnyOrderedVariable => {
                                         let db =
                                             OVAnyDb::init(ctx.clone(), variable_any_cfg.clone())
                                                 .await
                                                 .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::CurrentUnorderedVariable => {
                                         let db = UVCurrentDb::init(
@@ -161,7 +164,7 @@ fn bench_fixed_init(c: &mut Criterion) {
                                         )
                                         .await
                                         .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::CurrentOrderedVariable => {
                                         let db = OVCurrentDb::init(
@@ -170,7 +173,7 @@ fn bench_fixed_init(c: &mut Criterion) {
                                         )
                                         .await
                                         .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                 }
                             }

--- a/storage/src/qmdb/benches/keyless/generate.rs
+++ b/storage/src/qmdb/benches/keyless/generate.rs
@@ -78,7 +78,7 @@ async fn gen_random_keyless(ctx: Context, num_operations: u64) -> KeylessDb {
         }
     }
     let (durable, _) = db.commit(None).await.unwrap();
-    let mut clean = durable.into_merkleized();
+    let clean = durable.into_merkleized();
     clean.sync().await.unwrap();
 
     clean
@@ -97,7 +97,7 @@ fn bench_keyless_generate(c: &mut Criterion) {
                     let mut total_elapsed = Duration::ZERO;
                     for _ in 0..iters {
                         let start = Instant::now();
-                        let mut db = gen_random_keyless(ctx.clone(), operations).await;
+                        let db = gen_random_keyless(ctx.clone(), operations).await;
                         db.sync().await.unwrap();
                         total_elapsed += start.elapsed();
 

--- a/storage/src/qmdb/benches/variable/generate.rs
+++ b/storage/src/qmdb/benches/variable/generate.rs
@@ -137,7 +137,7 @@ where
 
     // Convert durable → provable (clean) for pruning
     let mut clean = durable.into_merkleized().await?;
-    clean.prune(clean.inactivity_floor_loc()).await?;
+    clean.prune(clean.inactivity_floor_loc().await).await?;
     clean.sync().await?;
 
     let elapsed = start.elapsed();

--- a/storage/src/qmdb/benches/variable/init.rs
+++ b/storage/src/qmdb/benches/variable/init.rs
@@ -43,7 +43,10 @@ where
     let mutable = db.into_mutable();
     let durable = gen_random_kv(mutable, elements, operations, COMMIT_FREQUENCY).await;
     let mut clean = durable.into_merkleized().await.unwrap();
-    clean.prune(clean.inactivity_floor_loc()).await.unwrap();
+    clean
+        .prune(clean.inactivity_floor_loc().await)
+        .await
+        .unwrap();
     clean.sync().await.unwrap();
     drop(clean);
 }
@@ -103,27 +106,27 @@ fn bench_variable_init(c: &mut Criterion) {
                                         let db = UVariableDb::init(ctx.clone(), any_cfg.clone())
                                             .await
                                             .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::AnyOrdered => {
                                         let db = OVariableDb::init(ctx.clone(), any_cfg.clone())
                                             .await
                                             .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::CurrentUnordered => {
                                         let db =
                                             UVCurrentDb::init(ctx.clone(), current_cfg.clone())
                                                 .await
                                                 .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                     Variant::CurrentOrdered => {
                                         let db =
                                             OVCurrentDb::init(ctx.clone(), current_cfg.clone())
                                                 .await
                                                 .unwrap();
-                                        assert_ne!(db.bounds().end, 0);
+                                        assert_ne!(db.bounds().await.end, 0);
                                     }
                                 }
                             }

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -23,8 +23,10 @@ use crate::{
 use commonware_codec::{Codec, CodecFixedShared, FixedSize, Read};
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_parallel::ThreadPool;
-use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, Storage};
+use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, RwLock, Storage};
 use commonware_utils::Array;
+#[cfg(any(test, feature = "test-traits"))]
+use std::future::Future;
 use std::num::{NonZeroU64, NonZeroUsize};
 
 pub mod db;
@@ -217,7 +219,7 @@ where
 
     Ok(db::Db {
         any,
-        status,
+        status: RwLock::new(status),
         state: db::Merkleized { root },
     })
 }
@@ -292,7 +294,7 @@ where
 
     Ok(db::Db {
         any,
-        status,
+        status: RwLock::new(status),
         state: db::Merkleized { root },
     })
 }
@@ -301,13 +303,13 @@ where
 #[cfg(any(test, feature = "test-traits"))]
 pub trait BitmapPrunedBits {
     /// Returns the number of bits that have been pruned from the bitmap.
-    fn pruned_bits(&self) -> u64;
+    fn pruned_bits(&self) -> impl Future<Output = u64> + Send;
 
     /// Returns the value of the bit at the given index.
-    fn get_bit(&self, index: u64) -> bool;
+    fn get_bit(&self, index: u64) -> impl Future<Output = bool> + Send;
 
     /// Returns the position of the oldest retained bit.
-    fn oldest_retained(&self) -> u64;
+    fn oldest_retained(&self) -> impl Future<Output = u64> + Send;
 }
 
 #[cfg(test)]
@@ -453,16 +455,16 @@ pub mod tests {
                 .await
                 .unwrap();
             let (db, _) = db.commit(None).await.unwrap();
-            let mut db: C = db.into_merkleized().await.unwrap();
+            let db: C = db.into_merkleized().await.unwrap();
             db.sync().await.unwrap();
 
             // Drop and reopen the db
-            let root = db.root();
+            let root = db.root().await;
             drop(db);
             let db: C = open_db_clone(context.with_label("second"), partition).await;
 
             // Ensure the root matches
-            assert_eq!(db.root(), root);
+            assert_eq!(db.root().await, root);
 
             db.destroy().await.unwrap();
             context.auditor().state()
@@ -478,13 +480,13 @@ pub mod tests {
                 .await
                 .unwrap();
             let (db, _) = db.commit(None).await.unwrap();
-            let mut db: C = db.into_merkleized().await.unwrap();
+            let db: C = db.into_merkleized().await.unwrap();
             db.sync().await.unwrap();
 
-            let root = db.root();
+            let root = db.root().await;
             drop(db);
             let db: C = open_db(context.with_label("second"), partition).await;
-            assert_eq!(db.root(), root);
+            assert_eq!(db.root().await, root);
 
             db.destroy().await.unwrap();
             context.auditor().state()
@@ -512,63 +514,89 @@ pub mod tests {
             let partition = "build_random_fail_commit".to_string();
             let rng_seed = context.next_u64();
             let db: C = open_db(context.with_label("first"), partition.clone()).await;
-            let db = apply_random_ops::<C>(ELEMENTS, true, rng_seed, db.into_mutable())
-                .await
-                .unwrap();
+            let db = Box::pin(apply_random_ops::<C>(
+                ELEMENTS,
+                true,
+                rng_seed,
+                db.into_mutable(),
+            ))
+            .await
+            .unwrap();
             let (db, _) = db.commit(None).await.unwrap();
             let mut db: C = db.into_merkleized().await.unwrap();
-            let committed_root = db.root();
-            let committed_op_count = db.bounds().end;
-            let committed_inactivity_floor = db.inactivity_floor_loc();
+            let committed_root = db.root().await;
+            let committed_op_count = db.bounds().await.end;
+            let committed_inactivity_floor = db.inactivity_floor_loc().await;
             db.prune(committed_inactivity_floor).await.unwrap();
 
             // Perform more random operations without committing any of them.
-            let db = apply_random_ops::<C>(ELEMENTS, false, rng_seed + 1, db.into_mutable())
-                .await
-                .unwrap();
+            let db = Box::pin(apply_random_ops::<C>(
+                ELEMENTS,
+                false,
+                rng_seed + 1,
+                db.into_mutable(),
+            ))
+            .await
+            .unwrap();
 
             // SCENARIO #1: Simulate a crash that happens before any writes. Upon reopening, the
             // state of the DB should be as of the last commit.
             drop(db);
             let db: C = open_db(context.with_label("scenario1"), partition.clone()).await;
-            assert_eq!(db.root(), committed_root);
-            assert_eq!(db.bounds().end, committed_op_count);
+            assert_eq!(db.root().await, committed_root);
+            assert_eq!(db.bounds().await.end, committed_op_count);
 
             // Re-apply the exact same uncommitted operations.
-            let db = apply_random_ops::<C>(ELEMENTS, false, rng_seed + 1, db.into_mutable())
-                .await
-                .unwrap();
+            let db = Box::pin(apply_random_ops::<C>(
+                ELEMENTS,
+                false,
+                rng_seed + 1,
+                db.into_mutable(),
+            ))
+            .await
+            .unwrap();
 
             // SCENARIO #2: Simulate a crash that happens after the any db has been committed, but
             // before the state of the pruned bitmap can be written to disk (i.e., before
             // into_merkleized is called). We do this by committing and then dropping the durable
             // db without calling close or into_merkleized.
             let (durable_db, _) = db.commit(None).await.unwrap();
-            let committed_op_count = durable_db.bounds().end;
+            let committed_op_count = durable_db.bounds().await.end;
             drop(durable_db);
 
             // We should be able to recover, so the root should differ from the previous commit, and
             // the op count should be greater than before.
             let db: C = open_db(context.with_label("scenario2"), partition.clone()).await;
-            let scenario_2_root = db.root();
+            let scenario_2_root = db.root().await;
 
             // To confirm the second committed hash is correct we'll re-build the DB in a new
             // partition, but without any failures. They should have the exact same state.
             let fresh_partition = "build_random_fail_commit_fresh".to_string();
             let db: C = open_db(context.with_label("fresh"), fresh_partition.clone()).await;
-            let db = apply_random_ops::<C>(ELEMENTS, true, rng_seed, db.into_mutable())
-                .await
-                .unwrap();
+            let db = Box::pin(apply_random_ops::<C>(
+                ELEMENTS,
+                true,
+                rng_seed,
+                db.into_mutable(),
+            ))
+            .await
+            .unwrap();
             let (db, _) = db.commit(None).await.unwrap();
-            let db = apply_random_ops::<C>(ELEMENTS, false, rng_seed + 1, db.into_mutable())
-                .await
-                .unwrap();
+            let db = Box::pin(apply_random_ops::<C>(
+                ELEMENTS,
+                false,
+                rng_seed + 1,
+                db.into_mutable(),
+            ))
+            .await
+            .unwrap();
             let (db, _) = db.commit(None).await.unwrap();
             let mut db: C = db.into_merkleized().await.unwrap();
-            db.prune(db.inactivity_floor_loc()).await.unwrap();
+            let floor = db.inactivity_floor_loc().await;
+            db.prune(floor).await.unwrap();
             // State from scenario #2 should match that of a successful commit.
-            assert_eq!(db.bounds().end, committed_op_count);
-            assert_eq!(db.root(), scenario_2_root);
+            assert_eq!(db.bounds().await.end, committed_op_count);
+            assert_eq!(db.root().await, scenario_2_root);
 
             db.destroy().await.unwrap();
         });
@@ -618,7 +646,7 @@ pub mod tests {
                     let (db_2, _) = db_pruning_mut.commit(None).await.unwrap();
                     let mut clean_pruning: C = db_2.into_merkleized().await.unwrap();
                     clean_pruning
-                        .prune(clean_no_pruning.inactivity_floor_loc())
+                        .prune(clean_no_pruning.inactivity_floor_loc().await)
                         .await
                         .unwrap();
                     db_no_pruning_mut = clean_no_pruning.into_mutable();
@@ -633,14 +661,14 @@ pub mod tests {
             db_pruning = db_2.into_merkleized().await.unwrap();
 
             // Get roots from both databases - they should match
-            let root_no_pruning = db_no_pruning.root();
-            let root_pruning = db_pruning.root();
+            let root_no_pruning = db_no_pruning.root().await;
+            let root_pruning = db_pruning.root().await;
             assert_eq!(root_no_pruning, root_pruning);
 
             // Also verify inactivity floors match
             assert_eq!(
-                db_no_pruning.inactivity_floor_loc(),
-                db_pruning.inactivity_floor_loc()
+                db_no_pruning.inactivity_floor_loc().await,
+                db_pruning.inactivity_floor_loc().await
             );
 
             db_no_pruning.destroy().await.unwrap();
@@ -675,15 +703,15 @@ pub mod tests {
                 .await
                 .unwrap();
             let (db, _) = db.commit(None).await.unwrap();
-            let mut db: C = db.into_merkleized().await.unwrap();
+            let db: C = db.into_merkleized().await.unwrap();
 
             // The bitmap should have been pruned during into_merkleized().
-            let pruned_bits_before = db.pruned_bits();
+            let pruned_bits_before = db.pruned_bits().await;
             warn!(
                 "pruned_bits_before={}, inactivity_floor={}, op_count={}",
                 pruned_bits_before,
-                *db.inactivity_floor_loc(),
-                *db.bounds().end
+                *db.inactivity_floor_loc().await,
+                *db.bounds().await.end
             );
 
             // Verify we actually have some pruning (otherwise the test is meaningless).
@@ -697,7 +725,7 @@ pub mod tests {
             db.sync().await.unwrap();
 
             // Record the root before dropping.
-            let root_before = db.root();
+            let root_before = db.root().await;
             drop(db);
 
             // Reopen the database.
@@ -705,7 +733,7 @@ pub mod tests {
 
             // The pruned bits count should match. If sync() didn't persist the bitmap pruned
             // state, this would be 0.
-            let pruned_bits_after = db.pruned_bits();
+            let pruned_bits_after = db.pruned_bits().await;
             warn!("pruned_bits_after={}", pruned_bits_after);
 
             assert_eq!(
@@ -714,7 +742,7 @@ pub mod tests {
             );
 
             // Also verify the root matches.
-            assert_eq!(db.root(), root_before);
+            assert_eq!(db.root().await, root_before);
 
             db.destroy().await.unwrap();
         });
@@ -744,9 +772,8 @@ pub mod tests {
         const ELEMENTS: u64 = 1000;
 
         let executor = deterministic::Runner::default();
-        let mut open_db_clone = open_db.clone();
         executor.start(|context| async move {
-            let mut db = open_db_clone(context.with_label("first"), "build_big".to_string())
+            let mut db = open_db(context.with_label("first"), "build_big".to_string())
                 .await
                 .into_mutable();
 
@@ -783,26 +810,15 @@ pub mod tests {
             let (db, _) = db.commit(None).await.unwrap();
             let mut db: C = db.into_merkleized().await.unwrap();
             db.sync().await.unwrap();
-            db.prune(db.inactivity_floor_loc()).await.unwrap();
+            db.prune(db.inactivity_floor_loc().await).await.unwrap();
 
             // Verify expected state after prune.
-            assert_eq!(db.bounds().end, Location::new_unchecked(expected_op_count));
             assert_eq!(
-                db.inactivity_floor_loc(),
-                Location::new_unchecked(expected_inactivity_floor)
+                db.bounds().await.end,
+                Location::new_unchecked(expected_op_count)
             );
-
-            // Record root before dropping.
-            let root = db.root();
-            db.sync().await.unwrap();
-            drop(db);
-
-            // Reopen the db and verify it has exactly the same state.
-            let db: C = open_db(context.with_label("second"), "build_big".to_string()).await;
-            assert_eq!(root, db.root());
-            assert_eq!(db.bounds().end, Location::new_unchecked(expected_op_count));
             assert_eq!(
-                db.inactivity_floor_loc(),
+                db.inactivity_floor_loc().await,
                 Location::new_unchecked(expected_inactivity_floor)
             );
 
@@ -818,6 +834,23 @@ pub mod tests {
                     assert!(db.get(&k).await.unwrap().is_none());
                 }
             }
+
+            // Record root before dropping.
+            let root = db.root().await;
+            db.sync().await.unwrap();
+            drop(db);
+
+            // Reopen the db and verify it has exactly the same state.
+            let db: C = open_db(context.with_label("second"), "build_big".to_string()).await;
+            assert_eq!(root, db.root().await);
+            assert_eq!(
+                db.bounds().await.end,
+                Location::new_unchecked(expected_op_count)
+            );
+            assert_eq!(
+                db.inactivity_floor_loc().await,
+                Location::new_unchecked(expected_inactivity_floor)
+            );
         });
     }
 

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -175,8 +175,8 @@ where
         };
         let height = Self::grafting_height();
         let mmr = &self.any.log.mmr;
-        let proof =
-            OperationProof::<H::Digest, N>::new(hasher, &self.status, height, mmr, loc).await?;
+        let status = self.status.read().await;
+        let proof = OperationProof::<H::Digest, N>::new(hasher, &*status, height, mmr, loc).await?;
 
         Ok(KeyValueProof {
             proof,
@@ -195,8 +195,8 @@ where
         key: &K,
     ) -> Result<super::ExclusionProof<K, V, H::Digest, N>, Error> {
         let height = Self::grafting_height();
-        let grafted_mmr =
-            GraftingStorage::<'_, H, _, _>::new(&self.status, &self.any.log.mmr, height);
+        let status = self.status.read().await;
+        let grafted_mmr = GraftingStorage::<'_, H, _, _>::new(&*status, &self.any.log.mmr, height);
 
         let span = self.any.get_span(key).await?;
         let loc = match &span {
@@ -207,11 +207,15 @@ where
                 }
                 *loc
             }
-            None => self.size().checked_sub(1).expect("db shouldn't be empty"),
+            None => self
+                .size()
+                .await
+                .checked_sub(1)
+                .expect("db shouldn't be empty"),
         };
 
         let op_proof =
-            OperationProof::<H::Digest, N>::new(hasher, &self.status, height, &grafted_mmr, loc)
+            OperationProof::<H::Digest, N>::new(hasher, &*status, height, &grafted_mmr, loc)
                 .await?;
 
         Ok(match span {
@@ -244,11 +248,12 @@ where
     /// Updates `key` to have value `value`. The operation is reflected in the snapshot, but will be
     /// subject to rollback until the next successful `commit`.
     pub async fn update(&mut self, key: K, value: V::Value) -> Result<(), Error> {
+        let status = self.status.get_mut();
         self.any
             .update_with_callback(key, value, |loc| {
-                self.status.push(true);
+                status.push(true);
                 if let Some(loc) = loc {
-                    self.status.set_bit(*loc, false);
+                    status.set_bit(*loc, false);
                 }
             })
             .await
@@ -258,11 +263,12 @@ where
     /// be subject to rollback until the next successful `commit`. Returns true if the key was
     /// created, false if it already existed.
     pub async fn create(&mut self, key: K, value: V::Value) -> Result<bool, Error> {
+        let status = self.status.get_mut();
         self.any
             .create_with_callback(key, value, |loc| {
-                self.status.push(true);
+                status.push(true);
                 if let Some(loc) = loc {
-                    self.status.set_bit(*loc, false);
+                    status.set_bit(*loc, false);
                 }
             })
             .await
@@ -273,12 +279,13 @@ where
     /// successful `commit`. Returns true if the key was deleted, false if it was already inactive.
     pub async fn delete(&mut self, key: K) -> Result<bool, Error> {
         let mut r = false;
+        let status = self.status.get_mut();
         self.any
             .delete_with_callback(key, |append, loc| {
                 if let Some(loc) = loc {
-                    self.status.set_bit(*loc, false);
+                    status.set_bit(*loc, false);
                 }
-                self.status.push(append);
+                status.push(append);
                 r = true;
             })
             .await?;
@@ -329,6 +336,10 @@ where
     async fn update(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
         self.update(key, value).await
     }
+
+    async fn create(&mut self, key: Self::Key, value: Self::Value) -> Result<bool, Self::Error> {
+        self.create(key, value).await
+    }
 }
 
 // StoreDeletable for (Unmerkleized, NonDurable) (aka mutable) state
@@ -367,7 +378,7 @@ where
     where
         Iter: Iterator<Item = (K, Option<V::Value>)> + Send + 'a,
     {
-        let status = &mut self.status;
+        let status = self.status.get_mut();
         self.any
             .write_batch_with_callback(iter, move |append: bool, loc: Option<Location>| {
                 status.push(append);

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -368,7 +368,7 @@ pub mod test {
             // Make sure size-constrained batches of operations are provable from the oldest
             // retained op to tip.
             let max_ops = 4;
-            let end_loc = db.size();
+            let end_loc = db.size().await;
             let start_loc = db.any.inactivity_floor_loc();
 
             for loc in *start_loc..*end_loc {
@@ -427,10 +427,15 @@ pub mod test {
             assert!(matches!(res, Err(Error::KeyNotFound)));
 
             let start = *db.inactivity_floor_loc();
-            for i in start..db.status.len() {
-                if !db.status.get_bit(i) {
-                    continue;
-                }
+            // Collect active indices first, then drop the read guard
+            let active_indices: Vec<u64> = {
+                let status = db.status.read().await;
+                (start..status.len())
+                    .filter(|&i| status.get_bit(i))
+                    .collect()
+            };
+
+            for i in active_indices {
                 // Found an active operation! Create a proof for its active current key/value if
                 // it's a key-updating operation.
                 let op = db.any.log.read(Location::new_unchecked(i)).await.unwrap();
@@ -714,13 +719,13 @@ pub mod test {
             db.delete(key_exists_1).await.unwrap();
             db.delete(key_exists_2).await.unwrap();
             let (db, _) = db.commit(None).await.unwrap();
-            let mut db = db.into_merkleized().await.unwrap();
+            let db = db.into_merkleized().await.unwrap();
             db.sync().await.unwrap();
             let root = db.root();
             // This root should be different than the empty root from earlier since the DB now has a
             // non-zero number of operations.
             assert!(db.is_empty());
-            assert_ne!(db.bounds().end, 0);
+            assert_ne!(db.bounds().await.end, 0);
             assert_ne!(root, empty_root);
 
             let proof = db

--- a/storage/src/qmdb/current/ordered/test_trait_impls.rs
+++ b/storage/src/qmdb/current/ordered/test_trait_impls.rs
@@ -219,16 +219,16 @@ impl<
         const N: usize,
     > BitmapPrunedBits for fixed::Db<E, K, V, H, T, N, Merkleized<DigestOf<H>>, Durable>
 {
-    fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+    async fn pruned_bits(&self) -> u64 {
+        self.status.read().await.pruned_bits()
     }
 
-    fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+    async fn get_bit(&self, index: u64) -> bool {
+        self.status.read().await.get_bit(index)
     }
 
-    fn oldest_retained(&self) -> u64 {
-        *self.any.log.bounds().start
+    async fn oldest_retained(&self) -> u64 {
+        *self.any.log.bounds().await.start
     }
 }
 
@@ -243,16 +243,16 @@ impl<
 where
     VariableOperation<K, V>: Read,
 {
-    fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+    async fn pruned_bits(&self) -> u64 {
+        self.status.read().await.pruned_bits()
     }
 
-    fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+    async fn get_bit(&self, index: u64) -> bool {
+        self.status.read().await.get_bit(index)
     }
 
-    fn oldest_retained(&self) -> u64 {
-        *self.any.log.bounds().start
+    async fn oldest_retained(&self) -> u64 {
+        *self.any.log.bounds().await.start
     }
 }
 
@@ -360,16 +360,16 @@ impl<
     > BitmapPrunedBits
     for fixed::partitioned::Db<E, K, V, H, T, P, N, Merkleized<DigestOf<H>>, Durable>
 {
-    fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+    async fn pruned_bits(&self) -> u64 {
+        self.status.read().await.pruned_bits()
     }
 
-    fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+    async fn get_bit(&self, index: u64) -> bool {
+        self.status.read().await.get_bit(index)
     }
 
-    fn oldest_retained(&self) -> u64 {
-        *self.any.log.bounds().start
+    async fn oldest_retained(&self) -> u64 {
+        *self.any.log.bounds().await.start
     }
 }
 
@@ -488,15 +488,15 @@ impl<
 where
     VariableOperation<K, V>: Read,
 {
-    fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+    async fn pruned_bits(&self) -> u64 {
+        self.status.read().await.pruned_bits()
     }
 
-    fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+    async fn get_bit(&self, index: u64) -> bool {
+        self.status.read().await.get_bit(index)
     }
 
-    fn oldest_retained(&self) -> u64 {
-        *self.any.log.bounds().start
+    async fn oldest_retained(&self) -> u64 {
+        *self.any.log.bounds().await.start
     }
 }

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -383,7 +383,7 @@ mod test {
             // Make sure size-constrained batches of operations are provable from the oldest
             // retained op to tip.
             let max_ops = 4;
-            let end_loc = db.size();
+            let end_loc = db.size().await;
             let start_loc = db.any.inactivity_floor_loc();
 
             for loc in *start_loc..*end_loc {
@@ -442,10 +442,14 @@ mod test {
             assert!(matches!(res, Err(Error::KeyNotFound)));
 
             let start = *db.inactivity_floor_loc();
-            for i in start..db.status.len() {
-                if !db.status.get_bit(i) {
-                    continue;
-                }
+            // Collect active indices first, then drop the read guard.
+            let active_indices: Vec<u64> = {
+                let status = db.status.read().await;
+                (start..status.len())
+                    .filter(|&i| status.get_bit(i))
+                    .collect()
+            };
+            for i in active_indices {
                 // Found an active operation! Create a proof for its active current key/value if
                 // it's a key-updating operation.
                 let op = db.any.log.read(Location::new_unchecked(i)).await.unwrap();
@@ -738,13 +742,13 @@ mod test {
             db.delete(key_exists_1).await.unwrap();
             db.delete(key_exists_2).await.unwrap();
             let (db, _) = db.commit(None).await.unwrap();
-            let mut db = db.into_merkleized().await.unwrap();
+            let db = db.into_merkleized().await.unwrap();
             db.sync().await.unwrap();
             let root = db.root();
             // This root should be different than the empty root from earlier since the DB now has a
             // non-zero number of operations.
             assert!(db.is_empty());
-            assert_ne!(db.bounds().end, 0);
+            assert_ne!(db.bounds().await.end, 0);
             assert_ne!(root, empty_root);
 
             let proof = db

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -92,7 +92,7 @@ impl<D: Digest> RangeProof<D> {
         max_ops: NonZeroU64,
     ) -> Result<(Self, Vec<C::Item>, Vec<[u8; N]>), Error> {
         // Compute the start and end locations & positions of the range.
-        let leaves = mmr.leaves();
+        let leaves = mmr.leaves().await;
         if start_loc >= leaves {
             return Err(crate::mmr::Error::RangeOutOfBounds(start_loc).into());
         }

--- a/storage/src/qmdb/current/unordered/test_trait_impls.rs
+++ b/storage/src/qmdb/current/unordered/test_trait_impls.rs
@@ -219,16 +219,16 @@ impl<
         const N: usize,
     > BitmapPrunedBits for fixed::Db<E, K, V, H, T, N, Merkleized<DigestOf<H>>, Durable>
 {
-    fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+    async fn pruned_bits(&self) -> u64 {
+        self.status.read().await.pruned_bits()
     }
 
-    fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+    async fn get_bit(&self, index: u64) -> bool {
+        self.status.read().await.get_bit(index)
     }
 
-    fn oldest_retained(&self) -> u64 {
-        *self.any.log.bounds().start
+    async fn oldest_retained(&self) -> u64 {
+        *self.any.log.bounds().await.start
     }
 }
 
@@ -243,16 +243,16 @@ impl<
 where
     VariableOperation<K, V>: Read,
 {
-    fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+    async fn pruned_bits(&self) -> u64 {
+        self.status.read().await.pruned_bits()
     }
 
-    fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+    async fn get_bit(&self, index: u64) -> bool {
+        self.status.read().await.get_bit(index)
     }
 
-    fn oldest_retained(&self) -> u64 {
-        *self.any.log.bounds().start
+    async fn oldest_retained(&self) -> u64 {
+        *self.any.log.bounds().await.start
     }
 }
 
@@ -360,16 +360,16 @@ impl<
     > BitmapPrunedBits
     for fixed::partitioned::Db<E, K, V, H, T, P, N, Merkleized<DigestOf<H>>, Durable>
 {
-    fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+    async fn pruned_bits(&self) -> u64 {
+        self.status.read().await.pruned_bits()
     }
 
-    fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+    async fn get_bit(&self, index: u64) -> bool {
+        self.status.read().await.get_bit(index)
     }
 
-    fn oldest_retained(&self) -> u64 {
-        *self.any.log.bounds().start
+    async fn oldest_retained(&self) -> u64 {
+        *self.any.log.bounds().await.start
     }
 }
 
@@ -488,15 +488,15 @@ impl<
 where
     VariableOperation<K, V>: Read,
 {
-    fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+    async fn pruned_bits(&self) -> u64 {
+        self.status.read().await.pruned_bits()
     }
 
-    fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+    async fn get_bit(&self, index: u64) -> bool {
+        self.status.read().await.get_bit(index)
     }
 
-    fn oldest_retained(&self) -> u64 {
-        *self.any.log.bounds().start
+    async fn oldest_retained(&self) -> u64 {
+        *self.any.log.bounds().await.start
     }
 }

--- a/storage/src/qmdb/current/unordered/variable.rs
+++ b/storage/src/qmdb/current/unordered/variable.rs
@@ -374,7 +374,7 @@ mod test {
             // Make sure size-constrained batches of operations are provable from the oldest
             // retained op to tip.
             let max_ops = 4;
-            let end_loc = db.size();
+            let end_loc = db.size().await;
             let start_loc = db.any.inactivity_floor_loc();
 
             for loc in *start_loc..*end_loc {
@@ -433,10 +433,15 @@ mod test {
             assert!(matches!(res, Err(Error::KeyNotFound)));
 
             let start = *db.inactivity_floor_loc();
-            for i in start..db.status.len() {
-                if !db.status.get_bit(i) {
-                    continue;
-                }
+            // Collect active indices first, then drop the read guard
+            let active_indices: Vec<u64> = {
+                let status = db.status.read().await;
+                (start..status.len())
+                    .filter(|&i| status.get_bit(i))
+                    .collect()
+            };
+
+            for i in active_indices {
                 // Found an active operation! Create a proof for its active current key/value if
                 // it's a key-updating operation.
                 let (key, value) = match db.any.log.read(Location::new_unchecked(i)).await.unwrap()

--- a/storage/src/qmdb/immutable/sync.rs
+++ b/storage/src/qmdb/immutable/sync.rs
@@ -23,7 +23,7 @@ impl<E, K, V, H, T> sync::Database for immutable::Immutable<E, K, V, H, T>
 where
     E: Storage + Clock + Metrics,
     K: Array,
-    V: VariableValue,
+    V: VariableValue + 'static,
     H: Hasher,
     T: Translator,
 {

--- a/storage/src/qmdb/immutable/sync.rs
+++ b/storage/src/qmdb/immutable/sync.rs
@@ -91,12 +91,16 @@ where
             Index::new(context.with_label("snapshot"), db_config.translator.clone());
 
         // Get the start of the log.
-        let start_loc = journal.bounds().start;
+        let start_loc = journal.bounds().await.start;
 
         // Build snapshot from the log
         build_snapshot_from_log(start_loc, &journal.journal, &mut snapshot, |_, _| {}).await?;
 
-        let last_commit_loc = journal.size().checked_sub(1).expect("commit should exist");
+        let last_commit_loc = journal
+            .size()
+            .await
+            .checked_sub(1)
+            .expect("commit should exist");
 
         let mut db = Self {
             journal,
@@ -109,8 +113,8 @@ where
         Ok(db)
     }
 
-    fn root(&self) -> Self::Digest {
-        self.root()
+    async fn root(&self) -> Self::Digest {
+        self.root().await
     }
 }
 
@@ -253,10 +257,10 @@ mod tests {
             let metadata = Some(Sha256::fill(1));
             let (durable_db, _) = target_db.commit(metadata).await.unwrap();
             let target_db = durable_db.into_merkleized();
-            let bounds = target_db.bounds();
+            let bounds = target_db.bounds().await;
             let target_op_count = bounds.end;
             let target_oldest_retained_loc = bounds.start;
-            let target_root = target_db.root();
+            let target_root = target_db.root().await;
 
             // Capture target database state before moving into config
             let mut expected_kvs: HashMap<sha256::Digest, sha256::Digest> = HashMap::new();
@@ -285,11 +289,11 @@ mod tests {
             let got_db: ImmutableSyncTest = sync::sync(config).await.unwrap();
 
             // Verify database state
-            assert_eq!(got_db.bounds().end, target_op_count);
-            assert_eq!(got_db.bounds().start, target_oldest_retained_loc);
+            assert_eq!(got_db.bounds().await.end, target_op_count);
+            assert_eq!(got_db.bounds().await.start, target_oldest_retained_loc);
 
             // Verify the root digest matches the target
-            assert_eq!(got_db.root(), target_root);
+            assert_eq!(got_db.root().await, target_root);
 
             // Verify that the synced database matches the target state
             for (key, expected_value) in &expected_kvs {
@@ -343,10 +347,10 @@ mod tests {
             let (durable_db, _) = target_db.commit(Some(Sha256::fill(1))).await.unwrap(); // Commit to establish a valid root
             let target_db = durable_db.into_merkleized();
 
-            let bounds = target_db.bounds();
+            let bounds = target_db.bounds().await;
             let target_op_count = bounds.end;
             let target_oldest_retained_loc = bounds.start;
-            let target_root = target_db.root();
+            let target_root = target_db.root().await;
 
             let db_config = create_sync_config(&format!("empty_sync_{}", context.next_u64()));
             let target_db = Arc::new(RwLock::new(target_db));
@@ -366,9 +370,9 @@ mod tests {
             let got_db: ImmutableSyncTest = sync::sync(config).await.unwrap();
 
             // Verify database state
-            assert_eq!(got_db.bounds().end, target_op_count);
-            assert_eq!(got_db.bounds().start, target_oldest_retained_loc);
-            assert_eq!(got_db.root(), target_root);
+            assert_eq!(got_db.bounds().await.end, target_op_count);
+            assert_eq!(got_db.bounds().await.start, target_oldest_retained_loc);
+            assert_eq!(got_db.root().await, target_root);
             assert_eq!(got_db.get_metadata().await.unwrap(), Some(Sha256::fill(1)));
 
             got_db.destroy().await.unwrap();
@@ -394,8 +398,8 @@ mod tests {
             let target_db = durable_db.into_merkleized();
 
             // Capture target state
-            let target_root = target_db.root();
-            let bounds = target_db.bounds();
+            let target_root = target_db.root().await;
+            let bounds = target_db.bounds().await;
             let lower_bound = bounds.start;
             let op_count = bounds.end;
 
@@ -419,11 +423,11 @@ mod tests {
             let mut synced_db: ImmutableSyncTest = sync::sync(config).await.unwrap();
 
             // Verify initial sync worked
-            assert_eq!(synced_db.root(), target_root);
+            assert_eq!(synced_db.root().await, target_root);
 
             // Save state before closing
-            let expected_root = synced_db.root();
-            let bounds = synced_db.bounds();
+            let expected_root = synced_db.root().await;
+            let bounds = synced_db.bounds().await;
             let expected_op_count = bounds.end;
             let expected_oldest_retained_loc = bounds.start;
 
@@ -435,9 +439,12 @@ mod tests {
                 .unwrap();
 
             // Verify state is preserved
-            assert_eq!(reopened_db.root(), expected_root);
-            assert_eq!(reopened_db.bounds().end, expected_op_count);
-            assert_eq!(reopened_db.bounds().start, expected_oldest_retained_loc);
+            assert_eq!(reopened_db.root().await, expected_root);
+            assert_eq!(reopened_db.bounds().await.end, expected_op_count);
+            assert_eq!(
+                reopened_db.bounds().await.start,
+                expected_oldest_retained_loc
+            );
 
             // Verify data integrity
             for op in &target_ops {
@@ -470,10 +477,10 @@ mod tests {
             let target_db = durable_db.into_merkleized();
 
             // Capture the state after first commit
-            let bounds = target_db.bounds();
+            let bounds = target_db.bounds().await;
             let initial_lower_bound = bounds.start;
             let initial_upper_bound = bounds.end;
-            let initial_root = target_db.root();
+            let initial_root = target_db.root().await;
 
             // Add more operations to create the extended target
             // (use different seed to avoid key collisions)
@@ -482,8 +489,8 @@ mod tests {
             apply_ops(&mut target_db, additional_ops.clone()).await;
             let (durable_db, _) = target_db.commit(None).await.unwrap();
             let target_db = durable_db.into_merkleized();
-            let final_upper_bound = target_db.bounds().end;
-            let final_root = target_db.root();
+            let final_upper_bound = target_db.bounds().await.end;
+            let final_root = target_db.root().await;
 
             // Wrap target database for shared mutable access
             let target_db = Arc::new(commonware_runtime::RwLock::new(target_db));
@@ -511,7 +518,7 @@ mod tests {
                         NextStep::Continue(new_client) => new_client,
                         NextStep::Complete(_) => panic!("client should not be complete"),
                     };
-                    let log_size = client.journal().size();
+                    let log_size = client.journal().bounds().await.end;
                     if log_size > initial_lower_bound {
                         break client;
                     }
@@ -531,7 +538,7 @@ mod tests {
             let synced_db = client.sync().await.unwrap();
 
             // Verify the synced database has the expected final state
-            assert_eq!(synced_db.root(), final_root);
+            assert_eq!(synced_db.root().await, final_root);
 
             // Verify the target database matches the synced database
             let target_db = Arc::try_unwrap(target_db).map_or_else(
@@ -539,9 +546,12 @@ mod tests {
                 |rw_lock| rw_lock.into_inner(),
             );
             {
-                assert_eq!(synced_db.bounds().end, target_db.bounds().end);
-                assert_eq!(synced_db.bounds().start, target_db.bounds().start);
-                assert_eq!(synced_db.root(), target_db.root());
+                assert_eq!(synced_db.bounds().await.end, target_db.bounds().await.end);
+                assert_eq!(
+                    synced_db.bounds().await.start,
+                    target_db.bounds().await.start
+                );
+                assert_eq!(synced_db.root().await, target_db.root().await);
             }
 
             // Verify all expected operations are present in the synced database
@@ -606,8 +616,8 @@ mod tests {
             let (durable_db, _) = target_db.commit(None).await.unwrap();
             let target_db = durable_db.into_merkleized();
 
-            let target_root = target_db.root();
-            let bounds = target_db.bounds();
+            let target_root = target_db.root().await;
+            let bounds = target_db.bounds().await;
             let lower_bound = bounds.start;
             let op_count = bounds.end;
 
@@ -634,8 +644,8 @@ mod tests {
             let synced_db: ImmutableSyncTest = sync::sync(config).await.unwrap();
 
             // Verify state matches the specified range
-            assert_eq!(synced_db.root(), target_root);
-            assert_eq!(synced_db.bounds().end, op_count);
+            assert_eq!(synced_db.root().await, target_root);
+            assert_eq!(synced_db.bounds().await.end, op_count);
 
             synced_db.destroy().await.unwrap();
             let target_db =
@@ -681,8 +691,8 @@ mod tests {
             apply_ops(&mut target_db, last_op.clone()).await;
             let (durable_db, _) = target_db.commit(None).await.unwrap();
             let target_db = durable_db.into_merkleized();
-            let root = target_db.root();
-            let bounds = target_db.bounds();
+            let root = target_db.root().await;
+            let bounds = target_db.bounds().await;
             let lower_bound = bounds.start;
             let upper_bound = bounds.end; // Up to the last operation
 
@@ -704,8 +714,8 @@ mod tests {
             let sync_db: ImmutableSyncTest = sync::sync(config).await.unwrap();
 
             // Verify database state
-            assert_eq!(sync_db.bounds().end, upper_bound);
-            assert_eq!(sync_db.root(), root);
+            assert_eq!(sync_db.bounds().await.end, upper_bound);
+            assert_eq!(sync_db.root().await, root);
 
             sync_db.destroy().await.unwrap();
             let target_db =
@@ -744,8 +754,8 @@ mod tests {
             drop(sync_db);
 
             // Prepare target
-            let root = target_db.root();
-            let bounds = target_db.bounds();
+            let root = target_db.root().await;
+            let bounds = target_db.bounds().await;
             let lower_bound = bounds.start;
             let upper_bound = bounds.end;
 
@@ -766,8 +776,8 @@ mod tests {
             };
             let sync_db: ImmutableSyncTest = sync::sync(config).await.unwrap();
 
-            assert_eq!(sync_db.bounds().end, upper_bound);
-            assert_eq!(sync_db.root(), root);
+            assert_eq!(sync_db.bounds().await.end, upper_bound);
+            assert_eq!(sync_db.root().await, root);
 
             sync_db.destroy().await.unwrap();
             let target_db =
@@ -793,10 +803,10 @@ mod tests {
             target_db.prune(Location::new_unchecked(10)).await.unwrap();
 
             // Capture initial target state
-            let bounds = target_db.bounds();
+            let bounds = target_db.bounds().await;
             let initial_lower_bound = bounds.start;
             let initial_upper_bound = bounds.end;
-            let initial_root = target_db.root();
+            let initial_root = target_db.root().await;
 
             // Create client with initial target
             let (update_sender, update_receiver) = mpsc::channel(1);
@@ -854,10 +864,10 @@ mod tests {
             let target_db = durable_db.into_merkleized();
 
             // Capture initial target state
-            let bounds = target_db.bounds();
+            let bounds = target_db.bounds().await;
             let initial_lower_bound = bounds.start;
             let initial_upper_bound = bounds.end;
-            let initial_root = target_db.root();
+            let initial_root = target_db.root().await;
 
             // Create client with initial target
             let (update_sender, update_receiver) = mpsc::channel(1);
@@ -915,10 +925,10 @@ mod tests {
             let target_db = durable_db.into_merkleized();
 
             // Capture initial target state
-            let bounds = target_db.bounds();
+            let bounds = target_db.bounds().await;
             let initial_lower_bound = bounds.start;
             let initial_upper_bound = bounds.end;
-            let initial_root = target_db.root();
+            let initial_root = target_db.root().await;
 
             // Apply more operations to the target database
             // (use different seed to avoid key collisions)
@@ -934,10 +944,10 @@ mod tests {
             let target_db = durable_db.into_merkleized();
 
             // Capture final target state
-            let bounds = target_db.bounds();
+            let bounds = target_db.bounds().await;
             let final_lower_bound = bounds.start;
             let final_upper_bound = bounds.end;
-            let final_root = target_db.root();
+            let final_root = target_db.root().await;
 
             // Assert we're actually updating the bounds
             assert_ne!(final_lower_bound, initial_lower_bound);
@@ -973,9 +983,9 @@ mod tests {
             let synced_db: ImmutableSyncTest = sync::sync(config).await.unwrap();
 
             // Verify the synced database has the expected state
-            assert_eq!(synced_db.root(), final_root);
-            assert_eq!(synced_db.bounds().end, final_upper_bound);
-            assert_eq!(synced_db.bounds().start, final_lower_bound);
+            assert_eq!(synced_db.root().await, final_root);
+            assert_eq!(synced_db.bounds().await.end, final_upper_bound);
+            assert_eq!(synced_db.bounds().await.start, final_lower_bound);
 
             synced_db.destroy().await.unwrap();
             let target_db = Arc::try_unwrap(target_db).map_or_else(
@@ -1000,10 +1010,10 @@ mod tests {
             let target_db = durable_db.into_merkleized();
 
             // Capture initial target state
-            let bounds = target_db.bounds();
+            let bounds = target_db.bounds().await;
             let initial_lower_bound = bounds.start;
             let initial_upper_bound = bounds.end;
-            let initial_root = target_db.root();
+            let initial_root = target_db.root().await;
 
             // Create client with initial target
             let (update_sender, update_receiver) = mpsc::channel(1);
@@ -1059,10 +1069,10 @@ mod tests {
             let target_db = durable_db.into_merkleized();
 
             // Capture target state
-            let bounds = target_db.bounds();
+            let bounds = target_db.bounds().await;
             let lower_bound = bounds.start;
             let upper_bound = bounds.end;
-            let root = target_db.root();
+            let root = target_db.root().await;
 
             // Create client with target that will complete immediately
             let (update_sender, update_receiver) = mpsc::channel(1);
@@ -1093,9 +1103,9 @@ mod tests {
                 .await;
 
             // Verify the synced database has the expected state
-            assert_eq!(synced_db.root(), root);
-            assert_eq!(synced_db.bounds().end, upper_bound);
-            assert_eq!(synced_db.bounds().start, lower_bound);
+            assert_eq!(synced_db.root().await, root);
+            assert_eq!(synced_db.bounds().await.end, upper_bound);
+            assert_eq!(synced_db.bounds().await.start, lower_bound);
 
             synced_db.destroy().await.unwrap();
             Arc::try_unwrap(target_db)

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -52,7 +52,7 @@
 
 use crate::{
     index::{Cursor, Unordered as Index},
-    journal::contiguous::{Contiguous, MutableContiguous},
+    journal::contiguous::{Contiguous, ContiguousReader as _, MutableContiguous},
     mmr::{mem::State as MerkleizationState, Location},
     qmdb::{operation::Operation, store::State as DurabilityState},
     UnmerkleizedBitMap,
@@ -151,7 +151,8 @@ where
     I: Index<Value = Location>,
     F: FnMut(bool, Option<Location>),
 {
-    let stream = log
+    let reader = log.reader().await;
+    let stream = reader
         .replay(SNAPSHOT_READ_BUFFER_SIZE, *inactivity_floor_loc)
         .await?;
     pin_mut!(stream);

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -152,10 +152,10 @@ where
     F: FnMut(bool, Option<Location>),
 {
     let stream = log
-        .replay(*inactivity_floor_loc, SNAPSHOT_READ_BUFFER_SIZE)
+        .replay(SNAPSHOT_READ_BUFFER_SIZE, *inactivity_floor_loc)
         .await?;
     pin_mut!(stream);
-    let last_commit_loc = log.size().saturating_sub(1);
+    let last_commit_loc = log.size().await.saturating_sub(1);
     let mut active_keys: usize = 0;
     while let Some(result) = stream.next().await {
         let (loc, op) = result?;
@@ -356,7 +356,7 @@ where
         }
 
         // Update the operation's snapshot location to point to tip.
-        cursor.update(Location::new_unchecked(self.log.size()));
+        cursor.update(Location::new_unchecked(self.log.size().await));
         drop(cursor);
 
         // Apply the operation at tip.
@@ -380,7 +380,7 @@ where
     where
         I: Index<Value = Location>,
     {
-        let tip_loc = Location::new_unchecked(self.log.size());
+        let tip_loc = Location::new_unchecked(self.log.size().await);
         loop {
             assert!(
                 *inactivity_floor_loc < tip_loc,

--- a/storage/src/qmdb/store/batch.rs
+++ b/storage/src/qmdb/store/batch.rs
@@ -107,8 +107,7 @@ pub mod tests {
         Box::pin(test_delete_unchecked(new_db, counter)).await?;
         Box::pin(test_write_batch_from_to_empty(new_db, counter)).await?;
         Box::pin(test_write_batch(new_db, counter)).await?;
-        Box::pin(test_update_delete_update(new_db, counter)).await?;
-        Ok(())
+        Box::pin(test_update_delete_update(new_db, counter)).await
     }
 
     fn next_db<D, F: NewDbIndexed<D>>(

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -70,5 +70,5 @@ pub trait Database: Sized + Send {
     ) -> impl Future<Output = Result<Self, crate::qmdb::Error>> + Send;
 
     /// Get the root digest of the database for verification
-    fn root(&self) -> Self::Digest;
+    fn root(&self) -> impl Future<Output = Self::Digest> + Send;
 }

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -464,7 +464,7 @@ where
             .await?;
 
             // Verify the final root digest matches the final target
-            let got_root = database.root();
+            let got_root = database.root().await;
             let expected_root = self.target.root;
             if got_root != expected_root {
                 return Err(SyncError::Engine(EngineError::RootMismatch {

--- a/storage/src/qmdb/sync/journal.rs
+++ b/storage/src/qmdb/sync/journal.rs
@@ -62,7 +62,7 @@ where
     }
 
     async fn resize(&mut self, start: Location) -> Result<(), Self::Error> {
-        if self.size() <= start {
+        if self.size().await <= start {
             self.clear_to_size(*start).await
         } else {
             self.prune(*start).await.map(|_| ())
@@ -74,11 +74,13 @@ where
     }
 
     async fn size(&self) -> u64 {
-        Self::size(self)
+        self.bounds().await.end
     }
 
     async fn append(&mut self, op: Self::Op) -> Result<(), Self::Error> {
-        Self::append(self, op).await.map(|_| ())
+        crate::journal::contiguous::MutableContiguous::append(self, op)
+            .await
+            .map(|_| ())
     }
 }
 
@@ -100,7 +102,7 @@ where
         assert!(!range.is_empty(), "range must not be empty");
 
         let mut journal = Self::init(context, config).await?;
-        let size = journal.size();
+        let size = journal.size().await;
 
         if size > *range.end {
             return Err(crate::journal::Error::ItemOutOfRange(size));
@@ -117,7 +119,7 @@ where
     }
 
     async fn resize(&mut self, start: Location) -> Result<(), Self::Error> {
-        if self.size() <= start {
+        if self.size().await <= start {
             self.clear_to_size(*start).await
         } else {
             self.prune(*start).await.map(|_| ())
@@ -129,7 +131,7 @@ where
     }
 
     async fn size(&self) -> u64 {
-        Self::size(self)
+        Self::size(self).await
     }
 
     async fn append(&mut self, op: Self::Op) -> Result<(), Self::Error> {


### PR DESCRIPTION
This PR allows concurrent reads to a `Persistable` storage structure during a `sync` operation.  Previously sync was &mut, locking out concurrent readers. Implementations now leverage interior mutability to avoid the &mut requirement.

Unfortunately the change requires updating a lot of call sites since many getters are now async in order to acquire the interior read locks.

Only `freezer` remains to be updated with this capability, tracked here: https://github.com/commonwarexyz/monorepo/issues/2910

Changes all "replay" functions to have the same argument order (write buffer size before `start_pos`). [breaking api]

Towards: https://github.com/commonwarexyz/monorepo/issues/2857
