### PR TITLE
[cryptography/bls12381] Use Batch Inversion in Interpolator

### DIFF
--- a/math/src/poly.rs
+++ b/math/src/poly.rs
@@ -597,6 +597,20 @@ mod test {
         }
 
         #[test]
+        fn test_interpolate_with_zero_point_middle(f: Poly<F>) {
+            // Use 1, 2, ..., 0 as evaluation points (zero at last position)
+            prop_assume!(f != Poly::zero());
+            prop_assume!(f.required().get() >= 2);
+            prop_assume!(f.required().get() < F::MAX as u32);
+            let n = f.required().get();
+            let points: Vec<_> = (1..n).map(|i| F::from(i as u8)).chain(std::iter::once(F::zero())).collect();
+            let interpolator = Interpolator::new(points.iter().copied().enumerate());
+            let evals = Map::from_iter_dedup(points.iter().map(|p| f.eval(p)).enumerate());
+            let recovered = interpolator.interpolate(&evals, &Sequential);
+            assert_eq!(recovered.as_ref(), Some(f.constant()));
+        }
+
+        #[test]
         fn test_translate_scale(f: Poly<F>, x: F) {
             assert_eq!(f.translate(|c| x * c), f * &x);
         }


### PR DESCRIPTION
## Results
```
  ┌─────┬─────┬─────────┬───────────┬─────────┐
  │  n  │  t  │  Main   │ Optimized │ Speedup │
  ├─────┼─────┼─────────┼───────────┼─────────┤
  │ 5   │ 4   │ 167 µs  │ 161 µs    │ 1.04x   │
  ├─────┼─────┼─────────┼───────────┼─────────┤
  │ 10  │ 7   │ 252 µs  │ 240 µs    │ 1.05x   │
  ├─────┼─────┼─────────┼───────────┼─────────┤
  │ 20  │ 14  │ 444 µs  │ 424 µs    │ 1.05x   │
  ├─────┼─────┼─────────┼───────────┼─────────┤
  │ 50  │ 34  │ 621 µs  │ 421 µs    │ 1.47x   │
  ├─────┼─────┼─────────┼───────────┼─────────┤
  │ 100 │ 67  │ 955 µs  │ 835 µs    │ 1.14x   │
  ├─────┼─────┼─────────┼───────────┼─────────┤
  │ 250 │ 167 │ 2.88 ms │ 2.34 ms   │ 1.23x   │
  ├─────┼─────┼─────────┼───────────┼─────────┤
  │ 500 │ 334 │ 9.96 ms │ 5.97 ms   │ 1.67x   │
  └─────┴─────┴─────────┴───────────┴─────────┘
```