### PR TITLE
chore: remove redundant drop of old_item in ring sender

### DIFF
--- a/utils/src/channel/ring.rs
+++ b/utils/src/channel/ring.rs
@@ -131,8 +131,7 @@ impl<T: Send + Sync> Sink<T> for Sender<T> {
         let waker = shared.receiver_waker.take();
         drop(shared);
 
-        // Drop the old item after the lock is released to avoid potential mutex poisoning
-        drop(old_item);
+        // `old_item` is dropped after releasing the lock (end of scope)
 
         if let Some(w) = waker {
             w.wake();


### PR DESCRIPTION
Remove redundant explicit drop of old_item. The value is dropped at the end of the scope after the mutex guard is released, so the explicit drop call is unnecessary.