### PR TITLE
[marshal/coding] Support non-participant reconstruction

### DIFF
--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -795,15 +795,17 @@ where
         }
 
         // Send the leader's strong shard to tracked peers outside the participant set.
-        let non_participants = self
+        let non_participants: Vec<P> = self
             .tracked_peers
             .iter()
             .filter(|peer| participants.index(peer).is_none())
             .cloned()
             .collect();
-        let _ = sender
-            .send(Recipients::Some(non_participants), leader_shard, true)
-            .await;
+        if !non_participants.is_empty() {
+            let _ = sender
+                .send(Recipients::Some(non_participants), leader_shard, true)
+                .await;
+        }
 
         // Cache the block so we don't have to reconstruct it again.
         let block = Arc::new(block);


### PR DESCRIPTION
## Overview

Modifies the shard engine to allow non-participants to reconstruct blocks. For networks that employ DKG, a common practice is to allow for players to join 1 epoch ahead of their participation in the ceremony. Currently, this means that these nodes would need to rely on participants to forward them full blocks via the resolver. These participants were already sent a weak shard, but the leader never sent them a strong shard to form `CheckingData`.

After this PR, the leader will broadcast their own strong shard to members in the peer set that are not participants. This enables them to take advantage of the erasure coded broadcast path, and in doing so these non-participants put less of a burden on the members of the active committee.

A few rules were changed to support this:
- Leaders now send their own strong shard to non-participants.
- Non-participants now construct a reconstruction state machine on `Discovered`.
- Non-participants now accept strong shards, though the shard index is asserted to be that of the leader's, not self.
- During rebroadcast, an extra check was added to ensure only participants rebroadcast their shards.
