### PR TITLE
[storage/freezer] Add chain traversal limit to prevent infinite loops

### DIFF
--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -226,6 +226,8 @@ pub enum Error {
     Journal(#[from] crate::journal::Error),
     #[error("codec error: {0}")]
     Codec(#[from] commonware_codec::Error),
+    #[error("collision chain corruption detected: exceeded {0} iterations")]
+    ChainCorruption(u32),
 }
 
 /// Configuration for [Freezer].


### PR DESCRIPTION
The collision chain traversal in get_key() had no upper bound - if storage gets corrupted and forms a cycle,   we'd spin forever. Added a 64k iteration limit that returns an error if hit. Normal chains are tiny (bounded by table_resize_frequency) so this only triggers on actual corruption.