### PR TITLE
[release] 2026.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-bridge"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-broadcast",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-chat"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-coding",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-collector"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "commonware-codec",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-collector-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-codec",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-conformance"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "commonware-conformance-macros",
  "commonware-macros",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-conformance-macros"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-codec",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "blake3",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-deployer"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-estimator"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "clap",
  "colored",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-flood"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-invariants"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-macros",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-log"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "commonware-macros-impl",
  "commonware-utils",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-math-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-math",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-codec",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-codec",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-reshare"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "axum",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-runtime",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "commonware-codec",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "chacha20poly1305",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-sync"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "clap",
  "commonware-codec",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils-fuzz"
-version = "2026.2.0"
+version = "2026.3.0"
 dependencies = [
  "arbitrary",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2026.2.0"
+version = "2026.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://commonware.xyz"
@@ -87,26 +87,26 @@ chacha20poly1305 = { version = "0.10.1", default-features = false }
 chrono = "0.4.39"
 clap = "4.5.18"
 colored = "3.0.0"
-commonware-broadcast = { version = "2026.2.0", path = "broadcast" }
-commonware-codec = { version = "2026.2.0", path = "codec", default-features = false }
-commonware-coding = { version = "2026.2.0", path = "coding" }
-commonware-collector = { version = "2026.2.0", path = "collector" }
-commonware-conformance = { version = "2026.2.0", path = "conformance" }
-commonware-conformance-macros = { version = "2026.2.0", path = "conformance/macros" }
-commonware-consensus = { version = "2026.2.0", path = "consensus" }
-commonware-cryptography = { version = "2026.2.0", path = "cryptography", default-features = false }
-commonware-deployer = { version = "2026.2.0", path = "deployer", default-features = false }
-commonware-invariants = { version = "2026.2.0", path = "invariants" }
-commonware-macros = { version = "2026.2.0", path = "macros", default-features = false }
-commonware-macros-impl = { version = "2026.2.0", path = "macros/impl" }
-commonware-math = { version = "2026.2.0", path = "math", default-features = false }
-commonware-p2p = { version = "2026.2.0", path = "p2p" }
-commonware-parallel = { version = "2026.2.0", path = "parallel", default-features = false }
-commonware-resolver = { version = "2026.2.0", path = "resolver" }
-commonware-runtime = { version = "2026.2.0", path = "runtime" }
-commonware-storage = { version = "2026.2.0", path = "storage", default-features = false }
-commonware-stream = { version = "2026.2.0", path = "stream" }
-commonware-utils = { version = "2026.2.0", path = "utils", default-features = false }
+commonware-broadcast = { version = "2026.3.0", path = "broadcast" }
+commonware-codec = { version = "2026.3.0", path = "codec", default-features = false }
+commonware-coding = { version = "2026.3.0", path = "coding" }
+commonware-collector = { version = "2026.3.0", path = "collector" }
+commonware-conformance = { version = "2026.3.0", path = "conformance" }
+commonware-conformance-macros = { version = "2026.3.0", path = "conformance/macros" }
+commonware-consensus = { version = "2026.3.0", path = "consensus" }
+commonware-cryptography = { version = "2026.3.0", path = "cryptography", default-features = false }
+commonware-deployer = { version = "2026.3.0", path = "deployer", default-features = false }
+commonware-invariants = { version = "2026.3.0", path = "invariants" }
+commonware-macros = { version = "2026.3.0", path = "macros", default-features = false }
+commonware-macros-impl = { version = "2026.3.0", path = "macros/impl" }
+commonware-math = { version = "2026.3.0", path = "math", default-features = false }
+commonware-p2p = { version = "2026.3.0", path = "p2p" }
+commonware-parallel = { version = "2026.3.0", path = "parallel", default-features = false }
+commonware-resolver = { version = "2026.3.0", path = "resolver" }
+commonware-runtime = { version = "2026.3.0", path = "runtime" }
+commonware-storage = { version = "2026.3.0", path = "storage", default-features = false }
+commonware-stream = { version = "2026.3.0", path = "stream" }
+commonware-utils = { version = "2026.3.0", path = "utils", default-features = false }
 console-subscriber = "0.5.0"
 crc = "3.4.0"
 crc-fast = { version = "1.10.0", default-features = false }


### PR DESCRIPTION
## Stats

```
 .github/actions/disk/action.yml                    |   15 +-
 .github/scripts/lint_cargo_toml.py                 |   33 +-
 .github/workflows/coverage.yml                     |   27 +-
 .github/workflows/fast.yml                         |   50 +-
 .github/workflows/publish.yml                      |    5 +
 .github/workflows/slow.yml                         |   29 +-
 AGENTS.md                                          |  107 +-
 Cargo.lock                                         |  180 +-
 Cargo.toml                                         |   47 +-
 README.md                                          |    1 +
 broadcast/fuzz/Cargo.toml                          |    2 +-
 .../fuzz_targets/broadcast_engine_operations.rs    |   64 +-
 broadcast/src/buffered/config.rs                   |    7 +-
 broadcast/src/buffered/engine.rs                   |  281 +-
 broadcast/src/buffered/ingress.rs                  |   82 +-
 broadcast/src/buffered/mocks.rs                    |    9 +-
 broadcast/src/buffered/mod.rs                      |  651 +--
 broadcast/src/lib.rs                               |    2 +-
 clippy.toml                                        |   13 +
 codec/conformance.toml                             |   12 +
 codec/src/conformance.rs                           |   29 +-
 codec/src/lib.rs                                   |   14 +-
 codec/src/types/primitives.rs                      |   79 +
 coding/Cargo.toml                                  |    3 +-
 coding/conformance.toml                            |   18 +-
 coding/fuzz/Cargo.toml                             |    1 +
 coding/fuzz/src/lib.rs                             |   11 +-
 coding/proptest-regressions/field.txt              |    7 -
 coding/proptest-regressions/ntt.txt                |    9 -
 coding/proptest-regressions/zoda/field.txt         |    8 -
 coding/src/benches/bench.rs                        |  224 +-
 coding/src/benches/bench_size.rs                   |   17 +-
 coding/src/lib.rs                                  |  369 +-
 coding/src/no_coding.rs                            |   42 +-
 coding/src/reed_solomon.rs                         |  566 ++-
 coding/src/zoda.rs                                 |  273 +-
 collector/fuzz/fuzz_targets/collector.rs           |    6 +-
 collector/src/p2p/engine.rs                        |   29 +-
 collector/src/p2p/mocks/sender.rs                  |    4 +-
 collector/src/p2p/mod.rs                           |   50 +-
 consensus/Cargo.toml                               |    8 +-
 consensus/conformance.toml                         |   14 +-
 consensus/fuzz/Cargo.toml                          |    2 +-
 consensus/fuzz/src/disrupter.rs                    |    4 +-
 consensus/fuzz/src/invariants.rs                   |    6 +-
 consensus/fuzz/src/lib.rs                          |   18 +-
 consensus/src/aggregation/engine.rs                |   26 +-
 consensus/src/aggregation/mocks/monitor.rs         |   11 +-
 consensus/src/aggregation/mocks/provider.rs        |   10 +-
 consensus/src/aggregation/mod.rs                   |   31 +-
 consensus/src/aggregation/types.rs                 |    2 +-
 consensus/src/application/marshaled.rs             |  740 ---
 consensus/src/application/mod.rs                   |    7 -
 consensus/src/lib.rs                               |   68 +-
 consensus/src/marshal/actor.rs                     | 1138 -----
 consensus/src/marshal/ancestry.rs                  |  247 +
 consensus/src/marshal/application/mod.rs           |    2 +
 consensus/src/marshal/application/validation.rs    |  163 +
 .../src/marshal/application/verification_tasks.rs  |   61 +
 consensus/src/marshal/coding/marshaled.rs          | 1040 +++++
 consensus/src/marshal/coding/mod.rs                | 1521 +++++++
 consensus/src/marshal/coding/shards/engine.rs      | 4748 ++++++++++++++++++++
 consensus/src/marshal/coding/shards/mailbox.rs     |  192 +
 consensus/src/marshal/coding/shards/metrics.rs     |   89 +
 consensus/src/marshal/coding/shards/mod.rs         |   25 +
 consensus/src/marshal/coding/types.rs              |  833 ++++
 consensus/src/marshal/coding/validation.rs         |  570 +++
 consensus/src/marshal/coding/variant.rs            |  103 +
 consensus/src/marshal/config.rs                    |   18 +
 consensus/src/marshal/core/actor.rs                | 1627 +++++++
 consensus/src/marshal/{ => core}/cache.rs          |  205 +-
 consensus/src/marshal/{ingress => core}/mailbox.rs |  320 +-
 consensus/src/marshal/core/mod.rs                  |   50 +
 consensus/src/marshal/core/variant.rs              |  171 +
 consensus/src/marshal/ingress/mod.rs               |    2 -
 consensus/src/marshal/mocks/application.rs         |   55 +-
 consensus/src/marshal/mocks/block.rs               |   12 +-
 consensus/src/marshal/mocks/harness.rs             | 3571 +++++++++++++++
 consensus/src/marshal/mocks/mod.rs                 |    2 +
 consensus/src/marshal/mocks/resolver.rs            |   10 +-
 consensus/src/marshal/mocks/verifying.rs           |   84 +
 consensus/src/marshal/mod.rs                       | 2769 +-----------
 .../src/marshal/{ingress => resolver}/handler.rs   |  262 +-
 consensus/src/marshal/resolver/mod.rs              |   12 +-
 consensus/src/marshal/resolver/p2p.rs              |   40 +-
 consensus/src/marshal/standard/deferred.rs         |  976 ++++
 consensus/src/marshal/standard/inline.rs           |  496 ++
 consensus/src/marshal/standard/mod.rs              |  733 +++
 consensus/src/marshal/standard/validation.rs       |  356 ++
 consensus/src/marshal/standard/variant.rs          |   86 +
 consensus/src/marshal/store.rs                     |  127 +-
 consensus/src/ordered_broadcast/engine.rs          |   15 +-
 consensus/src/ordered_broadcast/mocks/monitor.rs   |   11 +-
 consensus/src/ordered_broadcast/mocks/provider.rs  |   10 +-
 consensus/src/ordered_broadcast/mod.rs             |   25 +-
 consensus/src/simplex/actors/batcher/actor.rs      |  135 +-
 consensus/src/simplex/actors/batcher/ingress.rs    |   20 +-
 consensus/src/simplex/actors/batcher/mod.rs        |  625 ++-
 consensus/src/simplex/actors/batcher/round.rs      |   39 +-
 consensus/src/simplex/actors/resolver/actor.rs     |    8 +-
 consensus/src/simplex/actors/resolver/state.rs     |   30 +-
 consensus/src/simplex/actors/voter/actor.rs        |  175 +-
 consensus/src/simplex/actors/voter/ingress.rs      |   15 +-
 consensus/src/simplex/actors/voter/mod.rs          | 4301 ++++++++++++++----
 consensus/src/simplex/actors/voter/round.rs        |   56 +-
 consensus/src/simplex/actors/voter/state.rs        | 1164 ++++-
 consensus/src/simplex/config.rs                    |   18 +-
 consensus/src/simplex/engine.rs                    |   12 +-
 consensus/src/simplex/metrics.rs                   |   40 +
 consensus/src/simplex/mocks/application.rs         |   57 +-
 consensus/src/simplex/mocks/equivocator.rs         |    9 +-
 consensus/src/simplex/mocks/relay.rs               |   15 +-
 consensus/src/simplex/mocks/reporter.rs            |   50 +-
 consensus/src/simplex/mod.rs                       |  683 +--
 consensus/src/simplex/scheme/reporter.rs           |   10 +-
 consensus/src/simplex/types.rs                     |   18 +
 consensus/src/types.rs                             |  329 +-
 cryptography/Cargo.toml                            |   14 +-
 cryptography/conformance.toml                      |    2 +-
 cryptography/src/blake3/mod.rs                     |    6 +-
 .../benches/threshold_batch_verify_same_message.rs |  183 +-
 ...eshold_batch_verify_same_message_precomputed.rs |  187 +-
 .../src/bls12381/benches/threshold_recover.rs      |   74 +-
 cryptography/src/bls12381/dkg.rs                   |  617 ++-
 cryptography/src/bls12381/primitives/group.rs      |  279 +-
 .../src/bls12381/primitives/ops/threshold.rs       |    2 +-
 cryptography/src/bls12381/primitives/sharing.rs    |  317 +-
 cryptography/src/bls12381/scheme.rs                |    4 +-
 cryptography/src/certificate.rs                    |  233 +-
 cryptography/src/ed25519/scheme.rs                 |    4 +-
 cryptography/src/handshake/cipher.rs               |   35 +-
 cryptography/src/lib.rs                            |   11 +-
 deployer/src/aws/authorize.rs                      |    5 +-
 docs/blogs/coding.html                             |  167 +
 docs/blogs/is-it-ready-yet.html                    |  304 ++
 docs/blogs/is-it-ready-yet.md                      |  101 +
 docs/blogs/its-a-grind.html                        |  220 +
 docs/blogs/its-a-grind.md                          |   39 +
 docs/blogs/zoda.html                               |   26 +-
 docs/blogs/zoda.md                                 |    2 +
 docs/imgs/address-poisoning.jpeg                   |  Bin 0 -> 83024 bytes
 docs/imgs/alto_coding_4.png                        |  Bin 0 -> 1084229 bytes
 docs/imgs/alto_coding_8.png                        |  Bin 0 -> 811309 bytes
 docs/imgs/certify_sequence.png                     |  Bin 0 -> 259041 bytes
 docs/imgs/coding_chain.png                         |  Bin 0 -> 364999 bytes
 docs/imgs/coding_commitment_construction.png       |  Bin 0 -> 72941 bytes
 docs/imgs/coding_dissemination.png                 |  Bin 0 -> 308946 bytes
 docs/imgs/compressed-index.png                     |  Bin 0 -> 245665 bytes
 docs/imgs/is-it-ready-yet.png                      |  Bin 0 -> 331803 bytes
 docs/imgs/radix-tree.png                           |  Bin 0 -> 311848 bytes
 docs/index.html                                    |   22 +-
 examples/bridge/src/bin/validator.rs               |   16 +-
 examples/chat/src/handler.rs                       |   13 +-
 examples/chat/src/logger.rs                        |    5 +-
 examples/chat/src/main.rs                          |    4 +-
 examples/estimator/src/main.rs                     |   16 +-
 examples/log/src/gui.rs                            |   16 +-
 examples/log/src/main.rs                           |    6 +-
 examples/reshare/src/application/core.rs           |   10 +-
 examples/reshare/src/application/scheme.rs         |   12 +-
 examples/reshare/src/application/types.rs          |    2 +-
 examples/reshare/src/dkg/actor.rs                  |   24 +-
 examples/reshare/src/dkg/mod.rs                    |    5 +
 examples/reshare/src/dkg/state.rs                  |   82 +-
 examples/reshare/src/engine.rs                     |   52 +-
 examples/reshare/src/main.rs                       |    1 -
 examples/reshare/src/orchestrator/actor.rs         |   45 +-
 examples/reshare/src/setup.rs                      |    3 +-
 examples/reshare/src/validator.rs                  |   88 +-
 examples/sync/README.md                            |    6 +-
 examples/sync/src/bin/client.rs                    |   83 +-
 examples/sync/src/bin/server.rs                    |  230 +-
 examples/sync/src/databases/any.rs                 |   51 +-
 examples/sync/src/databases/current.rs             |  181 +
 examples/sync/src/databases/immutable.rs           |   59 +-
 examples/sync/src/databases/mod.rs                 |   18 +-
 examples/sync/src/lib.rs                           |    7 +-
 examples/sync/src/net/io.rs                        |   45 +-
 examples/sync/src/net/mod.rs                       |   12 +-
 examples/sync/src/net/wire.rs                      |   16 +-
 invariants/Cargo.toml                              |   28 +
 invariants/README.md                               |   10 +
 invariants/src/lib.rs                              |   12 +
 invariants/src/minifuzz.rs                         |  603 +++
 justfile                                           |   33 +-
 macros/Cargo.toml                                  |    1 +
 macros/tests/select.rs                             |    2 +-
 math/Cargo.toml                                    |   15 +-
 math/benches/interpolation.rs                      |   26 +
 math/conformance.toml                              |    2 +-
 math/fuzz/Cargo.toml                               |   21 +
 math/fuzz/fuzz_targets/main.rs                     |   10 +
 math/proptest-regressions/algebra.txt              |    7 -
 math/proptest-regressions/ntt.txt                  |   10 +
 math/proptest-regressions/poly.txt                 |    7 -
 math/src/algebra.rs                                |  550 ++-
 math/src/fields/goldilocks.rs                      |  189 +-
 math/src/lib.rs                                    |   34 +-
 math/src/ntt.rs                                    | 1515 ++++---
 math/src/poly.rs                                   |  304 +-
 math/src/test.rs                                   |   85 +-
 mcp/src/utils.test.ts                              |    2 +-
 p2p/Cargo.toml                                     |    1 +
 p2p/fuzz/src/lib.rs                                |    4 +-
 p2p/src/authenticated/data.rs                      |   50 +-
 p2p/src/authenticated/discovery/actors/dialer.rs   |   17 +-
 .../authenticated/discovery/actors/peer/actor.rs   |  225 +-
 .../authenticated/discovery/actors/router/actor.rs |    9 +-
 .../discovery/actors/router/ingress.rs             |   22 +-
 .../discovery/actors/spawner/actor.rs              |   36 +-
 .../discovery/actors/tracker/actor.rs              |   10 +-
 .../discovery/actors/tracker/directory.rs          |   60 +-
 .../discovery/actors/tracker/ingress.rs            |   22 +-
 .../discovery/actors/tracker/metrics.rs            |    8 +
 p2p/src/authenticated/discovery/channels.rs        |    4 +-
 p2p/src/authenticated/discovery/mod.rs             |  219 +-
 p2p/src/authenticated/discovery/types.rs           |   14 +-
 p2p/src/authenticated/lookup/actors/dialer.rs      |   17 +-
 p2p/src/authenticated/lookup/actors/peer/actor.rs  |  213 +-
 .../authenticated/lookup/actors/router/actor.rs    |    9 +-
 .../authenticated/lookup/actors/router/ingress.rs  |   22 +-
 .../authenticated/lookup/actors/spawner/actor.rs   |   35 +-
 .../authenticated/lookup/actors/tracker/actor.rs   |   18 +-
 .../lookup/actors/tracker/directory.rs             |   61 +-
 .../authenticated/lookup/actors/tracker/ingress.rs |    9 +-
 .../authenticated/lookup/actors/tracker/metrics.rs |    8 +
 p2p/src/authenticated/lookup/channels.rs           |    4 +-
 p2p/src/authenticated/lookup/mod.rs                |   31 +-
 p2p/src/authenticated/lookup/types.rs              |   14 +-
 p2p/src/lib.rs                                     |   59 +-
 p2p/src/simulated/ingress.rs                       |   31 +-
 p2p/src/simulated/mod.rs                           |   38 +-
 p2p/src/simulated/network.rs                       |   18 +-
 p2p/src/utils/codec.rs                             |  562 ++-
 p2p/src/utils/limited.rs                           |   24 +-
 p2p/src/utils/mux.rs                               |   15 +-
 resolver/src/p2p/config.rs                         |    2 +-
 resolver/src/p2p/engine.rs                         |   32 +-
 resolver/src/p2p/fetcher.rs                        |   47 +-
 resolver/src/p2p/mod.rs                            |  150 +-
 runtime/Cargo.toml                                 |    2 -
 runtime/fuzz/fuzz_targets/blob_integrity.rs        |   15 +-
 runtime/fuzz/fuzz_targets/buffer.rs                |   48 +-
 runtime/src/deterministic.rs                       |  355 +-
 runtime/src/iobuf/mod.rs                           | 3260 +++++++++++---
 runtime/src/iobuf/pool.rs                          | 1644 ++++---
 runtime/src/iouring/mod.rs                         | 1417 ++++--
 runtime/src/lib.rs                                 |  646 ++-
 runtime/src/mocks.rs                               |   28 +-
 runtime/src/network/audited.rs                     |   13 +-
 runtime/src/network/deterministic.rs               |   18 +-
 runtime/src/network/iouring.rs                     |  394 +-
 runtime/src/network/metered.rs                     |   20 +-
 runtime/src/network/mod.rs                         |   75 +-
 runtime/src/network/tokio.rs                       |   80 +-
 runtime/src/storage/audited.rs                     |   45 +-
 runtime/src/storage/faulty.rs                      |   70 +-
 runtime/src/storage/iouring.rs                     |  347 +-
 runtime/src/storage/memory.rs                      |   91 +-
 runtime/src/storage/metered.rs                     |   47 +-
 runtime/src/storage/mod.rs                         |  328 +-
 runtime/src/storage/tokio/fallback.rs              |   82 +-
 runtime/src/storage/tokio/mod.rs                   |   38 +-
 runtime/src/storage/tokio/unix.rs                  |  116 +-
 runtime/src/telemetry/traces/collector.rs          |   10 +-
 runtime/src/tokio/runtime.rs                       |  160 +-
 runtime/src/utils/buffer/benches/append.rs         |    2 +-
 runtime/src/utils/buffer/benches/read.rs           |    5 +-
 runtime/src/utils/buffer/mod.rs                    |  740 +--
 runtime/src/utils/buffer/paged/append.rs           |  642 ++-
 runtime/src/utils/buffer/paged/cache.rs            |  695 ++-
 runtime/src/utils/buffer/paged/mod.rs              |   11 +-
 runtime/src/utils/buffer/paged/read.rs             |   36 +-
 runtime/src/utils/buffer/read.rs                   |  126 +-
 runtime/src/utils/buffer/tip.rs                    |  312 +-
 runtime/src/utils/buffer/write.rs                  |  155 +-
 runtime/src/utils/cell.rs                          |    4 +
 runtime/src/utils/handle.rs                        |    9 +-
 runtime/src/utils/mod.rs                           |  641 ++-
 runtime/src/utils/supervision.rs                   |    9 +-
 scripts/find_unstable_public.sh                    |  142 +-
 scripts/stability_helpers.sh                       |   18 +
 storage/Cargo.toml                                 |    4 +-
 storage/conformance.toml                           |   48 +-
 storage/fuzz/Cargo.toml                            |   21 +
 storage/fuzz/fuzz_targets/archive_operations.rs    |   10 +-
 storage/fuzz/fuzz_targets/cache_operations.rs      |    5 +-
 .../fuzz/fuzz_targets/current_crash_recovery.rs    |  357 ++
 .../fuzz_targets/current_ordered_operations.rs     |  255 +-
 .../fuzz_targets/current_unordered_operations.rs   |  158 +-
 storage/fuzz/fuzz_targets/extract_pinned_nodes.rs  |    3 +-
 .../fuzz/fuzz_targets/fixed_journal_operations.rs  |   55 +-
 storage/fuzz/fuzz_targets/freezer_operations.rs    |    8 +-
 .../fuzz/fuzz_targets/journal_crash_recovery.rs    |  140 +-
 storage/fuzz/fuzz_targets/metadata_operations.rs   |    2 +-
 storage/fuzz/fuzz_targets/mmr_bitmap.rs            |   22 +-
 storage/fuzz/fuzz_targets/mmr_journaled.rs         |  362 +-
 .../fuzz_targets/mmr_journaled_crash_recovery.rs   |  167 +-
 storage/fuzz/fuzz_targets/mmr_operations.rs        |  155 +-
 storage/fuzz/fuzz_targets/ordinal_operations.rs    |    4 +-
 storage/fuzz/fuzz_targets/oversized_recovery.rs    |   17 +-
 storage/fuzz/fuzz_targets/proofs_malleability.rs   |   34 +-
 storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs   |   99 +-
 .../fuzz/fuzz_targets/qmdb_any_variable_sync.rs    |  201 +-
 storage/fuzz/fuzz_targets/qmdb_immutable.rs        |  189 +-
 storage/fuzz/fuzz_targets/qmdb_keyless.rs          |  148 +-
 storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs |  133 +-
 .../fuzz/fuzz_targets/qmdb_ordered_operations.rs   |  159 +-
 .../fuzz/fuzz_targets/qmdb_unordered_operations.rs |  128 +-
 storage/fuzz/fuzz_targets/queue_crash_recovery.rs  |  522 +++
 storage/fuzz/fuzz_targets/queue_operations.rs      |  295 ++
 storage/fuzz/fuzz_targets/range_proof.rs           |   16 +-
 storage/fuzz/fuzz_targets/store_operations.rs      |   44 +-
 storage/fuzz/fuzz_targets/verify_proof.rs          |    3 +-
 storage/src/archive/benches/utils.rs               |   18 +-
 storage/src/archive/conformance.rs                 |    4 +-
 storage/src/archive/immutable/mod.rs               |   72 +-
 storage/src/archive/immutable/storage.rs           |   12 +-
 storage/src/archive/mod.rs                         |  397 +-
 storage/src/archive/prunable/mod.rs                |  168 +-
 storage/src/archive/prunable/storage.rs            |  202 +-
 storage/src/bitmap/authenticated.rs                |  200 +-
 storage/src/bitmap/mod.rs                          |    5 +-
 storage/src/cache/mod.rs                           |   50 +-
 storage/src/cache/storage.rs                       |    2 +-
 storage/src/freezer/benches/utils.rs               |    8 +-
 storage/src/freezer/conformance.rs                 |    2 +-
 storage/src/freezer/mod.rs                         |  124 +-
 storage/src/freezer/storage.rs                     |  113 +-
 storage/src/index/benches/insert.rs                |   51 +-
 storage/src/index/mod.rs                           |   13 +-
 storage/src/journal/authenticated.rs               | 1153 +++--
 storage/src/journal/benches/bench.rs               |   24 +-
 storage/src/journal/benches/fixed_append.rs        |    2 +-
 storage/src/journal/benches/fixed_read_random.rs   |   10 +-
 .../src/journal/benches/fixed_read_sequential.rs   |    9 +-
 storage/src/journal/benches/fixed_replay.rs        |    7 +-
 storage/src/journal/benches/variable_replay.rs     |    9 +-
 storage/src/journal/conformance.rs                 |   22 +-
 storage/src/journal/contiguous/fixed.rs            | 1092 +++--
 storage/src/journal/contiguous/mod.rs              |   93 +-
 storage/src/journal/contiguous/tests.rs            |  440 +-
 storage/src/journal/contiguous/variable.rs         | 1387 +++---
 storage/src/journal/segmented/fixed.rs             |  176 +-
 storage/src/journal/segmented/glob.rs              |   16 +-
 storage/src/journal/segmented/manager.rs           |   34 +-
 storage/src/journal/segmented/oversized.rs         |  302 +-
 storage/src/journal/segmented/variable.rs          |  203 +-
 storage/src/kv/batch.rs                            |   45 +-
 storage/src/kv/mod.rs                              |    2 +-
 storage/src/lib.rs                                 |    9 +-
 storage/src/metadata/benches/utils.rs              |    2 +-
 storage/src/metadata/mod.rs                        |   62 +-
 storage/src/metadata/storage.rs                    |   17 +-
 storage/src/mmr/batch.rs                           | 1288 ++++++
 storage/src/mmr/benches/append.rs                  |   17 +-
 storage/src/mmr/benches/append_additional.rs       |   22 +-
 storage/src/mmr/benches/prove_many_elements.rs     |   28 +-
 storage/src/mmr/benches/prove_single_element.rs    |   26 +-
 storage/src/mmr/benches/update.rs                  |   38 +-
 storage/src/mmr/conformance.rs                     |   26 +-
 storage/src/mmr/grafting.rs                        |  936 ----
 storage/src/mmr/hasher.rs                          |   12 +-
 storage/src/mmr/iterator.rs                        |   46 +-
 storage/src/mmr/journaled.rs                       | 2211 ++++++---
 storage/src/mmr/location.rs                        |  269 +-
 storage/src/mmr/mem.rs                             | 1305 +++---
 storage/src/mmr/mod.rs                             |   14 +-
 storage/src/mmr/position.rs                        |  135 +-
 storage/src/mmr/proof.rs                           |  377 +-
 storage/src/mmr/read.rs                            |   74 +
 storage/src/mmr/storage.rs                         |    8 +-
 storage/src/mmr/verification.rs                    |   30 +-
 storage/src/ordinal/benches/utils.rs               |    2 +-
 storage/src/ordinal/mod.rs                         |  115 +-
 storage/src/ordinal/storage.rs                     |  102 +-
 storage/src/qmdb/any/batch.rs                      | 1456 ++++++
 storage/src/qmdb/any/db.rs                         |  393 +-
 storage/src/qmdb/any/mod.rs                        | 1620 ++++++-
 storage/src/qmdb/any/operation/fixed.rs            |   10 +-
 storage/src/qmdb/any/operation/mod.rs              |   61 +-
 storage/src/qmdb/any/operation/update/mod.rs       |   12 +-
 storage/src/qmdb/any/operation/update/ordered.rs   |   55 +-
 storage/src/qmdb/any/operation/update/unordered.rs |   55 +-
 storage/src/qmdb/any/operation/variable.rs         |   40 +-
 storage/src/qmdb/any/ordered/fixed.rs              | 1346 ++++--
 storage/src/qmdb/any/ordered/mod.rs                | 1523 +------
 storage/src/qmdb/any/ordered/variable.rs           |  381 +-
 storage/src/qmdb/any/states.rs                     |  128 -
 storage/src/qmdb/any/sync/mod.rs                   |   39 +-
 storage/src/qmdb/any/sync/tests.rs                 |  656 +--
 storage/src/qmdb/any/traits.rs                     |   94 +
 storage/src/qmdb/any/unordered/fixed.rs            |  819 ++--
 storage/src/qmdb/any/unordered/mod.rs              |  975 +---
 storage/src/qmdb/any/unordered/variable.rs         |  643 +--
 storage/src/qmdb/benches/fixed/generate.rs         |  207 +-
 storage/src/qmdb/benches/fixed/init.rs             |   51 +-
 storage/src/qmdb/benches/fixed/mod.rs              |  223 +-
 storage/src/qmdb/benches/keyless/generate.rs       |   53 +-
 storage/src/qmdb/benches/variable/generate.rs      |  144 +-
 storage/src/qmdb/benches/variable/init.rs          |   39 +-
 storage/src/qmdb/benches/variable/mod.rs           |  169 +-
 storage/src/qmdb/current/batch.rs                  | 1474 ++++++
 storage/src/qmdb/current/db.rs                     |  917 ++--
 storage/src/qmdb/current/grafting.rs               |  864 ++++
 storage/src/qmdb/current/mod.rs                    | 1243 ++++-
 storage/src/qmdb/current/ordered/db.rs             |  259 +-
 storage/src/qmdb/current/ordered/fixed.rs          |  492 +-
 storage/src/qmdb/current/ordered/mod.rs            |   86 +-
 .../src/qmdb/current/ordered/test_trait_impls.rs   |  208 +-
 storage/src/qmdb/current/ordered/variable.rs       |  468 +-
 storage/src/qmdb/current/proof.rs                  |  169 +-
 storage/src/qmdb/current/sync/mod.rs               |  595 +++
 storage/src/qmdb/current/sync/tests.rs             |  478 ++
 storage/src/qmdb/current/unordered/db.rs           |  173 +-
 storage/src/qmdb/current/unordered/fixed.rs        |  385 +-
 storage/src/qmdb/current/unordered/mod.rs          |   87 +-
 .../src/qmdb/current/unordered/test_trait_impls.rs |  193 +-
 storage/src/qmdb/current/unordered/variable.rs     |  397 +-
 storage/src/qmdb/immutable/batch.rs                |  253 ++
 storage/src/qmdb/immutable/mod.rs                  | 1432 ++++--
 storage/src/qmdb/immutable/sync.rs                 |  426 +-
 storage/src/qmdb/keyless/batch.rs                  |  228 +
 storage/src/qmdb/keyless/mod.rs                    | 1375 ++++--
 storage/src/qmdb/mod.rs                            |  223 +-
 storage/src/qmdb/operation.rs                      |   16 +-
 storage/src/qmdb/store/batch.rs                    |  379 --
 storage/src/qmdb/store/db.rs                       |  591 +--
 storage/src/qmdb/store/mod.rs                      |   86 +-
 storage/src/qmdb/sync/engine.rs                    |   32 +-
 storage/src/qmdb/sync/gaps.rs                      |   10 +-
 storage/src/qmdb/sync/journal.rs                   |   18 +-
 storage/src/qmdb/sync/mod.rs                       |    3 +-
 storage/src/qmdb/sync/resolver.rs                  |   12 +-
 storage/src/qmdb/sync/target.rs                    |   59 +-
 storage/src/qmdb/verify.rs                         |  280 +-
 storage/src/queue/conformance.rs                   |   83 +
 storage/src/queue/metrics.rs                       |   28 +
 storage/src/queue/mod.rs                           |   94 +
 storage/src/queue/shared.rs                        |  504 +++
 storage/src/queue/storage.rs                       | 1294 ++++++
 storage/src/translator.rs                          |  158 +-
 stream/fuzz/fuzz_targets/e2e.rs                    |   55 +-
 stream/src/encrypted.rs                            |   51 +-
 stream/src/utils/codec.rs                          |  108 +-
 utils/Cargo.toml                                   |   12 +-
 utils/conformance.toml                             |    4 +-
 utils/fuzz/fuzz_targets/historical_bitmap.rs       |    4 +-
 utils/src/benches/bench.rs                         |    3 -
 utils/src/bitmap/benches/bench.rs                  |    5 +
 utils/src/bitmap/benches/count_ones.rs             |   33 +
 utils/src/bitmap/historical/bitmap.rs              |   32 +-
 utils/src/bitmap/historical/tests.rs               |    2 +-
 utils/src/bitmap/mod.rs                            |  221 +-
 utils/src/bitmap/prunable.rs                       |  102 +-
 utils/src/channel/fallible.rs                      |   44 +-
 utils/src/channel/ring.rs                          |   23 +-
 utils/src/channel/tracked.rs                       |   18 +-
 utils/src/concurrency.rs                           |   10 +-
 utils/src/lib.rs                                   |    8 +-
 utils/src/rational/benches/bench.rs                |    5 +
 utils/src/{ => rational}/benches/log2_ceil.rs      |    0
 utils/src/{rational.rs => rational/mod.rs}         |    0
 utils/src/rng.rs                                   |  440 +-
 utils/src/sync/mod.rs                              |  253 ++
 utils/src/thread_local.rs                          |  329 ++
 466 files changed, 73751 insertions(+), 30030 deletions(-)
```