### PR TITLE
[consensus/ordered-broadcast] Batch-verify ack signatures

### DIFF
--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -13,7 +13,7 @@ use super::{
         Ack, Activity, Chunk, ChunkSigner, ChunkVerifier, Context, Error, Lock, Node, Parent,
         Proposal, SequencersProvider,
     },
-    AckManager, Config, TipManager,
+    AckManager, Config, TipManager, Verifier,
 };
 use crate::{
     types::{Epoch, EpochDelta, Height, HeightDelta},
@@ -40,7 +40,7 @@ use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner, Storage,
 };
 use commonware_storage::journal::segmented::variable::{Config as JournalConfig, Journal};
-use commonware_utils::{channel::oneshot, futures::Pool as FuturesPool, ordered::Quorum};
+use commonware_utils::{channel::oneshot, futures::Pool as FuturesPool, ordered::Quorum, Faults, N3f1};
 use futures::{
     future::{self, Either},
     pin_mut, StreamExt,
@@ -176,6 +176,9 @@ pub struct Engine<
     // This is comprised of votes or certificates.
     ack_manager: AckManager<C::PublicKey, P::Scheme, D>,
 
+    // Buffers incoming acks for batch signature verification.
+    verifier: Verifier<C::PublicKey, P::Scheme, D>,
+
     // The current epoch.
     epoch: Epoch,
 
@@ -243,6 +246,7 @@ impl<
             journals: BTreeMap::new(),
             tip_manager: TipManager::<C::PublicKey, P::Scheme, D>::new(),
             ack_manager: AckManager::<C::PublicKey, P::Scheme, D>::new(),
+            verifier: Verifier::<C::PublicKey, P::Scheme, D>::new(0),
             epoch: Epoch::zero(),
             priority_proposals: cfg.priority_proposals,
             priority_acks: cfg.priority_acks,
@@ -303,6 +307,12 @@ impl<
         let (latest, mut epoch_updates) = self.monitor.subscribe().await;
         self.epoch = latest;
 
+        // Set verifier quorum for the initial epoch
+        if let Some(scheme) = self.validators_provider.scoped(latest) {
+            let n = scheme.participants().len() as u32;
+            self.verifier.set_quorum(N3f1::quorum(n));
+        }
+
         // Before starting on the main loop, initialize my own sequencer journal
         // and attempt to rebroadcast if necessary.
         if let Some(ref signer) = self.sequencer_signer {
@@ -348,6 +358,12 @@ impl<
                 debug!(current = %self.epoch, new = %epoch, "refresh epoch");
                 assert!(epoch >= self.epoch);
                 self.epoch = epoch;
+
+                // Update the verifier quorum for the new epoch
+                if let Some(scheme) = self.validators_provider.scoped(epoch) {
+                    let n = scheme.participants().len() as u32;
+                    self.verifier.set_quorum(N3f1::quorum(n));
+                }
                 continue;
             },
 
@@ -445,7 +461,6 @@ impl<
                         break;
                     }
                 };
-                let mut guard = self.metrics.acks.guard(Status::Invalid);
                 let ack = match msg {
                     Ok(ack) => ack,
                     Err(err) => {
@@ -453,17 +468,11 @@ impl<
                         continue;
                     }
                 };
-                if let Err(err) = self.validate_ack(&ack, &sender) {
+                if let Err(err) = self.validate_ack_cheap(&ack, &sender) {
                     debug!(?err, ?sender, "ack validate failed");
                     continue;
                 };
-                if let Err(err) = self.handle_ack(&ack).await {
-                    debug!(?err, ?sender, "ack handle failed");
-                    guard.set(Status::Failure);
-                    continue;
-                }
-                debug!(?sender, epoch = %ack.epoch, sequencer = ?ack.chunk.sequencer, height = %ack.chunk.height, "ack");
-                guard.set(Status::Success);
+                self.verifier.add(ack, false);
             },
 
             // Handle completed verification futures.
@@ -492,6 +501,33 @@ impl<
                             .await
                         {
                             debug!(?err, ?context, ?payload, "verified handle failed");
+                        }
+                    }
+                }
+            },
+            on_end => {
+                // Batch-verify buffered acks when ready
+                if self.verifier.ready() {
+                    // Use the scheme for the current epoch for verification
+                    if let Some(scheme) = self.validators_provider.scoped(self.epoch) {
+                        let result = self.verifier.verify(
+                            &mut self.context,
+                            scheme.as_ref(),
+                            &self.strategy,
+                        );
+
+                        // Handle verified acks
+                        for ack in &result.acks {
+                            self.metrics.acks.inc(Status::Success);
+                            if let Err(err) = self.handle_ack(ack).await {
+                                debug!(?err, epoch = %ack.epoch, sequencer = ?ack.chunk.sequencer, height = %ack.chunk.height, "ack handle failed");
+                            }
+                        }
+
+                        // Log invalid signers
+                        for invalid in &result.invalid {
+                            debug!(?invalid, "invalid ack signature");
+                            self.metrics.acks.inc(Status::Invalid);
                         }
                     }
                 }
@@ -570,7 +606,8 @@ impl<
             recipients
         };
 
-        // Handle the ack internally
+        // Handle the ack internally (our own ack, already trusted)
+        self.verifier.add(ack.clone(), true);
         self.handle_ack(&ack).await?;
 
         // Send the ack to the network
@@ -838,7 +875,7 @@ impl<
         Ok(())
     }
 
-    /// Send a  `Node` message to all validators in the given epoch.
+    /// Send a `Node` message to all validators in the given epoch.
     async fn broadcast(
         &mut self,
         node: Node<C::PublicKey, P::Scheme, D>,
@@ -909,12 +946,13 @@ impl<
         )
     }
 
-    /// Takes a raw ack (from sender) from the p2p network and validates it.
+    /// Performs cheap validation on an ack from the network.
     ///
-    /// Returns the chunk, epoch, and vote if the ack is valid.
-    /// Returns an error if the ack is invalid.
-    fn validate_ack(
-        &mut self,
+    /// Checks epoch bounds, sender/signer match, and height range.
+    /// Does NOT verify the cryptographic signature -- that is deferred
+    /// to the batch verifier for efficiency.
+    fn validate_ack_cheap(
+        &self,
         ack: &Ack<C::PublicKey, P::Scheme, D>,
         sender: &<P::Scheme as Scheme>::PublicKey,
     ) -> Result<(), Error> {
@@ -960,11 +998,6 @@ impl<
                     bound_hi,
                 ));
             }
-        }
-
-        // Validate the vote signature
-        if !ack.verify(&mut self.context, scheme.as_ref(), &self.strategy) {
-            return Err(Error::InvalidAckSignature);
         }
 
         Ok(())

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -40,7 +40,9 @@ use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner, Storage,
 };
 use commonware_storage::journal::segmented::variable::{Config as JournalConfig, Journal};
-use commonware_utils::{channel::oneshot, futures::Pool as FuturesPool, ordered::Quorum, Faults, N3f1};
+use commonware_utils::{
+    channel::oneshot, futures::Pool as FuturesPool, ordered::Quorum, Faults, N3f1,
+};
 use futures::{
     future::{self, Either},
     pin_mut, StreamExt,

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -467,11 +467,13 @@ impl<
                     Ok(ack) => ack,
                     Err(err) => {
                         debug!(?err, ?sender, "ack decode failed");
+                        self.metrics.acks.inc(Status::Invalid);
                         continue;
                     }
                 };
                 if let Err(err) = self.validate_ack_cheap(&ack, &sender) {
                     debug!(?err, ?sender, "ack validate failed");
+                    self.metrics.acks.inc(Status::Dropped);
                     continue;
                 };
                 self.verifier.add(ack, false);

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -478,7 +478,7 @@ impl<
                         continue;
                     }
                 };
-                if let Err(err) = self.validate_ack_cheap(&ack, &sender) {
+                if let Err(err) = self.validate_ack(&ack, &sender) {
                     debug!(?err, ?sender, "ack validate failed");
                     self.metrics.acks.inc(Status::Dropped);
                     continue;
@@ -961,12 +961,12 @@ impl<
         )
     }
 
-    /// Performs cheap validation on an ack from the network.
+    /// Validates an ack from the network.
     ///
     /// Checks epoch bounds, sender/signer match, and height range.
     /// Does NOT verify the cryptographic signature -- that is deferred
     /// to the batch verifier for efficiency.
-    fn validate_ack_cheap(
+    fn validate_ack(
         &self,
         ack: &Ack<C::PublicKey, P::Scheme, D>,
         sender: &<P::Scheme as Scheme>::PublicKey,

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -64,6 +64,8 @@ cfg_if::cfg_if! {
         mod metrics;
         mod tip_manager;
         use tip_manager::TipManager;
+        mod verifier;
+        use verifier::Verifier;
     }
 }
 


### PR DESCRIPTION
Fixes #1002. Previously, `ordered_broadcast` verified each ack signature individually inline as it arrived (`scheme.verify_attestation()`), while the `certificate::Scheme` trait already exposes `verify_attestations()` for efficient batch verification. Simplex already uses batch verification via its `Verifier` struct; this PR brings the same optimization to `ordered_broadcast`.

- Add a `Verifier` that buffers incoming acks and batch-verifies their cryptographic signatures, replacing the previous inline per-ack verification
- Split `validate_ack` into cheap validation (epoch bounds, sender/signer match, height range) and deferred signature verification via the batch verifier
- Self-generated acks bypass the verifier as pre-verified for correct quorum accounting

## Motivation


## Design

The `Verifier` groups pending acks by their signing subject `(Chunk, Epoch)` -- acks sharing the same subject produce identical `AckSubject` values and can be batch-verified together. Readiness is quorum-aware:

- **Batchable schemes** (ed25519, BLS multisig, BLS threshold): verification is deferred until `verified + pending >= quorum` for a given subject
- **Non-batchable schemes** (secp256r1): verification happens eagerly since there is no batching benefit

Batch verification runs in the `on_end` block of the engine's `select_loop!`, so it executes after every select iteration. The verifier's quorum is updated whenever the epoch changes.