### PR TITLE
[runtime/iouring] handle transient io_uring_enter errors

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -1002,11 +1002,10 @@ impl IoUringLoop {
         self.metrics.pending_operations.set(self.waiters.len() as _);
     }
 
-    /// Submits pending operations and waits for completions.
+    /// Submits pending SQEs and waits for completions.
     ///
-    /// This submits all pending SQEs to the kernel and waits for at least
-    /// `want` completions to arrive. It can optionally use a timeout to bound
-    /// the wait time.
+    /// Attempts to wait for at least `want` completions but may return early on
+    /// timeout or transient errors.
     ///
     /// When a timeout is provided, this uses `submit_with_args` with the EXT_ARG
     /// feature to implement a bounded wait without injecting a timeout SQE


### PR DESCRIPTION
`submit_and_wait` is the single choke point for all `io_uring_enter` syscalls. Previously, only `ETIME` was handled, all other errors propagated to callers that `expect()` and panic. This adds handling for the three transient errors documented in the man page: `EINTR`/`EAGAIN`/`EBUSY` return to the caller so it can drain completions before re-entering. Also adds `EINTR` to the `should_retry` predicate used for individual CQE results (defensively as it shouldn't happen with io_uring AFAIU).

Fixes #3252.