### PR TITLE
[consensus/simplex] Use `Mock` Certificate (with Validity Assertion) in E2E Tests

### DIFF
--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -2415,15 +2415,18 @@ mod tests {
         partition::<_, _, RoundRobin>(scheme_mocks::fixture_with::<true, true, false, _>);
     }
 
-    fn slow_and_lossy_links<S, F, L>(seed: u64, mut fixture: F) -> String
+    fn slow_and_lossy_links_with<S, F, L>(
+        seed: u64,
+        n: u32,
+        required_containers: View,
+        mut fixture: F,
+    ) -> String
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
         L: Elector<S>,
     {
         // Create context
-        let n = 5;
-        let required_containers = View::new(50);
         let activity_timeout = ViewDelta::new(10);
         let skip_timeout = ViewDelta::new(5);
         let namespace = b"consensus".to_vec();
@@ -2566,6 +2569,15 @@ mod tests {
         })
     }
 
+    fn slow_and_lossy_links<S, F, L>(seed: u64, fixture: F) -> String
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+        L: Elector<S>,
+    {
+        slow_and_lossy_links_with::<S, F, L>(seed, 5, View::new(50), fixture)
+    }
+
     #[test_group("slow")]
     #[test_traced]
     fn test_slow_and_lossy_links() {
@@ -2579,6 +2591,17 @@ mod tests {
         slow_and_lossy_links::<_, _, RoundRobin>(0, secp256r1::fixture);
         slow_and_lossy_links::<_, _, RoundRobin>(
             0,
+            scheme_mocks::fixture_with::<true, true, false, _>,
+        );
+    }
+
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_slow_and_lossy_links_mock_strict_stress() {
+        slow_and_lossy_links_with::<_, _, RoundRobin>(
+            0,
+            10,
+            View::new(100),
             scheme_mocks::fixture_with::<true, true, false, _>,
         );
     }

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -914,6 +914,7 @@ mod tests {
         all_online::<_, _, RoundRobin>(bls12381_multisig::fixture::<MinSig, _>);
         all_online::<_, _, RoundRobin>(ed25519::fixture);
         all_online::<_, _, RoundRobin>(secp256r1::fixture);
+        all_online::<_, _, RoundRobin>(scheme_mocks::fixture_with::<true, true, false, _>);
     }
 
     fn observer<S, F, L>(mut fixture: F)
@@ -1082,6 +1083,7 @@ mod tests {
         observer::<_, _, RoundRobin>(bls12381_multisig::fixture::<MinSig, _>);
         observer::<_, _, RoundRobin>(ed25519::fixture);
         observer::<_, _, RoundRobin>(secp256r1::fixture);
+        observer::<_, _, RoundRobin>(scheme_mocks::fixture_with::<true, true, false, _>);
     }
 
     fn unclean_shutdown<S, F, L>(mut fixture: F)
@@ -1544,6 +1546,7 @@ mod tests {
         backfill::<_, _, RoundRobin>(bls12381_multisig::fixture::<MinSig, _>);
         backfill::<_, _, RoundRobin>(ed25519::fixture);
         backfill::<_, _, RoundRobin>(secp256r1::fixture);
+        backfill::<_, _, RoundRobin>(scheme_mocks::fixture_with::<true, true, false, _>);
     }
 
     fn one_offline<S, F, L>(mut fixture: F)
@@ -1793,6 +1796,7 @@ mod tests {
         one_offline::<_, _, RoundRobin>(bls12381_multisig::fixture::<MinSig, _>);
         one_offline::<_, _, RoundRobin>(ed25519::fixture);
         one_offline::<_, _, RoundRobin>(secp256r1::fixture);
+        one_offline::<_, _, RoundRobin>(scheme_mocks::fixture_with::<true, true, false, _>);
     }
 
     fn slow_validator<S, F, L>(mut fixture: F)
@@ -1985,6 +1989,7 @@ mod tests {
         slow_validator::<_, _, RoundRobin>(bls12381_multisig::fixture::<MinSig, _>);
         slow_validator::<_, _, RoundRobin>(ed25519::fixture);
         slow_validator::<_, _, RoundRobin>(secp256r1::fixture);
+        slow_validator::<_, _, RoundRobin>(scheme_mocks::fixture_with::<true, true, false, _>);
     }
 
     fn all_recovery<S, F, L>(mut fixture: F)
@@ -2202,6 +2207,7 @@ mod tests {
         all_recovery::<_, _, RoundRobin>(bls12381_multisig::fixture::<MinSig, _>);
         all_recovery::<_, _, RoundRobin>(ed25519::fixture);
         all_recovery::<_, _, RoundRobin>(secp256r1::fixture);
+        all_recovery::<_, _, RoundRobin>(scheme_mocks::fixture_with::<true, true, false, _>);
     }
 
     fn partition<S, F, L>(mut fixture: F)
@@ -2406,6 +2412,7 @@ mod tests {
         partition::<_, _, RoundRobin>(bls12381_multisig::fixture::<MinSig, _>);
         partition::<_, _, RoundRobin>(ed25519::fixture);
         partition::<_, _, RoundRobin>(secp256r1::fixture);
+        partition::<_, _, RoundRobin>(scheme_mocks::fixture_with::<true, true, false, _>);
     }
 
     fn slow_and_lossy_links<S, F, L>(seed: u64, mut fixture: F) -> String
@@ -2570,6 +2577,10 @@ mod tests {
         slow_and_lossy_links::<_, _, RoundRobin>(0, bls12381_multisig::fixture::<MinSig, _>);
         slow_and_lossy_links::<_, _, RoundRobin>(0, ed25519::fixture);
         slow_and_lossy_links::<_, _, RoundRobin>(0, secp256r1::fixture);
+        slow_and_lossy_links::<_, _, RoundRobin>(
+            0,
+            scheme_mocks::fixture_with::<true, true, false, _>,
+        );
     }
 
     #[test_group("slow")]
@@ -2646,6 +2657,16 @@ mod tests {
             let secp_state_2 = slow_and_lossy_links::<_, _, RoundRobin>(seed, secp256r1::fixture);
             assert_eq!(secp_state_1, secp_state_2);
 
+            let mock_state_1 = slow_and_lossy_links::<_, _, RoundRobin>(
+                seed,
+                scheme_mocks::fixture_with::<true, true, false, _>,
+            );
+            let mock_state_2 = slow_and_lossy_links::<_, _, RoundRobin>(
+                seed,
+                scheme_mocks::fixture_with::<true, true, false, _>,
+            );
+            assert_eq!(mock_state_1, mock_state_2);
+
             let states = [
                 ("threshold-vrf-minpk", ts_vrf_pk_state_1),
                 ("threshold-vrf-minsig", ts_vrf_sig_state_1),
@@ -2655,6 +2676,7 @@ mod tests {
                 ("multisig-minsig", ms_sig_state_1),
                 ("ed25519", ed_state_1),
                 ("secp256r1", secp_state_1),
+                ("mock-strict", mock_state_1),
             ];
 
             // Sanity check that different types can't be identical
@@ -4255,6 +4277,12 @@ mod tests {
         run_1k::<_, _, RoundRobin>(secp256r1::fixture);
     }
 
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_1k_mock_strict() {
+        run_1k::<_, _, RoundRobin>(scheme_mocks::fixture_with::<true, true, false, _>);
+    }
+
     fn engine_shutdown<S, F, L>(seed: u64, mut fixture: F, graceful: bool)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
@@ -4676,6 +4704,9 @@ mod tests {
         );
         attributable_reporter_filtering::<_, _, RoundRobin>(ed25519::fixture);
         attributable_reporter_filtering::<_, _, RoundRobin>(secp256r1::fixture);
+        attributable_reporter_filtering::<_, _, RoundRobin>(
+            scheme_mocks::fixture_with::<true, true, false, _>,
+        );
     }
 
     fn split_views_no_lockup<S, F, L>(mut fixture: F)
@@ -5644,6 +5675,25 @@ mod tests {
         );
     }
 
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_hailstorm_mock_strict() {
+        assert_eq!(
+            hailstorm::<_, _, RoundRobin>(
+                0,
+                10,
+                ViewDelta::new(15),
+                scheme_mocks::fixture_with::<true, true, false, _>
+            ),
+            hailstorm::<_, _, RoundRobin>(
+                0,
+                10,
+                ViewDelta::new(15),
+                scheme_mocks::fixture_with::<true, true, false, _>
+            )
+        );
+    }
+
     /// Configuration for a Twins testing campaign.
     ///
     /// A campaign generates adversarial primary/secondary recipient-set
@@ -6128,7 +6178,7 @@ mod tests {
                 &mut test_rng(),
                 TWINS_CAMPAIGN,
                 link,
-                scheme_mocks::fixture,
+                scheme_mocks::fixture_with::<true, true, false, _>,
             );
         }
     }
@@ -6152,7 +6202,7 @@ mod tests {
                 &mut test_rng(),
                 campaign,
                 link,
-                scheme_mocks::fixture,
+                scheme_mocks::fixture_with::<true, true, false, _>,
             );
         }
     }
@@ -6169,7 +6219,7 @@ mod tests {
             &mut test_rng(),
             campaign,
             TWINS_LINK,
-            scheme_mocks::fixture,
+            scheme_mocks::fixture_with::<true, true, false, _>,
         );
     }
 
@@ -6186,7 +6236,7 @@ mod tests {
             &mut test_rng(),
             campaign,
             TWINS_LINK,
-            scheme_mocks::fixture,
+            scheme_mocks::fixture_with::<true, true, false, _>,
         );
     }
 


### PR DESCRIPTION
Closes #3359

## Summary

Switches the `consensus/simplex` E2E tests from the permissive `scheme_mocks::fixture` 
to the strict `scheme_mocks::fixture_with::<true, true, false, _>`, so any invalid 
certificate assembly or verification panics immediately instead of silently returning `false`.

## Changes

- **4 twins tests** (`test_twins_*`): replaced permissive `scheme_mocks::fixture` with 
  strict `fixture_with::<true, true, false, _>`
- **Honest-path helpers** (`all_online`, `observer`, `backfill`, `one_offline`, 
  `slow_validator`, `all_recovery`, `partition`, `slow_and_lossy_links`, 
  `test_determinism`, `test_attributable_reporter_filtering`): added strict mock 
  as an extra matrix entry
- **`run_1k` and `hailstorm`**: added separate strict-mock runs
- **`test_invalid`**: intentionally left unchanged — this test expects honest nodes 
  to observe and count invalid material

## Testing

All 12 twins tests pass with the strict mock:
- `test_twins_ed25519_slow_`
- `test_twins_threshold_vrf_min_pk_slow_`
- `test_twins_threshold_vrf_min_sig_slow_`
- ... (12 passed; 0 failed)

## Related

- Depends on #3358 (`[cryptography] Add Fake Certificate`)