### PR TITLE
[consensus/ordered-broadcast] Fix typos and remove stale test lint allows

### DIFF
--- a/consensus/src/ordered_broadcast/ack_manager.rs
+++ b/consensus/src/ordered_broadcast/ack_manager.rs
@@ -158,11 +158,9 @@ impl<P: PublicKey, S: Scheme, D: Digest> AckManager<P, S, D> {
 }
 
 #[cfg(test)]
-#[allow(dead_code, unused_imports)]
 mod tests {
     use super::*;
     use crate::ordered_broadcast::{
-        mocks,
         scheme::{bls12381_multisig, bls12381_threshold, ed25519, secp256r1, Scheme},
         types::Chunk,
     };
@@ -175,7 +173,7 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_utils::test_rng;
     use helpers::Sha256Digest;
-    use rand::{rngs::StdRng, SeedableRng as _};
+    use rand::rngs::StdRng;
 
     const NAMESPACE: &[u8] = b"1234";
 

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -829,7 +829,7 @@ impl<
         Ok(())
     }
 
-    /// Send a  `Node` message to all validators in the given epoch.
+    /// Send a `Node` message to all validators in the given epoch.
     fn broadcast(
         &mut self,
         node: Node<C::PublicKey, P::Scheme, D>,

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -507,7 +507,7 @@ pub struct Node<P: PublicKey, S: Scheme, D: Digest> {
 
     /// Information about the parent chunk (previous height)
     ///
-    /// This part is not signed over, but it is used to verif that the previous chunk
+    /// This part is not signed over, but it is used to verify that the previous chunk
     /// in the chain was correctly broadcast. It contains the certificate that proves
     /// a quorum of validators acknowledged the parent.
     ///


### PR DESCRIPTION
Small cleanups in `ordered_broadcast`:
- Fix `verif` -> `verify` typo in `types.rs`
- Fix double space in `engine.rs` doc comment
- Remove blanket `#[allow(dead_code, unused_imports)]` on the `ack_manager` test module and drop the imports it was hiding

(Previously this PR also reworked the AGENTS.md namespace docs and fixed clippy 1.97 lints; the former was dropped and the latter landed on main in #4213.)