### PR TITLE
[coding/zoda] Accept caller-provided namespace in ZODA encoding

### DIFF
--- a/coding/fuzz/src/lib.rs
+++ b/coding/fuzz/src/lib.rs
@@ -101,7 +101,7 @@ pub fn fuzz_phased<S: PhasedScheme>(input: FuzzInput) {
         minimum_shards: NZU16!(min),
         extra_shards: NZU16!(recovery),
     };
-    let (commitment, shards) = S::encode(&config, data.as_slice(), &STRATEGY).unwrap();
+    let (commitment, shards) = S::encode(b"", &config, data.as_slice(), &STRATEGY).unwrap();
     assert_eq!(shards.len(), (recovery + min) as usize);
     let mut shards = (0u16..).zip(shards).collect::<Vec<_>>();
     shuffle.shuffle(&mut shards);
@@ -110,14 +110,14 @@ pub fn fuzz_phased<S: PhasedScheme>(input: FuzzInput) {
     // This lets us move our strong shard out directly while keeping the rest for forwarding.
     let (my_i, my_shard) = shards.pop().unwrap();
     let (my_checking_data, my_checked_shard, _) =
-        S::weaken(&config, &commitment, my_i, my_shard).unwrap();
+        S::weaken(b"", &config, &commitment, my_i, my_shard).unwrap();
 
     // Check `to_use - 1` forwarded shards, then include our own checked shard.
     let checked_shards = shards
         .into_iter()
         .take((to_use - 1) as usize)
         .map(|(i, shard)| {
-            let (_, _, weak_shard) = S::weaken(&config, &commitment, i, shard).unwrap();
+            let (_, _, weak_shard) = S::weaken(b"", &config, &commitment, i, shard).unwrap();
             S::check(&config, &commitment, &my_checking_data, i, weak_shard).unwrap()
         })
         .chain(iter::once(my_checked_shard))

--- a/coding/src/benches/bench_phased.rs
+++ b/coding/src/benches/bench_phased.rs
@@ -32,9 +32,9 @@ pub(crate) fn bench_encode_generic<S: PhasedScheme>(name: &str, c: &mut Criterio
                             },
                             |data| {
                                 if conc > 1 {
-                                    S::encode(&config, data.as_slice(), &strategy).unwrap()
+                                    S::encode(b"", &config, data.as_slice(), &strategy).unwrap()
                                 } else {
-                                    S::encode(&config, data.as_slice(), &Sequential).unwrap()
+                                    S::encode(b"", &config, data.as_slice(), &Sequential).unwrap()
                                 }
                             },
                             BatchSize::SmallInput,
@@ -71,9 +71,9 @@ pub(crate) fn bench_decode_generic<S: PhasedScheme>(name: &str, c: &mut Criterio
                                     rng.fill_bytes(&mut data);
 
                                     let (commitment, mut shards) = if conc > 1 {
-                                        S::encode(&config, data.as_slice(), &strategy).unwrap()
+                                        S::encode(b"", &config, data.as_slice(), &strategy).unwrap()
                                     } else {
-                                        S::encode(&config, data.as_slice(), &Sequential).unwrap()
+                                        S::encode(b"", &config, data.as_slice(), &Sequential).unwrap()
                                     };
 
                                     let my_shard = shards.pop().unwrap();
@@ -85,7 +85,7 @@ pub(crate) fn bench_decode_generic<S: PhasedScheme>(name: &str, c: &mut Criterio
                                         .map(|&i| {
                                             let shard = opt_shards[i as usize].take().unwrap();
                                             let (_, _, weak_shard) =
-                                                S::weaken(&config, &commitment, i, shard).unwrap();
+                                                S::weaken(b"", &config, &commitment, i, shard).unwrap();
                                             (i, weak_shard)
                                         })
                                         .collect();
@@ -93,7 +93,7 @@ pub(crate) fn bench_decode_generic<S: PhasedScheme>(name: &str, c: &mut Criterio
                                     let my_index =
                                         config.minimum_shards.get() + config.extra_shards.get() - 1;
                                     let (checking_data, my_checked_shard, _) =
-                                        S::weaken(&config, &commitment, my_index, my_shard)
+                                        S::weaken(b"", &config, &commitment, my_index, my_shard)
                                             .unwrap();
 
                                     (commitment, checking_data, my_checked_shard, weak_shards)

--- a/coding/src/benches/bench_phased_size.rs
+++ b/coding/src/benches/bench_phased_size.rs
@@ -26,11 +26,12 @@ fn bench_size<S: PhasedScheme>(name: &str) {
                 data
             };
 
-            let (commitment, mut shards) = S::encode(&config, data.as_slice(), &STRATEGY).unwrap();
+            let (commitment, mut shards) =
+                S::encode(b"", &config, data.as_slice(), &STRATEGY).unwrap();
             let strong_shard = shards.pop().unwrap();
             let my_index = config.minimum_shards.get() + config.extra_shards.get() - 1;
             let (_, _, weak_shard) =
-                S::weaken(&config, &commitment, my_index, strong_shard.clone()).unwrap();
+                S::weaken(b"", &config, &commitment, my_index, strong_shard.clone()).unwrap();
 
             println!(
                 "{} (strong_shard)/msg_len={} chunks={}: {} B",

--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -231,16 +231,17 @@ commonware_macros::stability_scope!(ALPHA {
     ///
     /// type Z = Zoda<Sha256>;
     ///
+    /// let namespace = b"my-application";
     /// let config = Config {
     ///     minimum_shards: NZU16!(2),
     ///     extra_shards: NZU16!(1),
     /// };
     /// let data = b"Hello!";
-    /// let (commitment, mut shards) = Z::encode(&config, data.as_slice(), &STRATEGY).unwrap();
+    /// let (commitment, mut shards) = Z::encode(namespace, &config, data.as_slice(), &STRATEGY).unwrap();
     ///
     /// let (checking_data, checked_0, _) =
-    ///     Z::weaken(&config, &commitment, 0, shards.remove(0)).unwrap();
-    /// let (_, _, weak_1) = Z::weaken(&config, &commitment, 1, shards.remove(0)).unwrap();
+    ///     Z::weaken(namespace, &config, &commitment, 0, shards.remove(0)).unwrap();
+    /// let (_, _, weak_1) = Z::weaken(namespace, &config, &commitment, 1, shards.remove(0)).unwrap();
     /// let checked_1 = Z::check(&config, &commitment, &checking_data, 1, weak_1).unwrap();
     ///
     /// let data2 = Z::decode(
@@ -299,8 +300,13 @@ commonware_macros::stability_scope!(ALPHA {
         ///
         /// Each shard and proof is intended for exactly one participant. The number of shards returned
         /// should equal `config.minimum_shards + config.extra_shards`.
+        ///
+        /// `namespace` is a caller-provided byte string used for domain separation. All parties
+        /// participating in the same session must use the same `namespace` when calling `encode`
+        /// and `weaken`. Using `b""` produces the default behavior with no caller-specific context.
         #[allow(clippy::type_complexity)]
         fn encode(
+            namespace: &[u8],
             config: &Config,
             data: impl Buf,
             strategy: &impl Strategy,
@@ -315,8 +321,11 @@ commonware_macros::stability_scope!(ALPHA {
         ///
         /// You also get [`PhasedScheme::CheckingData`], which has information you can use to check
         /// the shards you receive from others.
+        ///
+        /// `namespace` must match the one used in the corresponding `encode` call.
         #[allow(clippy::type_complexity)]
         fn weaken(
+            namespace: &[u8],
             config: &Config,
             commitment: &Self::Commitment,
             index: u16,
@@ -407,7 +416,7 @@ commonware_macros::stability_scope!(ALPHA {
             data: impl Buf,
             strategy: &impl Strategy,
         ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error> {
-            P::encode(config, data, strategy).map_err(PhasedAsSchemeError::Scheme)
+            P::encode(b"", config, data, strategy).map_err(PhasedAsSchemeError::Scheme)
         }
 
         fn check(
@@ -417,7 +426,7 @@ commonware_macros::stability_scope!(ALPHA {
             shard: &Self::Shard,
         ) -> Result<Self::CheckedShard, Self::Error> {
             let (checking_data, checked_shard, _) =
-                P::weaken(config, commitment, index, shard.clone())
+                P::weaken(b"", config, commitment, index, shard.clone())
                     .map_err(PhasedAsSchemeError::Scheme)?;
             Ok(PhasedCheckedShard {
                 checking_data,
@@ -650,7 +659,7 @@ mod test {
 
         fn roundtrip<S: PhasedScheme>(config: &Config, data: &[u8], selected: &[u16]) {
             let owner = *selected.first().expect("selected must not be empty");
-            let (commitment, shards) = S::encode(config, data, &Sequential).unwrap();
+            let (commitment, shards) = S::encode(b"", config, data, &Sequential).unwrap();
             let read_cfg = CodecConfig {
                 maximum_shard_size: MAX_SHARD_SIZE,
             };
@@ -660,15 +669,27 @@ mod test {
                 assert_eq!(decoded_shard, *shard);
             }
 
-            let (checking_data, own_checked, _) =
-                S::weaken(config, &commitment, owner, shards[owner as usize].clone()).unwrap();
+            let (checking_data, own_checked, _) = S::weaken(
+                b"",
+                config,
+                &commitment,
+                owner,
+                shards[owner as usize].clone(),
+            )
+            .unwrap();
             let mut checked_shards = vec![own_checked];
             for &index in selected {
                 if index == owner {
                     continue;
                 }
-                let (_, _, weak_shard) =
-                    S::weaken(config, &commitment, index, shards[index as usize].clone()).unwrap();
+                let (_, _, weak_shard) = S::weaken(
+                    b"",
+                    config,
+                    &commitment,
+                    index,
+                    shards[index as usize].clone(),
+                )
+                .unwrap();
                 let decoded_weak =
                     S::WeakShard::read_cfg(&mut weak_shard.encode(), &read_cfg).unwrap();
                 assert_eq!(decoded_weak, weak_shard);
@@ -694,13 +715,13 @@ mod test {
             data_a: &[u8],
             data_b: &[u8],
         ) {
-            let (commitment_a, shards_a) = S::encode(config, data_a, &Sequential).unwrap();
-            let (commitment_b, shards_b) = S::encode(config, data_b, &Sequential).unwrap();
+            let (commitment_a, shards_a) = S::encode(b"", config, data_a, &Sequential).unwrap();
+            let (commitment_b, shards_b) = S::encode(b"", config, data_b, &Sequential).unwrap();
 
             let (checking_data_a, checked_a, _) =
-                S::weaken(config, &commitment_a, 0, shards_a[0].clone()).unwrap();
+                S::weaken(b"", config, &commitment_a, 0, shards_a[0].clone()).unwrap();
             let (checking_data_b, checked_b, weak_b) =
-                S::weaken(config, &commitment_b, 1, shards_b[1].clone()).unwrap();
+                S::weaken(b"", config, &commitment_b, 1, shards_b[1].clone()).unwrap();
 
             let check_result = S::check(config, &commitment_a, &checking_data_a, 1, weak_b);
             assert!(
@@ -724,7 +745,7 @@ mod test {
                 config,
                 &commitment_b,
                 checking_data_b,
-                core::iter::empty(),
+                core::iter::empty::<&S::CheckedShard>(),
                 &Sequential,
             );
             assert!(

--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -383,6 +383,7 @@ impl<D: Digest> CheckingData<D> {
     ///
     /// We're also give a `checksum` matrix used to check the shards we receive.
     fn reckon(
+        namespace: &[u8],
         config: &Config,
         commitment: &Summary,
         data_bytes: usize,
@@ -391,6 +392,7 @@ impl<D: Digest> CheckingData<D> {
     ) -> Result<Self, Error> {
         let topology = Topology::reckon(config, data_bytes);
         let mut transcript = Transcript::new(NAMESPACE);
+        transcript.commit(namespace);
         transcript.commit((topology.data_bytes as u64).encode());
         transcript.commit(root.encode());
         let expected_commitment = transcript.summarize();
@@ -517,6 +519,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
     type Error = Error;
 
     fn encode(
+        namespace: &[u8],
         config: &Config,
         data: impl bytes::Buf,
         strategy: &impl Strategy,
@@ -550,6 +553,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
 
         // Step 4: Commit to the root, and the size of the data.
         let mut transcript = Transcript::new(NAMESPACE);
+        transcript.commit(namespace);
         transcript.commit((topology.data_bytes as u64).encode());
         transcript.commit(root.encode());
         let commitment = transcript.summarize();
@@ -595,6 +599,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
     }
 
     fn weaken(
+        namespace: &[u8],
         config: &Config,
         commitment: &Self::Commitment,
         index: u16,
@@ -605,6 +610,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
             shard: shard.rows,
         };
         let checking_data = CheckingData::reckon(
+            namespace,
             config,
             commitment,
             shard.data_bytes,
@@ -703,10 +709,11 @@ mod tests {
             extra_shards: NZU16!(1),
         };
         let data = b"duplicate shard coverage";
-        let (commitment, shards) = Zoda::<Sha256>::encode(&config, &data[..], &STRATEGY).unwrap();
+        let (commitment, shards) =
+            Zoda::<Sha256>::encode(b"", &config, &data[..], &STRATEGY).unwrap();
         let shard0 = shards[0].clone();
         let (checking_data, checked_shard0, _weak_shard0) =
-            Zoda::<Sha256>::weaken(&config, &commitment, 0, shard0).unwrap();
+            Zoda::<Sha256>::weaken(b"", &config, &commitment, 0, shard0).unwrap();
         let duplicate = CheckedShard {
             index: checked_shard0.index,
             shard: checked_shard0.shard.clone(),
@@ -759,7 +766,7 @@ mod tests {
         };
         let data = vec![0x5Au8; 256 * 1024];
         let (commitment, mut shards) =
-            Zoda::<Sha256>::encode(&config, &data[..], &STRATEGY).unwrap();
+            Zoda::<Sha256>::encode(b"", &config, &data[..], &STRATEGY).unwrap();
 
         let leader_i = 0usize;
         let a_i = 1usize;
@@ -768,6 +775,7 @@ mod tests {
         // Apply a shift to the checksums
         {
             let (checking_data, _, _) = Zoda::<Sha256>::weaken(
+                b"",
                 &config,
                 &commitment,
                 leader_i as u16,
@@ -791,14 +799,14 @@ mod tests {
         }
 
         assert!(matches!(
-            Zoda::<Sha256>::weaken(&config, &commitment, b_i as u16, shards[b_i].clone()),
+            Zoda::<Sha256>::weaken(b"", &config, &commitment, b_i as u16, shards[b_i].clone()),
             Err(Error::InvalidWeakShard)
         ));
 
         // Without robust Fiat-Shamir, this will succeed.
         // This should be rejected once follower-specific challenge binding is fixed.
         assert!(matches!(
-            Zoda::<Sha256>::weaken(&config, &commitment, a_i as u16, shards[a_i].clone()),
+            Zoda::<Sha256>::weaken(b"", &config, &commitment, a_i as u16, shards[a_i].clone()),
             Err(Error::InvalidWeakShard)
         ));
     }


### PR DESCRIPTION
Adds `namespace: &[u8]` as the first parameter to `PhasedScheme::encode` and `PhasedScheme::weaken`, and commits it to ZODA's Fiat-Shamir transcript before the data size and Merkle root. This aligns ZODA with every other protocol in the library (DKG, Handshake, Simplex) that follows a two-level namespace convention, enabling proper domain separation for multi-context ZODA usage. 

`PhasedAsScheme` (the compatibility adapter used by `commonware-consensus`) hardcodes `b""` internally, since `Scheme::encode` has no namespace parameter and both sides of the transcript must agree.

Closes #3229.