### PR TITLE
docs: fix comment mismatches in broadcast, storage, and resolver

### DIFF
--- a/broadcast/src/buffered/ingress.rs
+++ b/broadcast/src/buffered/ingress.rs
@@ -16,7 +16,7 @@ pub enum Message<P: PublicKey, M: Committable + Digestible> {
         responder: oneshot::Sender<Vec<P>>,
     },
 
-    /// Subscribe to a message by peer (optionally), commitment, and digest (optionally).
+    /// Subscribe to a message by commitment.
     ///
     /// The responder will be sent the first message for an commitment when it is available; either
     /// instantly (if cached) or when it is received from the network. The request can be canceled
@@ -48,7 +48,7 @@ impl<P: PublicKey, M: Committable + Digestible + Codec> Mailbox<P, M> {
         Self { sender }
     }
 
-    /// Subscribe to a message by peer (optionally), commitment, and digest (optionally).
+    /// Subscribe to a message by commitment.
     ///
     /// The responder will be sent the first message for an commitment when it is available; either
     /// instantly (if cached) or when it is received from the network. The request can be canceled

--- a/broadcast/src/buffered/ingress.rs
+++ b/broadcast/src/buffered/ingress.rs
@@ -16,7 +16,7 @@ pub enum Message<P: PublicKey, M: Committable + Digestible> {
         responder: oneshot::Sender<Vec<P>>,
     },
 
-    /// Subscribe to receive a message by digest.
+    /// Subscribe to a message by peer (optionally), commitment, and digest (optionally).
     ///
     /// The responder will be sent the first message for an commitment when it is available; either
     /// instantly (if cached) or when it is received from the network. The request can be canceled

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -105,9 +105,9 @@ impl<
         NetR: Receiver<PublicKey = P>,
     > Engine<E, P, D, B, Key, Con, Pro, NetS, NetR>
 {
-    /// Creates a new `Actor` with the given configuration.
+    /// Creates a new `Engine` with the given configuration.
     ///
-    /// Returns the actor and a mailbox to send messages to it.
+    /// Returns the engine and a mailbox to send messages to it.
     pub fn new(context: E, cfg: Config<P, D, B, Key, Con, Pro>) -> (Self, Mailbox<Key, P>) {
         let (sender, receiver) = mpsc::channel(cfg.mailbox_size);
 

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -443,8 +443,8 @@ where
     /// 3. Handles different event types (target updates, fetch results)
     /// 4. Coordinates request scheduling and operation application
     ///
-    /// Returns `StepResult::Complete(database)` when sync is finished, or
-    /// `StepResult::Continue(self)` when more work remains.
+    /// Returns `NextStep::Complete(database)` when sync is finished, or
+    /// `NextStep::Continue(self)` when more work remains.
     pub(crate) async fn step(mut self) -> Result<NextStep<Self, DB>, Error<DB, R>> {
         // Check if sync is complete
         if self.is_complete().await? {


### PR DESCRIPTION
Fixed a few doc comments that didn't match the actual code - Subscribe variant was missing some params in its description, NextStep was being called StepResult, and Engine was referred to as Actor. Just cleaning up the docs to match what the code actually does.