### PR TITLE
[Storage] Replace `mmr::Hasher` generic with associated type

### DIFF
--- a/storage/src/bitmap/authenticated.rs
+++ b/storage/src/bitmap/authenticated.rs
@@ -190,7 +190,7 @@ impl<E: Clock + RStorage + Metrics, D: Digest, const N: usize, S: State<D>> BitM
     /// Verify whether `proof` proves that the `chunk` containing the given bit belongs to the
     /// bitmap corresponding to `root`.
     pub fn verify_bit_inclusion(
-        hasher: &mut impl MmrHasher<D>,
+        hasher: &mut impl MmrHasher<Digest = D>,
         proof: &Proof<D>,
         chunk: &[u8; N],
         bit: u64,
@@ -280,7 +280,7 @@ impl<E: Clock + RStorage + Metrics, D: Digest, const N: usize> CleanBitMap<E, D,
         context: E,
         partition: &str,
         pool: Option<ThreadPool>,
-        hasher: &mut impl MmrHasher<D>,
+        hasher: &mut impl MmrHasher<Digest = D>,
     ) -> Result<Self, Error> {
         let metadata_cfg = MConfig {
             partition: partition.to_string(),
@@ -439,7 +439,7 @@ impl<E: Clock + RStorage + Metrics, D: Digest, const N: usize> CleanBitMap<E, D,
     /// Returns [Error::BitOutOfBounds] if `bit` is out of bounds.
     pub async fn proof(
         &self,
-        hasher: &mut impl MmrHasher<D>,
+        hasher: &mut impl MmrHasher<Digest = D>,
         bit: u64,
     ) -> Result<(Proof<D>, [u8; N]), Error> {
         if bit >= self.len() {
@@ -539,7 +539,7 @@ impl<E: Clock + RStorage + Metrics, D: Digest, const N: usize> DirtyBitMap<E, D,
     /// Merkleize all updates not yet reflected in the bitmap's root.
     pub async fn merkleize(
         mut self,
-        hasher: &mut impl MmrHasher<D>,
+        hasher: &mut impl MmrHasher<Digest = D>,
     ) -> Result<CleanBitMap<E, D, N>, Error> {
         // Add newly pushed complete chunks to the MMR.
         let start = self.authenticated_len;

--- a/storage/src/mmr/grafting.rs
+++ b/storage/src/mmr/grafting.rs
@@ -225,7 +225,8 @@ pub(super) fn source_pos(base_node_pos: Position, height: u32) -> Option<Positio
     Some(Position::new(peak_pos))
 }
 
-impl<H: CHasher> HasherTrait<H::Digest> for Hasher<'_, H> {
+impl<H: CHasher> HasherTrait for Hasher<'_, H> {
+    type Digest = H::Digest;
     type Inner = H;
 
     /// Computes the digest of a leaf in the peak_tree of a grafted MMR.
@@ -247,7 +248,7 @@ impl<H: CHasher> HasherTrait<H::Digest> for Hasher<'_, H> {
         self.hasher.finalize()
     }
 
-    fn fork(&self) -> impl HasherTrait<H::Digest> {
+    fn fork(&self) -> impl HasherTrait<Digest = H::Digest> {
         HasherFork::<H> {
             hasher: StandardHasher::new(),
             height: self.height,
@@ -283,7 +284,8 @@ impl<H: CHasher> HasherTrait<H::Digest> for Hasher<'_, H> {
     }
 }
 
-impl<H: CHasher> HasherTrait<H::Digest> for HasherFork<'_, H> {
+impl<H: CHasher> HasherTrait for HasherFork<'_, H> {
+    type Digest = H::Digest;
     type Inner = H;
 
     /// Computes the digest of a leaf in the peak_tree of a grafted MMR.
@@ -305,7 +307,7 @@ impl<H: CHasher> HasherTrait<H::Digest> for HasherFork<'_, H> {
         self.hasher.finalize()
     }
 
-    fn fork(&self) -> impl HasherTrait<H::Digest> {
+    fn fork(&self) -> impl HasherTrait<Digest = H::Digest> {
         HasherFork::<H> {
             hasher: StandardHasher::<H>::new(),
             height: self.height,
@@ -374,14 +376,15 @@ impl<'a, H: CHasher> Verifier<'a, H> {
     }
 }
 
-impl<H: CHasher> HasherTrait<H::Digest> for Verifier<'_, H> {
+impl<H: CHasher> HasherTrait for Verifier<'_, H> {
+    type Digest = H::Digest;
     type Inner = H;
 
     fn leaf_digest(&mut self, pos: Position, element: &[u8]) -> H::Digest {
         self.hasher.leaf_digest(pos, element)
     }
 
-    fn fork(&self) -> impl HasherTrait<H::Digest> {
+    fn fork(&self) -> impl HasherTrait<Digest = H::Digest> {
         Verifier::<H> {
             hasher: StandardHasher::new(),
             height: self.height,

--- a/storage/src/mmr/proof.rs
+++ b/storage/src/mmr/proof.rs
@@ -146,7 +146,7 @@ impl<D: Digest> Proof<D> {
         root: &D,
     ) -> bool
     where
-        H: Hasher<D>,
+        H: Hasher<Digest = D>,
     {
         self.verify_range_inclusion(hasher, &[element], loc, root)
     }
@@ -162,7 +162,7 @@ impl<D: Digest> Proof<D> {
         root: &D,
     ) -> bool
     where
-        H: Hasher<D>,
+        H: Hasher<Digest = D>,
         E: AsRef<[u8]>,
     {
         if !self.size.is_mmr_size() {
@@ -192,7 +192,7 @@ impl<D: Digest> Proof<D> {
         root: &D,
     ) -> bool
     where
-        H: Hasher<D>,
+        H: Hasher<Digest = D>,
         E: AsRef<[u8]>,
     {
         // Empty proof is valid for an empty MMR
@@ -347,7 +347,7 @@ impl<D: Digest> Proof<D> {
         root: &D,
     ) -> Result<Vec<(Position, D)>, super::Error>
     where
-        H: Hasher<D>,
+        H: Hasher<Digest = D>,
         E: AsRef<[u8]>,
     {
         let mut collected_digests = Vec::new();
@@ -376,7 +376,7 @@ impl<D: Digest> Proof<D> {
         start_loc: Location,
     ) -> Result<D, ReconstructionError>
     where
-        H: Hasher<D>,
+        H: Hasher<Digest = D>,
         E: AsRef<[u8]>,
     {
         if !self.size.is_mmr_size() {
@@ -399,7 +399,7 @@ impl<D: Digest> Proof<D> {
         mut collected_digests: Option<&mut Vec<(Position, D)>>,
     ) -> Result<Vec<D>, ReconstructionError>
     where
-        H: Hasher<D>,
+        H: Hasher<Digest = D>,
         E: AsRef<[u8]>,
     {
         if elements.is_empty() {
@@ -621,7 +621,7 @@ fn peak_digest_from_range<'a, D, H, E, S>(
 ) -> Result<D, ReconstructionError>
 where
     D: Digest,
-    H: Hasher<D>,
+    H: Hasher<Digest = D>,
     E: Iterator<Item: AsRef<[u8]>>,
     S: Iterator<Item = &'a D>,
 {

--- a/storage/src/mmr/stability.rs
+++ b/storage/src/mmr/stability.rs
@@ -4,7 +4,7 @@ use commonware_cryptography::{sha256, Hasher as _};
 /// Build an MMR for testing with 199 elements whose root should always equal
 /// `ROOTS[199]` if the MMR is built with the StandardHasher.
 pub fn build_test_mmr(
-    hasher: &mut impl Hasher<sha256::Digest>,
+    hasher: &mut impl Hasher<Digest = sha256::Digest>,
     mut mmr: CleanMmr<sha256::Digest>,
 ) -> CleanMmr<sha256::Digest> {
     for i in 0u64..199 {

--- a/storage/src/mmr/verification.rs
+++ b/storage/src/mmr/verification.rs
@@ -36,7 +36,7 @@ impl<D: Digest> ProofStore<D> {
         root: &D,
     ) -> Result<Self, Error>
     where
-        H: Hasher<D>,
+        H: Hasher<Digest = D>,
         E: AsRef<[u8]>,
     {
         let digests =


### PR DESCRIPTION
A hasher only produces one kind of digest, so it should use an associated type rather than being generic over any `D: Digest`. This brings `mmr::Hasher` in line with `commonware-cryptography::Hasher`, which uses an associated type and not a generic type bound.