### PR TITLE
[runtime/iouring] round config size to the next power of two

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -720,7 +720,7 @@ impl IoUringLoop {
         cfg.size = cfg
             .size
             .checked_next_power_of_two()
-            .expect("ring size rounds beyond u32");
+            .expect("ring size exceeds u32::MAX");
         let size = cfg.size as usize;
         let metrics = Arc::new(Metrics::new(registry));
         let (sender, receiver) = mpsc::channel(size);


### PR DESCRIPTION
This PR aligns io_uring capacity semantics by normalizing `Config::size` to the next power of two when the loop is constructed. Previously, non-power-of-two values could lead to a mismatch where the kernel ring was effectively larger than the runtime's waiter/channel limits. With this change, configured in-flight capacity matches the effective ring sizing behavior.

Related #2883.