### PR TITLE
fix: remove dead sum_hash in metamorph lthash fuzz target

### DIFF
--- a/cryptography/fuzz/fuzz_targets/metamorph_lthash.rs
+++ b/cryptography/fuzz/fuzz_targets/metamorph_lthash.rs
@@ -111,13 +111,11 @@ fn fuzz(input: FuzzInput) {
         MutationType::AddMultipleElementsThenSubtractSum => {
             let num_elements = (input.num_elements as usize % 32) + 1;
             let mut elements = Vec::new();
-            let mut sum_hash = LtHash::new();
 
             // Add random elements and collect them
             for _ in 0..num_elements {
                 let element = generate_random_bytes(&mut rng, 1, 256);
                 lthash.add(&element);
-                sum_hash.add(&element);
                 elements.push(element);
             }
 


### PR DESCRIPTION
The AddMultipleElementsThenSubtractSum mutation in metamorph_lthash.rs created a separate sum_hash LtHash and called sum_hash.add(&element) for each element, but this value was never used in any further computation or assertion. This made the fuzz target harder to read and performed redundant LtHash work that had no effect on the final checksum or the property being tested.