### PR TITLE
runtime/deterministic: reject pre-epoch start_time values

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -351,6 +351,10 @@ impl Config {
             self.cycle >= SYSTEM_TIME_PRECISION,
             "cycle duration must be greater than or equal to system time precision"
         );
+        assert!(
+            self.start_time >= UNIX_EPOCH,
+            "start time must be greater than or equal to unix epoch"
+        );
     }
 }
 
@@ -1985,6 +1989,13 @@ mod tests {
             // Check that the time matches the custom start time
             assert_eq!(context.current(), start_time);
         });
+    }
+
+    #[test]
+    #[should_panic(expected = "start time must be greater than or equal to unix epoch")]
+    fn test_bad_start_time() {
+        let cfg = Config::default().with_start_time(UNIX_EPOCH - Duration::from_secs(1));
+        deterministic::Runner::new(cfg);
     }
 
     #[cfg(not(feature = "external"))]


### PR DESCRIPTION
### Motivation
- Configurable `start_time` could be set to a `SystemTime` before `UNIX_EPOCH`, and trace-level logging calls `epoch_millis()` which panics for pre-epoch times, so the runtime must reject invalid start times to avoid crashes.

### Description
- Add a validation in `Config::assert()` that enforces `start_time >= UNIX_EPOCH` and add a focused unit test `test_bad_start_time` that expects construction with a pre-epoch time to panic with a clear message.

### Testing
- Ran `cargo test -p commonware-runtime deterministic::tests::test_bad_start_time` and it passed.
- Ran `cargo test -p commonware-runtime deterministic::tests::test_start_time` and it passed.
- Ran `cargo test -p commonware-runtime deterministic::tests::test_bad_cycle` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af29ceabb88326a7691460ffc450f4)