### PR TITLE
[p2p] remove dead recipients in run_network

### DIFF
--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -368,16 +368,16 @@ mod tests {
                     let sender = context
                         .with_label("sender")
                         .spawn(move |context| async move {
+                            // Get all peers not including self
+                            let mut recipients = addresses.clone();
+                            recipients.remove(i);
+                            recipients.sort();
+
                             // Loop forever to account for unexpected message drops
                             loop {
                                 match mode {
                                     Mode::One => {
-                                        for (j, recipient) in addresses.iter().enumerate() {
-                                            // Don't send message to self
-                                            if i == j {
-                                                continue;
-                                            }
-
+                                        for recipient in &recipients {
                                             // Loop until success
                                             loop {
                                                 let sent = sender
@@ -398,11 +398,6 @@ mod tests {
                                         }
                                     }
                                     Mode::Some | Mode::All => {
-                                        // Get all peers not including self
-                                        let mut recipients = addresses.clone();
-                                        recipients.remove(i);
-                                        recipients.sort();
-
                                         // Loop until all peer sends successful
                                         loop {
                                             let mut sent = sender

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -297,16 +297,20 @@ mod tests {
                     let sender = context
                         .with_label("sender")
                         .spawn(move |context| async move {
+                            // Get all peers not including self
+                            let mut recipients: Vec<_> = peers
+                                .iter()
+                                .enumerate()
+                                .filter(|(j, _)| i != *j)
+                                .map(|(_, (pk, _))| pk.clone())
+                                .collect();
+                            recipients.sort();
+
                             // Loop forever to account for unexpected message drops
                             loop {
                                 match mode {
                                     Mode::One => {
-                                        for (j, (pub_key, _)) in peers.iter().enumerate() {
-                                            // Don't send message to self
-                                            if i == j {
-                                                continue;
-                                            }
-
+                                        for pub_key in &recipients {
                                             // Loop until success
                                             loop {
                                                 let sent = sender
@@ -327,15 +331,6 @@ mod tests {
                                         }
                                     }
                                     Mode::Some | Mode::All => {
-                                        // Get all peers not including self
-                                        let mut recipients: Vec<_> = peers
-                                            .iter()
-                                            .enumerate()
-                                            .filter(|(j, _)| i != *j)
-                                            .map(|(_, (pk, _))| pk.clone())
-                                            .collect();
-                                        recipients.sort();
-
                                         // Loop until all peer sends successful
                                         loop {
                                             let mut sent = sender


### PR DESCRIPTION
The run_network helper in the lookup tests was cloning a peers vector into a local recipients variable in the Mode::Some and Mode::All branches, then sorting and pruning it, but never actually using it. The test logic instead relies on a separate public_keys vector for both the Recipients::Some call and the final equality assertion. This recipients variable was a leftover from the discovery tests, where it does carry the expected recipient set, but in lookup it has the wrong type ((PublicKey, Address)), cannot be passed into Recipients::Some, and effectively became dead code.