### PR TITLE
[consensus/simplex] Split: entry rebroadcast and interesting-window policy

### DIFF
--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -376,10 +376,7 @@ impl<
         if !retry {
             return;
         }
-        let past_view = view
-            .previous()
-            .expect("we should never be in the genesis view");
-        if let Some(certificate) = self.state.get_best_certificate(past_view) {
+        if let Some(certificate) = self.state.entry_certificate() {
             self.broadcast_certificate(certificate_sender, certificate)
                 .await;
         }
@@ -993,7 +990,7 @@ impl<
                 match msg {
                     Message::Proposal(proposal) => {
                         view = proposal.view();
-                        if !self.state.is_interesting(view, false) {
+                        if !self.state.is_interesting_vote(view) {
                             trace!(%view, "proposal is not interesting");
                             continue;
                         }
@@ -1005,7 +1002,7 @@ impl<
                     Message::Verified(certificate, from_resolver) => {
                         // Certificates can come from future views (they advance our view)
                         view = certificate.view();
-                        if !self.state.is_interesting(view, true) {
+                        if !self.state.is_interesting_certificate(view) {
                             trace!(%view, "certificate is not interesting");
                             continue;
                         }

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -114,6 +114,11 @@ pub struct State<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorCon
     /// at or above this view is observed.
     nullified_in_term: Option<View>,
 
+    /// View of the certificate that advanced us into the current view.
+    ///
+    /// `None` only for view 1 (bootstrapped from genesis).
+    entry_certificate_view: Option<View>,
+
     certification_candidates: BTreeSet<View>,
     outstanding_certifications: BTreeSet<View>,
 
@@ -154,6 +159,7 @@ impl<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: D
             genesis: None,
             views: BTreeMap::new(),
             nullified_in_term: None,
+            entry_certificate_view: None,
             certification_candidates: BTreeSet::new(),
             outstanding_certifications: BTreeSet::new(),
             current_view,
@@ -168,6 +174,7 @@ impl<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: D
         self.genesis = Some(genesis);
         self.enter_view(GENESIS_VIEW.next());
         self.set_leader(GENESIS_VIEW.next(), None);
+        self.entry_certificate_view = None;
     }
 
     /// Returns the epoch managed by this state machine.
@@ -190,14 +197,26 @@ impl<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: D
         min_active(self.activity_timeout, self.last_finalized)
     }
 
-    /// Returns whether `pending` is still relevant for progress, optionally allowing future views.
-    pub fn is_interesting(&self, pending: View, allow_future: bool) -> bool {
+    /// Returns whether a vote for `pending` is still relevant for progress.
+    pub fn is_interesting_vote(&self, pending: View) -> bool {
         interesting(
             self.activity_timeout,
             self.last_finalized,
             self.view,
             pending,
-            allow_future,
+            false,
+            self.term_length,
+        )
+    }
+
+    /// Returns whether a certificate for `pending` is relevant for progress.
+    pub fn is_interesting_certificate(&self, pending: View) -> bool {
+        interesting(
+            self.activity_timeout,
+            self.last_finalized,
+            self.view,
+            pending,
+            true,
             self.term_length,
         )
     }
@@ -377,8 +396,13 @@ impl<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: D
 
         // When term_length > 1, skip to the start of the next term.
         let next_view = view.next_term_start(self.term_length);
-        self.enter_view(next_view);
-        self.set_leader(next_view, Some(&nullification.certificate));
+        if self.enter_view(next_view) {
+            self.set_leader(next_view, Some(&nullification.certificate));
+        }
+        self.record_transition_certificate(
+            next_view,
+            Certificate::Nullification(nullification.clone()),
+        );
 
         // Track nullification metric per leader (if we know who the leader was)
         let round = self.create_round(view);
@@ -423,8 +447,11 @@ impl<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: D
             }
         }
 
-        self.enter_view(view.next());
-        self.set_leader(view.next(), Some(&finalization.certificate));
+        let next = view.next();
+        if self.enter_view(next) {
+            self.set_leader(next, Some(&finalization.certificate));
+        }
+        self.record_transition_certificate(next, Certificate::Finalization(finalization.clone()));
         self.create_round(view).add_finalization(finalization)
     }
 
@@ -693,7 +720,12 @@ impl<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: D
             .expect("notarization must exist for certified view");
 
         if is_success {
-            self.enter_view(view.next());
+            if self.enter_view(view.next()) {
+                self.record_transition_certificate(
+                    view.next(),
+                    Certificate::Notarization(notarization.clone()),
+                );
+            }
         } else {
             self.trigger_timeout(view, TimeoutReason::FailedCertification);
         }
@@ -739,6 +771,32 @@ impl<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: D
             None => return false,
         };
         round.nullification().is_some()
+    }
+
+    /// Returns the certificate that advanced us into the current view.
+    pub fn entry_certificate(&self) -> Option<Certificate<S, D>> {
+        let entry_view = self.entry_certificate_view?;
+        self.get_best_certificate(entry_view)
+    }
+
+    fn record_transition_certificate(&mut self, target_view: View, certificate: Certificate<S, D>) {
+        if self.view != target_view {
+            return;
+        }
+        let should_replace = self.entry_certificate().is_none_or(|current| {
+            Self::certificate_priority(&certificate) > Self::certificate_priority(&current)
+        });
+        if should_replace {
+            self.entry_certificate_view = Some(certificate.view());
+        }
+    }
+
+    const fn certificate_priority(certificate: &Certificate<S, D>) -> u8 {
+        match certificate {
+            Certificate::Finalization(_) => 3,
+            Certificate::Nullification(_) => 2,
+            Certificate::Notarization(_) => 1,
+        }
     }
 
     /// Returns true if certification for the view was aborted due to finalization.

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -378,11 +378,16 @@ pub(crate) fn interesting(
         return false;
     }
     if !allow_future {
-        // With term_length > 1, a nullification can skip us to the first
-        // view of the next term, so we accept messages up to next_term_start + 1
-        // (the +1 mirrors the standard current.next() lookahead).
-        let horizon = current.next_term_start(term_length);
-        if pending > horizon {
+        // Bound future acceptance to two windows:
+        // - [current, current + activity_timeout]
+        // - [next_term_start(current), next_term_start(current) + activity_timeout]
+        let current_window_end = current.saturating_add(activity_timeout);
+        let next_term_start = current.next_term_start(term_length);
+        let next_term_window_end = next_term_start.saturating_add(activity_timeout);
+
+        let in_current_window = pending <= current_window_end;
+        let in_next_term_window = pending >= next_term_start && pending <= next_term_window_end;
+        if !in_current_window && !in_next_term_window {
             return false;
         }
     }
@@ -458,7 +463,7 @@ mod tests {
 
     #[test]
     fn test_interesting() {
-        let activity_timeout = ViewDelta::new(10);
+        let activity_timeout = ViewDelta::new(2);
 
         // Genesis view is never interesting
         assert!(!interesting(
@@ -483,7 +488,7 @@ mod tests {
             activity_timeout,
             View::new(20),
             View::new(25),
-            View::new(5), // below min_active (10)
+            View::new(5), // below min_active (18)
             false,
             1
         ));
@@ -493,29 +498,59 @@ mod tests {
             activity_timeout,
             View::new(20),
             View::new(25),
-            View::new(10), // exactly min_active
+            View::new(18), // exactly min_active
             false,
             1
         ));
 
-        // Future view beyond current.next() is not interesting when allow_future is false
-        assert!(!interesting(
-            activity_timeout,
-            View::new(20),
-            View::new(25),
-            View::new(27),
-            false,
-            1
-        ));
-
-        // Future view beyond current.next() is interesting when allow_future is true
+        // Future view in the current future window is interesting.
         assert!(interesting(
             activity_timeout,
             View::new(20),
             View::new(25),
             View::new(27),
+            false,
+            10
+        ));
+
+        // Gap between current and next-term windows is not interesting.
+        assert!(!interesting(
+            activity_timeout,
+            View::new(20),
+            View::new(25),
+            View::new(29),
+            false,
+            10
+        ));
+
+        // Future view in next-term future window is interesting.
+        assert!(interesting(
+            activity_timeout,
+            View::new(20),
+            View::new(25),
+            View::new(32),
+            false,
+            10
+        ));
+
+        // Beyond next-term future window is not interesting when allow_future is false.
+        assert!(!interesting(
+            activity_timeout,
+            View::new(20),
+            View::new(25),
+            View::new(34),
+            false,
+            10
+        ));
+
+        // Future views beyond bounded windows are interesting when allow_future is true.
+        assert!(interesting(
+            activity_timeout,
+            View::new(20),
+            View::new(25),
+            View::new(80),
             true,
-            1
+            10
         ));
 
         // View at current.next() is interesting


### PR DESCRIPTION
## Summary
- switch retry rebroadcast to use explicit entry-certificate provenance for the current view (with finalization > nullification > notarization priority)
- tighten `interesting` future acceptance to two bounded windows: current-window and next-term-start window, each bounded by `activity_timeout`
- rename voter callsites to intent-based helpers (`is_interesting_vote`, `is_interesting_certificate`) to avoid policy booleans

## Scope
- logic-only split from the larger stable-leader branch
- touches only voter actor/state and simplex `interesting` helper