### PR TITLE
[storage] allow forking a child off of a prepared batch

### DIFF
--- a/storage/fuzz/fuzz_targets/mmr_journaled_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/mmr_journaled_crash_recovery.rs
@@ -277,7 +277,7 @@ fn fuzz(input: FuzzInput) {
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
 
         let mut hasher = StandardHasher::<Sha256>::new();
-        let mut mmr = Mmr::init(
+        let mmr = Mmr::init(
             ctx.with_label("recovered"),
             &mut hasher,
             mmr_config(

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -4,6 +4,59 @@
 //! Range (MMR). The item at index i in the journal corresponds to the leaf at Location i in the
 //! MMR. This structure enables efficient proofs that an item is included in the journal at a
 //! specific location.
+//!
+//! Merkleized journal batches can be retained as speculative parents while
+//! their finalized changesets are being appended and committed:
+//!
+//! ```ignore
+//! let merkleized = batch.merkleize();
+//! let pending_changeset = merkleized.finalize_incremental();
+//!
+//! let mut child = merkleized.new_batch();
+//! child.add(next_item);
+//! let child_changeset = child.merkleize().finalize_incremental();
+//! ```
+//!
+//! Branching from a retained merkleized batch is speculative. This branches
+//! from the prepared parent state, not from the last applied state of the live
+//! journal.
+//!
+//! Once the oldest prepared parent has been applied, descendants can be
+//! compacted back onto the live journal with [`Journal::rebase_batch`]. This
+//! drops one speculative ancestor level without copying the batch-local items
+//! or MMR delta.
+//!
+//! Manual rebasing is only needed to bound retained chain depth. If you never
+//! rebase, speculative reads continue to work, but they keep traversing the
+//! retained parent chain.
+//!
+//! A typical flow is:
+//!
+//! ```ignore
+//! let parent = batch.merkleize();
+//! let parent_changeset = parent.finalize_incremental();
+//!
+//! let child = {
+//!     let mut batch = parent.new_batch();
+//!     batch.add(next_item);
+//!     batch.merkleize()
+//! };
+//!
+//! // Parent is now reflected in the live journal/MMR.
+//! journal.apply_batch(parent_changeset).await?;
+//! journal.commit().await?;
+//!
+//! // Rebase the child onto the live journal to drop one speculative ancestor.
+//! let child = journal.rebase_batch(&child)?;
+//! let child_changeset = child.finalize_incremental();
+//! journal.apply_batch(child_changeset).await?;
+//! ```
+//!
+//! Rebasing is valid only once the live journal/MMR matches the frozen parent
+//! state captured by the batch. Calling [`Journal::rebase_batch`] too early, or
+//! on the wrong journal, returns [`Error::Mmr`] wrapping
+//! [`crate::mmr::Error::RebaseParentMismatch`] or
+//! [`crate::mmr::Error::RebaseParentRootMismatch`].
 
 use crate::{
     journal::{
@@ -69,7 +122,10 @@ impl<'a, H: Hasher, P: Readable<H::Digest>, Item: Encode> UnmerkleizedBatch<'a, 
     }
 
     /// Merkleize the batch, computing the root digest.
-    pub fn merkleize(mut self) -> MerkleizedBatch<'a, H, P, Item> {
+    pub fn merkleize(mut self) -> MerkleizedBatch<'a, H, P, Item>
+    where
+        P: BatchChainInfo<H::Digest>,
+    {
         MerkleizedBatch {
             inner: self.inner.merkleize(&mut self.hasher),
             items: Arc::new(self.items),
@@ -116,6 +172,7 @@ impl<'a, H: Hasher, P: Readable<H::Digest> + BatchChainInfo<H::Digest>, Item: Se
     fn base_size(&self) -> Position {
         self.inner.base_size()
     }
+
     fn collect_overwrites(&self, into: &mut BTreeMap<Position, H::Digest>) {
         self.inner.collect_overwrites(into);
     }
@@ -125,8 +182,8 @@ impl<'a, H: Hasher, P: Readable<H::Digest> + BatchChain<Item>, Item: Send + Sync
     for MerkleizedBatch<'a, H, P, Item>
 {
     fn collect(&self, into: &mut Vec<Arc<Vec<Item>>>) {
-        self.inner.parent().collect(into); // recurse to parent first
-        into.push(self.items.clone()); // Arc clone, not data clone
+        self.inner.parent().collect(into);
+        into.push(self.items.clone());
     }
 }
 
@@ -146,18 +203,43 @@ impl<'a, H: Hasher, P: Readable<H::Digest>, Item: Send + Sync + Encode>
     }
 }
 
-impl<'a, H: Hasher, P, Item: Send + Sync> MerkleizedBatch<'a, H, P, Item>
+impl<'a, H: Hasher, P: Readable<H::Digest>, Item: Send + Sync> MerkleizedBatch<'a, H, P, Item> {
+    /// Rebase this batch onto an equivalent live parent after that parent has
+    /// been applied, dropping one speculative ancestor from the item/MMR chain.
+    pub fn rebase<'b, Q>(&self, parent: &'b Q) -> Result<MerkleizedBatch<'b, H, Q, Item>, MmrError>
+    where
+        Q: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Item>,
+    {
+        Ok(MerkleizedBatch {
+            inner: self.inner.rebase(parent)?,
+            items: self.items.clone(),
+        })
+    }
+}
+
+impl<'a, H: Hasher, P, Item> MerkleizedBatch<'a, H, P, Item>
 where
     P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Item>,
+    Item: Send + Sync,
 {
-    /// Consume this batch, collecting the changes from its ancestors and itself into a
-    /// [Changeset] which can be applied to the journal.
-    pub fn finalize(self) -> Changeset<H::Digest, Item> {
+    /// Finalize this batch into a [`Changeset`] relative to the base of the
+    /// entire retained batch chain.
+    pub fn finalize(&self) -> Changeset<H::Digest, Item> {
         let mut items = Vec::new();
         self.collect(&mut items);
         Changeset {
             changeset: self.inner.finalize(),
             items,
+        }
+    }
+
+    /// Finalize this batch into a [`Changeset`] relative to its immediate
+    /// parent. This is the form used with [`Self::rebase`] for pipelined
+    /// speculative execution.
+    pub fn finalize_incremental(&self) -> Changeset<H::Digest, Item> {
+        Changeset {
+            changeset: self.inner.finalize_incremental(),
+            items: vec![self.items.clone()],
         }
     }
 }
@@ -169,6 +251,11 @@ pub struct Changeset<D: Digest, Item> {
     // The items to append.
     items: Vec<Arc<Vec<Item>>>,
 }
+
+/// A merkleized batch that is directly anchored to a live authenticated
+/// journal's MMR.
+pub type LiveMerkleizedBatch<'a, E, H, Item> =
+    MerkleizedBatch<'a, H, Mmr<E, <H as Hasher>::Digest>, Item>;
 
 /// An append-only data structure that maintains a sequential journal of items alongside a Merkle
 /// Mountain Range (MMR). The item at index i in the journal corresponds to the leaf at Location i
@@ -187,8 +274,7 @@ where
     /// Journal of items.
     /// Invariant: item i corresponds to leaf i in the MMR.
     pub(crate) journal: C,
-
-    pub(crate) hasher: StandardHasher<H>,
+    pub(crate) _hasher: core::marker::PhantomData<H>,
 }
 
 impl<E, C, H> Journal<E, C, H>
@@ -214,6 +300,19 @@ where
             hasher: StandardHasher::new(),
             items: Vec::new(),
         }
+    }
+
+    /// Rebase a speculative batch onto this live journal after its oldest
+    /// parent has been applied, dropping one speculative ancestor level.
+    pub fn rebase_batch<'a, P>(
+        &'a self,
+        batch: &MerkleizedBatch<'_, H, P, C::Item>,
+    ) -> Result<LiveMerkleizedBatch<'a, E, H, C::Item>, Error>
+    where
+        P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<C::Item>,
+        C::Item: Send + Sync,
+    {
+        batch.rebase(&self.mmr).map_err(Error::Mmr)
     }
 }
 
@@ -252,7 +351,7 @@ where
         Ok(Self {
             mmr,
             journal,
-            hasher,
+            _hasher: core::marker::PhantomData,
         })
     }
 
@@ -312,16 +411,21 @@ where
         Ok(())
     }
 
-    /// Append an item to the journal and update the MMR.
-    pub async fn append(&mut self, item: &C::Item) -> Result<Location, Error> {
+    /// Append an item to the journal and update the MMR using the supplied
+    /// hasher.
+    pub async fn append(
+        &self,
+        item: &C::Item,
+        hasher: &mut StandardHasher<H>,
+    ) -> Result<Location, Error> {
         let encoded_item = item.encode();
 
         // Append item to the journal, then update the MMR state.
         let loc = self.journal.append(item).await?;
         let changeset = {
             let mut batch = self.mmr.new_batch();
-            batch.add(&mut self.hasher, &encoded_item);
-            batch.merkleize(&mut self.hasher).finalize()
+            batch.add(hasher, &encoded_item);
+            batch.merkleize(hasher).finalize()
         };
         self.mmr.apply(changeset)?;
 
@@ -334,7 +438,7 @@ where
     /// batch that produced it was created. Multiple batches can be forked from the
     /// same parent for speculative execution, but only one may be applied. Applying
     /// a stale changeset returns an error.
-    pub async fn apply_batch(&mut self, batch: Changeset<H::Digest, C::Item>) -> Result<(), Error> {
+    pub async fn apply_batch(&self, batch: Changeset<H::Digest, C::Item>) -> Result<(), Error> {
         let actual = self.mmr.size();
         if batch.changeset.base_size != actual {
             return Err(MmrError::StaleChangeset {
@@ -527,7 +631,7 @@ where
         Ok(Self {
             mmr,
             journal,
-            hasher,
+            _hasher: core::marker::PhantomData,
         })
     }
 }
@@ -567,7 +671,7 @@ where
         Ok(Self {
             mmr,
             journal,
-            hasher,
+            _hasher: core::marker::PhantomData,
         })
     }
 }
@@ -595,11 +699,14 @@ where
     C: Mutable<Item: EncodeShared>,
     H: Hasher,
 {
-    async fn append(&mut self, item: &Self::Item) -> Result<u64, JournalError> {
-        let res = self.append(item).await.map_err(|e| match e {
-            Error::Journal(inner) => inner,
-            Error::Mmr(inner) => JournalError::Mmr(anyhow::Error::from(inner)),
-        })?;
+    async fn append(&self, item: &Self::Item) -> Result<u64, JournalError> {
+        let mut hasher = StandardHasher::<H>::new();
+        let res = Self::append(self, item, &mut hasher)
+            .await
+            .map_err(|e| match e {
+                Error::Journal(inner) => inner,
+                Error::Mmr(inner) => JournalError::Mmr(anyhow::Error::from(inner)),
+            })?;
 
         Ok(*res)
     }
@@ -613,8 +720,9 @@ where
 
         let leaves = *self.mmr.leaves();
         if leaves > size {
+            let mut hasher = StandardHasher::<H>::new();
             self.mmr
-                .rewind((leaves - size) as usize, &mut self.hasher)
+                .rewind((leaves - size) as usize, &mut hasher)
                 .await
                 .map_err(|error| JournalError::Mmr(anyhow::Error::from(error)))?;
         }
@@ -758,11 +866,12 @@ mod tests {
         suffix: &str,
         count: usize,
     ) -> AuthenticatedJournal {
-        let mut journal = create_empty_journal(context, suffix).await;
+        let journal = create_empty_journal(context, suffix).await;
+        let mut hasher = StandardHasher::new();
 
         for i in 0..count {
             let op = create_operation(i as u8);
-            let loc = journal.append(&op).await.unwrap();
+            let loc = journal.append(&op, &mut hasher).await.unwrap();
             assert_eq!(loc, Location::new(i as u64));
         }
 
@@ -913,11 +1022,15 @@ mod tests {
     fn test_align_with_mismatched_committed_ops() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut journal = create_empty_journal(context.with_label("first"), "mismatched").await;
+            let journal = create_empty_journal(context.with_label("first"), "mismatched").await;
+            let mut hasher = StandardHasher::new();
 
             // Add 20 uncommitted operations
             for i in 0..20 {
-                let loc = journal.append(&create_operation(i as u8)).await.unwrap();
+                let loc = journal
+                    .append(&create_operation(i as u8), &mut hasher)
+                    .await
+                    .unwrap();
                 assert_eq!(loc, Location::new(i as u64));
             }
 
@@ -1129,17 +1242,24 @@ mod tests {
                     AuthenticatedJournal::new(context, mmr_cfg, journal_cfg, |op| op.is_commit())
                         .await
                         .unwrap();
+                let mut hasher = StandardHasher::new();
 
                 // Add operations with a commit at position 5 (in section 0: 0-6)
                 for i in 0..5 {
-                    journal.append(&create_operation(i)).await.unwrap();
+                    journal
+                        .append(&create_operation(i), &mut hasher)
+                        .await
+                        .unwrap();
                 }
                 journal
-                    .append(&Operation::CommitFloor(None, Location::new(0)))
+                    .append(&Operation::CommitFloor(None, Location::new(0)), &mut hasher)
                     .await
                     .unwrap(); // pos 5
                 for i in 6..10 {
-                    journal.append(&create_operation(i)).await.unwrap();
+                    journal
+                        .append(&create_operation(i), &mut hasher)
+                        .await
+                        .unwrap();
                 }
                 assert_eq!(journal.size().await, 10);
 
@@ -1165,8 +1285,12 @@ mod tests {
                 assert!(bounds.is_empty());
 
                 // Test rewinding after pruning.
+                let mut hasher = StandardHasher::new();
                 for i in 0..255 {
-                    journal.append(&create_operation(i)).await.unwrap();
+                    journal
+                        .append(&create_operation(i), &mut hasher)
+                        .await
+                        .unwrap();
                 }
                 journal.prune(Location::new(100)).await.unwrap();
                 assert_eq!(journal.reader().await.bounds().start, 98);
@@ -1188,14 +1312,15 @@ mod tests {
     fn test_apply_op_and_read_operations() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut journal = create_empty_journal(context, "apply_op").await;
+            let journal = create_empty_journal(context, "apply_op").await;
+            let mut hasher = StandardHasher::new();
 
             assert_eq!(journal.size().await, 0);
 
             // Add 50 operations
             let expected_ops: Vec<_> = (0..50).map(|i| create_operation(i as u8)).collect();
             for (i, op) in expected_ops.iter().enumerate() {
-                let loc = journal.append(op).await.unwrap();
+                let loc = journal.append(op, &mut hasher).await.unwrap();
                 assert_eq!(loc, Location::new(i as u64));
                 assert_eq!(journal.size().await, (i + 1) as u64);
             }
@@ -1244,10 +1369,14 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut journal = create_journal_with_ops(context, "read_pruned", 100).await;
+            let mut hasher = StandardHasher::new();
 
             // Add commit and prune
             journal
-                .append(&Operation::CommitFloor(None, Location::new(50)))
+                .append(
+                    &Operation::CommitFloor(None, Location::new(50)),
+                    &mut hasher,
+                )
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
@@ -1303,19 +1432,19 @@ mod tests {
     fn test_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut journal =
-                create_empty_journal(context.with_label("first"), "close_pending").await;
+            let journal = create_empty_journal(context.with_label("first"), "close_pending").await;
+            let mut hasher = StandardHasher::new();
 
             // Add 20 operations
             let expected_ops: Vec<_> = (0..20).map(|i| create_operation(i as u8)).collect();
             for (i, op) in expected_ops.iter().enumerate() {
-                let loc = journal.append(op).await.unwrap();
+                let loc = journal.append(op, &mut hasher).await.unwrap();
                 assert_eq!(loc, Location::new(i as u64),);
             }
 
             // Add commit operation to commit the operations
             let commit_loc = journal
-                .append(&Operation::CommitFloor(None, Location::new(0)))
+                .append(&Operation::CommitFloor(None, Location::new(0)), &mut hasher)
                 .await
                 .unwrap();
             assert_eq!(
@@ -1357,10 +1486,14 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut journal = create_journal_with_ops(context, "prune_to", 100).await;
+            let mut hasher = StandardHasher::new();
 
             // Add commit at position 50
             journal
-                .append(&Operation::CommitFloor(None, Location::new(50)))
+                .append(
+                    &Operation::CommitFloor(None, Location::new(50)),
+                    &mut hasher,
+                )
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
@@ -1378,9 +1511,13 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut journal = create_journal_with_ops(context, "prune_boundary", 100).await;
+            let mut hasher = StandardHasher::new();
 
             journal
-                .append(&Operation::CommitFloor(None, Location::new(50)))
+                .append(
+                    &Operation::CommitFloor(None, Location::new(50)),
+                    &mut hasher,
+                )
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
@@ -1404,9 +1541,13 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut journal = create_journal_with_ops(context, "prune_count", 100).await;
+            let mut hasher = StandardHasher::new();
 
             journal
-                .append(&Operation::CommitFloor(None, Location::new(50)))
+                .append(
+                    &Operation::CommitFloor(None, Location::new(50)),
+                    &mut hasher,
+                )
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
@@ -1440,8 +1581,12 @@ mod tests {
             // Test after pruning
             let mut journal =
                 create_journal_with_ops(context.with_label("pruned"), "oldest", 100).await;
+            let mut hasher = StandardHasher::new();
             journal
-                .append(&Operation::CommitFloor(None, Location::new(50)))
+                .append(
+                    &Operation::CommitFloor(None, Location::new(50)),
+                    &mut hasher,
+                )
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
@@ -1475,8 +1620,12 @@ mod tests {
             // Test after pruning
             let mut journal =
                 create_journal_with_ops(context.with_label("pruned"), "boundary", 100).await;
+            let mut hasher = StandardHasher::new();
             journal
-                .append(&Operation::CommitFloor(None, Location::new(50)))
+                .append(
+                    &Operation::CommitFloor(None, Location::new(50)),
+                    &mut hasher,
+                )
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
@@ -1493,9 +1642,13 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut journal = create_journal_with_ops(context, "mmr_boundary", 50).await;
+            let mut hasher = StandardHasher::new();
 
             journal
-                .append(&Operation::CommitFloor(None, Location::new(25)))
+                .append(
+                    &Operation::CommitFloor(None, Location::new(25)),
+                    &mut hasher,
+                )
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
@@ -1650,7 +1803,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Create journal with initial operations
-            let mut journal = create_journal_with_ops(context, "proof_historical", 50).await;
+            let journal = create_journal_with_ops(context, "proof_historical", 50).await;
 
             // Capture root at historical state
             let mut hasher = StandardHasher::new();
@@ -1659,7 +1812,10 @@ mod tests {
 
             // Add more operations after the historical state
             for i in 50..100 {
-                journal.append(&create_operation(i as u8)).await.unwrap();
+                journal
+                    .append(&create_operation(i as u8), &mut hasher)
+                    .await
+                    .unwrap();
             }
             journal.sync().await.unwrap();
 
@@ -1692,9 +1848,13 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut journal = create_journal_with_ops(context, "proof_pruned", 50).await;
+            let mut hasher = StandardHasher::new();
 
             journal
-                .append(&Operation::CommitFloor(None, Location::new(25)))
+                .append(
+                    &Operation::CommitFloor(None, Location::new(25)),
+                    &mut hasher,
+                )
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
@@ -1769,7 +1929,7 @@ mod tests {
     fn test_speculative_batch() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut journal = create_journal_with_ops(context, "speculative_batch", 10).await;
+            let journal = create_journal_with_ops(context, "speculative_batch", 10).await;
             let original_root = journal.root();
 
             // Fork two independent speculative batches.
@@ -1810,13 +1970,13 @@ mod tests {
     fn test_speculative_batch_stacking() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut journal = create_journal_with_ops(context, "batch_stacking", 10).await;
+            let journal = create_journal_with_ops(context, "batch_stacking", 10).await;
 
             let op_a = create_operation(100);
             let op_b = create_operation(200);
 
             // Build stacked batches in a block so intermediate borrows drop.
-            let (expected_root, finalized) = {
+            let (parent_finalized, expected_root, finalized) = {
                 let mut batch_a = journal.new_batch();
                 batch_a.add(op_a.clone());
                 let merkleized_a = batch_a.merkleize();
@@ -1826,10 +1986,15 @@ mod tests {
                 let merkleized_b = batch_b.merkleize();
 
                 let root = merkleized_b.root();
-                (root, merkleized_b.finalize())
+                (
+                    merkleized_a.finalize_incremental(),
+                    root,
+                    merkleized_b.finalize_incremental(),
+                )
                 // merkleized_a dropped here, releasing &journal.mmr
             };
 
+            journal.apply_batch(parent_finalized).await.unwrap();
             journal.apply_batch(finalized).await.unwrap();
 
             assert_eq!(journal.root(), expected_root);
@@ -1843,11 +2008,144 @@ mod tests {
         });
     }
 
+    /// Finalizing a merkleized batch leaves it available as a speculative
+    /// parent across live journal application.
+    #[test_traced("INFO")]
+    fn test_finalize_leaves_merkleized_batch_available_across_apply() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let journal = create_journal_with_ops(context, "retained-batch-branching", 10).await;
+
+            let op_a = create_operation(100);
+            let op_b = create_operation(200);
+
+            let parent = {
+                let mut batch = journal.new_batch();
+                batch.add(op_a.clone());
+                batch.merkleize()
+            };
+            let parent_root = parent.root();
+            let parent_finalized = parent.finalize_incremental();
+
+            journal.apply_batch(parent_finalized).await.unwrap();
+            assert_eq!(journal.root(), parent_root);
+            assert_eq!(*journal.size().await, 11);
+            assert_eq!(journal.read(Location::new(10)).await.unwrap(), op_a);
+
+            let child = {
+                let mut batch = parent.new_batch();
+                batch.add(op_b.clone());
+                batch.merkleize()
+            };
+            let child_root = child.root();
+            let child_finalized = child.finalize_incremental();
+
+            assert_eq!(child_finalized.items.len(), 1);
+            assert_eq!(&*child_finalized.items[0], &vec![op_b.clone()]);
+
+            journal.apply_batch(child_finalized).await.unwrap();
+            assert_eq!(journal.root(), child_root);
+            assert_eq!(*journal.size().await, 12);
+            assert_eq!(journal.read(Location::new(11)).await.unwrap(), op_b);
+        });
+    }
+
+    /// After the parent batch is applied, descendants can be rebased onto the
+    /// live journal so future children no longer depend on the old parent.
+    #[test_traced("INFO")]
+    fn test_rebase_batch_compacts_one_parent_level() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let journal = create_journal_with_ops(context, "rebased-batch-branching", 10).await;
+
+            let op_a = create_operation(100);
+            let op_b = create_operation(200);
+            let op_c = create_operation(201);
+
+            let parent = {
+                let mut batch = journal.new_batch();
+                batch.add(op_a.clone());
+                batch.merkleize()
+            };
+            let parent_root = parent.root();
+            journal
+                .apply_batch(parent.finalize_incremental())
+                .await
+                .unwrap();
+            assert_eq!(journal.root(), parent_root);
+
+            let rebased_child = {
+                let mut batch = parent.new_batch();
+                batch.add(op_b.clone());
+                let child = batch.merkleize();
+                journal.rebase_batch(&child).unwrap()
+            };
+            drop(parent);
+
+            let grandchild = {
+                let mut batch = rebased_child.new_batch();
+                batch.add(op_c.clone());
+                batch.merkleize()
+            };
+            let expected_root = grandchild.root();
+
+            journal
+                .apply_batch(rebased_child.finalize_incremental())
+                .await
+                .unwrap();
+            journal
+                .apply_batch(grandchild.finalize_incremental())
+                .await
+                .unwrap();
+
+            assert_eq!(journal.root(), expected_root);
+            assert_eq!(*journal.size().await, 13);
+            assert_eq!(journal.read(Location::new(10)).await.unwrap(), op_a);
+            assert_eq!(journal.read(Location::new(11)).await.unwrap(), op_b);
+            assert_eq!(journal.read(Location::new(12)).await.unwrap(), op_c);
+        });
+    }
+
+    /// Rebasing must fail if the live journal no longer matches the frozen
+    /// parent state captured by the batch.
+    #[test_traced("INFO")]
+    fn test_rebase_batch_rejects_mismatched_parent() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let journal =
+                create_journal_with_ops(context.with_label("first"), "rebased-batch-mismatch", 10)
+                    .await;
+            let other = create_journal_with_ops(
+                context.with_label("second"),
+                "rebased-batch-mismatch-other",
+                11,
+            )
+            .await;
+
+            let parent = {
+                let mut batch = journal.new_batch();
+                batch.add(create_operation(100));
+                batch.merkleize()
+            };
+            let child = {
+                let mut batch = parent.new_batch();
+                batch.add(create_operation(200));
+                batch.merkleize()
+            };
+
+            let result = other.rebase_batch(&child);
+            assert!(matches!(
+                result,
+                Err(Error::Mmr(MmrError::RebaseParentRootMismatch))
+            ));
+        });
+    }
+
     #[test_traced("INFO")]
     fn test_stale_batch_sibling() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut journal = create_empty_journal(context, "stale-sibling").await;
+            let journal = create_empty_journal(context, "stale-sibling").await;
             let op_a = create_operation(1);
             let op_b = create_operation(2);
 
@@ -1890,7 +2188,7 @@ mod tests {
     fn test_stale_batch_chained() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut journal = create_journal_with_ops(context, "stale-chained", 5).await;
+            let journal = create_journal_with_ops(context, "stale-chained", 5).await;
 
             // Parent batch, then fork two children.
             let parent = {
@@ -1901,16 +2199,16 @@ mod tests {
             let child_a = {
                 let mut batch = parent.new_batch();
                 batch.add(create_operation(20));
-                batch.merkleize().finalize()
+                batch.merkleize().finalize_incremental()
             };
             let child_b = {
                 let mut batch = parent.new_batch();
                 batch.add(create_operation(30));
-                batch.merkleize().finalize()
+                batch.merkleize().finalize_incremental()
             };
-            drop(parent);
+            let parent_finalized = parent.finalize_incremental();
 
-            // Apply child_a, then child_b should be stale.
+            journal.apply_batch(parent_finalized).await.unwrap();
             journal.apply_batch(child_a).await.unwrap();
             let result = journal.apply_batch(child_b).await;
             assert!(
@@ -1924,10 +2222,10 @@ mod tests {
     }
 
     #[test_traced("INFO")]
-    fn test_stale_batch_parent_before_child() {
+    fn test_child_batch_after_parent_apply() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut journal = create_empty_journal(context, "stale-parent-first").await;
+            let journal = create_empty_journal(context, "stale-parent-first").await;
 
             // Create parent, then child.
             let (parent_finalized, child_finalized) = {
@@ -1939,21 +2237,14 @@ mod tests {
                 let child = {
                     let mut batch = parent.new_batch();
                     batch.add(create_operation(2));
-                    batch.merkleize().finalize()
+                    batch.merkleize().finalize_incremental()
                 };
-                (parent.finalize(), child)
+                (parent.finalize_incremental(), child)
             };
 
-            // Apply parent first -- child should now be stale.
+            // Apply parent first -- child should now apply successfully.
             journal.apply_batch(parent_finalized).await.unwrap();
-            let result = journal.apply_batch(child_finalized).await;
-            assert!(
-                matches!(
-                    result,
-                    Err(super::Error::Mmr(crate::mmr::Error::StaleChangeset { .. }))
-                ),
-                "expected StaleChangeset for child after parent applied, got {result:?}"
-            );
+            journal.apply_batch(child_finalized).await.unwrap();
         });
     }
 
@@ -1961,7 +2252,7 @@ mod tests {
     fn test_stale_batch_child_before_parent() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut journal = create_empty_journal(context, "stale-child-first").await;
+            let journal = create_empty_journal(context, "stale-child-first").await;
 
             // Create parent, then child.
             let (parent_finalized, child_finalized) = {
@@ -1973,21 +2264,21 @@ mod tests {
                 let child = {
                     let mut batch = parent.new_batch();
                     batch.add(create_operation(2));
-                    batch.merkleize().finalize()
+                    batch.merkleize().finalize_incremental()
                 };
-                (parent.finalize(), child)
+                (parent.finalize_incremental(), child)
             };
 
-            // Apply child first -- parent should now be stale.
-            journal.apply_batch(child_finalized).await.unwrap();
-            let result = journal.apply_batch(parent_finalized).await;
+            // Apply child first -- child should be stale until the parent is applied.
+            let result = journal.apply_batch(child_finalized).await;
             assert!(
                 matches!(
                     result,
                     Err(super::Error::Mmr(crate::mmr::Error::StaleChangeset { .. }))
                 ),
-                "expected StaleChangeset for parent after child applied, got {result:?}"
+                "expected StaleChangeset for child before parent applied, got {result:?}"
             );
+            journal.apply_batch(parent_finalized).await.unwrap();
         });
     }
 }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -839,7 +839,7 @@ impl<E: Clock + Storage + Metrics, A: CodecFixedShared> super::Contiguous for Jo
 }
 
 impl<E: Clock + Storage + Metrics, A: CodecFixedShared> Mutable for Journal<E, A> {
-    async fn append(&mut self, item: &Self::Item) -> Result<u64, Error> {
+    async fn append(&self, item: &Self::Item) -> Result<u64, Error> {
         Self::append(self, item).await
     }
 

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -84,7 +84,7 @@ pub trait Mutable: Contiguous + Send + Sync {
     /// Returns an error if the underlying storage operation fails or if the item cannot
     /// be encoded.
     fn append(
-        &mut self,
+        &self,
         item: &Self::Item,
     ) -> impl std::future::Future<Output = Result<u64, Error>> + Send;
 

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -102,7 +102,7 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("bounds-with-items".into()).await.unwrap();
+    let journal = factory("bounds-with-items".into()).await.unwrap();
 
     // Append some items
     for i in 0..10 {
@@ -174,7 +174,7 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("append-and-size".into()).await.unwrap();
+    let journal = factory("append-and-size".into()).await.unwrap();
 
     let pos1 = journal.append(&100).await.unwrap();
     let pos2 = journal.append(&200).await.unwrap();
@@ -199,7 +199,7 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("sequential-appends".into()).await.unwrap();
+    let journal = factory("sequential-appends".into()).await.unwrap();
 
     for i in 0..25u64 {
         let pos = journal.append(&(i * 10)).await.unwrap();
@@ -221,7 +221,7 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("replay-from-start".into()).await.unwrap();
+    let journal = factory("replay-from-start".into()).await.unwrap();
 
     for i in 0..10u64 {
         journal.append(&(i * 10)).await.unwrap();
@@ -253,7 +253,7 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("replay-from-middle".into()).await.unwrap();
+    let journal = factory("replay-from-middle".into()).await.unwrap();
 
     for i in 0..15u64 {
         journal.append(&(i * 10)).await.unwrap();
@@ -318,10 +318,10 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("through-trait".into()).await.unwrap();
+    let journal = factory("through-trait".into()).await.unwrap();
 
-    let pos1 = Mutable::append(&mut journal, &42).await.unwrap();
-    let pos2 = Mutable::append(&mut journal, &100).await.unwrap();
+    let pos1 = Mutable::append(&journal, &42).await.unwrap();
+    let pos2 = Mutable::append(&journal, &100).await.unwrap();
 
     assert_eq!(pos1, 0);
     assert_eq!(pos2, 1);
@@ -453,7 +453,7 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("sync-behavior".into()).await.unwrap();
+    let journal = factory("sync-behavior".into()).await.unwrap();
 
     for i in 0..5u64 {
         journal.append(&i).await.unwrap();
@@ -502,7 +502,7 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("replay-at-exact-size".into()).await.unwrap();
+    let journal = factory("replay-at-exact-size".into()).await.unwrap();
 
     for i in 0..10u64 {
         journal.append(&i).await.unwrap();
@@ -586,7 +586,7 @@ where
 
     // Create journal and append items
     {
-        let mut journal = factory(test_name.clone()).await.unwrap();
+        let journal = factory(test_name.clone()).await.unwrap();
 
         for i in 0..15u64 {
             let pos = journal.append(&(i * 10)).await.unwrap();
@@ -658,7 +658,7 @@ where
 
     // Re-open and verify pruned state persists
     {
-        let mut journal = factory(test_name.clone()).await.unwrap();
+        let journal = factory(test_name.clone()).await.unwrap();
 
         // size should still be 25
         assert_eq!(get_bounds(&journal).await.end, 25);
@@ -712,7 +712,7 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("read-by-position".into()).await.unwrap();
+    let journal = factory("read-by-position".into()).await.unwrap();
 
     for i in 0..1000u64 {
         journal.append(&(i * 100)).await.unwrap();
@@ -733,7 +733,7 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: PersistableContiguous,
 {
-    let mut journal = factory("read-out-of-range".into()).await.unwrap();
+    let journal = factory("read-out-of-range".into()).await.unwrap();
 
     journal.append(&42).await.unwrap();
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -904,7 +904,7 @@ impl<E: Clock + Storage + Metrics, V: CodecShared> Contiguous for Journal<E, V> 
 }
 
 impl<E: Clock + Storage + Metrics, V: CodecShared> Mutable for Journal<E, V> {
-    async fn append(&mut self, item: &Self::Item) -> Result<u64, Error> {
+    async fn append(&self, item: &Self::Item) -> Result<u64, Error> {
         Self::append(self, item).await
     }
 

--- a/storage/src/mmr/batch.rs
+++ b/storage/src/mmr/batch.rs
@@ -50,17 +50,69 @@
 //! // Apply the changeset back to the base MMR.
 //! mmr.apply(changeset).unwrap();
 //! ```
+//!
+//! If you need to keep branching while a merkleized batch is being finalized
+//! and applied, retain the merkleized batch as the branch parent:
+//!
+//! ```ignore
+//! let merkleized = batch.merkleize(&mut hasher);
+//! let pending_changeset = merkleized.finalize_incremental();
+//!
+//! let mut child = merkleized.new_batch();
+//! child.add(&mut hasher, b"leaf-2");
+//! let child_changeset = child.merkleize(&mut hasher).finalize_incremental();
+//! ```
+//!
+//! Branching from a retained merkleized batch is speculative. This branches
+//! from the prepared parent state, not from the last applied state of the
+//! underlying MMR.
+//!
+//! Once the oldest prepared parent has been applied, descendants can be
+//! compacted back onto the live MMR with [`MerkleizedBatch::rebase`]. This
+//! drops one speculative ancestor level without copying the batch-local delta.
+//!
+//! Manual rebasing is only needed to bound retained chain depth. If you never
+//! rebase, speculative reads continue to work, but they keep traversing the
+//! retained parent chain.
+//!
+//! A typical flow is:
+//!
+//! ```ignore
+//! let parent = batch.merkleize(&mut hasher);
+//! let parent_changeset = parent.finalize_incremental();
+//!
+//! let child = {
+//!     let mut batch = parent.new_batch();
+//!     batch.add(&mut hasher, b"leaf-2");
+//!     batch.merkleize(&mut hasher)
+//! };
+//!
+//! // Parent is now reflected in the live MMR.
+//! mmr.apply(parent_changeset).unwrap();
+//!
+//! // Rebase the child onto the live MMR to drop one speculative ancestor.
+//! let child_changeset = {
+//!     let child = child.rebase(&mmr).unwrap();
+//!     child.finalize_incremental()
+//! };
+//! mmr.apply(child_changeset).unwrap();
+//! ```
+//!
+//! Rebasing is valid only once the live parent matches the frozen parent state
+//! captured by the batch. Calling [`MerkleizedBatch::rebase`] too early, or on
+//! the wrong live MMR, returns [`Error::RebaseParentMismatch`] or
+//! [`Error::RebaseParentRootMismatch`].
 
 #[cfg(any(feature = "std", test))]
 use crate::mmr::iterator::pos_to_height;
 use crate::mmr::{
     hasher::Hasher,
     iterator::{nodes_needing_parents, PathIterator, PeakIterator},
-    mem::{Clean, Dirty, State},
+    mem::Dirty,
     read::{BatchChainInfo, Readable},
     Error, Location, Position,
 };
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 use commonware_cryptography::Digest;
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
@@ -69,41 +121,63 @@ cfg_if::cfg_if! {
     }
 }
 
-/// A batch of mutations against a parent MMR, which may itself be a merkleized batch.
-pub struct Batch<'a, D: Digest, P: Readable<D>, S: State<D> = Dirty> {
+/// A mutable batch of mutations against a parent MMR, which may itself be a
+/// merkleized batch.
+pub struct Batch<'a, D: Digest, P: Readable<D>> {
     /// The parent MMR.
     parent: &'a P,
     /// Nodes appended by this batch, at positions [parent.size(), parent.size() + appended.len()).
     appended: Vec<D>,
     /// Overwritten nodes at positions < parent.size(). Shadows parent data; later writes win.
     overwrites: BTreeMap<Position, D>,
-    /// Type-state: Dirty (mutable, no root) or `Clean<D>` (immutable, has root).
-    state: S,
+    /// Non-leaf nodes whose digests must be recomputed before merkleization.
+    state: Dirty,
     /// Thread pool for parallel merkleization.
     #[cfg(feature = "std")]
     pool: Option<ThreadPool>,
 }
 
 /// A batch whose root digest has not been computed.
-pub type UnmerkleizedBatch<'a, D, P> = Batch<'a, D, P, Dirty>;
+pub type UnmerkleizedBatch<'a, D, P> = Batch<'a, D, P>;
 
-/// A batch whose root digest has been computed.
-pub type MerkleizedBatch<'a, D, P> = Batch<'a, D, P, Clean<D>>;
+/// An immutable merkleized batch that can be retained as a speculative parent
+/// while its finalized changeset is being applied.
+pub struct MerkleizedBatch<'a, D: Digest, P: Readable<D>> {
+    /// The parent MMR.
+    parent: &'a P,
+    /// The parent MMR root when this batch was merkleized.
+    parent_root: D,
+    /// The parent MMR size when this batch was merkleized.
+    parent_size: Position,
+    /// The parent pruning boundary when this batch was merkleized.
+    parent_pruned_to_pos: Position,
+    /// The original base size for the entire batch chain.
+    parent_base_size: Position,
+    /// Nodes appended by this batch, at positions [parent.size(), parent.size() + appended.len()).
+    appended: Arc<Vec<D>>,
+    /// Overwritten nodes at positions < parent.size(). Shadows parent data; later writes win.
+    overwrites: Arc<BTreeMap<Position, D>>,
+    /// The root digest of the MMR after this batch is applied.
+    root: D,
+    /// Thread pool for parallel merkleization.
+    #[cfg(feature = "std")]
+    pool: Option<ThreadPool>,
+}
 
 /// Owned set of changes against a base MMR.
 /// Apply via [`super::mem::Mmr::apply`].
 pub struct Changeset<D: Digest> {
     /// Nodes appended after the base MMR's existing nodes.
-    pub(crate) appended: Vec<D>,
+    pub(crate) appended: Arc<Vec<D>>,
     /// Overwritten nodes within the base MMR's range.
-    pub(crate) overwrites: BTreeMap<Position, D>,
+    pub(crate) overwrites: Arc<BTreeMap<Position, D>>,
     /// Root digest after applying the changeset.
     pub(crate) root: D,
     /// Size of the base MMR when this changeset was created.
     pub(crate) base_size: Position,
 }
 
-impl<'a, D: Digest, P: Readable<D>, S: State<D>> Batch<'a, D, P, S> {
+impl<'a, D: Digest, P: Readable<D>> Batch<'a, D, P> {
     /// The total number of nodes visible through this batch.
     pub(crate) fn size(&self) -> Position {
         Position::new(*self.parent.size() + self.appended.len() as u64)
@@ -254,7 +328,10 @@ impl<'a, D: Digest, P: Readable<D>> UnmerkleizedBatch<'a, D, P> {
     }
 
     /// Consume this batch and produce an immutable [MerkleizedBatch] with computed root.
-    pub fn merkleize(mut self, hasher: &mut impl Hasher<Digest = D>) -> MerkleizedBatch<'a, D, P> {
+    pub fn merkleize(mut self, hasher: &mut impl Hasher<Digest = D>) -> MerkleizedBatch<'a, D, P>
+    where
+        P: BatchChainInfo<D>,
+    {
         let dirty = self.state.take_sorted_by_height();
 
         #[cfg(feature = "std")]
@@ -281,11 +358,15 @@ impl<'a, D: Digest, P: Readable<D>> UnmerkleizedBatch<'a, D, P> {
             .collect();
         let root = hasher.root(leaves, peaks.iter());
 
-        Batch {
+        MerkleizedBatch {
             parent: self.parent,
-            appended: self.appended,
-            overwrites: self.overwrites,
-            state: Clean { root },
+            parent_root: self.parent.root(),
+            parent_size: self.parent.size(),
+            parent_pruned_to_pos: self.parent.pruned_to_pos(),
+            parent_base_size: self.parent.base_size(),
+            appended: Arc::new(self.appended),
+            overwrites: Arc::new(self.overwrites),
+            root,
             #[cfg(feature = "std")]
             pool: self.pool,
         }
@@ -399,6 +480,28 @@ impl<'a, D: Digest, P: Readable<D>> UnmerkleizedBatch<'a, D, P> {
     }
 }
 
+impl<'a, D: Digest, P: Readable<D>> MerkleizedBatch<'a, D, P> {
+    /// The total number of nodes visible through this batch.
+    pub(crate) fn size(&self) -> Position {
+        Position::new(*self.parent_size + self.appended.len() as u64)
+    }
+
+    /// Resolve a node: overwrites -> appended -> parent.
+    fn get_node(&self, pos: Position) -> Option<D> {
+        if pos >= self.size() {
+            return None;
+        }
+        if let Some(d) = self.overwrites.get(&pos) {
+            return Some(*d);
+        }
+        if pos >= self.parent_size {
+            let index = (*pos - *self.parent_size) as usize;
+            return self.appended.get(index).copied();
+        }
+        self.parent.get_node(pos)
+    }
+}
+
 impl<'a, D: Digest, P: Readable<D>> Readable<D> for MerkleizedBatch<'a, D, P> {
     fn size(&self) -> Position {
         self.size()
@@ -409,11 +512,11 @@ impl<'a, D: Digest, P: Readable<D>> Readable<D> for MerkleizedBatch<'a, D, P> {
     }
 
     fn root(&self) -> D {
-        self.state.root
+        self.root
     }
 
     fn pruned_to_pos(&self) -> Position {
-        self.parent.pruned_to_pos()
+        self.parent_pruned_to_pos
     }
 }
 
@@ -421,13 +524,13 @@ impl<'a, D: Digest, P: Readable<D> + BatchChainInfo<D>> BatchChainInfo<D>
     for MerkleizedBatch<'a, D, P>
 {
     fn base_size(&self) -> Position {
-        self.parent.base_size()
+        self.parent_base_size
     }
 
     fn collect_overwrites(&self, into: &mut BTreeMap<Position, D>) {
         self.parent.collect_overwrites(into);
-        let base_size = self.parent.base_size();
-        for (&pos, &digest) in &self.overwrites {
+        let base_size = self.parent_base_size;
+        for (&pos, &digest) in self.overwrites.iter() {
             if pos < base_size {
                 into.insert(pos, digest);
             }
@@ -456,12 +559,54 @@ impl<'a, D: Digest, P: Readable<D>> MerkleizedBatch<'a, D, P> {
         batch
     }
 
+    /// Rebase this batch onto an equivalent live parent after that parent has
+    /// been applied, dropping one speculative ancestor from the read-through
+    /// chain.
+    pub fn rebase<'b, Q>(&self, parent: &'b Q) -> Result<MerkleizedBatch<'b, D, Q>, Error>
+    where
+        Q: Readable<D> + BatchChainInfo<D>,
+    {
+        let actual_size = parent.size();
+        let actual_pruned_to_pos = parent.pruned_to_pos();
+        if actual_size != self.parent_size || actual_pruned_to_pos != self.parent_pruned_to_pos {
+            return Err(Error::RebaseParentMismatch {
+                expected_size: self.parent_size,
+                expected_pruned_to_pos: self.parent_pruned_to_pos,
+                actual_size,
+                actual_pruned_to_pos,
+            });
+        }
+        let actual_root = parent.root();
+        if actual_root != self.parent_root {
+            return Err(Error::RebaseParentRootMismatch);
+        }
+
+        Ok(MerkleizedBatch {
+            parent,
+            parent_root: actual_root,
+            parent_size: actual_size,
+            parent_pruned_to_pos: actual_pruned_to_pos,
+            parent_base_size: parent.base_size(),
+            appended: self.appended.clone(),
+            overwrites: self.overwrites.clone(),
+            root: self.root,
+            #[cfg(feature = "std")]
+            pool: self.pool.clone(),
+        })
+    }
+
     /// Convert back to a dirty batch for further mutations.
     pub fn into_dirty(self) -> UnmerkleizedBatch<'a, D, P> {
         Batch {
             parent: self.parent,
-            appended: self.appended,
-            overwrites: self.overwrites,
+            appended: match Arc::try_unwrap(self.appended) {
+                Ok(appended) => appended,
+                Err(appended) => (*appended).clone(),
+            },
+            overwrites: match Arc::try_unwrap(self.overwrites) {
+                Ok(overwrites) => overwrites,
+                Err(overwrites) => (*overwrites).clone(),
+            },
             state: Dirty::default(),
             #[cfg(feature = "std")]
             pool: self.pool,
@@ -470,28 +615,40 @@ impl<'a, D: Digest, P: Readable<D>> MerkleizedBatch<'a, D, P> {
 }
 
 impl<'a, D: Digest, P: Readable<D> + BatchChainInfo<D>> MerkleizedBatch<'a, D, P> {
-    /// Flatten this batch chain into a single [`Changeset`] relative to the
-    /// ultimate base MMR.
-    pub fn finalize(self) -> Changeset<D> {
-        let base_size = self.parent.base_size();
-        let effective = self.size();
-
-        // Resolve nodes at [base_size, effective).
-        let mut appended = Vec::with_capacity((*effective - *base_size) as usize);
-        for i in *base_size..*effective {
-            appended.push(self.get_node(Position::new(i)).expect("node in range"));
-        }
-
-        // Collect overwrites from entire chain, filtered to positions < base_size.
+    /// Finalize this batch into a [`Changeset`] relative to the base of the
+    /// entire retained batch chain.
+    pub fn finalize(&self) -> Changeset<D> {
+        let base_size = self.base_size();
         let mut overwrites = BTreeMap::new();
         self.collect_overwrites(&mut overwrites);
-        overwrites.retain(|&pos, _| pos < base_size);
+
+        let mut appended = Vec::with_capacity((*self.size() - *base_size) as usize);
+        for pos in *base_size..*self.size() {
+            appended.push(
+                self.get_node(Position::new(pos))
+                    .expect("flattened appended node missing"),
+            );
+        }
 
         Changeset {
-            appended,
-            overwrites,
-            root: self.state.root,
+            appended: Arc::new(appended),
+            overwrites: Arc::new(overwrites),
+            root: self.root,
             base_size,
+        }
+    }
+}
+
+impl<'a, D: Digest, P: Readable<D>> MerkleizedBatch<'a, D, P> {
+    /// Finalize this batch into a [`Changeset`] relative to its immediate
+    /// parent. This is the form used with [`Self::rebase`] for pipelined
+    /// speculative execution.
+    pub fn finalize_incremental(&self) -> Changeset<D> {
+        Changeset {
+            appended: self.appended.clone(),
+            overwrites: self.overwrites.clone(),
+            root: self.root,
+            base_size: self.parent_size,
         }
     }
 }
@@ -709,9 +866,9 @@ mod tests {
         });
     }
 
-    /// Base <- A <- B. B.finalize() captures both A and B changes. Apply to base, verify.
+    /// Base <- A <- B. Apply A, then B, and verify the final root and nodes.
     #[test]
-    fn test_fork_of_fork_flattened_changeset() {
+    fn test_fork_of_fork_incremental_changesets() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             let mut hasher: Standard<Sha256> = Standard::new();
@@ -734,11 +891,12 @@ mod tests {
                 batch_b.add(&mut hasher, &element);
             }
             let merkleized_b = batch_b.merkleize(&mut hasher);
+            let a_changeset = merkleized_a.finalize_incremental();
             let b_root = merkleized_b.root();
+            let b_changeset = merkleized_b.finalize_incremental();
 
-            let changeset = merkleized_b.finalize();
-            drop(merkleized_a);
-            base.apply(changeset).unwrap();
+            base.apply(a_changeset).unwrap();
+            base.apply(b_changeset).unwrap();
 
             assert_eq!(*base.root(), b_root);
 
@@ -752,6 +910,139 @@ mod tests {
                     "node mismatch at pos {pos}"
                 );
             }
+        });
+    }
+
+    /// Finalizing a merkleized batch leaves it available as a speculative
+    /// parent for further branching.
+    #[test]
+    fn test_finalize_leaves_merkleized_batch_available_for_children() {
+        let executor = deterministic::Runner::default();
+        executor.start(|_| async move {
+            let mut hasher: Standard<Sha256> = Standard::new();
+            let base = build_reference(&mut hasher, 50);
+
+            let parent = {
+                let mut batch = UnmerkleizedBatch::new(&base);
+                for i in 50u64..60 {
+                    hasher.inner().update(&i.to_be_bytes());
+                    let element = hasher.inner().finalize();
+                    batch.add(&mut hasher, &element);
+                }
+                batch.merkleize(&mut hasher)
+            };
+            let parent_finalized = parent.finalize_incremental();
+            assert_eq!(parent_finalized.base_size, base.size());
+
+            let child = {
+                let mut batch = parent.new_batch();
+                for i in 60u64..70 {
+                    hasher.inner().update(&i.to_be_bytes());
+                    let element = hasher.inner().finalize();
+                    batch.add(&mut hasher, &element);
+                }
+                batch.merkleize(&mut hasher)
+            };
+            let child_root = child.root();
+            let child_finalized = child.finalize_incremental();
+            assert_eq!(child_finalized.base_size, parent.size());
+            assert_eq!(
+                Position::new(*child_finalized.base_size + child_finalized.appended.len() as u64),
+                build_reference(&mut hasher, 70).size(),
+            );
+            assert_eq!(child_root, *build_reference(&mut hasher, 70).root());
+        });
+    }
+
+    /// After the parent is applied, a child batch can be rebased onto the live
+    /// MMR so future descendants no longer depend on the old speculative parent.
+    #[test]
+    fn test_rebase_compacts_one_parent_level() {
+        let executor = deterministic::Runner::default();
+        executor.start(|_| async move {
+            let mut hasher: Standard<Sha256> = Standard::new();
+            let base = build_reference(&mut hasher, 50);
+            let mut live_after_parent = base.clone();
+
+            let parent = {
+                let mut batch = UnmerkleizedBatch::new(&base);
+                for i in 50u64..60 {
+                    hasher.inner().update(&i.to_be_bytes());
+                    let element = hasher.inner().finalize();
+                    batch.add(&mut hasher, &element);
+                }
+                batch.merkleize(&mut hasher)
+            };
+            let parent_finalized = parent.finalize_incremental();
+            live_after_parent.apply(parent_finalized).unwrap();
+
+            let rebased_child = {
+                let mut batch = parent.new_batch();
+                for i in 60u64..70 {
+                    hasher.inner().update(&i.to_be_bytes());
+                    let element = hasher.inner().finalize();
+                    batch.add(&mut hasher, &element);
+                }
+                let child = batch.merkleize(&mut hasher);
+                child.rebase(&live_after_parent).unwrap()
+            };
+            drop(parent);
+
+            let grandchild = {
+                let mut batch = rebased_child.new_batch();
+                for i in 70u64..75 {
+                    hasher.inner().update(&i.to_be_bytes());
+                    let element = hasher.inner().finalize();
+                    batch.add(&mut hasher, &element);
+                }
+                batch.merkleize(&mut hasher)
+            };
+            let expected_root = grandchild.root();
+
+            let mut live_after_grandchild = live_after_parent.clone();
+            live_after_grandchild
+                .apply(rebased_child.finalize_incremental())
+                .unwrap();
+            live_after_grandchild
+                .apply(grandchild.finalize_incremental())
+                .unwrap();
+
+            let reference = build_reference(&mut hasher, 75);
+            assert_eq!(*live_after_grandchild.root(), expected_root);
+            assert_eq!(live_after_grandchild.root(), reference.root());
+        });
+    }
+
+    /// Rebasing must fail if the candidate live parent no longer matches the
+    /// frozen parent state captured by the batch.
+    #[test]
+    fn test_rebase_rejects_mismatched_parent() {
+        let executor = deterministic::Runner::default();
+        executor.start(|_| async move {
+            let mut hasher: Standard<Sha256> = Standard::new();
+            let base = build_reference(&mut hasher, 10);
+
+            let parent = {
+                let mut batch = UnmerkleizedBatch::new(&base);
+                batch.add(&mut hasher, b"a");
+                batch.merkleize(&mut hasher)
+            };
+            let child = {
+                let mut batch = parent.new_batch();
+                batch.add(&mut hasher, b"b");
+                batch.merkleize(&mut hasher)
+            };
+
+            let other = build_reference(&mut hasher, 12);
+            let result = child.rebase(&other);
+            assert!(matches!(
+                result,
+                Err(Error::RebaseParentMismatch {
+                    expected_size,
+                    actual_size,
+                    ..
+                }) if expected_size == parent.size() && actual_size == other.size()
+            ));
         });
     }
 
@@ -1040,9 +1331,9 @@ mod tests {
         });
     }
 
-    /// Base <- A (overwrites leaf 5) <- B (adds). B's changeset includes A's overwrite.
+    /// Base <- A (overwrites leaf 5) <- B (adds). Apply A, then B, preserving the overwrite.
     #[test]
-    fn test_flattened_changeset_preserves_overwrites() {
+    fn test_incremental_changeset_preserves_overwrites() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             let mut hasher: Standard<Sha256> = Standard::new();
@@ -1067,9 +1358,10 @@ mod tests {
             let merkleized_b = batch_b.merkleize(&mut hasher);
             let b_root = merkleized_b.root();
 
-            let changeset = merkleized_b.finalize();
-            drop(merkleized_a);
-            base.apply(changeset).unwrap();
+            let a_changeset = merkleized_a.finalize();
+            let b_changeset = merkleized_b.finalize();
+            base.apply(a_changeset).unwrap();
+            base.apply(b_changeset).unwrap();
 
             assert_eq!(*base.root(), b_root);
 
@@ -1080,7 +1372,7 @@ mod tests {
     }
 
     /// Base <- A (overwrite leaf 5) <- B (overwrite leaf 10) <- C (add 10).
-    /// Flatten C's changeset, apply to base, verify root matches building the equivalent directly.
+    /// Apply A, then B, then C, and verify the result matches building the equivalent directly.
     #[test]
     fn test_three_deep_stacking() {
         let executor = deterministic::Runner::default();
@@ -1115,11 +1407,12 @@ mod tests {
             let merkleized_c = batch_c.merkleize(&mut hasher);
             let c_root = merkleized_c.root();
 
-            // Flatten C's changeset all the way to base.
-            let changeset = merkleized_c.finalize();
-            drop(merkleized_b);
-            drop(merkleized_a);
-            base.apply(changeset).unwrap();
+            let a_changeset = merkleized_a.finalize();
+            let b_changeset = merkleized_b.finalize();
+            let c_changeset = merkleized_c.finalize();
+            base.apply(a_changeset).unwrap();
+            base.apply(b_changeset).unwrap();
+            base.apply(c_changeset).unwrap();
 
             assert_eq!(*base.root(), c_root);
 
@@ -1155,7 +1448,7 @@ mod tests {
     }
 
     /// A overwrites leaf 5 with X, B overwrites leaf 5 with Y.
-    /// Flattened changeset should have Y (last writer wins).
+    /// Applying A then B should leave Y as the last writer.
     #[test]
     fn test_overwrite_collision_in_stack() {
         let executor = deterministic::Runner::default();
@@ -1181,9 +1474,10 @@ mod tests {
             let merkleized_b = batch_b.merkleize(&mut hasher);
             let b_root = merkleized_b.root();
 
-            let changeset = merkleized_b.finalize();
-            drop(merkleized_a);
-            base.apply(changeset).unwrap();
+            let a_changeset = merkleized_a.finalize();
+            let b_changeset = merkleized_b.finalize();
+            base.apply(a_changeset).unwrap();
+            base.apply(b_changeset).unwrap();
 
             assert_eq!(*base.root(), b_root);
 

--- a/storage/src/mmr/journaled.rs
+++ b/storage/src/mmr/journaled.rs
@@ -740,14 +740,26 @@ impl<E: RStorage + Clock + Metrics, D: Digest> Mmr<E, D> {
     /// batch that produced it was created. Multiple batches can be forked from
     /// the same parent for speculative execution, but only one may be applied.
     /// Applying a stale changeset returns [`Error::StaleChangeset`].
-    pub fn apply(&mut self, changeset: batch::Changeset<D>) -> Result<(), Error> {
-        self.inner.get_mut().mem_mmr.apply(changeset)?;
+    pub fn apply(&self, changeset: batch::Changeset<D>) -> Result<(), Error> {
+        self.inner.write().mem_mmr.apply(changeset)?;
         Ok(())
     }
 
     /// Create a new speculative batch with this MMR as its parent.
     pub fn new_batch(&self) -> UnmerkleizedBatch<'_, D, Self> {
         UnmerkleizedBatch::new(self).with_pool(self.pool())
+    }
+
+    /// Rebase a speculative batch onto this live MMR after its oldest parent
+    /// has been applied, dropping one speculative ancestor from the chain.
+    pub fn rebase_batch<'a, P>(
+        &'a self,
+        batch: &batch::MerkleizedBatch<'_, D, P>,
+    ) -> Result<batch::MerkleizedBatch<'a, D, Self>, Error>
+    where
+        P: Readable<D> + BatchChainInfo<D>,
+    {
+        batch.rebase(self)
     }
 
     /// Return the thread pool, if any.
@@ -908,7 +920,7 @@ mod tests {
             let test_mmr = build_test_mmr(&mut hasher, test_mmr, NUM_ELEMENTS);
             let expected_root = test_mmr.root();
 
-            let mut journaled_mmr = Mmr::init(
+            let journaled_mmr = Mmr::init(
                 context.clone(),
                 &mut Standard::<Sha256>::new(),
                 test_config(&context),
@@ -970,7 +982,7 @@ mod tests {
             assert_eq!(mmr.size(), 0);
             mmr.sync().await.unwrap();
 
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.with_label("second"),
                 &mut hasher,
                 test_config(&context),
@@ -1230,7 +1242,7 @@ mod tests {
         executor.start(|context| async move {
             let mut hasher: Standard<Sha256> = Standard::new();
             let cfg = test_config(&context);
-            let mut mmr = Mmr::init(context, &mut hasher, cfg).await.unwrap();
+            let mmr = Mmr::init(context, &mut hasher, cfg).await.unwrap();
             // Build a test MMR with 255 leaves
             const LEAF_COUNT: usize = 255;
             let mut leaves = Vec::with_capacity(LEAF_COUNT);
@@ -1289,7 +1301,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut hasher: Standard<Sha256> = Standard::new();
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.with_label("first"),
                 &mut hasher,
                 test_config(&context),
@@ -1382,7 +1394,7 @@ mod tests {
                 thread_pool: None,
                 page_cache: cfg_pruned.page_cache.clone(),
             };
-            let mut mmr = Mmr::init(context.with_label("unpruned"), &mut hasher, cfg_unpruned)
+            let mmr = Mmr::init(context.with_label("unpruned"), &mut hasher, cfg_unpruned)
                 .await
                 .unwrap();
             let mut leaves = Vec::with_capacity(LEAF_COUNT);
@@ -1520,7 +1532,7 @@ mod tests {
             let mut hasher: Standard<Sha256> = Standard::new();
             const LEAF_COUNT: usize = 2000;
             let mut leaves = Vec::with_capacity(LEAF_COUNT);
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.with_label("init"),
                 &mut hasher,
                 test_config(&context),
@@ -1608,7 +1620,7 @@ mod tests {
             // Create MMR with 10 elements
             let mut hasher = Standard::<Sha256>::new();
             let cfg = test_config(&context);
-            let mut mmr = Mmr::init(context, &mut hasher, cfg).await.unwrap();
+            let mmr = Mmr::init(context, &mut hasher, cfg).await.unwrap();
             let mut elements = Vec::new();
             for i in 0..10 {
                 elements.push(test_digest(i));
@@ -1698,7 +1710,7 @@ mod tests {
             mmr.prune_to_pos(prune_pos).await.unwrap();
 
             // Create reference MMR for verification to get correct size
-            let mut ref_mmr = Mmr::init(
+            let ref_mmr = Mmr::init(
                 context.with_label("ref"),
                 &mut hasher,
                 Config {
@@ -1751,7 +1763,7 @@ mod tests {
         executor.start(|context| async move {
             let mut hasher = Standard::<Sha256>::new();
 
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.with_label("server"),
                 &mut hasher,
                 Config {
@@ -1782,7 +1794,7 @@ mod tests {
             let range = Location::new(30)..Location::new(61);
 
             // Only apply elements up to end_loc to the reference MMR.
-            let mut ref_mmr = Mmr::init(
+            let ref_mmr = Mmr::init(
                 context.with_label("client"),
                 &mut hasher,
                 Config {
@@ -1833,7 +1845,7 @@ mod tests {
         executor.start(|context| async move {
             let mut hasher = Standard::<Sha256>::new();
             let cfg = test_config(&context);
-            let mut mmr = Mmr::init(context, &mut hasher, cfg).await.unwrap();
+            let mmr = Mmr::init(context, &mut hasher, cfg).await.unwrap();
 
             let element = test_digest(0);
             let changeset = {
@@ -1875,7 +1887,7 @@ mod tests {
                 pinned_nodes: None,
             };
 
-            let mut sync_mmr = Mmr::init_sync(context.clone(), sync_cfg, &mut hasher)
+            let sync_mmr = Mmr::init_sync(context.clone(), sync_cfg, &mut hasher)
                 .await
                 .unwrap();
 
@@ -1909,7 +1921,7 @@ mod tests {
             let mut hasher = Standard::<Sha256>::new();
 
             // Create initial MMR with elements.
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.with_label("init"),
                 &mut hasher,
                 test_config(&context),
@@ -2190,7 +2202,7 @@ mod tests {
             };
 
             // Create MMR with enough elements to span multiple sections.
-            let mut mmr = Mmr::init(context.with_label("init"), &mut hasher, cfg.clone())
+            let mmr = Mmr::init(context.with_label("init"), &mut hasher, cfg.clone())
                 .await
                 .unwrap();
             let changeset = {
@@ -2296,7 +2308,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut hasher = Standard::<Sha256>::new();
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.with_label("init"),
                 &mut hasher,
                 test_config(&context),
@@ -2345,7 +2357,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut hasher = Standard::<Sha256>::new();
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.with_label("init"),
                 &mut hasher,
                 test_config(&context),
@@ -2519,7 +2531,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut hasher = Standard::<Sha256>::new();
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.with_label("oob"),
                 &mut hasher,
                 test_config(&context),
@@ -2554,7 +2566,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut hasher = Standard::<Sha256>::new();
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.with_label("range_validation"),
                 &mut hasher,
                 test_config(&context),
@@ -2686,7 +2698,7 @@ mod tests {
             let mut hasher: Standard<Sha256> = Standard::new();
 
             // Build base journaled MMR with 10 elements.
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.clone(),
                 &mut Standard::<Sha256>::new(),
                 test_config(&context),
@@ -2723,12 +2735,13 @@ mod tests {
                 batch_b.add(&mut hasher, &element);
             }
             let merkleized_b = batch_b.merkleize(&mut hasher);
+            let changeset_a = merkleized_a.finalize_incremental();
             let expected_root = merkleized_b.root();
+            let changeset_b = merkleized_b.finalize_incremental();
 
-            // Flatten and apply.
-            let changeset = merkleized_b.finalize();
-            drop(merkleized_a);
-            mmr.apply(changeset).unwrap();
+            // Apply parent, then child.
+            mmr.apply(changeset_a).unwrap();
+            mmr.apply(changeset_b).unwrap();
             assert_eq!(mmr.root(), expected_root);
 
             // Build a reference in-memory MMR with 20 elements to verify.
@@ -2745,7 +2758,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut hasher: Standard<Sha256> = Standard::new();
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.clone(),
                 &mut Standard::<Sha256>::new(),
                 test_config(&context),

--- a/storage/src/mmr/mem.rs
+++ b/storage/src/mmr/mem.rs
@@ -452,13 +452,13 @@ impl<D: Digest> Mmr<D> {
         }
 
         // 1. Overwrite: write modified digests into surviving base nodes.
-        for (pos, digest) in changeset.overwrites {
+        for (&pos, &digest) in changeset.overwrites.iter() {
             let index = self.pos_to_index(pos);
             self.nodes[index] = digest;
         }
 
         // 2. Append: push new nodes onto the end.
-        for digest in changeset.appended {
+        for &digest in changeset.appended.iter() {
             self.nodes.push_back(digest);
         }
 
@@ -1334,15 +1334,17 @@ mod tests {
             let child_a = {
                 let mut batch = parent.new_batch();
                 batch.add(&mut hasher, b"leaf-2a");
-                batch.merkleize(&mut hasher).finalize()
+                batch.merkleize(&mut hasher).finalize_incremental()
             };
             let child_b = {
                 let mut batch = parent.new_batch();
                 batch.add(&mut hasher, b"leaf-2b");
-                batch.merkleize(&mut hasher).finalize()
+                batch.merkleize(&mut hasher).finalize_incremental()
             };
+            let parent = parent.finalize_incremental();
 
-            // Apply child_a, then child_b should be stale.
+            // Apply parent, then child_a. child_b should then be stale.
+            mmr.apply(parent).unwrap();
             mmr.apply(child_a).unwrap();
             let result = mmr.apply(child_b);
             assert!(
@@ -1369,17 +1371,13 @@ mod tests {
             let child = {
                 let mut batch = parent.new_batch();
                 batch.add(&mut hasher, b"leaf-1");
-                batch.merkleize(&mut hasher).finalize()
+                batch.merkleize(&mut hasher).finalize_incremental()
             };
-            let parent = parent.finalize();
+            let parent = parent.finalize_incremental();
 
-            // Apply parent first -- child should now be stale.
+            // Apply parent first -- child should now apply successfully.
             mmr.apply(parent).unwrap();
-            let result = mmr.apply(child);
-            assert!(
-                matches!(result, Err(Error::StaleChangeset { .. })),
-                "expected StaleChangeset for child after parent applied, got {result:?}"
-            );
+            mmr.apply(child).unwrap();
         });
     }
 
@@ -1400,17 +1398,17 @@ mod tests {
             let child = {
                 let mut batch = parent.new_batch();
                 batch.add(&mut hasher, b"leaf-1");
-                batch.merkleize(&mut hasher).finalize()
+                batch.merkleize(&mut hasher).finalize_incremental()
             };
-            let parent = parent.finalize();
+            let parent = parent.finalize_incremental();
 
-            // Apply child first -- parent should now be stale.
-            mmr.apply(child).unwrap();
-            let result = mmr.apply(parent);
+            // Apply child first -- child should be stale until parent is applied.
+            let result = mmr.apply(child);
             assert!(
                 matches!(result, Err(Error::StaleChangeset { .. })),
-                "expected StaleChangeset for parent after child applied, got {result:?}"
+                "expected StaleChangeset for child before parent applied, got {result:?}"
             );
+            mmr.apply(parent).unwrap();
         });
     }
 }

--- a/storage/src/mmr/mod.rs
+++ b/storage/src/mmr/mod.rs
@@ -148,6 +148,17 @@ pub enum Error {
         expected: Position,
         actual: Position,
     },
+    #[error(
+        "rebase parent mismatch: expected size {expected_size} / pruned_to_pos {expected_pruned_to_pos}, actual size {actual_size} / pruned_to_pos {actual_pruned_to_pos}"
+    )]
+    RebaseParentMismatch {
+        expected_size: Position,
+        expected_pruned_to_pos: Position,
+        actual_size: Position,
+        actual_pruned_to_pos: Position,
+    },
+    #[error("rebase parent root mismatch")]
+    RebaseParentRootMismatch,
 }
 
 impl From<LocationError> for Error {

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -44,7 +44,7 @@ use crate::{
             variable::{Config as VConfig, Journal as VJournal},
         },
     },
-    mmr::{journaled::Config as MmrConfig, Location},
+    mmr::{journaled::Config as MmrConfig, Location, StandardHasher},
     qmdb::{
         any::operation::{Operation, Update},
         operation::{Committable, Key},
@@ -181,7 +181,7 @@ where
         page_cache: cfg.page_cache,
     };
 
-    let mut log = authenticated::Journal::<_, FJournal<_, _>, _>::new(
+    let log = authenticated::Journal::<_, FJournal<_, _>, _>::new(
         context.with_label("log"),
         mmr_config,
         journal_config,
@@ -192,7 +192,8 @@ where
     if log.size().await == 0 {
         warn!("Authenticated log is empty, initializing new db");
         let commit_floor = Operation::CommitFloor(None, Location::new(0));
-        log.append(&commit_floor).await?;
+        let mut hasher = StandardHasher::<H>::new();
+        log.append(&commit_floor, &mut hasher).await?;
         log.sync().await?;
     }
 
@@ -238,7 +239,7 @@ where
         write_buffer: cfg.log_write_buffer,
     };
 
-    let mut log = authenticated::Journal::<_, VJournal<_, _>, _>::new(
+    let log = authenticated::Journal::<_, VJournal<_, _>, _>::new(
         context.with_label("log"),
         mmr_config,
         journal_config,
@@ -249,7 +250,8 @@ where
     if log.size().await == 0 {
         warn!("Authenticated log is empty, initializing new db");
         let commit_floor = Operation::CommitFloor(None, Location::new(0));
-        log.append(&commit_floor).await?;
+        let mut hasher = StandardHasher::<H>::new();
+        log.append(&commit_floor, &mut hasher).await?;
         log.sync().await?;
     }
 

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -531,8 +531,8 @@ pub(crate) mod test {
                 batch.write(key3, Some(vec![40]));
                 batch.merkleize(None).await.unwrap().finalize()
             };
-
-            // Apply child_a, then child_b should be stale.
+            // Apply child_a directly from the original base. child_b should
+            // then be stale because both children flatten the same parent.
             db.apply_batch(child_a).await.unwrap();
             let result = db.apply_batch(child_b).await;
             assert!(
@@ -566,7 +566,8 @@ pub(crate) mod test {
             };
             let parent = parent.finalize();
 
-            // Apply parent first -- child should now be stale.
+            // Apply parent first -- child is now stale because its finalized
+            // changeset already includes the parent segment.
             db.apply_batch(parent).await.unwrap();
             let result = db.apply_batch(child).await;
             assert!(
@@ -600,7 +601,8 @@ pub(crate) mod test {
             };
             let parent = parent.finalize();
 
-            // Apply child first -- parent should now be stale.
+            // Apply child first -- parent is now stale because the child
+            // already flattened the parent segment.
             db.apply_batch(child).await.unwrap();
             let result = db.apply_batch(parent).await;
             assert!(

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     kv,
     mmr::{
         journaled::{Config as MmrConfig, Mmr},
-        Location, Proof,
+        Location, Proof, StandardHasher,
     },
     qmdb::{any::VariableValue, build_snapshot_from_log, Error},
     translator::Translator,
@@ -267,7 +267,7 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: VariableValue, H: CHasher, T: T
             write_buffer: cfg.log_write_buffer,
         };
 
-        let mut journal = Journal::new(
+        let journal = Journal::new(
             context.clone(),
             mmr_cfg,
             journal_cfg,
@@ -277,7 +277,10 @@ impl<E: RStorage + Clock + Metrics, K: Array, V: VariableValue, H: CHasher, T: T
 
         if journal.size().await == 0 {
             warn!("Authenticated log is empty, initialized new db.");
-            journal.append(&Operation::Commit(None)).await?;
+            let mut hasher = StandardHasher::<H>::new();
+            journal
+                .append(&Operation::Commit(None), &mut hasher)
+                .await?;
             journal.sync().await?;
         }
 
@@ -1482,8 +1485,8 @@ pub(super) mod test {
                 batch.set(key3, vec![3]);
                 batch.merkleize(None).finalize()
             };
-
-            // Apply child A.
+            // Apply child A directly from the original base. Child B should
+            // then be stale because both children flatten the same parent.
             db.apply_batch(child_a).await.unwrap();
 
             // Child B is stale.
@@ -1516,12 +1519,11 @@ pub(super) mod test {
             child.set(key2, vec![2]);
             let child_changeset = child.merkleize(None).finalize();
 
-            // Apply parent first.
+            // Apply parent first. Child is now stale because its finalized
+            // changeset already includes the parent segment.
             let parent_changeset = parent_m.finalize();
             db.apply_batch(parent_changeset).await.unwrap();
 
-            // Child is stale because it expected to be applied on top of the
-            // pre-parent DB state.
             let result = db.apply_batch(child_changeset).await;
             assert!(
                 matches!(result, Err(Error::StaleChangeset { .. })),
@@ -1553,10 +1555,9 @@ pub(super) mod test {
             let child_changeset = child.merkleize(None).finalize();
             let parent_changeset = parent_m.finalize();
 
-            // Apply child first (it carries all parent ops too).
+            // Apply child first: parent is now stale because the child already
+            // flattened the parent segment.
             db.apply_batch(child_changeset).await.unwrap();
-
-            // Parent is stale.
             let result = db.apply_batch(parent_changeset).await;
             assert!(
                 matches!(result, Err(Error::StaleChangeset { .. })),

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     mmr::{
         journaled::{Config as MmrConfig, Mmr},
-        Location, Proof,
+        Location, Proof, StandardHasher,
     },
     qmdb::{
         any::VariableValue,
@@ -147,10 +147,13 @@ impl<E: Storage + Clock + Metrics, V: VariableValue, H: Hasher> Keyless<E, V, H>
             write_buffer: cfg.log_write_buffer,
         };
 
-        let mut journal = Journal::new(context, mmr_cfg, journal_cfg, Operation::is_commit).await?;
+        let journal = Journal::new(context, mmr_cfg, journal_cfg, Operation::is_commit).await?;
         if journal.size().await == 0 {
             warn!("no operations found in log, creating initial commit");
-            journal.append(&Operation::Commit(None)).await?;
+            let mut hasher = StandardHasher::<H>::new();
+            journal
+                .append(&Operation::Commit(None), &mut hasher)
+                .await?;
             journal.sync().await?;
         }
 
@@ -1677,8 +1680,8 @@ mod test {
                 batch.append(vec![3]);
                 batch.merkleize(None).finalize()
             };
-
-            // Apply child A.
+            // Apply child A directly from the original base. Child B should
+            // then be stale because both children flatten the same parent.
             db.apply_batch(child_a).await.unwrap();
 
             // Child B is stale.
@@ -1708,12 +1711,11 @@ mod test {
             child.append(vec![2]);
             let child_changeset = child.merkleize(None).finalize();
 
-            // Apply parent first.
+            // Apply parent first. Child is now stale because its finalized
+            // changeset already includes the parent segment.
             let parent_changeset = parent_m.finalize();
             db.apply_batch(parent_changeset).await.unwrap();
 
-            // Child is stale because it expected to be applied on top of the
-            // pre-parent DB state.
             let result = db.apply_batch(child_changeset).await;
             assert!(
                 matches!(result, Err(Error::StaleChangeset { .. })),
@@ -1742,10 +1744,9 @@ mod test {
             let child_changeset = child.merkleize(None).finalize();
             let parent_changeset = parent_m.finalize();
 
-            // Apply child first (it carries all parent ops too).
+            // Apply child first: parent is now stale because the child already
+            // flattened the parent segment.
             db.apply_batch(child_changeset).await.unwrap();
-
-            // Parent is stale.
             let result = db.apply_batch(parent_changeset).await;
             assert!(
                 matches!(result, Err(Error::StaleChangeset { .. })),


### PR DESCRIPTION
This PR extends the batch MMR API to allow forking a child off a branch after it's been prepared, which allows a user to start working on the next changes without having to wait for the previous batch to be fsync'ed.

Context: https://github.com/commonwarexyz/monorepo/issues/3334