### PR TITLE
[Storage] Reduce stack size in batch tests by moving state to heap

### DIFF
--- a/storage/src/qmdb/store/batch.rs
+++ b/storage/src/qmdb/store/batch.rs
@@ -63,21 +63,25 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         let mut new_db_clone = new_db.clone();
-        let state1 = executor.start(|context| async move {
-            let ctx = context.clone();
-            run_batch_tests(&mut |idx| new_db_clone(ctx.with_label(&format!("db_{idx}"))))
-                .await
-                .unwrap();
-            ctx.auditor().state()
+        let state1 = executor.start(|context| {
+            Box::pin(async move {
+                let ctx = context.clone();
+                run_batch_tests(&mut |idx| new_db_clone(ctx.with_label(&format!("db_{idx}"))))
+                    .await
+                    .unwrap();
+                ctx.auditor().state()
+            })
         });
 
         let executor = deterministic::Runner::default();
-        let state2 = executor.start(|context| async move {
-            let ctx = context.clone();
-            run_batch_tests(&mut |idx| new_db(ctx.with_label(&format!("db_{idx}"))))
-                .await
-                .unwrap();
-            ctx.auditor().state()
+        let state2 = executor.start(|context| {
+            Box::pin(async move {
+                let ctx = context.clone();
+                run_batch_tests(&mut |idx| new_db(ctx.with_label(&format!("db_{idx}"))))
+                    .await
+                    .unwrap();
+                ctx.auditor().state()
+            })
         });
 
         assert_eq!(state1, state2);
@@ -97,13 +101,13 @@ pub mod tests {
     {
         let counter = &mut 0usize;
 
-        test_overlay_reads(new_db, counter).await?;
-        test_create(new_db, counter).await?;
-        test_delete(new_db, counter).await?;
-        test_delete_unchecked(new_db, counter).await?;
-        test_write_batch_from_to_empty(new_db, counter).await?;
-        test_write_batch(new_db, counter).await?;
-        test_update_delete_update(new_db, counter).await?;
+        Box::pin(test_overlay_reads(new_db, counter)).await?;
+        Box::pin(test_create(new_db, counter)).await?;
+        Box::pin(test_delete(new_db, counter)).await?;
+        Box::pin(test_delete_unchecked(new_db, counter)).await?;
+        Box::pin(test_write_batch_from_to_empty(new_db, counter)).await?;
+        Box::pin(test_write_batch(new_db, counter)).await?;
+        Box::pin(test_update_delete_update(new_db, counter)).await?;
         Ok(())
     }
 


### PR DESCRIPTION
Adds `Box`es to move state from stack to heap.

Should resolve failures like [this](https://github.com/commonwarexyz/monorepo/actions/runs/21489698835/job/61908627520?pr=2987#step:6:1710) by making the test's stack smaller:

```
    thread 'qmdb::current::ordered::variable::test::test_batch' (9200) has overflowed its stack

    (test aborted)

  Cancelling due to test failure: 3 tests still running
        PASS [   1.363s] commonware-storage qmdb::current::ordered::fixed::test::test_current_db_different_pruning_delays_same_root
        PASS [  12.543s] commonware-storage qmdb::current::ordered::fixed::test::test_current_db_build_random_close_reopen
        PASS [  25.611s] commonware-storage qmdb::current::ordered::fixed::test::test_current_db_simulate_write_failures
────────────
     Summary [ 529.045s] 1272/1556 tests run: 1271 passed (12 slow), 1 failed, 1806 skipped
       ABORT [   0.375s] commonware-storage qmdb::current::ordered::variable::test::test_batch
           - with code 0xc00000fd: Recursion too deep; the stack overflowed. (os error 1001)
warning: 284/1556 tests were not run due to test failure (run with --no-fail-fast to run all tests, or run with --max-fail)
error: test run failed
error: Recipe `test` failed on line 55 with exit code 100
```