### PR TITLE
[utils] remove dead code in `pop()` method

### DIFF
--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -236,8 +236,7 @@ impl<const N: usize> BitMap<N> {
 
         // Clear the bit we just popped to maintain invariant (if it was 1)
         if bit {
-            let pos_in_chunk = last_bit_pos % Self::CHUNK_SIZE_BITS;
-            let chunk_byte = (pos_in_chunk / 8) as usize;
+            let chunk_byte = Self::chunk_byte_offset(last_bit_pos);
             let mask = Self::chunk_byte_bitmask(last_bit_pos);
             self.chunks.back_mut().unwrap()[chunk_byte] &= !mask;
         }


### PR DESCRIPTION
The `pop()` method manually calculated `chunk_byte` index instead of using the existing `chunk_byte_offset()` helper. This duplicated logic and left `pos_in_chunk` as dead code.

Use `chunk_byte_offset()` helper for consistency with `push()`, `flip()`, and `set()` methods.