### PR TITLE
Fix timeout crash in the channel fuzz test

### DIFF
--- a/utils/fuzz/fuzz_targets/channel.rs
+++ b/utils/fuzz/fuzz_targets/channel.rs
@@ -5,6 +5,8 @@ use commonware_utils::channel::tracked;
 use futures::executor::block_on;
 use libfuzzer_sys::fuzz_target;
 
+const BUFFER_SIZE: usize = 1000;
+
 #[derive(Arbitrary, Debug)]
 enum FuzzInput {
     SendReceive {
@@ -48,10 +50,22 @@ fn fuzz(input: FuzzInput) {
 
         FuzzInput::MultipleSends { batches, data } => {
             block_on(async {
-                let (sender, mut receiver) = tracked::bounded::<Vec<u8>, u32>(100);
+                let (sender, mut receiver) = tracked::bounded::<Vec<u8>, u32>(BUFFER_SIZE);
+                let mut in_flight = 0usize;
 
                 for (batch, d) in batches.iter().zip(data.iter()) {
+                    if in_flight >= BUFFER_SIZE {
+                        match receiver.recv().await {
+                            Some(msg) => {
+                                drop(msg);
+                                in_flight -= 1;
+                            }
+                            None => break,
+                        }
+                    }
+
                     let _ = sender.send(*batch, d.clone()).await;
+                    in_flight += 1;
                 }
 
                 let _ = sender.watermark();

--- a/utils/fuzz/fuzz_targets/channel.rs
+++ b/utils/fuzz/fuzz_targets/channel.rs
@@ -64,8 +64,10 @@ fn fuzz(input: FuzzInput) {
                         }
                     }
 
-                    let _ = sender.send(*batch, d.clone()).await;
-                    in_flight += 1;
+                    match sender.send(*batch, d.clone()).await {
+                        Ok(_) => in_flight += 1,
+                        Err(_) => break,
+                    }
                 }
 
                 let _ = sender.watermark();


### PR DESCRIPTION
This PR fixes a timeout panic in the fuzz test.
An example is attached.
[timeout-f2ba6140342df1d6331eec6df729b3b7bd4a894c.txt](https://github.com/user-attachments/files/25347978/timeout-f2ba6140342df1d6331eec6df729b3b7bd4a894c.txt)
