### PR TITLE
[examples/log] Migrate to actor SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,7 @@ version = "2026.3.0"
 dependencies = [
  "chrono",
  "clap",
+ "commonware-actor",
  "commonware-consensus",
  "commonware-cryptography",
  "commonware-macros",

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 chrono.workspace = true
 clap.workspace = true
+commonware-actor.workspace = true
 commonware-consensus.workspace = true
 commonware-cryptography.workspace = true
 commonware-macros.workspace = true

--- a/examples/log/src/application/actor.rs
+++ b/examples/log/src/application/actor.rs
@@ -1,88 +1,101 @@
 use super::{
-    ingress::{Mailbox, Message},
+    ingress::{Mailbox, MailboxMessage, MailboxReadWriteMessage},
     reporter::Reporter,
-    Config, Scheme,
+    Config,
+};
+use commonware_actor::{
+    service::{ActorService, ServiceBuilder},
+    Actor,
 };
 use commonware_consensus::types::Epoch;
 use commonware_cryptography::Hasher;
-use commonware_runtime::{spawn_cell, ContextCell, Handle, Spawner};
-use commonware_utils::{channel::mpsc, hex};
+use commonware_runtime::Spawner;
+use commonware_utils::{channel::fallible::OneshotExt, hex};
 use rand::Rng;
+use std::convert::Infallible;
 use tracing::info;
 
 /// Genesis message to use during initialization.
 const GENESIS: &[u8] = b"commonware is neat";
 
 /// Application actor.
-pub struct Application<R: Rng + Spawner, H: Hasher> {
-    context: ContextCell<R>,
+pub struct Application<H: Hasher> {
     hasher: H,
-    mailbox: mpsc::Receiver<Message<H::Digest>>,
 }
 
-impl<R: Rng + Spawner, H: Hasher> Application<R, H> {
-    /// Create a new application actor.
-    #[allow(clippy::type_complexity)]
-    pub fn new(
-        context: R,
-        config: Config<H>,
-    ) -> (Self, Scheme, Reporter<H::Digest>, Mailbox<H::Digest>) {
-        let (sender, mailbox) = mpsc::channel(config.mailbox_size);
-        (
-            Self {
-                context: ContextCell::new(context),
-                hasher: config.hasher,
-                mailbox,
-            },
-            config.scheme,
-            Reporter::new(),
-            Mailbox::new(sender),
-        )
-    }
+impl<E: Rng + Spawner, H: Hasher> Actor<E> for Application<H> {
+    type Mailbox = Mailbox<H::Digest>;
+    type Ingress = MailboxMessage<H::Digest>;
+    type Error = Infallible;
+    type Args = ();
+    type Snapshot = ();
 
-    /// Run the application actor.
-    pub fn start(mut self) -> Handle<()> {
-        spawn_cell!(self.context, self.run().await)
-    }
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {}
 
-    async fn run(mut self) {
-        while let Some(message) = self.mailbox.recv().await {
-            match message {
-                Message::Genesis { epoch, response } => {
-                    // Sanity check. We don't support multiple epochs.
-                    assert_eq!(epoch, Epoch::zero(), "epoch must be 0");
+    async fn on_read_write(
+        &mut self,
+        context: &mut E,
+        _args: &mut Self::Args,
+        message: MailboxReadWriteMessage<H::Digest>,
+    ) -> Result<(), Self::Error> {
+        match message {
+            MailboxReadWriteMessage::GetGenesis { epoch, response } => {
+                // Sanity check. We don't support multiple epochs.
+                assert_eq!(epoch, Epoch::zero(), "epoch must be 0");
 
-                    // Use the hash of the genesis message as the initial
-                    // payload.
-                    //
-                    // Since we don't verify that proposed messages link
-                    // to some parent, this doesn't really do anything
-                    // in this example.
-                    self.hasher.update(GENESIS);
-                    let digest = self.hasher.finalize();
-                    let _ = response.send(digest);
-                }
-                Message::Propose { response } => {
-                    // Generate a random message (secret to us)
-                    let mut msg = vec![0; 16];
-                    self.context.fill(&mut msg[..]);
-
-                    // Hash the message
-                    self.hasher.update(&msg);
-                    let digest = self.hasher.finalize();
-                    info!(msg = hex(&msg), payload = ?digest, "proposed");
-
-                    // Send digest to consensus
-                    let _ = response.send(digest);
-                }
-                Message::Verify { response } => {
-                    // Digests are already verified by consensus, so we don't need to check they are valid.
-                    //
-                    // If we linked payloads to their parent, we would verify
-                    // the parent included in the payload matches the provided context.
-                    let _ = response.send(true);
-                }
+                // Use the hash of the genesis message as the initial
+                // payload.
+                //
+                // Since we don't verify that proposed messages link
+                // to some parent, this doesn't really do anything
+                // in this example.
+                self.hasher.update(GENESIS);
+                let digest = self.hasher.finalize();
+                response.send_lossy(digest);
             }
+            MailboxReadWriteMessage::CreateProposal { response } => {
+                // Generate a random message (secret to us)
+                let mut msg = vec![0; 16];
+                context.fill(&mut msg[..]);
+
+                // Hash the message
+                self.hasher.update(&msg);
+                let digest = self.hasher.finalize();
+                info!(msg = hex(&msg), payload = ?digest, "proposed");
+
+                // Send digest to consensus
+                response.send_lossy(digest);
+            }
+            MailboxReadWriteMessage::VerifyProposal { response } => {
+                // Digests are already verified by consensus, so we don't need to check they are valid.
+                //
+                // If we linked payloads to their parent, we would verify
+                // the parent included in the payload matches the provided context.
+                response.send_lossy(true);
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct ApplicationHandle<R: Rng + Spawner, H: Hasher> {
+    pub reporter: Reporter<H::Digest>,
+    pub service: ActorService<R, Application<H>>,
+    pub mailbox: Mailbox<H::Digest>,
+}
+
+impl<H: Hasher> Application<H> {
+    /// Create a new application actor and start the service.
+    pub fn init<R: Rng + Spawner>(context: R, config: Config<H>) -> ApplicationHandle<R, H> {
+        let actor = Self {
+            hasher: config.hasher,
+        };
+        let (mailbox, service) =
+            ServiceBuilder::new(actor).build_with_capacity(context, config.mailbox_size);
+        ApplicationHandle {
+            reporter: Reporter::new(),
+            service,
+            mailbox,
         }
     }
 }

--- a/examples/log/src/application/mod.rs
+++ b/examples/log/src/application/mod.rs
@@ -3,6 +3,7 @@
 //! participants are active at a given view.
 
 use commonware_cryptography::Hasher;
+use std::num::NonZeroUsize;
 
 mod actor;
 pub use actor::Application;
@@ -16,10 +17,7 @@ pub struct Config<H: Hasher> {
     /// Hashing scheme to use.
     pub hasher: H,
 
-    /// Signing scheme for this network.
-    pub scheme: Scheme,
-
     /// Number of messages from consensus to hold in our backlog
     /// before blocking.
-    pub mailbox_size: usize,
+    pub mailbox_size: NonZeroUsize,
 }


### PR DESCRIPTION
## Overview

> [!NOTE]
> Do not merge, stacked on the actor SDK PR.

Migrates `examples/log` to use the [Actor SDK](https://github.com/commonwarexyz/monorepo/pull/3077).

related: https://github.com/commonwarexyz/monorepo/issues/3144
