### PR TITLE
[coding] remove HashSet from ReedSolomon decode duplicate check

### DIFF
--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -6,7 +6,7 @@ use commonware_parallel::Strategy;
 use commonware_storage::bmt::{self, Builder};
 use commonware_utils::Cached;
 use reed_solomon_simd::{Error as RsError, ReedSolomonDecoder, ReedSolomonEncoder};
-use std::{collections::HashSet, marker::PhantomData};
+use std::marker::PhantomData;
 use thiserror::Error;
 
 // Thread-local caches for reusing `ReedSolomonEncoder` and `ReedSolomonDecoder`
@@ -378,7 +378,6 @@ fn decode<H: Hasher, S: Strategy>(
 
     // Process checked chunks
     let shard_len = chunks[0].shard.len();
-    let mut seen = HashSet::new();
     let mut shard_digests: Vec<Option<H::Digest>> = vec![None; n];
     let mut provided_originals: Vec<(usize, &[u8])> = Vec::new();
     let mut provided_recoveries: Vec<(usize, &[u8])> = Vec::new();
@@ -388,12 +387,13 @@ fn decode<H: Hasher, S: Strategy>(
         if index >= total {
             return Err(Error::InvalidIndex(index));
         }
-        if !seen.insert(index) {
+        let digest_slot = &mut shard_digests[index as usize];
+        if digest_slot.is_some() {
             return Err(Error::DuplicateIndex(index));
         }
 
         // Add to provided shards and retain the checked digest for this index.
-        shard_digests[index as usize] = Some(chunk.digest);
+        *digest_slot = Some(chunk.digest);
         if index < min {
             provided_originals.push((index as usize, chunk.shard.as_ref()));
         } else {


### PR DESCRIPTION
<!-- What was wrong before these changes? -->
[ReedSolomon::decode](https://github.com/commonwarexyz/monorepo/blob/3dc39445c1f009596d7145020450fd2ad50889d0/coding/src/reed_solomon.rs#L641-L655) used a `HashSet<u16>` to detect duplicate shard indices, even though indices are bounded and we already keep a fixed-size `shard_digests` vector indexed by shard position. This added unnecessary hashing and extra allocation in a decode hot path.

<!-- Clear and concise summary of the changes in this PR -->
Removed the `HashSet` from `decode` and uses `shard_digests[index]` occupancy (`is_some`) to detect duplicates.  
Behavior and errors stay the same (`DuplicateIndex` on repeated index), while reducing overhead and simplifying the code path.