### PR TITLE
[storage/mmr/journaled] Tweak Readable for journaled MMR 

### DIFF
--- a/storage/src/merkle/mmr/journaled.rs
+++ b/storage/src/merkle/mmr/journaled.rs
@@ -882,6 +882,13 @@ impl<E: RStorage + Clock + Metrics, D: Digest> Mmr<E, D> {
     }
 }
 
+/// The [`Readable`] implementation for the journaled MMR operates only on the in-memory
+/// portion of the MMR. After [`Mmr::sync`], nodes that have been flushed to the journal
+/// are no longer accessible through this interface. In particular, [`Readable::get_node`]
+/// returns `None` for flushed positions, and [`Readable::pruned_to_pos`] reflects the
+/// in-memory boundary (which may be tighter than the journal's prune boundary reported by
+/// [`Mmr::bounds`]). This means batch operations like `update_leaf` will correctly reject
+/// leaves that have been synced out of memory with [`Error::ElementPruned`].
 impl<E: RStorage + Clock + Metrics, D: Digest> Readable for Mmr<E, D> {
     type Digest = D;
 
@@ -898,7 +905,7 @@ impl<E: RStorage + Clock + Metrics, D: Digest> Readable for Mmr<E, D> {
     }
 
     fn pruned_to_pos(&self) -> Position {
-        self.inner.read().pruned_to_pos
+        self.inner.read().mem_mmr.pruned_to_pos()
     }
 }
 
@@ -2913,6 +2920,42 @@ mod tests {
             assert!(
                 matches!(result, Err(Error::StaleChangeset { .. })),
                 "expected StaleChangeset, got {result:?}"
+            );
+
+            mmr.destroy().await.unwrap();
+        });
+    }
+
+    /// Regression: update_leaf on a synced-out leaf must return ElementPruned, not panic.
+    /// Before the fix, Readable::pruned_to_pos returned the journal's prune boundary
+    /// (which could be 0), so the batch accepted the update. During merkleize, get_node
+    /// returned None for the synced-out sibling and hit an expect panic.
+    #[test_traced]
+    fn test_update_leaf_after_sync_returns_pruned() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut hasher = Standard::<Sha256>::new();
+            let mut mmr = Mmr::init(context.clone(), &mut hasher, test_config(&context))
+                .await
+                .unwrap();
+
+            // Add 50 elements and sync (flushes all nodes to journal, prunes mem_mmr).
+            let changeset = {
+                let mut batch = mmr.new_batch();
+                for i in 0..50 {
+                    batch.add(&mut hasher, &test_digest(i));
+                }
+                batch.merkleize(&mut hasher).finalize()
+            };
+            mmr.apply(changeset).unwrap();
+            mmr.sync().await.unwrap();
+
+            // Attempt to update leaf 0 which has been synced out of memory.
+            let mut batch = mmr.new_batch();
+            let result = batch.update_leaf(&mut hasher, Location::new(0), b"updated");
+            assert!(
+                matches!(result, Err(Error::ElementPruned(_))),
+                "expected ElementPruned for synced-out leaf, got {result:?}"
             );
 
             mmr.destroy().await.unwrap();


### PR DESCRIPTION
Readable for the journaled MMR can only return nodes from the in-memory portion, since get_node is not async. This PR updates the Readable's bounds behavior to match this.   Issue identified by Gemini Deep Think:

```
Major Design Flaw: journaled::Mmr Panics on update_leaf
There is a severe architectural trap in how journaled::Mmr interacts with the Batch API. If a user attempts to update a leaf that has been flushed to the journal, it will pass the out-of-bounds checks but panic during merkleize.

The Root Cause:

journaled::Mmr implements the synchronous Readable::get_node by strictly deferring to its in-memory cache: self.inner.read().mem_mmr.get_node(pos).

When .sync() is called, mem_mmr is aggressively pruned. All synced nodes are discarded, leaving only the un-synced nodes and pinned_nodes (the peaks).

However, journaled::Mmr implements Readable::pruned_to_pos() by returning the journal's prune boundary (e.g., 0), not the mem_mmr's prune boundary.

If a user calls batch.update_leaf(0) on a synced MMR, the batch checks if pos < self.parent.pruned_to_pos() (0 < 0 is false). It incorrectly believes the node is fully available in memory and accepts the update.

When batch.merkleize_dirty() executes, it attempts to fetch the leaf's sibling to recompute the parent hash. It calls self.get_node(sibling_pos), which falls back to the Readable implementation. Because the sibling isn't in memory (and isn't a pinned peak), get_node returns None.

merkleize blindly hits .expect("left/right child missing") and panics.

Fix: Because Batch operations are completely synchronous and rely on memory-resident data via Readable, journaled::Mmr must expose the mem_mmr's boundaries to the Readable trait:

This ensures that update_leaf on a synced node correctly yields Error::ElementPruned instead of crashing the thread.
```

