### PR TITLE
[coding] Use the default minifuzz config where possible

### DIFF
--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -377,33 +377,26 @@ mod test {
 
     #[test]
     fn minifuzz_roundtrip_reed_solomon() {
-        minifuzz::Builder::default()
-            .with_seed(0)
-            .with_search_limit(64)
-            .test(|u| {
-                let (config, data, selected) = generate_case(u)?;
-                roundtrip::<ReedSolomon<Sha256>>(&config, &data, &selected);
-                Ok(())
-            });
+        minifuzz::test(|u| {
+            let (config, data, selected) = generate_case(u)?;
+            roundtrip::<ReedSolomon<Sha256>>(&config, &data, &selected);
+            Ok(())
+        });
     }
 
     #[test]
     fn minifuzz_roundtrip_no_coding() {
-        minifuzz::Builder::default()
-            .with_seed(0)
-            .with_search_limit(64)
-            .test(|u| {
-                let (config, data, selected) = generate_case(u)?;
-                roundtrip::<NoCoding<Sha256>>(&config, &data, &selected);
-                Ok(())
-            });
+        minifuzz::test(|u| {
+            let (config, data, selected) = generate_case(u)?;
+            roundtrip::<NoCoding<Sha256>>(&config, &data, &selected);
+            Ok(())
+        });
     }
 
     #[test_group("slow")]
     #[test]
     fn minifuzz_roundtrip_zoda() {
         minifuzz::Builder::default()
-            .with_seed(0)
             .with_search_limit(64)
             .test(|u| {
                 let (config, data, selected) = generate_case(u)?;


### PR DESCRIPTION
Noticed this oversight from when we first added minifuzz. We want to encourage people to use the default pattern where possible, for consistency. If it's not good enough, we should change the default.

In this case, previously we were using proptests, so there was not a fixed seed. (There are ways to configure minifuzz the re-use a seed to reproduce test results, similarly to proptest.)

Setting 64 iterations explicitly was actually bad for NoCoding and ReedSolomon, since they could do far more than that in 10 seconds (the minifuzz default).

For ZODA, the test is kept as slow, using an explicit iteration count.