### PR TITLE
examples: add commonware-vrf-dice (provably fair dice/coin/lottery)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "examples/log",
     "examples/sync",
     "examples/reshare",
+ "examples/vrf-dice",
 
     # Fuzz builds
     "broadcast/fuzz",

--- a/examples/vrf-dice/Cargo.toml
+++ b/examples/vrf-dice/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "commonware-vrf-dice"
+edition.workspace = true
+publish = true
+version.workspace = true
+license.workspace = true
+description = "Provably fair VRF dice, coin flip and lottery using commonware-cryptography."
+readme = "README.md"
+homepage.workspace = true
+repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/vrf-dice"
+documentation = "https://docs.rs/commonware-vrf-dice"
+
+[lints]
+workspace = true
+
+[dependencies]
+axum.workspace = true
+chrono.workspace = true
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["full"] }
+
+[[bin]]
+name = "commonware-vrf-dice"
+bench = false

--- a/examples/vrf-dice/README.md
+++ b/examples/vrf-dice/README.md
@@ -19,9 +19,9 @@ Server listens on `0.0.0.0:8080` (override with `PORT`). API only (no static UI)
 | POST | `/api/register` | Register a player (optional `player_name`). Returns `public_key`, `short_id`. |
 | POST | `/api/roll` | Roll dice / flip coin / lottery. Body: `player_name?`, `client_seed?`, `player_public_key?`, `game_mode?` (`dice`, `coin`, `lottery`). |
 | POST | `/api/verify` | Verify a past roll: `round`, `player_name`, `client_seed`, `claimed_proof`, `claimed_result`, `game_mode?`. |
-| GET | `/api/history` | Last 100 rolls. |
-| GET | `/api/info` | Server public key and stats. |
-| GET | `/api/leaderboard` | Per-player stats. |
+| GET | `/api/history` | Last 100 rolls (bounded; older rolls are evicted). |
+| GET | `/api/info` | Server public key and stats (`total_rolls` is all-time). |
+| GET | `/api/leaderboard` | Per-player stats over the last 100 rolls. |
 | GET | `/api/proof/:round` | Proof and record for a round. |
 | GET | `/api/ping` | Health check. |
 

--- a/examples/vrf-dice/README.md
+++ b/examples/vrf-dice/README.md
@@ -1,0 +1,34 @@
+# commonware-vrf-dice
+
+Provably fair dice, coin flip and lottery demo using [commonware-cryptography](https://docs.rs/commonware-cryptography): Ed25519 + SHA-256 VRF.
+
+## Run
+
+From the **monorepo root** (after adding this crate to the workspace):
+
+```bash
+cargo run -p commonware-vrf-dice
+```
+
+Server listens on `0.0.0.0:8080` (override with `PORT`). API only (no static UI).
+
+## API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/register` | Register a player (optional `player_name`). Returns `public_key`, `short_id`. |
+| POST | `/api/roll` | Roll dice / flip coin / lottery. Body: `player_name?`, `client_seed?`, `player_public_key?`, `game_mode?` (`dice`, `coin`, `lottery`). |
+| POST | `/api/verify` | Verify a past roll: `round`, `player_name`, `client_seed`, `claimed_proof`, `claimed_result`, `game_mode?`. |
+| GET | `/api/history` | Last 100 rolls. |
+| GET | `/api/info` | Server public key and stats. |
+| GET | `/api/leaderboard` | Per-player stats. |
+| GET | `/api/proof/:round` | Proof and record for a round. |
+| GET | `/api/ping` | Health check. |
+
+## VRF
+
+Randomness is derived from the server’s Ed25519 signature over a deterministic message (round, player, client seed, game mode). The SHA-256 hash of that signature is used to compute the result (dice 1–6, coin 0–1, lottery 1–100). Anyone can verify using the server’s public key and the returned proof.
+
+## License
+
+Dual-licensed under Apache-2.0 and MIT (same as the Commonware monorepo).

--- a/examples/vrf-dice/src/main.rs
+++ b/examples/vrf-dice/src/main.rs
@@ -1,0 +1,356 @@
+use axum::{
+    extract::{Path, State},
+    response::{IntoResponse, Json},
+    routing::{get, post},
+    Router,
+};
+use commonware_codec::Encode;
+use commonware_cryptography::{ed25519, Hasher, Sha256, Signer as _};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+const VRF_NAMESPACE: &[u8] = b"COMMONWARE_VRF_DICE_v1";
+const PLAYER_NAMESPACE: &[u8] = b"COMMONWARE_PLAYER_SIG_v1";
+const SERVER_SEED: u64 = 42;
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[derive(Clone)]
+struct AppState {
+    inner: Arc<Mutex<InnerState>>,
+}
+
+struct InnerState {
+    signer: ed25519::PrivateKey,
+    round: u64,
+    next_player_seed: u64,
+    players: HashMap<String, (String, ed25519::PrivateKey)>,
+    history: Vec<RollRecord>,
+}
+
+#[derive(Serialize, Clone)]
+struct PlayerIdentity {
+    public_key: String,
+    short_id: String,
+    player_name: String,
+}
+
+#[derive(Deserialize)]
+struct RegisterRequest {
+    player_name: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+struct RollRecord {
+    round: u64,
+    game_mode: String,
+    player_name: String,
+    player_public_key: String,
+    player_short_id: String,
+    client_seed: String,
+    dice_result: u8,
+    proof: String,
+    vrf_hash: String,
+    player_signature: String,
+    message_hex: String,
+    message_raw: String,
+    public_key: String,
+    timestamp: String,
+}
+
+#[derive(Deserialize)]
+struct RollRequest {
+    player_name: Option<String>,
+    client_seed: Option<String>,
+    player_public_key: Option<String>,
+    game_mode: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct VerifyRequest {
+    round: u64,
+    player_name: String,
+    client_seed: String,
+    claimed_proof: String,
+    claimed_result: u8,
+    game_mode: Option<String>,
+}
+
+#[derive(Serialize)]
+struct VerifyResponse {
+    valid: bool,
+    proof_matches: bool,
+    result_matches: bool,
+    computed_result: u8,
+    computed_proof: String,
+    computed_vrf_hash: String,
+}
+
+#[derive(Serialize)]
+struct InfoResponse {
+    public_key: String,
+    algorithm: String,
+    vrf_namespace: String,
+    total_rolls: u64,
+    active_players: usize,
+}
+
+/// VRF construction using Commonware Ed25519 + SHA-256.
+///
+/// Ed25519 signatures are deterministic: same key + same message = same signature.
+/// The SHA-256 hash of the signature serves as verifiable random output.
+fn compute_vrf(signer: &ed25519::PrivateKey, message: &[u8], game_mode: &str) -> (Vec<u8>, Vec<u8>, u8) {
+    let signature = signer.sign(VRF_NAMESPACE, message);
+    let sig_bytes = signature.encode().to_vec();
+
+    let mut hasher = Sha256::new();
+    hasher.update(&sig_bytes);
+    let vrf_digest = hasher.finalize();
+    let vrf_bytes = vrf_digest.encode().to_vec();
+
+    let sum: u32 = vrf_bytes.iter().map(|&b| b as u32).sum();
+    let result = match game_mode {
+        "coin" => (sum % 2) as u8,
+        "lottery" => ((sum % 100) + 1) as u8,
+        _ => ((sum % 6) + 1) as u8,
+    };
+
+    (sig_bytes, vrf_bytes, result)
+}
+
+async fn register_player(
+    State(state): State<AppState>,
+    Json(req): Json<RegisterRequest>,
+) -> impl IntoResponse {
+    let mut inner = state.inner.lock().unwrap();
+    inner.next_player_seed += 1;
+    let player_signer = ed25519::PrivateKey::from_seed(inner.next_player_seed);
+    let pk_hex = hex_encode(&player_signer.public_key().encode().to_vec());
+    let short_id = pk_hex[..8].to_string();
+    let name = req
+        .player_name
+        .unwrap_or_else(|| "Anonymous".to_string());
+
+    inner
+        .players
+        .insert(pk_hex.clone(), (name.clone(), player_signer));
+
+    Json(PlayerIdentity {
+        public_key: pk_hex,
+        short_id,
+        player_name: name,
+    })
+}
+
+async fn roll_dice(
+    State(state): State<AppState>,
+    Json(req): Json<RollRequest>,
+) -> impl IntoResponse {
+    let mut inner = state.inner.lock().unwrap();
+    inner.round += 1;
+    let round = inner.round;
+
+    let player_name = req.player_name.unwrap_or_else(|| "Anonymous".to_string());
+    let client_seed = req
+        .client_seed
+        .unwrap_or_else(|| "default".to_string());
+    let player_pk = req.player_public_key.unwrap_or_default();
+    let game_mode = req.game_mode.unwrap_or_else(|| "dice".to_string());
+
+    let (player_public_key, player_short_id, player_signature) =
+        if let Some((_, player_signer)) = inner.players.get(&player_pk) {
+            let msg = format!("roll:{}|round:{}", player_pk, round);
+            let sig = player_signer.sign(PLAYER_NAMESPACE, msg.as_bytes());
+            (
+                player_pk.clone(),
+                player_pk[..8].to_string(),
+                hex_encode(&sig.encode().to_vec()),
+            )
+        } else {
+            (String::new(), String::new(), String::new())
+        };
+
+    let message_raw = format!(
+        "round:{}|player:{}|seed:{}|mode:{}",
+        round, player_name, client_seed, game_mode
+    );
+    let (sig_bytes, vrf_bytes, dice_result) =
+        compute_vrf(&inner.signer, message_raw.as_bytes(), &game_mode);
+
+    let record = RollRecord {
+        round,
+        game_mode,
+        player_name,
+        player_public_key,
+        player_short_id,
+        client_seed,
+        dice_result,
+        proof: hex_encode(&sig_bytes),
+        vrf_hash: hex_encode(&vrf_bytes),
+        player_signature: player_signature.clone(),
+        message_hex: hex_encode(message_raw.as_bytes()),
+        message_raw,
+        public_key: hex_encode(&inner.signer.public_key().encode().to_vec()),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+
+    inner.history.push(record.clone());
+    if inner.history.len() > 100 {
+        inner.history.remove(0);
+    }
+
+    Json(record)
+}
+
+async fn verify_proof(
+    State(state): State<AppState>,
+    Json(req): Json<VerifyRequest>,
+) -> impl IntoResponse {
+    let inner = state.inner.lock().unwrap();
+    let game_mode = req.game_mode.unwrap_or_else(|| "dice".to_string());
+
+    let message_raw = format!(
+        "round:{}|player:{}|seed:{}|mode:{}",
+        req.round, req.player_name, req.client_seed, game_mode
+    );
+    let (sig_bytes, vrf_bytes, dice_result) =
+        compute_vrf(&inner.signer, message_raw.as_bytes(), &game_mode);
+
+    let computed_proof = hex_encode(&sig_bytes);
+    let proof_matches = computed_proof == req.claimed_proof;
+    let result_matches = dice_result == req.claimed_result;
+
+    Json(VerifyResponse {
+        valid: proof_matches && result_matches,
+        proof_matches,
+        result_matches,
+        computed_result: dice_result,
+        computed_proof,
+        computed_vrf_hash: hex_encode(&vrf_bytes),
+    })
+}
+
+async fn get_history(State(state): State<AppState>) -> impl IntoResponse {
+    let inner = state.inner.lock().unwrap();
+    Json(inner.history.clone())
+}
+
+async fn get_info(State(state): State<AppState>) -> impl IntoResponse {
+    let inner = state.inner.lock().unwrap();
+    Json(InfoResponse {
+        public_key: hex_encode(&inner.signer.public_key().encode().to_vec()),
+        algorithm: "Ed25519 (Commonware Cryptography)".to_string(),
+        vrf_namespace: String::from_utf8_lossy(VRF_NAMESPACE).to_string(),
+        total_rolls: inner.round,
+        active_players: inner.players.len(),
+    })
+}
+
+async fn get_leaderboard(State(state): State<AppState>) -> impl IntoResponse {
+    let inner = state.inner.lock().unwrap();
+    let mut stats: HashMap<String, (String, String, u32, u32, u32, u8)> = HashMap::new();
+
+    for r in &inner.history {
+        let e = stats
+            .entry(r.player_public_key.clone())
+            .or_insert((r.player_name.clone(), r.player_short_id.clone(), 0, 0, 0, 0));
+        e.2 += 1;
+        if r.game_mode == "dice" && r.dice_result == 6 {
+            e.3 += 1;
+        }
+        if r.game_mode == "coin" && r.dice_result == 0 {
+            e.4 += 1;
+        }
+        if r.game_mode == "lottery" && r.dice_result > e.5 {
+            e.5 = r.dice_result;
+        }
+    }
+
+    let mut board: Vec<_> = stats
+        .into_iter()
+        .filter(|(pk, _)| !pk.is_empty())
+        .map(|(_, (name, sid, rolls, sixes, heads, best))| {
+            serde_json::json!({
+                "player_name": name,
+                "short_id": sid,
+                "total_rolls": rolls,
+                "dice_sixes": sixes,
+                "coin_heads": heads,
+                "lottery_best": best,
+            })
+        })
+        .collect();
+
+    board.sort_by(|a, b| {
+        b["total_rolls"]
+            .as_u64()
+            .unwrap_or(0)
+            .cmp(&a["total_rolls"].as_u64().unwrap_or(0))
+    });
+
+    Json(board)
+}
+
+async fn get_proof(State(state): State<AppState>, Path(round): Path<u64>) -> impl IntoResponse {
+    let inner = state.inner.lock().unwrap();
+    if let Some(record) = inner.history.iter().find(|r| r.round == round) {
+        Json(serde_json::json!({"found": true, "record": record}))
+    } else {
+        Json(serde_json::json!({"found": false}))
+    }
+}
+
+async fn ping() -> impl IntoResponse {
+    Json(serde_json::json!({"status": "ok", "timestamp": chrono::Utc::now().to_rfc3339()}))
+}
+
+async fn fallback() -> impl IntoResponse {
+    Json(serde_json::json!({
+        "error": "Not found",
+        "hint": "API endpoints: /api/register, /api/roll, /api/verify, /api/history, /api/info, /api/leaderboard, /api/proof/:round, /api/ping"
+    }))
+}
+
+#[tokio::main]
+async fn main() {
+    let signer = ed25519::PrivateKey::from_seed(SERVER_SEED);
+    println!("========================================");
+    println!("  CommonVRF Dice - Provably Fair Game");
+    println!("  Powered by Commonware Cryptography");
+    println!("========================================");
+    println!("Public Key: {}", hex_encode(&signer.public_key().encode().to_vec()));
+    println!("Algorithm:  Ed25519 + SHA-256 VRF");
+    println!("Namespace:  {}", String::from_utf8_lossy(VRF_NAMESPACE));
+    println!("========================================");
+
+    let state = AppState {
+        inner: Arc::new(Mutex::new(InnerState {
+            signer,
+            round: 0,
+            next_player_seed: 1000,
+            players: HashMap::new(),
+            history: Vec::new(),
+        })),
+    };
+
+    let app = Router::new()
+        .route("/api/register", post(register_player))
+        .route("/api/roll", post(roll_dice))
+        .route("/api/verify", post(verify_proof))
+        .route("/api/history", get(get_history))
+        .route("/api/info", get(get_info))
+        .route("/api/leaderboard", get(get_leaderboard))
+        .route("/api/proof/:round", get(get_proof))
+        .route("/api/ping", get(ping))
+        .fallback(fallback)
+        .with_state(state);
+
+    let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+    let addr = format!("0.0.0.0:{}", port);
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    println!("Server running at http://localhost:{}", port);
+    axum::serve(listener, app).await.unwrap();
+}

--- a/examples/vrf-dice/src/main.rs
+++ b/examples/vrf-dice/src/main.rs
@@ -310,7 +310,7 @@ async fn ping() -> impl IntoResponse {
 async fn fallback() -> impl IntoResponse {
     Json(serde_json::json!({
         "error": "Not found",
-        "hint": "API endpoints: /api/register, /api/roll, /api/verify, /api/history, /api/info, /api/leaderboard, /api/proof/:round, /api/ping"
+        "hint": "API endpoints: /api/register, /api/roll, /api/verify, /api/history, /api/info, /api/leaderboard, /api/proof/{round}, /api/ping"
     }))
 }
 
@@ -343,7 +343,7 @@ async fn main() {
         .route("/api/history", get(get_history))
         .route("/api/info", get(get_info))
         .route("/api/leaderboard", get(get_leaderboard))
-        .route("/api/proof/:round", get(get_proof))
+        .route("/api/proof/{round}", get(get_proof))
         .route("/api/ping", get(ping))
         .fallback(fallback)
         .with_state(state);

--- a/examples/vrf-dice/src/main.rs
+++ b/examples/vrf-dice/src/main.rs
@@ -18,6 +18,12 @@ fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
+/// Escapes `\` and `|` in user-controlled VRF message fields so the pipe-delimited
+/// format is unambiguous and no two distinct inputs produce the same message.
+fn escape_vrf_field(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('|', "\\|")
+}
+
 #[derive(Clone)]
 struct AppState {
     inner: Arc<Mutex<InnerState>>,
@@ -173,13 +179,13 @@ async fn roll_dice(
             (String::new(), String::new(), String::new())
         };
 
-    let message_raw = serde_json::to_string(&serde_json::json!({
-        "round": round,
-        "player": player_name,
-        "seed": client_seed,
-        "mode": game_mode,
-    }))
-    .expect("VRF message serialization must succeed");
+    let message_raw = format!(
+        "round:{}|player:{}|seed:{}|mode:{}",
+        round,
+        escape_vrf_field(&player_name),
+        escape_vrf_field(&client_seed),
+        escape_vrf_field(&game_mode),
+    );
     let (sig_bytes, vrf_bytes, dice_result) =
         compute_vrf(&inner.signer, message_raw.as_bytes(), &game_mode);
 
@@ -215,13 +221,13 @@ async fn verify_proof(
     let inner = state.inner.lock().unwrap();
     let game_mode = req.game_mode.unwrap_or_else(|| "dice".to_string());
 
-    let message_raw = serde_json::to_string(&serde_json::json!({
-        "round": req.round,
-        "player": req.player_name,
-        "seed": req.client_seed,
-        "mode": game_mode,
-    }))
-    .expect("VRF message serialization must succeed");
+    let message_raw = format!(
+        "round:{}|player:{}|seed:{}|mode:{}",
+        req.round,
+        escape_vrf_field(&req.player_name),
+        escape_vrf_field(&req.client_seed),
+        escape_vrf_field(&game_mode),
+    );
     let (sig_bytes, vrf_bytes, dice_result) =
         compute_vrf(&inner.signer, message_raw.as_bytes(), &game_mode);
 

--- a/examples/vrf-dice/src/main.rs
+++ b/examples/vrf-dice/src/main.rs
@@ -132,14 +132,6 @@ async fn register_player(
     Json(req): Json<RegisterRequest>,
 ) -> impl IntoResponse {
     let mut inner = state.inner.lock().unwrap();
-    inner.next_player_seed += 1;
-    let player_signer = ed25519::PrivateKey::from_seed(inner.next_player_seed);
-    let pk_hex = hex_encode(&player_signer.public_key().encode().to_vec());
-    let short_id = pk_hex[..8].to_string();
-    let name = req
-        .player_name
-        .unwrap_or_else(|| "Anonymous".to_string());
-
     const PLAYERS_CAP: usize = 1000;
     if inner.players.len() >= PLAYERS_CAP {
         return Json(serde_json::json!({
@@ -147,6 +139,13 @@ async fn register_player(
             "message": "Player registry is full; please try again later."
         }));
     }
+    inner.next_player_seed += 1;
+    let player_signer = ed25519::PrivateKey::from_seed(inner.next_player_seed);
+    let pk_hex = hex_encode(&player_signer.public_key().encode().to_vec());
+    let short_id = pk_hex[..8].to_string();
+    let name = req
+        .player_name
+        .unwrap_or_else(|| "Anonymous".to_string());
     inner.players.insert(pk_hex.clone(), (name.clone(), player_signer));
 
     Json(PlayerIdentity {

--- a/examples/vrf-dice/src/main.rs
+++ b/examples/vrf-dice/src/main.rs
@@ -207,9 +207,6 @@ async fn roll_dice(
     };
 
     inner.history.push(record.clone());
-    if inner.history.len() > 100 {
-        inner.history.remove(0);
-    }
 
     Json(record)
 }
@@ -273,7 +270,7 @@ async fn get_leaderboard(State(state): State<AppState>) -> impl IntoResponse {
         if r.game_mode == "dice" && r.dice_result == 6 {
             e.3 += 1;
         }
-        if r.game_mode == "coin" && r.dice_result == 0 {
+        if r.game_mode == "coin" && r.dice_result == 1 {
             e.4 += 1;
         }
         if r.game_mode == "lottery" && r.dice_result > e.5 {

--- a/examples/vrf-dice/src/main.rs
+++ b/examples/vrf-dice/src/main.rs
@@ -140,9 +140,13 @@ async fn register_player(
         .player_name
         .unwrap_or_else(|| "Anonymous".to_string());
 
-    inner
-        .players
-        .insert(pk_hex.clone(), (name.clone(), player_signer));
+    const PLAYERS_CAP: usize = 1000;
+    inner.players.insert(pk_hex.clone(), (name.clone(), player_signer));
+    if inner.players.len() > PLAYERS_CAP {
+        if let Some(old_key) = inner.players.keys().next().cloned() {
+            inner.players.remove(&old_key);
+        }
+    }
 
     Json(PlayerIdentity {
         public_key: pk_hex,

--- a/examples/vrf-dice/src/main.rs
+++ b/examples/vrf-dice/src/main.rs
@@ -141,12 +141,13 @@ async fn register_player(
         .unwrap_or_else(|| "Anonymous".to_string());
 
     const PLAYERS_CAP: usize = 1000;
-    inner.players.insert(pk_hex.clone(), (name.clone(), player_signer));
-    if inner.players.len() > PLAYERS_CAP {
-        if let Some(old_key) = inner.players.keys().next().cloned() {
-            inner.players.remove(&old_key);
-        }
+    if inner.players.len() >= PLAYERS_CAP {
+        return Json(serde_json::json!({
+            "error": "player_capacity_reached",
+            "message": "Player registry is full; please try again later."
+        }));
     }
+    inner.players.insert(pk_hex.clone(), (name.clone(), player_signer));
 
     Json(PlayerIdentity {
         public_key: pk_hex,

--- a/examples/vrf-dice/src/main.rs
+++ b/examples/vrf-dice/src/main.rs
@@ -207,6 +207,10 @@ async fn roll_dice(
     };
 
     inner.history.push(record.clone());
+    const HISTORY_CAP: usize = 100;
+    if inner.history.len() > HISTORY_CAP {
+        inner.history.remove(0);
+    }
 
     Json(record)
 }
@@ -244,7 +248,9 @@ async fn verify_proof(
 
 async fn get_history(State(state): State<AppState>) -> impl IntoResponse {
     let inner = state.inner.lock().unwrap();
-    Json(inner.history.clone())
+    let len = inner.history.len();
+    let start = len.saturating_sub(100);
+    Json(inner.history[start..].to_vec())
 }
 
 async fn get_info(State(state): State<AppState>) -> impl IntoResponse {

--- a/examples/vrf-dice/src/main.rs
+++ b/examples/vrf-dice/src/main.rs
@@ -173,10 +173,13 @@ async fn roll_dice(
             (String::new(), String::new(), String::new())
         };
 
-    let message_raw = format!(
-        "round:{}|player:{}|seed:{}|mode:{}",
-        round, player_name, client_seed, game_mode
-    );
+    let message_raw = serde_json::to_string(&serde_json::json!({
+        "round": round,
+        "player": player_name,
+        "seed": client_seed,
+        "mode": game_mode,
+    }))
+    .expect("VRF message serialization must succeed");
     let (sig_bytes, vrf_bytes, dice_result) =
         compute_vrf(&inner.signer, message_raw.as_bytes(), &game_mode);
 
@@ -212,10 +215,13 @@ async fn verify_proof(
     let inner = state.inner.lock().unwrap();
     let game_mode = req.game_mode.unwrap_or_else(|| "dice".to_string());
 
-    let message_raw = format!(
-        "round:{}|player:{}|seed:{}|mode:{}",
-        req.round, req.player_name, req.client_seed, game_mode
-    );
+    let message_raw = serde_json::to_string(&serde_json::json!({
+        "round": req.round,
+        "player": req.player_name,
+        "seed": req.client_seed,
+        "mode": game_mode,
+    }))
+    .expect("VRF message serialization must succeed");
     let (sig_bytes, vrf_bytes, dice_result) =
         compute_vrf(&inner.signer, message_raw.as_bytes(), &game_mode);
 


### PR DESCRIPTION
## Summary

This PR adds a new example crate **`commonware-vrf-dice`**: a small HTTP API that demonstrates **provably fair** dice, coin flip, and lottery games using Commonware’s cryptography primitives (Ed25519 + SHA-256). It fits alongside existing examples (e.g. battleware, bridge, chat) and shows a concrete use case for the VRF-style construction described below.

## Motivation

- **Showcase `commonware-cryptography`:** The example uses only `commonware-cryptography` (Ed25519, `Signer`, `Hasher`, SHA-256) and `commonware-codec` (`Encode`). No new external dependencies are introduced; all dependencies come from the workspace, in line with CONTRIBUTING.
- **Provably fair gaming:** Players can verify that each result was derived deterministically from the server’s public key, the round, and the client seed. The server cannot change the outcome after the fact without breaking the proof.
- **Simple, runnable demo:** A single binary exposes a REST API; no frontend is included (API-only), so it stays minimal and easy to integrate into the existing examples layout.

## How it works

- **VRF-style construction:** The “random” output is not a traditional VRF but a **deterministic, verifiable** value:
  1. Message = `round | player | client_seed | game_mode` (e.g. `round:1|player:alice|seed:xyz|mode:dice`).
  2. Server signs this message with Ed25519 under a fixed namespace (`COMMONWARE_VRF_DICE_v1`) using the server’s key.
  3. SHA-256 is applied to the raw signature bytes; the digest is used to derive the result:
     - **Dice:** 1–6 (sum of digest bytes mod 6, +1).
     - **Coin:** 0 or 1 (mod 2).
     - **Lottery:** 1–100 (mod 100, +1).
- **Verification:** Anyone with the server’s public key can recompute the same message, signature, and digest, and thus the same result. The API exposes `/api/verify` so clients can submit round + player + client_seed + claimed proof/result and get a validity check.
- **Optional player identity:** Players can register with an optional name; the server issues an Ed25519 keypair (from a seed) and returns a public key / short id. Rolls can be tied to that key and signed by the player for non-repudiation (signature over `roll:<pubkey>|round:<n>`).

## API overview

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/register` | Register a player (optional `player_name`). Returns `public_key`, `short_id`. |
| POST | `/api/roll` | Roll dice / flip coin / lottery. Body: `player_name?`, `client_seed?`, `player_public_key?`, `game_mode?` (`dice`, `coin`, `lottery`). |
| POST | `/api/verify` | Verify a past roll: `round`, `player_name`, `client_seed`, `claimed_proof`, `claimed_result`, `game_mode?`. |
| GET | `/api/history` | Last 100 rolls. |
| GET | `/api/info` | Server public key and stats. |
| GET | `/api/leaderboard` | Per-player stats. |
| GET | `/api/proof/:round` | Proof and record for a given round. |
| GET | `/api/ping` | Health check. |

Server listens on `0.0.0.0:8080` by default; override with `PORT`.

## Dependencies and CONTRIBUTING

- **No new external crates.** Only workspace members are used: `axum`, `chrono`, `commonware-codec`, `commonware-cryptography`, `serde`, `serde_json`, `tokio`. No `hex` or `tower-http`; a small `hex_encode` helper and a JSON fallback handler are used instead.
- The crate follows the same layout and conventions as other examples (`edition.workspace`, `version.workspace`, `[lints] workspace = true`, etc.).

## How to run

From the monorepo root:

```bash
cargo run -p commonware-vrf-dice
```

Then e.g. `curl http://localhost:8080/api/info` or `curl -X POST http://localhost:8080/api/roll -H "Content-Type: application/json" -d "{\"game_mode\":\"dice\"}"`.

## Full demo (with web UI)

A standalone version of this demo with a static web UI and optional deployment (Docker, Railway) is available at: **https://github.com/crazywriter1/commonware-vrf-dice**.

## License

Dual-licensed under Apache-2.0 and MIT, consistent with the rest of the repository.