### PR TITLE
[gh] Use grep / sed for toolchain discovery

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -372,7 +372,7 @@ jobs:
         id: toolchain
         run: |
           if [ "${{ matrix.toolchain }}" = "msrv" ]; then
-            echo "version=$(yq -oy '.workspace.package.rust-version' Cargo.toml)" >> "$GITHUB_OUTPUT"
+            echo "version=$(grep -m1 '^rust-version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')" >> "$GITHUB_OUTPUT"
           else
             echo "version=${{ matrix.toolchain }}" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
After experiencing flakiness with yq because of comments in the TOML file (https://github.com/commonwarexyz/monorepo/actions/runs/21765688579/job/62800750837?pr=2983) this should hopefully fix that.