### PR TITLE
[Storage] Remove redundant type bounds

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -258,7 +258,6 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    U::Value: Send + Sync,
     P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
 {
     /// Read an operation at a given location from the correct source.
@@ -561,7 +560,6 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<update::Unordered<K, V>>: Codec,
-    V::Value: Send + Sync,
     P: Readable<H::Digest>
         + BatchChainInfo<H::Digest>
         + BatchChain<Operation<update::Unordered<K, V>>>,
@@ -684,7 +682,6 @@ where
     I: OrderedIndex<Value = Location>,
     H: Hasher,
     Operation<update::Ordered<K, V>>: Codec,
-    V::Value: Send + Sync,
     P: Readable<H::Digest>
         + BatchChainInfo<H::Digest>
         + BatchChain<Operation<update::Ordered<K, V>>>,
@@ -1187,7 +1184,6 @@ mod trait_impls {
         I: UnorderedIndex<Value = Location>,
         H: Hasher,
         Operation<update::Unordered<K, V>>: Codec,
-        V::Value: Send + Sync,
         P: Readable<H::Digest>
             + BatchChainInfo<H::Digest>
             + BatchChain<Operation<update::Unordered<K, V>>>,
@@ -1222,7 +1218,6 @@ mod trait_impls {
         I: OrderedIndex<Value = Location>,
         H: Hasher,
         Operation<update::Ordered<K, V>>: Codec,
-        V::Value: Send + Sync,
         P: Readable<H::Digest>
             + BatchChainInfo<H::Digest>
             + BatchChain<Operation<update::Ordered<K, V>>>,
@@ -1277,7 +1272,6 @@ mod trait_impls {
         I: UnorderedIndex<Value = Location>,
         H: Hasher,
         Operation<update::Unordered<K, V>>: Codec,
-        V::Value: Send + Sync,
     {
         type K = K;
         type V = V::Value;
@@ -1309,7 +1303,6 @@ mod trait_impls {
         I: OrderedIndex<Value = Location>,
         H: Hasher,
         Operation<update::Ordered<K, V>>: Codec,
-        V::Value: Send + Sync,
     {
         type K = K;
         type V = V::Value;

--- a/storage/src/qmdb/any/operation/mod.rs
+++ b/storage/src/qmdb/any/operation/mod.rs
@@ -1,11 +1,8 @@
 use crate::{
     mmr::Location,
-    qmdb::{
-        any::value::ValueEncoding,
-        operation::{Committable, Key},
-    },
+    qmdb::{any::value::ValueEncoding, operation::Committable},
 };
-use commonware_codec::{Codec, Encode as _, Error as CodecError, Read, Write};
+use commonware_codec::{Encode as _, Error as CodecError, Read, Write};
 use commonware_runtime::{Buf, BufMut};
 use commonware_utils::hex;
 use std::fmt;
@@ -60,10 +57,7 @@ where
     }
 }
 
-impl<S: Update> crate::qmdb::operation::Operation for Operation<S>
-where
-    S::Value: Codec,
-{
+impl<S: Update> crate::qmdb::operation::Operation for Operation<S> {
     type Key = S::Key;
 
     fn key(&self) -> Option<&Self::Key> {
@@ -90,10 +84,7 @@ where
     }
 }
 
-impl<S: Update> Committable for Operation<S>
-where
-    S::Value: Codec,
-{
+impl<S: Update> Committable for Operation<S> {
     fn is_commit(&self) -> bool {
         matches!(self, Self::CommitFloor(_, _))
     }
@@ -121,37 +112,7 @@ where
     }
 }
 
-impl<K, V> fmt::Display for Operation<update::Ordered<K, V>>
-where
-    K: Key,
-    V: ValueEncoding,
-    V::Value: Codec,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Delete(key) => write!(f, "[key:{} <deleted>]", hex(key)),
-            Self::Update(payload) => payload.fmt(f),
-            Self::CommitFloor(value, loc) => {
-                if let Some(value) = value {
-                    write!(
-                        f,
-                        "[commit {} with inactivity floor: {loc}]",
-                        hex(&value.encode())
-                    )
-                } else {
-                    write!(f, "[commit with inactivity floor: {loc}]")
-                }
-            }
-        }
-    }
-}
-
-impl<K, V> fmt::Display for Operation<update::Unordered<K, V>>
-where
-    K: Key,
-    V: ValueEncoding,
-    V::Value: Codec,
-{
+impl<S: Update> fmt::Display for Operation<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Delete(key) => write!(f, "[key:{} <deleted>]", hex(key)),

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -41,7 +41,6 @@ impl<
     > Db<E, C, I, H, Update<K, V>>
 where
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     async fn get_update_op(
         reader: &impl Reader<Item = Operation<K, V>>,
@@ -165,7 +164,6 @@ where
     ) -> Result<impl Stream<Item = Result<(K, V::Value), Error>> + 'a, Error>
     where
         V: 'a,
-        V::Value: Send + Sync,
     {
         let start_iter = self.snapshot.get(&start);
         let mut init_pending = self.fetch_all_updates(start_iter).await?;
@@ -291,7 +289,6 @@ where
     I: Index<Value = Location> + 'static,
     H: Hasher,
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     type Digest = H::Digest;
 }

--- a/storage/src/qmdb/any/unordered/mod.rs
+++ b/storage/src/qmdb/any/unordered/mod.rs
@@ -121,7 +121,6 @@ impl<
     > kv::Gettable for Db<E, C, I, H, Update<K, V>>
 where
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     type Key = K;
     type Value = V::Value;
@@ -142,7 +141,6 @@ where
     I: Index<Value = Location> + Send + Sync + 'static,
     H: Hasher,
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     type Digest = H::Digest;
 }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -416,7 +416,6 @@ where
     I: UnorderedIndex<Value = Location> + 'static,
     H: Hasher,
     Operation<update::Unordered<K, V>>: Codec,
-    V::Value: Send + Sync,
     P: Readable<H::Digest>
         + BatchChainInfo<H::Digest>
         + BatchChain<Operation<update::Unordered<K, V>>>,
@@ -466,7 +465,6 @@ where
     I: crate::index::Ordered<Value = Location> + 'static,
     H: Hasher,
     Operation<update::Ordered<K, V>>: Codec,
-    V::Value: Send + Sync,
     P: Readable<H::Digest>
         + BatchChainInfo<H::Digest>
         + BatchChain<Operation<update::Ordered<K, V>>>,
@@ -758,7 +756,6 @@ where
     I: UnorderedIndex<Value = Location> + 'static,
     H: Hasher,
     Operation<update::Unordered<K, V>>: Codec,
-    V::Value: Send + Sync,
     P: Readable<H::Digest>
         + BatchChainInfo<H::Digest>
         + BatchChain<Operation<update::Unordered<K, V>>>,
@@ -782,7 +779,6 @@ where
     I: crate::index::Ordered<Value = Location> + 'static,
     H: Hasher,
     Operation<update::Ordered<K, V>>: Codec,
-    V::Value: Send + Sync,
     P: Readable<H::Digest>
         + BatchChainInfo<H::Digest>
         + BatchChain<Operation<update::Ordered<K, V>>>,
@@ -871,7 +867,6 @@ mod trait_impls {
         I: UnorderedIndex<Value = Location> + 'static,
         H: Hasher,
         Operation<update::Unordered<K, V>>: Codec,
-        V::Value: Send + Sync,
         P: Readable<H::Digest>
             + BatchChainInfo<H::Digest>
             + BatchChain<Operation<update::Unordered<K, V>>>,
@@ -906,7 +901,6 @@ mod trait_impls {
         I: crate::index::Ordered<Value = Location> + 'static,
         H: Hasher,
         Operation<update::Ordered<K, V>>: Codec,
-        V::Value: Send + Sync,
         P: Readable<H::Digest>
             + BatchChainInfo<H::Digest>
             + BatchChain<Operation<update::Ordered<K, V>>>,
@@ -966,7 +960,6 @@ mod trait_impls {
         I: UnorderedIndex<Value = Location> + 'static,
         H: Hasher,
         Operation<update::Unordered<K, V>>: Codec,
-        V::Value: Send + Sync,
     {
         type K = K;
         type V = V::Value;
@@ -1010,7 +1003,6 @@ mod trait_impls {
         I: crate::index::Ordered<Value = Location> + 'static,
         H: Hasher,
         Operation<update::Ordered<K, V>>: Codec,
-        V::Value: Send + Sync,
     {
         type K = K;
         type V = V::Value;

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -49,7 +49,6 @@ impl<
     > Db<E, C, K, V, I, H, N>
 where
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     /// Get the value of `key` in the db, or None if it has no value.
     pub async fn get(&self, key: &K) -> Result<Option<V::Value>, Error> {
@@ -145,7 +144,6 @@ impl<
     > Db<E, C, K, V, I, H, N>
 where
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     /// Generate and return a proof of the current value of `key`, along with the other
     /// [KeyValueProof] required to verify the proof. Returns KeyNotFound error if the key is not
@@ -230,7 +228,6 @@ impl<
     > kv::Gettable for Db<E, C, K, V, I, H, N>
 where
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     type Key = K;
     type Value = V::Value;

--- a/storage/src/qmdb/current/unordered/db.rs
+++ b/storage/src/qmdb/current/unordered/db.rs
@@ -45,7 +45,6 @@ impl<
     > Db<E, C, K, V, I, H, N>
 where
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     /// Get the value of `key` in the db, or None if it has no value.
     pub async fn get(&self, key: &K) -> Result<Option<V::Value>, Error> {
@@ -78,7 +77,6 @@ impl<
     > Db<E, C, K, V, I, H, N>
 where
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     /// Generate and return a proof of the current value of `key`, along with the other
     /// [KeyValueProof] required to verify the proof. Returns KeyNotFound error if the key is not
@@ -112,7 +110,6 @@ impl<
     > kv::Gettable for Db<E, C, K, V, I, H, N>
 where
     Operation<K, V>: Codec,
-    V::Value: Send + Sync,
 {
     type Key = K;
     type Value = V::Value;


### PR DESCRIPTION
* Remove `V::Value: Send + Sync` / `V::Value: Codec` bounds where `V` is a `ValueEncoding`. `ValueEncoding::Value` is `CodecShared` which is `Codec + Send + `Sync` so these bounds are redundant.
* Combine `impl<K, V, S> fmt::Display for Operation<K, V, S>` implementations