### PR TITLE
[storage] fix bug in init_sync related to pinned nodes

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -49,14 +49,6 @@
 //! The `prune` method allows the `Journal` to prune blobs consisting entirely of items prior to a
 //! given point in history.
 //!
-//! # State Sync
-//!
-//! `Journal::init_sync` initializes a journal for state sync, handling existing data appropriately:
-//! - If no data exists, creates a journal at the sync range start
-//! - If data exists within range, prunes toward the lower bound (section-aligned)
-//! - If data exceeds the range, returns an error
-//! - If data is stale (before range), destroys and recreates
-//!
 //! # Replay
 //!
 //! The `replay` method supports fast reading of all unpruned items into memory.
@@ -74,10 +66,6 @@ use commonware_codec::CodecFixedShared;
 use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, Storage};
 use futures::{stream::Stream, StreamExt};
 use std::num::{NonZeroU64, NonZeroUsize};
-#[commonware_macros::stability(ALPHA)]
-use std::ops::Range;
-#[commonware_macros::stability(ALPHA)]
-use tracing::debug;
 use tracing::warn;
 
 /// Metadata key for storing the pruning boundary.
@@ -452,65 +440,6 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
             pruning_boundary: size, // No data exists yet
             metadata,
         })
-    }
-
-    /// Initialize a journal for synchronization, reusing existing data if possible.
-    ///
-    /// Handles sync scenarios based on existing journal data vs. the given sync range:
-    ///
-    /// 1. **No existing data**: Creates journal at `range.start` (or empty if `range.start == 0`)
-    /// 2. **Data within range**: Returns the journal (caller is responsible for pruning)
-    /// 3. **Data exceeds range**: Returns error
-    /// 4. **Stale data**: Destroys and recreates at `range.start`
-    #[commonware_macros::stability(ALPHA)]
-    pub(crate) async fn init_sync(
-        context: E,
-        cfg: Config,
-        range: Range<u64>,
-    ) -> Result<Self, Error> {
-        assert!(!range.is_empty(), "range must not be empty");
-
-        debug!(
-            range.start,
-            range.end,
-            items_per_blob = cfg.items_per_blob.get(),
-            "initializing contiguous fixed journal for sync"
-        );
-
-        let journal = Self::init(context.with_label("journal"), cfg.clone()).await?;
-        let size = journal.size();
-
-        // No existing data - initialize at the start of the sync range if needed
-        if size == 0 {
-            if range.start == 0 {
-                debug!("no existing journal data, returning empty journal");
-                return Ok(journal);
-            } else {
-                debug!(
-                    range.start,
-                    "no existing journal data, initializing at sync range start"
-                );
-                journal.destroy().await?;
-                return Self::init_at_size(context, cfg, range.start).await;
-            }
-        }
-
-        // Check if data exceeds the sync range
-        if size > range.end {
-            return Err(Error::ItemOutOfRange(size));
-        }
-
-        // If all existing data is before our sync range, destroy and recreate fresh
-        if size <= range.start {
-            debug!(
-                size,
-                range.start, "existing journal data is stale, re-initializing at start position"
-            );
-            journal.destroy().await?;
-            return Self::init_at_size(context, cfg, range.start).await;
-        }
-
-        Ok(journal)
     }
 
     /// Convert a global position to (section, position_in_section).

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -374,20 +374,18 @@ impl<E: RStorage + Clock + Metrics, D: Digest> CleanMmr<E, D> {
 
     /// Initialize an MMR for synchronization, reusing existing data if possible.
     ///
-    /// Handles three sync scenarios based on existing journal data vs. the given sync boundaries.
+    /// Handles sync scenarios based on existing journal data vs. the given sync range:
     ///
-    /// 1. **Fresh Start**: existing_size < range.start
+    /// 1. **Fresh Start**: existing_size <= range.start
     ///    - Deletes existing data (if any)
-    ///    - Creates new [Journal] with pruning boundary and size `range.start`
+    ///    - Creates new [Journal] with pruning boundary and size at `range.start`
     ///
-    /// 2. **Prune and Reuse**: range.start ≤ existing_size ≤ range.end
-    ///    - Sets in-memory MMR size to `existing_size`
+    /// 2. **Reuse**: range.start < existing_size <= range.end
+    ///    - Keeps existing journal data
     ///    - Prunes the journal toward `range.start` (section-aligned)
     ///
-    /// 3. **Prune and Rewind**: existing_size > range.end
-    ///    - Rewinds the journal to size `range.end`
-    ///    - Sets in-memory MMR size to `range.end`
-    ///    - Prunes the journal toward `range.start` (section-aligned)
+    /// 3. **Error**: existing_size > range.end
+    ///    - Returns [crate::journal::Error::ItemOutOfRange]
     pub async fn init_sync(
         context: E,
         cfg: SyncConfig<D>,
@@ -400,19 +398,24 @@ impl<E: RStorage + Clock + Metrics, D: Digest> CleanMmr<E, D> {
             page_cache: cfg.config.page_cache.clone(),
         };
 
-        // Open the journal.
-        let mut journal: Journal<E, D> = Journal::init_sync(
-            context.with_label("mmr_journal"),
-            journal_cfg,
-            *cfg.range.start..*cfg.range.end,
-        )
-        .await?;
+        // Open the journal, handling existing data vs sync range.
+        assert!(!cfg.range.is_empty(), "range must not be empty");
+        let mut journal: Journal<E, D> =
+            Journal::init(context.with_label("mmr_journal"), journal_cfg).await?;
+        let size = journal.size();
+
+        if size > *cfg.range.end {
+            return Err(crate::journal::Error::ItemOutOfRange(size).into());
+        }
+        if size <= *cfg.range.start && *cfg.range.start != 0 {
+            journal.clear_to_size(*cfg.range.start).await?;
+        }
+
         let journal_size = Position::new(journal.size());
-        assert!(journal_size <= *cfg.range.end);
 
         // Open the metadata.
         let metadata_cfg = MConfig {
-            partition: cfg.config.metadata_partition.clone(),
+            partition: cfg.config.metadata_partition,
             codec_config: ((0..).into(), ()),
         };
         let mut metadata = Metadata::init(context.with_label("mmr_metadata"), metadata_cfg).await?;
@@ -1885,21 +1888,23 @@ mod tests {
         });
     }
 
-    // Regression test: init_sync must compute pinned nodes BEFORE pruning the journal.
-    // Previously, init_sync would prune the journal first, then try to read pinned nodes
-    // from the pruned positions, causing MissingNode errors. This test uses a small
-    // items_per_blob to trigger section-aligned pruning that exposes the bug.
+    // Regression test: init_sync must compute pinned nodes BEFORE pruning the journal. Previously,
+    // init_sync would prune the journal first, then try to read pinned nodes from the pruned
+    // positions, causing MissingNode errors.
+    //
+    // Key setup: We create an MMR with data but DON'T prune it, so the metadata has no pinned
+    // nodes. Then init_sync must read pinned nodes from the journal before pruning it.
     #[test_traced]
     fn test_journaled_mmr_init_sync_computes_pinned_nodes_before_pruning() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut hasher = Standard::<Sha256>::new();
 
-            // Use small items_per_blob to create many sections and trigger pruning edge cases.
+            // Use small items_per_blob to create many sections and trigger pruning.
             let cfg = Config {
                 journal_partition: "mmr_journal".to_string(),
                 metadata_partition: "mmr_metadata".to_string(),
-                items_per_blob: NZU64!(7), // Small value to trigger the bug
+                items_per_blob: NZU64!(7),
                 write_buffer: NZUsize!(64),
                 thread_pool: None,
                 page_cache: CacheRef::new(PAGE_SIZE, PAGE_CACHE_SIZE),
@@ -1914,21 +1919,19 @@ mod tests {
             }
             mmr.sync().await.unwrap();
 
-            // Prune to a position that will be section-aligned.
-            let prune_pos = Position::new(50);
-            mmr.prune_to_pos(prune_pos).await.unwrap();
-
+            // Don't prune - this ensures metadata has no pinned nodes. init_sync will need to
+            // read pinned nodes from the journal.
             let original_size = mmr.size();
             let original_root = mmr.root();
             drop(mmr);
 
-            // Reopen via init_sync with a range that starts at the pruning boundary.
-            // The key is that range.start may not match the section-aligned boundary
-            // stored in the journal, so init_sync must compute pinned nodes before pruning.
+            // Reopen via init_sync with range.start > 0. This will prune the journal, so
+            // init_sync must read pinned nodes BEFORE pruning or they'll be lost.
+            let prune_pos = Position::new(50);
             let sync_cfg = SyncConfig::<sha256::Digest> {
                 config: cfg,
                 range: prune_pos..Position::new(200),
-                pinned_nodes: None, // Force init_sync to compute pinned nodes
+                pinned_nodes: None, // Force init_sync to compute pinned nodes from journal
             };
 
             let sync_mmr = Mmr::init_sync(context.with_label("sync"), sync_cfg, &mut hasher)


### PR DESCRIPTION
init_sync computes pinned nodes, which may fail if the journal is pruned *before* the computation.  This also prevents a failure race condition where we prune the journal but crash before writing the metadata, preventing recovery.