### PR TITLE
[collector] track commitments only after successful send

### DIFF
--- a/collector/src/p2p/engine.rs
+++ b/collector/src/p2p/engine.rs
@@ -150,20 +150,21 @@ where
                         recipients,
                         responder,
                     } => {
-                        // Track commitment (if not already tracked)
                         let commitment = request.commitment();
-                        let entry = self.tracked.entry(commitment).or_insert_with(|| {
-                            self.outstanding.inc();
-                            (HashSet::new(), HashSet::new())
-                        });
-
                         // Send the request to recipients
                         match req_tx
                             .send(recipients, request, self.priority_request)
                             .await
                         {
                             Ok(recipients) => {
-                                entry.0.extend(recipients.iter().cloned());
+                                // Track commitment only if a request was actually sent to any peer.
+                                if !recipients.is_empty() {
+                                    let entry = self.tracked.entry(commitment).or_insert_with(|| {
+                                        self.outstanding.inc();
+                                        (HashSet::new(), HashSet::new())
+                                    });
+                                    entry.0.extend(recipients.iter().cloned());
+                                }
                                 responder.send_lossy(Ok(recipients));
                             }
                             Err(err) => {


### PR DESCRIPTION

[collector::p2p::Engine](https://github.com/commonwarexyz/monorepo/blob/c0b0bbf5c39e2fa3d7d9623c46375cd5cd7438d1/collector/src/p2p/engine.rs#L25-L56) was creating a tracked commitment before network send completed.
If [send](https://github.com/commonwarexyz/monorepo/blob/c0b0bbf5c39e2fa3d7d9623c46375cd5cd7438d1/p2p/src/simulated/network.rs#L968-L992) failed (or returned no recipients), the commitment could remain in `tracked` without any real outbound request, which caused stale state and inaccurate `outstanding` tracking until manual cancel.

<!-- What changes are included in this PR? -->
Move commitment tracking to the successful send path and only track when at least one recipient was actually sent to.
This prevents stale tracked entries on send errors/empty recipient results while preserving existing behavior for valid sends.