### PR TITLE
refactor(examples/reshare): improve update callback readability

### DIFF
--- a/examples/reshare/src/dkg/actor.rs
+++ b/examples/reshare/src/dkg/actor.rs
@@ -192,7 +192,7 @@ where
     }
 
     /// Start the DKG actor.
-    pub fn start(
+    pub fn start<CB>(
         mut self,
         output: Option<Output<V, C::PublicKey>>,
         share: Option<Share>,
@@ -201,8 +201,11 @@ where
             impl Sender<PublicKey = C::PublicKey>,
             impl Receiver<PublicKey = C::PublicKey>,
         ),
-        callback: Box<dyn UpdateCallBack<V, C::PublicKey>>,
-    ) -> Handle<()> {
+        callback: CB,
+    ) -> Handle<()>
+    where
+        CB: UpdateCallBack<V, C::PublicKey> + 'static,
+    {
         // NOTE: In a production setting with a large validator set, the implementor may want
         // to choose a dedicated thread for the DKG actor. This actor can perform CPU-intensive
         // cryptographic operations.
@@ -212,7 +215,7 @@ where
         )
     }
 
-    async fn run(
+    async fn run<CB>(
         mut self,
         output: Option<Output<V, C::PublicKey>>,
         share: Option<Share>,
@@ -221,8 +224,11 @@ where
             impl Sender<PublicKey = C::PublicKey>,
             impl Receiver<PublicKey = C::PublicKey>,
         ),
-        mut callback: Box<dyn UpdateCallBack<V, C::PublicKey>>,
-    ) {
+        mut callback: CB,
+    )
+    where
+        CB: UpdateCallBack<V, C::PublicKey>,
+    {
         let max_read_size = NZU32!(self.peer_config.max_participants_per_round());
         let is_dkg = output.is_none();
         let epocher = FixedEpocher::new(BLOCKS_PER_EPOCH);

--- a/examples/reshare/src/engine.rs
+++ b/examples/reshare/src/engine.rs
@@ -315,7 +315,7 @@ where
     }
 
     #[allow(clippy::type_complexity, clippy::too_many_arguments)]
-    pub fn start(
+    pub fn start<CB>(
         mut self,
         votes: (
             impl Sender<PublicKey = C::PublicKey>,
@@ -341,8 +341,11 @@ where
             mpsc::Receiver<handler::Message<Block<H, C, V>>>,
             commonware_resolver::p2p::Mailbox<handler::Request<Block<H, C, V>>, C::PublicKey>,
         ),
-        callback: Box<dyn UpdateCallBack<V, C::PublicKey>>,
-    ) -> Handle<()> {
+        callback: CB,
+    ) -> Handle<()>
+    where
+        CB: UpdateCallBack<V, C::PublicKey> + 'static,
+    {
         spawn_cell!(
             self.context,
             self.run(
@@ -359,7 +362,7 @@ where
     }
 
     #[allow(clippy::type_complexity, clippy::too_many_arguments)]
-    async fn run(
+    async fn run<CB>(
         self,
         votes: (
             impl Sender<PublicKey = C::PublicKey>,
@@ -385,8 +388,11 @@ where
             mpsc::Receiver<handler::Message<Block<H, C, V>>>,
             commonware_resolver::p2p::Mailbox<handler::Request<Block<H, C, V>>, C::PublicKey>,
         ),
-        callback: Box<dyn UpdateCallBack<V, C::PublicKey>>,
-    ) {
+        callback: CB,
+    )
+    where
+        CB: UpdateCallBack<V, C::PublicKey> + 'static,
+    {
         let dkg_handle = self.dkg.start(
             self.config.output,
             self.config.share,


### PR DESCRIPTION
Removes boxed futures from the reshare callback path using a generic callback type and `impl Future + Send`. Reads more like normal async Rust and avoids the `Box::pin` plumbing (a pattern we adopted downstream for readability). totally fine to NAK if you guys prefer the original.