### PR TITLE
[runtime/p2p] Add fuzzing hooks for insitu-fuzz

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -24,6 +24,7 @@ commonware-stream.workspace = true
 commonware-utils.workspace = true
 either.workspace = true
 futures.workspace = true
+libc.workspace = true
 num-bigint.workspace = true
 num-integer.workspace = true
 num-rational.workspace = true
@@ -43,6 +44,8 @@ tracing-subscriber.workspace = true
 
 [features]
 mocks = []
+fuzz = []
+fuzzing = ["fuzz"]
 arbitrary = [
 	"commonware-codec/arbitrary",
 	"commonware-cryptography/arbitrary",

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -8,6 +8,7 @@
     html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
+#![cfg_attr(feature = "fuzz", feature(linkage))]
 
 use commonware_macros::{stability_mod, stability_scope};
 

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -12,6 +12,25 @@ use commonware_utils::{
 };
 use std::time::SystemTime;
 
+// Fuzzing hook provided by insitu-fuzz via weak linkage. Resolves to None when
+// insitu-fuzz is not linked, giving zero overhead in all non-fuzzing builds.
+#[cfg(feature = "fuzz")]
+extern "C" {
+    #[linkage = "extern_weak"]
+    static commonware_fuzz_corrupt_bytes: Option<unsafe extern "C" fn(*mut u8, usize) -> bool>;
+}
+
+#[cfg(feature = "fuzz")]
+#[inline(always)]
+fn corrupt_bytes_hook(msg: &mut [u8]) {
+    // SAFETY: weak linkage -- None when insitu-fuzz is not linked.
+    unsafe {
+        if let Some(corrupt_fn) = commonware_fuzz_corrupt_bytes {
+            corrupt_fn(msg.as_mut_ptr(), msg.len());
+        }
+    }
+}
+
 /// Wrap a [Sender] and [Receiver] with some [Codec].
 pub const fn wrap<S: Sender, R: Receiver, V: Codec>(
     config: V::Cfg,
@@ -53,6 +72,13 @@ impl<S: Sender, V: Codec> WrappedSender<S, V> {
         message: V,
         priority: bool,
     ) -> Result<Vec<S::PublicKey>, <S::Checked<'_> as CheckedSender>::Error> {
+        #[cfg(feature = "fuzz")]
+        let encoded = {
+            let mut buf = message.encode().into_vec();
+            corrupt_bytes_hook(&mut buf);
+            commonware_runtime::IoBuf::from(buf).into()
+        };
+        #[cfg(not(feature = "fuzz"))]
         let encoded = message.encode_with_pool(&self.pool);
         self.sender.send(recipients, encoded, priority).await
     }
@@ -88,6 +114,13 @@ impl<'a, S: Sender, V: Codec> CheckedWrappedSender<'a, S, V> {
         message: V,
         priority: bool,
     ) -> Result<Vec<S::PublicKey>, <S::Checked<'a> as CheckedSender>::Error> {
+        #[cfg(feature = "fuzz")]
+        let encoded = {
+            let mut buf = message.encode().into_vec();
+            corrupt_bytes_hook(&mut buf);
+            commonware_runtime::IoBuf::from(buf).into()
+        };
+        #[cfg(not(feature = "fuzz"))]
         let encoded = message.encode_with_pool(self.pool);
         self.sender.send(encoded, priority).await
     }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -65,6 +65,8 @@ arbitrary = [
 ]
 external = [ "pin-project" ]
 test-utils = []
+fuzz = []
+fuzzing = ["fuzz"]
 iouring = [ "iouring-network", "iouring-storage" ]
 iouring-network = [ "io-uring" ]
 iouring-storage = [ "io-uring" ]

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -106,6 +106,17 @@ use std::{
 use tracing::{info_span, trace, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+// Fuzzing hooks provided by insitu-fuzz via weak linkage. Both symbols resolve
+// to None at runtime when insitu-fuzz is not linked, so there is zero overhead
+// in normal builds even when the feature is enabled.
+#[cfg(feature = "fuzz")]
+extern "C" {
+    #[linkage = "extern_weak"]
+    static commonware_fuzz_permute_tasks: Option<unsafe extern "C" fn(*mut u128, usize) -> bool>;
+    #[linkage = "extern_weak"]
+    static insitu_fuzz_checkpoint: Option<unsafe extern "C" fn()>;
+}
+
 #[derive(Debug)]
 struct Metrics {
     iterations: Counter,
@@ -568,10 +579,36 @@ impl Runner {
             // Drain all ready tasks
             let mut queue = executor.tasks.drain();
 
+            // Fuzzer checkpoint: allows insitu-fuzz to snapshot state here for
+            // deferred fork (avoids replaying early messages on each iteration).
+            #[cfg(feature = "fuzz")]
+            // SAFETY: weak linkage -- None when insitu-fuzz is not linked.
+            unsafe {
+                if let Some(checkpoint) = insitu_fuzz_checkpoint {
+                    checkpoint();
+                }
+            }
+
             // Shuffle tasks (if more than one)
             if queue.len() > 1 {
-                let mut rng = executor.rng.lock();
-                queue.shuffle(&mut *rng);
+                // When insitu-fuzz is linked it supplies a fuzzer-controlled
+                // permutation so the fuzzer can explore scheduling orders.
+                #[cfg(feature = "fuzz")]
+                // SAFETY: weak linkage -- None when insitu-fuzz is not linked.
+                let did_permute = unsafe {
+                    if let Some(permute) = commonware_fuzz_permute_tasks {
+                        permute(queue.as_mut_ptr(), queue.len())
+                    } else {
+                        false
+                    }
+                };
+                #[cfg(not(feature = "fuzz"))]
+                let did_permute = false;
+
+                if !did_permute {
+                    let mut rng = executor.rng.lock();
+                    queue.shuffle(&mut *rng);
+                }
             }
 
             // Run all snapshotted tasks

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -20,6 +20,7 @@
     html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
+#![cfg_attr(feature = "fuzz", feature(linkage))]
 
 use commonware_macros::stability_scope;
 


### PR DESCRIPTION
Adds two weak-linkage FFI hook points behind `feature = "fuzz"`:

- `runtime/src/deterministic.rs`: `commonware_fuzz_permute_tasks` lets insitu-fuzz supply a fuzzer-controlled task ordering at each quiescent point, replacing the seeded RNG shuffle. `insitu_fuzz_checkpoint` lets AFL++ deferred-fork targets snapshot state mid-run.

- `p2p/src/utils/codec.rs`: `commonware_fuzz_corrupt_bytes` is called on the encoded wire bytes in both `WrappedSender::send` and `CheckedWrappedSender::send`, allowing the fuzzer to mutate messages before they are delivered.

Both hooks use `#[linkage = "extern_weak"]`: they compile to None when insitu-fuzz is not linked, so there is zero overhead in normal builds. The `fuzz` feature is off by default and not enabled by CI.

Part of the insitu-fuzz integration tracked in https://github.com/commonwarexyz/monorepo/issues/1398#issuecomment-3324548051