### PR TITLE
[insitu-fuzz] Add fuzzable_test macro and expose broadcast/buffered t…

### DIFF
--- a/broadcast/Cargo.toml
+++ b/broadcast/Cargo.toml
@@ -27,5 +27,8 @@ tracing.workspace = true
 [dev-dependencies]
 tracing-subscriber.workspace = true
 
+[features]
+fuzz = []
+
 [lib]
 bench = false

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -28,14 +28,16 @@ pub use ingress::Mailbox;
 pub(crate) use ingress::Message;
 mod metrics;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "fuzz"))]
 pub mod mocks;
 
-#[cfg(test)]
-mod tests {
+#[cfg(any(test, feature = "fuzz"))]
+#[cfg_attr(not(test), allow(dead_code, unused_imports))]
+pub mod tests {
     use super::{mocks::TestMessage, *};
     use crate::Broadcaster;
     use commonware_codec::RangeCfg;
+    use commonware_macros::fuzzable_test;
     use commonware_cryptography::{
         ed25519::{PrivateKey, PublicKey},
         Digestible, Hasher, Sha256, Signer as _,
@@ -52,6 +54,9 @@ mod tests {
 
     // Number of messages to cache per sender
     const CACHE_SIZE: usize = 10;
+
+    // Maximum message length for codec (prevents OOM under fuzz mutation)
+    const MAX_LEN: usize = 10_485_760;
 
     // Enough time to receive a cached message. Cannot be instantaneous as the test runtime
     // requires some time to switch context.
@@ -147,7 +152,7 @@ mod tests {
                 mailbox_size: 1024,
                 deque_size: CACHE_SIZE,
                 priority: false,
-                codec_config: RangeCfg::from(..),
+                codec_config: RangeCfg::from(..=MAX_LEN),
                 peer_provider: oracle.manager(),
             };
             let (engine, engine_mailbox) =
@@ -158,6 +163,7 @@ mod tests {
         mailboxes
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_broadcast() {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
@@ -211,6 +217,7 @@ mod tests {
         });
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_self_retrieval() {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
@@ -266,6 +273,7 @@ mod tests {
         });
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_packet_loss() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
@@ -311,6 +319,7 @@ mod tests {
         });
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_get_cached() {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
@@ -342,6 +351,7 @@ mod tests {
         });
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_get_nonexistent() {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
@@ -376,6 +386,7 @@ mod tests {
         });
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_cache_eviction_single_peer() {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
@@ -415,6 +426,7 @@ mod tests {
         });
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_cache_eviction_multi_peer() {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
@@ -480,6 +492,7 @@ mod tests {
         });
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_selective_recipients() {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
@@ -522,6 +535,7 @@ mod tests {
         });
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_ref_count_across_peers() {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
@@ -685,7 +699,7 @@ mod tests {
                 mailbox_size: 1024,
                 deque_size: CACHE_SIZE,
                 priority: false,
-                codec_config: RangeCfg::from(..),
+                codec_config: RangeCfg::from(..=MAX_LEN),
                 peer_provider: oracle.manager(),
             };
             let (engine, mailbox) =
@@ -774,7 +788,7 @@ mod tests {
                 mailbox_size: 1024,
                 deque_size: CACHE_SIZE,
                 priority: false,
-                codec_config: RangeCfg::from(..),
+                codec_config: RangeCfg::from(..=MAX_LEN),
                 peer_provider: oracle.manager(),
             };
             let (engine, engine_mailbox) =
@@ -785,6 +799,7 @@ mod tests {
         (mailboxes, handles)
     }
 
+    #[fuzzable_test]
     #[test_traced]
     fn test_operations_after_shutdown_do_not_panic() {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
@@ -890,6 +905,7 @@ mod tests {
         });
     }
 
+    #[fuzzable_test]
     #[test]
     fn test_clean_shutdown() {
         for seed in 0..25 {
@@ -915,7 +931,7 @@ mod tests {
                 mailbox_size: 1024,
                 deque_size: CACHE_SIZE,
                 priority: false,
-                codec_config: RangeCfg::from(..),
+                codec_config: RangeCfg::from(..=MAX_LEN),
                 peer_provider: oracle.manager(),
             };
             let (engine_b, mailbox_b) =
@@ -932,7 +948,7 @@ mod tests {
                     mailbox_size: 1024,
                     deque_size: CACHE_SIZE,
                     priority: false,
-                    codec_config: RangeCfg::from(..),
+                    codec_config: RangeCfg::from(..=MAX_LEN),
                     peer_provider: oracle.manager(),
                 };
                 let (engine, mailbox) = Engine::<_, PublicKey, TestMessage, _>::new(ctx, config);
@@ -986,7 +1002,7 @@ mod tests {
                 mailbox_size: 1024,
                 deque_size: CACHE_SIZE,
                 priority: false,
-                codec_config: RangeCfg::from(..),
+                codec_config: RangeCfg::from(..=MAX_LEN),
                 peer_provider: oracle.manager(),
             };
             let (engine_b, mailbox_b) =
@@ -1003,7 +1019,7 @@ mod tests {
                     mailbox_size: 1024,
                     deque_size: CACHE_SIZE,
                     priority: false,
-                    codec_config: RangeCfg::from(..),
+                    codec_config: RangeCfg::from(..=MAX_LEN),
                     peer_provider: oracle.manager(),
                 };
                 let (engine, mailbox) = Engine::<_, PublicKey, TestMessage, _>::new(ctx, config);

--- a/macros/impl/src/lib.rs
+++ b/macros/impl/src/lib.rs
@@ -742,3 +742,39 @@ pub fn select_loop(input: TokenStream) -> TokenStream {
     }
     .into()
 }
+
+/// Make a test function callable from fuzz harnesses.
+///
+/// Converts test attributes (`#[test]`, `#[test_traced]`, `#[test_async]`,
+/// `#[tokio::test]`) to `#[cfg_attr(test, ...)]` and makes the function `pub`.
+/// This allows fuzz harnesses to call the function directly while it continues
+/// to behave as a normal test function in `cargo test`.
+#[proc_macro_attribute]
+pub fn fuzzable_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemFn);
+    let sig = &input.sig;
+    let block = &input.block;
+    let converted_attrs: Vec<_> = input
+        .attrs
+        .iter()
+        .map(|attr| {
+            let is_test_attr = attr.path().is_ident("test")
+                || attr.path().is_ident("test_traced")
+                || attr.path().is_ident("test_async");
+            let is_tokio_test = attr.path().segments.len() == 2
+                && attr.path().segments.first().map(|s| s.ident == "tokio").unwrap_or(false)
+                && attr.path().segments.last().map(|s| s.ident == "test").unwrap_or(false);
+            if is_test_attr || is_tokio_test {
+                let meta = &attr.meta;
+                quote! { #[cfg_attr(test, #meta)] }
+            } else {
+                quote! { #attr }
+            }
+        })
+        .collect();
+    let output = quote! {
+        #(#converted_attrs)*
+        pub #sig #block
+    };
+    output.into()
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,7 +4,7 @@
 //! - [`select!`] - Biased async select over multiple futures (requires `std` feature)
 //! - [`select_loop!`] - Continuous select loop with shutdown handling (requires `std` feature)
 //! - [`stability`], [`stability_mod!`], [`stability_scope!`] - API stability annotations
-//! - [`test_async`], [`test_traced`], [`test_collect_traces`] - Test utilities
+//! - [`test_async`], [`test_traced`], [`test_collect_traces`], [`fuzzable_test`] - Test utilities
 //! - [`test_group`] - Nextest filter group annotations
 
 #![doc(
@@ -331,6 +331,7 @@ pub use commonware_macros_impl::test_group;
 ///     assert_eq!(2 + 2, 4);
 /// }
 /// ```
+pub use commonware_macros_impl::fuzzable_test;
 pub use commonware_macros_impl::test_traced;
 
 #[doc(hidden)]


### PR DESCRIPTION
- Add `fuzzable_test` proc macro to commonware-macros: converts test attributes to `#[cfg_attr(test, ...)]` and makes functions `pub`, allowing fuzz harnesses to call them directly while they remain normal tests under `cargo test`.
- Expose `broadcast::buffered::tests` and `broadcast::buffered::mocks` under `cfg(any(test, feature = "fuzz"))` as initial target module.
- Add `fuzz = []` feature to broadcast crate.
- Add `MAX_LEN` constant (10 MiB) to bound codec RangeCfg and prevent OOM under fuzz-mutated inputs.
- Annotate 11 fuzzable test functions with `#[fuzzable_test]`.