### PR TITLE
docs: fix typos in blog posts

### DIFF
--- a/docs/blogs/adb-current.html
+++ b/docs/blogs/adb-current.html
@@ -115,8 +115,6 @@
         <p>We remain on-schedule to release a production-ready version of <a href="https://docs.rs/commonware-storage">commonware-storage</a> later this year.</p>
     </div>
 
-    </div>
-
     <div id="footer-placeholder"></div>
     <script src="/shared.js"></script>
 </body>

--- a/docs/blogs/commonware-deployer.html
+++ b/docs/blogs/commonware-deployer.html
@@ -118,7 +118,7 @@
             <li><b>Tweak</b>: <i>deployer ec2 update</i> deploys new binaries and configs on each peer.</li>
             <li><b>Cleanup</b>: <i>deployer ec2 destroy</i> tears down all provisioned infrastructure.</li>
         </ol>
-        <p><i>Step through the full walkthrough in the <flood> <a href="https://github.com/commonwarexyz/monorepo/blob/main/examples/flood/README.md">README</a>.</i></p>
+        <p><i>Step through the full walkthrough in the <a href="https://github.com/commonwarexyz/monorepo/blob/main/examples/flood/README.md">flood README</a>.</i></p>
         <div class="image-container">
             <img src="/imgs/flood-grafana.png" alt="Automatically deployed Grafana dashboard for flood running on c7g.xlarge (4 vCPU, 8GB RAM)">
             <div class="image-caption">Figure 2: Automatically deployed Grafana dashboard for <i>flood</i> running on <i>c7g.xlarge (4 vCPU, 8GB RAM)</i></div>

--- a/docs/blogs/zoda.md
+++ b/docs/blogs/zoda.md
@@ -178,7 +178,7 @@ and treat them as missing instead.
 If the followers received a hash of each shard, then they could tell
 whether some data is actually the shard it claims to be, by hashing it.
 This comes at a penalty of transmitting $m \cdot 2^\lambda$ bits of data
-(guaranteeing no collisions up to a probability of $2^-\lambda$ requires $2 \lambda$ bit hashes).
+(guaranteeing no collisions up to a probability of $2^{-\lambda}$ requires $2 \lambda$ bit hashes).
 We can improve this a bit by having the leader use a vector commitment over the $m$ hashes.
 Each shard would then come with an opening, demonstrating that the $i$th hash
 in the vector is that of the shard.


### PR DESCRIPTION
Fix minor typos in documentation:

- `adb-current.html`: Remove duplicate `</div>` tag
- `commonware-deployer.html`: Fix invalid `<flood>` HTML tag
- `zoda.md`: Fix LaTeX exponent syntax