### PR TITLE
Fix collector fuzz panic

### DIFF
--- a/collector/fuzz/fuzz_targets/collector.rs
+++ b/collector/fuzz/fuzz_targets/collector.rs
@@ -26,6 +26,7 @@ use std::{
 
 const MAX_LEN: usize = 1_000_000;
 const MAX_OPERATIONS: usize = 256;
+const MIN_BUFFER_SIZE: u16 = 1;
 
 #[derive(Debug, Arbitrary)]
 enum RecipientsType {
@@ -411,6 +412,7 @@ fn fuzz(input: FuzzInput) {
                     priority_response,
                 } => {
                     let idx = (peer_idx as usize) % peers.len();
+                    let mailbox_size = mailbox_size.max(MIN_BUFFER_SIZE);
                     let handler = handlers.get(&idx).cloned().unwrap_or_else(|| {
                         FuzzHandler::new(true, StdRng::seed_from_u64(rng.gen()))
                     });


### PR DESCRIPTION
Fix panic in the collector fuzz test

```
thread '<unnamed>' (15111930) panicked at collector/src/p2p/engine.rs:72:24:
mpsc bounded channel requires buffer > 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
==97236== ERROR: libFuzzer: deadly signal
```