### PR TITLE
[consensus] Documentation: explicitly call out the determinism requirement of certify()

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -140,8 +140,7 @@ commonware_macros::stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         /// # Determinism Requirement
         ///
         /// The decision returned by `certify` must be deterministic and consistent across
-        /// all honest participants to ensure liveness. If honest participants disagree on
-        /// certification, the network may fail to reach the quorum needed for finalization.
+        /// all honest participants to ensure liveness.
         fn certify(
             &mut self,
             _round: Round,


### PR DESCRIPTION
Fixes #3042
