### PR TITLE
cell: panic formatting cleanup

### DIFF
--- a/runtime/src/utils/cell.rs
+++ b/runtime/src/utils/cell.rs
@@ -53,14 +53,14 @@ impl<C> Cell<C> {
     pub fn take(&mut self) -> C {
         match std::mem::replace(self, Self::Missing) {
             Self::Present(context) => context,
-            Self::Missing => panic!("{}", MISSING_CONTEXT),
+            Self::Missing => panic!("{MISSING_CONTEXT}"),
         }
     }
 
     /// Return a context to the slot, panicking if one is already present.
     pub fn restore(&mut self, context: C) {
         match self {
-            Self::Present(_) => panic!("{}", DUPLICATE_CONTEXT),
+            Self::Present(_) => panic!("{DUPLICATE_CONTEXT}"),
             Self::Missing => {
                 *self = Self::Present(context);
             }
@@ -75,7 +75,7 @@ impl<C> Cell<C> {
     pub fn as_present(&self) -> &C {
         match self {
             Self::Present(context) => context,
-            Self::Missing => panic!("{}", MISSING_CONTEXT),
+            Self::Missing => panic!("{MISSING_CONTEXT}"),
         }
     }
 
@@ -87,7 +87,7 @@ impl<C> Cell<C> {
     pub fn as_present_mut(&mut self) -> &mut C {
         match self {
             Self::Present(context) => context,
-            Self::Missing => panic!("{}", MISSING_CONTEXT),
+            Self::Missing => panic!("{MISSING_CONTEXT}"),
         }
     }
 
@@ -99,7 +99,7 @@ impl<C> Cell<C> {
     pub fn into_present(self) -> C {
         match self {
             Self::Present(context) => context,
-            Self::Missing => panic!("{}", MISSING_CONTEXT),
+            Self::Missing => panic!("{MISSING_CONTEXT}"),
         }
     }
 }


### PR DESCRIPTION
Use inline format interpolation for panic messages in Cell to simplify formatting and avoid unnecessary format placeholders