### PR TITLE
[utils] Remove `Faults::quorum_from_slice`

### DIFF
--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -514,7 +514,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
 
         let round = Round::new(Epoch::new(0), View::new(1));
@@ -582,7 +582,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
 
         let round = Round::new(Epoch::new(0), View::new(1));
@@ -626,7 +626,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let notarizes: Vec<_> = schemes
@@ -700,7 +700,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let nullify = create_nullify(&schemes[0], round);
@@ -733,7 +733,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let nullifies: Vec<_> = schemes
@@ -780,7 +780,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let finalize_a = create_finalize(&schemes[0], round, View::new(0), 1);
@@ -828,7 +828,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let finalizes: Vec<_> = schemes
@@ -880,7 +880,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let proposal_a = Proposal::new(round, View::new(0), sample_digest(10));
@@ -986,7 +986,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_vote = create_notarize(&schemes[0], round, View::new(0), 1);
@@ -1032,7 +1032,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
 
@@ -1077,7 +1077,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let finalizes: Vec<_> = schemes
@@ -1121,7 +1121,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_proposal = Proposal::new(round, View::new(0), sample_digest(1));
@@ -1149,7 +1149,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         assert!(verifier.nullifies.is_empty());
         assert!(!verifier.ready_nullifies());
@@ -1178,7 +1178,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         verifier.set_leader(Participant::new(0));
         assert!(verifier.finalizes.is_empty());
@@ -1208,7 +1208,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
 
@@ -1263,7 +1263,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
 
@@ -1305,7 +1305,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(schemes[0].clone(), quorum);
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_finalize = create_finalize(&schemes[0], round, View::new(0), 1);
@@ -1352,7 +1352,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         assert!(
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
@@ -1410,7 +1410,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         assert!(
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
@@ -1460,7 +1460,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes);
+        let quorum = N3f1::quorum(schemes.len());
         assert!(
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -426,7 +426,7 @@ mod tests {
         } = bls12381_threshold_vrf::fixture::<MinPk, _>(&mut rng, NAMESPACE, 5);
         let participants = Set::try_from_iter(participants).unwrap();
         let elector: RandomElector<ThresholdScheme> = Random.build(&participants);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
 
         // Create certificate for round (1, 2)
         let round1 = Round::new(Epoch::new(1), View::new(2));
@@ -547,7 +547,7 @@ mod tests {
                 } = bls12381_threshold_vrf::fixture::<MinPk, _>(&mut rng, NAMESPACE, n);
                 let participants = Set::try_from_iter(participants).unwrap();
                 let elector: RandomElector<ThresholdScheme> = Random.build(&participants);
-                let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+                let quorum = N3f1::quorum(schemes.len()) as usize;
 
                 // Generate deterministic round parameters
                 let epoch = rng.gen_range(0..1000);

--- a/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
@@ -1100,7 +1100,7 @@ mod tests {
     fn verify_votes_filters_bad_signers<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers::<V>(5, 13);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(5), 3);
 
         let mut votes: Vec<_> = schemes
@@ -1147,7 +1147,7 @@ mod tests {
 
     fn assemble_certificate_requires_quorum<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 17);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(7), 4);
 
         let votes: Vec<_> = schemes
@@ -1173,7 +1173,7 @@ mod tests {
 
     fn verify_certificate<V: Variant>() {
         let (schemes, verifier) = setup_signers::<V>(4, 19);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(9), 5);
 
         let votes: Vec<_> = schemes
@@ -1211,7 +1211,7 @@ mod tests {
     fn verify_certificate_detects_corruption<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 23);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(11), 6);
 
         let votes: Vec<_> = schemes
@@ -1263,7 +1263,7 @@ mod tests {
 
     fn certificate_codec_roundtrip<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(5, 29);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(13), 7);
 
         let votes: Vec<_> = schemes
@@ -1295,7 +1295,7 @@ mod tests {
 
     fn seed_codec_roundtrip<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(1), 0);
 
         let votes: Vec<_> = schemes
@@ -1330,7 +1330,7 @@ mod tests {
 
     fn seed_verify<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(1), 0);
 
         let votes: Vec<_> = schemes
@@ -1371,7 +1371,7 @@ mod tests {
 
     fn seedable<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 5);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(1), 0);
 
         let notarizes: Vec<_> = schemes
@@ -1434,7 +1434,7 @@ mod tests {
 
     fn certificate_verifier_accepts_certificates<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 37);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(15), 8);
 
         let votes: Vec<_> = schemes
@@ -1516,7 +1516,7 @@ mod tests {
 
     fn verify_certificate_returns_seed_randomness<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 43);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(19), 10);
 
         let votes: Vec<_> = schemes
@@ -1548,7 +1548,7 @@ mod tests {
 
     fn certificate_decode_rejects_length_mismatch<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 47);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(21), 11);
 
         let votes: Vec<_> = schemes
@@ -1620,7 +1620,7 @@ mod tests {
     fn verify_certificate_detects_seed_corruption<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 59);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(25), 13);
 
         let votes: Vec<_> = schemes
@@ -1673,7 +1673,7 @@ mod tests {
     fn encrypt_decrypt<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 61);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
 
         // Prepare a message to encrypt
         let message = b"Secret message for future view10";
@@ -1849,7 +1849,7 @@ mod tests {
     fn verify_certificate_rejects_malleability<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 73);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal = sample_proposal(Epoch::new(0), View::new(31), 16);
 
         let votes: Vec<_> = schemes
@@ -1913,7 +1913,7 @@ mod tests {
     fn verify_certificates_rejects_malleability<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 79);
-        let quorum = N3f1::quorum_from_slice(&schemes) as usize;
+        let quorum = N3f1::quorum(schemes.len()) as usize;
         let proposal1 = sample_proposal(Epoch::new(0), View::new(33), 17);
         let proposal2 = sample_proposal(Epoch::new(0), View::new(34), 18);
 

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -3089,7 +3089,7 @@ mod tests {
         let wrong_fixture = setup_seeded(5, 1, &f);
         let round = Round::new(Epoch::new(0), View::new(10));
         let proposal = Proposal::new(round, View::new(5), sample_digest(3));
-        let quorum = N3f1::quorum_from_slice(&fixture.schemes) as usize;
+        let quorum = N3f1::quorum(fixture.schemes.len()) as usize;
         let notarizes: Vec<_> = fixture
             .schemes
             .iter()
@@ -3127,7 +3127,7 @@ mod tests {
         let mut rng = test_rng();
         let round = Round::new(Epoch::new(0), View::new(10));
         let proposal = Proposal::new(round, View::new(5), sample_digest(4));
-        let quorum = N3f1::quorum_from_slice(&fixture.schemes) as usize;
+        let quorum = N3f1::quorum(fixture.schemes.len()) as usize;
         let notarizes: Vec<_> = fixture
             .schemes
             .iter()
@@ -3270,7 +3270,7 @@ mod tests {
         let wrong_fixture = setup_seeded(5, 1, &f);
         let round = Round::new(Epoch::new(0), View::new(10));
         let proposal = Proposal::new(round, View::new(5), sample_digest(9));
-        let quorum = N3f1::quorum_from_slice(&fixture.schemes) as usize;
+        let quorum = N3f1::quorum(fixture.schemes.len()) as usize;
         let finalizes: Vec<_> = fixture
             .schemes
             .iter()

--- a/utils/fuzz/fuzz_targets/lib_functions.rs
+++ b/utils/fuzz/fuzz_targets/lib_functions.rs
@@ -15,7 +15,6 @@ enum FuzzInput {
     FromHexFormatted { hex_str: String },
     MaxFaults { n: u32 },
     Quorum { n: u32 },
-    QuorumFromSlice { a: Vec<u8> },
     Union { a: Vec<u8>, b: Vec<u8> },
     UnionUnique { namespace: Vec<u8>, msg: Vec<u8> },
     Modulo { bytes: Vec<u8>, n: u64 },
@@ -130,15 +129,6 @@ fn fuzz(input: FuzzInput) {
             let faults = N3f1::max_faults(n);
 
             assert_eq!(q, n - faults);
-        }
-
-        FuzzInput::QuorumFromSlice { a } => {
-            let l = a.len() as u32;
-            if l == 0 {
-                return;
-            }
-            let q = N3f1::quorum_from_slice(a.as_slice());
-            assert_eq!(q, N3f1::quorum(l));
         }
 
         FuzzInput::Union { a, b } => {

--- a/utils/src/faults.rs
+++ b/utils/src/faults.rs
@@ -65,21 +65,6 @@ pub trait Faults {
         assert!(n > 0, "n must not be zero");
         n - Self::max_faults(n)
     }
-
-    /// Compute the quorum size from a slice length.
-    ///
-    /// Convenience method that converts the slice length to `u32` and calls [`Self::quorum`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the slice is empty or its length exceeds `u32::MAX`.
-    fn quorum_from_slice<T>(slice: &[T]) -> u32 {
-        let n: u32 = slice
-            .len()
-            .try_into()
-            .expect("slice length must be less than u32::MAX");
-        Self::quorum(n)
-    }
 }
 
 /// Fault model requiring `n >= 3f + 1` participants.
@@ -280,20 +265,6 @@ mod tests {
         // Verify invariants
         assert_eq!(n, expected_f + expected_l_quorum); // n = f + q
         assert_eq!(expected_m_quorum, 2 * expected_f + 1); // m = 2f + 1
-    }
-
-    #[test]
-    fn test_quorum_from_slice() {
-        let items = vec![1, 2, 3, 4, 5, 6, 7];
-        assert_eq!(N3f1::quorum_from_slice(&items), 5); // n=7, f=2, q=5
-        assert_eq!(N5f1::quorum_from_slice(&items), 6); // n=7, f=1, q=6
-    }
-
-    #[test]
-    #[should_panic(expected = "n must not be zero")]
-    fn test_quorum_from_empty_slice_panics() {
-        let items: Vec<u8> = vec![];
-        N3f1::quorum_from_slice(&items);
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Removes the `Faults::quorum_from_slice` function to simplify the trait's API.

closes #2793 