### PR TITLE
[workspace] Propagate `mocks` feature

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -42,7 +42,7 @@ commonware-runtime = { workspace = true, features = ["test-utils"] }
 tracing-subscriber.workspace = true
 
 [features]
-mocks = []
+mocks = [ "commonware-cryptography/mocks" ]
 arbitrary = [
 	"commonware-codec/arbitrary",
 	"commonware-cryptography/arbitrary",

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -43,7 +43,7 @@ development = ["commonware-resolver"]
 bench = false
 
 [features]
-mocks = []
+mocks = [ "commonware-cryptography/mocks", "commonware-p2p/mocks" ]
 arbitrary = [
 	"commonware-codec/arbitrary",
 	"commonware-cryptography/arbitrary",

--- a/zepter.yaml
+++ b/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         "propagate-feature",
         # These are the features to check:
-        "--features=std,arbitrary",
+        "--features=std,arbitrary,mocks",
         # Do not try to add a new section into `[features]` of `A` only because `B` exposes that feature.
         # There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",


### PR DESCRIPTION
## Overview

Enough crates use the `mocks` feature that it's worth adding to zepter's list of features to propagate.
