### PR TITLE
[cryptography/dkg] validate players length before cast in deal()

### DIFF
--- a/cryptography/src/bls12381/dkg.rs
+++ b/cryptography/src/bls12381/dkg.rs
@@ -1703,8 +1703,9 @@ pub fn deal<V: Variant, P: Clone + Ord, M: Faults>(
     mode: Mode,
     players: Set<P>,
 ) -> DealResult<V, P> {
-    if players.is_empty() {
-        return Err(Error::NumPlayers(0));
+    let participant_range = 1..u32::MAX as usize;
+    if !participant_range.contains(&players.len()) {
+        return Err(Error::NumPlayers(players.len()));
     }
     let n = NZU32!(players.len() as u32);
     let t = players.quorum::<M>();


### PR DESCRIPTION
Fixes #3062 

The issue flagged that `deal()` was casting `players.len() as u32` without validating the upper bound. Values above `u32::MAX` silently truncate — a set of `u32::MAX + 2` players would cast to `1`, causing `deal()` to compute a DKG with `n = 1` instead of the real participant count, producing cryptographically invalid shares with no error surfaced to the caller.

The issue decription alos mentioned that `Info::new()` already solves this exactly using a `participant_range` guard that covers both the lower bound (empty) and upper bound (overflow) in one check, reusing the existing `Error::NumPlayers` variant. `deal()` is a convenience helper that bypasses the full DKG path and had simply missed copying this guard.

The fix mirrors `Info::new()` directly so the validation pattern is consistent across the file.

Closes #3062 