### PR TITLE
Fix typos and grammatical errors in documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ _More primitives can be found in the [Cargo.toml](Cargo.toml) file (anything wit
 
 ### Key Design Principles
 1. **The Simpler The Better**: Code should look obviously correct and contain the minimum features necessary to achieve a goal.
-2. **Test Everything**: All code should be designed for deterministic and comprehensive testing. We employ an abstract runtime (`runtime/src/deterministic.rs`) commonly in the repository to drive tests.
+2. **Test Everything**: All code should be designed for deterministic and comprehensive testing. We employ an abstract runtime (`runtime/src/deterministic.rs`) commonly used throughout the repository to drive tests.
 3. **Performance Sensitive**: All primitives are optimized for high throughput/low latency.
 4. **Adversarial Safety**: All primitives are designed to operate robustly in adversarial environments.
 5. **Abstract Runtime**: All code outside the `runtime` primitive must be runtime-agnostic (never import `tokio` directly outside of `runtime/`). When requiring some `runtime`, use the provided traits in `runtime/src/lib.rs`.

--- a/pipeline/minimmit/quint/README.md
+++ b/pipeline/minimmit/quint/README.md
@@ -19,7 +19,7 @@ The specification supports various configurations for testing:
 - **N=6, F=0**: 6 replicas, no Byzantine replicas
 - **N=6, F=1**: 6 replicas, 1 Byzantine replica
 - **N=6, F=2**: 6 replicas, 2 Byzantine replicas (safety violations expected)
-- **N=7, F=1**: 7 replicas, no Byzantine replicas
+- **N=7, F=1**: 7 replicas, 1 Byzantine replica
 
 ## Safety Invariants
 

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -641,7 +641,7 @@ where
         //   - `created`
         //   - `updated`
         //
-        // Populate the the deleted and updated sets, and for deleted keys only, immediately update
+        // Populate the deleted and updated sets, and for deleted keys only, immediately update
         // the log and snapshot.
         let mut deleted = Vec::new();
         let mut updated = BTreeMap::new();


### PR DESCRIPTION


Fixed typos, duplicate words, and grammatical errors found in documentation and comments.

