### PR TITLE
[storage, docs] Fix spelling errors in comments and documentation

### DIFF
--- a/docs/blogs/zoda.html
+++ b/docs/blogs/zoda.html
@@ -371,7 +371,7 @@ Meier</a></div>
         particular row of <span class="math inline">\(Y\)</span>, here
         we receive <span class="math inline">\(S\)</span> rows, sampled
         at random. (We may modify <span class="math inline">\(m\)</span>
-        and <span class="math inline">\(n\)</span> to accomodate this
+        and <span class="math inline">\(n\)</span> to accommodate this
         fact). We also receive proofs of inclusion for each row.</p>
         <p>In order to convince us that our rows <span
         class="math inline">\(Y_S\)</span> came from <span

--- a/docs/blogs/zoda.md
+++ b/docs/blogs/zoda.md
@@ -249,7 +249,7 @@ of randomness in what follows, according to the _Fiat-Shamir_ paradigm.
 
 Whereas in the plain coding scheme, we received one particular row of $Y$,
 here we receive $S$ rows, sampled at random.
-(We may modify $m$ and $n$ to accomodate this fact).
+(We may modify $m$ and $n$ to accommodate this fact).
 We also receive proofs of inclusion for each row.
 
 In order to convince us that our rows $Y_S$ came from $G X$,

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -609,7 +609,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         position_to_section(self.size, self.items_per_section)
     }
 
-    /// Align the offsets journal and data journal to be consistent in case a crash occured
+    /// Align the offsets journal and data journal to be consistent in case a crash occurred
     /// on a previous run and left the journals in an inconsistent state.
     ///
     /// The data journal is the source of truth. This function scans it to determine
@@ -639,7 +639,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         };
 
         // Data journal is empty if there are no sections or if there is one section and it has no items.
-        // The latter should only occur if a crash occured after opening a data journal blob but
+        // The latter should only occur if a crash occurred after opening a data journal blob but
         // before writing to it.
         let data_empty =
             data.is_empty() || (data.num_sections() == 1 && items_in_last_section == 0);

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -641,7 +641,7 @@ where
         //   - `created`
         //   - `updated`
         //
-        // Populate the the deleted and updated sets, and for deleted keys only, immediately update
+        // Populate the deleted and updated sets, and for deleted keys only, immediately update
         // the log and snapshot.
         let mut deleted = Vec::new();
         let mut updated = BTreeMap::new();


### PR DESCRIPTION

- Fix spelling errors in comments and documentation
  - `occured` → `occurred` in storage/journal
  - Remove duplicate "the" in storage/qmdb
  - `accomodate` → `accommodate` in docs/blogs/zoda