### PR TITLE
[storage/qmdb] don't block reads on apply_batch commit

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -227,6 +227,42 @@ pub struct Changeset<K, D: Digest, Item: Send> {
     db_size: u64,
 }
 
+/// Opaque token returned by [`Db::prepare_apply_batch`] and consumed by
+/// [`Db::commit_pending_batch`].
+///
+/// This represents a batch that has been appended to the authenticated log but
+/// has not yet been published to the in-memory snapshot and metadata.
+pub struct PendingApply<K, D: Digest> {
+    /// The location of the first operation written by the batch.
+    start_loc: Location,
+
+    /// The prepared authenticated-log root after the batch was appended.
+    prepared_root: D,
+
+    /// Snapshot mutations to apply, in order.
+    snapshot_diffs: Vec<SnapshotDiff<K>>,
+
+    /// Net change in active key count.
+    active_keys_delta: isize,
+
+    /// Inactivity floor location after this batch's floor raise.
+    new_inactivity_floor_loc: Location,
+
+    /// Location of the CommitFloor operation appended by this batch.
+    new_last_commit_loc: Location,
+
+    /// The database size when the batch was created. Used to detect stale publication.
+    db_size: u64,
+}
+
+/// Opaque token returned by [`Db::commit_pending_batch`] and consumed by
+/// [`Db::finish_apply_batch`].
+///
+/// This represents a batch that has been appended to the authenticated log,
+/// durably committed, but not yet published to the in-memory snapshot and
+/// metadata.
+pub struct CommittedPendingApply<K, D: Digest>(PendingApply<K, D>);
+
 /// Batch-infrastructure state used during merkleization.
 ///
 /// Created by [`UnmerkleizedBatch::into_parts()`], which separates the pending
@@ -1140,7 +1176,27 @@ where
         &mut self,
         batch: Changeset<K, H::Digest, Operation<K, V, U>>,
     ) -> Result<Range<Location>, Error> {
-        let journal_size = *self.last_commit_loc + 1;
+        let pending = self.prepare_apply_batch(batch).await?;
+        let committed = self.commit_pending_batch(pending).await?;
+        self.finish_apply_batch(committed)
+    }
+
+    /// Append a changeset to the authenticated log but do not yet publish it to
+    /// the in-memory snapshot and metadata.
+    ///
+    /// This split phase is intended for callers that coordinate access with an
+    /// outer upgradable lock. They can:
+    /// 1. hold exclusive access long enough to call `prepare_apply_batch`,
+    /// 2. downgrade to shared access and call `commit_pending_batch`, and then
+    /// 3. re-acquire exclusive access and call `finish_apply_batch`.
+    ///
+    /// Errors returned from mutable journal operations are fatal; the database
+    /// should be reopened before further use.
+    pub async fn prepare_apply_batch(
+        &mut self,
+        batch: Changeset<K, H::Digest, Operation<K, V, U>>,
+    ) -> Result<PendingApply<K, H::Digest>, Error> {
+        let journal_size = *self.log.size().await;
         if batch.db_size != journal_size {
             return Err(Error::StaleChangeset {
                 expected: batch.db_size,
@@ -1152,12 +1208,58 @@ where
         // 1. Write all operations to the authenticated journal + apply MMR changeset.
         self.log.apply_batch(batch.journal_finalized).await?;
 
-        // 2. Flush journal to disk.
-        // TODO(#3118): allow fsync with non-mutable reference to database.
+        Ok(PendingApply {
+            start_loc,
+            prepared_root: self.log.root(),
+            snapshot_diffs: batch.snapshot_diffs,
+            active_keys_delta: batch.active_keys_delta,
+            new_inactivity_floor_loc: batch.new_inactivity_floor_loc,
+            new_last_commit_loc: batch.new_last_commit_loc,
+            db_size: batch.db_size,
+        })
+    }
+
+    /// Flush a previously prepared batch to disk.
+    ///
+    /// This persists the journal changes staged by `prepare_apply_batch` without
+    /// requiring mutable access to the database. Snapshot-based reads such as
+    /// `get()` may proceed during this call, but methods that expose the
+    /// underlying log/MMR state should remain serialized until
+    /// `finish_apply_batch` completes.
+    pub async fn commit_pending_batch(
+        &self,
+        pending: PendingApply<K, H::Digest>,
+    ) -> Result<CommittedPendingApply<K, H::Digest>, Error> {
+        if self.log.root() != pending.prepared_root {
+            return Err(Error::PendingApplyMismatch);
+        }
         self.log.commit().await?;
+        Ok(CommittedPendingApply(pending))
+    }
+
+    /// Publish a previously prepared and committed batch to the in-memory
+    /// snapshot and metadata.
+    ///
+    /// Errors returned from mutable journal operations are fatal; the database
+    /// should be reopened before further use.
+    pub fn finish_apply_batch(
+        &mut self,
+        committed: CommittedPendingApply<K, H::Digest>,
+    ) -> Result<Range<Location>, Error> {
+        let pending = committed.0;
+        let journal_size = *self.last_commit_loc + 1;
+        if pending.db_size != journal_size {
+            return Err(Error::StaleChangeset {
+                expected: pending.db_size,
+                actual: journal_size,
+            });
+        }
+        if self.log.root() != pending.prepared_root {
+            return Err(Error::PendingApplyMismatch);
+        }
 
         // 3. Apply snapshot diffs to the in-memory index.
-        for diff in batch.snapshot_diffs {
+        for diff in pending.snapshot_diffs {
             match diff {
                 SnapshotDiff::Update {
                     key,
@@ -1176,20 +1278,20 @@ where
         }
 
         // 4. Update DB metadata.
-        let new_active_keys = self.active_keys as isize + batch.active_keys_delta;
+        let new_active_keys = self.active_keys as isize + pending.active_keys_delta;
         debug_assert!(
             new_active_keys >= 0,
             "active_keys underflow: base={}, delta={}",
             self.active_keys,
-            batch.active_keys_delta
+            pending.active_keys_delta
         );
         self.active_keys = new_active_keys as usize;
-        self.inactivity_floor_loc = batch.new_inactivity_floor_loc;
-        self.last_commit_loc = batch.new_last_commit_loc;
+        self.inactivity_floor_loc = pending.new_inactivity_floor_loc;
+        self.last_commit_loc = pending.new_last_commit_loc;
 
         // 5. Return the committed location range.
         let end_loc = Location::new(*self.last_commit_loc + 1);
-        Ok(start_loc..end_loc)
+        Ok(pending.start_loc..end_loc)
     }
 }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -34,6 +34,28 @@
 //! let finalized = merkleized_child.finalize();
 //! db.apply_batch(finalized).await?;
 //! ```
+//!
+//! If the database is wrapped in an outer
+//! [commonware_utils::sync::UpgradableAsyncRwLock], callers can split apply
+//! into append, fsync, and publish phases so snapshot-based reads such as
+//! `get()` are not blocked during the underlying journal commit:
+//!
+//! ```ignore
+//! let upgradable = shared_db.upgradable_read().await;
+//! let mut writer = upgradable.upgrade().await;
+//! let pending = writer.prepare_apply_batch(finalized).await?;
+//! let upgradable = writer.downgrade_to_upgradable();
+//!
+//! let committed = upgradable.commit_pending_batch(pending).await?;
+//!
+//! let mut writer = upgradable.upgrade().await;
+//! writer.finish_apply_batch(committed)?;
+//! ```
+//!
+//! Methods that expose the underlying log/MMR state, such as `root()`,
+//! `bounds()`, proof generation, or `new_batch()`, may observe the
+//! prepared-but-unpublished state and should remain serialized until
+//! `finish_apply_batch` completes.
 
 use crate::{
     index::Unordered as UnorderedIndex,

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -230,6 +230,114 @@ pub(crate) mod test {
         db.apply_batch(finalized).await.unwrap();
     }
 
+    #[test_traced("WARN")]
+    fn test_any_fixed_db_prepare_commit_finish_apply_batch() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut db = open_db(context.with_label("db")).await;
+            let key = Sha256::hash(b"key");
+            let value = Sha256::hash(b"value");
+
+            let finalized = {
+                let mut batch = db.new_batch();
+                batch.write(key, Some(value));
+                batch.merkleize(None).await.unwrap().finalize()
+            };
+
+            let pending = db.prepare_apply_batch(finalized).await.unwrap();
+
+            // The journal has been extended, but reads still observe the last
+            // published snapshot until finish_apply_batch runs.
+            assert_eq!(db.get(&key).await.unwrap(), None);
+
+            let committed = db.commit_pending_batch(pending).await.unwrap();
+            assert_eq!(db.get(&key).await.unwrap(), None);
+
+            db.finish_apply_batch(committed).unwrap();
+            assert_eq!(db.get(&key).await.unwrap(), Some(value));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_any_fixed_db_pending_apply_mismatch() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut db_a = create_test_db(context.with_label("db_a")).await;
+            let db_b = create_test_db(context.with_label("db_b")).await;
+            let key = Sha256::hash(b"key");
+            let value = Sha256::hash(b"value");
+
+            let finalized = {
+                let mut batch = db_a.new_batch();
+                batch.write(key, Some(value));
+                batch.merkleize(None).await.unwrap().finalize()
+            };
+
+            let pending = db_a.prepare_apply_batch(finalized).await.unwrap();
+
+            assert!(matches!(
+                db_b.commit_pending_batch(pending).await,
+                Err(crate::qmdb::Error::PendingApplyMismatch)
+            ));
+
+            let mut db_c = create_test_db(context.with_label("db_c")).await;
+            let mut db_d = create_test_db(context.with_label("db_d")).await;
+            let finalized = {
+                let mut batch = db_c.new_batch();
+                batch.write(key, Some(value));
+                batch.merkleize(None).await.unwrap().finalize()
+            };
+            let pending = db_c.prepare_apply_batch(finalized).await.unwrap();
+            let committed = db_c.commit_pending_batch(pending).await.unwrap();
+            assert!(matches!(
+                db_d.finish_apply_batch(committed),
+                Err(crate::qmdb::Error::PendingApplyMismatch)
+            ));
+
+            db_a.destroy().await.unwrap();
+            db_b.destroy().await.unwrap();
+            db_c.destroy().await.unwrap();
+            db_d.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_any_fixed_db_second_prepare_is_stale() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut db = create_test_db(context.with_label("db")).await;
+            let key_a = Sha256::hash(b"key-a");
+            let value_a = Sha256::hash(b"value-a");
+            let key_b = Sha256::hash(b"key-b");
+            let value_b = Sha256::hash(b"value-b");
+
+            let finalized_a = {
+                let mut batch = db.new_batch();
+                batch.write(key_a, Some(value_a));
+                batch.merkleize(None).await.unwrap().finalize()
+            };
+            let finalized_b = {
+                let mut batch = db.new_batch();
+                batch.write(key_b, Some(value_b));
+                batch.merkleize(None).await.unwrap().finalize()
+            };
+
+            let pending = db.prepare_apply_batch(finalized_a).await.unwrap();
+
+            assert!(matches!(
+                db.prepare_apply_batch(finalized_b).await,
+                Err(crate::qmdb::Error::StaleChangeset { .. })
+            ));
+
+            let committed = db.commit_pending_batch(pending).await.unwrap();
+            db.finish_apply_batch(committed).unwrap();
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     // Test that replaying multiple updates of the same key on startup doesn't leave behind old data
     // in the snapshot.
     #[test_traced("WARN")]

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -86,6 +86,47 @@ pub struct Db<
     pub(super) root: DigestOf<H>,
 }
 
+/// Opaque token returned by [`Db::prepare_apply_batch`] and consumed by
+/// [`Db::commit_pending_batch`].
+///
+/// This represents a batch that has been appended to the inner Any database
+/// but has not yet been published to the Current-layer bitmap, grafted MMR,
+/// and canonical root.
+pub struct PendingApply<K, D: Digest> {
+    /// Pending publication for the inner Any database state.
+    inner: any::batch::PendingApply<K, D>,
+
+    /// The published canonical root before prepare_apply_batch ran.
+    base_root: D,
+
+    /// One bool per operation in the batch chain (pushes applied before clears).
+    bitmap_pushes: Vec<bool>,
+
+    /// Locations of bits to clear after pushing.
+    bitmap_clears: Vec<Location>,
+
+    /// Changeset for the grafted MMR.
+    grafted_changeset: mmr::Changeset<D>,
+
+    /// Precomputed canonical root.
+    canonical_root: D,
+}
+
+/// Opaque token returned by [`Db::commit_pending_batch`] and consumed by
+/// [`Db::finish_apply_batch`].
+///
+/// This represents a batch that has been appended to the inner Any database,
+/// durably committed, but not yet published to the Current-layer bitmap,
+/// grafted MMR, and canonical root.
+pub struct CommittedPendingApply<K, D: Digest> {
+    inner: any::batch::CommittedPendingApply<K, D>,
+    base_root: D,
+    bitmap_pushes: Vec<bool>,
+    bitmap_clears: Vec<Location>,
+    grafted_changeset: mmr::Changeset<D>,
+    canonical_root: D,
+}
+
 // Shared read-only functionality.
 impl<E, K, V, C, I, H, U, const N: usize> Db<E, C, I, H, U, N>
 where
@@ -373,25 +414,94 @@ where
         &mut self,
         batch: super::batch::Changeset<K, H::Digest, Operation<K, V, U>, N>,
     ) -> Result<Range<Location>, Error> {
-        // 1. Apply inner any batch (writes ops, updates snapshot).
-        let range = self.any.apply_batch(batch.inner).await?;
+        let pending = self.prepare_apply_batch(batch).await?;
+        let committed = self.commit_pending_batch(pending).await?;
+        self.finish_apply_batch(committed)
+    }
+
+    /// Append a changeset to the inner Any database but do not yet publish it
+    /// to the Current-layer bitmap, grafted MMR, or canonical root.
+    ///
+    /// This split phase is intended for callers that coordinate access with an
+    /// outer upgradable lock. They can:
+    /// 1. hold exclusive access long enough to call `prepare_apply_batch`,
+    /// 2. downgrade to shared access and call `commit_pending_batch`, and then
+    /// 3. re-acquire exclusive access and call `finish_apply_batch`.
+    ///
+    /// Errors returned from mutable journal operations are fatal; the database
+    /// should be reopened before further use.
+    pub async fn prepare_apply_batch(
+        &mut self,
+        batch: super::batch::Changeset<K, H::Digest, Operation<K, V, U>, N>,
+    ) -> Result<PendingApply<K, H::Digest>, Error> {
+        let inner = self.any.prepare_apply_batch(batch.inner).await?;
+        Ok(PendingApply {
+            inner,
+            base_root: self.root,
+            bitmap_pushes: batch.bitmap_pushes,
+            bitmap_clears: batch.bitmap_clears,
+            grafted_changeset: batch.grafted_changeset,
+            canonical_root: batch.canonical_root,
+        })
+    }
+
+    /// Flush a previously prepared batch to disk.
+    ///
+    /// This persists the journal changes staged by `prepare_apply_batch`
+    /// without requiring mutable access to the database. Snapshot-based reads
+    /// such as `get()` and the published canonical `root()` may proceed during
+    /// this call, but methods that expose the underlying ops log state such as
+    /// `bounds()` or `ops_root()` should remain serialized until
+    /// `finish_apply_batch` completes.
+    pub async fn commit_pending_batch(
+        &self,
+        pending: PendingApply<K, H::Digest>,
+    ) -> Result<CommittedPendingApply<K, H::Digest>, Error> {
+        if self.root != pending.base_root {
+            return Err(Error::PendingApplyMismatch);
+        }
+        let committed_inner = self.any.commit_pending_batch(pending.inner).await?;
+        Ok(CommittedPendingApply {
+            inner: committed_inner,
+            base_root: pending.base_root,
+            bitmap_pushes: pending.bitmap_pushes,
+            bitmap_clears: pending.bitmap_clears,
+            grafted_changeset: pending.grafted_changeset,
+            canonical_root: pending.canonical_root,
+        })
+    }
+
+    /// Publish a previously prepared and committed batch to the Current-layer
+    /// in-memory state.
+    ///
+    /// Errors returned from mutable journal operations are fatal; the database
+    /// should be reopened before further use.
+    pub fn finish_apply_batch(
+        &mut self,
+        committed: CommittedPendingApply<K, H::Digest>,
+    ) -> Result<Range<Location>, Error> {
+        if self.root != committed.base_root {
+            return Err(Error::PendingApplyMismatch);
+        }
+        // 1. Publish inner any batch (snapshot + metadata).
+        let range = self.any.finish_apply_batch(committed.inner)?;
 
         // 2. Push new bits FIRST. Must happen before clears because for chained
         //    batches, some clears target locations within the push range
         //    (ancestor-segment superseded ops that were pushed as active by an
         //    ancestor and then superseded by a descendant).
-        for &bit in &batch.bitmap_pushes {
+        for &bit in &committed.bitmap_pushes {
             self.status.push(bit);
         }
 
         // 3. Clear superseded locations: previous commit inactivation, diff
         //    base_old_locs, and ancestor-segment superseded locations (chaining).
-        for loc in &batch.bitmap_clears {
+        for loc in &committed.bitmap_clears {
             self.status.set_bit(**loc, false);
         }
 
         // 4. Apply precomputed grafted MMR changeset from merkleize().
-        self.grafted_mmr.apply(batch.grafted_changeset)?;
+        self.grafted_mmr.apply(committed.grafted_changeset)?;
 
         // 5. Prune bitmap chunks fully below the inactivity floor.
         self.status.prune_to_bit(*self.any.inactivity_floor_loc);
@@ -406,7 +516,7 @@ where
         }
 
         // 7. Use precomputed canonical root from merkleize().
-        self.root = batch.canonical_root;
+        self.root = committed.canonical_root;
 
         Ok(range)
     }

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -13,6 +13,27 @@
 //! db.apply_batch(finalized).await?;
 //! ```
 //!
+//! If the database is wrapped in an outer
+//! [commonware_utils::sync::UpgradableAsyncRwLock], callers can split apply
+//! into append, fsync, and publish phases so snapshot-based reads such as
+//! `get()` are not blocked during the underlying journal commit:
+//!
+//! ```ignore
+//! let upgradable = shared_db.upgradable_read().await;
+//! let mut writer = upgradable.upgrade().await;
+//! let pending = writer.prepare_apply_batch(finalized).await?;
+//! let upgradable = writer.downgrade_to_upgradable();
+//!
+//! let committed = upgradable.commit_pending_batch(pending).await?;
+//!
+//! let mut writer = upgradable.upgrade().await;
+//! writer.finish_apply_batch(committed)?;
+//! ```
+//!
+//! Methods that expose the underlying ops log state, such as `bounds()`,
+//! `ops_root()`, or `new_batch()`, may observe the prepared-but-unpublished
+//! state and should remain serialized until `finish_apply_batch` completes.
+//!
 //! # Motivation
 //!
 //! An [crate::qmdb::any] ("Any") database can prove that a key had a particular value at some

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -133,6 +133,84 @@ pub mod test {
         CurrentTest::init(context, cfg).await.unwrap()
     }
 
+    #[test_traced("DEBUG")]
+    pub fn test_current_db_prepare_commit_finish_apply_batch() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let partition = "split-apply".to_string();
+            let mut db = open_db(context.with_label("db"), partition).await;
+            let key = Sha256::fill(0x11);
+            let value = Sha256::fill(0x22);
+            let old_root = db.root();
+
+            let finalized = {
+                let mut batch = db.new_batch();
+                batch.write(key, Some(value));
+                batch.merkleize(None).await.unwrap().finalize()
+            };
+
+            let pending = db.prepare_apply_batch(finalized).await.unwrap();
+
+            // The log has been extended, but Current readers still observe the
+            // last published state until finish_apply_batch runs.
+            assert_eq!(db.get(&key).await.unwrap(), None);
+            assert_eq!(db.root(), old_root);
+
+            let committed = db.commit_pending_batch(pending).await.unwrap();
+            assert_eq!(db.get(&key).await.unwrap(), None);
+            assert_eq!(db.root(), old_root);
+
+            db.finish_apply_batch(committed).unwrap();
+            assert_eq!(db.get(&key).await.unwrap(), Some(value));
+            assert_ne!(db.root(), old_root);
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    pub fn test_current_db_pending_apply_mismatch() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut db_a = open_db(context.with_label("db_a"), "current-a".into()).await;
+            let db_b = open_db(context.with_label("db_b"), "current-b".into()).await;
+            let key = Sha256::fill(0x11);
+            let value = Sha256::fill(0x22);
+
+            let finalized = {
+                let mut batch = db_a.new_batch();
+                batch.write(key, Some(value));
+                batch.merkleize(None).await.unwrap().finalize()
+            };
+
+            let pending = db_a.prepare_apply_batch(finalized).await.unwrap();
+
+            assert!(matches!(
+                db_b.commit_pending_batch(pending).await,
+                Err(crate::qmdb::Error::PendingApplyMismatch)
+            ));
+
+            let mut db_c = open_db(context.with_label("db_c"), "current-c".into()).await;
+            let mut db_d = open_db(context.with_label("db_d"), "current-d".into()).await;
+            let finalized = {
+                let mut batch = db_c.new_batch();
+                batch.write(key, Some(value));
+                batch.merkleize(None).await.unwrap().finalize()
+            };
+            let pending = db_c.prepare_apply_batch(finalized).await.unwrap();
+            let committed = db_c.commit_pending_batch(pending).await.unwrap();
+            assert!(matches!(
+                db_d.finish_apply_batch(committed),
+                Err(crate::qmdb::Error::PendingApplyMismatch)
+            ));
+
+            db_a.destroy().await.unwrap();
+            db_b.destroy().await.unwrap();
+            db_c.destroy().await.unwrap();
+            db_d.destroy().await.unwrap();
+        });
+    }
+
     /// Build a tiny database and make sure we can't convince the verifier that some old value of a
     /// key is active. We specifically test over the partial chunk case, since these bits are yet to
     /// be committed to the underlying MMR.

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -112,6 +112,10 @@ pub enum Error {
     /// The changeset was created from a different database state than the current one.
     #[error("stale changeset: batch expected db size {expected}, but db has {actual}")]
     StaleChangeset { expected: u64, actual: u64 },
+
+    /// The pending apply token does not match the database's prepared state.
+    #[error("pending apply does not match the database's prepared state")]
+    PendingApplyMismatch,
 }
 
 impl From<crate::journal::authenticated::Error> for Error {


### PR DESCRIPTION
There's an underlying fsync in apply_batch that was read blocking. This PR splits the operation so the fsync can be performed without blocking reads.

Resolves: #3118