### PR TITLE
[justfile] Use `find` instead of `git ls-files`

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,16 +22,16 @@ build *args='':
 pre-pr: lint test-docs test check-stability
 
 # Fixes the formatting of the workspace
-fix-fmt:
-    git ls-files -z '*.rs' | xargs -0 {{ rustfmt }} {{ nightly_version }} --edition 2021
+fix-fmt *args='':
+    @find "{{source_dir()}}" -not \( -path '{{source_dir()}}/target/*' -prune \) -name '*.rs' -type f -print0 | xargs -0 {{ rustfmt }} {{ nightly_version }} --edition 2021 {{ args }}
 
 # Fixes the formatting of the `Cargo.toml` files in the workspace
 fix-toml-fmt:
-   find . -name Cargo.toml -type f -print0 | xargs -0 -n1 ./.github/scripts/lint_cargo_toml.py
+    find . -name Cargo.toml -type f -print0 | xargs -0 -n1 ./.github/scripts/lint_cargo_toml.py
 
 # Check the formatting of the workspace
 check-fmt:
-    git ls-files -z '*.rs' | xargs -0 {{ rustfmt }} {{ nightly_version }} --edition 2021 --check
+    just fix-fmt --check
 
 # Run clippy lints
 clippy *args='':


### PR DESCRIPTION
## Overview

Uses `find` instead of `git ls-files` to find all `*.rs` files in the repository for `rustfmt`. When using `git ls-files`, the current commands throw an error if a file was deleted:

```
git ls-files -z '*.rs' | xargs -0 rustfmt +nightly --edition 2021 --check
Error: file `resolver/src/p2p/config.rs` does not exist
Error writing files: failed to resolve mod `config`: /Users/ben/dev/cw-work/commonware/resolver/src/p2p/config.rs does not exist
error: Recipe `check-fmt` failed on line 34 with exit code 1
```