### PR TITLE
chore: remove nightly rustfmt config

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-# Imports
-imports_granularity = "Crate"
-group_imports = "One"


### PR DESCRIPTION
Removes nightly-only rustfmt options that produce warnings on stable toolchain