### PR TITLE
[p2p]: remove redundant schedule call in simulated transmitter begin

### DIFF
--- a/p2p/src/simulated/transmitter.rs
+++ b/p2p/src/simulated/transmitter.rs
@@ -680,9 +680,7 @@ impl<P: PublicKey> State<P> {
             "sending message",
         );
 
-        let completions = self.rebalance(now);
-        self.schedule(now);
-        completions
+        self.rebalance(now)
     }
 
     /// Returns the next sequence identifier used to preserve FIFO delivery per link.


### PR DESCRIPTION
## Why
`State::enqueue` already recalculates scheduling after `launch`, while `launch -> begin` also called `schedule(now)`.  
This caused duplicate queue scans in the normal successful start path without changing state.

## What changed
- Removed the extra `self.schedule(now)` call from `begin()` in p2p/src/simulated/transmitter.rs.
- Kept scheduling at call sites `enqueue`, `wake`, `finish` so behavior stays the same while avoiding redundant work.