### PR TITLE
[broadcast] Fix incorrect metric in cleanup_waiters

### DIFF
--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -456,7 +456,7 @@ impl<E: Clock + Spawner + Metrics, P: PublicKey, M: Committable + Digestible + C
 
             // Increment metrics for each dropped waiter
             for _ in 0..dropped_count {
-                self.metrics.get.inc(Status::Dropped);
+                self.metrics.subscribe.inc(Status::Dropped);
             }
 
             !waiters.is_empty()


### PR DESCRIPTION
Fixed a bug in `cleanup_waiters()` where dropped waiters were incorrectly incrementing `metrics.get` instead of `metrics.subscribe`.

Waiters are created exclusively by `handle_subscribe`, so their cleanup should update the `subscribe` metric, not the `get` metric. This was causing inaccurate monitoring data for both metrics.