### PR TITLE
[cryptography/dkg] provide getters for logs

### DIFF
--- a/cryptography/src/bls12381/dkg.rs
+++ b/cryptography/src/bls12381/dkg.rs
@@ -1065,7 +1065,7 @@ impl<V: Variant, S: Signer> SignedDealerLog<V, S> {
         &self.dealer
     }
 
-    /// Returns the raw, unsigned [`DealerLog`] wrapped by [`Self`].
+    /// Returns an unsigned [`DealerLog`].
     ///
     /// Use [`Self::check`] to return a verified [`DealerLog`].
     pub const fn log(&self) -> &DealerLog<V, S::PublicKey> {


### PR DESCRIPTION
These would be very useful to have. I want to inspect the contents of the dealer logs I am reading from chain without having to rely on debug logs. So right now I have created shadow-types that have the same `Read` and `Write` impls so I can encode the upstream logs and decode into my custom types.