### PR TITLE
Revert "[runtime/iouring] remove useless allow(dead_code) (#3102)"

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -105,6 +105,7 @@ impl From<IoBuf> for OpBuffer {
 /// The variant must match the descriptor type:
 /// - `Fd`: For network sockets and other OS file descriptors
 /// - `File`: For file-backed descriptors
+#[allow(dead_code)]
 pub enum OpFd {
     /// A socket or other OS file descriptor.
     Fd(Arc<OwnedFd>),


### PR DESCRIPTION
This reverts commit 3972a199493bc828d627ab89be63697413ae016e.