### PR TITLE
[examples/reshare] Set Max Pending

### DIFF
--- a/examples/reshare/src/engine.rs
+++ b/examples/reshare/src/engine.rs
@@ -273,7 +273,7 @@ where
                 value_write_buffer: WRITE_BUFFER,
                 block_codec_config: num_participants,
                 max_repair: MAX_REPAIR,
-                max_pending_acks: NZUsize!(16),
+                max_pending_acks: NZUsize!(1),
                 strategy: config.strategy.clone(),
             },
         )


### PR DESCRIPTION
Related: #3151

The deterministic runtime leads to some application logic being delayed a good bit (causing honest players to miss their chance to participate).