### PR TITLE
[cryptography] avoid redundant signature clone in certificate assemble

### DIFF
--- a/cryptography/src/ed25519/certificate/mod.rs
+++ b/cryptography/src/ed25519/certificate/mod.rs
@@ -233,7 +233,7 @@ impl<N: Namespace> Generic<N> {
             if usize::from(signer) >= self.participants.len() {
                 return None;
             }
-            let signature = signature.get().cloned()?;
+            signature.get()?;
             entries.push((signer, signature));
         }
         if entries.len() < self.participants.quorum::<M>() as usize {
@@ -244,7 +244,6 @@ impl<N: Namespace> Generic<N> {
         entries.sort_by_key(|(signer, _)| *signer);
         let (signer, signatures): (Vec<Participant>, Vec<_>) = entries.into_iter().unzip();
         let signers = Signers::from(self.participants.len(), signer);
-        let signatures = signatures.into_iter().map(Lazy::from).collect();
 
         Some(Certificate {
             signers,


### PR DESCRIPTION
<!-- Why were these changes needed? -->
[assemble](https://github.com/commonwarexyz/monorepo/blob/240e0207ee10c3c37a42867ce4de97b581c06b32/cryptography/src/ed25519/certificate/mod.rs#L223-L253) in the secp256r1 and ed25519 certificate schemes was decoding and cloning each attestation signature, then wrapping it back into `Lazy`.
That added unnecessary copy work and extra processing in a hot path.

<!-- What does this PR change? -->
Preserve the existing validation behavior ([signature.get()?](https://github.com/commonwarexyz/monorepo/blob/240e0207ee10c3c37a42867ce4de97b581c06b32/utils/src/ordered.rs#L77-L80)) and move `Lazy` signatures directly into the certificate payload.
This removes the redundant decode/clone/rewrap step in secp256r1 and ed25519 certificate assembly.