### PR TITLE
[Storage] Remove `pop` from `mmr::mem::CleanMmr` and downstream types

### DIFF
--- a/storage/fuzz/fuzz_targets/mmr_journaled.rs
+++ b/storage/fuzz/fuzz_targets/mmr_journaled.rs
@@ -176,18 +176,18 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 MmrJournaledOperation::Pop { count } => {
-                    // Pop requires Clean MMR
+                    // Pop requires Dirty MMR
                     let mut mmr = match mmr {
-                        MmrState::Clean(m) => m,
-                        MmrState::Dirty(m) => m.merkleize(&mut hasher),
+                        MmrState::Clean(m) => m.into_dirty(),
+                        MmrState::Dirty(m) => m,
                     };
 
                     if count as u64 <= mmr.leaves() {
-                        let _ = mmr.pop(&mut hasher, count as usize).await;
+                        let _ = mmr.pop(count as usize).await;
                         let new_len = mmr.leaves();
                         leaves.truncate(new_len.as_u64() as usize);
                     }
-                    MmrState::Clean(mmr)
+                    MmrState::Dirty(mmr)
                 }
 
                 MmrJournaledOperation::GetNode { pos } => {

--- a/storage/fuzz/fuzz_targets/mmr_operations.rs
+++ b/storage/fuzz/fuzz_targets/mmr_operations.rs
@@ -180,7 +180,9 @@ fn fuzz(input: FuzzInput) {
 
                 MmrOperation::Pop => {
                     let size_before = mmr.size();
-                    let mmr_result = mmr.pop(&mut hasher);
+                    let mut dirty_mmr = mmr.into_dirty();
+                    let mmr_result = dirty_mmr.pop();
+                    mmr = dirty_mmr.merkleize(&mut hasher, None);
                     let ref_result = reference.pop();
 
                     assert_eq!(

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -446,8 +446,8 @@ pub(crate) mod test {
             assert_eq!(min_ops, ops[0..3]);
 
             // Can't destroy the db unless it's durable, so we need to commit first.
-            let (single_db, _) = single_db.commit(None).await.unwrap();
-            single_db.destroy().await.unwrap();
+            let (single_db, _) = single_db.into_mutable().commit(None).await.unwrap();
+            single_db.into_merkleized().destroy().await.unwrap();
 
             db.destroy().await.unwrap();
         });
@@ -505,8 +505,8 @@ pub(crate) mod test {
                     &ref_root
                 ));
 
-                let (ref_db, _) = ref_db.commit(None).await.unwrap();
-                ref_db.destroy().await.unwrap();
+                let (ref_db, _) = ref_db.into_mutable().commit(None).await.unwrap();
+                ref_db.into_merkleized().destroy().await.unwrap();
             }
 
             db.destroy().await.unwrap();


### PR DESCRIPTION
Similar to #3027, removes a merkleized -> merkleized state transition, requiring callers to explicitly transition to unmerkleized state before popping bits