### PR TITLE
[p2p/simulated] Fix simulated Provider::subscribe race condition

### DIFF
--- a/p2p/src/simulated/ingress.rs
+++ b/p2p/src/simulated/ingress.rs
@@ -26,7 +26,7 @@ pub enum Message<P: PublicKey, E: Clock> {
         response: oneshot::Sender<Option<Set<P>>>,
     },
     Subscribe {
-        sender: mpsc::UnboundedSender<(u64, Set<P>, Set<P>)>,
+        response: oneshot::Sender<PeerSetSubscription<P>>,
     },
     SubscribeConnected {
         response: oneshot::Sender<ring::Receiver<Vec<P>>>,
@@ -257,10 +257,15 @@ impl<P: PublicKey, E: Clock> Oracle<P, E> {
     }
 
     /// Subscribe to notifications when new peer sets are added.
-    fn subscribe(&self) -> PeerSetSubscription<P> {
-        let (sender, receiver) = mpsc::unbounded_channel();
-        self.sender.0.send_lossy(Message::Subscribe { sender });
-        receiver
+    async fn subscribe(&self) -> PeerSetSubscription<P> {
+        self.sender
+            .0
+            .request(|response| Message::Subscribe { response })
+            .await
+            .unwrap_or_else(|| {
+                let (_, rx) = mpsc::unbounded_channel();
+                rx
+            })
     }
 }
 
@@ -294,7 +299,7 @@ impl<P: PublicKey, E: Clock> crate::Provider for Manager<P, E> {
     }
 
     async fn subscribe(&mut self) -> PeerSetSubscription<Self::PublicKey> {
-        self.oracle.subscribe()
+        self.oracle.subscribe().await
     }
 }
 
@@ -340,7 +345,7 @@ impl<P: PublicKey, E: Clock> crate::Provider for SocketManager<P, E> {
     }
 
     async fn subscribe(&mut self) -> PeerSetSubscription<P> {
-        self.oracle.subscribe()
+        self.oracle.subscribe().await
     }
 }
 

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -197,7 +197,7 @@ mod tests {
     use commonware_runtime::{
         count_running_tasks, deterministic, Clock, IoBuf, Metrics, Quota, Runner, Spawner,
     };
-    use commonware_utils::{channel::mpsc, hostname, ordered::Map, NZU32};
+    use commonware_utils::{channel::mpsc, hostname, ordered, ordered::Map, NZU32};
     use rand::Rng;
     use std::{
         collections::{BTreeMap, HashMap, HashSet},
@@ -3306,6 +3306,39 @@ mod tests {
             socket_manager
                 .overwrite([(pk1.clone(), addr.clone())].try_into().unwrap())
                 .await;
+        });
+    }
+
+    #[test]
+    fn test_subscribe_returns_current_peer_set() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (network, oracle) = Network::new(
+                context.with_label("network"),
+                Config {
+                    max_size: 1024 * 1024,
+                    disconnect_on_block: true,
+                    tracked_peer_sets: Some(3),
+                },
+            );
+            network.start();
+
+            // Create peers and track them
+            let pk1 = PrivateKey::from_seed(0).public_key();
+            let pk2 = PrivateKey::from_seed(1).public_key();
+            let peers = ordered::Set::try_from(vec![pk1.clone(), pk2.clone()]).unwrap();
+
+            let mut manager = oracle.manager();
+            Manager::track(&mut manager, 0, peers.clone()).await;
+
+            // Subscribe after tracking. The current peer set should be
+            // available immediately on the subscription channel.
+            let mut subscription = Provider::subscribe(&mut manager).await;
+            let (id, set, _all) = subscription
+                .try_recv()
+                .expect("current peer set should be available immediately after subscribe");
+            assert_eq!(id, 0);
+            assert_eq!(set, peers);
         });
     }
 }

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -371,7 +371,10 @@ impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> Network<E, P> 
                     let _ = response.send(self.peer_sets.get(&id).cloned());
                 }
             }
-            ingress::Message::Subscribe { sender } => {
+            ingress::Message::Subscribe { response } => {
+                // Create a new subscription channel
+                let (sender, receiver) = mpsc::unbounded_channel();
+
                 // Send the latest peer set upon subscription
                 if let Some((index, peers)) = self.peer_sets.last_key_value() {
                     let all = self.all_tracked_peers();
@@ -379,6 +382,9 @@ impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> Network<E, P> 
                     sender.send_lossy(notification);
                 }
                 self.subscribers.push(sender);
+
+                // Return the receiver to the caller
+                let _ = response.send(receiver);
             }
             ingress::Message::SubscribeConnected { response } => {
                 // Create a ring channel for the subscriber


### PR DESCRIPTION
## Summary

Fixed a race condition in the simulated network's `Provider::subscribe` implementation where callers could receive the subscription channel before the current peer set was sent through it. 

Changed `Oracle::subscribe()` from a synchronous fire-and-forget pattern (using `send_lossy`) to an async request/response pattern (using `request`), matching the authenticated variant's behavior. This ensures the current peer set is queued in the channel before the receiver is returned to the caller.

## Changes

- Modified `ingress::Message::Subscribe` variant to carry a `oneshot::Sender<PeerSetSubscription<P>>` instead of the sender directly
- Made `Oracle::subscribe()` async and use `request()` with proper error handling
- Updated the network handler to create the channel internally, send the current peer set, and return the receiver via the oneshot
- Added regression test `test_subscribe_returns_current_peer_set` to verify current peer set is available immediately after subscribing

## Test Plan

- All existing simulated network tests pass (67 tests)
- All p2p crate tests pass (303 tests)
- New regression test verifies the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)