### PR TITLE
[Storage] Add support for variable-length keys in ordered QMDBs

### DIFF
--- a/storage/src/qmdb/any/operation/mod.rs
+++ b/storage/src/qmdb/any/operation/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 use commonware_codec::{Codec, Encode as _};
-use commonware_utils::{hex, Array};
+use commonware_utils::hex;
 use std::fmt;
 
 pub(crate) mod fixed;
@@ -93,13 +93,13 @@ where
 
 impl<K, V> fmt::Display for Operation<K, V, update::Ordered<K, V>>
 where
-    K: Array + fmt::Display,
+    K: Key,
     V: ValueEncoding,
     V::Value: Codec,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Delete(key) => write!(f, "[key:{key} <deleted>]"),
+            Self::Delete(key) => write!(f, "[key:{} <deleted>]", hex(key)),
             Self::Update(payload) => payload.fmt(f),
             Self::CommitFloor(value, loc) => {
                 if let Some(value) = value {

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -14,14 +14,13 @@ use crate::{
     qmdb::{
         any::{db::Db, ValueEncoding},
         delete_known_loc,
-        operation::Operation as OperationTrait,
+        operation::{Key, Operation as OperationTrait},
         update_known_loc, DurabilityState, Error, MerkleizationState, NonDurable, Unmerkleized,
     },
 };
 use commonware_codec::{Codec, CodecShared};
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage};
-use commonware_utils::Array;
 #[cfg(any(test, feature = "test-traits"))]
 use core::ops::Range;
 use futures::{
@@ -43,7 +42,7 @@ type LocatedKey<K, V> = Option<(Location, Update<K, V>)>;
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: ValueEncoding,
         C: Contiguous<Item = Operation<K, V>>,
         I: Index<Value = Location>,
@@ -231,7 +230,7 @@ where
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: ValueEncoding,
         C: Mutable<Item = Operation<K, V>>,
         I: Index<Value = Location>,
@@ -468,7 +467,7 @@ where
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: ValueEncoding,
         C: Contiguous<Item = Operation<K, V>>,
         I: Index<Value = Location> + Send + Sync + 'static,
@@ -532,7 +531,7 @@ fn find_prev_key<'a, K: Ord, V>(key: &K, possible_previous: &'a BTreeMap<K, V>) 
 impl<E, K, V, C, I, H> Batchable for Db<E, C, I, H, Update<K, V>, Unmerkleized, NonDurable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<K, V>>,
     I: Index<Value = Location> + 'static,
@@ -553,7 +552,7 @@ where
 impl<E, K, V, C, I, H> CleanAny for Db<E, C, I, H, Update<K, V>, Merkleized<H>, Durable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     C: PersistableMutableLog<Operation<K, V>>,
     I: Index<Value = Location> + 'static,
@@ -573,7 +572,7 @@ impl<E, K, V, C, I, H> UnmerkleizedDurableAny
     for Db<E, C, I, H, Update<K, V>, Unmerkleized, Durable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     C: PersistableMutableLog<Operation<K, V>>,
     I: Index<Value = Location> + 'static,
@@ -600,7 +599,7 @@ impl<E, K, V, C, I, H> MerkleizedNonDurableAny
     for Db<E, C, I, H, Update<K, V>, Merkleized<H>, NonDurable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     C: PersistableMutableLog<Operation<K, V>>,
     I: Index<Value = Location> + 'static,
@@ -619,7 +618,7 @@ where
 impl<E, K, V, C, I, H> MutableAny for Db<E, C, I, H, Update<K, V>, Unmerkleized, NonDurable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     C: PersistableMutableLog<Operation<K, V>>,
     I: Index<Value = Location> + 'static,

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -247,10 +247,11 @@ impl<E, K, V, H, T> qmdb::sync::Database
     for OrderedVariableDb<E, K, V, H, T, Merkleized<H>, Durable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: VariableValue + 'static,
     H: Hasher,
     T: Translator,
+    OrderedVariableOp<K, V>: CodecShared,
 {
     type Context = E;
     type Op = OrderedVariableOp<K, V>;

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -36,9 +36,7 @@ use commonware_codec::{Codec, CodecShared, DecodeExt};
 use commonware_cryptography::{Digest, DigestOf, Hasher};
 use commonware_parallel::ThreadPool;
 use commonware_runtime::{Clock, Metrics, Storage};
-use commonware_utils::{
-    bitmap::Prunable as BitMap, sequence::prefixed_u64::U64, sync::AsyncMutex, Array,
-};
+use commonware_utils::{bitmap::Prunable as BitMap, sequence::prefixed_u64::U64, sync::AsyncMutex};
 use core::{num::NonZeroU64, ops::Range};
 use futures::future::try_join_all;
 use rayon::prelude::*;
@@ -129,7 +127,7 @@ pub struct Db<
 impl<E, K, V, C, I, H, U, const N: usize, S, D> Db<E, C, I, H, U, N, S, D>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Contiguous<Item = Operation<K, V, U>>,
@@ -173,7 +171,7 @@ where
 impl<E, K, V, U, C, I, H, D, const N: usize> Db<E, C, I, H, U, N, Merkleized<DigestOf<H>>, D>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Contiguous<Item = Operation<K, V, U>>,
@@ -338,7 +336,7 @@ where
 impl<E, K, V, U, C, I, H, const N: usize> Db<E, C, I, H, U, N, Merkleized<DigestOf<H>>, Durable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Mutable<Item = Operation<K, V, U>> + Persistable<Error = JournalError>,
@@ -383,7 +381,7 @@ where
 impl<E, K, V, U, C, I, H, const N: usize, D> Db<E, C, I, H, U, N, Unmerkleized, D>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Contiguous<Item = Operation<K, V, U>>,
@@ -484,7 +482,7 @@ where
 impl<E, K, V, U, C, I, H, const N: usize> Db<E, C, I, H, U, N, Unmerkleized, Durable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Contiguous<Item = Operation<K, V, U>>,
@@ -511,7 +509,7 @@ where
 impl<E, K, V, U, C, I, H, const N: usize> Db<E, C, I, H, U, N, Unmerkleized, NonDurable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Mutable<Item = Operation<K, V, U>> + Persistable<Error = JournalError>,
@@ -598,7 +596,7 @@ where
 impl<E, K, V, U, C, I, H, const N: usize> Db<E, C, I, H, U, N, Merkleized<DigestOf<H>>, NonDurable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Mutable<Item = Operation<K, V, U>>,
@@ -625,7 +623,7 @@ impl<E, K, V, U, C, I, H, const N: usize> Persistable
     for Db<E, C, I, H, U, N, Merkleized<DigestOf<H>>, Durable>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Mutable<Item = Operation<K, V, U>> + Persistable<Error = JournalError>,
@@ -657,7 +655,7 @@ impl<E, K, V, U, C, I, H, D, const N: usize> MerkleizedStore
     for Db<E, C, I, H, U, N, Merkleized<DigestOf<H>>, D>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Mutable<Item = Operation<K, V, U>>,
@@ -688,7 +686,7 @@ where
 impl<E, K, V, U, C, I, H, const N: usize, S, D> LogStore for Db<E, C, I, H, U, N, S, D>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Contiguous<Item = Operation<K, V, U>>,
@@ -713,7 +711,7 @@ impl<E, K, V, U, C, I, H, D, const N: usize> PrunableStore
     for Db<E, C, I, H, U, N, Merkleized<DigestOf<H>>, D>
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V>,
     C: Mutable<Item = Operation<K, V, U>>,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -182,7 +182,7 @@ use crate::{
             operation::{Operation, Update},
             FixedConfig as AnyFixedConfig, ValueEncoding, VariableConfig as AnyVariableConfig,
         },
-        operation::Committable,
+        operation::{Committable, Key},
         Durable, Error,
     },
     translator::Translator,
@@ -415,7 +415,7 @@ pub(super) async fn init_variable<E, K, V, U, H, T, I, const N: usize, NewIndex>
 >
 where
     E: Storage + Clock + Metrics,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     U: Update<K, V> + Send + Sync,
     H: Hasher,

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -17,18 +17,19 @@ use crate::{
             db::{Merkleized, State, Unmerkleized},
             proof::OperationProof,
         },
+        operation::Key,
         store, DurabilityState, Durable, Error, NonDurable,
     },
 };
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage};
-use commonware_utils::{bitmap::Prunable as BitMap, Array};
+use commonware_utils::bitmap::Prunable as BitMap;
 use futures::stream::Stream;
 
 /// Proof information for verifying a key has a particular value in the database.
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub struct KeyValueProof<K: Array, D: Digest, const N: usize> {
+pub struct KeyValueProof<K: Key, D: Digest, const N: usize> {
     pub proof: OperationProof<D, N>,
     pub next_key: K,
 }
@@ -44,7 +45,7 @@ pub type Db<E, C, K, V, I, H, const N: usize, S = Merkleized<DigestOf<H>>, D = D
 impl<
         E: Storage + Clock + Metrics,
         C: Contiguous<Item = Operation<K, V>>,
-        K: Array,
+        K: Key,
         V: ValueEncoding,
         I: OrderedIndex<Value = Location>,
         H: Hasher,
@@ -143,7 +144,7 @@ where
 impl<
         E: Storage + Clock + Metrics,
         C: Mutable<Item = Operation<K, V>>,
-        K: Array,
+        K: Key,
         V: ValueEncoding,
         I: OrderedIndex<Value = Location>,
         H: Hasher,
@@ -228,7 +229,7 @@ where
 impl<
         E: Storage + Clock + Metrics,
         C: Mutable<Item = Operation<K, V>>,
-        K: Array,
+        K: Key,
         V: ValueEncoding,
         I: OrderedIndex<Value = Location>,
         H: Hasher,
@@ -269,7 +270,7 @@ where
 impl<
         E: Storage + Clock + Metrics,
         C: Contiguous<Item = Operation<K, V>>,
-        K: Array,
+        K: Key,
         V: ValueEncoding,
         I: OrderedIndex<Value = Location>,
         H: Hasher,
@@ -296,7 +297,7 @@ impl<E, C, K, V, I, H, const N: usize> Batchable
 where
     E: Storage + Clock + Metrics,
     C: Mutable<Item = Operation<K, V>>,
-    K: Array,
+    K: Key,
     V: ValueEncoding,
     I: OrderedIndex<Value = Location> + 'static,
     H: Hasher,

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -11,9 +11,9 @@
 use crate::qmdb::{
     any::{ordered::Update, ValueEncoding},
     current::proof::OperationProof,
+    operation::Key,
 };
 use commonware_cryptography::Digest;
-use commonware_utils::Array;
 
 pub mod db;
 pub mod fixed;
@@ -146,7 +146,7 @@ pub mod tests {
 ///
 /// Verify using [Db::verify_exclusion_proof](fixed::Db::verify_exclusion_proof).
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub enum ExclusionProof<K: Array, V: ValueEncoding, D: Digest, const N: usize> {
+pub enum ExclusionProof<K: Key, V: ValueEncoding, D: Digest, const N: usize> {
     /// Proves that two keys are active in the database and adjacent to each other in the key
     /// ordering. Any key falling between them (non-inclusively) can be proven excluded.
     KeyValue(OperationProof<D, N>, Update<K, V>),

--- a/storage/src/qmdb/current/ordered/test_trait_impls.rs
+++ b/storage/src/qmdb/current/ordered/test_trait_impls.rs
@@ -16,12 +16,13 @@ use crate::{
             db::{Merkleized, Unmerkleized},
             BitmapPrunedBits,
         },
+        operation::Key,
         store::LogStore as _,
         Durable, Error, NonDurable,
     },
     translator::Translator,
 };
-use commonware_codec::Read;
+use commonware_codec::Codec;
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_utils::Array;
@@ -119,14 +120,14 @@ impl<
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
         const N: usize,
     > CleanAny for variable::Db<E, K, V, H, T, N, Merkleized<DigestOf<H>>, Durable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     type Mutable = variable::Db<E, K, V, H, T, N, Unmerkleized, NonDurable>;
 
@@ -137,14 +138,14 @@ where
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
         const N: usize,
     > UnmerkleizedDurableAny for variable::Db<E, K, V, H, T, N, Unmerkleized, Durable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     type Digest = H::Digest;
     type Operation = VariableOperation<K, V>;
@@ -162,7 +163,7 @@ where
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
@@ -170,7 +171,7 @@ impl<
     > MerkleizedNonDurableAny
     for variable::Db<E, K, V, H, T, N, Merkleized<DigestOf<H>>, NonDurable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     type Mutable = variable::Db<E, K, V, H, T, N, Unmerkleized, NonDurable>;
 
@@ -181,14 +182,14 @@ where
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
         const N: usize,
     > MutableAny for variable::Db<E, K, V, H, T, N, Unmerkleized, NonDurable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     type Digest = H::Digest;
     type Operation = VariableOperation<K, V>;
@@ -236,14 +237,14 @@ impl<
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
         const N: usize,
     > BitmapPrunedBits for variable::Db<E, K, V, H, T, N, Merkleized<DigestOf<H>>, Durable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     fn pruned_bits(&self) -> u64 {
         self.status.pruned_bits()
@@ -381,7 +382,7 @@ impl<
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
@@ -389,7 +390,7 @@ impl<
         const N: usize,
     > CleanAny for variable::partitioned::Db<E, K, V, H, T, P, N, Merkleized<DigestOf<H>>, Durable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     type Mutable = variable::partitioned::Db<E, K, V, H, T, P, N, Unmerkleized, NonDurable>;
 
@@ -400,7 +401,7 @@ where
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
@@ -409,7 +410,7 @@ impl<
     > UnmerkleizedDurableAny
     for variable::partitioned::Db<E, K, V, H, T, P, N, Unmerkleized, Durable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     type Digest = H::Digest;
     type Operation = VariableOperation<K, V>;
@@ -428,7 +429,7 @@ where
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
@@ -437,7 +438,7 @@ impl<
     > MerkleizedNonDurableAny
     for variable::partitioned::Db<E, K, V, H, T, P, N, Merkleized<DigestOf<H>>, NonDurable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     type Mutable = variable::partitioned::Db<E, K, V, H, T, P, N, Unmerkleized, NonDurable>;
 
@@ -448,7 +449,7 @@ where
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
@@ -456,7 +457,7 @@ impl<
         const N: usize,
     > MutableAny for variable::partitioned::Db<E, K, V, H, T, P, N, Unmerkleized, NonDurable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     type Digest = H::Digest;
     type Operation = VariableOperation<K, V>;
@@ -479,7 +480,7 @@ where
 
 impl<
         E: Storage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
@@ -488,7 +489,7 @@ impl<
     > BitmapPrunedBits
     for variable::partitioned::Db<E, K, V, H, T, P, N, Merkleized<DigestOf<H>>, Durable>
 where
-    VariableOperation<K, V>: Read,
+    VariableOperation<K, V>: Codec,
 {
     fn pruned_bits(&self) -> u64 {
         self.status.pruned_bits()

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -14,14 +14,14 @@ use crate::{
     qmdb::{
         any::{ordered::variable::Operation, value::VariableEncoding, VariableValue},
         current::{db::Merkleized, VariableConfig as Config},
+        operation::Key,
         Durable, Error,
     },
     translator::Translator,
 };
-use commonware_codec::Read;
+use commonware_codec::{Codec, Read};
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_runtime::{Clock, Metrics, Storage as RStorage};
-use commonware_utils::Array;
 
 pub type Db<E, K, V, H, T, const N: usize, S = Merkleized<DigestOf<H>>, D = Durable> =
     super::db::Db<
@@ -39,14 +39,14 @@ pub type Db<E, K, V, H, T, const N: usize, S = Merkleized<DigestOf<H>>, D = Dura
 // Functionality for the Merkleized state - init only.
 impl<
         E: RStorage + Clock + Metrics,
-        K: Array,
+        K: Key,
         V: VariableValue,
         H: Hasher,
         T: Translator,
         const N: usize,
     > Db<E, K, V, H, T, N, Merkleized<DigestOf<H>>, Durable>
 where
-    Operation<K, V>: Read,
+    Operation<K, V>: Codec,
 {
     /// Initializes a [Db] from the given `config`. Leverages parallel Merkleization to initialize
     /// the bitmap MMR if a thread pool is provided.
@@ -71,14 +71,14 @@ pub mod partitioned {
                 ordered::variable::partitioned::Operation, value::VariableEncoding, VariableValue,
             },
             current::{db::Merkleized, VariableConfig as Config},
+            operation::Key,
             Durable, Error,
         },
         translator::Translator,
     };
-    use commonware_codec::Read;
+    use commonware_codec::{Codec, Read};
     use commonware_cryptography::{DigestOf, Hasher};
     use commonware_runtime::{Clock, Metrics, Storage as RStorage};
-    use commonware_utils::Array;
 
     /// A partitioned variant of [super::Db].
     ///
@@ -110,7 +110,7 @@ pub mod partitioned {
 
     impl<
             E: RStorage + Clock + Metrics,
-            K: Array,
+            K: Key,
             V: VariableValue,
             H: Hasher,
             T: Translator,
@@ -118,7 +118,7 @@ pub mod partitioned {
             const N: usize,
         > Db<E, K, V, H, T, P, N, Merkleized<DigestOf<H>>, Durable>
     where
-        Operation<K, V>: Read,
+        Operation<K, V>: Codec,
     {
         /// Initializes a [Db] from the given `config`. Leverages parallel Merkleization to initialize
         /// the bitmap MMR if a thread pool is provided.


### PR DESCRIPTION
Same treatment as #3233 for ordered QMDBs. This PR (and #3233) implement resolve #3190.