### PR TITLE
fix(p2p): correct rate limiter cleanup interval

### DIFF
--- a/p2p/src/authenticated/discovery/actors/listener.rs
+++ b/p2p/src/authenticated/discovery/actors/listener.rs
@@ -190,7 +190,7 @@ impl<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + Metrics, C: S
                 }
 
                 // Cleanup the rate limiters periodically
-                if accepted > CLEANUP_INTERVAL {
+                if accepted >= CLEANUP_INTERVAL {
                     ip_rate_limiter.retain_recent();
                     subnet_rate_limiter.retain_recent();
                     accepted = 0;

--- a/p2p/src/authenticated/lookup/actors/listener.rs
+++ b/p2p/src/authenticated/lookup/actors/listener.rs
@@ -216,7 +216,7 @@ impl<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + Metrics, C: S
                 }
 
                 // Cleanup the rate limiters periodically
-                if accepted > CLEANUP_INTERVAL {
+                if accepted >= CLEANUP_INTERVAL {
                     ip_rate_limiter.retain_recent();
                     subnet_rate_limiter.retain_recent();
                     accepted = 0;


### PR DESCRIPTION
The cleanup condition `accepted > CLEANUP_INTERVAL` caused `retain_recent()` to run every 16,385 connections instead of the intended 16,384. Changed to `>=` so cleanup happens exactly at the configured interval.
 
Fixed in both discovery and lookup listeners.