### PR TITLE
[workspace] Link `std` in `cfg(test)`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -659,6 +659,17 @@ pub enum Error {
 - Only use characters that can be easily typed. For example, don't use em dashes (—) or arrows (→).
 - Do not describe trait implementations on the trait definition (e.g., "For production runtimes, this does X. For deterministic testing, this does Y."). These comments become stale as implementations change. Document what the trait does, not how specific implementations behave.
 
+### `lib.rs` Headers
+
+- For crates that allow `no_std`, enable `std` with an `std` feature flag or with `cfg(test)`. Example: `#![cfg_attr(not(any(feature = "std", test)), no_std)]`
+- Add the `commonware` logos with the doc attribute:
+```
+#![doc(
+    html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
+    html_favicon_url = "https://commonware.xyz/favicon.ico"
+)]
+```
+
 ### Naming Conventions
 
 - **Types**: `PascalCase` (e.g., `PublicKey`, `SignatureSet`)

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -194,7 +194,7 @@
     html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 commonware_macros::stability_scope!(BETA {
     #[cfg(not(feature = "std"))]

--- a/codec/src/types/bytes.rs
+++ b/codec/src/types/bytes.rs
@@ -36,8 +36,6 @@ impl Read for Bytes {
 mod tests {
     use super::*;
     use crate::{Decode, Encode};
-    #[cfg(not(feature = "std"))]
-    use alloc::vec;
     use bytes::Bytes;
 
     #[test]

--- a/codec/src/types/vec.rs
+++ b/codec/src/types/vec.rs
@@ -57,8 +57,6 @@ impl<T: Read> Read for Vec<T> {
 mod tests {
     use super::*;
     use crate::{DecodeRangeExt, Encode};
-    #[cfg(not(feature = "std"))]
-    use alloc::vec;
 
     #[test]
     fn test_vec() {

--- a/codec/src/varint.rs
+++ b/codec/src/varint.rs
@@ -427,8 +427,6 @@ fn size_signed<S: SPrim>(value: S) -> usize {
 mod tests {
     use super::*;
     use crate::{error::Error, DecodeExt, Encode};
-    #[cfg(not(feature = "std"))]
-    use alloc::vec::Vec;
     use bytes::Bytes;
 
     #[test]

--- a/conformance/macros/src/lib.rs
+++ b/conformance/macros/src/lib.rs
@@ -1,5 +1,10 @@
 //! Augment the development of [`commonware-conformance`](https://docs.rs/commonware-conformance) with procedural macros.
 
+#![doc(
+    html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
+    html_favicon_url = "https://commonware.xyz/favicon.ico"
+)]
+
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -41,6 +41,11 @@
 //! RUSTFLAGS="--cfg generate_conformance_tests" cargo test
 //! ```
 
+#![doc(
+    html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
+    html_favicon_url = "https://commonware.xyz/favicon.ico"
+)]
+
 pub use commonware_conformance_macros::conformance_tests;
 #[doc(hidden)]
 pub use commonware_macros;

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -8,7 +8,7 @@
     html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/macros/impl/src/lib.rs
+++ b/macros/impl/src/lib.rs
@@ -3,6 +3,11 @@
 //! This is an internal crate. Use [`commonware-macros`](https://docs.rs/commonware-macros)
 //! instead.
 
+#![doc(
+    html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
+    html_favicon_url = "https://commonware.xyz/favicon.ico"
+)]
+
 use crate::nextest::configured_test_groups;
 use proc_macro::TokenStream;
 use proc_macro2::Span;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -11,7 +11,7 @@
     html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 /// Select the first future that completes (biased by order).
 ///

--- a/math/src/fields/goldilocks.rs
+++ b/math/src/fields/goldilocks.rs
@@ -428,8 +428,6 @@ impl Field for F {
 #[cfg(test)]
 mod test {
     use super::*;
-    #[cfg(not(feature = "std"))]
-    use alloc::vec::Vec;
     use crate::algebra;
     use proptest::prelude::*;
 

--- a/math/src/lib.rs
+++ b/math/src/lib.rs
@@ -3,7 +3,7 @@
     html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -54,7 +54,11 @@
 //! assert_eq!(result, 55); // 1 + 4 + 9 + 16 + 25
 //! ```
 
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![doc(
+    html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
+    html_favicon_url = "https://commonware.xyz/favicon.ico"
+)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 commonware_macros::stability_scope!(BETA {
     use cfg_if::cfg_if;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -8,7 +8,7 @@
     html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 commonware_macros::stability_scope!(ALPHA {
     extern crate alloc;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -4,7 +4,7 @@
     html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 commonware_macros::stability_scope!(BETA {
     #[cfg(not(feature = "std"))]


### PR DESCRIPTION
## Overview

Unifies the approach to `no_std` declarations across the codebase to allow for linking `std` with `cfg(test)`. Previously, only `parallel` did this.
