### PR TITLE
[Storage] Change generic types to associated types

### DIFF
--- a/storage/src/bitmap/authenticated.rs
+++ b/storage/src/bitmap/authenticated.rs
@@ -630,9 +630,11 @@ impl<E: Clock + RStorage + Metrics, D: Digest, const N: usize> UnmerkleizedBitMa
     }
 }
 
-impl<E: Clock + RStorage + Metrics, D: Digest, const N: usize> Storage<D>
+impl<E: Clock + RStorage + Metrics, D: Digest, const N: usize> Storage
     for MerkleizedBitMap<E, D, N>
 {
+    type Digest = D;
+
     async fn size(&self) -> Position {
         self.size()
     }

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -51,7 +51,7 @@ impl<E: Storage + Clock + Metrics, D: Digest, Item> BatchChain<Item> for Mmr<E, 
 
 /// A speculative batch whose root digest has not yet been computed,
 /// in contrast to [MerkleizedBatch].
-pub struct UnmerkleizedBatch<'a, H: Hasher, P: Readable<H::Digest>, Item> {
+pub struct UnmerkleizedBatch<'a, H: Hasher, P: Readable<Digest = H::Digest>, Item> {
     // The inner batch of MMR leaf digests.
     inner: batch::UnmerkleizedBatch<'a, H::Digest, P>,
     // The hasher to use for hashing the items.
@@ -60,7 +60,9 @@ pub struct UnmerkleizedBatch<'a, H: Hasher, P: Readable<H::Digest>, Item> {
     items: Vec<Item>,
 }
 
-impl<'a, H: Hasher, P: Readable<H::Digest>, Item: Encode> UnmerkleizedBatch<'a, H, P, Item> {
+impl<'a, H: Hasher, P: Readable<Digest = H::Digest>, Item: Encode>
+    UnmerkleizedBatch<'a, H, P, Item>
+{
     /// Add an item to the batch.
     pub fn add(&mut self, item: Item) {
         let encoded = item.encode();
@@ -79,23 +81,24 @@ impl<'a, H: Hasher, P: Readable<H::Digest>, Item: Encode> UnmerkleizedBatch<'a, 
 
 /// A speculative batch whose root digest has been computed,
 /// in contrast to [UnmerkleizedBatch].
-pub struct MerkleizedBatch<'a, H: Hasher, P: Readable<H::Digest>, Item> {
+pub struct MerkleizedBatch<'a, H: Hasher, P: Readable<Digest = H::Digest>, Item> {
     // The inner batch of MMR leaf digests.
     inner: batch::MerkleizedBatch<'a, H::Digest, P>,
     // The items to append.
     items: Arc<Vec<Item>>,
 }
 
-impl<'a, H: Hasher, P: Readable<H::Digest>, Item> MerkleizedBatch<'a, H, P, Item> {
+impl<'a, H: Hasher, P: Readable<Digest = H::Digest>, Item> MerkleizedBatch<'a, H, P, Item> {
     /// Return the root digest of the authenticated journal after this batch is applied.
     pub fn root(&self) -> H::Digest {
         self.inner.root()
     }
 }
 
-impl<'a, H: Hasher, P: Readable<H::Digest>, Item: Send + Sync> Readable<H::Digest>
+impl<'a, H: Hasher, P: Readable<Digest = H::Digest>, Item: Send + Sync> Readable
     for MerkleizedBatch<'a, H, P, Item>
 {
+    type Digest = H::Digest;
     fn size(&self) -> Position {
         self.inner.size()
     }
@@ -110,9 +113,14 @@ impl<'a, H: Hasher, P: Readable<H::Digest>, Item: Send + Sync> Readable<H::Diges
     }
 }
 
-impl<'a, H: Hasher, P: Readable<H::Digest> + BatchChainInfo<H::Digest>, Item: Send + Sync>
-    BatchChainInfo<H::Digest> for MerkleizedBatch<'a, H, P, Item>
+impl<
+        'a,
+        H: Hasher,
+        P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
+        Item: Send + Sync,
+    > BatchChainInfo for MerkleizedBatch<'a, H, P, Item>
 {
+    type Digest = H::Digest;
     fn base_size(&self) -> Position {
         self.inner.base_size()
     }
@@ -121,8 +129,8 @@ impl<'a, H: Hasher, P: Readable<H::Digest> + BatchChainInfo<H::Digest>, Item: Se
     }
 }
 
-impl<'a, H: Hasher, P: Readable<H::Digest> + BatchChain<Item>, Item: Send + Sync> BatchChain<Item>
-    for MerkleizedBatch<'a, H, P, Item>
+impl<'a, H: Hasher, P: Readable<Digest = H::Digest> + BatchChain<Item>, Item: Send + Sync>
+    BatchChain<Item> for MerkleizedBatch<'a, H, P, Item>
 {
     fn collect(&self, into: &mut Vec<Arc<Vec<Item>>>) {
         self.inner.parent().collect(into); // recurse to parent first
@@ -130,7 +138,7 @@ impl<'a, H: Hasher, P: Readable<H::Digest> + BatchChain<Item>, Item: Send + Sync
     }
 }
 
-impl<'a, H: Hasher, P: Readable<H::Digest>, Item: Send + Sync + Encode>
+impl<'a, H: Hasher, P: Readable<Digest = H::Digest>, Item: Send + Sync + Encode>
     MerkleizedBatch<'a, H, P, Item>
 {
     /// Create a new speculative batch of operations with this batch as its parent.
@@ -148,7 +156,7 @@ impl<'a, H: Hasher, P: Readable<H::Digest>, Item: Send + Sync + Encode>
 
 impl<'a, H: Hasher, P, Item: Send + Sync> MerkleizedBatch<'a, H, P, Item>
 where
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Item>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Item>,
 {
     /// Consume this batch, collecting the changes from its ancestors and itself into a
     /// [Changeset] which can be applied to the journal.

--- a/storage/src/merkle/mmr/batch.rs
+++ b/storage/src/merkle/mmr/batch.rs
@@ -70,7 +70,7 @@ cfg_if::cfg_if! {
 }
 
 /// A batch of mutations against a parent MMR, which may itself be a merkleized batch.
-pub struct Batch<'a, D: Digest, P: Readable<D>, S: State<D> = Dirty> {
+pub struct Batch<'a, D: Digest, P: Readable<Digest = D>, S: State<D> = Dirty> {
     /// The parent MMR.
     parent: &'a P,
     /// Nodes appended by this batch, at positions [parent.size(), parent.size() + appended.len()).
@@ -103,7 +103,7 @@ pub struct Changeset<D: Digest> {
     pub(crate) base_size: Position,
 }
 
-impl<'a, D: Digest, P: Readable<D>, S: State<D>> Batch<'a, D, P, S> {
+impl<'a, D: Digest, P: Readable<Digest = D>, S: State<D>> Batch<'a, D, P, S> {
     /// The total number of nodes visible through this batch.
     pub(crate) fn size(&self) -> Position {
         Position::new(*self.parent.size() + self.appended.len() as u64)
@@ -135,7 +135,7 @@ impl<'a, D: Digest, P: Readable<D>, S: State<D>> Batch<'a, D, P, S> {
     }
 }
 
-impl<'a, D: Digest, P: Readable<D>> UnmerkleizedBatch<'a, D, P> {
+impl<'a, D: Digest, P: Readable<Digest = D>> UnmerkleizedBatch<'a, D, P> {
     /// The number of leaves visible through this batch.
     pub fn leaves(&self) -> Location {
         Location::try_from(self.size()).expect("invalid mmr size")
@@ -399,7 +399,9 @@ impl<'a, D: Digest, P: Readable<D>> UnmerkleizedBatch<'a, D, P> {
     }
 }
 
-impl<'a, D: Digest, P: Readable<D>> Readable<D> for MerkleizedBatch<'a, D, P> {
+impl<'a, D: Digest, P: Readable<Digest = D>> Readable for MerkleizedBatch<'a, D, P> {
+    type Digest = D;
+
     fn size(&self) -> Position {
         self.size()
     }
@@ -417,9 +419,11 @@ impl<'a, D: Digest, P: Readable<D>> Readable<D> for MerkleizedBatch<'a, D, P> {
     }
 }
 
-impl<'a, D: Digest, P: Readable<D> + BatchChainInfo<D>> BatchChainInfo<D>
+impl<'a, D: Digest, P: Readable<Digest = D> + BatchChainInfo<Digest = D>> BatchChainInfo
     for MerkleizedBatch<'a, D, P>
 {
+    type Digest = D;
+
     fn base_size(&self) -> Position {
         self.parent.base_size()
     }
@@ -435,7 +439,7 @@ impl<'a, D: Digest, P: Readable<D> + BatchChainInfo<D>> BatchChainInfo<D>
     }
 }
 
-impl<'a, D: Digest, P: Readable<D>> MerkleizedBatch<'a, D, P> {
+impl<'a, D: Digest, P: Readable<Digest = D>> MerkleizedBatch<'a, D, P> {
     /// Access the parent MMR.
     #[cfg(feature = "std")]
     pub(crate) const fn parent(&self) -> &P {
@@ -469,7 +473,9 @@ impl<'a, D: Digest, P: Readable<D>> MerkleizedBatch<'a, D, P> {
     }
 }
 
-impl<'a, D: Digest, P: Readable<D> + BatchChainInfo<D>> MerkleizedBatch<'a, D, P> {
+impl<'a, D: Digest, P: Readable<Digest = D> + BatchChainInfo<Digest = D>>
+    MerkleizedBatch<'a, D, P>
+{
     /// Flatten this batch chain into a single [`Changeset`] relative to the
     /// ultimate base MMR.
     pub fn finalize(self) -> Changeset<D> {

--- a/storage/src/merkle/mmr/journaled.rs
+++ b/storage/src/merkle/mmr/journaled.rs
@@ -866,7 +866,9 @@ impl<E: RStorage + Clock + Metrics, D: Digest> Mmr<E, D> {
     }
 }
 
-impl<E: RStorage + Clock + Metrics, D: Digest> Readable<D> for Mmr<E, D> {
+impl<E: RStorage + Clock + Metrics, D: Digest> Readable for Mmr<E, D> {
+    type Digest = D;
+
     fn size(&self) -> Position {
         self.size()
     }
@@ -884,7 +886,9 @@ impl<E: RStorage + Clock + Metrics, D: Digest> Readable<D> for Mmr<E, D> {
     }
 }
 
-impl<E: RStorage + Clock + Metrics, D: Digest> BatchChainInfo<D> for Mmr<E, D> {
+impl<E: RStorage + Clock + Metrics, D: Digest> BatchChainInfo for Mmr<E, D> {
+    type Digest = D;
+
     fn base_size(&self) -> Position {
         self.size()
     }
@@ -892,7 +896,9 @@ impl<E: RStorage + Clock + Metrics, D: Digest> BatchChainInfo<D> for Mmr<E, D> {
     fn collect_overwrites(&self, _into: &mut BTreeMap<Position, D>) {}
 }
 
-impl<E: RStorage + Clock + Metrics + Sync, D: Digest> Storage<D> for Mmr<E, D> {
+impl<E: RStorage + Clock + Metrics + Sync, D: Digest> Storage for Mmr<E, D> {
+    type Digest = D;
+
     async fn size(&self) -> Position {
         self.size()
     }

--- a/storage/src/merkle/mmr/mem.rs
+++ b/storage/src/merkle/mmr/mem.rs
@@ -494,7 +494,9 @@ impl<D: Digest> Mmr<D> {
     }
 }
 
-impl<D: Digest> Readable<D> for Mmr<D> {
+impl<D: Digest> Readable for Mmr<D> {
+    type Digest = D;
+
     fn size(&self) -> Position {
         self.size()
     }
@@ -512,7 +514,9 @@ impl<D: Digest> Readable<D> for Mmr<D> {
     }
 }
 
-impl<D: Digest> BatchChainInfo<D> for Mmr<D> {
+impl<D: Digest> BatchChainInfo for Mmr<D> {
+    type Digest = D;
+
     fn base_size(&self) -> Position {
         self.size()
     }

--- a/storage/src/merkle/mmr/read.rs
+++ b/storage/src/merkle/mmr/read.rs
@@ -10,15 +10,18 @@ use commonware_cryptography::Digest;
 use core::ops::Range;
 
 /// Read-only interface for a merkleized MMR.
-pub trait Readable<D: Digest>: Send + Sync {
+pub trait Readable: Send + Sync {
+    /// The digest type used by this MMR.
+    type Digest: Digest;
+
     /// Total number of nodes (retained + pruned).
     fn size(&self) -> Position;
 
     /// Digest of the node at `pos`, or `None` if pruned / out of bounds.
-    fn get_node(&self, pos: Position) -> Option<D>;
+    fn get_node(&self, pos: Position) -> Option<Self::Digest>;
 
     /// Root digest of the MMR.
-    fn root(&self) -> D;
+    fn root(&self) -> Self::Digest;
 
     /// Items before this position have been pruned.
     fn pruned_to_pos(&self) -> Position;
@@ -39,7 +42,7 @@ pub trait Readable<D: Digest>: Send + Sync {
     }
 
     /// Inclusion proof for the element at `loc`.
-    fn proof(&self, loc: Location) -> Result<Proof<D>, Error> {
+    fn proof(&self, loc: Location) -> Result<Proof<Self::Digest>, Error> {
         if !loc.is_valid() {
             return Err(Error::LocationOverflow(loc));
         }
@@ -50,7 +53,7 @@ pub trait Readable<D: Digest>: Send + Sync {
     }
 
     /// Inclusion proof for all elements in `range`.
-    fn range_proof(&self, range: Range<Location>) -> Result<Proof<D>, Error> {
+    fn range_proof(&self, range: Range<Location>) -> Result<Proof<Self::Digest>, Error> {
         let leaves = self.leaves();
         let positions = proof::nodes_required_for_range_proof(leaves, range)?;
         let digests = positions
@@ -62,7 +65,10 @@ pub trait Readable<D: Digest>: Send + Sync {
 }
 
 /// Information needed to flatten a chain of batches into a single [`super::batch::Changeset`].
-pub trait BatchChainInfo<D: Digest> {
+pub trait BatchChainInfo: Send + Sync {
+    /// The digest type used by this MMR.
+    type Digest: Digest;
+
     /// Number of nodes in the original MMR that the batch chain was forked
     /// from. This is constant through the entire chain.
     fn base_size(&self) -> Position;
@@ -70,5 +76,5 @@ pub trait BatchChainInfo<D: Digest> {
     /// Collect all overwrites that target nodes in the original MMR
     /// (i.e. positions < `base_size()`), walking from the deepest
     /// ancestor to the current batch. Later batches overwrite earlier ones.
-    fn collect_overwrites(&self, into: &mut BTreeMap<Position, D>);
+    fn collect_overwrites(&self, into: &mut BTreeMap<Position, Self::Digest>);
 }

--- a/storage/src/merkle/mmr/storage.rs
+++ b/storage/src/merkle/mmr/storage.rs
@@ -6,19 +6,26 @@ use commonware_cryptography::Digest;
 use std::future::Future;
 
 /// A trait for accessing MMR digests from storage.
-pub trait Storage<D: Digest>: Send + Sync {
+pub trait Storage: Send + Sync {
+    /// The digest type used by this MMR.
+    type Digest: Digest;
+
     /// Return the number of elements in the MMR.
     fn size(&self) -> impl Future<Output = Position> + Send;
 
     /// Return the specified node of the MMR if it exists & hasn't been pruned.
-    fn get_node(&self, position: Position)
-        -> impl Future<Output = Result<Option<D>, Error>> + Send;
+    fn get_node(
+        &self,
+        position: Position,
+    ) -> impl Future<Output = Result<Option<Self::Digest>, Error>> + Send;
 }
 
-impl<D> Storage<D> for Mmr<D>
+impl<D> Storage for Mmr<D>
 where
     D: Digest,
 {
+    type Digest = D;
+
     async fn size(&self) -> Position {
         self.size()
     }

--- a/storage/src/merkle/mmr/verification.rs
+++ b/storage/src/merkle/mmr/verification.rs
@@ -66,7 +66,8 @@ impl<D: Digest> ProofStore<D> {
     }
 }
 
-impl<D: Digest> Storage<D> for ProofStore<D> {
+impl<D: Digest> Storage for ProofStore<D> {
+    type Digest = D;
     async fn get_node(&self, pos: Position) -> Result<Option<D>, Error> {
         Ok(self.digests.get(&pos).cloned())
     }
@@ -84,7 +85,7 @@ impl<D: Digest> Storage<D> for ProofStore<D> {
 /// Returns [Error::RangeOutOfBounds] if any location in `range` > `mmr.size()`
 /// Returns [Error::ElementPruned] if some element needed to generate the proof has been pruned
 /// Returns [Error::Empty] if the requested range is empty
-pub async fn range_proof<D: Digest, S: Storage<D>>(
+pub async fn range_proof<D: Digest, S: Storage<Digest = D>>(
     mmr: &S,
     range: Range<Location>,
 ) -> Result<Proof<D>, Error> {
@@ -101,7 +102,7 @@ pub async fn range_proof<D: Digest, S: Storage<D>>(
 /// Returns [Error::RangeOutOfBounds] if any location in `range` > `leaves`
 /// Returns [Error::ElementPruned] if some element needed to generate the proof has been pruned
 /// Returns [Error::Empty] if the requested range is empty
-pub async fn historical_range_proof<D: Digest, S: Storage<D>>(
+pub async fn historical_range_proof<D: Digest, S: Storage<Digest = D>>(
     mmr: &S,
     leaves: Location,
     range: Range<Location>,
@@ -135,7 +136,7 @@ pub async fn historical_range_proof<D: Digest, S: Storage<D>>(
 /// Returns [Error::RangeOutOfBounds] if any location in `locations` > `mmr.size()`
 /// Returns [Error::ElementPruned] if some element needed to generate the proof has been pruned
 /// Returns [Error::Empty] if locations is empty
-pub async fn multi_proof<D: Digest, S: Storage<D>>(
+pub async fn multi_proof<D: Digest, S: Storage<Digest = D>>(
     mmr: &S,
     locations: &[Location],
 ) -> Result<Proof<D>, Error> {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -129,7 +129,7 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
 {
     /// The committed DB this batch is built on top of.
     db: &'a Db<E, C, I, H, U>,
@@ -171,7 +171,7 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
 {
     /// The committed DB this batch is built on top of.
     db: &'a Db<E, C, I, H, U>,
@@ -237,7 +237,7 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
 {
     db: &'a Db<E, C, I, H, U>,
     journal_batch: authenticated::UnmerkleizedBatch<'a, H, P, Operation<U>>,
@@ -257,7 +257,7 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
 {
     /// Read an operation at a given location from the correct source.
     ///
@@ -490,7 +490,7 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
 {
     /// Record a mutation. Use `Some(value)` for update/create, `None` for delete.
     ///
@@ -534,7 +534,7 @@ where
     I: UnorderedIndex<Value = Location> + 'static,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
 {
     /// Read through: mutations -> base diff -> committed DB.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error> {
@@ -558,8 +558,8 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<update::Unordered<K, V>>: Codec,
-    P: Readable<H::Digest>
-        + BatchChainInfo<H::Digest>
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
         + BatchChain<Operation<update::Unordered<K, V>>>,
 {
     /// Resolve mutations into operations, merkleize, and return a [`MerkleizedBatch`].
@@ -680,8 +680,8 @@ where
     I: OrderedIndex<Value = Location>,
     H: Hasher,
     Operation<update::Ordered<K, V>>: Codec,
-    P: Readable<H::Digest>
-        + BatchChainInfo<H::Digest>
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
         + BatchChain<Operation<update::Ordered<K, V>>>,
 {
     /// Resolve mutations into operations, merkleize, and return a [`MerkleizedBatch`].
@@ -944,7 +944,7 @@ where
     I: UnorderedIndex<Value = Location> + 'static,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
 {
     /// Read through: diff -> committed DB.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error> {
@@ -963,7 +963,7 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
 {
     /// Return the speculative root.
     pub fn root(&self) -> H::Digest {
@@ -998,7 +998,7 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
 {
     /// Consume this batch, producing an owned [`Changeset`].
     pub fn finalize(self) -> Changeset<U::Key, H::Digest, Operation<U>> {
@@ -1181,8 +1181,8 @@ mod trait_impls {
         I: UnorderedIndex<Value = Location>,
         H: Hasher,
         Operation<update::Unordered<K, V>>: Codec,
-        P: Readable<H::Digest>
-            + BatchChainInfo<H::Digest>
+        P: Readable<Digest = H::Digest>
+            + BatchChainInfo<Digest = H::Digest>
             + BatchChain<Operation<update::Unordered<K, V>>>,
     {
         type K = K;
@@ -1215,8 +1215,8 @@ mod trait_impls {
         I: OrderedIndex<Value = Location>,
         H: Hasher,
         Operation<update::Ordered<K, V>>: Codec,
-        P: Readable<H::Digest>
-            + BatchChainInfo<H::Digest>
+        P: Readable<Digest = H::Digest>
+            + BatchChainInfo<Digest = H::Digest>
             + BatchChain<Operation<update::Ordered<K, V>>>,
     {
         type K = K;
@@ -1245,7 +1245,9 @@ mod trait_impls {
         I: UnorderedIndex<Value = Location>,
         H: Hasher,
         Operation<U>: Codec,
-        P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
+        P: Readable<Digest = H::Digest>
+            + BatchChainInfo<Digest = H::Digest>
+            + BatchChain<Operation<U>>,
     {
         type Digest = H::Digest;
         type Changeset = Changeset<U::Key, H::Digest, Operation<U>>;

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -246,13 +246,15 @@ impl<B: BitmapRead<N>, const N: usize> BitmapRead<N> for BitmapDiff<'_, B, N> {
 /// Tries the batch chain's sync [`Readable`] first (which covers nodes appended
 /// or overwritten by the batch, plus anything still in the in-memory MMR).
 /// Falls through to the base's async [`MmrStorage`].
-struct BatchStorageAdapter<'a, D: Digest, R: Readable<D>, S: MmrStorage<D>> {
+struct BatchStorageAdapter<'a, D: Digest, R: Readable<Digest = D>, S: MmrStorage<Digest = D>> {
     batch: &'a R,
     base: &'a S,
     _phantom: core::marker::PhantomData<D>,
 }
 
-impl<'a, D: Digest, R: Readable<D>, S: MmrStorage<D>> BatchStorageAdapter<'a, D, R, S> {
+impl<'a, D: Digest, R: Readable<Digest = D>, S: MmrStorage<Digest = D>>
+    BatchStorageAdapter<'a, D, R, S>
+{
     const fn new(batch: &'a R, base: &'a S) -> Self {
         Self {
             batch,
@@ -262,9 +264,11 @@ impl<'a, D: Digest, R: Readable<D>, S: MmrStorage<D>> BatchStorageAdapter<'a, D,
     }
 }
 
-impl<D: Digest, R: Readable<D>, S: MmrStorage<D>> MmrStorage<D>
+impl<D: Digest, R: Readable<Digest = D>, S: MmrStorage<Digest = D>> MmrStorage
     for BatchStorageAdapter<'_, D, R, S>
 {
+    type Digest = D;
+
     async fn size(&self) -> Position {
         self.batch.size()
     }
@@ -287,8 +291,8 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     /// The inner any-layer batch that handles mutations, journal, and floor raise.
@@ -321,8 +325,8 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     /// The inner any-layer merkleized batch.
@@ -373,8 +377,8 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     pub(super) const fn new(
@@ -416,10 +420,10 @@ where
     I: UnorderedIndex<Value = Location> + 'static,
     H: Hasher,
     Operation<update::Unordered<K, V>>: Codec,
-    P: Readable<H::Digest>
-        + BatchChainInfo<H::Digest>
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
         + BatchChain<Operation<update::Unordered<K, V>>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     /// Read through: mutations -> base diff -> committed DB.
@@ -465,10 +469,10 @@ where
     I: crate::index::Ordered<Value = Location> + 'static,
     H: Hasher,
     Operation<update::Ordered<K, V>>: Codec,
-    P: Readable<H::Digest>
-        + BatchChainInfo<H::Digest>
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
         + BatchChain<Operation<update::Ordered<K, V>>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     /// Read through: mutations -> base diff -> committed DB.
@@ -602,8 +606,8 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     let old_grafted_leaves = *grafted_parent.leaves() as usize;
@@ -698,8 +702,8 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     /// Return the speculative root.
@@ -756,10 +760,10 @@ where
     I: UnorderedIndex<Value = Location> + 'static,
     H: Hasher,
     Operation<update::Unordered<K, V>>: Codec,
-    P: Readable<H::Digest>
-        + BatchChainInfo<H::Digest>
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
         + BatchChain<Operation<update::Unordered<K, V>>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     /// Read through: diff -> committed DB.
@@ -779,10 +783,10 @@ where
     I: crate::index::Ordered<Value = Location> + 'static,
     H: Hasher,
     Operation<update::Ordered<K, V>>: Codec,
-    P: Readable<H::Digest>
-        + BatchChainInfo<H::Digest>
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
         + BatchChain<Operation<update::Ordered<K, V>>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     /// Read through: diff -> committed DB.
@@ -800,8 +804,8 @@ where
     I: UnorderedIndex<Value = Location>,
     H: Hasher,
     Operation<U>: Codec,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
-    G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<U>>,
+    G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
     B: BitmapRead<N>,
 {
     /// Consume this batch, producing an owned [`Changeset`].
@@ -867,10 +871,10 @@ mod trait_impls {
         I: UnorderedIndex<Value = Location> + 'static,
         H: Hasher,
         Operation<update::Unordered<K, V>>: Codec,
-        P: Readable<H::Digest>
-            + BatchChainInfo<H::Digest>
+        P: Readable<Digest = H::Digest>
+            + BatchChainInfo<Digest = H::Digest>
             + BatchChain<Operation<update::Unordered<K, V>>>,
-        G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+        G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
         B: BitmapRead<N>,
     {
         type K = K;
@@ -901,10 +905,10 @@ mod trait_impls {
         I: crate::index::Ordered<Value = Location> + 'static,
         H: Hasher,
         Operation<update::Ordered<K, V>>: Codec,
-        P: Readable<H::Digest>
-            + BatchChainInfo<H::Digest>
+        P: Readable<Digest = H::Digest>
+            + BatchChainInfo<Digest = H::Digest>
             + BatchChain<Operation<update::Ordered<K, V>>>,
-        G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+        G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
         B: BitmapRead<N>,
     {
         type K = K;
@@ -933,8 +937,10 @@ mod trait_impls {
         I: UnorderedIndex<Value = Location>,
         H: Hasher,
         Operation<U>: Codec,
-        P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<U>>,
-        G: Readable<H::Digest> + BatchChainInfo<H::Digest>,
+        P: Readable<Digest = H::Digest>
+            + BatchChainInfo<Digest = H::Digest>
+            + BatchChain<Operation<U>>,
+        G: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest>,
         B: BitmapRead<N>,
     {
         type Digest = H::Digest;

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -142,7 +142,7 @@ where
     /// Returns a virtual [grafting::Storage] over the grafted MMR and ops MMR. For positions at or
     /// above the grafting height, returns grafted MMR node. For positions below the grafting
     /// height, the ops MMR is used.
-    fn grafted_storage(&self) -> impl mmr::storage::Storage<H::Digest> + '_ {
+    fn grafted_storage(&self) -> impl mmr::storage::Storage<Digest = H::Digest> + '_ {
         grafting::Storage::new(
             &self.grafted_mmr,
             grafting::height::<N>(),
@@ -469,8 +469,8 @@ pub(super) fn combine_roots<H: Hasher>(
 /// See the [Root structure](super) section in the module documentation.
 pub(super) async fn compute_db_root<
     H: Hasher,
-    G: mmr::read::Readable<H::Digest>,
-    S: mmr::storage::Storage<H::Digest>,
+    G: mmr::read::Readable<Digest = H::Digest>,
+    S: mmr::storage::Storage<Digest = H::Digest>,
     const N: usize,
 >(
     hasher: &mut StandardHasher<H>,
@@ -496,8 +496,8 @@ pub(super) async fn compute_db_root<
 /// `storage` is the grafted storage over the grafted MMR and the ops MMR.
 pub(super) async fn compute_grafted_mmr_root<
     H: Hasher,
-    G: mmr::read::Readable<H::Digest>,
-    S: mmr::storage::Storage<H::Digest>,
+    G: mmr::read::Readable<Digest = H::Digest>,
+    S: mmr::storage::Storage<Digest = H::Digest>,
 >(
     hasher: &mut StandardHasher<H>,
     storage: &grafting::Storage<'_, H::Digest, G, S>,
@@ -527,7 +527,7 @@ pub(super) async fn compute_grafted_mmr_root<
 /// When a thread pool is provided and there are enough chunks, hashing is parallelized.
 pub(super) async fn compute_grafted_leaves<H: Hasher, const N: usize>(
     hasher: &mut StandardHasher<H>,
-    ops_mmr: &impl mmr::storage::Storage<H::Digest>,
+    ops_mmr: &impl mmr::storage::Storage<Digest = H::Digest>,
     chunks: impl IntoIterator<Item = (usize, [u8; N])>,
     pool: Option<&ThreadPool>,
 ) -> Result<Vec<(Position, H::Digest)>, Error> {
@@ -593,7 +593,7 @@ pub(super) async fn build_grafted_mmr<H: Hasher, const N: usize>(
     hasher: &mut StandardHasher<H>,
     bitmap: &BitMap<N>,
     pinned_nodes: &[H::Digest],
-    ops_mmr: &impl mmr::storage::Storage<H::Digest>,
+    ops_mmr: &impl mmr::storage::Storage<Digest = H::Digest>,
     pool: Option<&ThreadPool>,
 ) -> Result<mmr::mem::Mmr<H::Digest>, Error> {
     let grafting_height = grafting::height::<N>();

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -319,14 +319,14 @@ impl<H: CHasher> HasherTrait for Verifier<'_, H> {
 /// Nodes below the grafting height are served from the ops MMR. Nodes at or above the grafting
 /// height are served from the grafted MMR (with ops-to-grafted position conversion). This allows
 /// standard MMR proof generation to work transparently over the combined structure.
-pub(super) struct Storage<'a, D: Digest, G: Readable<D>, S: StorageTrait<D>> {
+pub(super) struct Storage<'a, D: Digest, G: Readable<Digest = D>, S: StorageTrait<Digest = D>> {
     grafted_mmr: &'a G,
     grafting_height: u32,
     ops_mmr: &'a S,
     _digest: PhantomData<D>,
 }
 
-impl<'a, D: Digest, G: Readable<D>, S: StorageTrait<D>> Storage<'a, D, G, S> {
+impl<'a, D: Digest, G: Readable<Digest = D>, S: StorageTrait<Digest = D>> Storage<'a, D, G, S> {
     /// Creates a new [Storage] instance.
     pub(super) const fn new(grafted_mmr: &'a G, grafting_height: u32, ops_mmr: &'a S) -> Self {
         Self {
@@ -338,7 +338,11 @@ impl<'a, D: Digest, G: Readable<D>, S: StorageTrait<D>> Storage<'a, D, G, S> {
     }
 }
 
-impl<D: Digest, G: Readable<D>, S: StorageTrait<D>> StorageTrait<D> for Storage<'_, D, G, S> {
+impl<D: Digest, G: Readable<Digest = D>, S: StorageTrait<Digest = D>> StorageTrait
+    for Storage<'_, D, G, S>
+{
+    type Digest = D;
+
     async fn size(&self) -> Position {
         self.ops_mmr.size().await
     }

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -33,7 +33,7 @@ pub struct RangeProof<D: Digest> {
 
 impl<D: Digest> RangeProof<D> {
     /// Create a new range proof for the provided `range` of operations.
-    pub async fn new<H: CHasher<Digest = D>, S: Storage<D>, const N: usize>(
+    pub async fn new<H: CHasher<Digest = D>, S: Storage<Digest = D>, const N: usize>(
         hasher: &mut H,
         status: &BitMap<N>,
         storage: &S,
@@ -71,7 +71,7 @@ impl<D: Digest> RangeProof<D> {
     pub async fn new_with_ops<
         H: CHasher<Digest = D>,
         C: Contiguous,
-        S: Storage<D>,
+        S: Storage<Digest = D>,
         const N: usize,
     >(
         hasher: &mut H,
@@ -242,7 +242,7 @@ impl<D: Digest, const N: usize> OperationProof<D, N> {
     /// # Errors
     ///
     /// Returns [Error::OperationPruned] if `loc` falls in a pruned bitmap chunk.
-    pub async fn new<H: CHasher<Digest = D>, S: Storage<D>>(
+    pub async fn new<H: CHasher<Digest = D>, S: Storage<Digest = D>>(
         hasher: &mut H,
         status: &BitMap<N>,
         storage: &S,

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -37,7 +37,9 @@ where
     V: VariableValue,
     H: CHasher,
     T: Translator,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<K, V>>,
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
+        + BatchChain<Operation<K, V>>,
 {
     /// The committed DB this batch is built on top of.
     pub(super) immutable: &'a Immutable<E, K, V, H, T>,
@@ -71,7 +73,9 @@ where
     V: VariableValue,
     H: CHasher,
     T: Translator,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<K, V>>,
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
+        + BatchChain<Operation<K, V>>,
 {
     /// The committed DB this batch is built on top of.
     immutable: &'a Immutable<E, K, V, H, T>,
@@ -114,7 +118,9 @@ where
     V: VariableValue,
     H: CHasher,
     T: Translator,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<K, V>>,
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
+        + BatchChain<Operation<K, V>>,
 {
     /// Set a key to a value.
     ///
@@ -192,7 +198,9 @@ where
     V: VariableValue,
     H: CHasher,
     T: Translator,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<K, V>>,
+    P: Readable<Digest = H::Digest>
+        + BatchChainInfo<Digest = H::Digest>
+        + BatchChain<Operation<K, V>>,
 {
     /// Return the speculative root.
     pub fn root(&self) -> H::Digest {

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -20,7 +20,7 @@ where
     E: Storage + Clock + Metrics,
     V: VariableValue,
     H: Hasher,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<V>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<V>>,
 {
     /// The committed DB this batch is built on top of.
     pub(super) keyless: &'a Keyless<E, V, H>,
@@ -49,7 +49,7 @@ where
     E: Storage + Clock + Metrics,
     V: VariableValue,
     H: Hasher,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<V>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<V>>,
 {
     /// The committed DB this batch is built on top of.
     keyless: &'a Keyless<E, V, H>,
@@ -84,7 +84,7 @@ where
     E: Storage + Clock + Metrics,
     V: VariableValue,
     H: Hasher,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<V>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<V>>,
 {
     /// Append a value.
     /// Returns the uncommitted location where this value will be placed.
@@ -161,7 +161,7 @@ where
     E: Storage + Clock + Metrics,
     V: VariableValue,
     H: Hasher,
-    P: Readable<H::Digest> + BatchChainInfo<H::Digest> + BatchChain<Operation<V>>,
+    P: Readable<Digest = H::Digest> + BatchChainInfo<Digest = H::Digest> + BatchChain<Operation<V>>,
 {
     /// Return the speculative root.
     pub fn root(&self) -> H::Digest {


### PR DESCRIPTION
Convert `Readable<D>`, `BatchChainInfo<D>`, and `Storage<D>` traits from generic parameters to associated types. Each implementor has exactly one digest type.