### PR TITLE
Fast Verification of Decryption in TLE

### DIFF
--- a/cryptography/src/bls12381/batch_tle.rs
+++ b/cryptography/src/bls12381/batch_tle.rs
@@ -1,0 +1,400 @@
+use crate::bls12381::primitives::{group::Scalar, variant::Variant};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use commonware_math::algebra::{Additive, CryptoGroup, Random, Ring, Space};
+use rand_core::CryptoRngCore;
+use std::ops::Neg;
+
+/// Encrypted bit.
+///
+/// The VRF committee samples a random gamma and publishes `pk^gamma` and
+/// `H(id)^{gamma^{-1}}` for each target identity. Callers pass these
+/// pre-processed values to encrypt/decrypt/verify.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ciphertext<V: Variant> {
+    /// Commitment u = alpha * G.
+    pub u: V::Public,
+    /// Encrypted message c = (alpha + m) * H(id)^{gamma^{-1}}.
+    pub c: V::Signature,
+}
+
+/// Encrypt a single bit for a given target.
+///
+/// The bit m in {0, 1} is encrypted as:
+/// - u = alpha * G
+/// - c = (alpha + m) * h_id
+///
+/// # Arguments
+/// * `public` - The gamma-modified public key `pk^gamma` from the committee.
+/// * `h_id` - The pre-processed target point `H(id)^{gamma^{-1}}` from the
+///   committee. This cannot be computed locally.
+pub fn encrypt_bit<R: CryptoRngCore, V: Variant>(
+    rng: &mut R,
+    h_id: &V::Signature,
+    bit: bool,
+) -> Ciphertext<V> {
+    // Sample random alpha
+    let alpha = Scalar::random(rng);
+
+    // u = alpha * G
+    let mut u = V::Public::generator();
+    u *= &alpha;
+
+    // c = (alpha + m) * H(id)^{gamma^{-1}}
+    let scalar = if bit { alpha + &Scalar::one() } else { alpha };
+    let mut c = *h_id;
+    c *= &scalar;
+
+    Ciphertext { u, c }
+}
+
+/// Decrypt a bit ciphertext using the public key and signature over the target.
+///
+/// Computes e(pk^gamma, c) * e(-u, sig_id) and checks:
+/// - result == identity -> 0
+/// - result == e(pk^gamma, H(id)^{gamma^{-1}}) -> 1
+/// - Otherwise -> None (invalid)
+///
+/// # Arguments
+/// * `public` - The gamma-modified public key `pk^gamma`.
+/// * `signature` - The BLS signature over the target identity.
+/// * `h_id` - The pre-processed target point `H(id)^{gamma^{-1}}`.
+pub fn decrypt_bit<V: Variant>(
+    public: &V::Public,
+    signature: &V::Signature,
+    h_id: &V::Signature,
+    ciphertext: &Ciphertext<V>,
+) -> Option<bool> {
+    let lhs = V::pairing(public, &ciphertext.c);
+    let rhs = V::pairing(&ciphertext.u.neg(), signature);
+    let m = lhs.mul(&rhs);
+
+    if m.is_one() {
+        Some(false)
+    } else {
+        let base = V::pairing(public, h_id);
+        if m == base {
+            Some(true)
+        } else {
+            None
+        }
+    }
+}
+
+/// Batch-verify that claimed decryptions are correct for a set of ciphertexts.
+///
+/// All ciphertexts must be encrypted to the same target. Messages are bits
+/// (0 or 1).
+///
+/// The verification equation:
+///
+/// ```text
+/// e(pk^gamma, Σ c_i*r_i - (Σ r_i*m_i)*H(id)^{gamma^{-1}}) * e(-Σ u_i*r_i, sig_id) == 1
+/// ```
+///
+/// Uses one [V::Signature] MSM, one [V::Public] MSM, and two pairings.
+///
+/// # Arguments
+/// * `public` - The gamma-modified public key `pk^gamma`.
+/// * `signature` - The BLS signature over the target identity.
+/// * `h_id` - The pre-processed target point `H(id)^{gamma^{-1}}`.
+pub fn verify_decryption<R, V>(
+    rng: &mut R,
+    public: &V::Public,
+    signature: &V::Signature,
+    h_id: &V::Signature,
+    ciphertexts: &[Ciphertext<V>],
+    messages: &[bool],
+) -> bool
+where
+    R: CryptoRngCore,
+    V: Variant,
+    V::Public: Space<Scalar>,
+    V::Signature: Space<Scalar>,
+{
+    assert_eq!(ciphertexts.len(), messages.len());
+    if ciphertexts.is_empty() {
+        return true;
+    }
+
+    let n = ciphertexts.len();
+
+    // Sample random challenge scalars
+    let t0 = std::time::Instant::now();
+    let challenges: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut *rng)).collect();
+    let t_challenges = t0.elapsed();
+
+    // V::Signature MSM: Σ c_i * r_i
+    let t0 = std::time::Instant::now();
+    let c_points: Vec<V::Signature> = ciphertexts.iter().map(|ct| ct.c).collect();
+    let c_agg = V::Signature::msm(&c_points, &challenges, &commonware_parallel::Sequential);
+    let t_sig_msm = t0.elapsed();
+
+    // V::Public MSM: Σ u_i * r_i
+    let t0 = std::time::Instant::now();
+    let u_points: Vec<V::Public> = ciphertexts.iter().map(|ct| ct.u).collect();
+    let u_agg = V::Public::msm(&u_points, &challenges, &commonware_parallel::Sequential);
+    let t_pub_msm = t0.elapsed();
+
+    // Scalar sum: s = Σ_{m_i=1} r_i
+    let t0 = std::time::Instant::now();
+    let mut msg_scalar = Scalar::zero();
+    for (r, &m) in challenges.iter().zip(messages.iter()) {
+        if m {
+            msg_scalar = msg_scalar + r;
+        }
+    }
+
+    // sig_term = Σ c_i*r_i - (Σ r_i*m_i)*H(id)^{gamma^{-1}}
+    let mut msg_term = *h_id;
+    msg_term *= &(-msg_scalar);
+    let sig_term = c_agg + &msg_term;
+    let t_scalar = t0.elapsed();
+
+    // Check: e(pk^gamma, sig_term) * e(-u_agg, sig_id) == 1
+    let t0 = std::time::Instant::now();
+    let lhs = V::pairing(public, &sig_term);
+    let rhs = V::pairing(&u_agg.neg(), signature);
+    let result = lhs.mul(&rhs).is_one();
+    let t_pairing = t0.elapsed();
+
+    println!(
+        "  verify_decryption(n={n}): challenges={t_challenges:.2?}, sig_msm={t_sig_msm:.2?}, pub_msm={t_pub_msm:.2?}, scalar={t_scalar:.2?}, pairing={t_pairing:.2?}",
+    );
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bls12381::primitives::{ops, ops::hash_with_namespace, variant::MinPk};
+    use commonware_utils::test_rng;
+    use std::time::Instant;
+
+    /// Compute H(id)^{gamma^{-1}} for tests.
+    ///
+    /// In production this is provided by the VRF committee. Here we just
+    /// use the raw hash (gamma = 1).
+    fn test_h_id(namespace: &[u8], target: &[u8]) -> <MinPk as Variant>::Signature {
+        hash_with_namespace::<MinPk>(MinPk::MESSAGE, namespace, target)
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_bit() {
+        let mut rng = test_rng();
+        let (master_secret, master_public) = ops::keypair::<_, MinPk>(&mut rng);
+        let target = 200u64.to_be_bytes();
+        let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
+        let h_id = test_h_id(b"_TLE_", &target);
+
+        // Encrypt and decrypt bit = 0
+        let ct0 = encrypt_bit::<_, MinPk>(&mut rng, &h_id, false);
+        assert_eq!(
+            decrypt_bit::<MinPk>(&master_public, &signature, &h_id, &ct0),
+            Some(false)
+        );
+
+        // Encrypt and decrypt bit = 1
+        let ct1 = encrypt_bit::<_, MinPk>(&mut rng, &h_id, true);
+        assert_eq!(
+            decrypt_bit::<MinPk>(&master_public, &signature, &h_id, &ct1),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_decrypt_bit_wrong_signature() {
+        let mut rng = test_rng();
+        let (_, master_public) = ops::keypair::<_, MinPk>(&mut rng);
+        let (wrong_secret, _) = ops::keypair::<_, MinPk>(&mut rng);
+        let target = 210u64.to_be_bytes();
+        let wrong_signature = ops::sign_message::<MinPk>(&wrong_secret, b"_TLE_", &target);
+        let h_id = test_h_id(b"_TLE_", &target);
+
+        let ct = encrypt_bit::<_, MinPk>(&mut rng, &h_id, true);
+        assert_eq!(
+            decrypt_bit::<MinPk>(&master_public, &wrong_signature, &h_id, &ct),
+            None
+        );
+    }
+
+    #[test]
+    fn test_verify_decryption_valid() {
+        let mut rng = test_rng();
+        let (master_secret, master_public) = ops::keypair::<_, MinPk>(&mut rng);
+        let target = 300u64.to_be_bytes();
+        let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
+        let h_id = test_h_id(b"_TLE_", &target);
+
+        let bits = [true, false, true, true, false];
+        let ciphertexts: Vec<_> = bits
+            .iter()
+            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
+            .collect();
+
+        assert!(verify_decryption::<_, MinPk>(
+            &mut rng,
+            &master_public,
+            &signature,
+            &h_id,
+            &ciphertexts,
+            &bits,
+        ));
+    }
+
+    #[test]
+    fn test_verify_decryption_wrong_message() {
+        let mut rng = test_rng();
+        let (master_secret, master_public) = ops::keypair::<_, MinPk>(&mut rng);
+        let target = 400u64.to_be_bytes();
+        let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
+        let h_id = test_h_id(b"_TLE_", &target);
+
+        let bits = [true, false, true];
+        let ciphertexts: Vec<_> = bits
+            .iter()
+            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
+            .collect();
+
+        // Flip one bit
+        let wrong_bits = [true, true, true];
+        assert!(!verify_decryption::<_, MinPk>(
+            &mut rng,
+            &master_public,
+            &signature,
+            &h_id,
+            &ciphertexts,
+            &wrong_bits,
+        ));
+    }
+
+    #[test]
+    fn test_verify_decryption_wrong_signature() {
+        let mut rng = test_rng();
+        let (_, master_public) = ops::keypair::<_, MinPk>(&mut rng);
+        let (wrong_secret, _) = ops::keypair::<_, MinPk>(&mut rng);
+        let target = 500u64.to_be_bytes();
+        let wrong_signature = ops::sign_message::<MinPk>(&wrong_secret, b"_TLE_", &target);
+        let h_id = test_h_id(b"_TLE_", &target);
+
+        let bits = [true, false];
+        let ciphertexts: Vec<_> = bits
+            .iter()
+            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
+            .collect();
+
+        assert!(!verify_decryption::<_, MinPk>(
+            &mut rng,
+            &master_public,
+            &wrong_signature,
+            &h_id,
+            &ciphertexts,
+            &bits,
+        ));
+    }
+
+    fn bench_individual_vs_batch(n: usize) {
+        let mut rng = test_rng();
+        let (master_secret, master_public) = ops::keypair::<_, MinPk>(&mut rng);
+        let target = 600u64.to_be_bytes();
+        let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
+        let h_id = test_h_id(b"_TLE_", &target);
+
+        let bits: Vec<bool> = (0..n).map(|i| i % 3 != 0).collect();
+        let ciphertexts: Vec<_> = bits
+            .iter()
+            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
+            .collect();
+
+        // Individual decryption
+        let start = Instant::now();
+        for (ct, &expected) in ciphertexts.iter().zip(bits.iter()) {
+            let result = decrypt_bit::<MinPk>(&master_public, &signature, &h_id, ct);
+            assert_eq!(result, Some(expected));
+        }
+        let individual = start.elapsed();
+
+        // Batch verification
+        let start = Instant::now();
+        let valid = verify_decryption::<_, MinPk>(
+            &mut rng,
+            &master_public,
+            &signature,
+            &h_id,
+            &ciphertexts,
+            &bits,
+        );
+        let batch = start.elapsed();
+        assert!(valid);
+
+        println!(
+            "n={n}: individual={individual:.2?} ({:.2?}/ct), batch={batch:.2?} ({:.2?}/ct), speedup={:.1}x",
+            individual / n as u32,
+            batch / n as u32,
+            individual.as_secs_f64() / batch.as_secs_f64(),
+        );
+    }
+
+    #[test]
+    fn test_bench_individual_vs_batch() {
+        for &n in &[10, 100, 1000] {
+            bench_individual_vs_batch(n);
+        }
+    }
+
+    fn bench_parallel_individual_vs_batch(n: usize) {
+        use rayon::prelude::*;
+
+        let mut rng = test_rng();
+        let (master_secret, master_public) = ops::keypair::<_, MinPk>(&mut rng);
+        let target = 700u64.to_be_bytes();
+        let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
+        let h_id = test_h_id(b"_TLE_", &target);
+
+        let bits: Vec<bool> = (0..n).map(|i| i % 3 != 0).collect();
+        let ciphertexts: Vec<_> = bits
+            .iter()
+            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
+            .collect();
+
+        // Parallel individual decryption
+        let start = Instant::now();
+        let results: Vec<_> = ciphertexts
+            .par_iter()
+            .map(|ct| decrypt_bit::<MinPk>(&master_public, &signature, &h_id, ct))
+            .collect();
+        let parallel_individual = start.elapsed();
+        for (result, &expected) in results.iter().zip(bits.iter()) {
+            assert_eq!(*result, Some(expected));
+        }
+
+        // Batch verification
+        let start = Instant::now();
+        let valid = verify_decryption::<_, MinPk>(
+            &mut rng,
+            &master_public,
+            &signature,
+            &h_id,
+            &ciphertexts,
+            &bits,
+        );
+        let batch = start.elapsed();
+        assert!(valid);
+
+        println!(
+            "n={n}: parallel_individual={parallel_individual:.2?} ({:.2?}/ct), batch={batch:.2?} ({:.2?}/ct), speedup={:.1}x",
+            parallel_individual / n as u32,
+            batch / n as u32,
+            parallel_individual.as_secs_f64() / batch.as_secs_f64(),
+        );
+    }
+
+    #[test]
+    fn test_bench_parallel_individual_vs_batch() {
+        for &n in &[500, 5000] {
+            bench_parallel_individual_vs_batch(n);
+        }
+    }
+}

--- a/cryptography/src/bls12381/batch_tle.rs
+++ b/cryptography/src/bls12381/batch_tle.rs
@@ -1,12 +1,17 @@
-use crate::bls12381::primitives::{group::Scalar, variant::Variant};
+use crate::bls12381::primitives::{
+    group::{Scalar, GT},
+    variant::Variant,
+};
+use crate::{Hasher, Sha256};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use commonware_math::algebra::{Additive, CryptoGroup, Random, Ring, Space};
+use commonware_math::algebra::{Additive, CryptoGroup, Random, Space};
 use rand_core::CryptoRngCore;
+use std::collections::HashMap;
 use std::ops::Neg;
 
-/// Encrypted bit.
+/// Encrypted message from a small message space {0, ..., 2^k - 1}.
 ///
 /// The VRF committee samples a random gamma and publishes `pk^gamma` and
 /// `H(id)^{gamma^{-1}}` for each target identity. Callers pass these
@@ -19,20 +24,49 @@ pub struct Ciphertext<V: Variant> {
     pub c: V::Signature,
 }
 
-/// Encrypt a single bit for a given target.
+/// Hash a GT element to a 32-byte key for table lookup.
+fn hash_gt(gt: &GT) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(&gt.as_slice());
+    hasher.finalize().0
+}
+
+/// Discrete log lookup table mapping hashed GT elements to messages.
 ///
-/// The bit m in {0, 1} is encrypted as:
+/// Stores `H(base^m) -> m` for `m in 0..2^k` where
+/// `base = e(pk^gamma, H(id)^{gamma^{-1}})`.
+///
+/// This table is reused across all decryptions for the same target.
+pub type Table = HashMap<[u8; 32], u64>;
+
+/// Precompute a discrete log lookup table for decryption.
+pub fn build_table<V: Variant>(public: &V::Public, h_id: &V::Signature, k: u32) -> Table {
+    assert!(k <= 20, "message space too large");
+    let size = 1usize << k;
+    let mut table = HashMap::with_capacity(size);
+    let base = V::pairing(public, h_id);
+    let mut acc = GT::one();
+    for m in 0..size {
+        table.insert(hash_gt(&acc), m as u64);
+        acc = acc.mul(&base);
+    }
+    table
+}
+
+/// Encrypt a message from {0, ..., 2^k - 1} for a given target.
+///
+/// The message m is encrypted as:
 /// - u = alpha * G
 /// - c = (alpha + m) * h_id
 ///
 /// # Arguments
-/// * `public` - The gamma-modified public key `pk^gamma` from the committee.
-/// * `h_id` - The pre-processed target point `H(id)^{gamma^{-1}}` from the
+/// * `h_id_gamma` - The pre-processed target point `H(id)^{gamma^{-1}}` from the
 ///   committee. This cannot be computed locally.
-pub fn encrypt_bit<R: CryptoRngCore, V: Variant>(
+/// * `message` - The message to encrypt (must be < 2^k).
+pub fn encrypt<R: CryptoRngCore, V: Variant>(
     rng: &mut R,
-    h_id: &V::Signature,
-    bit: bool,
+    h_id_gamma: &V::Signature,
+    message: u64,
 ) -> Ciphertext<V> {
     // Sample random alpha
     let alpha = Scalar::random(rng);
@@ -42,55 +76,45 @@ pub fn encrypt_bit<R: CryptoRngCore, V: Variant>(
     u *= &alpha;
 
     // c = (alpha + m) * H(id)^{gamma^{-1}}
-    let scalar = if bit { alpha + &Scalar::one() } else { alpha };
-    let mut c = *h_id;
+    let m_scalar = Scalar::from_u64(message);
+    let scalar = alpha + &m_scalar;
+    let mut c = *h_id_gamma;
     c *= &scalar;
 
     Ciphertext { u, c }
 }
 
-/// Decrypt a bit ciphertext using the public key and signature over the target.
+/// Decrypt a ciphertext using the public key, signature, and a precomputed
+/// lookup table.
 ///
-/// Computes e(pk^gamma, c) * e(-u, sig_id) and checks:
-/// - result == identity -> 0
-/// - result == e(pk^gamma, H(id)^{gamma^{-1}}) -> 1
-/// - Otherwise -> None (invalid)
+/// Computes `e(pk^gamma, c) * e(-u, sig_id)` and looks up the hashed result
+/// in the table to recover the message.
 ///
 /// # Arguments
-/// * `public` - The gamma-modified public key `pk^gamma`.
+/// * `pk_gamma` - The gamma-modified public key `pk^gamma`.
 /// * `signature` - The BLS signature over the target identity.
-/// * `h_id` - The pre-processed target point `H(id)^{gamma^{-1}}`.
-pub fn decrypt_bit<V: Variant>(
-    public: &V::Public,
+/// * `table` - Precomputed lookup table from [build_table].
+pub fn decrypt<V: Variant>(
+    pk_gamma: &V::Public,
     signature: &V::Signature,
-    h_id: &V::Signature,
+    table: &Table,
     ciphertext: &Ciphertext<V>,
-) -> Option<bool> {
-    let lhs = V::pairing(public, &ciphertext.c);
+) -> Option<u64> {
+    let lhs = V::pairing(pk_gamma, &ciphertext.c);
     let rhs = V::pairing(&ciphertext.u.neg(), signature);
-    let m = lhs.mul(&rhs);
-
-    if m.is_one() {
-        Some(false)
-    } else {
-        let base = V::pairing(public, h_id);
-        if m == base {
-            Some(true)
-        } else {
-            None
-        }
-    }
+    let target = lhs.mul(&rhs);
+    table.get(&hash_gt(&target)).copied()
 }
 
 /// Batch-verify that claimed decryptions are correct for a set of ciphertexts.
 ///
-/// All ciphertexts must be encrypted to the same target. Messages are bits
-/// (0 or 1).
+/// All ciphertexts must be encrypted to the same target. Messages are from
+/// {0, ..., 2^k - 1}.
 ///
 /// The verification equation:
 ///
 /// ```text
-/// e(pk^gamma, Σ c_i*r_i - (Σ r_i*m_i)*H(id)^{gamma^{-1}}) * e(-Σ u_i*r_i, sig_id) == 1
+/// e(pk^gamma, Σ c_i*r_i - (Σ r_i*m_i)*h_id) * e(-Σ u_i*r_i, sig_id) == 1
 /// ```
 ///
 /// Uses one [V::Signature] MSM, one [V::Public] MSM, and two pairings.
@@ -98,14 +122,14 @@ pub fn decrypt_bit<V: Variant>(
 /// # Arguments
 /// * `public` - The gamma-modified public key `pk^gamma`.
 /// * `signature` - The BLS signature over the target identity.
-/// * `h_id` - The pre-processed target point `H(id)^{gamma^{-1}}`.
+/// * `h_id_gamma` - The pre-processed target point `H(id)^{gamma^{-1}}`.
 pub fn verify_decryption<R, V>(
     rng: &mut R,
-    public: &V::Public,
+    pk_gamma: &V::Public,
     signature: &V::Signature,
-    h_id: &V::Signature,
+    h_id_gamma: &V::Signature,
     ciphertexts: &[Ciphertext<V>],
-    messages: &[bool],
+    messages: &[u64],
 ) -> bool
 where
     R: CryptoRngCore,
@@ -137,24 +161,23 @@ where
     let u_agg = V::Public::msm(&u_points, &challenges, &commonware_parallel::Sequential);
     let t_pub_msm = t0.elapsed();
 
-    // Scalar sum: s = Σ_{m_i=1} r_i
+    // Scalar sum: s = Σ r_i * m_i
     let t0 = std::time::Instant::now();
     let mut msg_scalar = Scalar::zero();
     for (r, &m) in challenges.iter().zip(messages.iter()) {
-        if m {
-            msg_scalar = msg_scalar + r;
-        }
+        let m_scalar = Scalar::from_u64(m);
+        msg_scalar = msg_scalar + &(r.clone() * &m_scalar);
     }
 
-    // sig_term = Σ c_i*r_i - (Σ r_i*m_i)*H(id)^{gamma^{-1}}
-    let mut msg_term = *h_id;
+    // sig_term = Σ c_i*r_i - (Σ r_i*m_i)*h_id
+    let mut msg_term = *h_id_gamma;
     msg_term *= &(-msg_scalar);
     let sig_term = c_agg + &msg_term;
     let t_scalar = t0.elapsed();
 
     // Check: e(pk^gamma, sig_term) * e(-u_agg, sig_id) == 1
     let t0 = std::time::Instant::now();
-    let lhs = V::pairing(public, &sig_term);
+    let lhs = V::pairing(pk_gamma, &sig_term);
     let rhs = V::pairing(&u_agg.neg(), signature);
     let result = lhs.mul(&rhs).is_one();
     let t_pairing = t0.elapsed();
@@ -173,39 +196,31 @@ mod tests {
     use commonware_utils::test_rng;
     use std::time::Instant;
 
-    /// Compute H(id)^{gamma^{-1}} for tests.
-    ///
-    /// In production this is provided by the VRF committee. Here we just
-    /// use the raw hash (gamma = 1).
+    /// Compute H(id)^{gamma^{-1}} for tests (gamma = 1).
     fn test_h_id(namespace: &[u8], target: &[u8]) -> <MinPk as Variant>::Signature {
         hash_with_namespace::<MinPk>(MinPk::MESSAGE, namespace, target)
     }
 
     #[test]
-    fn test_encrypt_decrypt_bit() {
+    fn test_encrypt_decrypt() {
         let mut rng = test_rng();
         let (master_secret, master_public) = ops::keypair::<_, MinPk>(&mut rng);
         let target = 200u64.to_be_bytes();
         let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
         let h_id = test_h_id(b"_TLE_", &target);
 
-        // Encrypt and decrypt bit = 0
-        let ct0 = encrypt_bit::<_, MinPk>(&mut rng, &h_id, false);
-        assert_eq!(
-            decrypt_bit::<MinPk>(&master_public, &signature, &h_id, &ct0),
-            Some(false)
-        );
+        let k = 4; // message space {0, ..., 15}
+        let table = build_table::<MinPk>(&master_public, &h_id, k);
 
-        // Encrypt and decrypt bit = 1
-        let ct1 = encrypt_bit::<_, MinPk>(&mut rng, &h_id, true);
-        assert_eq!(
-            decrypt_bit::<MinPk>(&master_public, &signature, &h_id, &ct1),
-            Some(true)
-        );
+        for m in 0..1u64 << k {
+            let ct = encrypt::<_, MinPk>(&mut rng, &h_id, m);
+            let result = decrypt::<MinPk>(&master_public, &signature, &table, &ct);
+            assert_eq!(result, Some(m), "failed for m={m}");
+        }
     }
 
     #[test]
-    fn test_decrypt_bit_wrong_signature() {
+    fn test_decrypt_wrong_signature() {
         let mut rng = test_rng();
         let (_, master_public) = ops::keypair::<_, MinPk>(&mut rng);
         let (wrong_secret, _) = ops::keypair::<_, MinPk>(&mut rng);
@@ -213,9 +228,10 @@ mod tests {
         let wrong_signature = ops::sign_message::<MinPk>(&wrong_secret, b"_TLE_", &target);
         let h_id = test_h_id(b"_TLE_", &target);
 
-        let ct = encrypt_bit::<_, MinPk>(&mut rng, &h_id, true);
+        let table = build_table::<MinPk>(&master_public, &h_id, 4);
+        let ct = encrypt::<_, MinPk>(&mut rng, &h_id, 7);
         assert_eq!(
-            decrypt_bit::<MinPk>(&master_public, &wrong_signature, &h_id, &ct),
+            decrypt::<MinPk>(&master_public, &wrong_signature, &table, &ct),
             None
         );
     }
@@ -228,11 +244,21 @@ mod tests {
         let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
         let h_id = test_h_id(b"_TLE_", &target);
 
-        let bits = [true, false, true, true, false];
-        let ciphertexts: Vec<_> = bits
+        let k = 4;
+        let table = build_table::<MinPk>(&master_public, &h_id, k);
+        let msgs: Vec<u64> = vec![0, 5, 15, 3, 11];
+        let ciphertexts: Vec<_> = msgs
             .iter()
-            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
+            .map(|&m| encrypt::<_, MinPk>(&mut rng, &h_id, m))
             .collect();
+
+        // Verify decryptions are correct
+        for (ct, &m) in ciphertexts.iter().zip(msgs.iter()) {
+            assert_eq!(
+                decrypt::<MinPk>(&master_public, &signature, &table, ct),
+                Some(m)
+            );
+        }
 
         assert!(verify_decryption::<_, MinPk>(
             &mut rng,
@@ -240,7 +266,7 @@ mod tests {
             &signature,
             &h_id,
             &ciphertexts,
-            &bits,
+            &msgs,
         ));
     }
 
@@ -252,21 +278,20 @@ mod tests {
         let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
         let h_id = test_h_id(b"_TLE_", &target);
 
-        let bits = [true, false, true];
-        let ciphertexts: Vec<_> = bits
+        let msgs: Vec<u64> = vec![1, 2, 3];
+        let ciphertexts: Vec<_> = msgs
             .iter()
-            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
+            .map(|&m| encrypt::<_, MinPk>(&mut rng, &h_id, m))
             .collect();
 
-        // Flip one bit
-        let wrong_bits = [true, true, true];
+        let wrong_msgs: Vec<u64> = vec![1, 4, 3];
         assert!(!verify_decryption::<_, MinPk>(
             &mut rng,
             &master_public,
             &signature,
             &h_id,
             &ciphertexts,
-            &wrong_bits,
+            &wrong_msgs,
         ));
     }
 
@@ -279,10 +304,10 @@ mod tests {
         let wrong_signature = ops::sign_message::<MinPk>(&wrong_secret, b"_TLE_", &target);
         let h_id = test_h_id(b"_TLE_", &target);
 
-        let bits = [true, false];
-        let ciphertexts: Vec<_> = bits
+        let msgs: Vec<u64> = vec![5, 10];
+        let ciphertexts: Vec<_> = msgs
             .iter()
-            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
+            .map(|&m| encrypt::<_, MinPk>(&mut rng, &h_id, m))
             .collect();
 
         assert!(!verify_decryption::<_, MinPk>(
@@ -291,27 +316,30 @@ mod tests {
             &wrong_signature,
             &h_id,
             &ciphertexts,
-            &bits,
+            &msgs,
         ));
     }
 
-    fn bench_individual_vs_batch(n: usize) {
+    fn bench_individual_vs_batch(n: usize, k: u32) {
         let mut rng = test_rng();
         let (master_secret, master_public) = ops::keypair::<_, MinPk>(&mut rng);
         let target = 600u64.to_be_bytes();
         let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
         let h_id = test_h_id(b"_TLE_", &target);
 
-        let bits: Vec<bool> = (0..n).map(|i| i % 3 != 0).collect();
-        let ciphertexts: Vec<_> = bits
+        let max_msg = 1u64 << k;
+        let table = build_table::<MinPk>(&master_public, &h_id, k);
+
+        let msgs: Vec<u64> = (0..n).map(|i| (i as u64) % max_msg).collect();
+        let ciphertexts: Vec<_> = msgs
             .iter()
-            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
+            .map(|&m| encrypt::<_, MinPk>(&mut rng, &h_id, m))
             .collect();
 
         // Individual decryption
         let start = Instant::now();
-        for (ct, &expected) in ciphertexts.iter().zip(bits.iter()) {
-            let result = decrypt_bit::<MinPk>(&master_public, &signature, &h_id, ct);
+        for (ct, &expected) in ciphertexts.iter().zip(msgs.iter()) {
+            let result = decrypt::<MinPk>(&master_public, &signature, &table, ct);
             assert_eq!(result, Some(expected));
         }
         let individual = start.elapsed();
@@ -324,13 +352,13 @@ mod tests {
             &signature,
             &h_id,
             &ciphertexts,
-            &bits,
+            &msgs,
         );
         let batch = start.elapsed();
         assert!(valid);
 
         println!(
-            "n={n}: individual={individual:.2?} ({:.2?}/ct), batch={batch:.2?} ({:.2?}/ct), speedup={:.1}x",
+            "n={n} k={k}: individual={individual:.2?} ({:.2?}/ct), batch={batch:.2?} ({:.2?}/ct), speedup={:.1}x",
             individual / n as u32,
             batch / n as u32,
             individual.as_secs_f64() / batch.as_secs_f64(),
@@ -339,62 +367,10 @@ mod tests {
 
     #[test]
     fn test_bench_individual_vs_batch() {
-        for &n in &[10, 100, 1000] {
-            bench_individual_vs_batch(n);
-        }
-    }
-
-    fn bench_parallel_individual_vs_batch(n: usize) {
-        use rayon::prelude::*;
-
-        let mut rng = test_rng();
-        let (master_secret, master_public) = ops::keypair::<_, MinPk>(&mut rng);
-        let target = 700u64.to_be_bytes();
-        let signature = ops::sign_message::<MinPk>(&master_secret, b"_TLE_", &target);
-        let h_id = test_h_id(b"_TLE_", &target);
-
-        let bits: Vec<bool> = (0..n).map(|i| i % 3 != 0).collect();
-        let ciphertexts: Vec<_> = bits
-            .iter()
-            .map(|&b| encrypt_bit::<_, MinPk>(&mut rng, &h_id, b))
-            .collect();
-
-        // Parallel individual decryption
-        let start = Instant::now();
-        let results: Vec<_> = ciphertexts
-            .par_iter()
-            .map(|ct| decrypt_bit::<MinPk>(&master_public, &signature, &h_id, ct))
-            .collect();
-        let parallel_individual = start.elapsed();
-        for (result, &expected) in results.iter().zip(bits.iter()) {
-            assert_eq!(*result, Some(expected));
-        }
-
-        // Batch verification
-        let start = Instant::now();
-        let valid = verify_decryption::<_, MinPk>(
-            &mut rng,
-            &master_public,
-            &signature,
-            &h_id,
-            &ciphertexts,
-            &bits,
-        );
-        let batch = start.elapsed();
-        assert!(valid);
-
-        println!(
-            "n={n}: parallel_individual={parallel_individual:.2?} ({:.2?}/ct), batch={batch:.2?} ({:.2?}/ct), speedup={:.1}x",
-            parallel_individual / n as u32,
-            batch / n as u32,
-            parallel_individual.as_secs_f64() / batch.as_secs_f64(),
-        );
-    }
-
-    #[test]
-    fn test_bench_parallel_individual_vs_batch() {
-        for &n in &[500, 5000] {
-            bench_parallel_individual_vs_batch(n);
+        for &n in &[100, 1000, 10000, 100000] {
+            for &k in &[1, 16] {
+                bench_individual_vs_batch(n, k);
+            }
         }
     }
 }

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! - `portable`: Enables `portable` feature on `blst` (<https://github.com/supranational/blst?tab=readme-ov-file#platform-and-language-compatibility>).
 
+pub mod batch_tle;
 pub mod certificate;
 #[cfg(feature = "std")]
 pub mod dkg;

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -15,7 +15,8 @@ use crate::Secret;
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use blst::{
-    blst_bendian_from_fp12, blst_bendian_from_scalar, blst_expand_message_xmd, blst_fp12, blst_fr,
+    blst_bendian_from_fp12, blst_bendian_from_scalar, blst_expand_message_xmd, blst_fp12,
+    blst_fp12_cyclotomic_sqr, blst_fp12_is_one, blst_fp12_mul, blst_fp12_one, blst_fr,
     blst_fr_add, blst_fr_cneg, blst_fr_from_scalar, blst_fr_from_uint64, blst_fr_inverse,
     blst_fr_mul, blst_fr_rshift, blst_fr_sub, blst_hash_to_g1, blst_hash_to_g2, blst_keygen,
     blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_cneg, blst_p1_compress, blst_p1_double,
@@ -431,6 +432,73 @@ impl GT {
     /// Create GT from blst_fp12.
     pub(crate) const fn from_blst_fp12(fp12: blst_fp12) -> Self {
         Self(fp12)
+    }
+
+    /// Multiplies two GT elements.
+    pub fn mul(&self, other: &GT) -> GT {
+        let mut out = blst_fp12::default();
+        // SAFETY: blst_fp12_mul writes a valid blst_fp12 to `out` from two valid inputs.
+        unsafe {
+            blst_fp12_mul(&mut out, &self.0, &other.0);
+        }
+        GT(out)
+    }
+
+    /// Returns the identity element (one) in GT.
+    pub fn one() -> GT {
+        // SAFETY: blst_fp12_one returns a valid pointer to the constant identity element.
+        GT(unsafe { *blst_fp12_one() })
+    }
+
+    /// Returns true if this element is the identity (one).
+    pub fn is_one(&self) -> bool {
+        // SAFETY: blst_fp12_is_one reads from a valid blst_fp12.
+        unsafe { blst_fp12_is_one(&self.0) }
+    }
+
+    /// Computes self^scalar using square-and-multiply.
+    ///
+    /// Uses cyclotomic squaring, which is faster than general fp12
+    /// squaring for elements in the cyclotomic subgroup (i.e. pairing outputs).
+    pub fn scalar_mul(&self, scalar: &Scalar) -> GT {
+        let s = scalar.as_blst_scalar();
+        // blst_scalar.b is little-endian
+        let bytes = &s.b;
+
+        // Find the highest set bit
+        let mut top_byte = SCALAR_LENGTH - 1;
+        while top_byte > 0 && bytes[top_byte] == 0 {
+            top_byte -= 1;
+        }
+        if bytes[top_byte] == 0 {
+            return GT::one();
+        }
+        let top_bit = 7 - bytes[top_byte].leading_zeros() as usize;
+
+        // Square-and-multiply (MSB to LSB)
+        let mut acc = self.0;
+        let base = &self.0;
+        let mut started = false;
+        for byte_idx in (0..=top_byte).rev() {
+            let b = bytes[byte_idx];
+            let bit_start = if byte_idx == top_byte { top_bit } else { 7 };
+            for bit in (0..=bit_start).rev() {
+                if started {
+                    // SAFETY: blst_fp12_cyclotomic_sqr supports in-place operation.
+                    unsafe { blst_fp12_cyclotomic_sqr(&mut acc, &acc) };
+                }
+                if (b >> bit) & 1 == 1 {
+                    if started {
+                        // SAFETY: blst_fp12_mul supports in-place when ret aliases a.
+                        unsafe { blst_fp12_mul(&mut acc, &acc, base) };
+                    } else {
+                        started = true;
+                    }
+                }
+            }
+        }
+
+        if started { GT(acc) } else { GT::one() }
     }
 
     /// Converts the GT element to its canonical big-endian byte representation.


### PR DESCRIPTION
## Scheme Description

Implements the CPA secure version where the committee additionally holds shares of a random value $\gamma$ and $\gamma^{-1}$ and publish:
- $\gamma \cdot \text{pk}$
- ${\gamma^{-1}} \cdot H(\text{id})$ for all possible $\text{id}$ that users will encrypt to. Note that this doubles the total communication from the committee as they publish signatures on $H(\text{id})$ anyway.

We can avoid this at the cost of moving base group MSMs to the target group.

## Summary

Adds a batch timelock encryption (TLE) module for BLS12-381 that encrypts messages from a small message space $\{0, \ldots, 2^k - 1\}$ and supports efficient batch verification of decryptions. 

- **Encrypt/Decrypt**: Each ciphertext is $(u = \alpha \cdot G,\; c = (\alpha + m) \cdot ({\gamma^{-1}} \cdot H(\text{id}))$. Decryption uses 2 pairings and a precomputed discrete-log lookup table (`HashMap<[u8; 32], u64>`) that maps hashed $\mathbb{G}_T$ elements to messages.
- **Batch verification**: Verifies $n$ claimed decryptions with 2 MSMs + 2 pairings (constant regardless of $n$), compared to $2n$ pairings for individual decryption. Uses random linear combination with challenge scalars.
- **$\mathbb{G}_T$ operations**: Added `mul`, `one`, `is_one`, and `scalar_mul` (square-and-multiply with cyclotomic squaring) to the `GT` type in `group.rs`.
- **Lookup table**: `build_table` precomputes $\text{SHA256}(\text{pk} \circ (m\cdot H(\text{id}))) \to m$ for $m \in \{0, \ldots, 2^k - 1\}$. Table keys are 32-byte hashes instead of full 576-byte $\mathbb{G}_T$ elements.

The scheme assumes a VRF committee publishes $\text{pk}^\gamma$ and $H(\text{id})^{\gamma^{-1}}$ for each target identity. All public functions accept these pre-processed values as inputs.

### Encryption

Given a message $m \in \{0, \ldots, 2^k - 1\}$ and the committee-provided $H(\text{id})^{\gamma^{-1}}$:

- Sample $\alpha \leftarrow \mathbb{F}$
- $\text{ct}_0 = (\alpha + m) \cdot ({\gamma^{-1}} \cdot H(\text{id}))$
- $\text{ct}_1 = \alpha \cdot [1]_1$

### Decryption

Given the BLS signature $\sigma_{\text{id}}$ over the target identity:

- Compute $\text{ct}'_0 = \text{pk}^\gamma \circ \text{ct}_0$ (pairing)
- Recover $m$ as the discrete log of $\text{ct}'_0 - \text{ct}_1 \circ \sigma_{\text{id}}$ with respect to $\text{pk} \circ H(\text{id})$

For small message spaces, the discrete log is recovered via a precomputed lookup table mapping $\text{SHA256}(\text{base}^m) \to m$.

### Batch Verification

To verify $B$ claimed decryptions $\{m_i\}$ for ciphertexts encrypted to the same target, sample random challenges $r_i$ and check:

$$(\gamma \cdot \text{pk})  \circ \left(\sum_i r_i \cdot \text{ct}_0^i - \left(\sum_i r_i \cdot m_i\right) \cdot ({\gamma^{-1}} \cdot H(\text{id}))\right) - \left(\sum_i r_i \cdot \text{ct}_1^i\right) \circ \sigma_{\text{id}} \stackrel{?}{=} 0$$

This requires one $\mathbb{G}_2$-MSM of size $B$, one $\mathbb{G}_1$-MSM of size $B$, and two pairings (constant). Following [[FGHP09]](https://eprint.iacr.org/2008/015.pdf), the challenge scalars can be sampled from a smaller range $[0, 2^\ell)$ to further reduce MSM cost, with soundness error at most $2^{-\ell}$.

## Benchmark results (single-threaded)
Ran on a 2019 Intel MacBook Pro

| $n$ | $k$ | Individual | Batch | Speedup | $\mathbb{G}_2$-MSM | $\mathbb{G}_1$-MSM | Scalar | Pairing |
|---|---|---|---|---|---|---|---|---|
| 100 | 1 | 489.82ms | 43.77ms | 11.2x | 27.58ms | 9.70ms | 691.46us | 4.87ms |
| 100 | 8 | 489.83ms | 43.78ms | 11.2x | 27.27ms | 9.59ms | 684.74us | 4.88ms |
| 100 | 16 | 490.42ms | 43.33ms | 11.3x | 27.27ms | 9.59ms | 684.74us | 4.88ms |
| 1,000 | 1 | 4.57s | 226.30ms | 20.2x | 158.06ms | 55.31ms | 785.93us | 4.44ms |
| 1,000 | 8 | 4.19s | 205.94ms | 20.3x | 143.43ms | 50.57ms | 716.41us | 4.07ms |
| 1,000 | 16 | 3.77s | 189.81ms | 19.9x | 132.16ms | 46.71ms | 658.46us | 3.76ms |
| 10,000 | 1 | 28.11s | 872.10ms | 32.2x | 610.14ms | 216.04ms | 1.27ms | 2.42ms |
| 10,000 | 8 | 20.97s | 667.02ms | 31.4x | 466.03ms | 165.27ms | 983.63us | 1.88ms |
| 10,000 | 16 | 16.54s | 559.52ms | 29.6x | 391.42ms | 138.09ms | 827.81us | 1.56ms |
| 100,000 | 1 | 209.49s | 5.74s | 36.5x | 3.95s | 1.42s | 8.10ms | 2.03ms |
| 100,000 | 8 | 182.64s | 5.52s | 33.1x | 3.81s | 1.36s | 7.78ms | 1.95ms |
| 100,000 | 16 | 161.38s | 4.01s | 40.3x | 2.76s | 983.29ms | 5.71ms | 1.43ms |
