### PR TITLE
Fix documentation formatting and spelling errors

### DIFF
--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -1,6 +1,6 @@
 # commonware-sync
 
- [![Crates.io](https://img.shields.io/crates/v/commonware-sync.svg)](https://crates.io/crates/commonware-sync)
+[![Crates.io](https://img.shields.io/crates/v/commonware-sync.svg)](https://crates.io/crates/commonware-sync)
 
 Continuously synchronize state between a server and client with [qmdb::any::Any](https://docs.rs/commonware-storage/latest/commonware_storage/qmdb/any/struct.Any.html) and [qmdb::immutable::Immutable](https://docs.rs/commonware-storage/latest/commonware_storage/qmdb/immutable/struct.Immutable.html)
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -609,7 +609,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         position_to_section(self.size, self.items_per_section)
     }
 
-    /// Align the offsets journal and data journal to be consistent in case a crash occured
+    /// Align the offsets journal and data journal to be consistent in case a crash occurred
     /// on a previous run and left the journals in an inconsistent state.
     ///
     /// The data journal is the source of truth. This function scans it to determine
@@ -639,7 +639,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         };
 
         // Data journal is empty if there are no sections or if there is one section and it has no items.
-        // The latter should only occur if a crash occured after opening a data journal blob but
+        // The latter should only occur if a crash occurred after opening a data journal blob but
         // before writing to it.
         let data_empty =
             data.is_empty() || (data.num_sections() == 1 && items_in_last_section == 0);


### PR DESCRIPTION


Fixed minor documentation issues: removed extra whitespace and corrected spelling errors.

