### PR TITLE
[workspace] Remove slow flag from minifuzz tests

### DIFF
--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1759,37 +1759,31 @@ mod tests {
         num::NonZeroUsize,
     };
 
-    #[test_group("slow")]
     #[test]
     fn test_scalar_as_field() {
         minifuzz::test(test_suites::fuzz_field::<Scalar>);
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_scalar_as_field_ntt() {
         minifuzz::test(test_suites::fuzz_field_ntt::<Scalar>);
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_g1_as_space() {
         minifuzz::test(test_suites::fuzz_space_ring::<Scalar, G1>);
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_g2_as_space() {
         minifuzz::test(test_suites::fuzz_space_ring::<Scalar, G2>);
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_hash_to_g1() {
         minifuzz::test(test_suites::fuzz_hash_to_group::<G1>);
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_hash_to_g2() {
         minifuzz::test(test_suites::fuzz_hash_to_group::<G2>);
@@ -2194,7 +2188,6 @@ mod tests {
         assert_eq!(G::msm(&pts, &scalars, &par), single_point * &single_scalar);
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_msm_parallel_g1() {
         minifuzz::test(|u| {
@@ -2210,7 +2203,6 @@ mod tests {
         });
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_msm_parallel_g2() {
         minifuzz::test(|u| {
@@ -2226,7 +2218,6 @@ mod tests {
         });
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_msm_parallel_edge_cases_g1() {
         minifuzz::test(|u| {
@@ -2244,7 +2235,6 @@ mod tests {
         });
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_msm_parallel_edge_cases_g2() {
         minifuzz::test(|u| {

--- a/cryptography/src/bls12381/primitives/sharing.rs
+++ b/cryptography/src/bls12381/primitives/sharing.rs
@@ -441,7 +441,6 @@ impl<V: Variant> Read for Sharing<V> {
 mod tests {
     use super::*;
     use commonware_invariants::minifuzz;
-    use commonware_macros::test_group;
     use commonware_utils::ordered::Map;
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -464,7 +463,6 @@ mod tests {
             .expect_err("roots mode must be rejected when max mode is counter");
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_all_scalars_matches_scalar() {
         minifuzz::test(|u| {
@@ -486,7 +484,6 @@ mod tests {
         });
     }
 
-    #[test_group("slow")]
     #[test]
     fn test_subset_interpolation_recovers_constant() {
         minifuzz::test(|u| {

--- a/math/src/algebra.rs
+++ b/math/src/algebra.rs
@@ -754,7 +754,6 @@ commonware_macros::stability_scope!(ALPHA {
             }
         }
 
-        #[commonware_macros::test_group("slow")]
         #[test]
         fn test_fuzz() {
             commonware_invariants::minifuzz::test(|u| u.arbitrary::<Plan>()?.run(u));

--- a/math/src/fields/goldilocks.rs
+++ b/math/src/fields/goldilocks.rs
@@ -474,7 +474,6 @@ pub mod fuzz {
         }
     }
 
-    #[commonware_macros::test_group("slow")]
     #[test]
     fn test_fuzz() {
         commonware_invariants::minifuzz::test(|u| u.arbitrary::<Plan>()?.run(u));

--- a/math/src/ntt.rs
+++ b/math/src/ntt.rs
@@ -1455,7 +1455,6 @@ pub mod fuzz {
         }
     }
 
-    #[commonware_macros::test_group("slow")]
     #[test]
     fn test_fuzz() {
         use commonware_invariants::minifuzz;

--- a/math/src/poly.rs
+++ b/math/src/poly.rs
@@ -676,7 +676,6 @@ pub mod fuzz {
         }
     }
 
-    #[commonware_macros::test_group("slow")]
     #[test]
     fn test_fuzz() {
         commonware_invariants::minifuzz::test(|u| u.arbitrary::<Plan>()?.run(u));

--- a/math/src/test.rs
+++ b/math/src/test.rs
@@ -279,7 +279,6 @@ commonware_macros::stability_scope!(ALPHA {
             }
         }
 
-        #[commonware_macros::test_group("slow")]
         #[test]
         fn test_fuzz() {
             use commonware_invariants::minifuzz;


### PR DESCRIPTION
In #3274, we used a 10s cutoff to mark tests as slow.

Minifuzz, in its default configuration, aims to use 10s, but will overshoot by about 10 ms or so. Unfortunately, this lead to it being considered as slow, and not run in the default profile.

The tests are intended to be quick to run, with a fuller execution being done by the real test suite. This allows quick local feedback and iteration, which is useful for humans and agents alike.