### PR TITLE
[ci] Don't cancel other build jobs if one fails

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -302,6 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         toolchain:
           - msrv


### PR DESCRIPTION
## Overview

Adjusts the MSRV + nightly + stable build job to not cancel other jobs if one fails. We block on stable + MSRV, but may allow changes where the workspace fails to build with the nightly toolchain to be merged.
