### PR TITLE
[workspace] Re-categorize tests

### DIFF
--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -256,6 +256,7 @@ mod test {
     use commonware_codec::Encode;
     use commonware_cryptography::Sha256;
     use commonware_invariants::minifuzz;
+    use commonware_macros::test_group;
     use commonware_parallel::Sequential;
     use commonware_utils::NZU16;
 
@@ -398,6 +399,7 @@ mod test {
             });
     }
 
+    #[test_group("slow")]
     #[test]
     fn minifuzz_roundtrip_zoda() {
         minifuzz::Builder::default()

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -353,6 +353,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("INFO")]
     fn test_all_online() {
         all_online(bls12381_threshold::fixture::<MinPk, _>);
@@ -562,6 +563,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test_traced("INFO")]
     fn test_unclean_byzantine_shutdown() {
         unclean_byzantine_shutdown(bls12381_threshold::fixture::<MinPk, _>);
@@ -766,6 +768,7 @@ mod tests {
         deterministic::Runner::from(checkpoint).start(f2);
     }
 
+    #[test_group("slow")]
     #[test_traced("INFO")]
     fn test_unclean_shutdown_with_unsigned_height() {
         unclean_shutdown_with_unsigned_height(bls12381_threshold::fixture::<MinPk, _>);
@@ -824,6 +827,7 @@ mod tests {
         })
     }
 
+    #[test_group("slow")]
     #[test_traced("INFO")]
     fn test_slow_and_lossy_links() {
         slow_and_lossy_links(bls12381_threshold::fixture::<MinPk, _>, 0);
@@ -934,6 +938,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("INFO")]
     fn test_one_offline() {
         one_offline(bls12381_threshold::fixture::<MinPk, _>);

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -90,13 +90,14 @@ mod tests {
         sha256::Sha256,
         Committable, Digestible, Hasher as _,
     };
-    use commonware_macros::{select, test_traced};
+    use commonware_macros::{select, test_group, test_traced};
     use commonware_p2p::Manager;
     use commonware_parallel::Sequential;
     use commonware_runtime::{deterministic, Clock, Metrics, Runner};
     use commonware_utils::NZU16;
     use std::time::Duration;
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_coding_finalize_good_links() {
         for seed in 0..5 {
@@ -106,6 +107,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_coding_finalize_bad_links() {
         for seed in 0..5 {
@@ -115,6 +117,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_coding_finalize_good_links_quorum_sees_finalization() {
         for seed in 0..5 {
@@ -124,6 +127,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_coding_finalize_bad_links_quorum_sees_finalization() {
         for seed in 0..5 {

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -62,7 +62,7 @@ mod tests {
         sha256::Sha256,
         Digestible, Hasher as _,
     };
-    use commonware_macros::test_traced;
+    use commonware_macros::{test_group, test_traced};
     use commonware_runtime::{deterministic, Clock, Metrics, Runner};
     use commonware_utils::channel::oneshot;
     use std::time::Duration;
@@ -77,6 +77,7 @@ mod tests {
         assert_eq!(r1, r2);
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_standard_finalize_good_links() {
         for seed in 0..5 {
@@ -85,6 +86,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_standard_finalize_bad_links() {
         for seed in 0..5 {
@@ -93,6 +95,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_standard_finalize_good_links_quorum_sees_finalization() {
         for seed in 0..5 {
@@ -101,6 +104,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_standard_finalize_bad_links_quorum_sees_finalization() {
         for seed in 0..5 {

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -383,6 +383,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_all_online() {
         all_online(bls12381_threshold::fixture::<MinPk, _>);
@@ -470,6 +471,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_unclean_shutdown() {
         unclean_shutdown(bls12381_threshold::fixture::<MinPk, _>);
@@ -601,6 +603,7 @@ mod tests {
         })
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_slow_and_lossy_links() {
         slow_and_lossy_links(bls12381_threshold::fixture::<MinPk, _>, 0);
@@ -708,6 +711,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_invalid_signature_injection() {
         invalid_signature_injection(bls12381_threshold::fixture::<MinPk, _>);
@@ -1032,6 +1036,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_external_sequencer() {
         external_sequencer(bls12381_threshold::fixture::<MinPk, _>);

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -899,6 +899,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_all_online() {
         all_online::<_, _, Random>(bls12381_threshold_vrf::fixture::<MinPk, _>);
@@ -1066,6 +1067,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_observer() {
         observer::<_, _, Random>(bls12381_threshold_vrf::fixture::<MinPk, _>);
@@ -1527,6 +1529,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_backfill() {
         backfill::<_, _, Random>(bls12381_threshold_vrf::fixture::<MinPk, _>);
@@ -1775,6 +1778,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_one_offline() {
         one_offline::<_, _, Random>(bls12381_threshold_vrf::fixture::<MinPk, _>);
@@ -1966,6 +1970,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_slow_validator() {
         slow_validator::<_, _, Random>(bls12381_threshold_vrf::fixture::<MinPk, _>);
@@ -2182,6 +2187,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_all_recovery() {
         all_recovery::<_, _, Random>(bls12381_threshold_vrf::fixture::<MinPk, _>);
@@ -2549,6 +2555,7 @@ mod tests {
         })
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_slow_and_lossy_links() {
         slow_and_lossy_links::<_, _, Random>(0, bls12381_threshold_vrf::fixture::<MinPk, _>);
@@ -4375,6 +4382,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_children_shutdown_on_engine_abort() {
         for seed in 0..10 {
@@ -4413,6 +4421,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_graceful_shutdown() {
         for seed in 0..10 {
@@ -5020,6 +5029,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced]
     fn test_split_views_no_lockup() {
         split_views_no_lockup::<_, _, Random>(bls12381_threshold_vrf::fixture::<MinPk, _>);

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1750,6 +1750,7 @@ mod tests {
     use crate::bls12381::primitives::group::Scalar;
     use commonware_codec::{DecodeExt, Encode};
     use commonware_invariants::minifuzz;
+    use commonware_macros::test_group;
     use commonware_math::algebra::{test_suites, Random};
     use commonware_parallel::{Rayon, Sequential};
     use commonware_utils::test_rng;
@@ -1758,31 +1759,37 @@ mod tests {
         num::NonZeroUsize,
     };
 
+    #[test_group("slow")]
     #[test]
     fn test_scalar_as_field() {
         minifuzz::test(test_suites::fuzz_field::<Scalar>);
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_scalar_as_field_ntt() {
         minifuzz::test(test_suites::fuzz_field_ntt::<Scalar>);
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_g1_as_space() {
         minifuzz::test(test_suites::fuzz_space_ring::<Scalar, G1>);
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_g2_as_space() {
         minifuzz::test(test_suites::fuzz_space_ring::<Scalar, G2>);
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_hash_to_g1() {
         minifuzz::test(test_suites::fuzz_hash_to_group::<G1>);
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_hash_to_g2() {
         minifuzz::test(test_suites::fuzz_hash_to_group::<G2>);
@@ -1938,6 +1945,7 @@ mod tests {
         assert_eq!(expected_g1, result_g1, "G1 MSM basic case failed");
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_g2_msm() {
         let mut rng = test_rng();
@@ -2186,6 +2194,7 @@ mod tests {
         assert_eq!(G::msm(&pts, &scalars, &par), single_point * &single_scalar);
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_msm_parallel_g1() {
         minifuzz::test(|u| {
@@ -2201,6 +2210,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_msm_parallel_g2() {
         minifuzz::test(|u| {
@@ -2216,6 +2226,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_msm_parallel_edge_cases_g1() {
         minifuzz::test(|u| {
@@ -2233,6 +2244,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_msm_parallel_edge_cases_g2() {
         minifuzz::test(|u| {

--- a/cryptography/src/bls12381/primitives/sharing.rs
+++ b/cryptography/src/bls12381/primitives/sharing.rs
@@ -441,6 +441,7 @@ impl<V: Variant> Read for Sharing<V> {
 mod tests {
     use super::*;
     use commonware_invariants::minifuzz;
+    use commonware_macros::test_group;
     use commonware_utils::ordered::Map;
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -463,6 +464,7 @@ mod tests {
             .expect_err("roots mode must be rejected when max mode is counter");
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_all_scalars_matches_scalar() {
         minifuzz::test(|u| {
@@ -484,6 +486,7 @@ mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_subset_interpolation_recovers_constant() {
         minifuzz::test(|u| {

--- a/math/src/algebra.rs
+++ b/math/src/algebra.rs
@@ -754,6 +754,7 @@ commonware_macros::stability_scope!(ALPHA {
             }
         }
 
+        #[commonware_macros::test_group("slow")]
         #[test]
         fn test_fuzz() {
             commonware_invariants::minifuzz::test(|u| u.arbitrary::<Plan>()?.run(u));

--- a/math/src/fields/goldilocks.rs
+++ b/math/src/fields/goldilocks.rs
@@ -474,6 +474,7 @@ pub mod fuzz {
         }
     }
 
+    #[commonware_macros::test_group("slow")]
     #[test]
     fn test_fuzz() {
         commonware_invariants::minifuzz::test(|u| u.arbitrary::<Plan>()?.run(u));

--- a/math/src/ntt.rs
+++ b/math/src/ntt.rs
@@ -1455,6 +1455,7 @@ pub mod fuzz {
         }
     }
 
+    #[commonware_macros::test_group("slow")]
     #[test]
     fn test_fuzz() {
         use commonware_invariants::minifuzz;

--- a/math/src/poly.rs
+++ b/math/src/poly.rs
@@ -676,6 +676,7 @@ pub mod fuzz {
         }
     }
 
+    #[commonware_macros::test_group("slow")]
     #[test]
     fn test_fuzz() {
         commonware_invariants::minifuzz::test(|u| u.arbitrary::<Plan>()?.run(u));

--- a/math/src/test.rs
+++ b/math/src/test.rs
@@ -279,6 +279,7 @@ commonware_macros::stability_scope!(ALPHA {
             }
         }
 
+        #[commonware_macros::test_group("slow")]
         #[test]
         fn test_fuzz() {
             use commonware_invariants::minifuzz;

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -193,7 +193,7 @@ mod tests {
         ed25519::{self, PrivateKey, PublicKey},
         Signer as _,
     };
-    use commonware_macros::select;
+    use commonware_macros::{select, test_group};
     use commonware_runtime::{
         count_running_tasks, deterministic, Clock, IoBuf, Metrics, Quota, Runner, Spawner,
     };
@@ -325,6 +325,7 @@ mod tests {
         }
     }
 
+    #[test_group("slow")]
     #[test]
     fn test_determinism() {
         compare_outputs(25, 25);

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -923,7 +923,7 @@ pub(crate) mod test {
         ordered::{fixed::Db as OrderedFixedDb, variable::Db as OrderedVariableDb},
         unordered::{fixed::Db as UnorderedFixedDb, variable::Db as UnorderedVariableDb},
     };
-    use commonware_macros::test_traced;
+    use commonware_macros::{test_group, test_traced};
     use commonware_runtime::{deterministic, Runner as _};
 
     // Type aliases for all 12 variants (all use OneCap for collision coverage).
@@ -1040,6 +1040,7 @@ pub(crate) mod test {
         }};
     }
 
+    #[test_group("slow")]
     #[test_traced("DEBUG")]
     fn test_all_variants_steps_not_reset() {
         let executor = deterministic::Runner::default();
@@ -1048,6 +1049,7 @@ pub(crate) mod test {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_log_replay() {
         let executor = deterministic::Runner::default();
@@ -1056,6 +1058,7 @@ pub(crate) mod test {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_build_and_authenticate() {
         let executor = deterministic::Runner::default();
@@ -1064,6 +1067,7 @@ pub(crate) mod test {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_historical_proof_basic() {
         let executor = deterministic::Runner::default();
@@ -1072,6 +1076,7 @@ pub(crate) mod test {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_historical_proof_invalid() {
         let executor = deterministic::Runner::default();
@@ -1080,6 +1085,7 @@ pub(crate) mod test {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_historical_proof_edge_cases() {
         let executor = deterministic::Runner::default();
@@ -1088,6 +1094,7 @@ pub(crate) mod test {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_multiple_commits_delete_replayed() {
         let executor = deterministic::Runner::default();
@@ -1096,6 +1103,7 @@ pub(crate) mod test {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_non_empty_recovery() {
         let executor = deterministic::Runner::default();
@@ -1104,6 +1112,7 @@ pub(crate) mod test {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_empty_recovery() {
         let executor = deterministic::Runner::default();

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1067,7 +1067,7 @@ pub mod tests {
 
     use crate::translator::OneCap;
     use commonware_cryptography::{sha256::Digest, Sha256};
-    use commonware_macros::test_traced;
+    use commonware_macros::{test_group, test_traced};
 
     // Type aliases for all 12 variants (all use OneCap for collision coverage).
     type OrderedFixedDb = ordered::fixed::Db<Context, Digest, Digest, Sha256, OneCap, 32>;
@@ -1203,6 +1203,7 @@ pub mod tests {
         test_current_db_build_big::<C, F, Fut>(open_db, 1957, 838);
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_build_random_close_reopen() {
         let executor = deterministic::Runner::default();
@@ -1211,6 +1212,7 @@ pub mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_simulate_write_failures() {
         let executor = deterministic::Runner::default();
@@ -1219,6 +1221,7 @@ pub mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_different_pruning_delays_same_root() {
         let executor = deterministic::Runner::default();
@@ -1227,6 +1230,7 @@ pub mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_all_variants_sync_persists_bitmap_pruning_boundary() {
         let executor = deterministic::Runner::default();
@@ -1235,6 +1239,7 @@ pub mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_ordered_variants_build_big() {
         let executor = deterministic::Runner::default();
@@ -1243,6 +1248,7 @@ pub mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("WARN")]
     fn test_unordered_variants_build_big() {
         let executor = deterministic::Runner::default();
@@ -1251,6 +1257,7 @@ pub mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("DEBUG")]
     fn test_all_variants_steps_not_reset() {
         let executor = deterministic::Runner::default();
@@ -1259,6 +1266,7 @@ pub mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("DEBUG")]
     fn test_ordered_variants_build_small_close_reopen() {
         let executor = deterministic::Runner::default();
@@ -1267,6 +1275,7 @@ pub mod tests {
         });
     }
 
+    #[test_group("slow")]
     #[test_traced("DEBUG")]
     fn test_unordered_variants_build_small_close_reopen() {
         let executor = deterministic::Runner::default();


### PR DESCRIPTION
## Overview

Re-categorizes tests in the workspace that take more than 10s to run into `#[test_group("slow")]`
