### PR TITLE
[p2p] Avoid panic in Drop implementations

### DIFF
--- a/p2p/src/authenticated/discovery/actors/tracker/reservation.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/reservation.rs
@@ -33,10 +33,9 @@ impl<P: PublicKey> Reservation<P> {
 
 impl<P: PublicKey> Drop for Reservation<P> {
     fn drop(&mut self) {
-        let mut releaser = self
-            .releaser
-            .take()
-            .expect("Reservation::drop called twice");
-        releaser.release(self.metadata.clone());
+        // Use if-let instead of expect to avoid panic during unwinding.
+        if let Some(mut releaser) = self.releaser.take() {
+            releaser.release(self.metadata.clone());
+        }
     }
 }

--- a/p2p/src/authenticated/lookup/actors/tracker/reservation.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/reservation.rs
@@ -33,10 +33,9 @@ impl<P: PublicKey> Reservation<P> {
 
 impl<P: PublicKey> Drop for Reservation<P> {
     fn drop(&mut self) {
-        let mut releaser = self
-            .releaser
-            .take()
-            .expect("Reservation::drop called twice");
-        releaser.release(self.metadata.clone());
+        // Use if-let instead of expect to avoid panic during unwinding.
+        if let Some(mut releaser) = self.releaser.take() {
+            releaser.release(self.metadata.clone());
+        }
     }
 }

--- a/p2p/src/utils/mux.rs
+++ b/p2p/src/utils/mux.rs
@@ -274,15 +274,13 @@ impl<R: Receiver> Debug for SubReceiver<R> {
 impl<R: Receiver> Drop for SubReceiver<R> {
     fn drop(&mut self) {
         // Take the control channel to avoid cloning.
-        let control_tx = self
-            .control_tx
-            .take()
-            .expect("SubReceiver::drop called twice");
-
-        // Deregister the subchannel immediately.
-        control_tx.send_lossy(Control::Deregister {
-            subchannel: self.subchannel,
-        });
+        // Use if-let instead of expect to avoid panic during unwinding.
+        if let Some(control_tx) = self.control_tx.take() {
+            // Deregister the subchannel immediately.
+            control_tx.send_lossy(Control::Deregister {
+                subchannel: self.subchannel,
+            });
+        }
     }
 }
 


### PR DESCRIPTION
Replace expect() with if-let in Drop implementations to avoid potential double-panic during unwinding. Affects SubReceiver and Reservation types.  