### PR TITLE
[storage/bmt] Tighten MAX_LEVELS from 255 to 32

### DIFF
--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -49,9 +49,10 @@ use commonware_runtime::{Buf, BufMut};
 use commonware_utils::{non_empty_vec, vec::NonEmptyVec};
 use thiserror::Error;
 
-/// There should never be more than 255 levels in a proof (would mean the Binary Merkle Tree
-/// has more than 2^255 leaves).
-pub const MAX_LEVELS: usize = u8::MAX as usize;
+/// There should never be more than 32 sibling levels in a proof. Since `leaf_count` is a `u32`,
+/// a tree can have at most `u32::MAX` leaves, which requires at most `u32::BITS = 32` sibling
+/// hashes per item in a multi-proof (one per level from the leaf up to, but not including, the root).
+pub const MAX_LEVELS: usize = u32::BITS as usize;
 
 /// Errors that can occur when working with a Binary Merkle Tree (BMT).
 #[derive(Error, Debug)]


### PR DESCRIPTION
MAX_LEVELS in storage/src/bmt was set to u8::MAX = 255, but since leaf_count in Proof is a u32, the tree can have at most 2^32 - 1 leaves, requiring at most u32::BITS = 32 sibling hashes per item in a multi-proof.

Proof::read_cfg computes max_siblings = max_items * MAX_LEVELS and allocates up to that many digests before any cryptographic verification

For a 1 MiB maximum_shard_size in ZODA's StrongShard, the old bound allowed ~1 GB of allocation per proof; the new bound caps it at ~128 MB (~8x reduction).

Why u32::BITS = 32 is the exact tight bound:
levels_in_tree(u32::MAX) = 33 total levels, and siblings_required_for_multi_proof iterates for level in 0..levels_count - 1 — so 32 sibling levels is the maximum any valid proof can ever contain. No legitimate proof can exceed this bound.