### PR TITLE
[cryptography] allow "unclosed" appends in Transcript

### DIFF
--- a/cryptography/src/transcript.rs
+++ b/cryptography/src/transcript.rs
@@ -132,7 +132,7 @@ impl Transcript {
         self.pending += data.len() as u64;
     }
 
-    fn unflushed(&self) -> bool {
+    const fn unflushed(&self) -> bool {
         self.pending != 0
     }
 }


### PR DESCRIPTION
Rather than panicking if an append is not followed by commit, we instead just perform a clone, internally, instead.

Closes #2871