### PR TITLE
ci: integrate forked rustfmt with select! and select_loop! support

### DIFF
--- a/.github/workflows/build-forked-rustfmt.yml
+++ b/.github/workflows/build-forked-rustfmt.yml
@@ -48,13 +48,13 @@ jobs:
         full_commit="$(git -C fork rev-parse HEAD)"
         sha="$(cut -d ' ' -f1 "dist/${asset}.sha256")"
         cat > dist/RELEASE_NOTES.md <<EOF
-Forked rustfmt build
+        Forked rustfmt build
 
-Commit: ${full_commit}
-Toolchain: ${{ inputs.toolchain }}
-Asset: ${asset}
-SHA256: ${sha}
-EOF
+        Commit: ${full_commit}
+        Toolchain: ${{ inputs.toolchain }}
+        Asset: ${asset}
+        SHA256: ${sha}
+        EOF
     - name: Publish release
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-forked-rustfmt.yml
+++ b/.github/workflows/build-forked-rustfmt.yml
@@ -1,0 +1,72 @@
+name: Build Forked Rustfmt
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit in andresilva/rustfmt to build (short or full hash)"
+        required: true
+        type: string
+      toolchain:
+        description: "Rust toolchain used to build rustfmt"
+        required: false
+        default: "nightly-2025-11-15"
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout fork
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      with:
+        repository: andresilva/rustfmt
+        ref: ${{ inputs.commit }}
+        path: fork
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+      with:
+        toolchain: ${{ inputs.toolchain }}
+    - name: Build rustfmt
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd fork
+        cargo build --release --bin rustfmt
+        cd ..
+
+        commit="${{ inputs.commit }}"
+        asset="forked-rustfmt-${commit}-linux-x64"
+        mkdir -p dist
+        cp "fork/target/release/rustfmt" "dist/${asset}"
+        strip "dist/${asset}" || true
+        sha256sum "dist/${asset}" > "dist/${asset}.sha256"
+
+        full_commit="$(git -C fork rev-parse HEAD)"
+        sha="$(cut -d ' ' -f1 "dist/${asset}.sha256")"
+        cat > dist/RELEASE_NOTES.md <<EOF
+Forked rustfmt build
+
+Commit: ${full_commit}
+Toolchain: ${{ inputs.toolchain }}
+Asset: ${asset}
+SHA256: ${sha}
+EOF
+    - name: Publish release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        tag="forked-rustfmt-${{ inputs.commit }}"
+        title="Forked rustfmt ${{ inputs.commit }}"
+        if ! gh release view "$tag" >/dev/null 2>&1; then
+          gh release create "$tag" --title "$title" --notes-file dist/RELEASE_NOTES.md
+        else
+          gh release edit "$tag" --title "$title" --notes-file dist/RELEASE_NOTES.md
+        fi
+        gh release upload "$tag" dist/* --clobber

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -18,6 +18,7 @@ env:
   UDEPS_VERSION: 0.1.57
   NIGHTLY_VERSION: nightly-2025-11-15
   PANDOC_VERSION: 3.8.2.1
+  FORKED_RUSTFMT_COMMIT: e20ec8b
 
 jobs:
   Lint:
@@ -51,6 +52,36 @@ jobs:
         tool: just@1.43.0
     - name: Fmt
       run: just check-fmt
+    - name: Restore forked rustfmt cache
+      if: runner.os == 'Linux'
+      id: forked-rustfmt-cache
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ runner.temp }}/forked-rustfmt/${{ env.FORKED_RUSTFMT_COMMIT }}
+        key: ${{ runner.os }}-forked-rustfmt-${{ env.FORKED_RUSTFMT_COMMIT }}
+    - name: Download forked rustfmt
+      if: runner.os == 'Linux' && steps.forked-rustfmt-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="${FORKED_RUSTFMT_COMMIT}"
+        tag="forked-rustfmt-${commit}"
+        asset="forked-rustfmt-${commit}-linux-x64"
+        dir="${{ runner.temp }}/forked-rustfmt/${commit}"
+        mkdir -p "$dir"
+        base_url="https://github.com/${{ github.repository }}/releases/download/${tag}"
+        curl -fsSL -H "Authorization: Bearer ${{ github.token }}" -o "$dir/$asset" "$base_url/$asset"
+        curl -fsSL -H "Authorization: Bearer ${{ github.token }}" -o "$dir/$asset.sha256" "$base_url/$asset.sha256"
+        (cd "$dir" && sha256sum -c "$asset.sha256")
+        chmod +x "$dir/$asset"
+    - name: Fmt (forked rustfmt)
+      if: runner.os == 'Linux'
+      env:
+        RUSTFMT: ${{ runner.temp }}/forked-rustfmt/${{ env.FORKED_RUSTFMT_COMMIT }}/forked-rustfmt-${{ env.FORKED_RUSTFMT_COMMIT }}-linux-x64
+        NIGHTLY_VERSION: ""
+      run: |
+        chmod +x "$RUSTFMT"
+        just check-fmt
     - name: Lint
       run: just clippy ${{ matrix.flags }}
     - name: Check docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,21 @@ To fix formatting automatically, run:
 $ just fix-fmt
 ```
 
+CI runs formatting checks with two rustfmt binaries:
+- Official rustfmt from the Rust toolchain (standard formatting rules)
+- A forked rustfmt that adds support for custom macros like `select!` and `select_loop!`
+
+You do not need the forked rustfmt locally. If the forked check fails in CI and you want to reproduce it, download the release asset and run:
+
+```bash
+$ RUSTFMT=/path/to/forked-rustfmt NIGHTLY_VERSION="" just check-fmt
+```
+
+To update the forked rustfmt used in CI:
+- Run the `Build Forked Rustfmt` workflow with the new fork commit.
+- Update `FORKED_RUSTFMT_COMMIT` in `.github/workflows/fast.yml`.
+- Ensure the release contains `forked-rustfmt-<commit>-linux-x64` and `forked-rustfmt-<commit>-linux-x64.sha256`.
+
 Before making a PR, to run all lints and tests, run:
 
 ```bash


### PR DESCRIPTION
Fixes #2978

## Summary
This PR integrates the forked rustfmt (with support for `select!` and `select_loop!` macros) into the CI pipeline, as discussed in #2978 and implemented in #2927.

## Changes
- ✅ Added workflow to build and publish forked rustfmt binaries (`build-forked-rustfmt.yml`)
- ✅ Updated `fast.yml` to run both official and forked rustfmt
- ✅ Added caching for forked rustfmt binary
- ✅ Documented the setup in `CONTRIBUTING.md`
- ✅ CI-only integration - no local installation required

## Implementation Details
- Fork source: https://github.com/andresilva/rustfmt @ `e20ec8b`
- Binary published as GitHub Release asset
- Cached by OS + commit hash
- Separate formatting step, doesn't replace official rustfmt

## Note
The `build-forked-rustfmt` workflow needs to be run manually once to create the initial binary release. After that, CI will download and cache it automatically.

## References
- Related PR: #2927
- Issue: #2978