### PR TITLE
[codec/conformance] remove unused import

### DIFF
--- a/codec/src/conformance.rs
+++ b/codec/src/conformance.rs
@@ -9,7 +9,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use commonware_conformance::Conformance;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use std::{fmt::Debug, marker::PhantomData};
+use std::marker::PhantomData;
 
 /// Initial size of the random buffer used for generating arbitrary values.
 const INITIAL_BUFFER_SIZE: usize = 4096;


### PR DESCRIPTION
This import is not used anywhere (the derivation #[derive(Debug)] does not require it in scope).