### PR TITLE
[workspace] Remove `aws` feature from `deployer`'s defaults

### DIFF
--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/commonware-deployer"
 workspace = true
 
 [features]
-default = [ "aws" ]
+default = []
 aws = [
 	"aws-config",
 	"aws-sdk-ec2",
@@ -24,6 +24,7 @@ aws = [
 	"commonware-cryptography",
 	"futures",
 	"reqwest",
+	"serde_yaml",
 	"thiserror",
 	"tokio",
 	"tracing",
@@ -43,7 +44,7 @@ commonware-macros.workspace = true
 futures = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
-serde_yaml.workspace = true
+serde_yaml = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"], optional = true }
 tracing = { workspace = true, optional = true }


### PR DESCRIPTION
## Overview

Removes `commonware-deployer/aws` from the default features of the crate. The feature is still required with the binary.