### PR TITLE
[consensus/aggregation] fix unused rebroadcast metric

### DIFF
--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -411,9 +411,13 @@ impl<
                     .pop()
                     .expect("no rebroadcast deadline");
                 trace!(%height, "rebroadcasting");
+                let mut guard = self.metrics.rebroadcast.guard(Status::Invalid);
                 if let Err(err) = self.handle_rebroadcast(height, &mut sender).await {
                     warn!(?err, %height, "rebroadcast failed");
-                };
+                    guard.set(Status::Failure);
+                } else {
+                    guard.set(Status::Success);
+                }
             },
         }
 

--- a/consensus/src/aggregation/metrics.rs
+++ b/consensus/src/aggregation/metrics.rs
@@ -15,6 +15,8 @@ pub struct Metrics<E: RuntimeMetrics + Clock> {
     pub acks: status::Counter,
     /// Number of certificates produced
     pub certificates: Counter,
+    /// Number of rebroadcast attempts by status
+    pub rebroadcast: status::Counter,
     /// Histogram of application digest durations
     pub digest_duration: histogram::Timed<E>,
 }
@@ -46,7 +48,7 @@ impl<E: RuntimeMetrics + Clock> Metrics<E> {
         context.register(
             "rebroadcast",
             "Number of rebroadcast attempts by status",
-            rebroadcast,
+            rebroadcast.clone(),
         );
         let digest_duration = Histogram::new(histogram::Buckets::LOCAL);
         context.register(
@@ -61,6 +63,7 @@ impl<E: RuntimeMetrics + Clock> Metrics<E> {
             digest,
             acks,
             certificates,
+            rebroadcast,
             digest_duration: histogram::Timed::new(digest_duration, clock),
         }
     }


### PR DESCRIPTION
The `rebroadcast` metric was registered to Prometheus but the field was dropped from the struct during refactoring in #1834. This caused the metric to always show 0.

Restore the field and record success/failure status in `handle_rebroadcast`.