### PR TITLE
Make fuzz tests easier to run on MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ serde_json = "1.0.122"
 serde_yaml = "0.9.34"
 sha2 = { version = "0.10.8", default-features = false }
 syn = "2.0.0"
-sysinfo = "0.37.2"
+sysinfo = { version = "0.37.2", default-features = false }
 thiserror = { version = "2.0.12", default-features = false }
 tokio = "1.43.0"
 toml = "0.9.8"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -35,7 +35,6 @@ rand.workspace = true
 rand_core.workspace = true
 rayon.workspace = true
 sha2.workspace = true
-sysinfo.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
@@ -47,12 +46,19 @@ version = "0.2.15"
 features = ["js"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+
+# Enable the apple-sandbox feature only on macos
 axum.workspace = true
 console-subscriber = { workspace = true, features = ["parking_lot"], optional = true }
 criterion = { workspace = true, features = ["async"] }
 opentelemetry-otlp = { workspace = true, features = ["http-proto"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 tokio = { workspace = true, features = ["full"] }
+[target.'cfg(target_os = "macos")'.dependencies]
+sysinfo = { workspace = true, default-features = false, features = ["system", "apple-sandbox"] }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+sysinfo = { workspace = true, default-features = false, features = ["system"] }
 
 [features]
 default = []


### PR DESCRIPTION
Some people had issues without this feature enabled locally, so this enables it conditionally, just for that platform.