### PR TITLE
[examples] Add overview descriptions to flood and reshare READMEs

### DIFF
--- a/examples/flood/README.md
+++ b/examples/flood/README.md
@@ -2,8 +2,13 @@
 
 [![Crates.io](https://img.shields.io/crates/v/commonware-flood.svg)](https://crates.io/crates/commonware-flood)
 
-Flood peers [deployed to AWS EC2](https://docs.rs/commonware-deployer/latest/commonware_deployer/ec2/index.html) with
-random messages.
+This example demonstrates how to build an application that employs
+[commonware-p2p::authenticated::discovery](https://docs.rs/commonware-p2p/latest/commonware_p2p/authenticated/discovery/index.html)
+to flood peers deployed to AWS EC2 with random messages and measure delivery latency. Peers are identified using
+[commonware-cryptography::ed25519](https://docs.rs/commonware-cryptography/latest/commonware_cryptography/ed25519/index.html)
+key pairs and deployed across multiple AWS regions using
+[commonware-deployer](https://docs.rs/commonware-deployer/latest/commonware_deployer/ec2/index.html). Performance is
+tracked via Prometheus metrics and visualized with a Grafana dashboard.
 
 ## Setup
 

--- a/examples/flood/src/lib.rs
+++ b/examples/flood/src/lib.rs
@@ -1,4 +1,9 @@
-//! Spam peers deployed to AWS EC2 with random messages.
+//! This example demonstrates how to build an application that employs
+//! [commonware_p2p::authenticated::discovery] to flood peers deployed to AWS EC2 with random
+//! messages and measure delivery latency. Peers are identified using
+//! [commonware_cryptography::ed25519] key pairs and deployed across multiple AWS regions using
+//! [commonware_deployer]. Performance is tracked via Prometheus metrics and visualized with a
+//! Grafana dashboard.
 //!
 //! # Setup
 //!

--- a/examples/reshare/README.md
+++ b/examples/reshare/README.md
@@ -4,6 +4,23 @@
 
 Reshare a threshold secret over an epoched log.
 
+## Overview
+
+`commonware-reshare` demonstrates how to build an application that employs [commonware_consensus::simplex](https://docs.rs/commonware-consensus/latest/commonware_consensus/simplex/index.html)
+and [commonware_cryptography::bls12381::dkg](https://docs.rs/commonware-cryptography/latest/commonware_cryptography/bls12381/dkg/index.html)
+to periodically reshare a BLS12-381 threshold secret across epochs with a dynamic validator set.
+
+The system starts by bootstrapping consensus with Ed25519 signatures (non-threshold) and executes a distributed key
+generation (DKG) protocol to establish threshold shares. Once the DKG completes, consensus transitions to BLS12-381
+threshold signing. At each subsequent epoch boundary, the secret is reshared to accommodate validator set changes.
+
+Key features:
+- Two startup modes: trusted setup (pre-generated shares) or DKG (distributed share generation).
+- Epoch-based consensus with dynamic dealer selection per epoch.
+- Persistent DKG state via [commonware_storage](https://docs.rs/commonware-storage) journals for crash recovery.
+- Byzantine fault tolerance using the Simplex consensus protocol with an N3f1 threshold.
+- Authenticated peer-to-peer networking via [commonware_p2p](https://docs.rs/commonware-p2p) with 6 muxed channels for votes, certificates, resolver, broadcast, marshal, and DKG messages.
+
 ## Setup
 
 _To run this example, you must first install [Rust](https://www.rust-lang.org/tools/install) and [`mprocs`](https://github.com/pvolok/mprocs)._


### PR DESCRIPTION
## Summary
Just noticed that the other examples (bridge, chat, estimator, log, sync) had pretty descriptive overviews/explanations in their ReadMe's, so I thought I would add the same to these two examples cuz I didn't know what they were immediately :)

## Changes
- Added an overview section to `examples/flood/README.md` and `examples/flood/src/lib.rs`
- Added an overview section to `examples/reshare/README.md`