### PR TITLE
[runtime/iouring] replace raw SQE submission with high-level requests

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -2201,6 +2201,115 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_fill_submission_queue_orphans_closed_request_before_first_submit() {
+        // Verify dropping the caller before the loop stages the first SQE
+        // retires both send and read-at requests locally instead of issuing
+        // any I/O.
+        let cfg = Config::default();
+        let mut registry = Registry::default();
+        let (handle, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        // Keep the test focused on request staging instead of wake rearm.
+        iouring.wake_rearm_needed = false;
+
+        let (tx, rx) = oneshot::channel();
+        drop(rx);
+        handle
+            .enqueue(Request::Send(SendRequest {
+                fd: Arc::new(UnixStream::pair().unwrap().0.into()),
+                write: IoBufs::from(IoBuf::from(b"hello")).into(),
+                deadline: Some(Instant::now() + Duration::from_secs(1)),
+                result: None,
+                sender: tx,
+            }))
+            .await
+            .expect("request should enqueue");
+
+        let at_capacity = iouring
+            .fill_submission_queue(&mut ring)
+            .expect("channel should remain connected");
+
+        // The request should retire locally without consuming waiter or SQ
+        // capacity, and its scheduled deadline should disappear as well.
+        assert!(!at_capacity);
+        assert!(iouring.waiters.is_empty());
+        assert_eq!(ring.submission().len(), 0);
+        assert_eq!(iouring.timeout_wheel.next_deadline(), None);
+
+        let (sock_left, _sock_right) = UnixStream::pair().unwrap();
+        // SAFETY: sock_left is a valid fd that we own. This request is
+        // orphaned before staging, so the file descriptor is never submitted.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+        let (tx, rx) = oneshot::channel();
+        drop(rx);
+        handle
+            .enqueue(Request::ReadAt(ReadAtRequest {
+                file: Arc::new(file),
+                offset: 0,
+                len: 8,
+                read: 0,
+                buf: IoBufMut::with_capacity(8),
+                result: None,
+                sender: tx,
+            }))
+            .await
+            .expect("request should enqueue");
+
+        let at_capacity = iouring
+            .fill_submission_queue(&mut ring)
+            .expect("channel should remain connected");
+
+        // The read request should take the same orphan path as send.
+        assert!(!at_capacity);
+        assert!(iouring.waiters.is_empty());
+        assert_eq!(ring.submission().len(), 0);
+        assert_eq!(iouring.timeout_wheel.next_deadline(), None);
+    }
+
+    #[tokio::test]
+    async fn test_fill_submission_queue_orphans_closed_ready_queue_entry_locally() {
+        // Verify an orphaned waiter parked in the ready queue retires
+        // locally instead of staging another SQE.
+        let cfg = Config::default();
+        let mut registry = Registry::default();
+        let (_handle, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        // Keep the test focused on ready-queue staging instead of wake rearm.
+        iouring.wake_rearm_needed = false;
+
+        let (tx, rx) = oneshot::channel();
+        drop(rx);
+        let waiter_id = iouring.waiters.insert(
+            Request::Recv(RecvRequest {
+                fd: Arc::new(UnixStream::pair().unwrap().0.into()),
+                buf: IoBufMut::with_capacity(8),
+                offset: 4,
+                len: 8,
+                exact: true,
+                deadline: None,
+                result: None,
+                sender: tx,
+            }),
+            Some(1),
+        );
+        iouring.timeout_wheel.schedule(waiter_id, 1);
+        iouring.ready_queue.push_back(waiter_id);
+
+        let at_capacity = iouring
+            .fill_submission_queue(&mut ring)
+            .expect("channel should remain connected");
+
+        // Restaging should notice the closed caller, drop the request locally,
+        // and clean up its deadline tracking without touching the SQ.
+        assert!(!at_capacity);
+        assert!(iouring.waiters.is_empty());
+        assert_eq!(ring.submission().len(), 0);
+        assert_eq!(iouring.timeout_wheel.next_deadline(), None);
+    }
+
+    #[tokio::test]
     async fn test_single_issuer() {
         // Verify SINGLE_ISSUER still allows normal request submission and completion.
         let cfg = Config {

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -577,10 +577,20 @@ impl IoUringLoop {
     ///
     /// If the request was marked for cancellation while sitting in the ready
     /// queue (timeout fired between requeue and staging), it is completed with
-    /// a timeout error instead of issuing a follow-up SQE.
+    /// a timeout error instead of issuing a follow-up SQE. If the original
+    /// caller dropped its wait handle before staging, the request is retired
+    /// locally without issuing another SQE.
     fn stage_request(&mut self, waiter_id: WaiterId, submission_queue: &mut SubmissionQueue<'_>) {
         match self.waiters.stage(waiter_id) {
             StageOutcome::Timeout(request) => request.timeout(),
+            StageOutcome::Orphaned { target_tick } => {
+                // The caller disappeared before another SQE was issued, so all that
+                // remains is to release deadline tracking (the waiter, and associated
+                // resources, were already dropped inside `Waiters`).
+                if let Some(tick) = target_tick {
+                    self.timeout_wheel.remove(tick);
+                }
+            }
             StageOutcome::Submit(sqe) => {
                 // SAFETY:
                 // - All resources are stored in `self.waiters` until CQE processing, so

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -577,7 +577,7 @@ impl IoUringLoop {
     /// If the request was marked for cancellation while sitting in the ready
     /// queue (timeout fired between requeue and staging), it is completed with
     /// a timeout error instead of issuing a follow-up SQE.
-    fn stage_request(&mut self, waiter_id: WaiterId, sq: &mut SubmissionQueue<'_>) {
+    fn stage_request(&mut self, waiter_id: WaiterId, submission_queue: &mut SubmissionQueue<'_>) {
         match self.waiters.stage(waiter_id) {
             StageOutcome::Timeout(request) => request.timeout(),
             StageOutcome::Submit(sqe) => {
@@ -586,7 +586,9 @@ impl IoUringLoop {
                 //   SQE pointers remain valid and FD numbers cannot be reused early.
                 // - SQ capacity was checked by caller.
                 unsafe {
-                    sq.push(&sqe).expect("unable to push to queue");
+                    submission_queue
+                        .push(&sqe)
+                        .expect("unable to push to queue");
                 }
             }
         }
@@ -597,12 +599,12 @@ impl IoUringLoop {
     /// Stops when all queued requests are staged or the SQ reaches capacity.
     /// Returns `true` when SQ capacity is hit and at least one ready request
     /// remains queued.
-    fn stage_ready_requests(&mut self, sq: &mut SubmissionQueue<'_>) -> bool {
-        while !sq.is_full() {
+    fn stage_ready_requests(&mut self, submission_queue: &mut SubmissionQueue<'_>) -> bool {
+        while !submission_queue.is_full() {
             let Some(waiter_id) = self.ready_queue.pop_front() else {
                 return false;
             };
-            self.stage_request(waiter_id, sq);
+            self.stage_request(waiter_id, submission_queue);
         }
 
         !self.ready_queue.is_empty()
@@ -676,9 +678,8 @@ impl IoUringLoop {
 
         let at_sq_capacity = submission_queue.is_full();
         let at_waiter_capacity = self.waiters.len() == self.cfg.size as usize;
-        let has_pending_work = !self.ready_queue.is_empty() || !self.pending_cancels.is_empty();
 
-        Some(at_sq_capacity || at_waiter_capacity || has_pending_work)
+        Some(at_sq_capacity || at_waiter_capacity)
     }
 
     /// Stage queued cancellation SQEs from `pending_cancels` in FIFO order.
@@ -686,14 +687,16 @@ impl IoUringLoop {
     /// Stops when all queued cancellations are staged or the SQ reaches
     /// capacity. Returns `true` when SQ capacity is hit and at least one
     /// cancellation remains queued.
-    fn stage_cancellations(&mut self, sq: &mut SubmissionQueue<'_>) -> bool {
-        while !sq.is_full() {
+    fn stage_cancellations(&mut self, submission_queue: &mut SubmissionQueue<'_>) -> bool {
+        while !submission_queue.is_full() {
             let Some(waiter_id) = self.pending_cancels.pop_front() else {
                 return false;
             };
-            // `pending_cancels` only contains cancel-requested waiters. If the
-            // waiter no longer has an SQE in flight, there is nothing left for
-            // the kernel to cancel.
+
+            // This waiter timed out earlier, but its queued cancel may have
+            // gone stale before we got around to staging it. If the original
+            // op CQE already retired the outstanding SQE, there is nothing
+            // left for the kernel to cancel.
             if !self.waiters.is_in_flight(waiter_id) {
                 continue;
             }
@@ -704,7 +707,9 @@ impl IoUringLoop {
 
             // SAFETY: AsyncCancel SQE uses stable user_data only.
             unsafe {
-                sq.push(&cancel).expect("unable to push cancel to queue");
+                submission_queue
+                    .push(&cancel)
+                    .expect("unable to push cancel to queue");
             }
         }
 
@@ -735,7 +740,10 @@ impl IoUringLoop {
         }
 
         match self.waiters.on_completion(user_data, cqe.result()) {
-            CompletionOutcome::Cancel => {}
+            CompletionOutcome::Cancel => {
+                // Async-cancel CQEs are handled entirely inside `Waiters` they do
+                // not directly complete or requeue a logical request here.
+            }
             CompletionOutcome::Requeue(waiter_id) => {
                 // Request needs another SQE. Add it to the ready queue.
                 self.ready_queue.push_back(waiter_id);
@@ -775,6 +783,9 @@ impl IoUringLoop {
             if self.waiters.cancel(entry.waiter_id) {
                 // Once cancel is requested, this waiter is no longer deadline-active.
                 self.timeout_wheel.remove(entry.target_tick);
+                // Only timed-out waiters with an outstanding op SQE need
+                // AsyncCancel. Waiters parked in the ready queue have no
+                // kernel op to cancel and will time out locally when restaged.
                 if self.waiters.is_in_flight(entry.waiter_id) {
                     self.pending_cancels.push_back(entry.waiter_id);
                 }

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -143,7 +143,7 @@ use io_uring::{
     IoUring,
 };
 use prometheus_client::{metrics::gauge::Gauge, registry::Registry};
-use request::{ActiveRequest, CqeAction, Request};
+use request::{ActiveRequest, Request};
 use std::{
     collections::VecDeque,
     sync::Arc,
@@ -154,7 +154,7 @@ mod request;
 mod timeout;
 use timeout::{Tick, TimeoutWheel};
 mod waiter;
-use waiter::{WaiterId, WaiterState, Waiters};
+use waiter::{CqeOutcome, StageAction, WaiterId, WaiterState, Waiters};
 mod waker;
 use waker::{Waker, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
 
@@ -429,7 +429,7 @@ impl IoUringLoop {
             Some(deadline) => match self.timeout_wheel.target_tick(deadline) {
                 Some(target_tick) => Some(target_tick),
                 None => {
-                    active.finish_timeout();
+                    active.timeout();
                     return None;
                 }
             },
@@ -450,28 +450,19 @@ impl IoUringLoop {
     /// queue (timeout fired between requeue and staging), it is completed with
     /// a timeout error instead of issuing a follow-up SQE.
     fn stage_request(&mut self, waiter_id: WaiterId, sq: &mut SubmissionQueue<'_>) {
-        let sqe = {
-            let Some((request, state)) = self.waiters.get_mut(waiter_id) else {
-                return;
-            };
-            if matches!(state, WaiterState::CancelRequested) {
-                // No in-flight SQE remains for ready-queue-only timeouts.
-                if let Some(request) = self.waiters.remove(waiter_id) {
-                    request.finish_timeout();
+        match self.waiters.stage_sqe(waiter_id) {
+            StageAction::Ignore => {}
+            StageAction::CompleteTimeout(request) => request.timeout(),
+            StageAction::Submit(sqe) => {
+                // SAFETY:
+                // - All resources are stored in `self.waiters` until CQE processing, so
+                //   SQE pointers remain valid and FD numbers cannot be reused early.
+                // - SQ capacity was checked by caller.
+                unsafe {
+                    sq.push(&sqe).expect("unable to push to queue");
                 }
-                return;
             }
-            request.build_sqe(waiter_id)
-        };
-        // SAFETY:
-        // - All resources are stored in `self.waiters` until CQE processing, so
-        //   SQE pointers remain valid and FD numbers cannot be reused early.
-        // - SQ capacity was checked by caller.
-        unsafe {
-            sq.push(&sqe).expect("unable to push to queue");
         }
-        let marked = self.waiters.mark_in_flight(waiter_id);
-        assert!(marked, "staged request missing from waiter table");
     }
 
     /// Stage requeued requests from `ready_queue` in FIFO order.
@@ -616,30 +607,20 @@ impl IoUringLoop {
             return;
         }
 
-        // Route op/cancel completions through waiter state.
-        let Some((request, state, waiter_id)) = self.waiters.on_cqe(user_data, cqe.result()) else {
-            return;
-        };
-
-        // Let the request state machine process the CQE result.
-        match request.on_cqe(state, cqe.result()) {
-            CqeAction::Complete => {
-                // Remove active deadline tracking when this request completes.
-                if let WaiterState::Active {
-                    target_tick: Some(tick),
-                } = state
-                {
-                    self.timeout_wheel.remove(tick);
-                }
-
-                // Remove request from waiter table and deliver the result.
-                if let Some(completed) = self.waiters.remove(waiter_id) {
-                    completed.finish();
-                }
-            }
-            CqeAction::Requeue => {
+        match self.waiters.on_cqe(user_data, cqe.result()) {
+            CqeOutcome::Ignore => {}
+            CqeOutcome::Requeue(waiter_id) => {
                 // Request needs another SQE. Add it to the ready queue.
                 self.ready_queue.push_back(waiter_id);
+            }
+            CqeOutcome::Complete {
+                request,
+                target_tick,
+            } => {
+                if let Some(tick) = target_tick {
+                    self.timeout_wheel.remove(tick);
+                }
+                request.finish();
             }
         }
     }
@@ -950,7 +931,10 @@ mod tests {
                 iouring.waiters.cancel(waiter_id),
                 "cancel should transition waiter to cancel-requested"
             );
-            assert!(iouring.waiters.mark_in_flight(waiter_id));
+            assert!(matches!(
+                iouring.waiters.stage_sqe(waiter_id),
+                StageAction::Submit(_)
+            ));
             iouring.pending_cancels.push_back(waiter_id);
         }
 
@@ -1107,8 +1091,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left1.into()),
                 buf: IoBufMut::with_capacity(1),
-                target_len: 1,
-                received: 0,
+                offset: 0,
+                len: 1,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(200)),
                 sender: tx1,
@@ -1129,8 +1113,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left2.into()),
                 buf: IoBufMut::with_capacity(8),
-                target_len: 8,
-                received: 0,
+                offset: 0,
+                len: 8,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(80)),
                 sender: tx2,
@@ -1228,19 +1212,18 @@ mod tests {
         }));
         let old_slot = iouring.waiters.insert(old_req, Some(1));
         iouring.timeout_wheel.schedule(old_slot, 1);
-        // Simulate completion: get mut access then remove.
-        if let Some((
-            _request,
-            WaiterState::Active {
-                target_tick: Some(tick),
-            },
-            _,
-        )) = iouring.waiters.on_cqe(old_slot.user_data(), 0)
+        // Simulate completion after the waiter had an op staged.
+        assert!(matches!(
+            iouring.waiters.stage_sqe(old_slot),
+            StageAction::Submit(_)
+        ));
+        if let CqeOutcome::Complete {
+            request,
+            target_tick: Some(tick),
+        } = iouring.waiters.on_cqe(old_slot.user_data(), 0)
         {
             iouring.timeout_wheel.remove(tick);
-        }
-        if let Some(completed) = iouring.waiters.remove(old_slot) {
-            completed.finish();
+            request.finish();
         }
 
         // Reuse the same slot for a new waiter with a later timeout.
@@ -1254,7 +1237,10 @@ mod tests {
         }));
         let slot_index = iouring.waiters.insert(req, Some(3));
         assert_eq!(slot_index.index(), old_slot.index());
-        assert!(iouring.waiters.mark_in_flight(slot_index));
+        assert!(matches!(
+            iouring.waiters.stage_sqe(slot_index),
+            StageAction::Submit(_)
+        ));
         iouring.timeout_wheel.schedule(slot_index, 3);
 
         // At tick 1, only the stale old entry should expire. The new waiter must
@@ -1313,14 +1299,17 @@ mod tests {
         let req = ActiveRequest::from_request(Request::Recv(RecvRequest {
             fd: Arc::new(left.into()),
             buf: IoBufMut::with_capacity(5),
-            target_len: 5,
-            received: 0,
+            offset: 0,
+            len: 5,
             exact: false,
             deadline: Some(Instant::now() + Duration::from_secs(1)),
             sender: tx,
         }));
         let slot_index = iouring.waiters.insert(req, Some(2));
-        assert!(iouring.waiters.mark_in_flight(slot_index));
+        assert!(matches!(
+            iouring.waiters.stage_sqe(slot_index),
+            StageAction::Submit(_)
+        ));
         assert!(
             iouring.waiters.cancel(slot_index),
             "cancel should transition active waiter"
@@ -1330,25 +1319,19 @@ mod tests {
 
         // Simulate op CQE arriving with positive result (5 bytes read).
         // Even though cancel was requested, a complete positive result wins.
-        if let Some((request, state, waiter_id)) = iouring.waiters.on_cqe(slot_index.user_data(), 5)
+        if let CqeOutcome::Complete { request, .. } =
+            iouring.waiters.on_cqe(slot_index.user_data(), 5)
         {
-            match request.on_cqe(state, 5) {
-                CqeAction::Complete => {
-                    if let Some(completed) = iouring.waiters.remove(waiter_id) {
-                        completed.finish();
-                    }
-                }
-                CqeAction::Requeue => {
-                    panic!("should not requeue");
-                }
-            }
+            request.finish();
         }
 
         // Late cancel CQE should be ignored.
-        assert!(iouring
-            .waiters
-            .on_cqe(slot_index.cancel_user_data(), -libc::ECANCELED)
-            .is_none());
+        assert!(matches!(
+            iouring
+                .waiters
+                .on_cqe(slot_index.cancel_user_data(), -libc::ECANCELED),
+            CqeOutcome::Ignore
+        ));
 
         let (_, result) = futures::executor::block_on(rx).expect("missing completion");
         // exact=false recv with 5 bytes should succeed.
@@ -1374,8 +1357,8 @@ mod tests {
                 .send(Request::Recv(RecvRequest {
                     fd: Arc::new(left_pipe.into()),
                     buf: IoBufMut::with_capacity(5),
-                    target_len: 5,
-                    received: 0,
+                    offset: 0,
+                    len: 5,
                     exact: false,
                     deadline: None,
                     sender: recv_tx,
@@ -1434,8 +1417,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                target_len: 8,
-                received: 0,
+                offset: 0,
+                len: 8,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_secs(1)),
                 sender: tx,
@@ -1502,8 +1485,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                target_len: 8,
-                received: 0,
+                offset: 0,
+                len: 8,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(50)),
                 sender: tx,
@@ -1539,8 +1522,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                target_len: 8,
-                received: 0,
+                offset: 0,
+                len: 8,
                 exact: false,
                 deadline: None,
                 sender: tx,
@@ -1581,8 +1564,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                target_len: 8,
-                received: 0,
+                offset: 0,
+                len: 8,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(50)),
                 sender: tx,
@@ -1620,8 +1603,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                target_len: 8,
-                received: 0,
+                offset: 0,
+                len: 8,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(500)),
                 sender: tx,
@@ -1671,8 +1654,8 @@ mod tests {
                 .send(Request::Recv(RecvRequest {
                     fd: Arc::new(left.into()),
                     buf: IoBufMut::with_capacity(8),
-                    target_len: 8,
-                    received: 0,
+                    offset: 0,
+                    len: 8,
                     exact: false,
                     deadline: Some(deadline),
                     sender: tx,
@@ -1717,8 +1700,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left.into()),
                 buf: IoBufMut::with_capacity(total),
-                target_len: total,
-                received: 0,
+                offset: 0,
+                len: total,
                 exact: true,
                 deadline: None,
                 sender: tx,
@@ -1768,8 +1751,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left.into()),
                 buf: IoBufMut::with_capacity(total),
-                target_len: total,
-                received: 0,
+                offset: 0,
+                len: total,
                 exact: true,
                 deadline: None,
                 sender: tx,
@@ -1826,8 +1809,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left.into()),
                 buf: IoBufMut::with_capacity(100),
-                target_len: 100,
-                received: 0,
+                offset: 0,
+                len: 100,
                 exact: true,
                 deadline: Some(Instant::now() + Duration::from_millis(80)),
                 sender: tx,
@@ -1869,23 +1852,25 @@ mod tests {
         let request = ActiveRequest::from_request(Request::Recv(RecvRequest {
             fd: Arc::new(left.into()),
             buf: IoBufMut::with_capacity(8),
-            target_len: 8,
-            received: 0,
+            offset: 0,
+            len: 8,
             exact: true,
             deadline: Some(Instant::now() + Duration::from_millis(25)),
             sender: tx,
         }));
         let waiter_id = iouring.waiters.insert(request, Some(1));
-        assert!(iouring.waiters.mark_in_flight(waiter_id));
+        assert!(matches!(
+            iouring.waiters.stage_sqe(waiter_id),
+            StageAction::Submit(_)
+        ));
         iouring.timeout_wheel.schedule(waiter_id, 1);
 
         // Simulate a short recv CQE so the logical request requeues itself but
         // no longer has a kernel op outstanding.
-        let (request, state, waiter_id) = iouring
-            .waiters
-            .on_cqe(waiter_id.user_data(), 4)
-            .expect("missing partial recv completion");
-        assert!(matches!(request.on_cqe(state, 4), CqeAction::Requeue));
+        let waiter_id = match iouring.waiters.on_cqe(waiter_id.user_data(), 4) {
+            CqeOutcome::Requeue(waiter_id) => waiter_id,
+            _ => panic!("missing partial recv completion"),
+        };
         iouring.ready_queue.push_back(waiter_id);
 
         std::thread::sleep(iouring.cfg.timeout_wheel_tick + Duration::from_millis(2));
@@ -1997,8 +1982,8 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(sock_left.into()),
                 buf: IoBufMut::with_capacity(5),
-                target_len: 5,
-                received: 0,
+                offset: 0,
+                len: 5,
                 exact: true,
                 deadline: None,
                 sender: recv_tx,

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -645,12 +645,8 @@ impl IoUringLoop {
         // Stage operations until the channel is empty, waiter capacity is hit,
         // or the SQ is full. Waiter capacity is bounded by `cfg.size`.
         while self.waiters.len() < self.cfg.size as usize && !submission_queue.is_full() {
-            // Active waiter capacity is bounded by `cfg.size`.
-            if self.waiters.len() == self.cfg.size as usize {
-                break;
-            }
-
-            // Try to drain one request from the channel.
+            // Try to drain one operation from the channel. If the channel is empty, we're
+            // done for now.
             let request = match self.receiver.try_recv() {
                 Ok(request) => request,
                 Err(TryRecvError::Disconnected) => return None,

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -1255,35 +1255,6 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_wake_cqe_rearms_after_multishot_termination() {
-        // Verify a wake CQE without the multishot `more` flag requests a poll
-        // reinstallation for the next staging pass.
-        let cfg = Config::default();
-        let mut registry = Registry::default();
-        let (_submitter, mut iouring) = IoUringLoop::new(cfg, &mut registry);
-        iouring.wake_rearm_needed = false;
-
-        #[repr(C)]
-        struct RawCqe {
-            user_data: u64,
-            res: i32,
-            flags: u32,
-        }
-
-        // SAFETY: `CqueueEntry` is a `repr(C)` newtype over the same 16-byte CQE
-        // layout: `user_data`, `res`, and `flags`.
-        let cqe = unsafe {
-            std::mem::transmute::<RawCqe, CqueueEntry>(RawCqe {
-                user_data: WAKE_USER_DATA,
-                res: 1,
-                flags: 0,
-            })
-        };
-        iouring.handle_cqe(cqe);
-        assert!(iouring.wake_rearm_needed);
-    }
-
-    #[test]
     fn test_cancel_completion_returns_saved_op_result() {
         // Verify a successful operation CQE still wins if it races with a timeout cancel.
         let cfg = Config::default();
@@ -1335,6 +1306,85 @@ mod tests {
         let (_, result) = futures::executor::block_on(rx).expect("missing completion");
         // exact=false recv with 5 bytes should succeed.
         assert_eq!(result.unwrap(), 5);
+        assert_eq!(iouring.waiters.len(), 0);
+    }
+
+    #[test]
+    fn test_staged_cancel_cqe_is_ignored_after_timeout_completion() {
+        // Drive the "cancel SQE already staged" race explicitly:
+        //
+        // 1. Stage an exact recv with a deadline and register it with the wheel.
+        // 2. Advance time so the waiter becomes cancel-requested and queues an
+        //    AsyncCancel.
+        // 3. Stage that cancel SQE into the ring, but do not complete it yet.
+        // 4. Deliver a partial op CQE after cancellation was requested. For an
+        //    exact recv, that must complete locally as Timeout instead of
+        //    requeueing.
+        // 5. Finally, deliver the late cancel CQE and confirm it is ignored
+        //    because the waiter was already removed by step 4.
+        let cfg = Config {
+            max_request_timeout: Duration::from_millis(100),
+            timeout_wheel_tick: Duration::from_millis(5),
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        let (left, _right) = UnixStream::pair().unwrap();
+        let (tx, rx) = oneshot::channel();
+        let req = ActiveRequest::from_request(Request::Recv(RecvRequest {
+            fd: Arc::new(left.into()),
+            buf: IoBufMut::with_capacity(8),
+            offset: 0,
+            len: 8,
+            exact: true,
+            deadline: Some(Instant::now() + Duration::from_millis(25)),
+            sender: tx,
+        }));
+        let waiter_id = iouring.waiters.insert(req, Some(1));
+        assert!(matches!(
+            iouring.waiters.stage_sqe(waiter_id),
+            StageAction::Submit(_)
+        ));
+        iouring.timeout_wheel.schedule(waiter_id, 1);
+
+        // Expire the deadline so the waiter transitions to cancel-requested and
+        // the loop queues an AsyncCancel for the in-flight recv SQE.
+        std::thread::sleep(iouring.cfg.timeout_wheel_tick + Duration::from_millis(2));
+        iouring.advance_timeouts();
+        assert_eq!(iouring.pending_cancels.len(), 1);
+
+        // Stage the queued AsyncCancel. It is now in the SQ, but there is still
+        // no cancel CQE, so the operation CQE can still win the race.
+        {
+            let mut submission_queue = ring.submission();
+            assert!(!iouring.stage_cancellations(&mut submission_queue));
+            assert_eq!(submission_queue.len(), 1);
+        }
+        assert!(iouring.pending_cancels.is_empty());
+
+        // A partial result after cancellation was requested must complete this
+        // exact recv as Timeout rather than parking it back in the ready queue.
+        match iouring.waiters.on_cqe(waiter_id.user_data(), 4) {
+            CqeOutcome::Complete {
+                request,
+                target_tick: None,
+            } => request.finish(),
+            _ => panic!("missing timeout completion from op CQE"),
+        }
+
+        // The cancel CQE arrives after the waiter was already removed, so it
+        // should be treated as stale and ignored.
+        assert!(matches!(
+            iouring
+                .waiters
+                .on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED),
+            CqeOutcome::Ignore
+        ));
+
+        let (_buf, result) = futures::executor::block_on(rx).expect("missing completion");
+        assert!(matches!(result, Err(crate::Error::Timeout)));
         assert_eq!(iouring.waiters.len(), 0);
     }
 

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -154,7 +154,7 @@ mod request;
 mod timeout;
 use timeout::{Tick, TimeoutWheel};
 mod waiter;
-use waiter::{CompletionOutcome, StageAction, WaiterId, Waiters};
+use waiter::{CompletionOutcome, StageOutcome, WaiterId, Waiters};
 mod waker;
 use waker::{Waker, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
 
@@ -451,9 +451,9 @@ impl IoUringLoop {
     /// a timeout error instead of issuing a follow-up SQE.
     fn stage_request(&mut self, waiter_id: WaiterId, sq: &mut SubmissionQueue<'_>) {
         match self.waiters.stage(waiter_id) {
-            StageAction::Ignore => {}
-            StageAction::Timeout(request) => request.timeout(),
-            StageAction::Submit(sqe) => {
+            StageOutcome::Ignore => {}
+            StageOutcome::Timeout(request) => request.timeout(),
+            StageOutcome::Submit(sqe) => {
                 // SAFETY:
                 // - All resources are stored in `self.waiters` until CQE processing, so
                 //   SQE pointers remain valid and FD numbers cannot be reused early.
@@ -929,7 +929,7 @@ mod tests {
             let waiter_id = iouring.waiters.insert(request, None);
             assert!(matches!(
                 iouring.waiters.stage(waiter_id),
-                StageAction::Submit(_)
+                StageOutcome::Submit(_)
             ));
             assert!(
                 iouring.waiters.cancel(waiter_id),
@@ -1019,7 +1019,7 @@ mod tests {
         assert_eq!(ring.submission().len(), 0);
         assert!(matches!(
             iouring.waiters.stage(waiter_id),
-            StageAction::Timeout(_)
+            StageOutcome::Timeout(_)
         ));
     }
 
@@ -1214,7 +1214,7 @@ mod tests {
         // Simulate completion after the waiter had an op staged.
         assert!(matches!(
             iouring.waiters.stage(old_slot),
-            StageAction::Submit(_)
+            StageOutcome::Submit(_)
         ));
         if let CompletionOutcome::Complete {
             request,
@@ -1238,7 +1238,7 @@ mod tests {
         assert_eq!(slot_index.index(), old_slot.index());
         assert!(matches!(
             iouring.waiters.stage(slot_index),
-            StageAction::Submit(_)
+            StageOutcome::Submit(_)
         ));
         iouring.timeout_wheel.schedule(slot_index, 3);
 
@@ -1278,7 +1278,7 @@ mod tests {
         let slot_index = iouring.waiters.insert(req, Some(2));
         assert!(matches!(
             iouring.waiters.stage(slot_index),
-            StageAction::Submit(_)
+            StageOutcome::Submit(_)
         ));
         assert!(
             iouring.waiters.cancel(slot_index),
@@ -1345,7 +1345,7 @@ mod tests {
         let waiter_id = iouring.waiters.insert(req, Some(1));
         assert!(matches!(
             iouring.waiters.stage(waiter_id),
-            StageAction::Submit(_)
+            StageOutcome::Submit(_)
         ));
         iouring.timeout_wheel.schedule(waiter_id, 1);
 
@@ -1910,7 +1910,7 @@ mod tests {
         let waiter_id = iouring.waiters.insert(request, Some(1));
         assert!(matches!(
             iouring.waiters.stage(waiter_id),
-            StageAction::Submit(_)
+            StageOutcome::Submit(_)
         ));
         iouring.timeout_wheel.schedule(waiter_id, 1);
 
@@ -1929,7 +1929,7 @@ mod tests {
         assert!(iouring.pending_cancels.is_empty());
         assert!(matches!(
             iouring.waiters.stage(waiter_id),
-            StageAction::Timeout(_)
+            StageOutcome::Timeout(_)
         ));
     }
 

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -451,7 +451,6 @@ impl IoUringLoop {
     /// a timeout error instead of issuing a follow-up SQE.
     fn stage_request(&mut self, waiter_id: WaiterId, sq: &mut SubmissionQueue<'_>) {
         match self.waiters.stage(waiter_id) {
-            StageOutcome::Ignore => {}
             StageOutcome::Timeout(request) => request.timeout(),
             StageOutcome::Submit(sqe) => {
                 // SAFETY:
@@ -608,7 +607,7 @@ impl IoUringLoop {
         }
 
         match self.waiters.on_completion(user_data, cqe.result()) {
-            CompletionOutcome::Ignore => {}
+            CompletionOutcome::Cancel => {}
             CompletionOutcome::Requeue(waiter_id) => {
                 // Request needs another SQE. Add it to the ready queue.
                 self.ready_queue.push_back(waiter_id);
@@ -1138,15 +1137,17 @@ mod tests {
     }
 
     #[test]
-    fn test_stage_request_ignores_stale_ready_queue_entry() {
-        // Verify stale ready-queue ids are ignored if the slot was already
-        // removed and reused before the requeue entry is revisited.
+    fn test_stage_request_panics_on_stale_ready_queue_entry() {
+        // A stale ready-queue id should be treated as an internal logic error:
+        // once a waiter is queued for restaging, no production path should
+        // remove and reuse that slot before the queue entry is revisited.
         let cfg = Config::default();
         let mut registry = Registry::default();
         let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
         let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
 
-        // Create and remove one waiter so the ready queue can later point at a stale generation.
+        // Create and complete one waiter so the ready queue can later point at
+        // a stale generation.
         let (sock_left, _sock_right) = UnixStream::pair().unwrap();
         // SAFETY: sock_left is a valid fd that we own.
         let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
@@ -1158,10 +1159,14 @@ mod tests {
             })),
             None,
         );
-        let _ = iouring
-            .waiters
-            .remove(stale)
-            .expect("missing original waiter");
+        assert!(matches!(
+            iouring.waiters.stage(stale),
+            StageOutcome::Submit(_)
+        ));
+        match iouring.waiters.on_completion(stale.user_data(), 0) {
+            CompletionOutcome::Complete { request, .. } => request.finish(),
+            _ => panic!("sync waiter should complete immediately"),
+        }
 
         // Reuse the same slot with a new generation to prove `stage_request`
         // matches on the full waiter id, not just the slot index.
@@ -1179,13 +1184,11 @@ mod tests {
         assert_eq!(reused.index(), stale.index());
         assert_ne!(reused, stale);
 
-        {
+        let stale_ready = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut sq = ring.submission();
             iouring.stage_request(stale, &mut sq);
-        }
-
-        // The stale entry should be ignored without disturbing the live waiter.
-        assert_eq!(ring.submission().len(), 0);
+        }));
+        assert!(stale_ready.is_err());
         assert!(!iouring.waiters.is_in_flight(reused));
     }
 
@@ -1300,7 +1303,7 @@ mod tests {
             iouring
                 .waiters
                 .on_completion(slot_index.cancel_user_data(), -libc::ECANCELED),
-            CompletionOutcome::Ignore
+            CompletionOutcome::Cancel
         ));
 
         let (_, result) = futures::executor::block_on(rx).expect("missing completion");
@@ -1380,7 +1383,7 @@ mod tests {
             iouring
                 .waiters
                 .on_completion(waiter_id.cancel_user_data(), -libc::ECANCELED),
-            CompletionOutcome::Ignore
+            CompletionOutcome::Cancel
         ));
 
         let (_buf, result) = futures::executor::block_on(rx).expect("missing completion");
@@ -2000,7 +2003,7 @@ mod tests {
 
         // Ready-queue staging should retire the waiter locally and leave the SQ untouched.
         assert!(!at_capacity);
-        assert!(iouring.waiters.remove(waiter_id).is_none());
+        assert!(iouring.waiters.is_empty());
         assert_eq!(ring.submission().len(), 0);
         let result = rx.await.expect("missing timeout completion");
         assert!(matches!(result, Err(crate::Error::Timeout)));

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -43,7 +43,8 @@
 //! Loop behavior:
 //!   1) Drain CQEs.
 //!   2) Advance timeouts.
-//!   3) Stage cancels, ready requests, then new inbound requests into SQ.
+//!   3) Rarely rearm wake polling, then stage cancels, ready-queue requests,
+//!      and new inbound requests into SQ.
 //!   4) Submit and block in io_uring_enter until a CQE (data or wake) arrives.
 //! ```
 //!
@@ -65,6 +66,20 @@
 //! - If the original op CQE only makes partial/retryable progress after timeout, the caller
 //!   sees timeout and no follow-up SQE is issued
 //!
+//! ## Submission Policy
+//!
+//! A logical request may need multiple SQEs before it completes. The loop keeps
+//! such requests on a FIFO ready queue and stages work in this order:
+//! 1. Rarely, a wake poll rearm SQE when a prior multishot wake CQE ended the
+//!    existing poll registration.
+//! 2. Cancellation SQEs for timed-out requests.
+//! 3. Ready-queue requests that were already admitted and need another SQE.
+//! 4. Fresh requests drained from the channel, until waiter or SQ capacity is hit.
+//!
+//! During shutdown, there is no new channel work, so the drain phase continues
+//! servicing cancellations and the ready queue until requests complete, time
+//! out, or are abandoned by `shutdown_timeout`.
+//!
 //! ## Wake Handling
 //!
 //! To avoid submission latency while the loop is blocked in `submit_and_wait`, the loop maintains
@@ -85,8 +100,9 @@
 //!
 //! ## Liveness Model
 //!
-//! This loop enforces a configured upper bound on in-flight requests, and submissions are staged
-//! from a FIFO MPSC queue.
+//! This loop enforces a configured upper bound on in-flight requests. New submissions arrive
+//! through a FIFO MPSC queue, but already-admitted requests may be restaged ahead of that queue
+//! according to the submission policy above.
 //!
 //! This implies a bounded-liveness caveat: if all in-flight requests are waiting on operations
 //! that are still queued behind the capacity limit, the loop cannot make progress until some
@@ -453,11 +469,26 @@ impl IoUringLoop {
         }
     }
 
-    /// Stage inbound requests into the SQ.
+    /// Stage requeued requests from `ready_queue` in FIFO order.
     ///
-    /// Checks ready work first on every iteration. In the same pass, it rearms
-    /// wake polling if needed and stages pending cancellations before new
-    /// requests.
+    /// Stops when all queued requests are staged or the SQ reaches capacity.
+    /// Returns `true` when SQ capacity is hit and at least one ready request
+    /// remains queued.
+    fn stage_ready_requests(&mut self, sq: &mut SubmissionQueue<'_>) -> bool {
+        while !sq.is_full() {
+            let Some(waiter_id) = self.ready_queue.pop_front() else {
+                return false;
+            };
+            self.stage_request(waiter_id, sq);
+        }
+
+        !self.ready_queue.is_empty()
+    }
+
+    /// Stage pending submission work into the SQ.
+    ///
+    /// In one pass, this may rearm wake polling, stage cancellations, restage
+    /// ready-queue requests, and admit new requests.
     ///
     /// Advances `processed_seq` by exactly the number of drained submissions.
     ///
@@ -480,13 +511,14 @@ impl IoUringLoop {
             return Some(true);
         }
 
-        while !sq.is_full() {
-            // Ready queue has priority over new inbound requests.
-            if let Some(waiter_id) = self.ready_queue.pop_front() {
-                self.stage_request(waiter_id, &mut sq);
-                continue;
-            }
+        // Requeued work already owns waiter capacity, so restage it before
+        // admitting fresh channel requests.
+        if self.stage_ready_requests(&mut sq) {
+            return Some(true);
+        }
 
+        // Remaining SQ capacity can now be used to admit new requests.
+        while !sq.is_full() {
             // Active waiter capacity is bounded by `cfg.size`.
             if self.waiters.len() == self.cfg.size as usize {
                 break;
@@ -595,7 +627,7 @@ impl IoUringLoop {
                 }
             }
             CqeAction::Requeue => {
-                // Request needs another SQE. Add to ready queue.
+                // Request needs another SQE. Add it to the ready queue.
                 self.ready_queue.push_back(waiter_id);
             }
         }
@@ -662,12 +694,22 @@ impl IoUringLoop {
             }
 
             // Keep userspace deadline processing alive during shutdown so
-            // in-flight timed operations preserve their ETIMEDOUT semantics.
+            // in-flight timed operations preserve their ETIMEDOUT semantics,
+            // and continue staging requeued requests so partially-complete or
+            // retrying requests can keep making progress.
             self.advance_timeouts();
             {
                 let mut submission_queue = ring.submission();
                 self.stage_cancellations(&mut submission_queue);
+                self.stage_ready_requests(&mut submission_queue);
             }
+
+            // Staging can directly complete the last waiter (for example, when a
+            // timed-out requeued request is removed instead of reissued).
+            if self.waiters.is_empty() {
+                break;
+            }
+
             let timeout = match (remaining, self.timeout_wheel.next_deadline()) {
                 (Some(remaining), Some(deadline)) => Some(remaining.min(deadline)),
                 (Some(remaining), None) => Some(remaining),
@@ -789,6 +831,7 @@ mod tests {
     use prometheus_client::registry::Registry;
     use request::{RecvRequest, SendRequest, SyncRequest};
     use std::{
+        io::Write,
         os::{
             fd::{AsRawFd, FromRawFd, IntoRawFd},
             unix::net::UnixStream,
@@ -1479,6 +1522,66 @@ mod tests {
         handle.join().unwrap();
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_shutdown_no_timeout_processes_ready_queue() {
+        let cfg = Config {
+            shutdown_timeout: None,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
+        let handle = std::thread::spawn(move || iouring.run());
+
+        // Use a socket pair so we can feed the recv in two phases and control
+        // exactly when the request is requeued.
+        let (left, right) = UnixStream::pair().unwrap();
+        left.set_nonblocking(true).unwrap();
+        right.set_nonblocking(true).unwrap();
+
+        let total = 100usize;
+        let (tx, rx) = oneshot::channel();
+
+        // Submit an exact recv large enough that the first short write cannot
+        // complete it. After the first CQE, the request must requeue itself.
+        submitter
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(left.into()),
+                buf: IoBufMut::with_capacity(total),
+                len: total,
+                received: 0,
+                exact: true,
+                deadline: None,
+                sender: tx,
+            }))
+            .await
+            .unwrap();
+
+        // Deliver only part of the payload so the recv makes progress and lands
+        // in the ready queue awaiting a follow-up SQE.
+        (&right).write_all(&[1u8; 10]).unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Trigger shutdown after the request has been requeued but before it
+        // has necessarily been restaged. Drain must continue servicing the
+        // ready queue from this point onward.
+        drop(submitter);
+
+        // Finish the request after shutdown has started. Drain must continue
+        // staging ready-queue work or this recv will hang forever.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (&right).write_all(&[2u8; 90]).unwrap();
+
+        // The recv should still complete successfully even though shutdown was
+        // initiated between the first and second stages of the logical request.
+        let (_, result) = tokio::time::timeout(Duration::from_secs(2), rx)
+            .await
+            .expect("shutdown recv timed out")
+            .expect("missing shutdown recv completion");
+        assert_eq!(result.unwrap(), total);
+
+        handle.join().unwrap();
+    }
+
     #[tokio::test]
     async fn test_timeout_fires_while_request_in_ready_queue() {
         // Regression test: a request that made partial progress and was
@@ -1540,20 +1643,52 @@ mod tests {
         let (sender, iouring) = IoUringLoop::new(cfg, &mut registry);
         let uring_thread = std::thread::spawn(move || iouring.run());
 
-        // Submit a sync (Nop-equivalent).
-        let (sock_left, _) = UnixStream::pair().unwrap();
-        // SAFETY: sock_left is a valid fd that we own.
-        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
-        let (tx, rx) = oneshot::channel();
+        // Use a real request/response pair instead of a nop-style operation so
+        // the test proves that submissions and completions still work with the
+        // SINGLE_ISSUER ring configuration enabled.
+        let (sock_left, sock_right) = UnixStream::pair().unwrap();
+        let (recv_tx, recv_rx) = oneshot::channel();
+
+        // Queue the recv first so the send has a real consumer and we exercise
+        // the normal cross-request wake/completion path.
         sender
-            .send(Request::Sync(SyncRequest {
-                file: Arc::new(file),
-                sender: tx,
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(sock_left.into()),
+                buf: IoBufMut::with_capacity(5),
+                len: 5,
+                received: 0,
+                exact: true,
+                deadline: None,
+                sender: recv_tx,
             }))
             .await
             .unwrap();
 
-        let _result = rx.await.unwrap();
+        let (send_tx, send_rx) = oneshot::channel();
+        sender
+            .send(Request::Send(SendRequest {
+                fd: Arc::new(sock_right.into()),
+                bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
+                deadline: None,
+                sender: send_tx,
+            }))
+            .await
+            .unwrap();
+
+        // The recv must observe the full payload, which shows that the request
+        // made it through submission, wakeup, and completion successfully.
+        let (_, recv_result) = tokio::time::timeout(Duration::from_secs(2), recv_rx)
+            .await
+            .expect("recv timed out")
+            .expect("missing recv completion");
+        assert_eq!(recv_result.unwrap(), 5);
+
+        // The paired send must also complete cleanly.
+        let send_result = tokio::time::timeout(Duration::from_secs(2), send_rx)
+            .await
+            .expect("send timed out")
+            .expect("missing send completion");
+        assert!(send_result.is_ok());
 
         drop(sender);
         uring_thread.join().unwrap();

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -619,29 +619,29 @@ impl IoUringLoop {
     /// producer channel disconnected.
     fn fill_submission_queue(&mut self, ring: &mut IoUring) -> Option<bool> {
         let mut drained = 0u64;
-        let mut sq = ring.submission();
+        let mut submission_queue = ring.submission();
         let mut wheel_aligned = self.timeout_wheel.next_deadline().is_some();
 
         // Reinstall wake poll only when a prior wake CQE indicated multishot
         // termination. Otherwise keep the existing poll registration.
         if std::mem::take(&mut self.wake_rearm_needed) {
-            self.waker.reinstall(&mut sq);
+            self.waker.reinstall(&mut submission_queue);
         }
 
         // Stage pending cancel SQEs first so timed-out requests are canceled promptly.
-        if self.stage_cancellations(&mut sq) {
+        if self.stage_cancellations(&mut submission_queue) {
             // If cancels alone filled the SQ, submit them first.
             return Some(true);
         }
 
         // Requeued work already owns waiter capacity, so restage it before
         // admitting fresh channel requests.
-        if self.stage_ready_requests(&mut sq) {
+        if self.stage_ready_requests(&mut submission_queue) {
             return Some(true);
         }
 
         // Remaining SQ capacity can now be used to admit new requests.
-        while !sq.is_full() {
+        while !submission_queue.is_full() {
             // Active waiter capacity is bounded by `cfg.size`.
             if self.waiters.len() == self.cfg.size as usize {
                 break;
@@ -667,14 +667,14 @@ impl IoUringLoop {
             }
 
             if let Some(waiter_id) = self.admit_request(request) {
-                self.stage_request(waiter_id, &mut sq);
+                self.stage_request(waiter_id, &mut submission_queue);
             }
         }
 
         // Track which submitted sequence has been consumed.
         self.processed_seq = self.processed_seq.wrapping_add(drained) & SUBMISSION_SEQ_MASK;
 
-        let at_sq_capacity = sq.is_full();
+        let at_sq_capacity = submission_queue.is_full();
         let at_waiter_capacity = self.waiters.len() == self.cfg.size as usize;
         let has_pending_work = !self.ready_queue.is_empty() || !self.pending_cancels.is_empty();
 

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -494,6 +494,7 @@ impl IoUringLoop {
                 self.handle_cqe(cqe);
             }
 
+            // Process due deadlines before staging new submissions so timed-out
             // requests move to cancellation promptly and free capacity sooner.
             self.advance_timeouts();
 

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -932,18 +932,6 @@ fn new_ring(cfg: &Config) -> Result<IoUring, std::io::Error> {
     builder.build(cfg.size)
 }
 
-/// Returns whether some result should be retried due to a transient error.
-///
-/// Errors considered transient:
-/// * EAGAIN: There is no data ready. Try again later.
-/// * EWOULDBLOCK: Operation would block.
-/// * EINTR: A signal interrupted the operation before any data was transferred.
-pub const fn should_retry(return_value: i32) -> bool {
-    return_value == -libc::EAGAIN
-        || return_value == -libc::EWOULDBLOCK
-        || return_value == -libc::EINTR
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -979,19 +967,6 @@ mod tests {
         };
         let (_, iouring) = IoUringLoop::new(cfg, &mut registry);
         assert_eq!(iouring.cfg.size, 1_024);
-    }
-
-    #[test]
-    fn test_should_retry_classification() {
-        // Transient retryable codes.
-        for code in [-libc::EAGAIN, -libc::EWOULDBLOCK, -libc::EINTR] {
-            assert!(should_retry(code));
-        }
-
-        // Non-transient examples.
-        for code in [0, -libc::EINVAL, -libc::ETIMEDOUT] {
-            assert!(!should_retry(code));
-        }
     }
 
     #[test]

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -60,7 +60,8 @@
 //! Requests can optionally carry an absolute deadline. When present:
 //! - The loop tracks deadline ticks in a userspace timing wheel
 //! - Already-expired requests complete immediately with timeout before SQE submission
-//! - In-flight requests that expire submit an async-cancel SQE
+//! - Requests that still have an SQE in flight submit an async-cancel SQE on expiry
+//! - Requests parked only in the ready queue time out locally without staging cancel SQEs
 //! - Timeouts apply to the whole logical request, not individual SQEs
 //! - If the original op CQE completes the whole request, the caller sees success
 //! - If the original op CQE only makes partial/retryable progress after timeout, the caller
@@ -166,8 +167,8 @@ pub use request::{ReadAtRequest, SyncRequest, WriteAtRequest};
 #[cfg(feature = "iouring-network")]
 pub use request::{RecvRequest, SendRequest};
 
-#[derive(Debug)]
 /// Tracks io_uring metrics.
+#[derive(Debug)]
 pub struct Metrics {
     /// Number of active logical requests whose CQEs haven't yet been fully
     /// processed. Note this metric doesn't include timeouts, which are
@@ -191,9 +192,9 @@ impl Metrics {
     }
 }
 
-#[derive(Clone, Debug)]
 /// Configuration for an io_uring instance.
 /// See `man io_uring`.
+#[derive(Clone, Debug)]
 pub struct Config {
     /// Requested size of the ring.
     ///
@@ -449,17 +450,19 @@ impl IoUringLoop {
     /// queue (timeout fired between requeue and staging), it is completed with
     /// a timeout error instead of issuing a follow-up SQE.
     fn stage_request(&mut self, waiter_id: WaiterId, sq: &mut SubmissionQueue<'_>) {
-        let Some((request, state)) = self.waiters.get_mut(waiter_id) else {
-            return;
-        };
-        if matches!(state, WaiterState::CancelRequested) {
-            // No in-flight SQE to cancel. Complete the request directly.
-            if let Some(request) = self.waiters.remove(waiter_id) {
-                request.finish_timeout();
+        let sqe = {
+            let Some((request, state)) = self.waiters.get_mut(waiter_id) else {
+                return;
+            };
+            if matches!(state, WaiterState::CancelRequested) {
+                // No in-flight SQE remains for ready-queue-only timeouts.
+                if let Some(request) = self.waiters.remove(waiter_id) {
+                    request.finish_timeout();
+                }
+                return;
             }
-            return;
-        }
-        let sqe = request.build_sqe(waiter_id);
+            request.build_sqe(waiter_id)
+        };
         // SAFETY:
         // - All resources are stored in `self.waiters` until CQE processing, so
         //   SQE pointers remain valid and FD numbers cannot be reused early.
@@ -467,6 +470,8 @@ impl IoUringLoop {
         unsafe {
             sq.push(&sqe).expect("unable to push to queue");
         }
+        let marked = self.waiters.mark_in_flight(waiter_id);
+        assert!(marked, "staged request missing from waiter table");
     }
 
     /// Stage requeued requests from `ready_queue` in FIFO order.
@@ -568,6 +573,12 @@ impl IoUringLoop {
             let Some(waiter_id) = self.pending_cancels.pop_front() else {
                 return false;
             };
+            // `pending_cancels` only contains cancel-requested waiters. If the
+            // waiter no longer has an SQE in flight, there is nothing left for
+            // the kernel to cancel.
+            if !self.waiters.is_in_flight(waiter_id) {
+                continue;
+            }
 
             let cancel = AsyncCancel::new(waiter_id.user_data())
                 .build()
@@ -656,7 +667,9 @@ impl IoUringLoop {
             if self.waiters.cancel(entry.waiter_id) {
                 // Once cancel is requested, this waiter is no longer deadline-active.
                 self.timeout_wheel.remove(entry.target_tick);
-                self.pending_cancels.push_back(entry.waiter_id);
+                if self.waiters.is_in_flight(entry.waiter_id) {
+                    self.pending_cancels.push_back(entry.waiter_id);
+                }
             }
         }
     }
@@ -874,6 +887,7 @@ mod tests {
 
     #[test]
     fn test_submit_and_wait_non_etime_error_is_not_misclassified() {
+        // Verify `submit_and_wait` only treats `ETIME` as the bounded-wait timeout case.
         let cfg = Config::default();
         let mut registry = Registry::default();
         let (_submitter, iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
@@ -893,7 +907,24 @@ mod tests {
     }
 
     #[test]
+    fn test_new_ring_iopoll_builder_path_is_exercised() {
+        // Verify the optional IOPOLL builder branch is reachable even on hosts
+        // where the kernel rejects the resulting configuration.
+        let cfg = Config {
+            io_poll: true,
+            ..Default::default()
+        };
+
+        match new_ring(&cfg) {
+            Ok(_ring) => {}
+            Err(err) => assert!(err.raw_os_error().is_some()),
+        }
+    }
+
+    #[test]
     fn test_fill_submission_queue_returns_true_when_cancel_staging_fills_sq() {
+        // Verify cancel staging reports SQ saturation so the loop drains completions
+        // before trying to enqueue more work.
         let cfg = Config {
             size: 8,
             ..Default::default()
@@ -919,6 +950,7 @@ mod tests {
                 iouring.waiters.cancel(waiter_id),
                 "cancel should transition waiter to cancel-requested"
             );
+            assert!(iouring.waiters.mark_in_flight(waiter_id));
             iouring.pending_cancels.push_back(waiter_id);
         }
 
@@ -930,8 +962,87 @@ mod tests {
         assert!(!iouring.pending_cancels.is_empty());
     }
 
+    #[test]
+    fn test_fill_submission_queue_returns_true_when_ready_staging_fills_sq() {
+        // Verify requeued work can also saturate the SQ and force the loop to
+        // return early with ready-queue work still pending.
+        let cfg = Config {
+            size: 8,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        // Leave wake rearm enabled so the wake poll consumes one SQE and the
+        // ready queue cannot fully drain in a single staging pass.
+        for _ in 0..cfg.size as usize {
+            let (sock_left, _sock_right) =
+                UnixStream::pair().expect("failed to create unix socket pair");
+            // SAFETY: sock_left is a valid fd that we own.
+            let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+            let (tx, _rx) = oneshot::channel();
+            let request = ActiveRequest::from_request(Request::Sync(SyncRequest {
+                file: Arc::new(file),
+                sender: tx,
+            }));
+            let waiter_id = iouring.waiters.insert(request, None);
+            iouring.ready_queue.push_back(waiter_id);
+        }
+
+        let at_capacity = iouring
+            .fill_submission_queue(&mut ring)
+            .expect("channel should remain connected");
+
+        assert!(at_capacity);
+        assert!(!iouring.ready_queue.is_empty());
+    }
+
+    #[test]
+    fn test_fill_submission_queue_skips_cancel_for_ready_queue_timeout() {
+        // Verify pending cancel entries are discarded once the waiter no longer
+        // has an operation SQE in flight.
+        let cfg = Config::default();
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        // Keep the test focused on cancel staging instead of wake rearm.
+        iouring.wake_rearm_needed = false;
+
+        // Insert a waiter that is already marked cancel-requested but was never
+        // staged, matching the "timed out while parked in ready_queue" shape.
+        let (sock_left, _sock_right) =
+            UnixStream::pair().expect("failed to create unix socket pair");
+        // SAFETY: sock_left is a valid fd that we own.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+        let (tx, _rx) = oneshot::channel();
+        let request = ActiveRequest::from_request(Request::Sync(SyncRequest {
+            file: Arc::new(file),
+            sender: tx,
+        }));
+        let waiter_id = iouring.waiters.insert(request, None);
+        assert!(iouring.waiters.cancel(waiter_id));
+        iouring.pending_cancels.push_back(waiter_id);
+
+        let at_capacity = iouring
+            .fill_submission_queue(&mut ring)
+            .expect("channel should remain connected");
+
+        // No cancel SQE should be staged because there is no in-flight op left to cancel.
+        assert!(!at_capacity);
+        assert!(iouring.pending_cancels.is_empty());
+        assert_eq!(ring.submission().len(), 0);
+        let (_, state) = iouring
+            .waiters
+            .get_mut(waiter_id)
+            .expect("waiter should still be present");
+        assert!(matches!(state, WaiterState::CancelRequested));
+    }
+
     #[tokio::test]
     async fn test_fill_submission_queue_expired_deadline_completes_immediately() {
+        // Verify already-expired requests are completed locally instead of being staged.
         let cfg = Config::default();
         let mut registry = Registry::default();
         let (submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
@@ -971,6 +1082,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout_slot_reuse_does_not_cancel_new_waiter_early() {
+        // Verify stale timeout-wheel entries from an earlier generation do not
+        // cancel a newly inserted waiter that reused the same slot.
         let cfg = Config {
             // Keep ring size realistic; size=1 can deadlock progress in some setups.
             // Waiter slot reuse is still exercised because we complete op1 before op2.
@@ -987,7 +1100,6 @@ mod tests {
         // leaving a stale timeout entry that should be ignored later after slot reuse.
         let (left1, right1) = UnixStream::pair().unwrap();
         // Write a byte so the recv completes immediately.
-        use std::io::Write;
         (&right1).write_all(&[42]).unwrap();
 
         let (tx1, rx1) = oneshot::channel();
@@ -995,7 +1107,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left1.into()),
                 buf: IoBufMut::with_capacity(1),
-                len: 1,
+                target_len: 1,
                 received: 0,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(200)),
@@ -1017,7 +1129,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left2.into()),
                 buf: IoBufMut::with_capacity(8),
-                len: 8,
+                target_len: 8,
                 received: 0,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(80)),
@@ -1043,7 +1155,60 @@ mod tests {
     }
 
     #[test]
+    fn test_stage_request_ignores_stale_ready_queue_entry() {
+        // Verify stale ready-queue ids are ignored if the slot was already
+        // removed and reused before the requeue entry is revisited.
+        let cfg = Config::default();
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        // Create and remove one waiter so the ready queue can later point at a stale generation.
+        let (sock_left, _sock_right) = UnixStream::pair().unwrap();
+        // SAFETY: sock_left is a valid fd that we own.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+        let (tx, _rx) = oneshot::channel();
+        let stale = iouring.waiters.insert(
+            ActiveRequest::from_request(Request::Sync(SyncRequest {
+                file: Arc::new(file),
+                sender: tx,
+            })),
+            None,
+        );
+        let _ = iouring
+            .waiters
+            .remove(stale)
+            .expect("missing original waiter");
+
+        // Reuse the same slot with a new generation to prove `stage_request`
+        // matches on the full waiter id, not just the slot index.
+        let (sock_left, _sock_right) = UnixStream::pair().unwrap();
+        // SAFETY: sock_left is a valid fd that we own.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+        let (tx, _rx) = oneshot::channel();
+        let reused = iouring.waiters.insert(
+            ActiveRequest::from_request(Request::Sync(SyncRequest {
+                file: Arc::new(file),
+                sender: tx,
+            })),
+            None,
+        );
+        assert_eq!(reused.index(), stale.index());
+        assert_ne!(reused, stale);
+
+        {
+            let mut sq = ring.submission();
+            iouring.stage_request(stale, &mut sq);
+        }
+
+        // The stale entry should be ignored without disturbing the live waiter.
+        assert_eq!(ring.submission().len(), 0);
+        assert!(!iouring.waiters.is_in_flight(reused));
+    }
+
+    #[test]
     fn test_advance_timeouts_ignores_stale_entry_after_slot_reuse() {
+        // Verify timeout-wheel advancement ignores stale entries from a reused waiter slot.
         let cfg = Config {
             max_request_timeout: Duration::from_millis(100),
             ..Default::default()
@@ -1089,6 +1254,7 @@ mod tests {
         }));
         let slot_index = iouring.waiters.insert(req, Some(3));
         assert_eq!(slot_index.index(), old_slot.index());
+        assert!(iouring.waiters.mark_in_flight(slot_index));
         iouring.timeout_wheel.schedule(slot_index, 3);
 
         // At tick 1, only the stale old entry should expire. The new waiter must
@@ -1104,27 +1270,57 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_wake_cqe_rearms_after_multishot_termination() {
+        // Verify a wake CQE without the multishot `more` flag requests a poll
+        // reinstallation for the next staging pass.
+        let cfg = Config::default();
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg, &mut registry);
+        iouring.wake_rearm_needed = false;
+
+        #[repr(C)]
+        struct RawCqe {
+            user_data: u64,
+            res: i32,
+            flags: u32,
+        }
+
+        // SAFETY: `CqueueEntry` is a `repr(C)` newtype over the same 16-byte CQE
+        // layout: `user_data`, `res`, and `flags`.
+        let cqe = unsafe {
+            std::mem::transmute::<RawCqe, CqueueEntry>(RawCqe {
+                user_data: WAKE_USER_DATA,
+                res: 1,
+                flags: 0,
+            })
+        };
+        iouring.handle_cqe(cqe);
+        assert!(iouring.wake_rearm_needed);
+    }
+
+    #[test]
     fn test_cancel_completion_returns_saved_op_result() {
+        // Verify a successful operation CQE still wins if it races with a timeout cancel.
         let cfg = Config::default();
         let mut registry = Registry::default();
         let (_submitter, mut iouring) = IoUringLoop::new(cfg, &mut registry);
 
         let (left, right) = UnixStream::pair().unwrap();
         // Write data so a recv would succeed.
-        use std::io::Write;
         (&right).write_all(b"hello").unwrap();
 
         let (tx, rx) = oneshot::channel();
         let req = ActiveRequest::from_request(Request::Recv(RecvRequest {
             fd: Arc::new(left.into()),
             buf: IoBufMut::with_capacity(5),
-            len: 5,
+            target_len: 5,
             received: 0,
             exact: false,
             deadline: Some(Instant::now() + Duration::from_secs(1)),
             sender: tx,
         }));
         let slot_index = iouring.waiters.insert(req, Some(2));
+        assert!(iouring.waiters.mark_in_flight(slot_index));
         assert!(
             iouring.waiters.cancel(slot_index),
             "cancel should transition active waiter"
@@ -1162,7 +1358,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_wake_path_progress_scenarios() {
-        for _ in [true, false] {
+        // Run both wake-path variants: one with strict success assertions and
+        // one that only checks for forward progress without inspecting results.
+        for should_succeed in [true, false] {
             let cfg = Config::default();
             let mut registry = Registry::default();
             let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
@@ -1176,7 +1374,7 @@ mod tests {
                 .send(Request::Recv(RecvRequest {
                     fd: Arc::new(left_pipe.into()),
                     buf: IoBufMut::with_capacity(5),
-                    len: 5,
+                    target_len: 5,
                     received: 0,
                     exact: false,
                     deadline: None,
@@ -1198,12 +1396,20 @@ mod tests {
                 .expect("failed to send send");
 
             let timeout = tokio::time::timeout(Duration::from_secs(2), async {
-                let (_, recv_result) = recv_rx.await.expect("missing recv result");
-                assert!(recv_result.unwrap() > 0);
-                let send_result = send_rx.await.expect("missing send result");
-                assert!(send_result.is_ok());
+                if should_succeed {
+                    let (_, recv_result) = recv_rx.await.expect("missing recv result");
+                    assert!(recv_result.unwrap() > 0);
+                    let send_result = send_rx.await.expect("missing send result");
+                    assert!(send_result.is_ok());
+                } else {
+                    let _ = recv_rx.await;
+                    let _ = send_rx.await;
+                }
             });
-            assert!(timeout.await.is_ok(), "wake path test timed out");
+            assert!(
+                timeout.await.is_ok(),
+                "wake path test timed out (should_succeed={should_succeed})"
+            );
 
             drop(submitter);
             handle.join().unwrap();
@@ -1212,6 +1418,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_timeout() {
+        // Verify a timed recv completes with timeout once its deadline expires.
         let cfg = Config {
             max_request_timeout: Duration::from_secs(1),
             ..Default::default()
@@ -1227,7 +1434,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                len: 8,
+                target_len: 8,
                 received: 0,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_secs(1)),
@@ -1245,6 +1452,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_no_timeout() {
+        // Verify shutdown waits for the last in-flight request when no cutoff is configured.
         let cfg = Config {
             shutdown_timeout: None,
             ..Default::default()
@@ -1277,6 +1485,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_no_timeout_continues_deadline_processing() {
+        // Verify shutdown-without-cutoff still advances deadlines until timed requests resolve.
         let cfg = Config {
             max_request_timeout: Duration::from_millis(250),
             timeout_wheel_tick: Duration::from_millis(5),
@@ -1293,7 +1502,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                len: 8,
+                target_len: 8,
                 received: 0,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(50)),
@@ -1314,6 +1523,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_timeout() {
+        // Verify a bounded shutdown abandons requests that never complete.
         let cfg = Config {
             shutdown_timeout: Some(Duration::from_secs(1)),
             ..Default::default()
@@ -1329,7 +1539,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                len: 8,
+                target_len: 8,
                 received: 0,
                 exact: false,
                 deadline: None,
@@ -1353,6 +1563,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_timeout_preserves_deadline_result() {
+        // Verify a bounded shutdown still lets an already-expiring request report timeout
+        // when the deadline wins the race against the shutdown cutoff.
         let cfg = Config {
             max_request_timeout: Duration::from_millis(250),
             timeout_wheel_tick: Duration::from_millis(5),
@@ -1369,7 +1581,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                len: 8,
+                target_len: 8,
                 received: 0,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(50)),
@@ -1390,6 +1602,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_timeout_abandons_timed_op_after_cutoff() {
+        // Verify a bounded shutdown abandons even deadline-bearing requests
+        // once the shutdown cutoff expires before the request deadline.
         let cfg = Config {
             max_request_timeout: Duration::from_millis(750),
             timeout_wheel_tick: Duration::from_millis(5),
@@ -1406,7 +1620,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
-                len: 8,
+                target_len: 8,
                 received: 0,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(500)),
@@ -1415,10 +1629,14 @@ mod tests {
             .await
             .unwrap();
 
+        // Trigger shutdown well before the request deadline so shutdown, not
+        // deadline processing, is responsible for completing the test.
         // Give the loop a chance to submit the long-running op before shutdown.
         tokio::time::sleep(Duration::from_millis(10)).await;
         drop(submitter);
 
+        // The request should be abandoned once shutdown times out, which drops
+        // the oneshot sender instead of returning a logical timeout result.
         let err = tokio::time::timeout(Duration::from_secs(2), rx)
             .await
             .expect("shutdown abandonment timed out")
@@ -1429,6 +1647,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_deadline_timeout_ensure_enough_capacity() {
+        // Verify timed requests are still drained correctly when timeout-driven
+        // cancel traffic exceeds the ring's SQ capacity in a single pass.
         let cfg = Config {
             size: 8,
             max_request_timeout: Duration::from_millis(50),
@@ -1451,7 +1671,7 @@ mod tests {
                 .send(Request::Recv(RecvRequest {
                     fd: Arc::new(left.into()),
                     buf: IoBufMut::with_capacity(8),
-                    len: 8,
+                    target_len: 8,
                     received: 0,
                     exact: false,
                     deadline: Some(deadline),
@@ -1497,7 +1717,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left.into()),
                 buf: IoBufMut::with_capacity(total),
-                len: total,
+                target_len: total,
                 received: 0,
                 exact: true,
                 deadline: None,
@@ -1507,7 +1727,6 @@ mod tests {
             .unwrap();
 
         // Write data in two chunks so the recv must make partial progress.
-        use std::io::Write;
         (&right).write_all(&[1u8; 40]).unwrap();
         tokio::time::sleep(Duration::from_millis(20)).await;
         (&right).write_all(&[2u8; 60]).unwrap();
@@ -1524,6 +1743,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_no_timeout_processes_ready_queue() {
+        // Verify shutdown draining continues staging ready-queue work until a partially
+        // completed logical request reaches its terminal result.
         let cfg = Config {
             shutdown_timeout: None,
             ..Default::default()
@@ -1547,7 +1768,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left.into()),
                 buf: IoBufMut::with_capacity(total),
-                len: total,
+                target_len: total,
                 received: 0,
                 exact: true,
                 deadline: None,
@@ -1605,7 +1826,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(left.into()),
                 buf: IoBufMut::with_capacity(100),
-                len: 100,
+                target_len: 100,
                 received: 0,
                 exact: true,
                 deadline: Some(Instant::now() + Duration::from_millis(80)),
@@ -1616,7 +1837,6 @@ mod tests {
 
         // Write partial data so the recv makes progress and gets requeued,
         // then let the deadline expire before sending the rest.
-        use std::io::Write;
         (&right).write_all(&[1u8; 10]).unwrap();
 
         let (_, result) = tokio::time::timeout(Duration::from_secs(5), rx)
@@ -1632,8 +1852,130 @@ mod tests {
         handle.join().unwrap();
     }
 
+    #[test]
+    fn test_ready_queue_timeout_skips_cancel_staging() {
+        // Verify timeout processing does not enqueue AsyncCancel for requests
+        // that already retired their last SQE and are only waiting in ready_queue.
+        let cfg = Config {
+            max_request_timeout: Duration::from_millis(100),
+            timeout_wheel_tick: Duration::from_millis(5),
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg, &mut registry);
+
+        let (left, _right) = UnixStream::pair().unwrap();
+        let (tx, _rx) = oneshot::channel();
+        let request = ActiveRequest::from_request(Request::Recv(RecvRequest {
+            fd: Arc::new(left.into()),
+            buf: IoBufMut::with_capacity(8),
+            target_len: 8,
+            received: 0,
+            exact: true,
+            deadline: Some(Instant::now() + Duration::from_millis(25)),
+            sender: tx,
+        }));
+        let waiter_id = iouring.waiters.insert(request, Some(1));
+        assert!(iouring.waiters.mark_in_flight(waiter_id));
+        iouring.timeout_wheel.schedule(waiter_id, 1);
+
+        // Simulate a short recv CQE so the logical request requeues itself but
+        // no longer has a kernel op outstanding.
+        let (request, state, waiter_id) = iouring
+            .waiters
+            .on_cqe(waiter_id.user_data(), 4)
+            .expect("missing partial recv completion");
+        assert!(matches!(request.on_cqe(state, 4), CqeAction::Requeue));
+        iouring.ready_queue.push_back(waiter_id);
+
+        std::thread::sleep(iouring.cfg.timeout_wheel_tick + Duration::from_millis(2));
+        iouring.advance_timeouts();
+
+        // Timeout should mark the waiter canceled locally without staging `AsyncCancel`.
+        assert!(iouring.pending_cancels.is_empty());
+        let (_, state) = iouring
+            .waiters
+            .get_mut(waiter_id)
+            .expect("ready-queue waiter should remain tracked");
+        assert!(matches!(state, WaiterState::CancelRequested));
+    }
+
+    #[test]
+    fn test_drain_breaks_after_local_ready_queue_timeout_finishes_last_waiter() {
+        // Verify shutdown drain exits immediately once ready-queue staging
+        // finishes the final waiter locally instead of restaging another SQE.
+        let cfg = Config {
+            shutdown_timeout: None,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+        iouring.wake_rearm_needed = false;
+
+        // Seed drain with exactly one waiter that is already canceled and only
+        // remains in the ready queue.
+        let (tx, rx) = oneshot::channel();
+        let waiter_id = iouring.waiters.insert(
+            ActiveRequest::from_request(Request::Send(SendRequest {
+                fd: Arc::new(UnixStream::pair().unwrap().0.into()),
+                bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
+                deadline: Some(Instant::now() + Duration::from_secs(1)),
+                sender: tx,
+            })),
+            Some(1),
+        );
+        assert!(iouring.waiters.cancel(waiter_id));
+        iouring.ready_queue.push_back(waiter_id);
+
+        iouring.drain(&mut ring);
+
+        // Drain should finish the waiter locally and exit without staging more SQEs.
+        assert!(iouring.waiters.is_empty());
+        assert_eq!(ring.submission().len(), 0);
+        let result = futures::executor::block_on(rx).expect("missing timeout completion");
+        assert!(matches!(result, Err(crate::Error::Timeout)));
+    }
+
+    #[tokio::test]
+    async fn test_fill_submission_queue_completes_cancelled_ready_queue_entry_locally() {
+        // Verify a cancel-requested waiter parked in the ready queue completes
+        // immediately with timeout instead of restaging another SQE.
+        let cfg = Config::default();
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        // Keep the test focused on ready-queue staging instead of wake rearm.
+        iouring.wake_rearm_needed = false;
+
+        // Insert a canceled waiter whose next transition should be a local timeout completion.
+        let (tx, rx) = oneshot::channel();
+        let request = ActiveRequest::from_request(Request::Send(SendRequest {
+            fd: Arc::new(UnixStream::pair().unwrap().0.into()),
+            bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
+            deadline: Some(Instant::now() + Duration::from_secs(1)),
+            sender: tx,
+        }));
+        let waiter_id = iouring.waiters.insert(request, Some(1));
+        assert!(iouring.waiters.cancel(waiter_id));
+        iouring.ready_queue.push_back(waiter_id);
+
+        let at_capacity = iouring
+            .fill_submission_queue(&mut ring)
+            .expect("channel should remain connected");
+
+        // Ready-queue staging should retire the waiter locally and leave the SQ untouched.
+        assert!(!at_capacity);
+        assert!(iouring.waiters.remove(waiter_id).is_none());
+        assert_eq!(ring.submission().len(), 0);
+        let result = rx.await.expect("missing timeout completion");
+        assert!(matches!(result, Err(crate::Error::Timeout)));
+    }
+
     #[tokio::test]
     async fn test_single_issuer() {
+        // Verify SINGLE_ISSUER still allows normal request submission and completion.
         let cfg = Config {
             single_issuer: true,
             ..Default::default()
@@ -1655,7 +1997,7 @@ mod tests {
             .send(Request::Recv(RecvRequest {
                 fd: Arc::new(sock_left.into()),
                 buf: IoBufMut::with_capacity(5),
-                len: 5,
+                target_len: 5,
                 received: 0,
                 exact: true,
                 deadline: None,

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -1,10 +1,10 @@
 //! io_uring event loop implementation.
 //!
-//! This module provides a high-level interface for submitting operations to Linux's io_uring
+//! This module provides a high-level interface for submitting logical requests to Linux's io_uring
 //! subsystem and receiving their results. The design centers around a single event loop that
 //! manages the submission queue (SQ) and completion queue (CQ) of an io_uring instance.
 //!
-//! Work is submitted via [Submitter], which pushes operations into an MPSC queue and signals
+//! Work is submitted via [Submitter], which pushes [Request]s into an MPSC queue and signals
 //! an internal `eventfd` wake source. The event loop blocks in `io_uring_enter` and is woken by:
 //! - normal CQE progress in the ring
 //! - `eventfd` readiness when new work is queued or all submitters are dropped
@@ -24,47 +24,46 @@
 //!
 //! The core of this implementation is [IoUringLoop::run], which blocks its calling thread while
 //! operating an event loop that:
-//! 1. Drains operation requests from a bounded MPSC channel fed by [Submitter]
-//! 2. Assigns unique IDs to each operation and submits them to io_uring's submission queue (SQE)
+//! 1. Drains logical requests from a bounded MPSC channel fed by [Submitter]
+//! 2. Admits requests into the waiter table and submits their first SQE
 //! 3. Processes io_uring completion queue entries (CQEs), including internal wake CQEs
-//! 4. Routes completion results back to the original requesters via oneshot channels
+//! 4. Handles partial progress and retryable errors by requeuing requests
+//! 5. Routes typed completion results back to the original requesters via oneshot channels
 //!
-//! ## Operation Flow
+//! ## Request Flow
 //!
 //! ```text
 //! Data path:
 //!   Client task -> Submitter -> bounded MPSC -> IoUringLoop -> SQE -> io_uring
-//!   Client task <- oneshot <- IoUringLoop <- CQE <- io_uring
+//!   Client task <- typed oneshot <- IoUringLoop <- CQE <- io_uring
 //!
 //! Wake path:
 //!   Submitter --write(eventfd)--> wake_fd --POLLIN CQE (WAKE_USER_DATA)--> IoUringLoop
 //!
 //! Loop behavior:
 //!   1) Drain CQEs.
-//!   2) Drain MPSC and stage SQEs.
-//!   3) Submit and block in io_uring_enter until a CQE (data or wake) arrives.
+//!   2) Advance timeouts.
+//!   3) Stage cancels, ready requests, then new inbound requests into SQ.
+//!   4) Submit and block in io_uring_enter until a CQE (data or wake) arrives.
 //! ```
 //!
 //! ## Work Tracking
 //!
-//! Each submitted operation is assigned a waiter id that serves as the
-//! `user_data` field in the SQE. The event loop maintains a flat `Waiters` store where
-//! each slot maps to:
-//! - A oneshot sender for returning results to the caller
-//! - An optional buffer that must be kept alive for the duration of the operation
-//! - An optional FD handle to prevent descriptor reuse while the operation is in flight
-//! - Timeout lifecycle state for deadline tracking and cancellation
+//! Each admitted request is assigned a waiter id that serves as the `user_data` field in its
+//! SQEs. The event loop maintains a flat `Waiters` store where each slot maps to an
+//! [ActiveRequest] that owns all resources (buffers, FDs, progress state, completion sender)
+//! needed for the request's lifetime.
 //!
 //! ## Timeout Handling
 //!
-//! Operations can optionally carry an absolute deadline via [Op::deadline]. When present:
+//! Requests can optionally carry an absolute deadline. When present:
 //! - The loop tracks deadline ticks in a userspace timing wheel
-//! - Already-expired operations complete immediately with `ETIMEDOUT` before SQE submission
-//! - In-flight operations that expire submit an async-cancel SQE
-//! - A timed-out waiter is removed only after both original-op and cancel CQEs arrive
-//! - If the original op CQE result is `ECANCELED`, the caller sees `ETIMEDOUT`
-//! - If the original op CQE result arrives before cancel completion, that original
-//!   result is returned
+//! - Already-expired requests complete immediately with timeout before SQE submission
+//! - In-flight requests that expire submit an async-cancel SQE
+//! - Timeouts apply to the whole logical request, not individual SQEs
+//! - If the original op CQE completes the whole request, the caller sees success
+//! - If the original op CQE only makes partial/retryable progress after timeout, the caller
+//!   sees timeout and no follow-up SQE is issued
 //!
 //! ## Wake Handling
 //!
@@ -77,21 +76,21 @@
 //!
 //! ## Shutdown Process
 //!
-//! When the operation channel closes, the event loop enters a drain phase:
-//! 1. Stops accepting new operations
-//! 2. Waits for all in-flight operations to complete or be cancelled
-//! 3. If `shutdown_timeout` is configured, abandons remaining operations after the timeout
+//! When the request channel closes, the event loop enters a drain phase:
+//! 1. Stops accepting new requests
+//! 2. Waits for all in-flight requests to complete or be cancelled
+//! 3. If `shutdown_timeout` is configured, abandons remaining requests after the timeout
 //! 4. Cleans up and exits. Dropping the last submitter signals `eventfd` so shutdown is observed
 //!    promptly even if the loop is blocked.
 //!
 //! ## Liveness Model
 //!
-//! This loop enforces a configured upper bound on in-flight operations, and submissions are staged
+//! This loop enforces a configured upper bound on in-flight requests, and submissions are staged
 //! from a FIFO MPSC queue.
 //!
-//! This implies a bounded-liveness caveat: if all in-flight operations are waiting on operations
+//! This implies a bounded-liveness caveat: if all in-flight requests are waiting on operations
 //! that are still queued behind the capacity limit, the loop cannot make progress until some
-//! in-flight operation completes or is canceled.
+//! in-flight request completes or is canceled.
 //!
 //! Concrete example with `cfg.size = 2`:
 //!
@@ -103,138 +102,60 @@
 //!    cannot free capacity on its own.
 //!
 //! The runtime cannot infer dependency relationships between arbitrary queued and in-flight
-//! operations, so it cannot implement dependency-aware admission (and doing so generically would
+//! requests, so it cannot implement dependency-aware admission (and doing so generically would
 //! add substantial overhead).
 //!
-//! The practical way to recover from this condition is cancellation via per-op timeouts. When
-//! timed-out in-flight operations are canceled, waiter capacity is eventually released and queued
-//! operations can be staged. Without cancellation, liveness depends on workload structure: callers
-//! must avoid submission patterns where in-flight operations require later queued operations to
-//! run.
+//! The practical way to recover from this condition is cancellation via per-request timeouts.
+//! When timed-out in-flight requests are canceled, waiter capacity is eventually released and
+//! queued requests can be staged. Without cancellation, liveness depends on workload structure:
+//! callers must avoid submission patterns where in-flight requests require later queued requests
+//! to run.
 //!
 //! Operational guidance:
-//! - Workloads that may create causal dependencies across queued and in-flight operations must use
-//!   per-op timeouts.
-//! - If cancellation is disabled, callers must guarantee that in-flight operations never depend on
-//!   later queued operations, otherwise the loop can deadlock.
+//! - Workloads that may create causal dependencies across queued and in-flight requests must use
+//!   per-request timeouts.
+//! - If cancellation is disabled, callers must guarantee that in-flight requests never depend on
+//!   later queued requests, otherwise the loop can deadlock.
 
-use crate::{IoBuf, IoBufMut, IoBufs};
-use commonware_utils::channel::{
-    mpsc::{self, error::TryRecvError},
-    oneshot,
-};
+use commonware_utils::channel::mpsc::{self, error::TryRecvError};
 use io_uring::{
     cqueue::Entry as CqueueEntry,
     opcode::AsyncCancel,
-    squeue::{Entry as SqueueEntry, SubmissionQueue},
+    squeue::SubmissionQueue,
     types::{SubmitArgs, Timespec},
     IoUring,
 };
 use prometheus_client::{metrics::gauge::Gauge, registry::Registry};
+use request::{ActiveRequest, CqeAction, Request};
 use std::{
     collections::VecDeque,
-    fs::File,
-    os::fd::OwnedFd,
     sync::Arc,
     time::{Duration, Instant},
 };
 
+mod request;
 mod timeout;
 use timeout::{Tick, TimeoutWheel};
 mod waiter;
-use waiter::{CompletedWaiter, WaiterId, Waiters};
+use waiter::{WaiterId, WaiterState, Waiters};
 mod waker;
 use waker::{Waker, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
 
 /// Packed `io_uring` `user_data` value.
-pub type UserData = u64;
+type UserData = u64;
 
-/// Buffer for io_uring operations.
-///
-/// The variant must match the operation type:
-/// - `Read`: For operations where the kernel writes INTO the buffer (e.g., recv, read)
-/// - `Write`: For operations where the kernel reads FROM a single contiguous buffer (e.g., send, write)
-/// - `WriteVectored`: For operations where the kernel reads FROM multiple buffers (e.g., writev)
-#[derive(Debug)]
-pub enum OpBuffer {
-    /// Buffer for read operations - kernel writes into this.
-    Read(IoBufMut),
-    /// Buffer for write operations - kernel reads from this.
-    Write(IoBuf),
-    /// Buffers for vectored write operations - kernel reads from these.
-    WriteVectored(IoBufs),
-}
-
-impl From<IoBufMut> for OpBuffer {
-    fn from(buf: IoBufMut) -> Self {
-        Self::Read(buf)
-    }
-}
-
-impl From<IoBuf> for OpBuffer {
-    fn from(buf: IoBuf) -> Self {
-        Self::Write(buf)
-    }
-}
-
-impl From<IoBufs> for OpBuffer {
-    fn from(bufs: IoBufs) -> Self {
-        Self::WriteVectored(bufs)
-    }
-}
-
-/// File descriptor for io_uring operations.
-///
-/// The variant must match the descriptor type:
-/// - `Fd`: For network sockets and other OS file descriptors
-/// - `File`: For file-backed descriptors
-pub enum OpFd {
-    /// A socket or other OS file descriptor.
-    ///
-    /// NOTE: this is only used by the network backend, hence the allow dead
-    /// code. The field itself is never read regardless, since this only exists
-    /// to keep the FD alive until operation completion.
-    #[cfg_attr(not(feature = "iouring-network"), allow(dead_code))]
-    Fd(#[allow(dead_code)] Arc<OwnedFd>),
-    /// A file-backed descriptor.
-    ///
-    /// NOTE: this is only used by the storage backend, hence the allow dead
-    /// code. The field itself is never read regardless, since this only exists
-    /// to keep the FD alive until operation completion.
-    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
-    File(#[allow(dead_code)] Arc<File>),
-}
-
-/// Owned iovecs that back a vectored io_uring operation.
-///
-/// This wrapper allows transferring iovec arrays through channels while keeping
-/// the pointed-to buffer memory alive through [`OpBuffer`].
-///
-/// The field is never read directly, since this only exists to keep the iovecs
-/// alive until operation completion.
-pub struct OpIovecs(#[allow(dead_code)] Box<[libc::iovec]>);
-
-impl OpIovecs {
-    pub const fn new(iovecs: Box<[libc::iovec]>) -> Self {
-        Self(iovecs)
-    }
-
-    pub fn as_ptr(&self) -> *const libc::iovec {
-        self.0.as_ptr()
-    }
-}
-
-// SAFETY: `OpIovecs` only carries raw iovec descriptors. The pointed-to memory
-// is owned by `OpBuffer` and retained for the operation lifetime by the
-// io_uring waiter map.
-unsafe impl Send for OpIovecs {}
+pub use request::Request as IoUringRequest;
+#[cfg(feature = "iouring-storage")]
+pub use request::{ReadAtRequest, SyncRequest, WriteAtRequest};
+#[cfg(feature = "iouring-network")]
+pub use request::{RecvRequest, SendRequest};
 
 #[derive(Debug)]
 /// Tracks io_uring metrics.
 pub struct Metrics {
-    /// Number of operations submitted to the io_uring whose CQEs haven't
-    /// yet been processed. Note this metric doesn't include timeouts,
-    /// which are generated internally by the io_uring event loop.
+    /// Number of active logical requests whose CQEs haven't yet been fully
+    /// processed. Note this metric doesn't include timeouts, which are
+    /// generated internally by the io_uring event loop.
     /// This is updated in the main loop and at shutdown drain exit, so it may
     /// temporarily vary from the exact in-flight count between update points.
     pending_operations: Gauge,
@@ -247,7 +168,7 @@ impl Metrics {
         };
         registry.register(
             "pending_operations",
-            "Number of operations submitted to the io_uring whose CQEs haven't yet been processed",
+            "Number of active logical requests in the io_uring loop",
             metrics.pending_operations.clone(),
         );
         metrics
@@ -275,16 +196,16 @@ pub struct Config {
     /// `single_issuer` when `run` is executed on a dedicated thread.
     /// See IORING_SETUP_SINGLE_ISSUER in <https://man7.org/linux/man-pages/man2/io_uring_setup.2.html>.
     pub single_issuer: bool,
-    /// Maximum operation timeout supported by the userspace timeout wheel.
+    /// Maximum request timeout supported by the userspace timeout wheel.
     ///
     /// Deadlines are clamped to this horizon. This value should be set to the
-    /// largest expected per-operation deadline budget.
-    pub max_op_timeout: Duration,
-    /// The maximum time the io_uring event loop will wait for in-flight operations
+    /// largest expected per-request deadline budget.
+    pub max_request_timeout: Duration,
+    /// The maximum time the io_uring event loop will wait for in-flight requests
     /// to complete before abandoning them during shutdown.
-    /// If None, the event loop will wait indefinitely for in-flight operations
+    /// If None, the event loop will wait indefinitely for in-flight requests
     /// to complete before shutting down. In this case, the caller should be careful
-    /// to ensure that the operations submitted to the io_uring will eventually complete.
+    /// to ensure that the requests submitted to the io_uring will eventually complete.
     pub shutdown_timeout: Option<Duration>,
     /// Tick granularity used by the userspace timeout wheel.
     ///
@@ -299,48 +220,15 @@ impl Default for Config {
             size: 128,
             io_poll: false,
             single_issuer: false,
-            max_op_timeout: Duration::from_secs(60),
+            max_request_timeout: Duration::from_secs(60),
             shutdown_timeout: None,
             timeout_wheel_tick: Duration::from_millis(5),
         }
     }
 }
 
-/// An operation submitted to [IoUringLoop], processed by [IoUringLoop::run].
-pub struct Op {
-    /// The submission queue entry to be submitted to the ring.
-    /// Its user data field will be overwritten. Users shouldn't rely on it.
-    pub work: SqueueEntry,
-    /// Sends the result of the operation and `buffer`.
-    pub sender: oneshot::Sender<(i32, Option<OpBuffer>)>,
-    /// Absolute deadline for this operation, if any.
-    ///
-    /// If present and the operation has not completed by this deadline, the
-    /// loop issues an async cancel SQE.
-    pub deadline: Option<Instant>,
-    /// The buffer used for the operation, if any.
-    /// - For reads: `OpBuffer::Read(IoBufMut)` - kernel writes into this
-    /// - For writes: `OpBuffer::Write(IoBuf)` - kernel reads from this
-    /// - For vectored writes: `OpBuffer::WriteVectored(IoBufs)` - kernel reads from these
-    /// - None for operations that don't use a buffer (e.g. sync, timeout)
-    ///
-    /// We hold the buffer(s) here so it's guaranteed to live until the operation
-    /// completes, preventing use-after-free issues.
-    pub buffer: Option<OpBuffer>,
-    /// The file descriptor used for the operation, if any.
-    ///
-    /// We hold the descriptor here so the OS cannot reuse the FD number
-    /// while the operation is queued or in-flight.
-    pub fd: Option<OpFd>,
-    /// Owned iovecs used by vectored operations, if any.
-    ///
-    /// We hold these iovecs here so they're guaranteed to live until the operation
-    /// completes, preventing use-after-free issues.
-    pub iovecs: Option<OpIovecs>,
-}
-
 struct SubmitterInner {
-    sender: Option<mpsc::Sender<Op>>,
+    sender: Option<mpsc::Sender<Request>>,
     waker: Waker,
 }
 
@@ -357,23 +245,23 @@ impl Drop for SubmitterInner {
     }
 }
 
-/// Handle for submitting operations to an [IoUringLoop].
+/// Handle for submitting requests to an [IoUringLoop].
 #[derive(Clone)]
 pub struct Submitter {
     inner: Arc<SubmitterInner>,
 }
 
 impl Submitter {
-    /// Submit an operation to the io_uring loop.
+    /// Submit a request to the io_uring loop.
     ///
     /// On success, this publishes one submission and conditionally rings the loop's
     /// `eventfd` wake source if sleep intent is armed.
-    pub async fn send(&self, op: Op) -> Result<(), mpsc::error::SendError<Op>> {
+    pub async fn send(&self, request: Request) -> Result<(), mpsc::error::SendError<Request>> {
         self.inner
             .sender
             .as_ref()
             .expect("submitter sender is only taken on drop")
-            .send(op)
+            .send(request)
             .await?;
 
         // Publish submission and ring eventfd only if loop sleep intent is armed.
@@ -387,23 +275,24 @@ impl Submitter {
 pub(crate) struct IoUringLoop {
     cfg: Config,
     metrics: Arc<Metrics>,
-    receiver: mpsc::Receiver<Op>,
+    receiver: mpsc::Receiver<Request>,
     waiters: Waiters,
+    ready_queue: VecDeque<WaiterId>,
+    pending_cancels: VecDeque<WaiterId>,
     timeout_wheel: TimeoutWheel,
     waker: Waker,
     wake_rearm_needed: bool,
     processed_seq: u64,
-    pending_cancels: VecDeque<WaiterId>,
 }
 
 impl IoUringLoop {
     /// Create a new io_uring loop and submit handle.
     ///
-    /// The loop allocates its own metrics, operation channel, and internal `eventfd` wake source.
+    /// The loop allocates its own metrics, request channel, and internal `eventfd` wake source.
     pub(crate) fn new(mut cfg: Config, registry: &mut Registry) -> (Submitter, Self) {
         assert!(
-            !cfg.max_op_timeout.is_zero(),
-            "max_op_timeout must be non-zero for timeout wheel"
+            !cfg.max_request_timeout.is_zero(),
+            "max_request_timeout must be non-zero for timeout wheel"
         );
         assert!(
             !cfg.timeout_wheel_tick.is_zero(),
@@ -417,8 +306,11 @@ impl IoUringLoop {
         let metrics = Arc::new(Metrics::new(registry));
         let (sender, receiver) = mpsc::channel(size);
         let waker = Waker::new().expect("unable to create wake eventfd");
-        let timeout_wheel =
-            TimeoutWheel::new(cfg.max_op_timeout, cfg.timeout_wheel_tick, Instant::now());
+        let timeout_wheel = TimeoutWheel::new(
+            cfg.max_request_timeout,
+            cfg.timeout_wheel_tick,
+            Instant::now(),
+        );
         let waiters = Waiters::new(size);
 
         let submitter = Submitter {
@@ -435,11 +327,12 @@ impl IoUringLoop {
                 metrics,
                 receiver,
                 waiters,
+                ready_queue: VecDeque::with_capacity(size),
+                pending_cancels: VecDeque::with_capacity(size),
                 timeout_wheel,
                 waker,
                 wake_rearm_needed: true,
                 processed_seq: 0,
-                pending_cancels: VecDeque::with_capacity(size),
             },
         )
     }
@@ -455,13 +348,12 @@ impl IoUringLoop {
                 self.handle_cqe(cqe);
             }
 
-            // Process due deadlines before staging new submissions so timed-out
-            // waiters move to cancellation promptly and free capacity sooner.
+            // requests move to cancellation promptly and free capacity sooner.
             self.advance_timeouts();
 
             // Stage as much inbound work as capacity allows.
             let Some(at_capacity) = self.fill_submission_queue(&mut ring) else {
-                // Producer side disconnected. Drain in-flight operations and exit.
+                // Producer side disconnected. Drain in-flight requests and exit.
                 self.drain(&mut ring);
                 return;
             };
@@ -508,10 +400,64 @@ impl IoUringLoop {
         }
     }
 
-    /// Stage inbound operations into the SQ.
+    /// Admit a request into the waiter table and schedule its timeout.
     ///
-    /// In the same pass, it rearms wake polling if needed and stages pending
-    /// cancellations before new operations.
+    /// Returns the waiter id if the request was admitted, or `None` if the
+    /// deadline already expired (in which case the request is completed
+    /// immediately with a timeout error).
+    fn admit_request(&mut self, request: Request) -> Option<WaiterId> {
+        let deadline = request.deadline();
+        let active = ActiveRequest::from_request(request);
+        let target_tick = match deadline {
+            Some(deadline) => match self.timeout_wheel.target_tick(deadline) {
+                Some(target_tick) => Some(target_tick),
+                None => {
+                    active.finish_timeout();
+                    return None;
+                }
+            },
+            None => None,
+        };
+
+        let waiter_id = self.waiters.insert(active, target_tick);
+        if let Some(target_tick) = target_tick {
+            self.timeout_wheel.schedule(waiter_id, target_tick);
+        }
+
+        Some(waiter_id)
+    }
+
+    /// Build and push the SQE for a request in the waiter table.
+    ///
+    /// If the request was marked for cancellation while sitting in the ready
+    /// queue (timeout fired between requeue and staging), it is completed with
+    /// a timeout error instead of issuing a follow-up SQE.
+    fn stage_request(&mut self, waiter_id: WaiterId, sq: &mut SubmissionQueue<'_>) {
+        let Some((request, state)) = self.waiters.get_mut(waiter_id) else {
+            return;
+        };
+        if matches!(state, WaiterState::CancelRequested) {
+            // No in-flight SQE to cancel. Complete the request directly.
+            if let Some(request) = self.waiters.remove(waiter_id) {
+                request.finish_timeout();
+            }
+            return;
+        }
+        let sqe = request.build_sqe(waiter_id);
+        // SAFETY:
+        // - All resources are stored in `self.waiters` until CQE processing, so
+        //   SQE pointers remain valid and FD numbers cannot be reused early.
+        // - SQ capacity was checked by caller.
+        unsafe {
+            sq.push(&sqe).expect("unable to push to queue");
+        }
+    }
+
+    /// Stage inbound requests into the SQ.
+    ///
+    /// Checks ready work first on every iteration. In the same pass, it rearms
+    /// wake polling if needed and stages pending cancellations before new
+    /// requests.
     ///
     /// Advances `processed_seq` by exactly the number of drained submissions.
     ///
@@ -519,28 +465,36 @@ impl IoUringLoop {
     /// producer channel disconnected.
     fn fill_submission_queue(&mut self, ring: &mut IoUring) -> Option<bool> {
         let mut drained = 0u64;
-        let mut submission_queue = ring.submission();
+        let mut sq = ring.submission();
         let mut wheel_aligned = self.timeout_wheel.next_deadline().is_some();
 
         // Reinstall wake poll only when a prior wake CQE indicated multishot
         // termination. Otherwise keep the existing poll registration.
         if std::mem::take(&mut self.wake_rearm_needed) {
-            self.waker.reinstall(&mut submission_queue);
+            self.waker.reinstall(&mut sq);
         }
 
-        // Stage pending cancel SQEs first so timed-out operations are canceled promptly.
-        if self.stage_cancellations(&mut submission_queue) {
+        // Stage pending cancel SQEs first so timed-out requests are canceled promptly.
+        if self.stage_cancellations(&mut sq) {
             // If cancels alone filled the SQ, submit them first.
             return Some(true);
         }
 
-        // Stage operations until the channel is empty, waiter capacity is hit,
-        // or the SQ is full. Waiter capacity is bounded by `cfg.size`.
-        while self.waiters.len() < self.cfg.size as usize && !submission_queue.is_full() {
-            // Try to drain one operation from the channel. If the channel is empty, we're
-            // done for now.
-            let op = match self.receiver.try_recv() {
-                Ok(work) => work,
+        while !sq.is_full() {
+            // Ready queue has priority over new inbound requests.
+            if let Some(waiter_id) = self.ready_queue.pop_front() {
+                self.stage_request(waiter_id, &mut sq);
+                continue;
+            }
+
+            // Active waiter capacity is bounded by `cfg.size`.
+            if self.waiters.len() == self.cfg.size as usize {
+                break;
+            }
+
+            // Try to drain one request from the channel.
+            let request = match self.receiver.try_recv() {
+                Ok(request) => request,
                 Err(TryRecvError::Disconnected) => return None,
                 Err(TryRecvError::Empty) => break,
             };
@@ -549,65 +503,27 @@ impl IoUringLoop {
             // `processed_seq` stays in sync with the published sequence domain.
             drained += 1;
 
-            let Op {
-                mut work,
-                sender,
-                buffer,
-                fd,
-                iovecs,
-                deadline,
-            } = op;
-
-            let target_tick = if let Some(deadline) = deadline {
-                // Avoid per-loop clock reads when no deadlines are active.
-                // When the first deadline arrives after an idle period, align
-                // wheel time once before converting deadlines to ticks.
-                if !wheel_aligned {
-                    assert!(self.timeout_wheel.advance(Instant::now()).is_none());
-                    wheel_aligned = true;
-                }
-
-                match self.timeout_wheel.target_tick(deadline) {
-                    Some(target_tick) => Some(target_tick),
-                    None => {
-                        // Deadline already expired before this operation reached staging.
-                        // Return result immediately to caller.
-                        let _ = sender.send((-libc::ETIMEDOUT, buffer));
-                        continue;
-                    }
-                }
-            } else {
-                None
-            };
-
-            // Store in-flight operation state before submission.
-            let waiter_id = self.waiters.insert(sender, buffer, fd, iovecs, target_tick);
-            if let Some(target_tick) = target_tick {
-                self.timeout_wheel.schedule(waiter_id, target_tick);
+            // Avoid per-loop clock reads when no deadlines are active. When the
+            // first deadline arrives after an idle period, align wheel time once
+            // before converting deadlines to ticks.
+            if !wheel_aligned && request.has_deadline() {
+                assert!(self.timeout_wheel.advance(Instant::now()).is_none());
+                wheel_aligned = true;
             }
 
-            // Tag SQE with waiter id for completion matching.
-            work = work.user_data(waiter_id.user_data());
-
-            // Submit the operation.
-            //
-            // SAFETY:
-            // - `buffer` and `fd` are stored in `self.waiters` until CQE processing, so
-            //   SQE pointers remain valid and FD numbers cannot be reused early.
-            // - SQ capacity was checked above, so this push fits.
-            unsafe {
-                submission_queue
-                    .push(&work)
-                    .expect("unable to push to queue");
+            if let Some(waiter_id) = self.admit_request(request) {
+                self.stage_request(waiter_id, &mut sq);
             }
         }
 
         // Track which submitted sequence has been consumed.
         self.processed_seq = self.processed_seq.wrapping_add(drained) & SUBMISSION_SEQ_MASK;
 
-        let at_sq_capacity = submission_queue.is_full();
+        let at_sq_capacity = sq.is_full();
         let at_waiter_capacity = self.waiters.len() == self.cfg.size as usize;
-        Some(at_waiter_capacity || at_sq_capacity)
+        let has_pending_work = !self.ready_queue.is_empty() || !self.pending_cancels.is_empty();
+
+        Some(at_sq_capacity || at_waiter_capacity || has_pending_work)
     }
 
     /// Stage queued cancellation SQEs from `pending_cancels` in FIFO order.
@@ -615,8 +531,8 @@ impl IoUringLoop {
     /// Stops when all queued cancellations are staged or the SQ reaches
     /// capacity. Returns `true` when SQ capacity is hit and at least one
     /// cancellation remains queued.
-    fn stage_cancellations(&mut self, submission_queue: &mut SubmissionQueue<'_>) -> bool {
-        while !submission_queue.is_full() {
+    fn stage_cancellations(&mut self, sq: &mut SubmissionQueue<'_>) -> bool {
+        while !sq.is_full() {
             let Some(waiter_id) = self.pending_cancels.pop_front() else {
                 return false;
             };
@@ -627,9 +543,7 @@ impl IoUringLoop {
 
             // SAFETY: AsyncCancel SQE uses stable user_data only.
             unsafe {
-                submission_queue
-                    .push(&cancel)
-                    .expect("unable to push cancel to queue");
+                sq.push(&cancel).expect("unable to push cancel to queue");
             }
         }
 
@@ -639,7 +553,7 @@ impl IoUringLoop {
     /// Handle a single CQE from the ring.
     ///
     /// Internal wake CQEs are handled in-place. All other CQEs are forwarded to
-    /// waiter lifecycle tracking and may complete a waiter.
+    /// the request state machine for progress evaluation.
     fn handle_cqe(&mut self, cqe: CqueueEntry) {
         let user_data = cqe.user_data();
         if user_data == WAKE_USER_DATA {
@@ -659,37 +573,35 @@ impl IoUringLoop {
             return;
         }
 
-        // Route op/cancel completions through waiter state. Only terminal
-        // transitions return a completed waiter to deliver to the caller.
-        if let Some(completed) = self.waiters.on_completion(user_data, cqe.result()) {
-            self.deliver_completion(completed);
+        // Route op/cancel completions through waiter state.
+        let Some((request, state, waiter_id)) = self.waiters.on_cqe(user_data, cqe.result()) else {
+            return;
+        };
+
+        // Let the request state machine process the CQE result.
+        match request.on_cqe(state, cqe.result()) {
+            CqeAction::Complete => {
+                // Remove active deadline tracking when this request completes.
+                if let WaiterState::Active {
+                    target_tick: Some(tick),
+                } = state
+                {
+                    self.timeout_wheel.remove(tick);
+                }
+
+                // Remove request from waiter table and deliver the result.
+                if let Some(completed) = self.waiters.remove(waiter_id) {
+                    completed.finish();
+                }
+            }
+            CqeAction::Requeue => {
+                // Request needs another SQE. Add to ready queue.
+                self.ready_queue.push_back(waiter_id);
+            }
         }
     }
 
-    /// Deliver a completed waiter to its caller and clean up timeout state.
-    fn deliver_completion(&mut self, completed: CompletedWaiter) {
-        let CompletedWaiter {
-            sender,
-            buffer,
-            mut result,
-            cancelled,
-            target_tick,
-        } = completed;
-
-        // Remove active deadline tracking when this waiter completes.
-        if let Some(target_tick) = target_tick {
-            self.timeout_wheel.remove(target_tick);
-        }
-
-        // Surface timeout as ETIMEDOUT when cancellation succeeded.
-        if cancelled && result == -libc::ECANCELED {
-            result = -libc::ETIMEDOUT;
-        }
-
-        let _ = sender.send((result, buffer));
-    }
-
-    /// Advance the timeout wheel and enqueue cancellations for newly expired waiters.
+    /// Advance the timeout wheel and enqueue cancellations for newly expired requests.
     ///
     /// This is a no-op when no active deadlines exist. Expired stale wheel
     /// entries are ignored when waiter generation no longer matches.
@@ -707,11 +619,9 @@ impl IoUringLoop {
         // Mark expired waiters as cancel-requested and queue their IDs for
         // later cancel SQE staging.
         for entry in expired {
-            // `None` means stale timeout entry (slot reused) or waiter already
-            // transitioned to cancelled/completed.
-            if let Some(cancel_user_data) = self.waiters.cancel(entry.waiter_id) {
-                assert_eq!(cancel_user_data, entry.waiter_id.cancel_user_data());
-
+            // `false` means stale timeout entry (slot reused) or waiter already
+            // transitioned to cancel-requested/completed.
+            if self.waiters.cancel(entry.waiter_id) {
                 // Once cancel is requested, this waiter is no longer deadline-active.
                 self.timeout_wheel.remove(entry.target_tick);
                 self.pending_cancels.push_back(entry.waiter_id);
@@ -719,7 +629,7 @@ impl IoUringLoop {
         }
     }
 
-    /// Drain in-flight operations during shutdown.
+    /// Drain in-flight requests during shutdown.
     ///
     /// Keeps draining CQEs until all waiters complete or shutdown budget is
     /// exhausted.
@@ -874,14 +784,15 @@ pub const fn should_retry(return_value: i32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{IoBuf, IoBufMut};
     use commonware_utils::channel::oneshot::{self, error::RecvError};
-    use io_uring::{
-        opcode,
-        types::{Fd, Timespec},
-    };
     use prometheus_client::registry::Registry;
+    use request::{RecvRequest, SendRequest, SyncRequest};
     use std::{
-        os::{fd::AsRawFd, unix::net::UnixStream},
+        os::{
+            fd::{AsRawFd, FromRawFd, IntoRawFd},
+            unix::net::UnixStream,
+        },
         time::Duration,
     };
 
@@ -894,7 +805,6 @@ mod tests {
             ..Default::default()
         };
         let (_, iouring) = IoUringLoop::new(cfg, &mut registry);
-
         assert_eq!(iouring.cfg.size, 1_024);
 
         // Already-power-of-two size is preserved.
@@ -940,25 +850,6 @@ mod tests {
     }
 
     #[test]
-    fn test_opbuffer_write_vectored_and_opiovecs_helpers() {
-        let write_vectored =
-            OpBuffer::from(IoBufs::from(vec![IoBuf::from(b"a"), IoBuf::from(b"b")]));
-        match write_vectored {
-            OpBuffer::WriteVectored(_) => {}
-            _ => panic!("expected write-vectored buffer variant"),
-        }
-
-        let iovecs = vec![libc::iovec {
-            iov_base: std::ptr::null_mut(),
-            iov_len: 0,
-        }]
-        .into_boxed_slice();
-        let expected = iovecs.as_ptr();
-        let owned = OpIovecs::new(iovecs);
-        assert_eq!(owned.as_ptr(), expected);
-    }
-
-    #[test]
     fn test_fill_submission_queue_returns_true_when_cancel_staging_fills_sq() {
         let cfg = Config {
             size: 8,
@@ -971,13 +862,20 @@ mod tests {
         // Queue enough cancellations to overflow one staging pass once wake poll
         // rearm also consumes an SQE.
         for _ in 0..cfg.size as usize {
+            let (sock_left, _sock_right) =
+                UnixStream::pair().expect("failed to create unix socket pair");
+            // SAFETY: sock_left is a valid fd that we own.
+            let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
             let (tx, _rx) = oneshot::channel();
-            let waiter_id = iouring.waiters.insert(tx, None, None, None, None);
-            let cancel_user_data = iouring
-                .waiters
-                .cancel(waiter_id)
-                .expect("cancel should transition waiter to cancel-requested");
-            assert_eq!(cancel_user_data, waiter_id.cancel_user_data());
+            let request = ActiveRequest::from_request(Request::Sync(SyncRequest {
+                file: Arc::new(file),
+                sender: tx,
+            }));
+            let waiter_id = iouring.waiters.insert(request, None);
+            assert!(
+                iouring.waiters.cancel(waiter_id),
+                "cancel should transition waiter to cancel-requested"
+            );
             iouring.pending_cancels.push_back(waiter_id);
         }
 
@@ -996,7 +894,7 @@ mod tests {
         let (submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
         let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
 
-        // Keep this test focused on operation staging, not wake rearm behavior.
+        // Keep this test focused on request staging, not wake rearm behavior.
         iouring.wake_rearm_needed = false;
 
         let (tx, rx) = oneshot::channel();
@@ -1005,16 +903,15 @@ mod tests {
             .unwrap_or_else(Instant::now);
 
         submitter
-            .send(Op {
-                work: opcode::Nop::new().build(),
-                sender: tx,
-                buffer: None,
-                fd: None,
-                iovecs: None,
+            .send(Request::Send(SendRequest {
+                // SAFETY: pair() returns valid fds; we own the left end.
+                fd: Arc::new(UnixStream::pair().unwrap().0.into()),
+                bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
                 deadline: Some(past_deadline),
-            })
+                sender: tx,
+            }))
             .await
-            .expect("failed to enqueue op");
+            .expect("failed to enqueue request");
 
         let at_capacity = iouring
             .fill_submission_queue(&mut ring)
@@ -1025,9 +922,8 @@ mod tests {
         assert!(iouring.waiters.is_empty());
         assert_eq!(ring.submission().len(), 0);
 
-        let (result, buffer) = rx.await.expect("missing timeout completion");
-        assert_eq!(result, -libc::ETIMEDOUT);
-        assert!(buffer.is_none());
+        let result = rx.await.expect("missing timeout completion");
+        assert!(matches!(result, Err(crate::Error::Timeout)));
     }
 
     #[tokio::test]
@@ -1036,7 +932,7 @@ mod tests {
             // Keep ring size realistic; size=1 can deadlock progress in some setups.
             // Waiter slot reuse is still exercised because we complete op1 before op2.
             size: 8,
-            max_op_timeout: Duration::from_millis(200),
+            max_request_timeout: Duration::from_millis(200),
             timeout_wheel_tick: Duration::from_millis(5),
             ..Default::default()
         };
@@ -1046,51 +942,54 @@ mod tests {
 
         // First operation completes quickly but still carries a generous deadline,
         // leaving a stale timeout entry that should be ignored later after slot reuse.
+        let (left1, right1) = UnixStream::pair().unwrap();
+        // Write a byte so the recv completes immediately.
+        use std::io::Write;
+        (&right1).write_all(&[42]).unwrap();
+
         let (tx1, rx1) = oneshot::channel();
         submitter
-            .send(Op {
-                work: opcode::Nop::new().build(),
-                sender: tx1,
-                buffer: None,
-                fd: None,
-                iovecs: None,
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(left1.into()),
+                buf: IoBufMut::with_capacity(1),
+                len: 1,
+                received: 0,
+                exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(200)),
-            })
+                sender: tx1,
+            }))
             .await
-            .expect("failed to submit first operation");
-        let (result1, _) = tokio::time::timeout(Duration::from_secs(2), rx1)
+            .expect("failed to submit first request");
+
+        let (_buf1, result1) = tokio::time::timeout(Duration::from_secs(2), rx1)
             .await
             .expect("first completion timed out")
             .expect("missing first completion");
-        assert_eq!(result1, 0);
+        assert!(result1.is_ok());
 
-        // Second operation reuses the only waiter slot and blocks until timeout.
-        let (left, _right) = UnixStream::pair().expect("failed to create unix stream pair");
-        let mut buf = IoBufMut::with_capacity(8);
-        let recv =
-            opcode::Recv::new(Fd(left.as_raw_fd()), buf.as_mut_ptr(), buf.capacity() as _).build();
+        // Second request reuses the slot and blocks until timeout.
+        let (left2, _right2) = UnixStream::pair().expect("failed to create unix stream pair");
         let (tx2, rx2) = oneshot::channel();
         submitter
-            .send(Op {
-                work: recv,
-                sender: tx2,
-                buffer: Some(buf.into()),
-                fd: None,
-                iovecs: None,
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(left2.into()),
+                buf: IoBufMut::with_capacity(8),
+                len: 8,
+                received: 0,
+                exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(80)),
-            })
+                sender: tx2,
+            }))
             .await
-            .expect("failed to submit second operation");
+            .expect("failed to submit second request");
 
-        // If stale timeout entries were not ignored, this could time out around the first
-        // operation's deadline (~15ms) instead of the second one (~80ms).
         let start = Instant::now();
-        let (result2, _) = tokio::time::timeout(Duration::from_secs(2), rx2)
+        let (_buf2, result2) = tokio::time::timeout(Duration::from_secs(2), rx2)
             .await
             .expect("second completion timed out")
             .expect("missing second completion");
         let elapsed = start.elapsed();
-        assert_eq!(result2, -libc::ETIMEDOUT);
+        assert!(matches!(result2, Err(crate::Error::Timeout)));
         assert!(
             elapsed >= Duration::from_millis(50),
             "timeout fired too early after slot reuse: {elapsed:?}"
@@ -1103,7 +1002,7 @@ mod tests {
     #[test]
     fn test_advance_timeouts_ignores_stale_entry_after_slot_reuse() {
         let cfg = Config {
-            max_op_timeout: Duration::from_millis(100),
+            max_request_timeout: Duration::from_millis(100),
             ..Default::default()
         };
         let mut registry = Registry::default();
@@ -1111,18 +1010,41 @@ mod tests {
 
         // Schedule an old waiter at tick 1, then complete it early so the wheel
         // retains a stale entry for this slot/tick pair.
+        let (sock_left, _) = UnixStream::pair().unwrap();
+        // SAFETY: sock_left is a valid fd that we own.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
         let (old_tx, _old_rx) = oneshot::channel();
-        let old_slot = iouring.waiters.insert(old_tx, None, None, None, Some(1));
+        let old_req = ActiveRequest::from_request(Request::Sync(SyncRequest {
+            file: Arc::new(file),
+            sender: old_tx,
+        }));
+        let old_slot = iouring.waiters.insert(old_req, Some(1));
         iouring.timeout_wheel.schedule(old_slot, 1);
-        let completed = iouring
-            .waiters
-            .on_completion(old_slot.user_data(), 0)
-            .expect("missing waiter completion");
-        iouring.deliver_completion(completed);
+        // Simulate completion: get mut access then remove.
+        if let Some((
+            _request,
+            WaiterState::Active {
+                target_tick: Some(tick),
+            },
+            _,
+        )) = iouring.waiters.on_cqe(old_slot.user_data(), 0)
+        {
+            iouring.timeout_wheel.remove(tick);
+        }
+        if let Some(completed) = iouring.waiters.remove(old_slot) {
+            completed.finish();
+        }
 
         // Reuse the same slot for a new waiter with a later timeout.
+        let (sock_left2, _) = UnixStream::pair().unwrap();
+        // SAFETY: sock_left2 is a valid fd that we own.
+        let file2 = unsafe { std::fs::File::from_raw_fd(sock_left2.into_raw_fd()) };
         let (tx, _rx) = oneshot::channel();
-        let slot_index = iouring.waiters.insert(tx, None, None, None, Some(3));
+        let req = ActiveRequest::from_request(Request::Sync(SyncRequest {
+            file: Arc::new(file2),
+            sender: tx,
+        }));
+        let slot_index = iouring.waiters.insert(req, Some(3));
         assert_eq!(slot_index.index(), old_slot.index());
         iouring.timeout_wheel.schedule(slot_index, 3);
 
@@ -1143,149 +1065,143 @@ mod tests {
         let cfg = Config::default();
         let mut registry = Registry::default();
         let (_submitter, mut iouring) = IoUringLoop::new(cfg, &mut registry);
+
+        let (left, right) = UnixStream::pair().unwrap();
+        // Write data so a recv would succeed.
+        use std::io::Write;
+        (&right).write_all(b"hello").unwrap();
+
         let (tx, rx) = oneshot::channel();
-        let slot_index = iouring.waiters.insert(tx, None, None, None, Some(2));
-        let cancel = iouring
-            .waiters
-            .cancel(slot_index)
-            .expect("cancel should transition active waiter");
-        assert_eq!(cancel, slot_index.cancel_user_data());
+        let req = ActiveRequest::from_request(Request::Recv(RecvRequest {
+            fd: Arc::new(left.into()),
+            buf: IoBufMut::with_capacity(5),
+            len: 5,
+            received: 0,
+            exact: false,
+            deadline: Some(Instant::now() + Duration::from_secs(1)),
+            sender: tx,
+        }));
+        let slot_index = iouring.waiters.insert(req, Some(2));
+        assert!(
+            iouring.waiters.cancel(slot_index),
+            "cancel should transition active waiter"
+        );
         iouring.timeout_wheel.schedule(slot_index, 2);
         iouring.timeout_wheel.remove(2);
 
-        // Simulate op CQE first, then cancel CQE.
-        // The op result should be delivered immediately and the late cancel CQE ignored.
-        let completed = iouring
-            .waiters
-            .on_completion(slot_index.user_data(), 123)
-            .expect("missing completion");
-        iouring.deliver_completion(completed);
-        let completed = iouring
-            .waiters
-            .on_completion(slot_index.cancel_user_data(), -libc::ECANCELED);
-        assert!(completed.is_none());
-
-        let (result, _) = futures::executor::block_on(rx).expect("missing completion");
-        assert_eq!(result, 123);
-        assert_eq!(iouring.waiters.len(), 0);
-    }
-
-    async fn recv_then_send(cfg: Config, should_succeed: bool) {
-        // Create a new io_uring instance
-        let mut registry = Registry::default();
-        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
-        let handle = std::thread::spawn(move || iouring.run());
-
-        let (left_pipe, right_pipe) = UnixStream::pair().unwrap();
-
-        // Submit a read
-        let msg = IoBuf::from(b"hello");
-        let mut buf = IoBufMut::with_capacity(msg.len());
-        let recv =
-            opcode::Recv::new(Fd(left_pipe.as_raw_fd()), buf.as_mut_ptr(), msg.len() as _).build();
-        let (recv_tx, recv_rx) = oneshot::channel();
-        submitter
-            .send(Op {
-                work: recv,
-                sender: recv_tx,
-                buffer: Some(buf.into()),
-                fd: None,
-                iovecs: None,
-                deadline: None,
-            })
-            .await
-            .expect("failed to send work");
-
-        // Submit a write that satisfies the read.
-        let write =
-            opcode::Write::new(Fd(right_pipe.as_raw_fd()), msg.as_ptr(), msg.len() as _).build();
-        let (write_tx, write_rx) = oneshot::channel();
-        submitter
-            .send(Op {
-                work: write,
-                sender: write_tx,
-                buffer: Some(msg.into()),
-                fd: None,
-                iovecs: None,
-                deadline: None,
-            })
-            .await
-            .expect("failed to send work");
-
-        // Wait for the read and write operations to complete.
-        if should_succeed {
-            let (result, _) = recv_rx.await.expect("failed to receive result");
-            assert!(result > 0, "recv failed: {result}");
-            let (result, _) = write_rx.await.expect("failed to receive result");
-            assert!(result > 0, "write failed: {result}");
-        } else {
-            let _ = recv_rx.await;
-            let _ = write_rx.await;
+        // Simulate op CQE arriving with positive result (5 bytes read).
+        // Even though cancel was requested, a complete positive result wins.
+        if let Some((request, state, waiter_id)) = iouring.waiters.on_cqe(slot_index.user_data(), 5)
+        {
+            match request.on_cqe(state, 5) {
+                CqeAction::Complete => {
+                    if let Some(completed) = iouring.waiters.remove(waiter_id) {
+                        completed.finish();
+                    }
+                }
+                CqeAction::Requeue => {
+                    panic!("should not requeue");
+                }
+            }
         }
-        drop(submitter);
-        handle.join().unwrap();
+
+        // Late cancel CQE should be ignored.
+        assert!(iouring
+            .waiters
+            .on_cqe(slot_index.cancel_user_data(), -libc::ECANCELED)
+            .is_none());
+
+        let (_, result) = futures::executor::block_on(rx).expect("missing completion");
+        // exact=false recv with 5 bytes should succeed.
+        assert_eq!(result.unwrap(), 5);
+        assert_eq!(iouring.waiters.len(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_wake_path_progress_scenarios() {
-        for should_succeed in [true, false] {
-            // Run both wake-path scenarios:
-            // - strict success assertions enabled
-            // - branch-only progress check (no success assertions)
-            let timeout = tokio::time::timeout(
-                Duration::from_secs(2),
-                recv_then_send(Default::default(), should_succeed),
-            );
-            assert!(
-                timeout.await.is_ok(),
-                "recv_then_send timed out unexpectedly (should_succeed={should_succeed})"
-            );
+        for _ in [true, false] {
+            let cfg = Config::default();
+            let mut registry = Registry::default();
+            let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
+            let handle = std::thread::spawn(move || iouring.run());
+
+            let (left_pipe, right_pipe) = UnixStream::pair().unwrap();
+
+            // Submit a recv.
+            let (recv_tx, recv_rx) = oneshot::channel();
+            submitter
+                .send(Request::Recv(RecvRequest {
+                    fd: Arc::new(left_pipe.into()),
+                    buf: IoBufMut::with_capacity(5),
+                    len: 5,
+                    received: 0,
+                    exact: false,
+                    deadline: None,
+                    sender: recv_tx,
+                }))
+                .await
+                .expect("failed to send recv");
+
+            // Submit a send that satisfies the recv.
+            let (send_tx, send_rx) = oneshot::channel();
+            submitter
+                .send(Request::Send(SendRequest {
+                    fd: Arc::new(right_pipe.into()),
+                    bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
+                    deadline: None,
+                    sender: send_tx,
+                }))
+                .await
+                .expect("failed to send send");
+
+            let timeout = tokio::time::timeout(Duration::from_secs(2), async {
+                let (_, recv_result) = recv_rx.await.expect("missing recv result");
+                assert!(recv_result.unwrap() > 0);
+                let send_result = send_rx.await.expect("missing send result");
+                assert!(send_result.is_ok());
+            });
+            assert!(timeout.await.is_ok(), "wake path test timed out");
+
+            drop(submitter);
+            handle.join().unwrap();
         }
     }
 
     #[tokio::test]
     async fn test_timeout() {
-        // Create an io_uring instance
         let cfg = Config {
-            max_op_timeout: std::time::Duration::from_secs(1),
+            max_request_timeout: Duration::from_secs(1),
             ..Default::default()
         };
         let mut registry = Registry::default();
         let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
         let handle = std::thread::spawn(move || iouring.run());
 
-        // Submit a work item that will time out (because we don't write to the pipe)
+        // Submit a recv that will time out (because we don't write to the pipe).
         let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
-        let mut buf = IoBufMut::with_capacity(8);
-        let work = opcode::Recv::new(
-            Fd(pipe_left.as_raw_fd()),
-            buf.as_mut_ptr(),
-            buf.capacity() as _,
-        )
-        .build();
         let (tx, rx) = oneshot::channel();
-        let deadline = Instant::now() + Duration::from_secs(1);
         submitter
-            .send(Op {
-                work,
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left.into()),
+                buf: IoBufMut::with_capacity(8),
+                len: 8,
+                received: 0,
+                exact: false,
+                deadline: Some(Instant::now() + Duration::from_secs(1)),
                 sender: tx,
-                buffer: Some(buf.into()),
-                fd: None,
-                iovecs: None,
-                deadline: Some(deadline),
-            })
+            }))
             .await
-            .expect("failed to send work");
-        // Wait for the timeout
-        let (result, _) = rx.await.expect("failed to receive result");
-        assert_eq!(result, -libc::ETIMEDOUT);
+            .expect("failed to send request");
+
+        let (_, result) = rx.await.expect("failed to receive result");
+        assert!(matches!(result, Err(crate::Error::Timeout)));
+
         drop(submitter);
         handle.join().unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_no_timeout() {
-        // Create an io_uring instance with shutdown timeout disabled
         let cfg = Config {
             shutdown_timeout: None,
             ..Default::default()
@@ -1294,36 +1210,32 @@ mod tests {
         let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
         let handle = std::thread::spawn(move || iouring.run());
 
-        // Submit an operation that will complete after shutdown
-        let timeout = Timespec::new().sec(3);
-        let timeout = opcode::Timeout::new(&timeout).build();
+        // Submit a low-level nop-equivalent: a sync on a real fd.
+        let (sock_left, _) = UnixStream::pair().unwrap();
+        // SAFETY: sock_left is a valid fd that we own.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Op {
-                work: timeout,
+            .send(Request::Sync(SyncRequest {
+                file: Arc::new(file),
                 sender: tx,
-                buffer: None,
-                fd: None,
-                iovecs: None,
-                deadline: None,
-            })
+            }))
             .await
             .unwrap();
 
-        // Drop submission channel to trigger io_uring shutdown
-        drop(submitter);
-
         // With `shutdown_timeout = None`, shutdown waits until all in-flight
-        // operations complete.
-        let (result, _) = rx.await.unwrap();
-        assert_eq!(result, -libc::ETIME);
+        // requests complete. Fsync on a socket should complete quickly.
+        drop(submitter);
+        let result = rx.await.unwrap();
+        // Socket fsync may succeed or fail, either is fine for this test.
+        let _ = result;
         handle.join().unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_no_timeout_continues_deadline_processing() {
         let cfg = Config {
-            max_op_timeout: Duration::from_millis(250),
+            max_request_timeout: Duration::from_millis(250),
             timeout_wheel_tick: Duration::from_millis(5),
             shutdown_timeout: None,
             ..Default::default()
@@ -1332,34 +1244,33 @@ mod tests {
         let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
         let handle = std::thread::spawn(move || iouring.run());
 
-        let timeout = Timespec::new().sec(5_000);
-        let timeout = opcode::Timeout::new(&timeout).build();
+        let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Op {
-                work: timeout,
-                sender: tx,
-                buffer: None,
-                fd: None,
-                iovecs: None,
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left.into()),
+                buf: IoBufMut::with_capacity(8),
+                len: 8,
+                received: 0,
+                exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(50)),
-            })
+                sender: tx,
+            }))
             .await
             .unwrap();
 
         drop(submitter);
 
-        let (result, _) = tokio::time::timeout(Duration::from_secs(2), rx)
+        let (_, result) = tokio::time::timeout(Duration::from_secs(2), rx)
             .await
             .expect("deadline completion timed out")
             .expect("missing deadline completion");
-        assert_eq!(result, -libc::ETIMEDOUT);
+        assert!(matches!(result, Err(crate::Error::Timeout)));
         handle.join().unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_timeout() {
-        // Create an io_uring instance with shutdown timeout enabled
         let cfg = Config {
             shutdown_timeout: Some(Duration::from_secs(1)),
             ..Default::default()
@@ -1368,29 +1279,29 @@ mod tests {
         let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
         let handle = std::thread::spawn(move || iouring.run());
 
-        // Submit an operation that will complete long after shutdown starts
-        let timeout = Timespec::new().sec(5_000);
-        let timeout = opcode::Timeout::new(&timeout).build();
+        // Submit a recv that will never complete (nobody writes to the pipe).
+        let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Op {
-                work: timeout,
-                sender: tx,
-                buffer: None,
-                fd: None,
-                iovecs: None,
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left.into()),
+                buf: IoBufMut::with_capacity(8),
+                len: 8,
+                received: 0,
+                exact: false,
                 deadline: None,
-            })
+                sender: tx,
+            }))
             .await
             .unwrap();
 
-        // Give the event loop a chance to enter the blocking submit and wait before shutdown
+        // Give the event loop a chance to enter the blocking submit and wait.
         tokio::time::sleep(Duration::from_millis(10)).await;
 
-        // Drop submission channel to trigger io_uring shutdown
+        // Drop submission channel to trigger shutdown.
         drop(submitter);
 
-        // The event loop should shut down before the `timeout` fires,
+        // The event loop should shut down before the recv completes,
         // dropping `tx` and causing `rx` to return RecvError.
         let err = rx.await.unwrap_err();
         assert!(matches!(err, RecvError { .. }));
@@ -1400,7 +1311,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_timeout_preserves_deadline_result() {
         let cfg = Config {
-            max_op_timeout: Duration::from_millis(250),
+            max_request_timeout: Duration::from_millis(250),
             timeout_wheel_tick: Duration::from_millis(5),
             shutdown_timeout: Some(Duration::from_millis(500)),
             ..Default::default()
@@ -1409,35 +1320,35 @@ mod tests {
         let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
         let handle = std::thread::spawn(move || iouring.run());
 
-        let timeout = Timespec::new().sec(5_000);
-        let timeout = opcode::Timeout::new(&timeout).build();
+        let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Op {
-                work: timeout,
-                sender: tx,
-                buffer: None,
-                fd: None,
-                iovecs: None,
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left.into()),
+                buf: IoBufMut::with_capacity(8),
+                len: 8,
+                received: 0,
+                exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(50)),
-            })
+                sender: tx,
+            }))
             .await
             .unwrap();
 
         drop(submitter);
 
-        let (result, _) = tokio::time::timeout(Duration::from_secs(2), rx)
+        let (_, result) = tokio::time::timeout(Duration::from_secs(2), rx)
             .await
             .expect("deadline completion timed out")
             .expect("missing deadline completion");
-        assert_eq!(result, -libc::ETIMEDOUT);
+        assert!(matches!(result, Err(crate::Error::Timeout)));
         handle.join().unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_shutdown_timeout_abandons_timed_op_after_cutoff() {
         let cfg = Config {
-            max_op_timeout: Duration::from_millis(750),
+            max_request_timeout: Duration::from_millis(750),
             timeout_wheel_tick: Duration::from_millis(5),
             shutdown_timeout: Some(Duration::from_millis(50)),
             ..Default::default()
@@ -1446,18 +1357,18 @@ mod tests {
         let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
         let handle = std::thread::spawn(move || iouring.run());
 
-        let timeout = Timespec::new().sec(5_000);
-        let timeout = opcode::Timeout::new(&timeout).build();
+        let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Op {
-                work: timeout,
-                sender: tx,
-                buffer: None,
-                fd: None,
-                iovecs: None,
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left.into()),
+                buf: IoBufMut::with_capacity(8),
+                len: 8,
+                received: 0,
+                exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(500)),
-            })
+                sender: tx,
+            }))
             .await
             .unwrap();
 
@@ -1474,76 +1385,145 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_shutdown_timeout_with_completion() {
-        let cfg = Config {
-            shutdown_timeout: Some(Duration::from_secs(2)),
-            ..Default::default()
-        };
-        let mut registry = Registry::default();
-        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
-        let handle = std::thread::spawn(move || iouring.run());
-
-        // Complete during shutdown drain to exercise the `got_completion` branch.
-        let timeout = Timespec::new().sec(1);
-        let timeout = opcode::Timeout::new(&timeout).build();
-        let (tx, rx) = oneshot::channel();
-        submitter
-            .send(Op {
-                work: timeout,
-                sender: tx,
-                buffer: None,
-                fd: None,
-                iovecs: None,
-                deadline: None,
-            })
-            .await
-            .unwrap();
-
-        drop(submitter);
-        let (result, _) = rx.await.expect("missing completion");
-        assert_eq!(result, -libc::ETIME);
-        handle.join().unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_deadline_timeout_ensure_enough_capacity() {
-        // Regression test: many operations with deadlines should batch without
-        // requiring linked timeout SQEs or ring-size doubling.
         let cfg = Config {
             size: 8,
-            max_op_timeout: Duration::from_millis(50),
+            max_request_timeout: Duration::from_millis(50),
             ..Default::default()
         };
         let mut registry = Registry::default();
         let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
         let handle = std::thread::spawn(move || iouring.run());
 
-        // Submit more operations than the SQ size to force batching.
+        // Submit more timed requests than the SQ size to force batching.
         let total = 64usize;
-        let mut rxs = Vec::with_capacity(total);
         let deadline = Instant::now() + Duration::from_millis(50);
+        let mut peers = Vec::with_capacity(total);
+        let mut rxs = Vec::with_capacity(total);
         for _ in 0..total {
-            let nop = opcode::Nop::new().build();
+            let (left, right) = UnixStream::pair().unwrap();
+            peers.push(right);
             let (tx, rx) = oneshot::channel();
             submitter
-                .send(Op {
-                    work: nop,
-                    sender: tx,
-                    buffer: None,
-                    fd: None,
-                    iovecs: None,
+                .send(Request::Recv(RecvRequest {
+                    fd: Arc::new(left.into()),
+                    buf: IoBufMut::with_capacity(8),
+                    len: 8,
+                    received: 0,
+                    exact: false,
                     deadline: Some(deadline),
-                })
+                    sender: tx,
+                }))
                 .await
                 .unwrap();
             rxs.push(rx);
         }
 
-        // All NOPs should complete successfully
+        // All requests should complete with timeout rather than getting stuck
+        // behind waiter capacity.
         for rx in rxs {
-            let (res, _) = rx.await.unwrap();
-            assert_eq!(res, 0, "NOP op failed: {res}");
+            let (_, result) = tokio::time::timeout(Duration::from_secs(2), rx)
+                .await
+                .expect("deadline completion timed out")
+                .expect("missing deadline completion");
+            assert!(matches!(result, Err(crate::Error::Timeout)));
         }
+
+        drop(peers);
+        drop(submitter);
+        handle.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_exact_recv_partial_progress() {
+        // Exercise the exact=true recv path where the kernel returns partial
+        // data and the loop must requeue for a follow-up SQE.
+        let cfg = Config::default();
+        let mut registry = Registry::default();
+        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
+        let handle = std::thread::spawn(move || iouring.run());
+
+        let (left, right) = UnixStream::pair().unwrap();
+        // Set the socket to non-blocking so partial writes are possible.
+        left.set_nonblocking(true).unwrap();
+        right.set_nonblocking(true).unwrap();
+
+        let total = 100;
+        let (tx, rx) = oneshot::channel();
+        submitter
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(left.into()),
+                buf: IoBufMut::with_capacity(total),
+                len: total,
+                received: 0,
+                exact: true,
+                deadline: None,
+                sender: tx,
+            }))
+            .await
+            .unwrap();
+
+        // Write data in two chunks so the recv must make partial progress.
+        use std::io::Write;
+        (&right).write_all(&[1u8; 40]).unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        (&right).write_all(&[2u8; 60]).unwrap();
+
+        let (_, result) = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("recv timed out")
+            .expect("missing completion");
+        assert_eq!(result.unwrap(), total);
+
+        drop(submitter);
+        handle.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_timeout_fires_while_request_in_ready_queue() {
+        // Regression test: a request that made partial progress and was
+        // requeued must be completed with timeout if the deadline expires
+        // before the ready queue entry is staged. Without this fix, the
+        // request would leak in the waiter table forever.
+        let cfg = Config {
+            max_request_timeout: Duration::from_millis(200),
+            timeout_wheel_tick: Duration::from_millis(5),
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
+        let handle = std::thread::spawn(move || iouring.run());
+
+        let (left, right) = UnixStream::pair().unwrap();
+
+        // Submit an exact recv for 100 bytes with a short deadline.
+        let (tx, rx) = oneshot::channel();
+        submitter
+            .send(Request::Recv(RecvRequest {
+                fd: Arc::new(left.into()),
+                buf: IoBufMut::with_capacity(100),
+                len: 100,
+                received: 0,
+                exact: true,
+                deadline: Some(Instant::now() + Duration::from_millis(80)),
+                sender: tx,
+            }))
+            .await
+            .unwrap();
+
+        // Write partial data so the recv makes progress and gets requeued,
+        // then let the deadline expire before sending the rest.
+        use std::io::Write;
+        (&right).write_all(&[1u8; 10]).unwrap();
+
+        let (_, result) = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("recv should not hang")
+            .expect("missing completion");
+        assert!(
+            matches!(result, Err(crate::Error::Timeout)),
+            "expected timeout, got {result:?}"
+        );
 
         drop(submitter);
         handle.join().unwrap();
@@ -1551,8 +1531,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_issuer() {
-        // Test that SINGLE_ISSUER with DEFER_TASKRUN works correctly.
-        // The simplest test: just submit a no-op and verify it completes.
         let cfg = Config {
             single_issuer: true,
             ..Default::default()
@@ -1560,29 +1538,23 @@ mod tests {
 
         let mut registry = Registry::default();
         let (sender, iouring) = IoUringLoop::new(cfg, &mut registry);
-
-        // Run io_uring in a dedicated thread
         let uring_thread = std::thread::spawn(move || iouring.run());
 
-        // Submit a no-op
+        // Submit a sync (Nop-equivalent).
+        let (sock_left, _) = UnixStream::pair().unwrap();
+        // SAFETY: sock_left is a valid fd that we own.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
         let (tx, rx) = oneshot::channel();
         sender
-            .send(Op {
-                work: opcode::Nop::new().build(),
+            .send(Request::Sync(SyncRequest {
+                file: Arc::new(file),
                 sender: tx,
-                buffer: None,
-                fd: None,
-                iovecs: None,
-                deadline: None,
-            })
+            }))
             .await
             .unwrap();
 
-        // Verify it completes successfully
-        let (result, _) = rx.await.unwrap();
-        assert_eq!(result, 0);
+        let _result = rx.await.unwrap();
 
-        // Clean shutdown
         drop(sender);
         uring_thread.join().unwrap();
     }

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -1096,6 +1096,47 @@ mod tests {
     }
 
     #[test]
+    fn test_fill_submission_queue_returns_true_when_fresh_staging_fills_sq() {
+        // Verify newly submitted work can fill the SQ before waiter capacity is exhausted.
+        let cfg = Config {
+            size: 8,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        // Leave wake rearm enabled so it consumes one SQE up front. The fresh
+        // request staging loop should then stop because the SQ fills first,
+        // while waiter capacity still has room left.
+        futures::executor::block_on(async {
+            for _ in 0..cfg.size as usize {
+                let (sock_left, _sock_right) =
+                    UnixStream::pair().expect("failed to create unix socket pair");
+                // SAFETY: sock_left is a valid fd that we own.
+                let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+                let (tx, _rx) = oneshot::channel();
+                submitter
+                    .enqueue(Request::Sync(SyncRequest {
+                        file: Arc::new(file),
+                        result: None,
+                        sender: tx,
+                    }))
+                    .await
+                    .expect("failed to enqueue request");
+            }
+        });
+
+        let at_capacity = iouring
+            .fill_submission_queue(&mut ring)
+            .expect("channel should remain connected");
+
+        assert!(at_capacity);
+        assert!(ring.submission().is_full());
+        assert!(iouring.waiters.len() < cfg.size as usize);
+    }
+
+    #[test]
     fn test_fill_submission_queue_skips_cancel_for_ready_queue_timeout() {
         // Verify pending cancel entries are discarded once the waiter no longer
         // has an operation SQE in flight.
@@ -1176,6 +1217,42 @@ mod tests {
 
         let result = rx.await.expect("missing timeout completion");
         assert!(matches!(result, Err(crate::Error::Timeout)));
+    }
+
+    #[test]
+    fn test_handle_recv_panics_on_invalid_buffer_bounds() {
+        // Verify the public recv helper rejects impossible offset/len shapes
+        // before it can enqueue a malformed request.
+        let cfg = Config::default();
+        let mut registry = Registry::default();
+        let (handle, io_loop) = IoUringLoop::new(cfg, &mut registry);
+        drop(io_loop);
+
+        let offset_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let (left, _right) = UnixStream::pair().unwrap();
+            let _ = futures::executor::block_on(handle.recv(
+                Arc::new(left.into()),
+                IoBufMut::with_capacity(4),
+                5,
+                4,
+                true,
+                Instant::now() + Duration::from_secs(1),
+            ));
+        }));
+        assert!(offset_panic.is_err());
+
+        let capacity_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let (left, _right) = UnixStream::pair().unwrap();
+            let _ = futures::executor::block_on(handle.recv(
+                Arc::new(left.into()),
+                IoBufMut::with_capacity(4),
+                0,
+                5,
+                true,
+                Instant::now() + Duration::from_secs(1),
+            ));
+        }));
+        assert!(capacity_panic.is_err());
     }
 
     #[tokio::test]

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -747,7 +747,7 @@ impl IoUringLoop {
                 if let Some(tick) = target_tick {
                     self.timeout_wheel.remove(tick);
                 }
-                request.finish();
+                request.complete();
             }
         }
     }
@@ -1258,7 +1258,7 @@ mod tests {
             StageOutcome::Submit(_)
         ));
         match iouring.waiters.on_completion(stale.user_data(), 0) {
-            CompletionOutcome::Complete { request, .. } => request.finish(),
+            CompletionOutcome::Complete { request, .. } => request.complete(),
             _ => panic!("sync waiter should complete immediately"),
         }
 
@@ -1321,7 +1321,7 @@ mod tests {
         } = iouring.waiters.on_completion(old_slot.user_data(), 0)
         {
             iouring.timeout_wheel.remove(tick);
-            request.finish();
+            request.complete();
         }
 
         // Reuse the same slot for a new waiter with a later timeout.
@@ -1393,7 +1393,7 @@ mod tests {
         if let CompletionOutcome::Complete { request, .. } =
             iouring.waiters.on_completion(slot_index.user_data(), 5)
         {
-            request.finish();
+            request.complete();
         }
 
         // Late cancel CQE should be ignored.
@@ -1474,7 +1474,7 @@ mod tests {
             CompletionOutcome::Complete {
                 request,
                 target_tick: None,
-            } => request.finish(),
+            } => request.complete(),
             _ => panic!("missing timeout completion from op CQE"),
         }
 

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -642,8 +642,9 @@ impl IoUringLoop {
             return Some(true);
         }
 
-        // Remaining SQ capacity can now be used to admit new requests.
-        while !submission_queue.is_full() {
+        // Stage operations until the channel is empty, waiter capacity is hit,
+        // or the SQ is full. Waiter capacity is bounded by `cfg.size`.
+        while self.waiters.len() < self.cfg.size as usize && !submission_queue.is_full() {
             // Active waiter capacity is bounded by `cfg.size`.
             if self.waiters.len() == self.cfg.size as usize {
                 break;
@@ -678,7 +679,6 @@ impl IoUringLoop {
 
         let at_sq_capacity = submission_queue.is_full();
         let at_waiter_capacity = self.waiters.len() == self.cfg.size as usize;
-
         Some(at_sq_capacity || at_waiter_capacity)
     }
 

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -4,7 +4,7 @@
 //! subsystem and receiving their results. The design centers around a single event loop that
 //! manages the submission queue (SQ) and completion queue (CQ) of an io_uring instance.
 //!
-//! Work is submitted via [Submitter], which pushes [Request]s into an MPSC queue and signals
+//! Work is submitted via [Handle], which pushes [Request]s into an MPSC queue and signals
 //! an internal `eventfd` wake source. The event loop blocks in `io_uring_enter` and is woken by:
 //! - normal CQE progress in the ring
 //! - `eventfd` readiness when new work is queued or all submitters are dropped
@@ -24,7 +24,7 @@
 //!
 //! The core of this implementation is [IoUringLoop::run], which blocks its calling thread while
 //! operating an event loop that:
-//! 1. Drains logical requests from a bounded MPSC channel fed by [Submitter]
+//! 1. Drains logical requests from a bounded MPSC channel fed by [Handle]
 //! 2. Admits requests into the waiter table and submits their first SQE
 //! 3. Processes io_uring completion queue entries (CQEs), including internal wake CQEs
 //! 4. Handles partial progress and retryable errors by requeuing requests
@@ -34,11 +34,11 @@
 //!
 //! ```text
 //! Data path:
-//!   Client task -> Submitter -> bounded MPSC -> IoUringLoop -> SQE -> io_uring
+//!   Client task -> Handle -> bounded MPSC -> IoUringLoop -> SQE -> io_uring
 //!   Client task <- typed oneshot <- IoUringLoop <- CQE <- io_uring
 //!
 //! Wake path:
-//!   Submitter --write(eventfd)--> wake_fd --POLLIN CQE (WAKE_USER_DATA)--> IoUringLoop
+//!   Handle --write(eventfd)--> wake_fd --POLLIN CQE (WAKE_USER_DATA)--> IoUringLoop
 //!
 //! Loop behavior:
 //!   1) Drain CQEs.
@@ -52,7 +52,7 @@
 //!
 //! Each admitted request is assigned a waiter id that serves as the `user_data` field in its
 //! SQEs. The event loop maintains a flat `Waiters` store where each slot maps to an
-//! [ActiveRequest] that owns all resources (buffers, FDs, progress state, completion sender)
+//! [Request] that owns all resources (buffers, FDs, progress state, completion sender)
 //! needed for the request's lifetime.
 //!
 //! ## Timeout Handling
@@ -85,7 +85,7 @@
 //!
 //! To avoid submission latency while the loop is blocked in `submit_and_wait`, the loop maintains
 //! a multishot `PollAdd` on an internal `eventfd`.
-//! - [Submitter::send] increments an atomic submission sequence
+//! - [Handle::enqueue] increments an atomic submission sequence
 //! - Wake CQEs drain `eventfd` readiness and re-install poll when `IORING_CQE_F_MORE` is not set
 //! - The loop uses an arm-and-recheck sleep handshake (`submitted_seq` vs `processed_seq`)
 //! - Submitters ring `eventfd` only while sleep intent is armed
@@ -134,7 +134,11 @@
 //! - If cancellation is disabled, callers must guarantee that in-flight requests never depend on
 //!   later queued requests, otherwise the loop can deadlock.
 
-use commonware_utils::channel::mpsc::{self, error::TryRecvError};
+use crate::{Error, IoBufMut, IoBufs};
+use commonware_utils::channel::{
+    mpsc::{self, error::TryRecvError},
+    oneshot,
+};
 use io_uring::{
     cqueue::Entry as CqueueEntry,
     opcode::AsyncCancel,
@@ -143,9 +147,11 @@ use io_uring::{
     IoUring,
 };
 use prometheus_client::{metrics::gauge::Gauge, registry::Registry};
-use request::{ActiveRequest, Request};
+use request::{ReadAtRequest, RecvRequest, Request, SendRequest, SyncRequest, WriteAtRequest};
 use std::{
     collections::VecDeque,
+    fs::File,
+    os::fd::OwnedFd,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -160,12 +166,6 @@ use waker::{Waker, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
 
 /// Packed `io_uring` `user_data` value.
 type UserData = u64;
-
-pub use request::Request as IoUringRequest;
-#[cfg(feature = "iouring-storage")]
-pub use request::{ReadAtRequest, SyncRequest, WriteAtRequest};
-#[cfg(feature = "iouring-network")]
-pub use request::{RecvRequest, SendRequest};
 
 /// Tracks io_uring metrics.
 #[derive(Debug)]
@@ -244,12 +244,12 @@ impl Default for Config {
     }
 }
 
-struct SubmitterInner {
+struct HandleInner {
     sender: Option<mpsc::Sender<Request>>,
     waker: Waker,
 }
 
-impl Drop for SubmitterInner {
+impl Drop for HandleInner {
     fn drop(&mut self) {
         // Disconnect first, then wake. This avoids a race where the loop
         // handles a wake CQE before channel closure becomes observable.
@@ -264,20 +264,20 @@ impl Drop for SubmitterInner {
 
 /// Handle for submitting requests to an [IoUringLoop].
 #[derive(Clone)]
-pub struct Submitter {
-    inner: Arc<SubmitterInner>,
+pub struct Handle {
+    inner: Arc<HandleInner>,
 }
 
-impl Submitter {
-    /// Submit a request to the io_uring loop.
+impl Handle {
+    /// Enqueue a request for the io_uring loop.
     ///
     /// On success, this publishes one submission and conditionally rings the loop's
     /// `eventfd` wake source if sleep intent is armed.
-    pub async fn send(&self, request: Request) -> Result<(), mpsc::error::SendError<Request>> {
+    async fn enqueue(&self, request: Request) -> Result<(), mpsc::error::SendError<Request>> {
         self.inner
             .sender
             .as_ref()
-            .expect("submitter sender is only taken on drop")
+            .expect("handle sender is only taken on drop")
             .send(request)
             .await?;
 
@@ -285,6 +285,135 @@ impl Submitter {
         self.inner.waker.publish();
 
         Ok(())
+    }
+
+    /// Submit a logical send request and wait for its completion.
+    #[cfg_attr(not(feature = "iouring-network"), allow(dead_code))]
+    pub async fn send(
+        &self,
+        fd: Arc<OwnedFd>,
+        bufs: IoBufs,
+        deadline: Instant,
+    ) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        self.enqueue(Request::Send(SendRequest {
+            fd,
+            write: bufs.into(),
+            deadline: Some(deadline),
+            result: None,
+            sender: tx,
+        }))
+        .await
+        .map_err(|_| Error::SendFailed)?;
+        rx.await.map_err(|_| Error::SendFailed)?
+    }
+
+    /// Submit a logical recv request and wait for its completion.
+    #[cfg_attr(not(feature = "iouring-network"), allow(dead_code))]
+    pub async fn recv(
+        &self,
+        fd: Arc<OwnedFd>,
+        buf: IoBufMut,
+        offset: usize,
+        len: usize,
+        exact: bool,
+        deadline: Instant,
+    ) -> Result<(IoBufMut, usize), (IoBufMut, Error)> {
+        assert!(
+            offset <= len && len <= buf.capacity(),
+            "recv invariant violated: need offset <= len <= capacity"
+        );
+        let (tx, rx) = oneshot::channel();
+        let request = Request::Recv(RecvRequest {
+            fd,
+            buf,
+            offset,
+            len,
+            exact,
+            deadline: Some(deadline),
+            result: None,
+            sender: tx,
+        });
+        if let Err(err) = self.enqueue(request).await {
+            let Request::Recv(request) = err.0 else {
+                unreachable!("recv enqueue returned wrong request variant");
+            };
+            return Err((request.buf, Error::RecvFailed));
+        }
+
+        rx.await.unwrap_or_else(|_| {
+            // Once the request is admitted, ownership of `buf` moves into the
+            // loop. If the loop dies before replying, there is no owned buffer
+            // left to recover here, so return an empty placeholder.
+            Err((IoBufMut::default(), Error::RecvFailed))
+        })
+    }
+
+    /// Submit a logical positioned read request and wait for its completion.
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    pub async fn read_at(
+        &self,
+        file: Arc<File>,
+        offset: u64,
+        len: usize,
+        buf: IoBufMut,
+    ) -> Result<IoBufMut, (IoBufMut, Error)> {
+        assert!(len <= buf.capacity(), "read_at len exceeds buffer capacity");
+        let (tx, rx) = oneshot::channel();
+        let request = Request::ReadAt(ReadAtRequest {
+            file,
+            offset,
+            len,
+            read: 0,
+            buf,
+            result: None,
+            sender: tx,
+        });
+        if let Err(err) = self.enqueue(request).await {
+            let Request::ReadAt(request) = err.0 else {
+                unreachable!("read_at enqueue returned wrong request variant");
+            };
+            return Err((request.buf, Error::ReadFailed));
+        }
+
+        rx.await.unwrap_or_else(|_| {
+            // Once the request is admitted, ownership of `buf` moves into the
+            // loop. If the loop dies before replying, there is no owned buffer
+            // left to recover here, so return an empty placeholder.
+            Err((IoBufMut::default(), Error::ReadFailed))
+        })
+    }
+
+    /// Submit a logical positioned write request and wait for its completion.
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    pub async fn write_at(&self, file: Arc<File>, offset: u64, bufs: IoBufs) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        self.enqueue(Request::WriteAt(WriteAtRequest {
+            file,
+            offset,
+            written: 0,
+            write: bufs.into(),
+            result: None,
+            sender: tx,
+        }))
+        .await
+        .map_err(|_| Error::WriteFailed)?;
+        rx.await.map_err(|_| Error::WriteFailed)?
+    }
+
+    /// Submit a logical fsync request and wait for its completion.
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    pub async fn sync(&self, file: Arc<File>) -> std::io::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.enqueue(Request::Sync(SyncRequest {
+            file,
+            result: None,
+            sender: tx,
+        }))
+        .await
+        .map_err(|_| std::io::Error::other("failed to send work"))?;
+        rx.await
+            .map_err(|_| std::io::Error::other("failed to read result"))?
     }
 }
 
@@ -306,7 +435,7 @@ impl IoUringLoop {
     /// Create a new io_uring loop and submit handle.
     ///
     /// The loop allocates its own metrics, request channel, and internal `eventfd` wake source.
-    pub(crate) fn new(mut cfg: Config, registry: &mut Registry) -> (Submitter, Self) {
+    pub(crate) fn new(mut cfg: Config, registry: &mut Registry) -> (Handle, Self) {
         assert!(
             !cfg.max_request_timeout.is_zero(),
             "max_request_timeout must be non-zero for timeout wheel"
@@ -330,15 +459,15 @@ impl IoUringLoop {
         );
         let waiters = Waiters::new(size);
 
-        let submitter = Submitter {
-            inner: Arc::new(SubmitterInner {
+        let handle = Handle {
+            inner: Arc::new(HandleInner {
                 sender: Some(sender),
                 waker: waker.clone(),
             }),
         };
 
         (
-            submitter,
+            handle,
             Self {
                 cfg,
                 metrics,
@@ -424,19 +553,18 @@ impl IoUringLoop {
     /// immediately with a timeout error).
     fn admit_request(&mut self, request: Request) -> Option<WaiterId> {
         let deadline = request.deadline();
-        let active = ActiveRequest::from_request(request);
         let target_tick = match deadline {
             Some(deadline) => match self.timeout_wheel.target_tick(deadline) {
                 Some(target_tick) => Some(target_tick),
                 None => {
-                    active.timeout();
+                    request.timeout();
                     return None;
                 }
             },
             None => None,
         };
 
-        let waiter_id = self.waiters.insert(active, target_tick);
+        let waiter_id = self.waiters.insert(request, target_tick);
         if let Some(target_tick) = target_tick {
             self.timeout_wheel.schedule(waiter_id, target_tick);
         }
@@ -821,6 +949,7 @@ mod tests {
     use super::*;
     use crate::{IoBuf, IoBufMut};
     use commonware_utils::channel::oneshot::{self, error::RecvError};
+    use futures::future::{join, join_all};
     use prometheus_client::registry::Registry;
     use request::{RecvRequest, SendRequest, SyncRequest};
     use std::{
@@ -921,10 +1050,11 @@ mod tests {
             // SAFETY: sock_left is a valid fd that we own.
             let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
             let (tx, _rx) = oneshot::channel();
-            let request = ActiveRequest::from_request(Request::Sync(SyncRequest {
+            let request = Request::Sync(SyncRequest {
                 file: Arc::new(file),
+                result: None,
                 sender: tx,
-            }));
+            });
             let waiter_id = iouring.waiters.insert(request, None);
             assert!(matches!(
                 iouring.waiters.stage(waiter_id),
@@ -965,10 +1095,11 @@ mod tests {
             // SAFETY: sock_left is a valid fd that we own.
             let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
             let (tx, _rx) = oneshot::channel();
-            let request = ActiveRequest::from_request(Request::Sync(SyncRequest {
+            let request = Request::Sync(SyncRequest {
                 file: Arc::new(file),
+                result: None,
                 sender: tx,
-            }));
+            });
             let waiter_id = iouring.waiters.insert(request, None);
             iouring.ready_queue.push_back(waiter_id);
         }
@@ -1000,10 +1131,11 @@ mod tests {
         // SAFETY: sock_left is a valid fd that we own.
         let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
         let (tx, _rx) = oneshot::channel();
-        let request = ActiveRequest::from_request(Request::Sync(SyncRequest {
+        let request = Request::Sync(SyncRequest {
             file: Arc::new(file),
+            result: None,
             sender: tx,
-        }));
+        });
         let waiter_id = iouring.waiters.insert(request, None);
         assert!(iouring.waiters.cancel(waiter_id));
         iouring.pending_cancels.push_back(waiter_id);
@@ -1039,11 +1171,12 @@ mod tests {
             .unwrap_or_else(Instant::now);
 
         submitter
-            .send(Request::Send(SendRequest {
+            .enqueue(Request::Send(SendRequest {
                 // SAFETY: pair() returns valid fds; we own the left end.
                 fd: Arc::new(UnixStream::pair().unwrap().0.into()),
-                bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
+                write: IoBufs::from(IoBuf::from(b"hello")).into(),
                 deadline: Some(past_deadline),
+                result: None,
                 sender: tx,
             }))
             .await
@@ -1084,49 +1217,34 @@ mod tests {
         // Write a byte so the recv completes immediately.
         (&right1).write_all(&[42]).unwrap();
 
-        let (tx1, rx1) = oneshot::channel();
-        submitter
-            .send(Request::Recv(RecvRequest {
-                fd: Arc::new(left1.into()),
-                buf: IoBufMut::with_capacity(1),
-                offset: 0,
-                len: 1,
-                exact: false,
-                deadline: Some(Instant::now() + Duration::from_millis(200)),
-                sender: tx1,
-            }))
+        let (_buf1, read1) = submitter
+            .recv(
+                Arc::new(left1.into()),
+                IoBufMut::with_capacity(1),
+                0,
+                1,
+                false,
+                Instant::now() + Duration::from_millis(200),
+            )
             .await
-            .expect("failed to submit first request");
-
-        let (_buf1, result1) = tokio::time::timeout(Duration::from_secs(2), rx1)
-            .await
-            .expect("first completion timed out")
-            .expect("missing first completion");
-        assert!(result1.is_ok());
+            .expect("first recv should succeed");
+        assert!(read1 > 0);
 
         // Second request reuses the slot and blocks until timeout.
         let (left2, _right2) = UnixStream::pair().expect("failed to create unix stream pair");
-        let (tx2, rx2) = oneshot::channel();
-        submitter
-            .send(Request::Recv(RecvRequest {
-                fd: Arc::new(left2.into()),
-                buf: IoBufMut::with_capacity(8),
-                offset: 0,
-                len: 8,
-                exact: false,
-                deadline: Some(Instant::now() + Duration::from_millis(80)),
-                sender: tx2,
-            }))
-            .await
-            .expect("failed to submit second request");
-
         let start = Instant::now();
-        let (_buf2, result2) = tokio::time::timeout(Duration::from_secs(2), rx2)
-            .await
-            .expect("second completion timed out")
-            .expect("missing second completion");
+        let result2 = submitter
+            .recv(
+                Arc::new(left2.into()),
+                IoBufMut::with_capacity(8),
+                0,
+                8,
+                false,
+                Instant::now() + Duration::from_millis(80),
+            )
+            .await;
         let elapsed = start.elapsed();
-        assert!(matches!(result2, Err(crate::Error::Timeout)));
+        assert!(matches!(result2, Err((_, crate::Error::Timeout))));
         assert!(
             elapsed >= Duration::from_millis(50),
             "timeout fired too early after slot reuse: {elapsed:?}"
@@ -1153,10 +1271,11 @@ mod tests {
         let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
         let (tx, _rx) = oneshot::channel();
         let stale = iouring.waiters.insert(
-            ActiveRequest::from_request(Request::Sync(SyncRequest {
+            Request::Sync(SyncRequest {
                 file: Arc::new(file),
+                result: None,
                 sender: tx,
-            })),
+            }),
             None,
         );
         assert!(matches!(
@@ -1175,10 +1294,11 @@ mod tests {
         let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
         let (tx, _rx) = oneshot::channel();
         let reused = iouring.waiters.insert(
-            ActiveRequest::from_request(Request::Sync(SyncRequest {
+            Request::Sync(SyncRequest {
                 file: Arc::new(file),
+                result: None,
                 sender: tx,
-            })),
+            }),
             None,
         );
         assert_eq!(reused.index(), stale.index());
@@ -1208,10 +1328,11 @@ mod tests {
         // SAFETY: sock_left is a valid fd that we own.
         let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
         let (old_tx, _old_rx) = oneshot::channel();
-        let old_req = ActiveRequest::from_request(Request::Sync(SyncRequest {
+        let old_req = Request::Sync(SyncRequest {
             file: Arc::new(file),
+            result: None,
             sender: old_tx,
-        }));
+        });
         let old_slot = iouring.waiters.insert(old_req, Some(1));
         iouring.timeout_wheel.schedule(old_slot, 1);
         // Simulate completion after the waiter had an op staged.
@@ -1233,10 +1354,11 @@ mod tests {
         // SAFETY: sock_left2 is a valid fd that we own.
         let file2 = unsafe { std::fs::File::from_raw_fd(sock_left2.into_raw_fd()) };
         let (tx, _rx) = oneshot::channel();
-        let req = ActiveRequest::from_request(Request::Sync(SyncRequest {
+        let req = Request::Sync(SyncRequest {
             file: Arc::new(file2),
+            result: None,
             sender: tx,
-        }));
+        });
         let slot_index = iouring.waiters.insert(req, Some(3));
         assert_eq!(slot_index.index(), old_slot.index());
         assert!(matches!(
@@ -1269,15 +1391,16 @@ mod tests {
         (&right).write_all(b"hello").unwrap();
 
         let (tx, rx) = oneshot::channel();
-        let req = ActiveRequest::from_request(Request::Recv(RecvRequest {
+        let req = Request::Recv(RecvRequest {
             fd: Arc::new(left.into()),
             buf: IoBufMut::with_capacity(5),
             offset: 0,
             len: 5,
             exact: false,
             deadline: Some(Instant::now() + Duration::from_secs(1)),
+            result: None,
             sender: tx,
-        }));
+        });
         let slot_index = iouring.waiters.insert(req, Some(2));
         assert!(matches!(
             iouring.waiters.stage(slot_index),
@@ -1306,9 +1429,11 @@ mod tests {
             CompletionOutcome::Cancel
         ));
 
-        let (_, result) = futures::executor::block_on(rx).expect("missing completion");
+        let (_, result) = futures::executor::block_on(rx)
+            .expect("missing completion")
+            .expect("recv should succeed");
         // exact=false recv with 5 bytes should succeed.
-        assert_eq!(result.unwrap(), 5);
+        assert_eq!(result, 5);
         assert_eq!(iouring.waiters.len(), 0);
     }
 
@@ -1336,15 +1461,16 @@ mod tests {
 
         let (left, _right) = UnixStream::pair().unwrap();
         let (tx, rx) = oneshot::channel();
-        let req = ActiveRequest::from_request(Request::Recv(RecvRequest {
+        let req = Request::Recv(RecvRequest {
             fd: Arc::new(left.into()),
             buf: IoBufMut::with_capacity(8),
             offset: 0,
             len: 8,
             exact: true,
             deadline: Some(Instant::now() + Duration::from_millis(25)),
+            result: None,
             sender: tx,
-        }));
+        });
         let waiter_id = iouring.waiters.insert(req, Some(1));
         assert!(matches!(
             iouring.waiters.stage(waiter_id),
@@ -1386,8 +1512,10 @@ mod tests {
             CompletionOutcome::Cancel
         ));
 
-        let (_buf, result) = futures::executor::block_on(rx).expect("missing completion");
-        assert!(matches!(result, Err(crate::Error::Timeout)));
+        assert!(matches!(
+            futures::executor::block_on(rx).expect("missing completion"),
+            Err((_, crate::Error::Timeout))
+        ));
         assert_eq!(iouring.waiters.len(), 0);
     }
 
@@ -1404,41 +1532,29 @@ mod tests {
             let (left_pipe, right_pipe) = UnixStream::pair().unwrap();
 
             // Submit a recv.
-            let (recv_tx, recv_rx) = oneshot::channel();
-            submitter
-                .send(Request::Recv(RecvRequest {
-                    fd: Arc::new(left_pipe.into()),
-                    buf: IoBufMut::with_capacity(5),
-                    offset: 0,
-                    len: 5,
-                    exact: false,
-                    deadline: None,
-                    sender: recv_tx,
-                }))
-                .await
-                .expect("failed to send recv");
-
-            // Submit a send that satisfies the recv.
-            let (send_tx, send_rx) = oneshot::channel();
-            submitter
-                .send(Request::Send(SendRequest {
-                    fd: Arc::new(right_pipe.into()),
-                    bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
-                    deadline: None,
-                    sender: send_tx,
-                }))
-                .await
-                .expect("failed to send send");
+            let recv = submitter.recv(
+                Arc::new(left_pipe.into()),
+                IoBufMut::with_capacity(5),
+                0,
+                5,
+                false,
+                Instant::now() + Duration::from_secs(5),
+            );
+            let send = submitter.send(
+                Arc::new(right_pipe.into()),
+                IoBufs::from(IoBuf::from(b"hello")),
+                Instant::now() + Duration::from_secs(5),
+            );
 
             let timeout = tokio::time::timeout(Duration::from_secs(2), async {
+                let (recv_result, send_result) = join(recv, send).await;
                 if should_succeed {
-                    let (_, recv_result) = recv_rx.await.expect("missing recv result");
-                    assert!(recv_result.unwrap() > 0);
-                    let send_result = send_rx.await.expect("missing send result");
-                    assert!(send_result.is_ok());
+                    let (_, read) = recv_result.expect("recv should succeed");
+                    assert!(read > 0);
+                    send_result.expect("send should succeed");
                 } else {
-                    let _ = recv_rx.await;
-                    let _ = send_rx.await;
+                    let _ = recv_result;
+                    let _ = send_result;
                 }
             });
             assert!(
@@ -1464,22 +1580,20 @@ mod tests {
 
         // Submit a recv that will time out (because we don't write to the pipe).
         let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
-        let (tx, rx) = oneshot::channel();
-        submitter
-            .send(Request::Recv(RecvRequest {
-                fd: Arc::new(pipe_left.into()),
-                buf: IoBufMut::with_capacity(8),
-                offset: 0,
-                len: 8,
-                exact: false,
-                deadline: Some(Instant::now() + Duration::from_secs(1)),
-                sender: tx,
-            }))
-            .await
-            .expect("failed to send request");
 
-        let (_, result) = rx.await.expect("failed to receive result");
-        assert!(matches!(result, Err(crate::Error::Timeout)));
+        assert!(matches!(
+            submitter
+                .recv(
+                    Arc::new(pipe_left.into()),
+                    IoBufMut::with_capacity(8),
+                    0,
+                    8,
+                    false,
+                    Instant::now() + Duration::from_secs(1),
+                )
+                .await,
+            Err((_, crate::Error::Timeout))
+        ));
 
         drop(submitter);
         handle.join().unwrap();
@@ -1502,8 +1616,9 @@ mod tests {
         let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Request::Sync(SyncRequest {
+            .enqueue(Request::Sync(SyncRequest {
                 file: Arc::new(file),
+                result: None,
                 sender: tx,
             }))
             .await
@@ -1534,13 +1649,14 @@ mod tests {
         let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Request::Recv(RecvRequest {
+            .enqueue(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
                 offset: 0,
                 len: 8,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(50)),
+                result: None,
                 sender: tx,
             }))
             .await
@@ -1548,11 +1664,13 @@ mod tests {
 
         drop(submitter);
 
-        let (_, result) = tokio::time::timeout(Duration::from_secs(2), rx)
+        let result = tokio::time::timeout(Duration::from_secs(2), rx)
             .await
-            .expect("deadline completion timed out")
-            .expect("missing deadline completion");
-        assert!(matches!(result, Err(crate::Error::Timeout)));
+            .expect("deadline completion timed out");
+        assert!(matches!(
+            result.expect("missing deadline completion"),
+            Err((_, crate::Error::Timeout))
+        ));
         handle.join().unwrap();
     }
 
@@ -1571,13 +1689,14 @@ mod tests {
         let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Request::Recv(RecvRequest {
+            .enqueue(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
                 offset: 0,
                 len: 8,
                 exact: false,
                 deadline: None,
+                result: None,
                 sender: tx,
             }))
             .await
@@ -1613,13 +1732,14 @@ mod tests {
         let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Request::Recv(RecvRequest {
+            .enqueue(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
                 offset: 0,
                 len: 8,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(50)),
+                result: None,
                 sender: tx,
             }))
             .await
@@ -1627,11 +1747,13 @@ mod tests {
 
         drop(submitter);
 
-        let (_, result) = tokio::time::timeout(Duration::from_secs(2), rx)
+        let result = tokio::time::timeout(Duration::from_secs(2), rx)
             .await
-            .expect("deadline completion timed out")
-            .expect("missing deadline completion");
-        assert!(matches!(result, Err(crate::Error::Timeout)));
+            .expect("deadline completion timed out");
+        assert!(matches!(
+            result.expect("missing deadline completion"),
+            Err((_, crate::Error::Timeout))
+        ));
         handle.join().unwrap();
     }
 
@@ -1652,13 +1774,14 @@ mod tests {
         let (pipe_left, _pipe_right) = UnixStream::pair().unwrap();
         let (tx, rx) = oneshot::channel();
         submitter
-            .send(Request::Recv(RecvRequest {
+            .enqueue(Request::Recv(RecvRequest {
                 fd: Arc::new(pipe_left.into()),
                 buf: IoBufMut::with_capacity(8),
                 offset: 0,
                 len: 8,
                 exact: false,
                 deadline: Some(Instant::now() + Duration::from_millis(500)),
+                result: None,
                 sender: tx,
             }))
             .await
@@ -1697,34 +1820,34 @@ mod tests {
         let total = 64usize;
         let deadline = Instant::now() + Duration::from_millis(50);
         let mut peers = Vec::with_capacity(total);
-        let mut rxs = Vec::with_capacity(total);
+        let mut recvs = Vec::with_capacity(total);
         for _ in 0..total {
             let (left, right) = UnixStream::pair().unwrap();
             peers.push(right);
-            let (tx, rx) = oneshot::channel();
-            submitter
-                .send(Request::Recv(RecvRequest {
-                    fd: Arc::new(left.into()),
-                    buf: IoBufMut::with_capacity(8),
-                    offset: 0,
-                    len: 8,
-                    exact: false,
-                    deadline: Some(deadline),
-                    sender: tx,
-                }))
-                .await
-                .unwrap();
-            rxs.push(rx);
+            recvs.push({
+                let submitter = submitter.clone();
+                async move {
+                    submitter
+                        .recv(
+                            Arc::new(left.into()),
+                            IoBufMut::with_capacity(8),
+                            0,
+                            8,
+                            false,
+                            deadline,
+                        )
+                        .await
+                }
+            });
         }
 
         // All requests should complete with timeout rather than getting stuck
         // behind waiter capacity.
-        for rx in rxs {
-            let (_, result) = tokio::time::timeout(Duration::from_secs(2), rx)
-                .await
-                .expect("deadline completion timed out")
-                .expect("missing deadline completion");
-            assert!(matches!(result, Err(crate::Error::Timeout)));
+        for result in tokio::time::timeout(Duration::from_secs(2), join_all(recvs))
+            .await
+            .expect("deadline completion timed out")
+        {
+            assert!(matches!(result, Err((_, crate::Error::Timeout))));
         }
 
         drop(peers);
@@ -1747,30 +1870,27 @@ mod tests {
         right.set_nonblocking(true).unwrap();
 
         let total = 100;
-        let (tx, rx) = oneshot::channel();
-        submitter
-            .send(Request::Recv(RecvRequest {
-                fd: Arc::new(left.into()),
-                buf: IoBufMut::with_capacity(total),
-                offset: 0,
-                len: total,
-                exact: true,
-                deadline: None,
-                sender: tx,
-            }))
-            .await
-            .unwrap();
+        let recv = submitter.recv(
+            Arc::new(left.into()),
+            IoBufMut::with_capacity(total),
+            0,
+            total,
+            true,
+            Instant::now() + Duration::from_secs(5),
+        );
 
         // Write data in two chunks so the recv must make partial progress.
-        (&right).write_all(&[1u8; 40]).unwrap();
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        (&right).write_all(&[2u8; 60]).unwrap();
+        let writer = async {
+            (&right).write_all(&[1u8; 40]).unwrap();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            (&right).write_all(&[2u8; 60]).unwrap();
+        };
 
-        let (_, result) = tokio::time::timeout(Duration::from_secs(5), rx)
+        let (recv_result, ()) = tokio::time::timeout(Duration::from_secs(5), join(recv, writer))
             .await
-            .expect("recv timed out")
-            .expect("missing completion");
-        assert_eq!(result.unwrap(), total);
+            .expect("recv timed out");
+        let (_, result) = recv_result.expect("recv should succeed");
+        assert_eq!(result, total);
 
         drop(submitter);
         handle.join().unwrap();
@@ -1800,13 +1920,14 @@ mod tests {
         // Submit an exact recv large enough that the first short write cannot
         // complete it. After the first CQE, the request must requeue itself.
         submitter
-            .send(Request::Recv(RecvRequest {
+            .enqueue(Request::Recv(RecvRequest {
                 fd: Arc::new(left.into()),
                 buf: IoBufMut::with_capacity(total),
                 offset: 0,
                 len: total,
                 exact: true,
                 deadline: None,
+                result: None,
                 sender: tx,
             }))
             .await
@@ -1832,8 +1953,9 @@ mod tests {
         let (_, result) = tokio::time::timeout(Duration::from_secs(2), rx)
             .await
             .expect("shutdown recv timed out")
-            .expect("missing shutdown recv completion");
-        assert_eq!(result.unwrap(), total);
+            .expect("missing shutdown recv completion")
+            .expect("recv should succeed during shutdown");
+        assert_eq!(result, total);
 
         handle.join().unwrap();
     }
@@ -1856,30 +1978,26 @@ mod tests {
         let (left, right) = UnixStream::pair().unwrap();
 
         // Submit an exact recv for 100 bytes with a short deadline.
-        let (tx, rx) = oneshot::channel();
-        submitter
-            .send(Request::Recv(RecvRequest {
-                fd: Arc::new(left.into()),
-                buf: IoBufMut::with_capacity(100),
-                offset: 0,
-                len: 100,
-                exact: true,
-                deadline: Some(Instant::now() + Duration::from_millis(80)),
-                sender: tx,
-            }))
-            .await
-            .unwrap();
+        let recv = submitter.recv(
+            Arc::new(left.into()),
+            IoBufMut::with_capacity(100),
+            0,
+            100,
+            true,
+            Instant::now() + Duration::from_millis(80),
+        );
 
         // Write partial data so the recv makes progress and gets requeued,
         // then let the deadline expire before sending the rest.
-        (&right).write_all(&[1u8; 10]).unwrap();
+        let writer = async {
+            (&right).write_all(&[1u8; 10]).unwrap();
+        };
 
-        let (_, result) = tokio::time::timeout(Duration::from_secs(5), rx)
+        let (result, ()) = tokio::time::timeout(Duration::from_secs(5), join(recv, writer))
             .await
-            .expect("recv should not hang")
-            .expect("missing completion");
+            .expect("recv should not hang");
         assert!(
-            matches!(result, Err(crate::Error::Timeout)),
+            matches!(result, Err((_, crate::Error::Timeout))),
             "expected timeout, got {result:?}"
         );
 
@@ -1901,15 +2019,16 @@ mod tests {
 
         let (left, _right) = UnixStream::pair().unwrap();
         let (tx, _rx) = oneshot::channel();
-        let request = ActiveRequest::from_request(Request::Recv(RecvRequest {
+        let request = Request::Recv(RecvRequest {
             fd: Arc::new(left.into()),
             buf: IoBufMut::with_capacity(8),
             offset: 0,
             len: 8,
             exact: true,
             deadline: Some(Instant::now() + Duration::from_millis(25)),
+            result: None,
             sender: tx,
-        }));
+        });
         let waiter_id = iouring.waiters.insert(request, Some(1));
         assert!(matches!(
             iouring.waiters.stage(waiter_id),
@@ -1953,12 +2072,13 @@ mod tests {
         // remains in the ready queue.
         let (tx, rx) = oneshot::channel();
         let waiter_id = iouring.waiters.insert(
-            ActiveRequest::from_request(Request::Send(SendRequest {
+            Request::Send(SendRequest {
                 fd: Arc::new(UnixStream::pair().unwrap().0.into()),
-                bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
+                write: IoBufs::from(IoBuf::from(b"hello")).into(),
                 deadline: Some(Instant::now() + Duration::from_secs(1)),
+                result: None,
                 sender: tx,
-            })),
+            }),
             Some(1),
         );
         assert!(iouring.waiters.cancel(waiter_id));
@@ -1987,12 +2107,13 @@ mod tests {
 
         // Insert a canceled waiter whose next transition should be a local timeout completion.
         let (tx, rx) = oneshot::channel();
-        let request = ActiveRequest::from_request(Request::Send(SendRequest {
+        let request = Request::Send(SendRequest {
             fd: Arc::new(UnixStream::pair().unwrap().0.into()),
-            bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
             deadline: Some(Instant::now() + Duration::from_secs(1)),
+            result: None,
             sender: tx,
-        }));
+        });
         let waiter_id = iouring.waiters.insert(request, Some(1));
         assert!(iouring.waiters.cancel(waiter_id));
         iouring.ready_queue.push_back(waiter_id);
@@ -2025,48 +2146,33 @@ mod tests {
         // the test proves that submissions and completions still work with the
         // SINGLE_ISSUER ring configuration enabled.
         let (sock_left, sock_right) = UnixStream::pair().unwrap();
-        let (recv_tx, recv_rx) = oneshot::channel();
-
         // Queue the recv first so the send has a real consumer and we exercise
         // the normal cross-request wake/completion path.
-        sender
-            .send(Request::Recv(RecvRequest {
-                fd: Arc::new(sock_left.into()),
-                buf: IoBufMut::with_capacity(5),
-                offset: 0,
-                len: 5,
-                exact: true,
-                deadline: None,
-                sender: recv_tx,
-            }))
-            .await
-            .unwrap();
-
-        let (send_tx, send_rx) = oneshot::channel();
-        sender
-            .send(Request::Send(SendRequest {
-                fd: Arc::new(sock_right.into()),
-                bufs: crate::IoBufs::from(IoBuf::from(b"hello")),
-                deadline: None,
-                sender: send_tx,
-            }))
-            .await
-            .unwrap();
+        let recv = sender.recv(
+            Arc::new(sock_left.into()),
+            IoBufMut::with_capacity(5),
+            0,
+            5,
+            true,
+            Instant::now() + Duration::from_secs(5),
+        );
+        let send = sender.send(
+            Arc::new(sock_right.into()),
+            IoBufs::from(IoBuf::from(b"hello")),
+            Instant::now() + Duration::from_secs(5),
+        );
 
         // The recv must observe the full payload, which shows that the request
         // made it through submission, wakeup, and completion successfully.
-        let (_, recv_result) = tokio::time::timeout(Duration::from_secs(2), recv_rx)
-            .await
-            .expect("recv timed out")
-            .expect("missing recv completion");
-        assert_eq!(recv_result.unwrap(), 5);
+        let (recv_result, send_result) =
+            tokio::time::timeout(Duration::from_secs(2), join(recv, send))
+                .await
+                .expect("recv/send timed out");
+        let (_, read) = recv_result.expect("recv should succeed");
+        assert_eq!(read, 5);
 
         // The paired send must also complete cleanly.
-        let send_result = tokio::time::timeout(Duration::from_secs(2), send_rx)
-            .await
-            .expect("send timed out")
-            .expect("missing send completion");
-        assert!(send_result.is_ok());
+        send_result.expect("send should succeed");
 
         drop(sender);
         uring_thread.join().unwrap();

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -154,7 +154,7 @@ mod request;
 mod timeout;
 use timeout::{Tick, TimeoutWheel};
 mod waiter;
-use waiter::{CqeOutcome, StageAction, WaiterId, Waiters};
+use waiter::{CompletionOutcome, StageAction, WaiterId, Waiters};
 mod waker;
 use waker::{Waker, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
 
@@ -450,7 +450,7 @@ impl IoUringLoop {
     /// queue (timeout fired between requeue and staging), it is completed with
     /// a timeout error instead of issuing a follow-up SQE.
     fn stage_request(&mut self, waiter_id: WaiterId, sq: &mut SubmissionQueue<'_>) {
-        match self.waiters.stage_sqe(waiter_id) {
+        match self.waiters.stage(waiter_id) {
             StageAction::Ignore => {}
             StageAction::Timeout(request) => request.timeout(),
             StageAction::Submit(sqe) => {
@@ -607,13 +607,13 @@ impl IoUringLoop {
             return;
         }
 
-        match self.waiters.on_cqe(user_data, cqe.result()) {
-            CqeOutcome::Ignore => {}
-            CqeOutcome::Requeue(waiter_id) => {
+        match self.waiters.on_completion(user_data, cqe.result()) {
+            CompletionOutcome::Ignore => {}
+            CompletionOutcome::Requeue(waiter_id) => {
                 // Request needs another SQE. Add it to the ready queue.
                 self.ready_queue.push_back(waiter_id);
             }
-            CqeOutcome::Complete {
+            CompletionOutcome::Complete {
                 request,
                 target_tick,
             } => {
@@ -928,7 +928,7 @@ mod tests {
             }));
             let waiter_id = iouring.waiters.insert(request, None);
             assert!(matches!(
-                iouring.waiters.stage_sqe(waiter_id),
+                iouring.waiters.stage(waiter_id),
                 StageAction::Submit(_)
             ));
             assert!(
@@ -1018,7 +1018,7 @@ mod tests {
         assert!(iouring.pending_cancels.is_empty());
         assert_eq!(ring.submission().len(), 0);
         assert!(matches!(
-            iouring.waiters.stage_sqe(waiter_id),
+            iouring.waiters.stage(waiter_id),
             StageAction::Timeout(_)
         ));
     }
@@ -1213,13 +1213,13 @@ mod tests {
         iouring.timeout_wheel.schedule(old_slot, 1);
         // Simulate completion after the waiter had an op staged.
         assert!(matches!(
-            iouring.waiters.stage_sqe(old_slot),
+            iouring.waiters.stage(old_slot),
             StageAction::Submit(_)
         ));
-        if let CqeOutcome::Complete {
+        if let CompletionOutcome::Complete {
             request,
             target_tick: Some(tick),
-        } = iouring.waiters.on_cqe(old_slot.user_data(), 0)
+        } = iouring.waiters.on_completion(old_slot.user_data(), 0)
         {
             iouring.timeout_wheel.remove(tick);
             request.finish();
@@ -1237,7 +1237,7 @@ mod tests {
         let slot_index = iouring.waiters.insert(req, Some(3));
         assert_eq!(slot_index.index(), old_slot.index());
         assert!(matches!(
-            iouring.waiters.stage_sqe(slot_index),
+            iouring.waiters.stage(slot_index),
             StageAction::Submit(_)
         ));
         iouring.timeout_wheel.schedule(slot_index, 3);
@@ -1277,7 +1277,7 @@ mod tests {
         }));
         let slot_index = iouring.waiters.insert(req, Some(2));
         assert!(matches!(
-            iouring.waiters.stage_sqe(slot_index),
+            iouring.waiters.stage(slot_index),
             StageAction::Submit(_)
         ));
         assert!(
@@ -1289,8 +1289,8 @@ mod tests {
 
         // Simulate op CQE arriving with positive result (5 bytes read).
         // Even though cancel was requested, a complete positive result wins.
-        if let CqeOutcome::Complete { request, .. } =
-            iouring.waiters.on_cqe(slot_index.user_data(), 5)
+        if let CompletionOutcome::Complete { request, .. } =
+            iouring.waiters.on_completion(slot_index.user_data(), 5)
         {
             request.finish();
         }
@@ -1299,8 +1299,8 @@ mod tests {
         assert!(matches!(
             iouring
                 .waiters
-                .on_cqe(slot_index.cancel_user_data(), -libc::ECANCELED),
-            CqeOutcome::Ignore
+                .on_completion(slot_index.cancel_user_data(), -libc::ECANCELED),
+            CompletionOutcome::Ignore
         ));
 
         let (_, result) = futures::executor::block_on(rx).expect("missing completion");
@@ -1344,7 +1344,7 @@ mod tests {
         }));
         let waiter_id = iouring.waiters.insert(req, Some(1));
         assert!(matches!(
-            iouring.waiters.stage_sqe(waiter_id),
+            iouring.waiters.stage(waiter_id),
             StageAction::Submit(_)
         ));
         iouring.timeout_wheel.schedule(waiter_id, 1);
@@ -1366,8 +1366,8 @@ mod tests {
 
         // A partial result after cancellation was requested must complete this
         // exact recv as Timeout rather than parking it back in the ready queue.
-        match iouring.waiters.on_cqe(waiter_id.user_data(), 4) {
-            CqeOutcome::Complete {
+        match iouring.waiters.on_completion(waiter_id.user_data(), 4) {
+            CompletionOutcome::Complete {
                 request,
                 target_tick: None,
             } => request.finish(),
@@ -1379,8 +1379,8 @@ mod tests {
         assert!(matches!(
             iouring
                 .waiters
-                .on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED),
-            CqeOutcome::Ignore
+                .on_completion(waiter_id.cancel_user_data(), -libc::ECANCELED),
+            CompletionOutcome::Ignore
         ));
 
         let (_buf, result) = futures::executor::block_on(rx).expect("missing completion");
@@ -1909,15 +1909,15 @@ mod tests {
         }));
         let waiter_id = iouring.waiters.insert(request, Some(1));
         assert!(matches!(
-            iouring.waiters.stage_sqe(waiter_id),
+            iouring.waiters.stage(waiter_id),
             StageAction::Submit(_)
         ));
         iouring.timeout_wheel.schedule(waiter_id, 1);
 
         // Simulate a short recv CQE so the logical request requeues itself but
         // no longer has a kernel op outstanding.
-        let waiter_id = match iouring.waiters.on_cqe(waiter_id.user_data(), 4) {
-            CqeOutcome::Requeue(waiter_id) => waiter_id,
+        let waiter_id = match iouring.waiters.on_completion(waiter_id.user_data(), 4) {
+            CompletionOutcome::Requeue(waiter_id) => waiter_id,
             _ => panic!("missing partial recv completion"),
         };
         iouring.ready_queue.push_back(waiter_id);
@@ -1928,7 +1928,7 @@ mod tests {
         // Timeout should mark the waiter canceled locally without staging `AsyncCancel`.
         assert!(iouring.pending_cancels.is_empty());
         assert!(matches!(
-            iouring.waiters.stage_sqe(waiter_id),
+            iouring.waiters.stage(waiter_id),
             StageAction::Timeout(_)
         ));
     }

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -154,7 +154,7 @@ mod request;
 mod timeout;
 use timeout::{Tick, TimeoutWheel};
 mod waiter;
-use waiter::{CqeOutcome, StageAction, WaiterId, WaiterState, Waiters};
+use waiter::{CqeOutcome, StageAction, WaiterId, Waiters};
 mod waker;
 use waker::{Waker, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
 
@@ -452,7 +452,7 @@ impl IoUringLoop {
     fn stage_request(&mut self, waiter_id: WaiterId, sq: &mut SubmissionQueue<'_>) {
         match self.waiters.stage_sqe(waiter_id) {
             StageAction::Ignore => {}
-            StageAction::CompleteTimeout(request) => request.timeout(),
+            StageAction::Timeout(request) => request.timeout(),
             StageAction::Submit(sqe) => {
                 // SAFETY:
                 // - All resources are stored in `self.waiters` until CQE processing, so
@@ -914,8 +914,8 @@ mod tests {
         let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
         let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
 
-        // Queue enough cancellations to overflow one staging pass once wake poll
-        // rearm also consumes an SQE.
+        // Queue enough in-flight cancellations to overflow one staging pass once
+        // wake poll rearm also consumes an SQE.
         for _ in 0..cfg.size as usize {
             let (sock_left, _sock_right) =
                 UnixStream::pair().expect("failed to create unix socket pair");
@@ -927,14 +927,14 @@ mod tests {
                 sender: tx,
             }));
             let waiter_id = iouring.waiters.insert(request, None);
-            assert!(
-                iouring.waiters.cancel(waiter_id),
-                "cancel should transition waiter to cancel-requested"
-            );
             assert!(matches!(
                 iouring.waiters.stage_sqe(waiter_id),
                 StageAction::Submit(_)
             ));
+            assert!(
+                iouring.waiters.cancel(waiter_id),
+                "cancel should transition waiter to cancel-requested"
+            );
             iouring.pending_cancels.push_back(waiter_id);
         }
 
@@ -1017,11 +1017,10 @@ mod tests {
         assert!(!at_capacity);
         assert!(iouring.pending_cancels.is_empty());
         assert_eq!(ring.submission().len(), 0);
-        let (_, state) = iouring
-            .waiters
-            .get_mut(waiter_id)
-            .expect("waiter should still be present");
-        assert!(matches!(state, WaiterState::CancelRequested));
+        assert!(matches!(
+            iouring.waiters.stage_sqe(waiter_id),
+            StageAction::Timeout(_)
+        ));
     }
 
     #[tokio::test]
@@ -1878,11 +1877,10 @@ mod tests {
 
         // Timeout should mark the waiter canceled locally without staging `AsyncCancel`.
         assert!(iouring.pending_cancels.is_empty());
-        let (_, state) = iouring
-            .waiters
-            .get_mut(waiter_id)
-            .expect("ready-queue waiter should remain tracked");
-        assert!(matches!(state, WaiterState::CancelRequested));
+        assert!(matches!(
+            iouring.waiters.stage_sqe(waiter_id),
+            StageAction::Timeout(_)
+        ));
     }
 
     #[test]

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -124,6 +124,19 @@ impl Request {
         self.deadline().is_some()
     }
 
+    /// Return whether this request should be treated as orphaned.
+    ///
+    /// A request is orphaned only when its completion receiver has been dropped
+    /// and this request kind stops driving follow-up SQEs in that state.
+    pub fn is_orphaned(&self) -> bool {
+        match self {
+            Self::Send(s) => s.sender.is_closed(),
+            Self::Recv(r) => r.sender.is_closed(),
+            Self::ReadAt(r) => r.sender.is_closed(),
+            Self::WriteAt(_) | Self::Sync(_) => false,
+        }
+    }
+
     /// Build the next SQE for this request, tagged with `waiter_id`.
     pub fn build_sqe(&mut self, waiter_id: WaiterId) -> SqueueEntry {
         let sqe = match self {
@@ -153,11 +166,29 @@ impl Request {
     /// Deliver the stored result to the caller via its oneshot sender.
     pub fn complete(self) {
         match self {
-            Self::Send(s) => s.finish(),
-            Self::Recv(r) => r.finish(),
-            Self::ReadAt(r) => r.finish(),
-            Self::WriteAt(w) => w.finish(),
-            Self::Sync(s) => s.finish(),
+            Self::Send(s) => {
+                let _ = s.sender.send(s.result.unwrap_or(Err(Error::SendFailed)));
+            }
+            Self::Recv(r) => {
+                let result = match r.result.unwrap_or(Err(Error::RecvFailed)) {
+                    Ok(read) => Ok((r.buf, read)),
+                    Err(err) => Err((r.buf, err)),
+                };
+                let _ = r.sender.send(result);
+            }
+            Self::ReadAt(r) => {
+                let result = match r.result.unwrap_or(Err(Error::ReadFailed)) {
+                    Ok(()) => Ok(r.buf),
+                    Err(err) => Err((r.buf, err)),
+                };
+                let _ = r.sender.send(result);
+            }
+            Self::WriteAt(w) => {
+                let _ = w.sender.send(w.result.unwrap_or(Err(Error::WriteFailed)));
+            }
+            Self::Sync(s) => {
+                let _ = s.sender.send(s.result.unwrap_or(Ok(())));
+            }
         }
     }
 
@@ -325,13 +356,6 @@ impl SendRequest {
             }
         }
     }
-
-    /// Deliver the cached terminal send result to the caller.
-    fn finish(self) {
-        let _ = self
-            .sender
-            .send(self.result.unwrap_or(Err(Error::SendFailed)));
-    }
 }
 
 /// Logical network recv request and its in-loop state.
@@ -412,15 +436,6 @@ impl RecvRequest {
             }
         }
     }
-
-    /// Deliver the cached recv result and owned buffer to the caller.
-    fn finish(self) {
-        let result = match self.result.unwrap_or(Err(Error::RecvFailed)) {
-            Ok(read) => Ok((self.buf, read)),
-            Err(err) => Err((self.buf, err)),
-        };
-        let _ = self.sender.send(result);
-    }
 }
 
 /// Logical positioned file read request and its in-loop state.
@@ -492,15 +507,6 @@ impl ReadAtRequest {
                 }
             }
         }
-    }
-
-    /// Deliver the cached read result and owned buffer to the caller.
-    fn finish(self) {
-        let result = match self.result.unwrap_or(Err(Error::ReadFailed)) {
-            Ok(()) => Ok(self.buf),
-            Err(err) => Err((self.buf, err)),
-        };
-        let _ = self.sender.send(result);
     }
 }
 
@@ -581,13 +587,6 @@ impl WriteAtRequest {
             }
         }
     }
-
-    /// Deliver the cached write result to the caller.
-    fn finish(self) {
-        let _ = self
-            .sender
-            .send(self.result.unwrap_or(Err(Error::WriteFailed)));
-    }
 }
 
 /// Logical fsync request and its in-loop state.
@@ -625,11 +624,6 @@ impl SyncRequest {
                 true
             }
         }
-    }
-
-    /// Deliver the cached fsync result to the caller.
-    fn finish(self) {
-        let _ = self.sender.send(self.result.unwrap_or(Ok(())));
     }
 }
 

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -133,6 +133,8 @@ impl Request {
             Self::Send(s) => s.sender.is_closed(),
             Self::Recv(r) => r.sender.is_closed(),
             Self::ReadAt(r) => r.sender.is_closed(),
+            // Keep storage write/sync behavior aligned with `storage/tokio/unix.rs`,
+            // where spawned blocking work continues running after caller drop.
             Self::WriteAt(_) | Self::Sync(_) => false,
         }
     }

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -210,7 +210,7 @@ pub enum CqeAction {
 /// Each variant owns its completion sender, all buffers and FDs needed by the
 /// kernel, and progress cursors. The loop calls [build_sqe](Self::build_sqe)
 /// to produce the next SQE, [on_cqe](Self::on_cqe) to evaluate completions,
-/// and [finish](Self::finish) or [finish_timeout](Self::finish_timeout) to
+/// and [finish](Self::finish) or [timeout](Self::timeout) to
 /// deliver results.
 ///
 // SAFETY: `WriteBuffers::Vectored` owns both the `IoBufs` backing storage and

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -22,12 +22,11 @@ const IOVEC_BATCH_SIZE: usize = 32;
 
 /// Normalized write buffer for [SendRequest] and [WriteAtRequest].
 ///
-/// Single-buffer writes track a byte cursor. Vectored writes track progress
-/// via [IoBufs::advance] and reuse a pre-allocated iovec scratch buffer.
+/// Preserves a single-buffer fast path and a vectored path with reusable
+/// iovec scratch space.
 pub(super) enum WriteBuffers {
     Single {
         buf: IoBuf,
-        cursor: usize,
     },
     Vectored {
         bufs: IoBufs,
@@ -40,7 +39,7 @@ impl From<IoBufs> for WriteBuffers {
     /// or a vectored representation with reusable iovec scratch space.
     fn from(bufs: IoBufs) -> Self {
         match bufs.try_into_single() {
-            Ok(buf) => Self::Single { buf, cursor: 0 },
+            Ok(buf) => Self::Single { buf },
             Err(bufs) => {
                 let max_iovecs = bufs.chunk_count().min(IOVEC_BATCH_SIZE);
                 let iovecs: Box<[libc::iovec]> = std::iter::repeat_n(
@@ -61,7 +60,7 @@ impl WriteBuffers {
     /// Return the remaining number of bytes that still need to be written.
     fn remaining_len(&self) -> usize {
         match self {
-            Self::Single { buf, cursor } => buf.len() - *cursor,
+            Self::Single { buf } => buf.len(),
             Self::Vectored { bufs, .. } => bufs.len(),
         }
     }
@@ -71,54 +70,12 @@ impl WriteBuffers {
         self.remaining_len() == 0
     }
 
-    /// Advance the logical write cursor after a successful CQE.
+    /// Advance the remaining bytes after a successful CQE.
     fn advance(&mut self, n: usize) {
         match self {
-            Self::Single { cursor, .. } => *cursor += n,
+            Self::Single { buf } => buf.advance(n),
             Self::Vectored { bufs, .. } => bufs.advance(n),
         }
-    }
-}
-
-/// Refresh the iovec scratch from the current `IoBufs` state.
-fn refresh_iovecs(bufs: &IoBufs, iovecs: &mut Box<[libc::iovec]>) -> u32 {
-    let max_iovecs = bufs.chunk_count().min(iovecs.len());
-    // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
-    let io_slices: &mut [std::io::IoSlice<'_>] = unsafe {
-        std::slice::from_raw_parts_mut(
-            iovecs.as_mut_ptr().cast::<std::io::IoSlice<'_>>(),
-            max_iovecs,
-        )
-    };
-    bufs.chunks_vectored(io_slices)
-        .try_into()
-        .expect("iovecs_len exceeds u32")
-}
-
-/// Classified raw CQE result code.
-///
-/// `classify` pre-merges `ECANCELED + CancelRequested` into [`RawResult::TimeoutCancel`]
-/// so that per-variant `on_cqe` handlers never see a raw ECANCELED.
-enum RawResult {
-    Retryable,
-    TimeoutCancel,
-    HardError(i32),
-    Zero,
-    Positive(usize),
-}
-
-/// Classify a raw CQE result code against the current waiter state.
-const fn classify_result(result: i32, state: WaiterState) -> RawResult {
-    if super::should_retry(result) {
-        RawResult::Retryable
-    } else if result == -libc::ECANCELED && matches!(state, WaiterState::CancelRequested) {
-        RawResult::TimeoutCancel
-    } else if result < 0 {
-        RawResult::HardError(result)
-    } else if result == 0 {
-        RawResult::Zero
-    } else {
-        RawResult::Positive(result as usize)
     }
 }
 
@@ -223,15 +180,62 @@ impl Request {
             Self::Sync(s) => {
                 // Sync requests currently do not carry deadlines, but keep the
                 // timeout path consistent with storage's std::io::Result API.
-                let _ = s.sender.send(Err(sync_timeout_error()));
+                let _ = s.sender.send(Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "request timed out",
+                )));
             }
         }
     }
 }
 
-/// Build the std::io::Error used if storage requests ever time out locally.
-fn sync_timeout_error() -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::TimedOut, "request timed out")
+/// Shared classification of a CQE result for the request state machines.
+///
+/// `CqeResult::from_raw` collapses the raw io_uring result space into the small
+/// set of cases the per-request state machines care about:
+/// - `EAGAIN`, `EWOULDBLOCK`, and `EINTR` become [`CqeResult::Retryable`]
+/// - `ECANCELED` becomes [`CqeResult::TimeoutCancel`] only when the waiter was
+///   already in [`WaiterState::CancelRequested`]
+/// - other negative results stay as [`CqeResult::HardError`]
+/// - zero stays distinct because some request kinds treat it differently from
+///   a hard error
+/// - positive results carry their byte or item count as [`CqeResult::Positive`]
+///
+/// This helper intentionally does not assign request-specific meaning beyond
+/// that normalization. For example, [`CqeResult::Zero`] means EOF for reads
+/// and recvs, but success for fsync.
+enum CqeResult {
+    /// Transient kernel result that may be retried with another SQE.
+    Retry,
+    /// `ECANCELED` for an operation whose waiter had already timed out and
+    /// requested async cancellation.
+    Cancelled,
+    /// Non-retryable negative CQE result code.
+    Error(i32),
+    /// Successful CQE with zero progress.
+    Zero,
+    /// Successful CQE with positive progress.
+    Positive(usize),
+}
+
+impl CqeResult {
+    /// Build a classified result from a raw CQE result code and waiter state.
+    const fn from_raw(result: i32, state: WaiterState) -> Self {
+        // Transient "try again later" results:
+        // - EAGAIN / EWOULDBLOCK: no data or capacity was ready yet
+        // - EINTR: interrupted before completion
+        if result == -libc::EAGAIN || result == -libc::EWOULDBLOCK || result == -libc::EINTR {
+            Self::Retry
+        } else if result == -libc::ECANCELED && matches!(state, WaiterState::CancelRequested) {
+            Self::Cancelled
+        } else if result < 0 {
+            Self::Error(result)
+        } else if result == 0 {
+            Self::Zero
+        } else {
+            Self::Positive(result as usize)
+        }
+    }
 }
 
 /// Logical network send request and its in-loop state.
@@ -253,16 +257,9 @@ impl SendRequest {
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.fd.as_raw_fd());
         match &mut self.write {
-            WriteBuffers::Single { buf, cursor } => {
-                assert!(
-                    *cursor <= buf.len(),
-                    "send cursor exceeds buffer length: cursor={} len={}",
-                    *cursor,
-                    buf.len()
-                );
-                // SAFETY: buf is an IoBuf with stable memory. cursor <= buf.len().
-                let ptr = unsafe { buf.as_ptr().add(*cursor) };
-                let remaining = buf.len() - *cursor;
+            WriteBuffers::Single { buf } => {
+                let ptr = buf.as_ptr();
+                let remaining = buf.remaining();
                 opcode::Send::new(
                     fd,
                     ptr,
@@ -273,7 +270,19 @@ impl SendRequest {
                 .build()
             }
             WriteBuffers::Vectored { bufs, iovecs } => {
-                let iovecs_len = refresh_iovecs(bufs, iovecs);
+                let max_iovecs = bufs.chunk_count().min(iovecs.len());
+                // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
+                let io_slices: &mut [std::io::IoSlice<'_>] = unsafe {
+                    std::slice::from_raw_parts_mut(
+                        iovecs.as_mut_ptr().cast::<std::io::IoSlice<'_>>(),
+                        max_iovecs,
+                    )
+                };
+                let iovecs_len = bufs
+                    .chunks_vectored(io_slices)
+                    .try_into()
+                    .expect("iovecs_len exceeds u32");
+
                 // `Writev` is sufficient here because network sends only need
                 // ordered byte delivery; this layer does not need sendmsg
                 // ancillary data or zerocopy completion management.
@@ -285,21 +294,21 @@ impl SendRequest {
     /// Classify one send CQE and decide whether the logical request completes
     /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
-        match classify_result(result, state) {
-            RawResult::Retryable if matches!(state, WaiterState::CancelRequested) => {
+        match CqeResult::from_raw(result, state) {
+            CqeResult::Retry if matches!(state, WaiterState::CancelRequested) => {
                 self.result = Some(Err(Error::Timeout));
                 true
             }
-            RawResult::Retryable => false,
-            RawResult::TimeoutCancel => {
+            CqeResult::Retry => false,
+            CqeResult::Cancelled => {
                 self.result = Some(Err(Error::Timeout));
                 true
             }
-            RawResult::HardError(_) | RawResult::Zero => {
+            CqeResult::Error(_) | CqeResult::Zero => {
                 self.result = Some(Err(Error::SendFailed));
                 true
             }
-            RawResult::Positive(n) => {
+            CqeResult::Positive(n) => {
                 self.write.advance(n);
                 if self.write.is_complete() {
                     self.result = Some(Ok(()));
@@ -370,21 +379,21 @@ impl RecvRequest {
     /// Classify one recv CQE and decide whether the logical request completes
     /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
-        match classify_result(result, state) {
-            RawResult::Retryable if matches!(state, WaiterState::CancelRequested) => {
+        match CqeResult::from_raw(result, state) {
+            CqeResult::Retry if matches!(state, WaiterState::CancelRequested) => {
                 self.result = Some(Err(Error::Timeout));
                 true
             }
-            RawResult::Retryable => false,
-            RawResult::TimeoutCancel => {
+            CqeResult::Retry => false,
+            CqeResult::Cancelled => {
                 self.result = Some(Err(Error::Timeout));
                 true
             }
-            RawResult::HardError(_) | RawResult::Zero => {
+            CqeResult::Error(_) | CqeResult::Zero => {
                 self.result = Some(Err(Error::RecvFailed));
                 true
             }
-            RawResult::Positive(n) => {
+            CqeResult::Positive(n) => {
                 let remaining = self.len - self.offset;
                 assert!(
                     n <= remaining,
@@ -458,17 +467,17 @@ impl ReadAtRequest {
     /// Classify one read CQE and decide whether the logical request completes
     /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
-        match classify_result(result, state) {
-            RawResult::Retryable => false,
-            RawResult::TimeoutCancel | RawResult::HardError(_) => {
+        match CqeResult::from_raw(result, state) {
+            CqeResult::Retry => false,
+            CqeResult::Cancelled | CqeResult::Error(_) => {
                 self.result = Some(Err(Error::ReadFailed));
                 true
             }
-            RawResult::Zero => {
+            CqeResult::Zero => {
                 self.result = Some(Err(Error::BlobInsufficientLength));
                 true
             }
-            RawResult::Positive(n) => {
+            CqeResult::Positive(n) => {
                 let remaining = self.len - self.read;
                 assert!(
                     n <= remaining,
@@ -517,20 +526,9 @@ impl WriteAtRequest {
         let fd = Fd(self.file.as_raw_fd());
         let offset = self.offset + self.written as u64;
         match &mut self.write {
-            WriteBuffers::Single { buf, cursor } => {
-                assert_eq!(
-                    self.written, *cursor,
-                    "single-buffer write cursor must match written byte count"
-                );
-                assert!(
-                    *cursor <= buf.len(),
-                    "write_at cursor exceeds buffer length: cursor={} len={}",
-                    *cursor,
-                    buf.len()
-                );
-                // SAFETY: buf is an IoBuf with stable memory. cursor <= buf.len().
-                let ptr = unsafe { buf.as_ptr().add(*cursor) };
-                let remaining = buf.len() - *cursor;
+            WriteBuffers::Single { buf } => {
+                let ptr = buf.as_ptr();
+                let remaining = buf.remaining();
                 opcode::Write::new(
                     fd,
                     ptr,
@@ -542,7 +540,19 @@ impl WriteAtRequest {
                 .build()
             }
             WriteBuffers::Vectored { bufs, iovecs } => {
-                let iovecs_len = refresh_iovecs(bufs, iovecs);
+                let max_iovecs = bufs.chunk_count().min(iovecs.len());
+                // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
+                let io_slices: &mut [std::io::IoSlice<'_>] = unsafe {
+                    std::slice::from_raw_parts_mut(
+                        iovecs.as_mut_ptr().cast::<std::io::IoSlice<'_>>(),
+                        max_iovecs,
+                    )
+                };
+                let iovecs_len = bufs
+                    .chunks_vectored(io_slices)
+                    .try_into()
+                    .expect("iovecs_len exceeds u32");
+
                 opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len)
                     .offset(offset)
                     .build()
@@ -553,27 +563,15 @@ impl WriteAtRequest {
     /// Classify one write CQE and decide whether the logical request completes
     /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
-        match classify_result(result, state) {
-            RawResult::Retryable => false,
-            RawResult::TimeoutCancel | RawResult::HardError(_) | RawResult::Zero => {
+        match CqeResult::from_raw(result, state) {
+            CqeResult::Retry => false,
+            CqeResult::Cancelled | CqeResult::Error(_) | CqeResult::Zero => {
                 self.result = Some(Err(Error::WriteFailed));
                 true
             }
-            RawResult::Positive(n) => {
-                if let WriteBuffers::Single { cursor, .. } = &self.write {
-                    assert_eq!(
-                        self.written, *cursor,
-                        "single-buffer write cursor must match written byte count"
-                    );
-                }
+            CqeResult::Positive(n) => {
                 self.written += n;
                 self.write.advance(n);
-                if let WriteBuffers::Single { cursor, .. } = &self.write {
-                    assert_eq!(
-                        self.written, *cursor,
-                        "single-buffer write cursor must match written byte count"
-                    );
-                }
                 if self.write.is_complete() {
                     self.result = Some(Ok(()));
                     true
@@ -612,17 +610,17 @@ impl SyncRequest {
     /// Classify one fsync CQE and decide whether the logical request completes
     /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
-        match classify_result(result, state) {
-            RawResult::Retryable => false,
-            RawResult::TimeoutCancel => {
+        match CqeResult::from_raw(result, state) {
+            CqeResult::Retry => false,
+            CqeResult::Cancelled => {
                 self.result = Some(Err(std::io::Error::from_raw_os_error(libc::ECANCELED)));
                 true
             }
-            RawResult::HardError(code) => {
+            CqeResult::Error(code) => {
                 self.result = Some(Err(std::io::Error::from_raw_os_error(-code)));
                 true
             }
-            RawResult::Zero | RawResult::Positive(_) => {
+            CqeResult::Zero | CqeResult::Positive(_) => {
                 self.result = Some(Ok(()));
                 true
             }
@@ -658,6 +656,23 @@ mod tests {
         // SAFETY: `left` is a valid owned fd and is transferred into `File`.
         let file = unsafe { File::from_raw_fd(left.into_raw_fd()) };
         Arc::new(file)
+    }
+
+    #[test]
+    fn test_cqe_result_from_raw_retryable_codes() {
+        for code in [-libc::EAGAIN, -libc::EWOULDBLOCK, -libc::EINTR] {
+            assert!(matches!(
+                CqeResult::from_raw(code, WaiterState::Active { target_tick: None }),
+                CqeResult::Retry
+            ));
+        }
+
+        for code in [0, -libc::EINVAL, -libc::ETIMEDOUT] {
+            assert!(!matches!(
+                CqeResult::from_raw(code, WaiterState::Active { target_tick: None }),
+                CqeResult::Retry
+            ));
+        }
     }
 
     #[test]

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -151,7 +151,7 @@ impl Request {
     }
 
     /// Deliver the stored result to the caller via its oneshot sender.
-    pub fn finish(self) {
+    pub fn complete(self) {
         match self {
             Self::Send(s) => s.finish(),
             Self::Recv(r) => r.finish(),
@@ -790,7 +790,7 @@ mod tests {
         });
         assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 2));
         assert!(request.on_cqe(WaiterState::CancelRequested, -libc::EAGAIN));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing send result"),
             Err(Error::Timeout)
@@ -807,7 +807,7 @@ mod tests {
         });
         assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 2));
         assert!(request.on_cqe(WaiterState::CancelRequested, 1));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing partial-timeout result"),
             Err(Error::Timeout)
@@ -823,7 +823,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing timeout-cancel result"),
             Err(Error::Timeout)
@@ -843,7 +843,7 @@ mod tests {
         });
         assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 3));
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 2));
-        request.finish();
+        request.complete();
         block_on(rx)
             .expect("missing send completion")
             .expect("send should complete successfully");
@@ -858,7 +858,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing zero-result completion"),
             Err(Error::SendFailed)
@@ -873,7 +873,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing hard-error completion"),
             Err(Error::SendFailed)
@@ -889,7 +889,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::CancelRequested, 5));
-        request.finish();
+        request.complete();
         block_on(rx)
             .expect("missing send completion")
             .expect("send should complete successfully");
@@ -926,7 +926,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 3));
-        request.finish();
+        request.complete();
         let (_buf, read) = block_on(rx)
             .expect("missing recv completion")
             .expect("recv should complete successfully");
@@ -947,7 +947,7 @@ mod tests {
         });
         assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 3));
         assert!(request.on_cqe(WaiterState::CancelRequested, 1));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing timeout completion"),
             Err((_, Error::Timeout))
@@ -966,7 +966,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::CancelRequested, -libc::EINTR));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing retryable completion"),
             Err((_, Error::Timeout))
@@ -984,7 +984,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing timeout-cancel completion"),
             Err((_, Error::Timeout))
@@ -1003,7 +1003,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::CancelRequested, 5));
-        request.finish();
+        request.complete();
         let (_buf, read) = block_on(rx)
             .expect("missing successful completion")
             .expect("recv should complete successfully");
@@ -1040,7 +1040,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing zero completion"),
             Err((_, Error::RecvFailed))
@@ -1058,7 +1058,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing error completion"),
             Err((_, Error::RecvFailed))
@@ -1095,7 +1095,7 @@ mod tests {
         });
         assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 2));
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 3));
-        request.finish();
+        request.complete();
         block_on(rx)
             .expect("missing read completion")
             .expect("read should complete successfully");
@@ -1112,7 +1112,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing eof completion"),
             Err((_, Error::BlobInsufficientLength))
@@ -1129,7 +1129,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing read failure"),
             Err((_, Error::ReadFailed))
@@ -1147,7 +1147,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing timeout-cancel failure"),
             Err((_, Error::ReadFailed))
@@ -1182,7 +1182,7 @@ mod tests {
         });
         assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 2));
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 3));
-        request.finish();
+        request.complete();
         block_on(rx)
             .expect("missing write completion")
             .expect("write should complete successfully");
@@ -1202,7 +1202,7 @@ mod tests {
         });
         assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 4));
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 1));
-        request.finish();
+        request.complete();
         block_on(rx)
             .expect("missing vectored write completion")
             .expect("vectored write should complete successfully");
@@ -1218,7 +1218,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing zero-result write"),
             Err(Error::WriteFailed)
@@ -1234,7 +1234,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing write failure"),
             Err(Error::WriteFailed)
@@ -1251,7 +1251,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing timeout-cancel write failure"),
             Err(Error::WriteFailed)
@@ -1279,7 +1279,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
-        request.finish();
+        request.complete();
         let err = block_on(rx)
             .expect("missing timeout cancel result")
             .expect_err("expected timeout cancel error");
@@ -1293,7 +1293,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
-        request.finish();
+        request.complete();
         let err = block_on(rx)
             .expect("missing hard error result")
             .expect_err("expected hard error");
@@ -1307,7 +1307,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
-        request.finish();
+        request.complete();
         block_on(rx)
             .expect("missing zero-result completion")
             .expect("sync should succeed on zero");
@@ -1319,7 +1319,7 @@ mod tests {
             sender: tx,
         });
         assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 1));
-        request.finish();
+        request.complete();
         block_on(rx)
             .expect("missing positive-result completion")
             .expect("sync should succeed on positive");
@@ -1352,7 +1352,7 @@ mod tests {
             result: None,
             sender: tx,
         });
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing send fallback"),
             Err(Error::SendFailed)
@@ -1369,7 +1369,7 @@ mod tests {
             result: None,
             sender: tx,
         });
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing recv fallback"),
             Err((_, Error::RecvFailed))
@@ -1386,7 +1386,7 @@ mod tests {
             result: None,
             sender: tx,
         });
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing read fallback"),
             Err((_, Error::ReadFailed))
@@ -1401,7 +1401,7 @@ mod tests {
             result: None,
             sender: tx,
         });
-        request.finish();
+        request.complete();
         assert!(matches!(
             block_on(rx).expect("missing write fallback"),
             Err(Error::WriteFailed)
@@ -1415,7 +1415,7 @@ mod tests {
             result: None,
             sender: tx,
         });
-        request.finish();
+        request.complete();
         block_on(rx)
             .expect("missing sync fallback")
             .expect("sync fallback should be success");

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -59,19 +59,18 @@ pub struct SendRequest {
 }
 
 /// Network receive request. When `exact` is false, any positive byte count
-/// completes successfully. When `exact` is true, exactly `target_len -
-/// received` additional bytes must be received.
+/// completes successfully. When `exact` is true, exactly `len - offset`
+/// additional bytes must be received.
 pub struct RecvRequest {
     pub fd: Arc<OwnedFd>,
     pub buf: IoBufMut,
-    /// Total byte count target tracked by the active request.
+    /// Byte offset into `buf` where the next recv should write.
+    pub offset: usize,
+    /// Total target length tracked by the active request.
     ///
-    /// This includes any existing `received` offset, so callers appending into
-    /// a partially-filled buffer should pass `offset + bytes_to_read`.
-    pub target_len: usize,
-    /// Byte offset into `buf` where received data starts. The active request
-    /// tracks progress from this offset.
-    pub received: usize,
+    /// This request fills `buf[offset..len]` and may requeue until `offset`
+    /// reaches `len`.
+    pub len: usize,
     pub exact: bool,
     pub deadline: Option<Instant>,
     pub sender: oneshot::Sender<(IoBufMut, Result<usize, Error>)>,
@@ -243,14 +242,14 @@ impl ActiveRequest {
             }),
             Request::Recv(r) => {
                 assert!(
-                    r.received <= r.target_len && r.target_len <= r.buf.capacity(),
-                    "recv invariant violated: need received <= target_len <= capacity"
+                    r.offset <= r.len && r.len <= r.buf.capacity(),
+                    "recv invariant violated: need offset <= len <= capacity"
                 );
                 Self::Recv(ActiveRecv {
                     fd: r.fd,
                     buf: r.buf,
-                    target_len: r.target_len,
-                    received: r.received,
+                    offset: r.offset,
+                    len: r.len,
                     exact: r.exact,
                     result: None,
                     sender: r.sender,
@@ -326,7 +325,7 @@ impl ActiveRequest {
 
     /// Deliver a timeout error. Used when a deadline expires before the
     /// first SQE is submitted.
-    pub fn finish_timeout(self) {
+    pub fn timeout(self) {
         match self {
             Self::Send(s) => {
                 let _ = s.sender.send(Err(Error::Timeout));
@@ -442,10 +441,10 @@ pub struct ActiveRecv {
     fd: Arc<OwnedFd>,
     /// Destination buffer owned by the request.
     buf: IoBufMut,
-    /// Total recv target, including any existing `received` offset.
-    target_len: usize,
-    /// Bytes already written into `buf`.
-    received: usize,
+    /// Byte offset into `buf` where the next recv should write.
+    offset: usize,
+    /// Total recv target, including any existing filled prefix before `offset`.
+    len: usize,
     /// Whether the recv must fill the full target before succeeding.
     exact: bool,
     /// Terminal result captured by `on_cqe` and delivered by `finish`.
@@ -459,13 +458,13 @@ impl ActiveRecv {
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.fd.as_raw_fd());
         assert!(
-            self.received <= self.target_len && self.target_len <= self.buf.capacity(),
-            "recv invariant violated: need received <= target_len <= capacity"
+            self.offset <= self.len && self.len <= self.buf.capacity(),
+            "recv invariant violated: need offset <= len <= capacity"
         );
         // SAFETY: buf is an IoBufMut with stable memory.
-        // received <= target_len <= capacity.
-        let ptr = unsafe { self.buf.as_mut_ptr().add(self.received) };
-        let remaining = self.target_len - self.received;
+        // offset <= len <= capacity.
+        let ptr = unsafe { self.buf.as_mut_ptr().add(self.offset) };
+        let remaining = self.len - self.offset;
         opcode::Recv::new(fd, ptr, remaining as u32).build()
     }
 
@@ -487,9 +486,9 @@ impl ActiveRecv {
                 CqeAction::Complete
             }
             RawResult::Positive(n) => {
-                self.received += n;
-                if !self.exact || self.received >= self.target_len {
-                    self.result = Some(Ok(self.received));
+                self.offset += n;
+                if !self.exact || self.offset >= self.len {
+                    self.result = Some(Ok(self.offset));
                     CqeAction::Complete
                 } else if matches!(state, WaiterState::CancelRequested) {
                     self.result = Some(Err(Error::Timeout));
@@ -760,18 +759,14 @@ mod tests {
         )
     }
 
-    fn make_recv_request(
-        target_len: usize,
-        received: usize,
-        exact: bool,
-    ) -> (ActiveRequest, RecvRx) {
+    fn make_recv_request(len: usize, offset: usize, exact: bool) -> (ActiveRequest, RecvRx) {
         let (tx, rx) = oneshot::channel();
         (
             ActiveRequest::from_request(Request::Recv(RecvRequest {
                 fd: make_socket_fd(),
-                buf: IoBufMut::with_capacity(target_len),
-                target_len,
-                received,
+                buf: IoBufMut::with_capacity(len),
+                offset,
+                len,
                 exact,
                 deadline: None,
                 sender: tx,
@@ -837,8 +832,8 @@ mod tests {
         let recv = Request::Recv(RecvRequest {
             fd: make_socket_fd(),
             buf: IoBufMut::with_capacity(8),
-            target_len: 8,
-            received: 0,
+            offset: 0,
+            len: 8,
             exact: true,
             deadline: Some(recv_deadline),
             sender: oneshot::channel().0,
@@ -862,8 +857,8 @@ mod tests {
             let _ = ActiveRequest::from_request(Request::Recv(RecvRequest {
                 fd: make_socket_fd(),
                 buf: IoBufMut::with_capacity(4),
-                target_len: 4,
-                received: 5,
+                offset: 5,
+                len: 4,
                 exact: true,
                 deadline: None,
                 sender: oneshot::channel().0,
@@ -875,8 +870,8 @@ mod tests {
             let _ = ActiveRequest::from_request(Request::Recv(RecvRequest {
                 fd: make_socket_fd(),
                 buf: IoBufMut::with_capacity(4),
-                target_len: 5,
-                received: 0,
+                offset: 0,
+                len: 5,
                 exact: true,
                 deadline: None,
                 sender: oneshot::channel().0,
@@ -1282,7 +1277,7 @@ mod tests {
 
         // Local timeout delivery should use TimedOut for the storage-facing API.
         let (request, rx) = make_sync_request();
-        request.finish_timeout();
+        request.timeout();
         let err = block_on(rx)
             .expect("missing timeout result")
             .expect_err("expected timeout error");
@@ -1337,25 +1332,25 @@ mod tests {
 
         // Network operations should map directly to the shared logical timeout.
         let (request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        request.finish_timeout();
+        request.timeout();
         assert!(matches!(
             block_on(rx).expect("missing send timeout"),
             Err(Error::Timeout)
         ));
 
         let (request, rx) = make_recv_request(5, 0, true);
-        request.finish_timeout();
+        request.timeout();
         let (_buf, result) = block_on(rx).expect("missing recv timeout");
         assert!(matches!(result, Err(Error::Timeout)));
 
         // Storage reads and writes also use the common logical timeout surface.
         let (request, rx) = make_read_request(5);
-        request.finish_timeout();
+        request.timeout();
         let (_buf, result) = block_on(rx).expect("missing read timeout");
         assert!(matches!(result, Err(Error::Timeout)));
 
         let (request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        request.finish_timeout();
+        request.timeout();
         assert!(matches!(
             block_on(rx).expect("missing write timeout"),
             Err(Error::Timeout)
@@ -1363,7 +1358,7 @@ mod tests {
 
         // Sync uses `std::io::ErrorKind::TimedOut` to match its storage-facing API.
         let (request, rx) = make_sync_request();
-        request.finish_timeout();
+        request.timeout();
         let err = block_on(rx)
             .expect("missing sync timeout")
             .expect_err("sync timeout should be an error");

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -762,6 +762,20 @@ mod tests {
             let _ = request.build_sqe(WaiterId::new(0, 0));
         });
         assert!(read_oversized.is_err());
+
+        let read_overread = std::panic::catch_unwind(|| {
+            let mut request = Request::ReadAt(ReadAtRequest {
+                file: make_file_fd(),
+                offset: 0,
+                len: 4,
+                read: 5,
+                buf: IoBufMut::with_capacity(8),
+                result: None,
+                sender: oneshot::channel().0,
+            });
+            let _ = request.build_sqe(WaiterId::new(0, 0));
+        });
+        assert!(read_overread.is_err());
     }
 
     #[test]

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -199,14 +199,6 @@ const fn classify_result(result: i32, state: WaiterState) -> RawResult {
     }
 }
 
-/// Action the loop takes after evaluating a CQE against a request.
-pub enum CqeAction {
-    /// Request is terminal. Remove from waiter table and deliver result.
-    Complete,
-    /// Request needs another SQE. Enqueue in the ready queue.
-    Requeue,
-}
-
 /// In-flight request state machine stored in the waiter table.
 ///
 /// Each variant owns its completion sender, all buffers and FDs needed by the
@@ -302,9 +294,9 @@ impl ActiveRequest {
 
     /// Evaluate a CQE result against this request's progress and state.
     ///
-    /// Returns [CqeAction::Complete] when the request reached a terminal
-    /// state, or [CqeAction::Requeue] when another SQE is needed.
-    pub fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+    /// Returns `true` when the request reached a terminal state, or `false`
+    /// when another SQE is needed.
+    pub fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
         match self {
             Self::Send(s) => s.on_cqe(state, result),
             Self::Recv(r) => r.on_cqe(state, result),
@@ -403,34 +395,34 @@ impl ActiveSend {
 
     /// Classify one send CQE and decide whether the logical request completes
     /// or needs another SQE.
-    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
         match classify_result(result, state) {
             RawResult::Retryable if matches!(state, WaiterState::CancelRequested) => {
                 self.result = Some(Err(Error::Timeout));
-                CqeAction::Complete
+                true
             }
-            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::Retryable => false,
             RawResult::TimeoutCancel => {
                 self.result = Some(Err(Error::Timeout));
-                CqeAction::Complete
+                true
             }
             RawResult::HardError(_) | RawResult::Zero => {
                 self.result = Some(Err(Error::SendFailed));
-                CqeAction::Complete
+                true
             }
             RawResult::Positive(n) => {
                 self.write.advance(n);
                 if self.write.is_complete() {
                     self.result = Some(Ok(()));
-                    CqeAction::Complete
+                    true
                 } else if matches!(state, WaiterState::CancelRequested) {
                     // Any send error after partial progress means some prefix
                     // of the frame may already be on the wire. Callers must
                     // drop the connection rather than retrying on this sink.
                     self.result = Some(Err(Error::Timeout));
-                    CqeAction::Complete
+                    true
                 } else {
-                    CqeAction::Requeue
+                    false
                 }
             }
         }
@@ -486,20 +478,20 @@ impl ActiveRecv {
 
     /// Classify one recv CQE and decide whether the logical request completes
     /// or needs another SQE.
-    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
         match classify_result(result, state) {
             RawResult::Retryable if matches!(state, WaiterState::CancelRequested) => {
                 self.result = Some(Err(Error::Timeout));
-                CqeAction::Complete
+                true
             }
-            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::Retryable => false,
             RawResult::TimeoutCancel => {
                 self.result = Some(Err(Error::Timeout));
-                CqeAction::Complete
+                true
             }
             RawResult::HardError(_) | RawResult::Zero => {
                 self.result = Some(Err(Error::RecvFailed));
-                CqeAction::Complete
+                true
             }
             RawResult::Positive(n) => {
                 let remaining = self.len - self.offset;
@@ -510,12 +502,12 @@ impl ActiveRecv {
                 self.offset += n;
                 if !self.exact || self.offset >= self.len {
                     self.result = Some(Ok(self.offset));
-                    CqeAction::Complete
+                    true
                 } else if matches!(state, WaiterState::CancelRequested) {
                     self.result = Some(Err(Error::Timeout));
-                    CqeAction::Complete
+                    true
                 } else {
-                    CqeAction::Requeue
+                    false
                 }
             }
         }
@@ -572,16 +564,16 @@ impl ActiveReadAt {
 
     /// Classify one read CQE and decide whether the logical request completes
     /// or needs another SQE.
-    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
         match classify_result(result, state) {
-            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::Retryable => false,
             RawResult::TimeoutCancel | RawResult::HardError(_) => {
                 self.result = Some(Err(Error::ReadFailed));
-                CqeAction::Complete
+                true
             }
             RawResult::Zero => {
                 self.result = Some(Err(Error::BlobInsufficientLength));
-                CqeAction::Complete
+                true
             }
             RawResult::Positive(n) => {
                 let remaining = self.len - self.read;
@@ -592,9 +584,9 @@ impl ActiveReadAt {
                 self.read += n;
                 if self.read >= self.len {
                     self.result = Some(Ok(()));
-                    CqeAction::Complete
+                    true
                 } else {
-                    CqeAction::Requeue
+                    false
                 }
             }
         }
@@ -665,12 +657,12 @@ impl ActiveWriteAt {
 
     /// Classify one write CQE and decide whether the logical request completes
     /// or needs another SQE.
-    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
         match classify_result(result, state) {
-            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::Retryable => false,
             RawResult::TimeoutCancel | RawResult::HardError(_) | RawResult::Zero => {
                 self.result = Some(Err(Error::WriteFailed));
-                CqeAction::Complete
+                true
             }
             RawResult::Positive(n) => {
                 if let WriteBuffers::Single { cursor, .. } = &self.write {
@@ -689,9 +681,9 @@ impl ActiveWriteAt {
                 }
                 if self.write.is_complete() {
                     self.result = Some(Ok(()));
-                    CqeAction::Complete
+                    true
                 } else {
-                    CqeAction::Requeue
+                    false
                 }
             }
         }
@@ -724,20 +716,20 @@ impl ActiveSync {
 
     /// Classify one fsync CQE and decide whether the logical request completes
     /// or needs another SQE.
-    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> bool {
         match classify_result(result, state) {
-            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::Retryable => false,
             RawResult::TimeoutCancel => {
                 self.result = Some(Err(std::io::Error::from_raw_os_error(libc::ECANCELED)));
-                CqeAction::Complete
+                true
             }
             RawResult::HardError(code) => {
                 self.result = Some(Err(std::io::Error::from_raw_os_error(-code)));
-                CqeAction::Complete
+                true
             }
             RawResult::Zero | RawResult::Positive(_) => {
                 self.result = Some(Ok(()));
-                CqeAction::Complete
+                true
             }
         }
     }
@@ -765,6 +757,14 @@ mod tests {
     type RecvRx = oneshot::Receiver<(IoBufMut, Result<usize, Error>)>;
     type ReadRx = oneshot::Receiver<(IoBufMut, Result<(), Error>)>;
     type SyncRx = oneshot::Receiver<std::io::Result<()>>;
+
+    fn assert_requeue(completed: bool) {
+        assert!(!completed);
+    }
+
+    fn assert_complete(completed: bool) {
+        assert!(completed);
+    }
 
     fn active_state() -> WaiterState {
         WaiterState::Active { target_tick: None }
@@ -933,21 +933,12 @@ mod tests {
 
         // Retryable CQEs should simply requeue while the request is still active.
         let (mut request, _rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EAGAIN),
-            CqeAction::Requeue
-        ));
+        assert_requeue(request.on_cqe(active_state(), -libc::EAGAIN));
 
         // Partial progress followed by a retry after timeout should resolve to timeout.
         let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(active_state(), 2),
-            CqeAction::Requeue
-        ));
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, -libc::EAGAIN),
-            CqeAction::Complete
-        ));
+        assert_requeue(request.on_cqe(active_state(), 2));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::EAGAIN));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing send result"),
@@ -956,14 +947,8 @@ mod tests {
 
         // Partial progress after timeout must also resolve to timeout rather than requeueing.
         let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(active_state(), 2),
-            CqeAction::Requeue
-        ));
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, 1),
-            CqeAction::Complete
-        ));
+        assert_requeue(request.on_cqe(active_state(), 2));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, 1));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing partial-timeout result"),
@@ -972,10 +957,7 @@ mod tests {
 
         // A canceled send that comes back as ECANCELED should also resolve to timeout.
         let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing timeout-cancel result"),
@@ -987,14 +969,8 @@ mod tests {
         vectored.append(IoBuf::from(b"abc"));
         vectored.append(IoBuf::from(b"de"));
         let (mut request, rx) = make_send_request(vectored);
-        assert!(matches!(
-            request.on_cqe(active_state(), 3),
-            CqeAction::Requeue
-        ));
-        assert!(matches!(
-            request.on_cqe(active_state(), 2),
-            CqeAction::Complete
-        ));
+        assert_requeue(request.on_cqe(active_state(), 3));
+        assert_complete(request.on_cqe(active_state(), 2));
         request.finish();
         block_on(rx)
             .expect("missing send completion")
@@ -1002,10 +978,7 @@ mod tests {
 
         // Zero-byte and hard-error CQEs should both surface as send failures.
         let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(active_state(), 0),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), 0));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing zero-result completion"),
@@ -1013,10 +986,7 @@ mod tests {
         ));
 
         let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EIO),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), -libc::EIO));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing hard-error completion"),
@@ -1025,10 +995,7 @@ mod tests {
 
         // A fully successful CQE still wins even if timeout was already requested.
         let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, 5),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, 5));
         request.finish();
         block_on(rx)
             .expect("missing send completion")
@@ -1041,17 +1008,11 @@ mod tests {
 
         // Retryable CQEs should requeue while the recv is still active.
         let (mut request, _rx) = make_recv_request(5, 0, true);
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EAGAIN),
-            CqeAction::Requeue
-        ));
+        assert_requeue(request.on_cqe(active_state(), -libc::EAGAIN));
 
         // Non-exact recv should complete as soon as any positive byte count arrives.
         let (mut request, rx) = make_recv_request(5, 0, false);
-        assert!(matches!(
-            request.on_cqe(active_state(), 3),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), 3));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing recv completion");
         assert_eq!(result.expect("recv should complete successfully"), 3);
@@ -1059,43 +1020,28 @@ mod tests {
         // Exact recv should requeue after partial progress, but timeout wins if the follow-up CQE
         // arrives after cancellation was requested.
         let (mut request, rx) = make_recv_request(5, 0, true);
-        assert!(matches!(
-            request.on_cqe(active_state(), 3),
-            CqeAction::Requeue
-        ));
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, 1),
-            CqeAction::Complete
-        ));
+        assert_requeue(request.on_cqe(active_state(), 3));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, 1));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing timeout completion");
         assert!(matches!(result, Err(Error::Timeout)));
 
         // Retryable and ECANCELED completions after timeout should both resolve to timeout.
         let (mut request, rx) = make_recv_request(5, 0, true);
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, -libc::EINTR),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::EINTR));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing retryable completion");
         assert!(matches!(result, Err(Error::Timeout)));
 
         let (mut request, rx) = make_recv_request(5, 0, true);
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing timeout-cancel completion");
         assert!(matches!(result, Err(Error::Timeout)));
 
         // A fully successful CQE still wins after timeout was requested.
         let (mut request, rx) = make_recv_request(5, 0, true);
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, 5),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, 5));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing successful completion");
         assert_eq!(result.expect("recv should complete successfully"), 5);
@@ -1110,19 +1056,13 @@ mod tests {
 
         // Zero-byte and hard-error CQEs should both surface as recv failures.
         let (mut request, rx) = make_recv_request(5, 0, true);
-        assert!(matches!(
-            request.on_cqe(active_state(), 0),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), 0));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing zero completion");
         assert!(matches!(result, Err(Error::RecvFailed)));
 
         let (mut request, rx) = make_recv_request(5, 0, true);
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EIO),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), -libc::EIO));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing error completion");
         assert!(matches!(result, Err(Error::RecvFailed)));
@@ -1134,50 +1074,32 @@ mod tests {
 
         // Retryable CQEs should requeue the positioned read.
         let (mut request, _rx) = make_read_request(5);
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EAGAIN),
-            CqeAction::Requeue
-        ));
+        assert_requeue(request.on_cqe(active_state(), -libc::EAGAIN));
 
         // Partial reads should requeue until the full logical length is satisfied.
         let (mut request, rx) = make_read_request(5);
-        assert!(matches!(
-            request.on_cqe(active_state(), 2),
-            CqeAction::Requeue
-        ));
-        assert!(matches!(
-            request.on_cqe(active_state(), 3),
-            CqeAction::Complete
-        ));
+        assert_requeue(request.on_cqe(active_state(), 2));
+        assert_complete(request.on_cqe(active_state(), 3));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing read completion");
         result.expect("read should complete successfully");
 
         // EOF and hard-error CQEs should map to the storage read error surface.
         let (mut request, rx) = make_read_request(5);
-        assert!(matches!(
-            request.on_cqe(active_state(), 0),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), 0));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing eof completion");
         assert!(matches!(result, Err(Error::BlobInsufficientLength)));
 
         let (mut request, rx) = make_read_request(5);
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EIO),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), -libc::EIO));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing read failure");
         assert!(matches!(result, Err(Error::ReadFailed)));
 
         // Timeout cancellation should also surface as a read failure.
         let (mut request, rx) = make_read_request(5);
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing timeout-cancel failure");
         assert!(matches!(result, Err(Error::ReadFailed)));
@@ -1189,21 +1111,12 @@ mod tests {
 
         // Retryable CQEs should requeue the positioned write.
         let (mut request, _rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EAGAIN),
-            CqeAction::Requeue
-        ));
+        assert_requeue(request.on_cqe(active_state(), -libc::EAGAIN));
 
         // Single-buffer writes should track partial progress until complete.
         let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(active_state(), 2),
-            CqeAction::Requeue
-        ));
-        assert!(matches!(
-            request.on_cqe(active_state(), 3),
-            CqeAction::Complete
-        ));
+        assert_requeue(request.on_cqe(active_state(), 2));
+        assert_complete(request.on_cqe(active_state(), 3));
         request.finish();
         block_on(rx)
             .expect("missing write completion")
@@ -1214,14 +1127,8 @@ mod tests {
         vectored.append(IoBuf::from(b"abc"));
         vectored.append(IoBuf::from(b"de"));
         let (mut request, rx) = make_write_request(vectored);
-        assert!(matches!(
-            request.on_cqe(active_state(), 4),
-            CqeAction::Requeue
-        ));
-        assert!(matches!(
-            request.on_cqe(active_state(), 1),
-            CqeAction::Complete
-        ));
+        assert_requeue(request.on_cqe(active_state(), 4));
+        assert_complete(request.on_cqe(active_state(), 1));
         request.finish();
         block_on(rx)
             .expect("missing vectored write completion")
@@ -1229,10 +1136,7 @@ mod tests {
 
         // Zero-byte and hard-error CQEs should surface as write failures.
         let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(active_state(), 0),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), 0));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing zero-result write"),
@@ -1240,10 +1144,7 @@ mod tests {
         ));
 
         let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EIO),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), -libc::EIO));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing write failure"),
@@ -1252,10 +1153,7 @@ mod tests {
 
         // Timeout cancellation should also surface as a write failure.
         let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing timeout-cancel write failure"),
@@ -1269,17 +1167,11 @@ mod tests {
 
         // Retryable CQEs should requeue the fsync request.
         let (mut request, _rx) = make_sync_request();
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EINTR),
-            CqeAction::Requeue
-        ));
+        assert_requeue(request.on_cqe(active_state(), -libc::EINTR));
 
         // Timeout cancellation should preserve the kernel ECANCELED surface for sync callers.
         let (mut request, rx) = make_sync_request();
-        assert!(matches!(
-            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
         let err = block_on(rx)
             .expect("missing timeout cancel result")
@@ -1288,10 +1180,7 @@ mod tests {
 
         // Hard errors should round-trip as std::io::Error values.
         let (mut request, rx) = make_sync_request();
-        assert!(matches!(
-            request.on_cqe(active_state(), -libc::EIO),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), -libc::EIO));
         request.finish();
         let err = block_on(rx)
             .expect("missing hard error result")
@@ -1300,20 +1189,14 @@ mod tests {
 
         // Both zero and positive CQE results should count as sync success.
         let (mut request, rx) = make_sync_request();
-        assert!(matches!(
-            request.on_cqe(active_state(), 0),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), 0));
         request.finish();
         block_on(rx)
             .expect("missing zero-result completion")
             .expect("sync should succeed on zero");
 
         let (mut request, rx) = make_sync_request();
-        assert!(matches!(
-            request.on_cqe(active_state(), 1),
-            CqeAction::Complete
-        ));
+        assert_complete(request.on_cqe(active_state(), 1));
         request.finish();
         block_on(rx)
             .expect("missing positive-result completion")

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -372,6 +372,12 @@ impl ActiveSend {
         let fd = Fd(self.fd.as_raw_fd());
         match &mut self.write {
             WriteBuffers::Single { buf, cursor } => {
+                assert!(
+                    *cursor <= buf.len(),
+                    "send cursor exceeds buffer length: cursor={} len={}",
+                    *cursor,
+                    buf.len()
+                );
                 // SAFETY: buf is an IoBuf with stable memory. cursor <= buf.len().
                 let ptr = unsafe { buf.as_ptr().add(*cursor) };
                 let remaining = buf.len() - *cursor;
@@ -410,6 +416,9 @@ impl ActiveSend {
                     self.result = Some(Ok(()));
                     CqeAction::Complete
                 } else if matches!(state, WaiterState::CancelRequested) {
+                    // Any send error after partial progress means some prefix
+                    // of the frame may already be on the wire. Callers must
+                    // drop the connection rather than retrying on this sink.
                     self.result = Some(Err(Error::Timeout));
                     CqeAction::Complete
                 } else {
@@ -449,6 +458,10 @@ impl ActiveRecv {
     /// Build the next socket recv SQE for the unread suffix of the target.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.fd.as_raw_fd());
+        assert!(
+            self.received <= self.target_len && self.target_len <= self.buf.capacity(),
+            "recv invariant violated: need received <= target_len <= capacity"
+        );
         // SAFETY: buf is an IoBufMut with stable memory.
         // received <= target_len <= capacity.
         let ptr = unsafe { self.buf.as_mut_ptr().add(self.received) };
@@ -518,6 +531,10 @@ impl ActiveReadAt {
     /// Build the next positioned read SQE for the unread suffix of the target.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.file.as_raw_fd());
+        assert!(
+            self.read <= self.len && self.len <= self.buf.capacity(),
+            "read_at invariant violated: need read <= len <= capacity"
+        );
         // SAFETY: buf is an IoBufMut with stable memory. read <= len <= capacity.
         let ptr = unsafe { self.buf.as_mut_ptr().add(self.read) };
         let remaining = self.len - self.read;
@@ -541,6 +558,11 @@ impl ActiveReadAt {
                 CqeAction::Complete
             }
             RawResult::Positive(n) => {
+                let remaining = self.len - self.read;
+                assert!(
+                    n <= remaining,
+                    "read CQE exceeds requested length: n={n} remaining={remaining}"
+                );
                 self.read += n;
                 if self.read >= self.len {
                     self.result = Some(Ok(()));
@@ -583,6 +605,16 @@ impl ActiveWriteAt {
         let offset = self.offset + self.written as u64;
         match &mut self.write {
             WriteBuffers::Single { buf, cursor } => {
+                assert_eq!(
+                    self.written, *cursor,
+                    "single-buffer write cursor must match written byte count"
+                );
+                assert!(
+                    *cursor <= buf.len(),
+                    "write_at cursor exceeds buffer length: cursor={} len={}",
+                    *cursor,
+                    buf.len()
+                );
                 // SAFETY: buf is an IoBuf with stable memory. cursor <= buf.len().
                 let ptr = unsafe { buf.as_ptr().add(*cursor) };
                 let remaining = buf.len() - *cursor;
@@ -609,8 +641,20 @@ impl ActiveWriteAt {
                 CqeAction::Complete
             }
             RawResult::Positive(n) => {
+                if let WriteBuffers::Single { cursor, .. } = &self.write {
+                    assert_eq!(
+                        self.written, *cursor,
+                        "single-buffer write cursor must match written byte count"
+                    );
+                }
                 self.written += n;
                 self.write.advance(n);
+                if let WriteBuffers::Single { cursor, .. } = &self.write {
+                    assert_eq!(
+                        self.written, *cursor,
+                        "single-buffer write cursor must match written byte count"
+                    );
+                }
                 if self.write.is_complete() {
                     self.result = Some(Ok(()));
                     CqeAction::Complete

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -84,7 +84,7 @@ impl WriteBuffers {
 /// Each variant owns its completion sender, all buffers and FDs needed by the
 /// kernel, and progress cursors. The loop calls [build_sqe](Self::build_sqe)
 /// to produce the next SQE, [on_cqe](Self::on_cqe) to evaluate completions,
-/// and [finish](Self::finish) or [timeout](Self::timeout) to
+/// and [complete](Self::complete) or [timeout](Self::timeout) to
 /// deliver results.
 ///
 // SAFETY: `WriteBuffers::Vectored` owns both the `IoBufs` backing storage and
@@ -193,10 +193,10 @@ impl Request {
 ///
 /// `CqeResult::from_raw` collapses the raw io_uring result space into the small
 /// set of cases the per-request state machines care about:
-/// - `EAGAIN`, `EWOULDBLOCK`, and `EINTR` become [`CqeResult::Retryable`]
-/// - `ECANCELED` becomes [`CqeResult::TimeoutCancel`] only when the waiter was
+/// - `EAGAIN`, `EWOULDBLOCK`, and `EINTR` become [`CqeResult::Retry`]
+/// - `ECANCELED` becomes [`CqeResult::Cancelled`] only when the waiter was
 ///   already in [`WaiterState::CancelRequested`]
-/// - other negative results stay as [`CqeResult::HardError`]
+/// - other negative results stay as [`CqeResult::Error`]
 /// - zero stays distinct because some request kinds treat it differently from
 ///   a hard error
 /// - positive results carry their byte or item count as [`CqeResult::Positive`]

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -1,0 +1,601 @@
+//! Request types and active state machines for the io_uring loop.
+//!
+//! Callers submit a [Request] to the loop via [super::Submitter]. The loop
+//! converts it into an [ActiveRequest] that owns all resources (buffers, FDs,
+//! progress cursors, completion sender) needed to build follow-up SQEs and
+//! deliver a typed result.
+
+use super::waiter::{WaiterId, WaiterState};
+use crate::{Buf, Error, IoBuf, IoBufMut, IoBufs};
+use commonware_utils::channel::oneshot;
+use io_uring::{opcode, squeue::Entry as SqueueEntry, types::Fd};
+use std::{
+    fs::File,
+    os::fd::{AsRawFd, OwnedFd},
+    sync::Arc,
+    time::Instant,
+};
+
+/// Cap iovec batch size: larger iovecs reduce syscall count but increase
+/// per-write kernel setup overhead.
+const IOVEC_BATCH_SIZE: usize = 32;
+
+/// High-level request submitted by callers to the io_uring loop.
+pub enum Request {
+    #[cfg_attr(not(feature = "iouring-network"), allow(dead_code))]
+    Send(SendRequest),
+    #[cfg_attr(not(feature = "iouring-network"), allow(dead_code))]
+    Recv(RecvRequest),
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    ReadAt(ReadAtRequest),
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    WriteAt(WriteAtRequest),
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    Sync(SyncRequest),
+}
+
+impl Request {
+    /// Return the deadline for this request, if any.
+    pub const fn deadline(&self) -> Option<Instant> {
+        match self {
+            Self::Send(r) => r.deadline,
+            Self::Recv(r) => r.deadline,
+            Self::ReadAt(_) | Self::WriteAt(_) | Self::Sync(_) => None,
+        }
+    }
+
+    /// Return whether this request carries a deadline.
+    pub const fn has_deadline(&self) -> bool {
+        self.deadline().is_some()
+    }
+}
+
+/// Network send request. Completes when all bytes are written.
+pub struct SendRequest {
+    pub fd: Arc<OwnedFd>,
+    pub bufs: IoBufs,
+    pub deadline: Option<Instant>,
+    pub sender: oneshot::Sender<Result<(), Error>>,
+}
+
+/// Network receive request. When `exact` is false, any positive byte count
+/// completes successfully. When `exact` is true, exactly `len` bytes must be
+/// received.
+pub struct RecvRequest {
+    pub fd: Arc<OwnedFd>,
+    pub buf: IoBufMut,
+    /// Total byte count target (includes `received` offset).
+    pub len: usize,
+    /// Byte offset into `buf` where received data starts. The active request
+    /// tracks progress from this offset.
+    pub received: usize,
+    pub exact: bool,
+    pub deadline: Option<Instant>,
+    pub sender: oneshot::Sender<(IoBufMut, Result<usize, Error>)>,
+}
+
+/// Storage read request. Completes when exactly `len` bytes are read.
+pub struct ReadAtRequest {
+    pub file: Arc<File>,
+    pub offset: u64,
+    pub len: usize,
+    pub buf: IoBufMut,
+    pub sender: oneshot::Sender<(IoBufMut, Result<(), Error>)>,
+}
+
+/// Storage write request. Completes when all bytes are written.
+pub struct WriteAtRequest {
+    pub file: Arc<File>,
+    pub offset: u64,
+    pub bufs: IoBufs,
+    pub sender: oneshot::Sender<Result<(), Error>>,
+}
+
+/// Storage fsync request.
+pub struct SyncRequest {
+    pub file: Arc<File>,
+    pub sender: oneshot::Sender<std::io::Result<()>>,
+}
+
+/// Normalized write buffer for [ActiveSend] and [ActiveWriteAt].
+///
+/// Single-buffer writes track a byte cursor. Vectored writes track progress
+/// via [IoBufs::advance] and reuse a pre-allocated iovec scratch buffer.
+enum WriteBuffers {
+    Single {
+        buf: IoBuf,
+        cursor: usize,
+    },
+    Vectored {
+        bufs: IoBufs,
+        iovecs: Box<[libc::iovec]>,
+    },
+}
+
+impl WriteBuffers {
+    fn new(bufs: IoBufs) -> Self {
+        match bufs.try_into_single() {
+            Ok(buf) => Self::Single { buf, cursor: 0 },
+            Err(bufs) => {
+                let max_iovecs = bufs.chunk_count().min(IOVEC_BATCH_SIZE);
+                let iovecs: Box<[libc::iovec]> = std::iter::repeat_n(
+                    libc::iovec {
+                        iov_base: std::ptr::NonNull::<u8>::dangling().as_ptr().cast(),
+                        iov_len: 0,
+                    },
+                    max_iovecs,
+                )
+                .collect();
+                Self::Vectored { bufs, iovecs }
+            }
+        }
+    }
+
+    fn remaining_len(&self) -> usize {
+        match self {
+            Self::Single { buf, cursor } => buf.len() - *cursor,
+            Self::Vectored { bufs, .. } => bufs.len(),
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.remaining_len() == 0
+    }
+
+    fn advance(&mut self, n: usize) {
+        match self {
+            Self::Single { cursor, .. } => *cursor += n,
+            Self::Vectored { bufs, .. } => bufs.advance(n),
+        }
+    }
+}
+
+/// Refresh the iovec scratch from the current `IoBufs` state.
+fn refresh_iovecs(bufs: &IoBufs, iovecs: &mut Box<[libc::iovec]>) -> usize {
+    let max_iovecs = bufs.chunk_count().min(iovecs.len());
+    // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
+    let io_slices: &mut [std::io::IoSlice<'_>] = unsafe {
+        std::slice::from_raw_parts_mut(
+            iovecs.as_mut_ptr().cast::<std::io::IoSlice<'_>>(),
+            max_iovecs,
+        )
+    };
+    bufs.chunks_vectored(io_slices)
+}
+
+/// Classified raw CQE result code.
+///
+/// `classify` pre-merges `ECANCELED + CancelRequested` into [`RawResult::TimeoutCancel`]
+/// so that per-variant `on_cqe` handlers never see a raw ECANCELED.
+enum RawResult {
+    Retryable,
+    TimeoutCancel,
+    HardError(i32),
+    Zero,
+    Positive(usize),
+}
+
+/// Classify a raw CQE result code against the current waiter state.
+const fn classify_result(result: i32, state: WaiterState) -> RawResult {
+    if super::should_retry(result) {
+        RawResult::Retryable
+    } else if result == -libc::ECANCELED && matches!(state, WaiterState::CancelRequested) {
+        RawResult::TimeoutCancel
+    } else if result < 0 {
+        RawResult::HardError(result)
+    } else if result == 0 {
+        RawResult::Zero
+    } else {
+        RawResult::Positive(result as usize)
+    }
+}
+
+/// Action the loop takes after evaluating a CQE against a request.
+pub enum CqeAction {
+    /// Request is terminal. Remove from waiter table and deliver result.
+    Complete,
+    /// Request needs another SQE. Enqueue in the ready queue.
+    Requeue,
+}
+
+/// In-flight request state machine stored in the waiter table.
+///
+/// Each variant owns its completion sender, all buffers and FDs needed by the
+/// kernel, and progress cursors. The loop calls [build_sqe](Self::build_sqe)
+/// to produce the next SQE, [on_cqe](Self::on_cqe) to evaluate completions,
+/// and [finish](Self::finish) or [finish_timeout](Self::finish_timeout) to
+/// deliver results.
+///
+// SAFETY: The raw iovec pointers in `WriteBuffers::Vectored` point into the
+// `IoBufs` co-owned in the same variant. The pointed-to memory remains valid
+// for the request lifetime because both live in the same waiter slot.
+unsafe impl Send for ActiveRequest {}
+
+pub enum ActiveRequest {
+    Send(ActiveSend),
+    Recv(ActiveRecv),
+    ReadAt(ActiveReadAt),
+    WriteAt(ActiveWriteAt),
+    Sync(ActiveSync),
+}
+
+impl ActiveRequest {
+    /// Convert a caller-submitted [Request] into an active state machine.
+    pub fn from_request(request: Request) -> Self {
+        match request {
+            Request::Send(r) => Self::Send(ActiveSend {
+                fd: r.fd,
+                write: WriteBuffers::new(r.bufs),
+                result: None,
+                sender: r.sender,
+            }),
+            Request::Recv(r) => {
+                assert!(
+                    r.received <= r.len && r.len <= r.buf.capacity(),
+                    "recv invariant violated: need received <= len <= capacity"
+                );
+                Self::Recv(ActiveRecv {
+                    fd: r.fd,
+                    buf: r.buf,
+                    len: r.len,
+                    received: r.received,
+                    exact: r.exact,
+                    result: None,
+                    sender: r.sender,
+                })
+            }
+            Request::ReadAt(r) => {
+                assert!(
+                    r.len <= r.buf.capacity(),
+                    "read_at len exceeds buffer capacity"
+                );
+                Self::ReadAt(ActiveReadAt {
+                    file: r.file,
+                    offset: r.offset,
+                    len: r.len,
+                    read: 0,
+                    buf: r.buf,
+                    result: None,
+                    sender: r.sender,
+                })
+            }
+            Request::WriteAt(r) => Self::WriteAt(ActiveWriteAt {
+                file: r.file,
+                offset: r.offset,
+                written: 0,
+                write: WriteBuffers::new(r.bufs),
+                result: None,
+                sender: r.sender,
+            }),
+            Request::Sync(r) => Self::Sync(ActiveSync {
+                file: r.file,
+                result: None,
+                sender: r.sender,
+            }),
+        }
+    }
+
+    /// Build the next SQE for this request, tagged with `waiter_id`.
+    pub fn build_sqe(&mut self, waiter_id: WaiterId) -> SqueueEntry {
+        let sqe = match self {
+            Self::Send(s) => s.build_sqe(),
+            Self::Recv(r) => r.build_sqe(),
+            Self::ReadAt(r) => r.build_sqe(),
+            Self::WriteAt(w) => w.build_sqe(),
+            Self::Sync(s) => s.build_sqe(),
+        };
+        sqe.user_data(waiter_id.user_data())
+    }
+
+    /// Evaluate a CQE result against this request's progress and state.
+    ///
+    /// Returns [CqeAction::Complete] when the request reached a terminal
+    /// state, or [CqeAction::Requeue] when another SQE is needed.
+    pub fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+        match self {
+            Self::Send(s) => s.on_cqe(state, result),
+            Self::Recv(r) => r.on_cqe(state, result),
+            Self::ReadAt(r) => r.on_cqe(state, result),
+            Self::WriteAt(w) => w.on_cqe(state, result),
+            Self::Sync(s) => s.on_cqe(state, result),
+        }
+    }
+
+    /// Deliver the stored result to the caller via its oneshot sender.
+    pub fn finish(self) {
+        match self {
+            Self::Send(s) => s.finish(),
+            Self::Recv(r) => r.finish(),
+            Self::ReadAt(r) => r.finish(),
+            Self::WriteAt(w) => w.finish(),
+            Self::Sync(s) => s.finish(),
+        }
+    }
+
+    /// Deliver a timeout error. Used when a deadline expires before the
+    /// first SQE is submitted.
+    pub fn finish_timeout(self) {
+        match self {
+            Self::Send(s) => {
+                let _ = s.sender.send(Err(Error::Timeout));
+            }
+            Self::Recv(r) => {
+                let _ = r.sender.send((r.buf, Err(Error::Timeout)));
+            }
+            Self::ReadAt(r) => {
+                let _ = r.sender.send((r.buf, Err(Error::Timeout)));
+            }
+            Self::WriteAt(w) => {
+                let _ = w.sender.send(Err(Error::Timeout));
+            }
+            Self::Sync(s) => {
+                let _ = s.sender.send(Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "request timed out",
+                )));
+            }
+        }
+    }
+}
+
+pub struct ActiveSend {
+    fd: Arc<OwnedFd>,
+    write: WriteBuffers,
+    result: Option<Result<(), Error>>,
+    sender: oneshot::Sender<Result<(), Error>>,
+}
+
+impl ActiveSend {
+    fn build_sqe(&mut self) -> SqueueEntry {
+        let fd = Fd(self.fd.as_raw_fd());
+        match &mut self.write {
+            WriteBuffers::Single { buf, cursor } => {
+                // SAFETY: buf is an IoBuf with stable memory. cursor <= buf.len().
+                let ptr = unsafe { buf.as_ptr().add(*cursor) };
+                let remaining = buf.len() - *cursor;
+                opcode::Send::new(fd, ptr, remaining as u32).build()
+            }
+            WriteBuffers::Vectored { bufs, iovecs } => {
+                let iovecs_len = refresh_iovecs(bufs, iovecs);
+                opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len as _).build()
+            }
+        }
+    }
+
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+        match classify_result(result, state) {
+            RawResult::Retryable if matches!(state, WaiterState::CancelRequested) => {
+                self.result = Some(Err(Error::Timeout));
+                CqeAction::Complete
+            }
+            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::TimeoutCancel => {
+                self.result = Some(Err(Error::Timeout));
+                CqeAction::Complete
+            }
+            RawResult::HardError(_) | RawResult::Zero => {
+                self.result = Some(Err(Error::SendFailed));
+                CqeAction::Complete
+            }
+            RawResult::Positive(n) => {
+                self.write.advance(n);
+                if self.write.is_complete() {
+                    self.result = Some(Ok(()));
+                    CqeAction::Complete
+                } else if matches!(state, WaiterState::CancelRequested) {
+                    self.result = Some(Err(Error::Timeout));
+                    CqeAction::Complete
+                } else {
+                    CqeAction::Requeue
+                }
+            }
+        }
+    }
+
+    fn finish(self) {
+        let _ = self
+            .sender
+            .send(self.result.unwrap_or(Err(Error::SendFailed)));
+    }
+}
+
+pub struct ActiveRecv {
+    fd: Arc<OwnedFd>,
+    buf: IoBufMut,
+    len: usize,
+    received: usize,
+    exact: bool,
+    result: Option<Result<usize, Error>>,
+    sender: oneshot::Sender<(IoBufMut, Result<usize, Error>)>,
+}
+
+impl ActiveRecv {
+    fn build_sqe(&mut self) -> SqueueEntry {
+        let fd = Fd(self.fd.as_raw_fd());
+        // SAFETY: buf is an IoBufMut with stable memory. received <= len <= capacity.
+        let ptr = unsafe { self.buf.as_mut_ptr().add(self.received) };
+        let remaining = self.len - self.received;
+        opcode::Recv::new(fd, ptr, remaining as u32).build()
+    }
+
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+        match classify_result(result, state) {
+            RawResult::Retryable if matches!(state, WaiterState::CancelRequested) => {
+                self.result = Some(Err(Error::Timeout));
+                CqeAction::Complete
+            }
+            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::TimeoutCancel => {
+                self.result = Some(Err(Error::Timeout));
+                CqeAction::Complete
+            }
+            RawResult::HardError(_) | RawResult::Zero => {
+                self.result = Some(Err(Error::RecvFailed));
+                CqeAction::Complete
+            }
+            RawResult::Positive(n) => {
+                self.received += n;
+                if !self.exact || self.received >= self.len {
+                    self.result = Some(Ok(self.received));
+                    CqeAction::Complete
+                } else if matches!(state, WaiterState::CancelRequested) {
+                    self.result = Some(Err(Error::Timeout));
+                    CqeAction::Complete
+                } else {
+                    CqeAction::Requeue
+                }
+            }
+        }
+    }
+
+    fn finish(self) {
+        let _ = self
+            .sender
+            .send((self.buf, self.result.unwrap_or(Err(Error::RecvFailed))));
+    }
+}
+
+pub struct ActiveReadAt {
+    file: Arc<File>,
+    offset: u64,
+    len: usize,
+    read: usize,
+    buf: IoBufMut,
+    result: Option<Result<(), Error>>,
+    sender: oneshot::Sender<(IoBufMut, Result<(), Error>)>,
+}
+
+impl ActiveReadAt {
+    fn build_sqe(&mut self) -> SqueueEntry {
+        let fd = Fd(self.file.as_raw_fd());
+        // SAFETY: buf is an IoBufMut with stable memory. read <= len <= capacity.
+        let ptr = unsafe { self.buf.as_mut_ptr().add(self.read) };
+        let remaining = self.len - self.read;
+        let offset = self.offset + self.read as u64;
+        opcode::Read::new(fd, ptr, remaining as u32)
+            .offset(offset as _)
+            .build()
+    }
+
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+        match classify_result(result, state) {
+            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::TimeoutCancel | RawResult::HardError(_) => {
+                self.result = Some(Err(Error::ReadFailed));
+                CqeAction::Complete
+            }
+            RawResult::Zero => {
+                self.result = Some(Err(Error::BlobInsufficientLength));
+                CqeAction::Complete
+            }
+            RawResult::Positive(n) => {
+                self.read += n;
+                if self.read >= self.len {
+                    self.result = Some(Ok(()));
+                    CqeAction::Complete
+                } else {
+                    CqeAction::Requeue
+                }
+            }
+        }
+    }
+
+    fn finish(self) {
+        let _ = self
+            .sender
+            .send((self.buf, self.result.unwrap_or(Err(Error::ReadFailed))));
+    }
+}
+
+pub struct ActiveWriteAt {
+    file: Arc<File>,
+    offset: u64,
+    written: usize,
+    write: WriteBuffers,
+    result: Option<Result<(), Error>>,
+    sender: oneshot::Sender<Result<(), Error>>,
+}
+
+impl ActiveWriteAt {
+    fn build_sqe(&mut self) -> SqueueEntry {
+        let fd = Fd(self.file.as_raw_fd());
+        let offset = self.offset + self.written as u64;
+        match &mut self.write {
+            WriteBuffers::Single { buf, cursor } => {
+                // SAFETY: buf is an IoBuf with stable memory. cursor <= buf.len().
+                let ptr = unsafe { buf.as_ptr().add(*cursor) };
+                let remaining = buf.len() - *cursor;
+                opcode::Write::new(fd, ptr, remaining as u32)
+                    .offset(offset as _)
+                    .build()
+            }
+            WriteBuffers::Vectored { bufs, iovecs } => {
+                let iovecs_len = refresh_iovecs(bufs, iovecs);
+                opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len as _)
+                    .offset(offset as _)
+                    .build()
+            }
+        }
+    }
+
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+        match classify_result(result, state) {
+            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::TimeoutCancel | RawResult::HardError(_) | RawResult::Zero => {
+                self.result = Some(Err(Error::WriteFailed));
+                CqeAction::Complete
+            }
+            RawResult::Positive(n) => {
+                self.written += n;
+                self.write.advance(n);
+                if self.write.is_complete() {
+                    self.result = Some(Ok(()));
+                    CqeAction::Complete
+                } else {
+                    CqeAction::Requeue
+                }
+            }
+        }
+    }
+
+    fn finish(self) {
+        let _ = self
+            .sender
+            .send(self.result.unwrap_or(Err(Error::WriteFailed)));
+    }
+}
+
+pub struct ActiveSync {
+    file: Arc<File>,
+    result: Option<std::io::Result<()>>,
+    sender: oneshot::Sender<std::io::Result<()>>,
+}
+
+impl ActiveSync {
+    fn build_sqe(&self) -> SqueueEntry {
+        let fd = Fd(self.file.as_raw_fd());
+        opcode::Fsync::new(fd).build()
+    }
+
+    fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
+        match classify_result(result, state) {
+            RawResult::Retryable => CqeAction::Requeue,
+            RawResult::TimeoutCancel => {
+                self.result = Some(Err(std::io::Error::from_raw_os_error(libc::ECANCELED)));
+                CqeAction::Complete
+            }
+            RawResult::HardError(code) => {
+                self.result = Some(Err(std::io::Error::from_raw_os_error(-code)));
+                CqeAction::Complete
+            }
+            RawResult::Zero | RawResult::Positive(_) => {
+                self.result = Some(Ok(()));
+                CqeAction::Complete
+            }
+        }
+    }
+
+    fn finish(self) {
+        let _ = self.sender.send(self.result.unwrap_or(Ok(())));
+    }
+}

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -158,7 +158,7 @@ impl WriteBuffers {
 }
 
 /// Refresh the iovec scratch from the current `IoBufs` state.
-fn refresh_iovecs(bufs: &IoBufs, iovecs: &mut Box<[libc::iovec]>) -> usize {
+fn refresh_iovecs(bufs: &IoBufs, iovecs: &mut Box<[libc::iovec]>) -> u32 {
     let max_iovecs = bufs.chunk_count().min(iovecs.len());
     // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
     let io_slices: &mut [std::io::IoSlice<'_>] = unsafe {
@@ -168,6 +168,8 @@ fn refresh_iovecs(bufs: &IoBufs, iovecs: &mut Box<[libc::iovec]>) -> usize {
         )
     };
     bufs.chunks_vectored(io_slices)
+        .try_into()
+        .expect("iovecs_len exceeds u32")
 }
 
 /// Classified raw CQE result code.
@@ -380,14 +382,21 @@ impl ActiveSend {
                 // SAFETY: buf is an IoBuf with stable memory. cursor <= buf.len().
                 let ptr = unsafe { buf.as_ptr().add(*cursor) };
                 let remaining = buf.len() - *cursor;
-                opcode::Send::new(fd, ptr, remaining as u32).build()
+                opcode::Send::new(
+                    fd,
+                    ptr,
+                    remaining
+                        .try_into()
+                        .expect("single-buffer SQE length exceeds u32"),
+                )
+                .build()
             }
             WriteBuffers::Vectored { bufs, iovecs } => {
                 let iovecs_len = refresh_iovecs(bufs, iovecs);
                 // `Writev` is sufficient here because network sends only need
                 // ordered byte delivery; this layer does not need sendmsg
                 // ancillary data or zerocopy completion management.
-                opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len as _).build()
+                opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len).build()
             }
         }
     }
@@ -465,7 +474,14 @@ impl ActiveRecv {
         // offset <= len <= capacity.
         let ptr = unsafe { self.buf.as_mut_ptr().add(self.offset) };
         let remaining = self.len - self.offset;
-        opcode::Recv::new(fd, ptr, remaining as u32).build()
+        opcode::Recv::new(
+            fd,
+            ptr,
+            remaining
+                .try_into()
+                .expect("single-buffer SQE length exceeds u32"),
+        )
+        .build()
     }
 
     /// Classify one recv CQE and decide whether the logical request completes
@@ -486,6 +502,11 @@ impl ActiveRecv {
                 CqeAction::Complete
             }
             RawResult::Positive(n) => {
+                let remaining = self.len - self.offset;
+                assert!(
+                    n <= remaining,
+                    "recv CQE exceeds requested length: n={n} remaining={remaining}"
+                );
                 self.offset += n;
                 if !self.exact || self.offset >= self.len {
                     self.result = Some(Ok(self.offset));
@@ -538,9 +559,15 @@ impl ActiveReadAt {
         let ptr = unsafe { self.buf.as_mut_ptr().add(self.read) };
         let remaining = self.len - self.read;
         let offset = self.offset + self.read as u64;
-        opcode::Read::new(fd, ptr, remaining as u32)
-            .offset(offset as _)
-            .build()
+        opcode::Read::new(
+            fd,
+            ptr,
+            remaining
+                .try_into()
+                .expect("single-buffer SQE length exceeds u32"),
+        )
+        .offset(offset)
+        .build()
     }
 
     /// Classify one read CQE and decide whether the logical request completes
@@ -617,14 +644,20 @@ impl ActiveWriteAt {
                 // SAFETY: buf is an IoBuf with stable memory. cursor <= buf.len().
                 let ptr = unsafe { buf.as_ptr().add(*cursor) };
                 let remaining = buf.len() - *cursor;
-                opcode::Write::new(fd, ptr, remaining as u32)
-                    .offset(offset as _)
-                    .build()
+                opcode::Write::new(
+                    fd,
+                    ptr,
+                    remaining
+                        .try_into()
+                        .expect("single-buffer SQE length exceeds u32"),
+                )
+                .offset(offset)
+                .build()
             }
             WriteBuffers::Vectored { bufs, iovecs } => {
                 let iovecs_len = refresh_iovecs(bufs, iovecs);
-                opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len as _)
-                    .offset(offset as _)
+                opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len)
+                    .offset(offset)
                     .build()
             }
         }
@@ -720,9 +753,12 @@ mod tests {
     use super::*;
     use commonware_utils::channel::oneshot;
     use futures::executor::block_on;
-    use std::os::{
-        fd::{FromRawFd, IntoRawFd},
-        unix::net::UnixStream,
+    use std::{
+        os::{
+            fd::{FromRawFd, IntoRawFd},
+            unix::net::UnixStream,
+        },
+        panic::{catch_unwind, AssertUnwindSafe},
     };
 
     type SendRx = oneshot::Receiver<Result<(), Error>>;
@@ -1063,6 +1099,14 @@ mod tests {
         request.finish();
         let (_buf, result) = block_on(rx).expect("missing successful completion");
         assert_eq!(result.expect("recv should complete successfully"), 5);
+
+        // A kernel completion larger than the requested remaining length must
+        // trip the local invariant before it can corrupt buffer state.
+        let (mut request, _rx) = make_recv_request(5, 0, true);
+        let overflow = catch_unwind(AssertUnwindSafe(|| {
+            let _ = request.on_cqe(active_state(), 6);
+        }));
+        assert!(overflow.is_err());
 
         // Zero-byte and hard-error CQEs should both surface as recv failures.
         let (mut request, rx) = make_recv_request(5, 0, true);

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -59,13 +59,16 @@ pub struct SendRequest {
 }
 
 /// Network receive request. When `exact` is false, any positive byte count
-/// completes successfully. When `exact` is true, exactly `len` bytes must be
-/// received.
+/// completes successfully. When `exact` is true, exactly `target_len -
+/// received` additional bytes must be received.
 pub struct RecvRequest {
     pub fd: Arc<OwnedFd>,
     pub buf: IoBufMut,
-    /// Total byte count target (includes `received` offset).
-    pub len: usize,
+    /// Total byte count target tracked by the active request.
+    ///
+    /// This includes any existing `received` offset, so callers appending into
+    /// a partially-filled buffer should pass `offset + bytes_to_read`.
+    pub target_len: usize,
     /// Byte offset into `buf` where received data starts. The active request
     /// tracks progress from this offset.
     pub received: usize,
@@ -113,6 +116,8 @@ enum WriteBuffers {
 }
 
 impl WriteBuffers {
+    /// Normalize caller-provided buffers into either a single-buffer fast path
+    /// or a vectored representation with reusable iovec scratch space.
     fn new(bufs: IoBufs) -> Self {
         match bufs.try_into_single() {
             Ok(buf) => Self::Single { buf, cursor: 0 },
@@ -131,6 +136,7 @@ impl WriteBuffers {
         }
     }
 
+    /// Return the remaining number of bytes that still need to be written.
     fn remaining_len(&self) -> usize {
         match self {
             Self::Single { buf, cursor } => buf.len() - *cursor,
@@ -138,10 +144,12 @@ impl WriteBuffers {
         }
     }
 
+    /// Return whether all bytes have been consumed by completed writes.
     fn is_complete(&self) -> bool {
         self.remaining_len() == 0
     }
 
+    /// Advance the logical write cursor after a successful CQE.
     fn advance(&mut self, n: usize) {
         match self {
             Self::Single { cursor, .. } => *cursor += n,
@@ -206,9 +214,13 @@ pub enum CqeAction {
 /// and [finish](Self::finish) or [finish_timeout](Self::finish_timeout) to
 /// deliver results.
 ///
-// SAFETY: The raw iovec pointers in `WriteBuffers::Vectored` point into the
-// `IoBufs` co-owned in the same variant. The pointed-to memory remains valid
-// for the request lifetime because both live in the same waiter slot.
+// SAFETY: `WriteBuffers::Vectored` owns both the `IoBufs` backing storage and
+// the scratch `libc::iovec` array used to describe it to the kernel. The
+// iovec entries are initialized with dangling pointers and may be stale
+// between `build_sqe` calls, but they are never dereferenced in Rust. Each
+// `build_sqe` refreshes them from the co-owned `IoBufs` immediately before the
+// kernel can observe them, and the backing buffers remain owned by the same
+// waiter slot for the request lifetime.
 unsafe impl Send for ActiveRequest {}
 
 pub enum ActiveRequest {
@@ -231,13 +243,13 @@ impl ActiveRequest {
             }),
             Request::Recv(r) => {
                 assert!(
-                    r.received <= r.len && r.len <= r.buf.capacity(),
-                    "recv invariant violated: need received <= len <= capacity"
+                    r.received <= r.target_len && r.target_len <= r.buf.capacity(),
+                    "recv invariant violated: need received <= target_len <= capacity"
                 );
                 Self::Recv(ActiveRecv {
                     fd: r.fd,
                     buf: r.buf,
-                    len: r.len,
+                    target_len: r.target_len,
                     received: r.received,
                     exact: r.exact,
                     result: None,
@@ -329,23 +341,33 @@ impl ActiveRequest {
                 let _ = w.sender.send(Err(Error::Timeout));
             }
             Self::Sync(s) => {
-                let _ = s.sender.send(Err(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "request timed out",
-                )));
+                // Sync requests currently do not carry deadlines, but keep the
+                // timeout path consistent with storage's std::io::Result API.
+                let _ = s.sender.send(Err(sync_timeout_error()));
             }
         }
     }
 }
 
+/// Build the std::io::Error used if storage requests ever time out locally.
+fn sync_timeout_error() -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::TimedOut, "request timed out")
+}
+
+/// Active state for a logical network send request.
 pub struct ActiveSend {
+    /// Socket used by the current send SQE.
     fd: Arc<OwnedFd>,
+    /// Write cursor and buffers that still need to be sent.
     write: WriteBuffers,
+    /// Terminal result captured by `on_cqe` and delivered by `finish`.
     result: Option<Result<(), Error>>,
+    /// Completion channel for the top-level caller.
     sender: oneshot::Sender<Result<(), Error>>,
 }
 
 impl ActiveSend {
+    /// Build the next socket send SQE for the remaining bytes.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.fd.as_raw_fd());
         match &mut self.write {
@@ -357,11 +379,16 @@ impl ActiveSend {
             }
             WriteBuffers::Vectored { bufs, iovecs } => {
                 let iovecs_len = refresh_iovecs(bufs, iovecs);
+                // `Writev` is sufficient here because network sends only need
+                // ordered byte delivery; this layer does not need sendmsg
+                // ancillary data or zerocopy completion management.
                 opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len as _).build()
             }
         }
     }
 
+    /// Classify one send CQE and decide whether the logical request completes
+    /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
         match classify_result(result, state) {
             RawResult::Retryable if matches!(state, WaiterState::CancelRequested) => {
@@ -392,6 +419,7 @@ impl ActiveSend {
         }
     }
 
+    /// Deliver the cached terminal send result to the caller.
     fn finish(self) {
         let _ = self
             .sender
@@ -399,25 +427,37 @@ impl ActiveSend {
     }
 }
 
+/// Active state for a logical network recv request.
 pub struct ActiveRecv {
+    /// Socket used by the current recv SQE.
     fd: Arc<OwnedFd>,
+    /// Destination buffer owned by the request.
     buf: IoBufMut,
-    len: usize,
+    /// Total recv target, including any existing `received` offset.
+    target_len: usize,
+    /// Bytes already written into `buf`.
     received: usize,
+    /// Whether the recv must fill the full target before succeeding.
     exact: bool,
+    /// Terminal result captured by `on_cqe` and delivered by `finish`.
     result: Option<Result<usize, Error>>,
+    /// Completion channel for the top-level caller.
     sender: oneshot::Sender<(IoBufMut, Result<usize, Error>)>,
 }
 
 impl ActiveRecv {
+    /// Build the next socket recv SQE for the unread suffix of the target.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.fd.as_raw_fd());
-        // SAFETY: buf is an IoBufMut with stable memory. received <= len <= capacity.
+        // SAFETY: buf is an IoBufMut with stable memory.
+        // received <= target_len <= capacity.
         let ptr = unsafe { self.buf.as_mut_ptr().add(self.received) };
-        let remaining = self.len - self.received;
+        let remaining = self.target_len - self.received;
         opcode::Recv::new(fd, ptr, remaining as u32).build()
     }
 
+    /// Classify one recv CQE and decide whether the logical request completes
+    /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
         match classify_result(result, state) {
             RawResult::Retryable if matches!(state, WaiterState::CancelRequested) => {
@@ -435,7 +475,7 @@ impl ActiveRecv {
             }
             RawResult::Positive(n) => {
                 self.received += n;
-                if !self.exact || self.received >= self.len {
+                if !self.exact || self.received >= self.target_len {
                     self.result = Some(Ok(self.received));
                     CqeAction::Complete
                 } else if matches!(state, WaiterState::CancelRequested) {
@@ -448,6 +488,7 @@ impl ActiveRecv {
         }
     }
 
+    /// Deliver the cached recv result and owned buffer to the caller.
     fn finish(self) {
         let _ = self
             .sender
@@ -455,17 +496,26 @@ impl ActiveRecv {
     }
 }
 
+/// Active state for a logical positioned file read request.
 pub struct ActiveReadAt {
+    /// File used by the current read SQE.
     file: Arc<File>,
+    /// Starting file offset for the logical read.
     offset: u64,
+    /// Total number of bytes requested.
     len: usize,
+    /// Bytes already read into `buf`.
     read: usize,
+    /// Destination buffer owned by the request.
     buf: IoBufMut,
+    /// Terminal result captured by `on_cqe` and delivered by `finish`.
     result: Option<Result<(), Error>>,
+    /// Completion channel for the top-level caller.
     sender: oneshot::Sender<(IoBufMut, Result<(), Error>)>,
 }
 
 impl ActiveReadAt {
+    /// Build the next positioned read SQE for the unread suffix of the target.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.file.as_raw_fd());
         // SAFETY: buf is an IoBufMut with stable memory. read <= len <= capacity.
@@ -477,6 +527,8 @@ impl ActiveReadAt {
             .build()
     }
 
+    /// Classify one read CQE and decide whether the logical request completes
+    /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
         match classify_result(result, state) {
             RawResult::Retryable => CqeAction::Requeue,
@@ -500,6 +552,7 @@ impl ActiveReadAt {
         }
     }
 
+    /// Deliver the cached read result and owned buffer to the caller.
     fn finish(self) {
         let _ = self
             .sender
@@ -507,16 +560,24 @@ impl ActiveReadAt {
     }
 }
 
+/// Active state for a logical positioned file write request.
 pub struct ActiveWriteAt {
+    /// File used by the current write SQE.
     file: Arc<File>,
+    /// Starting file offset for the logical write.
     offset: u64,
+    /// Bytes already written successfully.
     written: usize,
+    /// Write cursor and buffers that still need to be written.
     write: WriteBuffers,
+    /// Terminal result captured by `on_cqe` and delivered by `finish`.
     result: Option<Result<(), Error>>,
+    /// Completion channel for the top-level caller.
     sender: oneshot::Sender<Result<(), Error>>,
 }
 
 impl ActiveWriteAt {
+    /// Build the next positioned write SQE for the remaining bytes.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.file.as_raw_fd());
         let offset = self.offset + self.written as u64;
@@ -538,6 +599,8 @@ impl ActiveWriteAt {
         }
     }
 
+    /// Classify one write CQE and decide whether the logical request completes
+    /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
         match classify_result(result, state) {
             RawResult::Retryable => CqeAction::Requeue,
@@ -558,6 +621,7 @@ impl ActiveWriteAt {
         }
     }
 
+    /// Deliver the cached write result to the caller.
     fn finish(self) {
         let _ = self
             .sender
@@ -565,18 +629,25 @@ impl ActiveWriteAt {
     }
 }
 
+/// Active state for a logical fsync request.
 pub struct ActiveSync {
+    /// File descriptor to sync.
     file: Arc<File>,
+    /// Terminal result captured by `on_cqe` and delivered by `finish`.
     result: Option<std::io::Result<()>>,
+    /// Completion channel for the top-level caller.
     sender: oneshot::Sender<std::io::Result<()>>,
 }
 
 impl ActiveSync {
+    /// Build the fsync SQE for this request.
     fn build_sqe(&self) -> SqueueEntry {
         let fd = Fd(self.file.as_raw_fd());
         opcode::Fsync::new(fd).build()
     }
 
+    /// Classify one fsync CQE and decide whether the logical request completes
+    /// or needs another SQE.
     fn on_cqe(&mut self, state: WaiterState, result: i32) -> CqeAction {
         match classify_result(result, state) {
             RawResult::Retryable => CqeAction::Requeue,
@@ -595,7 +666,663 @@ impl ActiveSync {
         }
     }
 
+    /// Deliver the cached fsync result to the caller.
     fn finish(self) {
         let _ = self.sender.send(self.result.unwrap_or(Ok(())));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_utils::channel::oneshot;
+    use futures::executor::block_on;
+    use std::os::{
+        fd::{FromRawFd, IntoRawFd},
+        unix::net::UnixStream,
+    };
+
+    type SendRx = oneshot::Receiver<Result<(), Error>>;
+    type RecvRx = oneshot::Receiver<(IoBufMut, Result<usize, Error>)>;
+    type ReadRx = oneshot::Receiver<(IoBufMut, Result<(), Error>)>;
+    type SyncRx = oneshot::Receiver<std::io::Result<()>>;
+
+    fn active_state() -> WaiterState {
+        WaiterState::Active { target_tick: None }
+    }
+
+    fn make_socket_fd() -> Arc<OwnedFd> {
+        let (left, _right) = UnixStream::pair().expect("failed to create unix socket pair");
+        Arc::new(left.into())
+    }
+
+    fn make_file_fd() -> Arc<File> {
+        let (left, _right) = UnixStream::pair().expect("failed to create unix socket pair");
+        // SAFETY: `left` is a valid owned fd and is transferred into `File`.
+        let file = unsafe { File::from_raw_fd(left.into_raw_fd()) };
+        Arc::new(file)
+    }
+
+    fn make_send_request(bufs: IoBufs) -> (ActiveRequest, SendRx) {
+        let (tx, rx) = oneshot::channel();
+        (
+            ActiveRequest::from_request(Request::Send(SendRequest {
+                fd: make_socket_fd(),
+                bufs,
+                deadline: None,
+                sender: tx,
+            })),
+            rx,
+        )
+    }
+
+    fn make_recv_request(
+        target_len: usize,
+        received: usize,
+        exact: bool,
+    ) -> (ActiveRequest, RecvRx) {
+        let (tx, rx) = oneshot::channel();
+        (
+            ActiveRequest::from_request(Request::Recv(RecvRequest {
+                fd: make_socket_fd(),
+                buf: IoBufMut::with_capacity(target_len),
+                target_len,
+                received,
+                exact,
+                deadline: None,
+                sender: tx,
+            })),
+            rx,
+        )
+    }
+
+    fn make_read_request(len: usize) -> (ActiveRequest, ReadRx) {
+        let (tx, rx) = oneshot::channel();
+        (
+            ActiveRequest::from_request(Request::ReadAt(ReadAtRequest {
+                file: make_file_fd(),
+                offset: 0,
+                len,
+                buf: IoBufMut::with_capacity(len),
+                sender: tx,
+            })),
+            rx,
+        )
+    }
+
+    fn make_write_request(bufs: IoBufs) -> (ActiveRequest, SendRx) {
+        let (tx, rx) = oneshot::channel();
+        (
+            ActiveRequest::from_request(Request::WriteAt(WriteAtRequest {
+                file: make_file_fd(),
+                offset: 0,
+                bufs,
+                sender: tx,
+            })),
+            rx,
+        )
+    }
+
+    fn make_sync_request() -> (ActiveRequest, SyncRx) {
+        let (tx, rx) = oneshot::channel();
+        (
+            ActiveRequest::from_request(Request::Sync(SyncRequest {
+                file: make_file_fd(),
+                sender: tx,
+            })),
+            rx,
+        )
+    }
+
+    #[test]
+    fn test_request_deadline_helpers_and_invariants() {
+        // Verify deadline helpers only report deadlines for network requests and
+        // that invalid request invariants still fail fast at construction time.
+        // Network requests carry optional deadlines that should be surfaced.
+        let send_deadline = Instant::now();
+        let send = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            bufs: IoBufs::from(IoBuf::from(b"hello")),
+            deadline: Some(send_deadline),
+            sender: oneshot::channel().0,
+        });
+        assert_eq!(send.deadline(), Some(send_deadline));
+        assert!(send.has_deadline());
+
+        let recv_deadline = Instant::now();
+        let recv = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(8),
+            target_len: 8,
+            received: 0,
+            exact: true,
+            deadline: Some(recv_deadline),
+            sender: oneshot::channel().0,
+        });
+        assert_eq!(recv.deadline(), Some(recv_deadline));
+        assert!(recv.has_deadline());
+
+        let read = Request::ReadAt(ReadAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            len: 4,
+            buf: IoBufMut::with_capacity(4),
+            sender: oneshot::channel().0,
+        });
+        assert_eq!(read.deadline(), None);
+        assert!(!read.has_deadline());
+
+        // Invalid request shapes should still panic at construction time so the
+        // loop never has to defend against impossible in-flight state.
+        let recv_overread = std::panic::catch_unwind(|| {
+            let _ = ActiveRequest::from_request(Request::Recv(RecvRequest {
+                fd: make_socket_fd(),
+                buf: IoBufMut::with_capacity(4),
+                target_len: 4,
+                received: 5,
+                exact: true,
+                deadline: None,
+                sender: oneshot::channel().0,
+            }));
+        });
+        assert!(recv_overread.is_err());
+
+        let recv_oversized = std::panic::catch_unwind(|| {
+            let _ = ActiveRequest::from_request(Request::Recv(RecvRequest {
+                fd: make_socket_fd(),
+                buf: IoBufMut::with_capacity(4),
+                target_len: 5,
+                received: 0,
+                exact: true,
+                deadline: None,
+                sender: oneshot::channel().0,
+            }));
+        });
+        assert!(recv_oversized.is_err());
+
+        let read_oversized = std::panic::catch_unwind(|| {
+            let _ = ActiveRequest::from_request(Request::ReadAt(ReadAtRequest {
+                file: make_file_fd(),
+                offset: 0,
+                len: 5,
+                buf: IoBufMut::with_capacity(4),
+                sender: oneshot::channel().0,
+            }));
+        });
+        assert!(read_oversized.is_err());
+    }
+
+    #[test]
+    fn test_active_send_paths() {
+        // Verify send state handling across retry, timeout, success, and hard-failure CQEs.
+
+        // Retryable CQEs should simply requeue while the request is still active.
+        let (mut request, _rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EAGAIN),
+            CqeAction::Requeue
+        ));
+
+        // Partial progress followed by a retry after timeout should resolve to timeout.
+        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(active_state(), 2),
+            CqeAction::Requeue
+        ));
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, -libc::EAGAIN),
+            CqeAction::Complete
+        ));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing send result"),
+            Err(Error::Timeout)
+        ));
+
+        // Partial progress after timeout must also resolve to timeout rather than requeueing.
+        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(active_state(), 2),
+            CqeAction::Requeue
+        ));
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, 1),
+            CqeAction::Complete
+        ));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing partial-timeout result"),
+            Err(Error::Timeout)
+        ));
+
+        // A canceled send that comes back as ECANCELED should also resolve to timeout.
+        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
+            CqeAction::Complete
+        ));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing timeout-cancel result"),
+            Err(Error::Timeout)
+        ));
+
+        // Vectored writes should advance across multiple CQEs and complete once all bytes are sent.
+        let mut vectored = IoBufs::default();
+        vectored.append(IoBuf::from(b"abc"));
+        vectored.append(IoBuf::from(b"de"));
+        let (mut request, rx) = make_send_request(vectored);
+        assert!(matches!(
+            request.on_cqe(active_state(), 3),
+            CqeAction::Requeue
+        ));
+        assert!(matches!(
+            request.on_cqe(active_state(), 2),
+            CqeAction::Complete
+        ));
+        request.finish();
+        block_on(rx)
+            .expect("missing send completion")
+            .expect("send should complete successfully");
+
+        // Zero-byte and hard-error CQEs should both surface as send failures.
+        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(active_state(), 0),
+            CqeAction::Complete
+        ));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing zero-result completion"),
+            Err(Error::SendFailed)
+        ));
+
+        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EIO),
+            CqeAction::Complete
+        ));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing hard-error completion"),
+            Err(Error::SendFailed)
+        ));
+
+        // A fully successful CQE still wins even if timeout was already requested.
+        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, 5),
+            CqeAction::Complete
+        ));
+        request.finish();
+        block_on(rx)
+            .expect("missing send completion")
+            .expect("send should complete successfully");
+    }
+
+    #[test]
+    fn test_active_recv_paths() {
+        // Verify recv state handling across buffered progress, timeout, success, and hard failure.
+
+        // Retryable CQEs should requeue while the recv is still active.
+        let (mut request, _rx) = make_recv_request(5, 0, true);
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EAGAIN),
+            CqeAction::Requeue
+        ));
+
+        // Non-exact recv should complete as soon as any positive byte count arrives.
+        let (mut request, rx) = make_recv_request(5, 0, false);
+        assert!(matches!(
+            request.on_cqe(active_state(), 3),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing recv completion");
+        assert_eq!(result.expect("recv should complete successfully"), 3);
+
+        // Exact recv should requeue after partial progress, but timeout wins if the follow-up CQE
+        // arrives after cancellation was requested.
+        let (mut request, rx) = make_recv_request(5, 0, true);
+        assert!(matches!(
+            request.on_cqe(active_state(), 3),
+            CqeAction::Requeue
+        ));
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, 1),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing timeout completion");
+        assert!(matches!(result, Err(Error::Timeout)));
+
+        // Retryable and ECANCELED completions after timeout should both resolve to timeout.
+        let (mut request, rx) = make_recv_request(5, 0, true);
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, -libc::EINTR),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing retryable completion");
+        assert!(matches!(result, Err(Error::Timeout)));
+
+        let (mut request, rx) = make_recv_request(5, 0, true);
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing timeout-cancel completion");
+        assert!(matches!(result, Err(Error::Timeout)));
+
+        // A fully successful CQE still wins after timeout was requested.
+        let (mut request, rx) = make_recv_request(5, 0, true);
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, 5),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing successful completion");
+        assert_eq!(result.expect("recv should complete successfully"), 5);
+
+        // Zero-byte and hard-error CQEs should both surface as recv failures.
+        let (mut request, rx) = make_recv_request(5, 0, true);
+        assert!(matches!(
+            request.on_cqe(active_state(), 0),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing zero completion");
+        assert!(matches!(result, Err(Error::RecvFailed)));
+
+        let (mut request, rx) = make_recv_request(5, 0, true);
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EIO),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing error completion");
+        assert!(matches!(result, Err(Error::RecvFailed)));
+    }
+
+    #[test]
+    fn test_active_read_at_paths() {
+        // Verify read-at state handling across retry, EOF, timeout-cancel, and hard failure.
+
+        // Retryable CQEs should requeue the positioned read.
+        let (mut request, _rx) = make_read_request(5);
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EAGAIN),
+            CqeAction::Requeue
+        ));
+
+        // Partial reads should requeue until the full logical length is satisfied.
+        let (mut request, rx) = make_read_request(5);
+        assert!(matches!(
+            request.on_cqe(active_state(), 2),
+            CqeAction::Requeue
+        ));
+        assert!(matches!(
+            request.on_cqe(active_state(), 3),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing read completion");
+        result.expect("read should complete successfully");
+
+        // EOF and hard-error CQEs should map to the storage read error surface.
+        let (mut request, rx) = make_read_request(5);
+        assert!(matches!(
+            request.on_cqe(active_state(), 0),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing eof completion");
+        assert!(matches!(result, Err(Error::BlobInsufficientLength)));
+
+        let (mut request, rx) = make_read_request(5);
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EIO),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing read failure");
+        assert!(matches!(result, Err(Error::ReadFailed)));
+
+        // Timeout cancellation should also surface as a read failure.
+        let (mut request, rx) = make_read_request(5);
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing timeout-cancel failure");
+        assert!(matches!(result, Err(Error::ReadFailed)));
+    }
+
+    #[test]
+    fn test_active_write_at_paths() {
+        // Verify write-at state handling across retry, partial progress, timeout-cancel, and failure.
+
+        // Retryable CQEs should requeue the positioned write.
+        let (mut request, _rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EAGAIN),
+            CqeAction::Requeue
+        ));
+
+        // Single-buffer writes should track partial progress until complete.
+        let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(active_state(), 2),
+            CqeAction::Requeue
+        ));
+        assert!(matches!(
+            request.on_cqe(active_state(), 3),
+            CqeAction::Complete
+        ));
+        request.finish();
+        block_on(rx)
+            .expect("missing write completion")
+            .expect("write should complete successfully");
+
+        // Vectored writes should advance across buffer boundaries and then complete.
+        let mut vectored = IoBufs::default();
+        vectored.append(IoBuf::from(b"abc"));
+        vectored.append(IoBuf::from(b"de"));
+        let (mut request, rx) = make_write_request(vectored);
+        assert!(matches!(
+            request.on_cqe(active_state(), 4),
+            CqeAction::Requeue
+        ));
+        assert!(matches!(
+            request.on_cqe(active_state(), 1),
+            CqeAction::Complete
+        ));
+        request.finish();
+        block_on(rx)
+            .expect("missing vectored write completion")
+            .expect("vectored write should complete successfully");
+
+        // Zero-byte and hard-error CQEs should surface as write failures.
+        let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(active_state(), 0),
+            CqeAction::Complete
+        ));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing zero-result write"),
+            Err(Error::WriteFailed)
+        ));
+
+        let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EIO),
+            CqeAction::Complete
+        ));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing write failure"),
+            Err(Error::WriteFailed)
+        ));
+
+        // Timeout cancellation should also surface as a write failure.
+        let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
+            CqeAction::Complete
+        ));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing timeout-cancel write failure"),
+            Err(Error::WriteFailed)
+        ));
+    }
+
+    #[test]
+    fn test_active_sync_paths() {
+        // Verify sync state handling across retry, timeout-cancel, error conversion, and success.
+
+        // Retryable CQEs should requeue the fsync request.
+        let (mut request, _rx) = make_sync_request();
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EINTR),
+            CqeAction::Requeue
+        ));
+
+        // Timeout cancellation should preserve the kernel ECANCELED surface for sync callers.
+        let (mut request, rx) = make_sync_request();
+        assert!(matches!(
+            request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let err = block_on(rx)
+            .expect("missing timeout cancel result")
+            .expect_err("expected timeout cancel error");
+        assert_eq!(err.raw_os_error(), Some(libc::ECANCELED));
+
+        // Hard errors should round-trip as std::io::Error values.
+        let (mut request, rx) = make_sync_request();
+        assert!(matches!(
+            request.on_cqe(active_state(), -libc::EIO),
+            CqeAction::Complete
+        ));
+        request.finish();
+        let err = block_on(rx)
+            .expect("missing hard error result")
+            .expect_err("expected hard error");
+        assert_eq!(err.raw_os_error(), Some(libc::EIO));
+
+        // Both zero and positive CQE results should count as sync success.
+        let (mut request, rx) = make_sync_request();
+        assert!(matches!(
+            request.on_cqe(active_state(), 0),
+            CqeAction::Complete
+        ));
+        request.finish();
+        block_on(rx)
+            .expect("missing zero-result completion")
+            .expect("sync should succeed on zero");
+
+        let (mut request, rx) = make_sync_request();
+        assert!(matches!(
+            request.on_cqe(active_state(), 1),
+            CqeAction::Complete
+        ));
+        request.finish();
+        block_on(rx)
+            .expect("missing positive-result completion")
+            .expect("sync should succeed on positive");
+
+        // Local timeout delivery should use TimedOut for the storage-facing API.
+        let (request, rx) = make_sync_request();
+        request.finish_timeout();
+        let err = block_on(rx)
+            .expect("missing timeout result")
+            .expect_err("expected timeout error");
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+    }
+
+    #[test]
+    fn test_finish_without_cqe_uses_fallback_results() {
+        // Verify shutdown-abandonment fallback results are delivered even if no CQE was processed.
+        // Network and storage requests each have their own fallback error surface.
+
+        // Network sends and recvs should preserve their wrapper-specific fallback errors.
+        let (request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing send fallback"),
+            Err(Error::SendFailed)
+        ));
+
+        let (request, rx) = make_recv_request(5, 0, true);
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing recv fallback");
+        assert!(matches!(result, Err(Error::RecvFailed)));
+
+        // Storage reads and writes should surface the corresponding storage wrapper errors.
+        let (request, rx) = make_read_request(5);
+        request.finish();
+        let (_buf, result) = block_on(rx).expect("missing read fallback");
+        assert!(matches!(result, Err(Error::ReadFailed)));
+
+        let (request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
+        request.finish();
+        assert!(matches!(
+            block_on(rx).expect("missing write fallback"),
+            Err(Error::WriteFailed)
+        ));
+
+        // Sync fallback remains success because the wrapper treats "no CQE seen"
+        // as an already-finished local sync during shutdown abandonment.
+        let (request, rx) = make_sync_request();
+        request.finish();
+        block_on(rx)
+            .expect("missing sync fallback")
+            .expect("sync fallback should be success");
+    }
+
+    #[test]
+    fn test_finish_timeout_delivers_timeout_results() {
+        // Verify the loop's immediate-timeout path delivers timeout to each request variant.
+        // Network and storage requests should each receive their type-specific
+        // timeout surface when no CQE was processed yet.
+
+        // Network operations should map directly to the shared logical timeout.
+        let (request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        request.finish_timeout();
+        assert!(matches!(
+            block_on(rx).expect("missing send timeout"),
+            Err(Error::Timeout)
+        ));
+
+        let (request, rx) = make_recv_request(5, 0, true);
+        request.finish_timeout();
+        let (_buf, result) = block_on(rx).expect("missing recv timeout");
+        assert!(matches!(result, Err(Error::Timeout)));
+
+        // Storage reads and writes also use the common logical timeout surface.
+        let (request, rx) = make_read_request(5);
+        request.finish_timeout();
+        let (_buf, result) = block_on(rx).expect("missing read timeout");
+        assert!(matches!(result, Err(Error::Timeout)));
+
+        let (request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
+        request.finish_timeout();
+        assert!(matches!(
+            block_on(rx).expect("missing write timeout"),
+            Err(Error::Timeout)
+        ));
+
+        // Sync uses `std::io::ErrorKind::TimedOut` to match its storage-facing API.
+        let (request, rx) = make_sync_request();
+        request.finish_timeout();
+        let err = block_on(rx)
+            .expect("missing sync timeout")
+            .expect_err("sync timeout should be an error");
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
     }
 }

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -1,9 +1,9 @@
-//! Request types and active state machines for the io_uring loop.
+//! Request types and state machines for the io_uring loop.
 //!
-//! Callers submit a [Request] to the loop via [super::Submitter]. The loop
-//! converts it into an [ActiveRequest] that owns all resources (buffers, FDs,
-//! progress cursors, completion sender) needed to build follow-up SQEs and
-//! deliver a typed result.
+//! Callers submit logical operations through [super::Handle]. The handle
+//! constructs a [Request] that owns all resources (buffers, FDs, progress
+//! cursors, completion sender) needed to build follow-up SQEs and deliver a
+//! typed result.
 
 use super::waiter::{WaiterId, WaiterState};
 use crate::{Buf, Error, IoBuf, IoBufMut, IoBufs};
@@ -20,90 +20,11 @@ use std::{
 /// per-write kernel setup overhead.
 const IOVEC_BATCH_SIZE: usize = 32;
 
-/// High-level request submitted by callers to the io_uring loop.
-pub enum Request {
-    #[cfg_attr(not(feature = "iouring-network"), allow(dead_code))]
-    Send(SendRequest),
-    #[cfg_attr(not(feature = "iouring-network"), allow(dead_code))]
-    Recv(RecvRequest),
-    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
-    ReadAt(ReadAtRequest),
-    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
-    WriteAt(WriteAtRequest),
-    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
-    Sync(SyncRequest),
-}
-
-impl Request {
-    /// Return the deadline for this request, if any.
-    pub const fn deadline(&self) -> Option<Instant> {
-        match self {
-            Self::Send(r) => r.deadline,
-            Self::Recv(r) => r.deadline,
-            Self::ReadAt(_) | Self::WriteAt(_) | Self::Sync(_) => None,
-        }
-    }
-
-    /// Return whether this request carries a deadline.
-    pub const fn has_deadline(&self) -> bool {
-        self.deadline().is_some()
-    }
-}
-
-/// Network send request. Completes when all bytes are written.
-pub struct SendRequest {
-    pub fd: Arc<OwnedFd>,
-    pub bufs: IoBufs,
-    pub deadline: Option<Instant>,
-    pub sender: oneshot::Sender<Result<(), Error>>,
-}
-
-/// Network receive request. When `exact` is false, any positive byte count
-/// completes successfully. When `exact` is true, exactly `len - offset`
-/// additional bytes must be received.
-pub struct RecvRequest {
-    pub fd: Arc<OwnedFd>,
-    pub buf: IoBufMut,
-    /// Byte offset into `buf` where the next recv should write.
-    pub offset: usize,
-    /// Total target length tracked by the active request.
-    ///
-    /// This request fills `buf[offset..len]` and may requeue until `offset`
-    /// reaches `len`.
-    pub len: usize,
-    pub exact: bool,
-    pub deadline: Option<Instant>,
-    pub sender: oneshot::Sender<(IoBufMut, Result<usize, Error>)>,
-}
-
-/// Storage read request. Completes when exactly `len` bytes are read.
-pub struct ReadAtRequest {
-    pub file: Arc<File>,
-    pub offset: u64,
-    pub len: usize,
-    pub buf: IoBufMut,
-    pub sender: oneshot::Sender<(IoBufMut, Result<(), Error>)>,
-}
-
-/// Storage write request. Completes when all bytes are written.
-pub struct WriteAtRequest {
-    pub file: Arc<File>,
-    pub offset: u64,
-    pub bufs: IoBufs,
-    pub sender: oneshot::Sender<Result<(), Error>>,
-}
-
-/// Storage fsync request.
-pub struct SyncRequest {
-    pub file: Arc<File>,
-    pub sender: oneshot::Sender<std::io::Result<()>>,
-}
-
-/// Normalized write buffer for [ActiveSend] and [ActiveWriteAt].
+/// Normalized write buffer for [SendRequest] and [WriteAtRequest].
 ///
 /// Single-buffer writes track a byte cursor. Vectored writes track progress
 /// via [IoBufs::advance] and reuse a pre-allocated iovec scratch buffer.
-enum WriteBuffers {
+pub(super) enum WriteBuffers {
     Single {
         buf: IoBuf,
         cursor: usize,
@@ -114,10 +35,10 @@ enum WriteBuffers {
     },
 }
 
-impl WriteBuffers {
+impl From<IoBufs> for WriteBuffers {
     /// Normalize caller-provided buffers into either a single-buffer fast path
     /// or a vectored representation with reusable iovec scratch space.
-    fn new(bufs: IoBufs) -> Self {
+    fn from(bufs: IoBufs) -> Self {
         match bufs.try_into_single() {
             Ok(buf) => Self::Single { buf, cursor: 0 },
             Err(bufs) => {
@@ -134,7 +55,9 @@ impl WriteBuffers {
             }
         }
     }
+}
 
+impl WriteBuffers {
     /// Return the remaining number of bytes that still need to be written.
     fn remaining_len(&self) -> usize {
         match self {
@@ -214,70 +137,34 @@ const fn classify_result(result: i32, state: WaiterState) -> RawResult {
 // `build_sqe` refreshes them from the co-owned `IoBufs` immediately before the
 // kernel can observe them, and the backing buffers remain owned by the same
 // waiter slot for the request lifetime.
-unsafe impl Send for ActiveRequest {}
+unsafe impl Send for Request {}
 
-pub enum ActiveRequest {
-    Send(ActiveSend),
-    Recv(ActiveRecv),
-    ReadAt(ActiveReadAt),
-    WriteAt(ActiveWriteAt),
-    Sync(ActiveSync),
+pub(super) enum Request {
+    #[cfg_attr(not(feature = "iouring-network"), allow(dead_code))]
+    Send(SendRequest),
+    #[cfg_attr(not(feature = "iouring-network"), allow(dead_code))]
+    Recv(RecvRequest),
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    ReadAt(ReadAtRequest),
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    WriteAt(WriteAtRequest),
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    Sync(SyncRequest),
 }
 
-impl ActiveRequest {
-    /// Convert a caller-submitted [Request] into an active state machine.
-    pub fn from_request(request: Request) -> Self {
-        match request {
-            Request::Send(r) => Self::Send(ActiveSend {
-                fd: r.fd,
-                write: WriteBuffers::new(r.bufs),
-                result: None,
-                sender: r.sender,
-            }),
-            Request::Recv(r) => {
-                assert!(
-                    r.offset <= r.len && r.len <= r.buf.capacity(),
-                    "recv invariant violated: need offset <= len <= capacity"
-                );
-                Self::Recv(ActiveRecv {
-                    fd: r.fd,
-                    buf: r.buf,
-                    offset: r.offset,
-                    len: r.len,
-                    exact: r.exact,
-                    result: None,
-                    sender: r.sender,
-                })
-            }
-            Request::ReadAt(r) => {
-                assert!(
-                    r.len <= r.buf.capacity(),
-                    "read_at len exceeds buffer capacity"
-                );
-                Self::ReadAt(ActiveReadAt {
-                    file: r.file,
-                    offset: r.offset,
-                    len: r.len,
-                    read: 0,
-                    buf: r.buf,
-                    result: None,
-                    sender: r.sender,
-                })
-            }
-            Request::WriteAt(r) => Self::WriteAt(ActiveWriteAt {
-                file: r.file,
-                offset: r.offset,
-                written: 0,
-                write: WriteBuffers::new(r.bufs),
-                result: None,
-                sender: r.sender,
-            }),
-            Request::Sync(r) => Self::Sync(ActiveSync {
-                file: r.file,
-                result: None,
-                sender: r.sender,
-            }),
+impl Request {
+    /// Return the deadline for this request, if any.
+    pub const fn deadline(&self) -> Option<Instant> {
+        match self {
+            Self::Send(r) => r.deadline,
+            Self::Recv(r) => r.deadline,
+            Self::ReadAt(_) | Self::WriteAt(_) | Self::Sync(_) => None,
         }
+    }
+
+    /// Return whether this request carries a deadline.
+    pub const fn has_deadline(&self) -> bool {
+        self.deadline().is_some()
     }
 
     /// Build the next SQE for this request, tagged with `waiter_id`.
@@ -325,10 +212,10 @@ impl ActiveRequest {
                 let _ = s.sender.send(Err(Error::Timeout));
             }
             Self::Recv(r) => {
-                let _ = r.sender.send((r.buf, Err(Error::Timeout)));
+                let _ = r.sender.send(Err((r.buf, Error::Timeout)));
             }
             Self::ReadAt(r) => {
-                let _ = r.sender.send((r.buf, Err(Error::Timeout)));
+                let _ = r.sender.send(Err((r.buf, Error::Timeout)));
             }
             Self::WriteAt(w) => {
                 let _ = w.sender.send(Err(Error::Timeout));
@@ -347,19 +234,21 @@ fn sync_timeout_error() -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::TimedOut, "request timed out")
 }
 
-/// Active state for a logical network send request.
-pub struct ActiveSend {
+/// Logical network send request and its in-loop state.
+pub(super) struct SendRequest {
     /// Socket used by the current send SQE.
-    fd: Arc<OwnedFd>,
+    pub(super) fd: Arc<OwnedFd>,
     /// Write cursor and buffers that still need to be sent.
-    write: WriteBuffers,
+    pub(super) write: WriteBuffers,
+    /// Absolute deadline for the whole logical request.
+    pub(super) deadline: Option<Instant>,
     /// Terminal result captured by `on_cqe` and delivered by `finish`.
-    result: Option<Result<(), Error>>,
+    pub(super) result: Option<Result<(), Error>>,
     /// Completion channel for the top-level caller.
-    sender: oneshot::Sender<Result<(), Error>>,
+    pub(super) sender: oneshot::Sender<Result<(), Error>>,
 }
 
-impl ActiveSend {
+impl SendRequest {
     /// Build the next socket send SQE for the remaining bytes.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.fd.as_raw_fd());
@@ -436,25 +325,27 @@ impl ActiveSend {
     }
 }
 
-/// Active state for a logical network recv request.
-pub struct ActiveRecv {
+/// Logical network recv request and its in-loop state.
+pub(super) struct RecvRequest {
     /// Socket used by the current recv SQE.
-    fd: Arc<OwnedFd>,
+    pub(super) fd: Arc<OwnedFd>,
     /// Destination buffer owned by the request.
-    buf: IoBufMut,
+    pub(super) buf: IoBufMut,
     /// Byte offset into `buf` where the next recv should write.
-    offset: usize,
+    pub(super) offset: usize,
     /// Total recv target, including any existing filled prefix before `offset`.
-    len: usize,
+    pub(super) len: usize,
     /// Whether the recv must fill the full target before succeeding.
-    exact: bool,
+    pub(super) exact: bool,
+    /// Absolute deadline for the whole logical request.
+    pub(super) deadline: Option<Instant>,
     /// Terminal result captured by `on_cqe` and delivered by `finish`.
-    result: Option<Result<usize, Error>>,
+    pub(super) result: Option<Result<usize, Error>>,
     /// Completion channel for the top-level caller.
-    sender: oneshot::Sender<(IoBufMut, Result<usize, Error>)>,
+    pub(super) sender: oneshot::Sender<Result<(IoBufMut, usize), (IoBufMut, Error)>>,
 }
 
-impl ActiveRecv {
+impl RecvRequest {
     /// Build the next socket recv SQE for the unread suffix of the target.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.fd.as_raw_fd());
@@ -515,31 +406,33 @@ impl ActiveRecv {
 
     /// Deliver the cached recv result and owned buffer to the caller.
     fn finish(self) {
-        let _ = self
-            .sender
-            .send((self.buf, self.result.unwrap_or(Err(Error::RecvFailed))));
+        let result = match self.result.unwrap_or(Err(Error::RecvFailed)) {
+            Ok(read) => Ok((self.buf, read)),
+            Err(err) => Err((self.buf, err)),
+        };
+        let _ = self.sender.send(result);
     }
 }
 
-/// Active state for a logical positioned file read request.
-pub struct ActiveReadAt {
+/// Logical positioned file read request and its in-loop state.
+pub(super) struct ReadAtRequest {
     /// File used by the current read SQE.
-    file: Arc<File>,
+    pub(super) file: Arc<File>,
     /// Starting file offset for the logical read.
-    offset: u64,
+    pub(super) offset: u64,
     /// Total number of bytes requested.
-    len: usize,
+    pub(super) len: usize,
     /// Bytes already read into `buf`.
-    read: usize,
+    pub(super) read: usize,
     /// Destination buffer owned by the request.
-    buf: IoBufMut,
+    pub(super) buf: IoBufMut,
     /// Terminal result captured by `on_cqe` and delivered by `finish`.
-    result: Option<Result<(), Error>>,
+    pub(super) result: Option<Result<(), Error>>,
     /// Completion channel for the top-level caller.
-    sender: oneshot::Sender<(IoBufMut, Result<(), Error>)>,
+    pub(super) sender: oneshot::Sender<Result<IoBufMut, (IoBufMut, Error)>>,
 }
 
-impl ActiveReadAt {
+impl ReadAtRequest {
     /// Build the next positioned read SQE for the unread suffix of the target.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.file.as_raw_fd());
@@ -594,29 +487,31 @@ impl ActiveReadAt {
 
     /// Deliver the cached read result and owned buffer to the caller.
     fn finish(self) {
-        let _ = self
-            .sender
-            .send((self.buf, self.result.unwrap_or(Err(Error::ReadFailed))));
+        let result = match self.result.unwrap_or(Err(Error::ReadFailed)) {
+            Ok(()) => Ok(self.buf),
+            Err(err) => Err((self.buf, err)),
+        };
+        let _ = self.sender.send(result);
     }
 }
 
-/// Active state for a logical positioned file write request.
-pub struct ActiveWriteAt {
+/// Logical positioned file write request and its in-loop state.
+pub(super) struct WriteAtRequest {
     /// File used by the current write SQE.
-    file: Arc<File>,
+    pub(super) file: Arc<File>,
     /// Starting file offset for the logical write.
-    offset: u64,
+    pub(super) offset: u64,
     /// Bytes already written successfully.
-    written: usize,
+    pub(super) written: usize,
     /// Write cursor and buffers that still need to be written.
-    write: WriteBuffers,
+    pub(super) write: WriteBuffers,
     /// Terminal result captured by `on_cqe` and delivered by `finish`.
-    result: Option<Result<(), Error>>,
+    pub(super) result: Option<Result<(), Error>>,
     /// Completion channel for the top-level caller.
-    sender: oneshot::Sender<Result<(), Error>>,
+    pub(super) sender: oneshot::Sender<Result<(), Error>>,
 }
 
-impl ActiveWriteAt {
+impl WriteAtRequest {
     /// Build the next positioned write SQE for the remaining bytes.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.file.as_raw_fd());
@@ -697,17 +592,17 @@ impl ActiveWriteAt {
     }
 }
 
-/// Active state for a logical fsync request.
-pub struct ActiveSync {
+/// Logical fsync request and its in-loop state.
+pub(super) struct SyncRequest {
     /// File descriptor to sync.
-    file: Arc<File>,
+    pub(super) file: Arc<File>,
     /// Terminal result captured by `on_cqe` and delivered by `finish`.
-    result: Option<std::io::Result<()>>,
+    pub(super) result: Option<std::io::Result<()>>,
     /// Completion channel for the top-level caller.
-    sender: oneshot::Sender<std::io::Result<()>>,
+    pub(super) sender: oneshot::Sender<std::io::Result<()>>,
 }
 
-impl ActiveSync {
+impl SyncRequest {
     /// Build the fsync SQE for this request.
     fn build_sqe(&self) -> SqueueEntry {
         let fd = Fd(self.file.as_raw_fd());
@@ -753,23 +648,6 @@ mod tests {
         panic::{catch_unwind, AssertUnwindSafe},
     };
 
-    type SendRx = oneshot::Receiver<Result<(), Error>>;
-    type RecvRx = oneshot::Receiver<(IoBufMut, Result<usize, Error>)>;
-    type ReadRx = oneshot::Receiver<(IoBufMut, Result<(), Error>)>;
-    type SyncRx = oneshot::Receiver<std::io::Result<()>>;
-
-    fn assert_requeue(completed: bool) {
-        assert!(!completed);
-    }
-
-    fn assert_complete(completed: bool) {
-        assert!(completed);
-    }
-
-    fn active_state() -> WaiterState {
-        WaiterState::Active { target_tick: None }
-    }
-
     fn make_socket_fd() -> Arc<OwnedFd> {
         let (left, _right) = UnixStream::pair().expect("failed to create unix socket pair");
         Arc::new(left.into())
@@ -782,83 +660,17 @@ mod tests {
         Arc::new(file)
     }
 
-    fn make_send_request(bufs: IoBufs) -> (ActiveRequest, SendRx) {
-        let (tx, rx) = oneshot::channel();
-        (
-            ActiveRequest::from_request(Request::Send(SendRequest {
-                fd: make_socket_fd(),
-                bufs,
-                deadline: None,
-                sender: tx,
-            })),
-            rx,
-        )
-    }
-
-    fn make_recv_request(len: usize, offset: usize, exact: bool) -> (ActiveRequest, RecvRx) {
-        let (tx, rx) = oneshot::channel();
-        (
-            ActiveRequest::from_request(Request::Recv(RecvRequest {
-                fd: make_socket_fd(),
-                buf: IoBufMut::with_capacity(len),
-                offset,
-                len,
-                exact,
-                deadline: None,
-                sender: tx,
-            })),
-            rx,
-        )
-    }
-
-    fn make_read_request(len: usize) -> (ActiveRequest, ReadRx) {
-        let (tx, rx) = oneshot::channel();
-        (
-            ActiveRequest::from_request(Request::ReadAt(ReadAtRequest {
-                file: make_file_fd(),
-                offset: 0,
-                len,
-                buf: IoBufMut::with_capacity(len),
-                sender: tx,
-            })),
-            rx,
-        )
-    }
-
-    fn make_write_request(bufs: IoBufs) -> (ActiveRequest, SendRx) {
-        let (tx, rx) = oneshot::channel();
-        (
-            ActiveRequest::from_request(Request::WriteAt(WriteAtRequest {
-                file: make_file_fd(),
-                offset: 0,
-                bufs,
-                sender: tx,
-            })),
-            rx,
-        )
-    }
-
-    fn make_sync_request() -> (ActiveRequest, SyncRx) {
-        let (tx, rx) = oneshot::channel();
-        (
-            ActiveRequest::from_request(Request::Sync(SyncRequest {
-                file: make_file_fd(),
-                sender: tx,
-            })),
-            rx,
-        )
-    }
-
     #[test]
     fn test_request_deadline_helpers_and_invariants() {
         // Verify deadline helpers only report deadlines for network requests and
-        // that invalid request invariants still fail fast at construction time.
+        // that invalid low-level request shapes still fail before reaching the kernel.
         // Network requests carry optional deadlines that should be surfaced.
         let send_deadline = Instant::now();
         let send = Request::Send(SendRequest {
             fd: make_socket_fd(),
-            bufs: IoBufs::from(IoBuf::from(b"hello")),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
             deadline: Some(send_deadline),
+            result: None,
             sender: oneshot::channel().0,
         });
         assert_eq!(send.deadline(), Some(send_deadline));
@@ -872,6 +684,7 @@ mod tests {
             len: 8,
             exact: true,
             deadline: Some(recv_deadline),
+            result: None,
             sender: oneshot::channel().0,
         });
         assert_eq!(recv.deadline(), Some(recv_deadline));
@@ -881,48 +694,57 @@ mod tests {
             file: make_file_fd(),
             offset: 0,
             len: 4,
+            read: 0,
             buf: IoBufMut::with_capacity(4),
+            result: None,
             sender: oneshot::channel().0,
         });
         assert_eq!(read.deadline(), None);
         assert!(!read.has_deadline());
 
-        // Invalid request shapes should still panic at construction time so the
-        // loop never has to defend against impossible in-flight state.
+        // Invalid request shapes should still panic as soon as low-level SQE
+        // construction would observe them.
         let recv_overread = std::panic::catch_unwind(|| {
-            let _ = ActiveRequest::from_request(Request::Recv(RecvRequest {
+            let mut request = Request::Recv(RecvRequest {
                 fd: make_socket_fd(),
                 buf: IoBufMut::with_capacity(4),
                 offset: 5,
                 len: 4,
                 exact: true,
                 deadline: None,
+                result: None,
                 sender: oneshot::channel().0,
-            }));
+            });
+            let _ = request.build_sqe(WaiterId::new(0, 0));
         });
         assert!(recv_overread.is_err());
 
         let recv_oversized = std::panic::catch_unwind(|| {
-            let _ = ActiveRequest::from_request(Request::Recv(RecvRequest {
+            let mut request = Request::Recv(RecvRequest {
                 fd: make_socket_fd(),
                 buf: IoBufMut::with_capacity(4),
                 offset: 0,
                 len: 5,
                 exact: true,
                 deadline: None,
+                result: None,
                 sender: oneshot::channel().0,
-            }));
+            });
+            let _ = request.build_sqe(WaiterId::new(0, 0));
         });
         assert!(recv_oversized.is_err());
 
         let read_oversized = std::panic::catch_unwind(|| {
-            let _ = ActiveRequest::from_request(Request::ReadAt(ReadAtRequest {
+            let mut request = Request::ReadAt(ReadAtRequest {
                 file: make_file_fd(),
                 offset: 0,
                 len: 5,
+                read: 0,
                 buf: IoBufMut::with_capacity(4),
+                result: None,
                 sender: oneshot::channel().0,
-            }));
+            });
+            let _ = request.build_sqe(WaiterId::new(0, 0));
         });
         assert!(read_oversized.is_err());
     }
@@ -932,13 +754,27 @@ mod tests {
         // Verify send state handling across retry, timeout, success, and hard-failure CQEs.
 
         // Retryable CQEs should simply requeue while the request is still active.
-        let (mut request, _rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_requeue(request.on_cqe(active_state(), -libc::EAGAIN));
+        let (tx, _rx) = oneshot::channel();
+        let mut request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EAGAIN));
 
         // Partial progress followed by a retry after timeout should resolve to timeout.
-        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_requeue(request.on_cqe(active_state(), 2));
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::EAGAIN));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 2));
+        assert!(request.on_cqe(WaiterState::CancelRequested, -libc::EAGAIN));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing send result"),
@@ -946,9 +782,16 @@ mod tests {
         ));
 
         // Partial progress after timeout must also resolve to timeout rather than requeueing.
-        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_requeue(request.on_cqe(active_state(), 2));
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, 1));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 2));
+        assert!(request.on_cqe(WaiterState::CancelRequested, 1));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing partial-timeout result"),
@@ -956,8 +799,15 @@ mod tests {
         ));
 
         // A canceled send that comes back as ECANCELED should also resolve to timeout.
-        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing timeout-cancel result"),
@@ -968,25 +818,46 @@ mod tests {
         let mut vectored = IoBufs::default();
         vectored.append(IoBuf::from(b"abc"));
         vectored.append(IoBuf::from(b"de"));
-        let (mut request, rx) = make_send_request(vectored);
-        assert_requeue(request.on_cqe(active_state(), 3));
-        assert_complete(request.on_cqe(active_state(), 2));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: vectored.into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 3));
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 2));
         request.finish();
         block_on(rx)
             .expect("missing send completion")
             .expect("send should complete successfully");
 
         // Zero-byte and hard-error CQEs should both surface as send failures.
-        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_complete(request.on_cqe(active_state(), 0));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing zero-result completion"),
             Err(Error::SendFailed)
         ));
 
-        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_complete(request.on_cqe(active_state(), -libc::EIO));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing hard-error completion"),
@@ -994,8 +865,15 @@ mod tests {
         ));
 
         // A fully successful CQE still wins even if timeout was already requested.
-        let (mut request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, 5));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::CancelRequested, 5));
         request.finish();
         block_on(rx)
             .expect("missing send completion")
@@ -1007,65 +885,169 @@ mod tests {
         // Verify recv state handling across buffered progress, timeout, success, and hard failure.
 
         // Retryable CQEs should requeue while the recv is still active.
-        let (mut request, _rx) = make_recv_request(5, 0, true);
-        assert_requeue(request.on_cqe(active_state(), -libc::EAGAIN));
+        let (tx, _rx) = oneshot::channel();
+        let mut request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EAGAIN));
 
         // Non-exact recv should complete as soon as any positive byte count arrives.
-        let (mut request, rx) = make_recv_request(5, 0, false);
-        assert_complete(request.on_cqe(active_state(), 3));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: false,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 3));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing recv completion");
-        assert_eq!(result.expect("recv should complete successfully"), 3);
+        let (_buf, read) = block_on(rx)
+            .expect("missing recv completion")
+            .expect("recv should complete successfully");
+        assert_eq!(read, 3);
 
         // Exact recv should requeue after partial progress, but timeout wins if the follow-up CQE
         // arrives after cancellation was requested.
-        let (mut request, rx) = make_recv_request(5, 0, true);
-        assert_requeue(request.on_cqe(active_state(), 3));
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, 1));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 3));
+        assert!(request.on_cqe(WaiterState::CancelRequested, 1));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing timeout completion");
-        assert!(matches!(result, Err(Error::Timeout)));
+        assert!(matches!(
+            block_on(rx).expect("missing timeout completion"),
+            Err((_, Error::Timeout))
+        ));
 
         // Retryable and ECANCELED completions after timeout should both resolve to timeout.
-        let (mut request, rx) = make_recv_request(5, 0, true);
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::EINTR));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::CancelRequested, -libc::EINTR));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing retryable completion");
-        assert!(matches!(result, Err(Error::Timeout)));
+        assert!(matches!(
+            block_on(rx).expect("missing retryable completion"),
+            Err((_, Error::Timeout))
+        ));
 
-        let (mut request, rx) = make_recv_request(5, 0, true);
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing timeout-cancel completion");
-        assert!(matches!(result, Err(Error::Timeout)));
+        assert!(matches!(
+            block_on(rx).expect("missing timeout-cancel completion"),
+            Err((_, Error::Timeout))
+        ));
 
         // A fully successful CQE still wins after timeout was requested.
-        let (mut request, rx) = make_recv_request(5, 0, true);
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, 5));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::CancelRequested, 5));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing successful completion");
-        assert_eq!(result.expect("recv should complete successfully"), 5);
+        let (_buf, read) = block_on(rx)
+            .expect("missing successful completion")
+            .expect("recv should complete successfully");
+        assert_eq!(read, 5);
 
         // A kernel completion larger than the requested remaining length must
         // trip the local invariant before it can corrupt buffer state.
-        let (mut request, _rx) = make_recv_request(5, 0, true);
+        let (tx, _rx) = oneshot::channel();
+        let mut request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
         let overflow = catch_unwind(AssertUnwindSafe(|| {
-            let _ = request.on_cqe(active_state(), 6);
+            let _ = request.on_cqe(WaiterState::Active { target_tick: None }, 6);
         }));
         assert!(overflow.is_err());
 
         // Zero-byte and hard-error CQEs should both surface as recv failures.
-        let (mut request, rx) = make_recv_request(5, 0, true);
-        assert_complete(request.on_cqe(active_state(), 0));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing zero completion");
-        assert!(matches!(result, Err(Error::RecvFailed)));
+        assert!(matches!(
+            block_on(rx).expect("missing zero completion"),
+            Err((_, Error::RecvFailed))
+        ));
 
-        let (mut request, rx) = make_recv_request(5, 0, true);
-        assert_complete(request.on_cqe(active_state(), -libc::EIO));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing error completion");
-        assert!(matches!(result, Err(Error::RecvFailed)));
+        assert!(matches!(
+            block_on(rx).expect("missing error completion"),
+            Err((_, Error::RecvFailed))
+        ));
     }
 
     #[test]
@@ -1073,36 +1055,88 @@ mod tests {
         // Verify read-at state handling across retry, EOF, timeout-cancel, and hard failure.
 
         // Retryable CQEs should requeue the positioned read.
-        let (mut request, _rx) = make_read_request(5);
-        assert_requeue(request.on_cqe(active_state(), -libc::EAGAIN));
+        let (tx, _rx) = oneshot::channel();
+        let mut request = Request::ReadAt(ReadAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            len: 5,
+            read: 0,
+            buf: IoBufMut::with_capacity(5),
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EAGAIN));
 
         // Partial reads should requeue until the full logical length is satisfied.
-        let (mut request, rx) = make_read_request(5);
-        assert_requeue(request.on_cqe(active_state(), 2));
-        assert_complete(request.on_cqe(active_state(), 3));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::ReadAt(ReadAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            len: 5,
+            read: 0,
+            buf: IoBufMut::with_capacity(5),
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 2));
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 3));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing read completion");
-        result.expect("read should complete successfully");
+        block_on(rx)
+            .expect("missing read completion")
+            .expect("read should complete successfully");
 
         // EOF and hard-error CQEs should map to the storage read error surface.
-        let (mut request, rx) = make_read_request(5);
-        assert_complete(request.on_cqe(active_state(), 0));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::ReadAt(ReadAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            len: 5,
+            read: 0,
+            buf: IoBufMut::with_capacity(5),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing eof completion");
-        assert!(matches!(result, Err(Error::BlobInsufficientLength)));
+        assert!(matches!(
+            block_on(rx).expect("missing eof completion"),
+            Err((_, Error::BlobInsufficientLength))
+        ));
 
-        let (mut request, rx) = make_read_request(5);
-        assert_complete(request.on_cqe(active_state(), -libc::EIO));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::ReadAt(ReadAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            len: 5,
+            read: 0,
+            buf: IoBufMut::with_capacity(5),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing read failure");
-        assert!(matches!(result, Err(Error::ReadFailed)));
+        assert!(matches!(
+            block_on(rx).expect("missing read failure"),
+            Err((_, Error::ReadFailed))
+        ));
 
         // Timeout cancellation should also surface as a read failure.
-        let (mut request, rx) = make_read_request(5);
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::ReadAt(ReadAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            len: 5,
+            read: 0,
+            buf: IoBufMut::with_capacity(5),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing timeout-cancel failure");
-        assert!(matches!(result, Err(Error::ReadFailed)));
+        assert!(matches!(
+            block_on(rx).expect("missing timeout-cancel failure"),
+            Err((_, Error::ReadFailed))
+        ));
     }
 
     #[test]
@@ -1110,13 +1144,29 @@ mod tests {
         // Verify write-at state handling across retry, partial progress, timeout-cancel, and failure.
 
         // Retryable CQEs should requeue the positioned write.
-        let (mut request, _rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_requeue(request.on_cqe(active_state(), -libc::EAGAIN));
+        let (tx, _rx) = oneshot::channel();
+        let mut request = Request::WriteAt(WriteAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            written: 0,
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EAGAIN));
 
         // Single-buffer writes should track partial progress until complete.
-        let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_requeue(request.on_cqe(active_state(), 2));
-        assert_complete(request.on_cqe(active_state(), 3));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::WriteAt(WriteAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            written: 0,
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 2));
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 3));
         request.finish();
         block_on(rx)
             .expect("missing write completion")
@@ -1126,25 +1176,49 @@ mod tests {
         let mut vectored = IoBufs::default();
         vectored.append(IoBuf::from(b"abc"));
         vectored.append(IoBuf::from(b"de"));
-        let (mut request, rx) = make_write_request(vectored);
-        assert_requeue(request.on_cqe(active_state(), 4));
-        assert_complete(request.on_cqe(active_state(), 1));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::WriteAt(WriteAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            written: 0,
+            write: vectored.into(),
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, 4));
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 1));
         request.finish();
         block_on(rx)
             .expect("missing vectored write completion")
             .expect("vectored write should complete successfully");
 
         // Zero-byte and hard-error CQEs should surface as write failures.
-        let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_complete(request.on_cqe(active_state(), 0));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::WriteAt(WriteAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            written: 0,
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing zero-result write"),
             Err(Error::WriteFailed)
         ));
 
-        let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_complete(request.on_cqe(active_state(), -libc::EIO));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::WriteAt(WriteAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            written: 0,
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing write failure"),
@@ -1152,8 +1226,16 @@ mod tests {
         ));
 
         // Timeout cancellation should also surface as a write failure.
-        let (mut request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::WriteAt(WriteAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            written: 0,
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing timeout-cancel write failure"),
@@ -1166,12 +1248,22 @@ mod tests {
         // Verify sync state handling across retry, timeout-cancel, error conversion, and success.
 
         // Retryable CQEs should requeue the fsync request.
-        let (mut request, _rx) = make_sync_request();
-        assert_requeue(request.on_cqe(active_state(), -libc::EINTR));
+        let (tx, _rx) = oneshot::channel();
+        let mut request = Request::Sync(SyncRequest {
+            file: make_file_fd(),
+            result: None,
+            sender: tx,
+        });
+        assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EINTR));
 
         // Timeout cancellation should preserve the kernel ECANCELED surface for sync callers.
-        let (mut request, rx) = make_sync_request();
-        assert_complete(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Sync(SyncRequest {
+            file: make_file_fd(),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::CancelRequested, -libc::ECANCELED));
         request.finish();
         let err = block_on(rx)
             .expect("missing timeout cancel result")
@@ -1179,8 +1271,13 @@ mod tests {
         assert_eq!(err.raw_os_error(), Some(libc::ECANCELED));
 
         // Hard errors should round-trip as std::io::Error values.
-        let (mut request, rx) = make_sync_request();
-        assert_complete(request.on_cqe(active_state(), -libc::EIO));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Sync(SyncRequest {
+            file: make_file_fd(),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EIO));
         request.finish();
         let err = block_on(rx)
             .expect("missing hard error result")
@@ -1188,22 +1285,37 @@ mod tests {
         assert_eq!(err.raw_os_error(), Some(libc::EIO));
 
         // Both zero and positive CQE results should count as sync success.
-        let (mut request, rx) = make_sync_request();
-        assert_complete(request.on_cqe(active_state(), 0));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Sync(SyncRequest {
+            file: make_file_fd(),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 0));
         request.finish();
         block_on(rx)
             .expect("missing zero-result completion")
             .expect("sync should succeed on zero");
 
-        let (mut request, rx) = make_sync_request();
-        assert_complete(request.on_cqe(active_state(), 1));
+        let (tx, rx) = oneshot::channel();
+        let mut request = Request::Sync(SyncRequest {
+            file: make_file_fd(),
+            result: None,
+            sender: tx,
+        });
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, 1));
         request.finish();
         block_on(rx)
             .expect("missing positive-result completion")
             .expect("sync should succeed on positive");
 
         // Local timeout delivery should use TimedOut for the storage-facing API.
-        let (request, rx) = make_sync_request();
+        let (tx, rx) = oneshot::channel();
+        let request = Request::Sync(SyncRequest {
+            file: make_file_fd(),
+            result: None,
+            sender: tx,
+        });
         request.timeout();
         let err = block_on(rx)
             .expect("missing timeout result")
@@ -1217,25 +1329,63 @@ mod tests {
         // Network and storage requests each have their own fallback error surface.
 
         // Network sends and recvs should preserve their wrapper-specific fallback errors.
-        let (request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        let (tx, rx) = oneshot::channel();
+        let request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing send fallback"),
             Err(Error::SendFailed)
         ));
 
-        let (request, rx) = make_recv_request(5, 0, true);
+        let (tx, rx) = oneshot::channel();
+        let request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing recv fallback");
-        assert!(matches!(result, Err(Error::RecvFailed)));
+        assert!(matches!(
+            block_on(rx).expect("missing recv fallback"),
+            Err((_, Error::RecvFailed))
+        ));
 
         // Storage reads and writes should surface the corresponding storage wrapper errors.
-        let (request, rx) = make_read_request(5);
+        let (tx, rx) = oneshot::channel();
+        let request = Request::ReadAt(ReadAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            len: 5,
+            read: 0,
+            buf: IoBufMut::with_capacity(5),
+            result: None,
+            sender: tx,
+        });
         request.finish();
-        let (_buf, result) = block_on(rx).expect("missing read fallback");
-        assert!(matches!(result, Err(Error::ReadFailed)));
+        assert!(matches!(
+            block_on(rx).expect("missing read fallback"),
+            Err((_, Error::ReadFailed))
+        ));
 
-        let (request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
+        let (tx, rx) = oneshot::channel();
+        let request = Request::WriteAt(WriteAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            written: 0,
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            result: None,
+            sender: tx,
+        });
         request.finish();
         assert!(matches!(
             block_on(rx).expect("missing write fallback"),
@@ -1244,7 +1394,12 @@ mod tests {
 
         // Sync fallback remains success because the wrapper treats "no CQE seen"
         // as an already-finished local sync during shutdown abandonment.
-        let (request, rx) = make_sync_request();
+        let (tx, rx) = oneshot::channel();
+        let request = Request::Sync(SyncRequest {
+            file: make_file_fd(),
+            result: None,
+            sender: tx,
+        });
         request.finish();
         block_on(rx)
             .expect("missing sync fallback")
@@ -1258,25 +1413,63 @@ mod tests {
         // timeout surface when no CQE was processed yet.
 
         // Network operations should map directly to the shared logical timeout.
-        let (request, rx) = make_send_request(IoBufs::from(IoBuf::from(b"hello")));
+        let (tx, rx) = oneshot::channel();
+        let request = Request::Send(SendRequest {
+            fd: make_socket_fd(),
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
         request.timeout();
         assert!(matches!(
             block_on(rx).expect("missing send timeout"),
             Err(Error::Timeout)
         ));
 
-        let (request, rx) = make_recv_request(5, 0, true);
+        let (tx, rx) = oneshot::channel();
+        let request = Request::Recv(RecvRequest {
+            fd: make_socket_fd(),
+            buf: IoBufMut::with_capacity(5),
+            offset: 0,
+            len: 5,
+            exact: true,
+            deadline: None,
+            result: None,
+            sender: tx,
+        });
         request.timeout();
-        let (_buf, result) = block_on(rx).expect("missing recv timeout");
-        assert!(matches!(result, Err(Error::Timeout)));
+        assert!(matches!(
+            block_on(rx).expect("missing recv timeout"),
+            Err((_, Error::Timeout))
+        ));
 
         // Storage reads and writes also use the common logical timeout surface.
-        let (request, rx) = make_read_request(5);
+        let (tx, rx) = oneshot::channel();
+        let request = Request::ReadAt(ReadAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            len: 5,
+            read: 0,
+            buf: IoBufMut::with_capacity(5),
+            result: None,
+            sender: tx,
+        });
         request.timeout();
-        let (_buf, result) = block_on(rx).expect("missing read timeout");
-        assert!(matches!(result, Err(Error::Timeout)));
+        assert!(matches!(
+            block_on(rx).expect("missing read timeout"),
+            Err((_, Error::Timeout))
+        ));
 
-        let (request, rx) = make_write_request(IoBufs::from(IoBuf::from(b"hello")));
+        let (tx, rx) = oneshot::channel();
+        let request = Request::WriteAt(WriteAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            written: 0,
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            result: None,
+            sender: tx,
+        });
         request.timeout();
         assert!(matches!(
             block_on(rx).expect("missing write timeout"),
@@ -1284,7 +1477,12 @@ mod tests {
         ));
 
         // Sync uses `std::io::ErrorKind::TimedOut` to match its storage-facing API.
-        let (request, rx) = make_sync_request();
+        let (tx, rx) = oneshot::channel();
+        let request = Request::Sync(SyncRequest {
+            file: make_file_fd(),
+            result: None,
+            sender: tx,
+        });
         request.timeout();
         let err = block_on(rx)
             .expect("missing sync timeout")

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -128,6 +128,12 @@ pub enum StageOutcome {
     /// The waiter was canceled while parked in the ready queue and should
     /// complete locally with timeout rather than issuing another SQE.
     Timeout(Request),
+    /// The original caller dropped its wait handle before this SQE could be
+    /// staged, so the waiter was retired locally.
+    Orphaned {
+        /// Active deadline tracking to remove from the timeout wheel, if any.
+        target_tick: Option<Tick>,
+    },
     /// The waiter is still active and produced an SQE for submission.
     Submit(SqueueEntry),
 }
@@ -251,11 +257,18 @@ impl Waiters {
 
     /// Stage the next SQE for a waiter.
     ///
-    /// If the waiter timed out while parked in the ready queue, this removes it
-    /// from the table and returns the request for local timeout completion.
+    /// This either returns the next SQE to issue, or removes the waiter from
+    /// the table and returns the local action that should happen instead.
     ///
-    /// When this returns [`StageOutcome::Submit`], the waiter is marked as
-    /// having an operation SQE outstanding immediately.
+    /// - [`StageOutcome::Submit`] leaves the waiter tracked and yields the next SQE.
+    /// - [`StageOutcome::Timeout`] removes the waiter and completes it locally with
+    ///   timeout.
+    /// - [`StageOutcome::Orphaned`] removes the waiter because the caller dropped its
+    ///   wait handle before restaging.
+    ///
+    /// When this returns [`StageOutcome::Submit`], the waiter is marked as having an
+    /// operation SQE outstanding immediately, so [`Waiters::is_in_flight`] will return
+    /// `true` for that waiter.
     ///
     /// Panics if `waiter_id` does not refer to a currently tracked waiter or if
     /// the waiter already has an operation SQE outstanding.
@@ -268,22 +281,32 @@ impl Waiters {
             .expect("stage called for untracked waiter");
         assert_eq!(slot.id, waiter_id, "stage called with stale waiter id");
 
-        if slot.state == WaiterState::CancelRequested {
-            StageOutcome::Timeout(self.take(index))
-        } else {
-            assert!(
-                !slot.in_flight,
-                "stage called for waiter with op already in flight"
-            );
-            slot.in_flight = true;
-            StageOutcome::Submit(slot.request.build_sqe(waiter_id))
+        match slot.state {
+            WaiterState::CancelRequested => StageOutcome::Timeout(self.take(index)),
+            WaiterState::Active { target_tick } if slot.request.is_orphaned() => {
+                // The current request still owns all resources, but there is no
+                // caller left to observe more progress, so retire it locally
+                // instead of issuing another SQE.
+                let _ = self.take(index);
+                StageOutcome::Orphaned { target_tick }
+            }
+            WaiterState::Active { .. } => {
+                assert!(
+                    !slot.in_flight,
+                    "stage called for waiter with op already in flight"
+                );
+                slot.in_flight = true;
+                StageOutcome::Submit(slot.request.build_sqe(waiter_id))
+            }
         }
     }
 
     /// Process one CQE for a waiter.
     ///
     /// Cancel CQEs are handled internally. Operation CQEs drive the request
-    /// state machine and return a high-level loop action.
+    /// state machine and return a high-level loop action. If the current SQE
+    /// completed but the original caller already dropped its wait handle, the
+    /// waiter is retired locally instead of requeueing another SQE.
     ///
     /// Panics if a non-cancel CQE does not refer to a currently tracked waiter,
     /// if it uses a stale waiter generation, or if the waiter has no operation
@@ -325,19 +348,23 @@ impl Waiters {
         assert!(slot.in_flight);
         slot.in_flight = false;
 
+        let state = slot.state;
         let completed = slot.request.on_cqe(slot.state, result);
-        if !completed {
-            return CompletionOutcome::Requeue(waiter_id);
-        }
+        if completed || slot.request.is_orphaned() {
+            // Either the request reached a terminal state, or the current SQE
+            // made non-terminal progress for a caller that is already gone. In
+            // both cases, remove the waiter now instead of requeueing another SQE.
+            let target_tick = match state {
+                WaiterState::Active { target_tick } => target_tick,
+                WaiterState::CancelRequested => None,
+            };
 
-        let target_tick = match slot.state {
-            WaiterState::Active { target_tick } => target_tick,
-            WaiterState::CancelRequested => None,
-        };
-
-        CompletionOutcome::Complete {
-            request: self.take(index),
-            target_tick,
+            CompletionOutcome::Complete {
+                request: self.take(index),
+                target_tick,
+            }
+        } else {
+            CompletionOutcome::Requeue(waiter_id)
         }
     }
 

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -381,7 +381,10 @@ impl Waiters {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::iouring::request::{Request, SyncRequest};
+    use crate::{
+        iouring::request::{ReadAtRequest, RecvRequest, Request, SendRequest, SyncRequest},
+        IoBuf, IoBufMut, IoBufs,
+    };
     use commonware_utils::channel::oneshot;
     use std::{
         os::fd::{FromRawFd, IntoRawFd},
@@ -639,6 +642,219 @@ mod tests {
         assert!(!waiters.is_in_flight(ready));
         let ready_state = waiter_state(&waiters, ready).expect("ready waiter missing");
         assert!(matches!(ready_state, WaiterState::CancelRequested));
+    }
+
+    #[test]
+    fn test_waiters_stage_orphans_closed_requests() {
+        // Verify closed send and read-at requests are removed locally before
+        // their first SQE is ever staged.
+        {
+            // Send request orphaned before first submit.
+            let mut waiters = Waiters::new(1);
+            let (tx, rx) = oneshot::channel();
+            drop(rx);
+            let waiter_id = waiters.insert(
+                Request::Send(SendRequest {
+                    fd: Arc::new(std::os::unix::net::UnixStream::pair().unwrap().0.into()),
+                    write: IoBufs::from(IoBuf::from(b"hello")).into(),
+                    deadline: None,
+                    result: None,
+                    sender: tx,
+                }),
+                Some(7),
+            );
+
+            match waiters.stage(waiter_id) {
+                StageOutcome::Orphaned {
+                    target_tick: Some(7),
+                } => {}
+                _ => panic!("closed send waiter should be orphaned before staging"),
+            }
+            assert!(waiters.is_empty());
+        }
+
+        {
+            // Read-at request orphaned before first submit.
+            let mut waiters = Waiters::new(1);
+            let (sock_left, _sock_right) =
+                std::os::unix::net::UnixStream::pair().expect("failed to create unix socket pair");
+            // SAFETY: sock_left is a valid fd that we own.
+            let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+            let (tx, rx) = oneshot::channel();
+            drop(rx);
+            let waiter_id = waiters.insert(
+                Request::ReadAt(ReadAtRequest {
+                    file: Arc::new(file),
+                    offset: 0,
+                    len: 8,
+                    read: 0,
+                    buf: IoBufMut::with_capacity(8),
+                    result: None,
+                    sender: tx,
+                }),
+                Some(8),
+            );
+
+            match waiters.stage(waiter_id) {
+                StageOutcome::Orphaned {
+                    target_tick: Some(8),
+                } => {}
+                _ => panic!("closed read waiter should be orphaned before staging"),
+            }
+            assert!(waiters.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_waiters_orphan_closed_requests_after_nonterminal_completion() {
+        // Verify retryable and partial-progress send, recv, and read-at CQEs
+        // remove the waiter instead of requeueing once the caller is gone.
+        {
+            // Send request orphaned after a retryable CQE.
+            let mut waiters = Waiters::new(1);
+            let (tx, rx) = oneshot::channel();
+            let waiter_id = waiters.insert(
+                Request::Send(SendRequest {
+                    fd: Arc::new(std::os::unix::net::UnixStream::pair().unwrap().0.into()),
+                    write: IoBufs::from(IoBuf::from(b"hello")).into(),
+                    deadline: None,
+                    result: None,
+                    sender: tx,
+                }),
+                Some(5),
+            );
+            assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
+            drop(rx);
+
+            match waiters.on_completion(waiter_id.user_data(), -libc::EAGAIN) {
+                CompletionOutcome::Complete {
+                    request,
+                    target_tick: Some(5),
+                } => request.complete(),
+                _ => panic!("closed send waiter should be orphaned after retry CQE"),
+            }
+            assert!(waiters.is_empty());
+        }
+
+        {
+            // Send request orphaned after a partial-progress CQE.
+            let mut waiters = Waiters::new(1);
+            let (tx, rx) = oneshot::channel();
+            let waiter_id = waiters.insert(
+                Request::Send(SendRequest {
+                    fd: Arc::new(std::os::unix::net::UnixStream::pair().unwrap().0.into()),
+                    write: IoBufs::from(IoBuf::from(b"hello")).into(),
+                    deadline: None,
+                    result: None,
+                    sender: tx,
+                }),
+                Some(5),
+            );
+            assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
+            drop(rx);
+
+            match waiters.on_completion(waiter_id.user_data(), 2) {
+                CompletionOutcome::Complete {
+                    request,
+                    target_tick: Some(5),
+                } => request.complete(),
+                _ => panic!("closed send waiter should be orphaned after partial CQE"),
+            }
+            assert!(waiters.is_empty());
+        }
+
+        {
+            // Exact recv orphaned after a retryable CQE.
+            let mut waiters = Waiters::new(1);
+            let (tx, rx) = oneshot::channel();
+            let waiter_id = waiters.insert(
+                Request::Recv(RecvRequest {
+                    fd: Arc::new(std::os::unix::net::UnixStream::pair().unwrap().0.into()),
+                    buf: IoBufMut::with_capacity(5),
+                    offset: 0,
+                    len: 5,
+                    exact: true,
+                    deadline: None,
+                    result: None,
+                    sender: tx,
+                }),
+                Some(6),
+            );
+            assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
+            drop(rx);
+
+            match waiters.on_completion(waiter_id.user_data(), -libc::EAGAIN) {
+                CompletionOutcome::Complete {
+                    request,
+                    target_tick: Some(6),
+                } => request.complete(),
+                _ => panic!("closed recv waiter should be orphaned after retry CQE"),
+            }
+            assert!(waiters.is_empty());
+        }
+
+        {
+            // Exact recv orphaned after a partial-progress CQE.
+            let mut waiters = Waiters::new(1);
+            let (tx, rx) = oneshot::channel();
+            let waiter_id = waiters.insert(
+                Request::Recv(RecvRequest {
+                    fd: Arc::new(std::os::unix::net::UnixStream::pair().unwrap().0.into()),
+                    buf: IoBufMut::with_capacity(5),
+                    offset: 0,
+                    len: 5,
+                    exact: true,
+                    deadline: None,
+                    result: None,
+                    sender: tx,
+                }),
+                Some(6),
+            );
+            assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
+            drop(rx);
+
+            match waiters.on_completion(waiter_id.user_data(), 3) {
+                CompletionOutcome::Complete {
+                    request,
+                    target_tick: Some(6),
+                } => request.complete(),
+                _ => panic!("closed recv waiter should be orphaned after partial CQE"),
+            }
+            assert!(waiters.is_empty());
+        }
+
+        {
+            // Read-at request orphaned after a partial-progress CQE.
+            let mut waiters = Waiters::new(1);
+            let (sock_left, _sock_right) =
+                std::os::unix::net::UnixStream::pair().expect("failed to create unix socket pair");
+            // SAFETY: sock_left is a valid fd that we own.
+            let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+            let (tx, rx) = oneshot::channel();
+            let waiter_id = waiters.insert(
+                Request::ReadAt(ReadAtRequest {
+                    file: Arc::new(file),
+                    offset: 0,
+                    len: 8,
+                    read: 0,
+                    buf: IoBufMut::with_capacity(8),
+                    result: None,
+                    sender: tx,
+                }),
+                Some(9),
+            );
+            assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
+            drop(rx);
+
+            match waiters.on_completion(waiter_id.user_data(), 3) {
+                CompletionOutcome::Complete {
+                    request,
+                    target_tick: Some(9),
+                } => request.complete(),
+                _ => panic!("closed read waiter should be orphaned after partial CQE"),
+            }
+            assert!(waiters.is_empty());
+        }
     }
 
     #[test]

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -1,10 +1,9 @@
-//! Waiter identity and lifecycle state for io_uring in-flight operations.
+//! Waiter identity and lifecycle state for io_uring in-flight requests.
 //!
-//! This module manages waiter IDs and waiter lifecycle transitions.
-//! It is the source of truth for in-flight operation completion state.
+//! This module manages waiter IDs and request lifecycle transitions.
+//! It is the source of truth for in-flight request completion state.
 
-use super::{OpBuffer, OpFd, OpIovecs, Tick, UserData};
-use commonware_utils::channel::oneshot;
+use super::{request::ActiveRequest, Tick, UserData};
 use tracing::warn;
 
 /// Stable waiter identity packed into SQE/CQE `user_data`.
@@ -84,76 +83,37 @@ impl WaiterId {
     ///
     /// The returned waiter id always has the cancel-tag bit stripped. The
     /// boolean reports whether that bit was set in the input value.
-    const fn from_user_data(user_data: UserData) -> (Self, bool) {
+    pub const fn from_user_data(user_data: UserData) -> (Self, bool) {
         let is_cancel = (user_data & Self::CANCEL_TAG) != 0;
         (Self(user_data & !Self::CANCEL_TAG), is_cancel)
     }
 }
 
-/// Lifecycle state of an in-flight waiter across operation and cancellation handling.
+/// Lifecycle state of an in-flight request.
 #[derive(Clone, Copy, Debug)]
-enum WaiterState {
-    /// Operation is active in the ring.
+pub enum WaiterState {
+    /// Request is active in the ring.
     Active {
-        /// Absolute wheel tick by which the operation must complete.
+        /// Absolute wheel tick by which the request must complete.
         ///
         /// If completion has not been observed by this tick, cancellation is
-        /// requested. `None` means this waiter has no timeout deadline.
+        /// requested. `None` means this request has no timeout deadline.
         target_tick: Option<Tick>,
     },
     /// Cancellation was requested and cancel SQE was submitted.
     CancelRequested,
 }
 
-/// State for one in-flight operation.
-///
-/// Holds the sender used for completion delivery and resources that must remain alive
-/// until CQE delivery.
+/// State for one in-flight logical request.
 struct Waiter {
     /// Stable identity of this waiter slot instance.
     id: WaiterId,
-    /// The oneshot sender used to deliver the operation result and buffer back to the
-    /// caller.
-    sender: oneshot::Sender<(i32, Option<OpBuffer>)>,
-    /// Waiter completion state.
     state: WaiterState,
-    /// The buffer associated with this operation, if any.
-    buffer: Option<OpBuffer>,
-    /// The file descriptor associated with this operation, if any. Used to keep the file
-    /// descriptor alive and prevent reuse while the operation is in-flight.
-    ///
-    /// NOTE: This field is never read since it only exists to keep the FD alive until
-    /// operation completion, hence the allow dead code.
-    #[allow(dead_code)]
-    fd: Option<OpFd>,
-    /// The iovec array associated with this operation, if any. Used to keep iovec
-    /// storage alive and prevent use-after-free while the operation is in-flight.
-    ///
-    /// NOTE: This field is never read since it only exists to keep iovecs alive until
-    /// operation completion, hence the allow dead code.
-    #[allow(dead_code)]
-    iovecs: Option<OpIovecs>,
+    /// The active request state machine.
+    request: ActiveRequest,
 }
 
-/// Waiter resources and metadata returned when a waiter reaches terminal state.
-pub struct CompletedWaiter {
-    /// Sender used to deliver completion back to the original caller.
-    pub sender: oneshot::Sender<(i32, Option<OpBuffer>)>,
-    /// Buffer to return to the caller.
-    pub buffer: Option<OpBuffer>,
-    /// Operation result code.
-    pub result: i32,
-    /// True when completion happened through cancellation handling.
-    pub cancelled: bool,
-    /// Scheduled deadline tick, when known.
-    ///
-    /// `None` means there is no deadline to remove from timeout tracking (either no
-    /// deadline was set, or completion was observed after cancellation had already
-    /// been requested).
-    pub target_tick: Option<Tick>,
-}
-
-/// Tracks in-flight operations and the state needed to complete them.
+/// Tracks in-flight logical requests and the state needed to complete them.
 pub struct Waiters {
     /// Waiters indexed by slot index.
     ///
@@ -166,8 +126,8 @@ pub struct Waiters {
 }
 
 impl Waiters {
-    /// Create an empty waiter set that can track at most `capacity` in-flight operations
-    /// at once.
+    /// Create an empty waiter set that can track at most `capacity` in-flight
+    /// requests at once.
     pub fn new(capacity: usize) -> Self {
         let mut entries = Vec::with_capacity(capacity);
         entries.resize_with(capacity, || None);
@@ -195,17 +155,10 @@ impl Waiters {
         self.len == 0
     }
 
-    /// Insert a waiter and return its assigned id.
+    /// Insert a request and return its assigned id.
     ///
     /// Panics if no free slot is available.
-    pub fn insert(
-        &mut self,
-        sender: oneshot::Sender<(i32, Option<OpBuffer>)>,
-        buffer: Option<OpBuffer>,
-        fd: Option<OpFd>,
-        iovecs: Option<OpIovecs>,
-        target_tick: Option<Tick>,
-    ) -> WaiterId {
+    pub fn insert(&mut self, request: ActiveRequest, target_tick: Option<Tick>) -> WaiterId {
         let id = self
             .free
             .pop()
@@ -213,11 +166,8 @@ impl Waiters {
         let index = id.index() as usize;
         let replaced = self.entries[index].replace(Waiter {
             id,
-            sender,
             state: WaiterState::Active { target_tick },
-            buffer,
-            fd,
-            iovecs,
+            request,
         });
         assert!(replaced.is_none(), "free slot should not contain waiter");
         self.len += 1;
@@ -226,43 +176,46 @@ impl Waiters {
 
     /// Request cancellation for an active waiter.
     ///
-    /// Returns cancellation `user_data` when the waiter exists and is active.
-    /// Returns `None` when the waiter id is stale, not present, or already
-    /// cancel-requested.
-    ///
-    /// Panics if `waiter_id` encodes a slot index outside this waiters set capacity.
-    pub fn cancel(&mut self, waiter_id: WaiterId) -> Option<UserData> {
-        let index = waiter_id.index() as usize;
-        let waiter = self.entries[index].as_mut()?;
-        if waiter.id != waiter_id {
-            return None;
+    /// Returns `true` when the waiter was successfully transitioned to
+    /// cancel-requested. Returns `false` when the waiter id is stale, not
+    /// present, or already cancel-requested.
+    pub fn cancel(&mut self, waiter_id: WaiterId) -> bool {
+        let Some(slot) = self.entries.get_mut(waiter_id.index() as usize) else {
+            return false;
+        };
+        let Some(slot) = slot.as_mut() else {
+            return false;
+        };
+        if slot.id != waiter_id {
+            return false;
         }
-        match waiter.state {
+        match slot.state {
             WaiterState::Active { .. } => {
-                waiter.state = WaiterState::CancelRequested;
-                Some(waiter_id.cancel_user_data())
+                slot.state = WaiterState::CancelRequested;
+                true
             }
-            WaiterState::CancelRequested => None,
+            WaiterState::CancelRequested => false,
         }
     }
 
-    /// Process one completion to waiter state.
+    /// Get mutable access to a request slot by user_data.
     ///
-    /// Returns a completed waiter when this completion reaches terminal state for
-    /// the waiter id, otherwise returns `None`.
+    /// Process one CQE for a waiter.
     ///
-    /// `None` includes stale waiter ids (for example, the slot was reused with a
-    /// newer generation).
+    /// Returns the request, its state, and waiter id if the slot is occupied
+    /// and the generation matches.
     ///
-    /// Panics if `user_data` decodes to a slot index outside this waiters set
-    /// capacity.
-    pub fn on_completion(&mut self, user_data: UserData, result: i32) -> Option<CompletedWaiter> {
+    /// Cancel CQEs are handled internally and always return `None`.
+    pub fn on_cqe(
+        &mut self,
+        user_data: UserData,
+        result: i32,
+    ) -> Option<(&mut ActiveRequest, WaiterState, WaiterId)> {
         let (waiter_id, is_cancel) = WaiterId::from_user_data(user_data);
         let index = waiter_id.index() as usize;
 
-        let waiter = self.entries[index].as_mut()?;
-        if waiter.id != waiter_id {
-            // Slot was reused, this CQE belongs to an older waiter generation.
+        let slot = self.entries[index].as_mut()?;
+        if slot.id != waiter_id {
             return None;
         }
 
@@ -285,45 +238,71 @@ impl Waiters {
             return None;
         }
 
-        let (cancelled, target_tick) = match waiter.state {
-            WaiterState::Active { target_tick } => (false, target_tick),
-            WaiterState::CancelRequested => (true, None),
-        };
+        let state = slot.state;
+        Some((&mut slot.request, state, waiter_id))
+    }
 
-        let Waiter {
-            id, sender, buffer, ..
-        } = self.entries[index].take().expect("missing waiter");
+    /// Get mutable access to a request by waiter id.
+    ///
+    /// Used by the loop to build SQEs for requests that are already in the
+    /// waiter table (e.g., from the ready queue).
+    pub fn get_mut(&mut self, waiter_id: WaiterId) -> Option<(&mut ActiveRequest, WaiterState)> {
+        let index = waiter_id.index() as usize;
+        let slot = self.entries[index].as_mut()?;
+        if slot.id != waiter_id {
+            return None;
+        }
+        Some((&mut slot.request, slot.state))
+    }
 
-        self.free.push(id.next_generation());
+    /// Remove a completed request slot by waiter id.
+    ///
+    /// Returns the `ActiveRequest` so the caller can finish it. The slot is
+    /// freed and its generation incremented for reuse.
+    ///
+    /// Returns `None` if the slot is empty or the generation doesn't match.
+    pub fn remove(&mut self, waiter_id: WaiterId) -> Option<ActiveRequest> {
+        let index = waiter_id.index() as usize;
+        let slot = self.entries[index].as_ref()?;
+        if slot.id != waiter_id {
+            return None;
+        }
+        let slot = self.entries[index].take().expect("missing waiter");
+        self.free.push(slot.id.next_generation());
         self.len -= 1;
-
-        Some(CompletedWaiter {
-            sender,
-            buffer,
-            result,
-            cancelled,
-            target_tick,
-        })
+        Some(slot.request)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::iobuf::{IoBuf, IoBufs};
+    use crate::iouring::request::{ActiveRequest, Request, SyncRequest};
+    use commonware_utils::channel::oneshot;
     use std::{
-        os::unix::net::UnixStream,
+        os::fd::{FromRawFd, IntoRawFd},
         panic::{catch_unwind, AssertUnwindSafe},
         sync::Arc,
     };
 
+    fn make_sync_request() -> (ActiveRequest, oneshot::Receiver<std::io::Result<()>>) {
+        let (sock_left, _sock_right) =
+            std::os::unix::net::UnixStream::pair().expect("failed to create unix socket pair");
+        // SAFETY: sock_left is a valid fd that we own.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+        let (tx, rx) = oneshot::channel();
+        let request = ActiveRequest::from_request(Request::Sync(SyncRequest {
+            file: Arc::new(file),
+            sender: tx,
+        }));
+        (request, rx)
+    }
+
     #[test]
     fn test_waiter_id_encoding_and_generation_wrap() {
-        // Generation bits are masked to the representable range.
         let wrapped = WaiterId::new(7, (WaiterId::GENERATION_MASK as u32).wrapping_add(5));
         assert_eq!(wrapped.generation(), 4);
 
-        // Generation wraps after reaching the max encoded value.
         let max = WaiterId::new(7, WaiterId::GENERATION_MASK as u32);
         assert_eq!(max.next_generation().generation(), 0);
 
@@ -331,7 +310,6 @@ mod tests {
         assert_eq!(waiter_id.index(), 7);
         assert_eq!(waiter_id.generation(), 3);
 
-        // Encoding/decoding must preserve id and tag semantics.
         let (decoded_op, is_cancel_op) = WaiterId::from_user_data(waiter_id.user_data());
         assert_eq!(decoded_op, waiter_id);
         assert!(!is_cancel_op);
@@ -348,68 +326,37 @@ mod tests {
         assert_eq!(waiters.len(), 0);
         assert!(waiters.is_empty());
 
-        let (tx0, _rx0) = oneshot::channel();
-        let (tx1, _rx1) = oneshot::channel();
-        let id0 = waiters.insert(tx0, Some(IoBuf::from(b"hello").into()), None, None, Some(5));
-        let id1 = waiters.insert(tx1, Some(IoBuf::from(b"world").into()), None, None, Some(9));
+        let (req0, _rx0) = make_sync_request();
+        let (req1, _rx1) = make_sync_request();
+        let id0 = waiters.insert(req0, Some(5));
+        let id1 = waiters.insert(req1, Some(9));
         assert_eq!((id0.index(), id1.index()), (0, 1));
         assert_eq!(waiters.len(), 2);
 
         // Completion for a stale generation must be ignored.
         let stale = WaiterId::new(id1.index(), id1.generation().wrapping_add(1));
-        assert!(waiters.on_completion(stale.user_data(), 0).is_none());
+        assert!(waiters.on_cqe(stale.user_data(), 0).is_none());
 
-        let completed1 = waiters
-            .on_completion(id1.user_data(), 7)
-            .expect("missing waiter completion");
-        assert_eq!(completed1.result, 7);
-        assert!(!completed1.cancelled);
-        assert_eq!(completed1.target_tick, Some(9));
-        assert!(matches!(
-            completed1.buffer.as_ref(),
-            Some(OpBuffer::Write(buf)) if buf.as_ref() == b"world"
-        ));
+        // Complete id1.
+        let result = waiters.on_cqe(id1.user_data(), 0);
+        assert!(result.is_some());
+        let request = waiters.remove(id1);
+        assert!(request.is_some());
         assert_eq!(waiters.len(), 1);
 
         // Next allocation reuses the freed slot with incremented generation.
-        let (tx2, _rx2) = oneshot::channel();
-        let id2 = waiters.insert(tx2, None, None, None, Some(11));
+        let (req2, _rx2) = make_sync_request();
+        let id2 = waiters.insert(req2, Some(11));
         assert_eq!(id2.index(), id1.index());
         assert_eq!(
             id2.generation(),
             id1.generation().wrapping_add(1) & (WaiterId::GENERATION_MASK as u32)
         );
 
-        let _ = waiters.on_completion(id0.user_data(), 1);
-        let _ = waiters.on_completion(id2.user_data(), 2);
-
-        // Cover vectored buffers plus fd/iovec keepalive storage.
-        let (tx3, _rx3) = oneshot::channel();
-        let vectored = IoBufs::from(vec![IoBuf::from(b"ab"), IoBuf::from(b"cd")]);
-        let iovecs = OpIovecs::new(
-            vec![libc::iovec {
-                iov_base: std::ptr::null_mut(),
-                iov_len: 0,
-            }]
-            .into_boxed_slice(),
-        );
-        assert!(!iovecs.as_ptr().is_null());
-        let (sock_left, _sock_right) =
-            UnixStream::pair().expect("failed to create unix socket pair");
-        let id3 = waiters.insert(
-            tx3,
-            Some(vectored.into()),
-            Some(OpFd::Fd(Arc::new(sock_left.into()))),
-            Some(iovecs),
-            None,
-        );
-        let completed3 = waiters
-            .on_completion(id3.user_data(), 9)
-            .expect("missing vectored completion");
-        assert!(matches!(
-            completed3.buffer,
-            Some(OpBuffer::WriteVectored(_))
-        ));
+        let _ = waiters.on_cqe(id0.user_data(), 0);
+        let _ = waiters.remove(id0);
+        let _ = waiters.on_cqe(id2.user_data(), 0);
+        let _ = waiters.remove(id2);
         assert!(waiters.is_empty());
     }
 
@@ -417,32 +364,35 @@ mod tests {
     fn test_waiters_cancel_paths() {
         let mut waiters = Waiters::new(3);
 
-        let (tx, _rx) = oneshot::channel();
-        let waiter_id = waiters.insert(tx, None, None, None, Some(2));
+        let (req, _rx) = make_sync_request();
+        let waiter_id = waiters.insert(req, Some(2));
 
         let stale = WaiterId::new(waiter_id.index(), waiter_id.generation().wrapping_add(1));
-        assert!(waiters.cancel(stale).is_none());
+        assert!(!waiters.cancel(stale));
 
-        let cancel = waiters
-            .cancel(waiter_id)
-            .expect("cancel should transition active waiter");
-        assert_eq!(cancel, waiter_id.cancel_user_data());
+        assert!(
+            waiters.cancel(waiter_id),
+            "cancel should transition active waiter"
+        );
 
-        // Cancel CQE does not complete the waiter. The op CQE delivers the result.
-        assert!(waiters.on_completion(cancel, -libc::ECANCELED).is_none());
-        let completed = waiters
-            .on_completion(waiter_id.user_data(), 123)
-            .expect("missing completion");
-        assert_eq!(completed.result, 123);
-        assert!(completed.cancelled);
-        assert_eq!(completed.target_tick, None);
+        // Cancel CQE does not complete the waiter.
+        assert!(waiters
+            .on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED)
+            .is_none());
+
+        // Op CQE completes the waiter.
+        let result = waiters.on_cqe(waiter_id.user_data(), 0);
+        assert!(result.is_some());
+        let (_, state, _) = result.unwrap();
+        assert!(matches!(state, WaiterState::CancelRequested));
+        let _ = waiters.remove(waiter_id);
         assert!(waiters.is_empty());
 
         // Late cancel CQE for the already-completed waiter should be ignored.
         assert!(waiters
-            .on_completion(waiter_id.cancel_user_data(), -libc::ECANCELED)
+            .on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED)
             .is_none());
-        assert!(waiters.on_completion(0, 1).is_none());
+        assert!(waiters.on_cqe(0, 1).is_none());
     }
 
     #[test]
@@ -450,29 +400,29 @@ mod tests {
         let mut waiters = Waiters::new(2);
 
         // Inserting beyond configured capacity should panic.
-        let (tx0, _rx0) = oneshot::channel();
-        let (tx1, _rx1) = oneshot::channel();
-        let _ = waiters.insert(tx0, None, None, None, None);
-        let _ = waiters.insert(tx1, None, None, None, None);
+        let (req0, _rx0) = make_sync_request();
+        let (req1, _rx1) = make_sync_request();
+        let _ = waiters.insert(req0, None);
+        let _ = waiters.insert(req1, None);
         let insert_overflow = catch_unwind(AssertUnwindSafe(|| {
-            let (tx2, _rx2) = oneshot::channel();
-            let _ = waiters.insert(tx2, None, None, None, None);
+            let (req2, _rx2) = make_sync_request();
+            let _ = waiters.insert(req2, None);
         }));
         assert!(insert_overflow.is_err());
 
         // Cancellation is allowed even when no deadline is tracked.
         let mut waiters = Waiters::new(2);
-        let (tx, _rx) = oneshot::channel();
-        let no_deadline = waiters.insert(tx, None, None, None, None);
-        let cancel = waiters
-            .cancel(no_deadline)
-            .expect("cancel should support active waiter without deadline");
-        assert_eq!(cancel, no_deadline.cancel_user_data());
+        let (req, _rx) = make_sync_request();
+        let no_deadline = waiters.insert(req, None);
+        assert!(
+            waiters.cancel(no_deadline),
+            "cancel should support active waiter without deadline"
+        );
 
         // Repeated cancel on the same waiter must be ignored.
-        let (tx, _rx) = oneshot::channel();
-        let active = waiters.insert(tx, None, None, None, Some(3));
-        let _ = waiters.cancel(active);
-        assert!(waiters.cancel(active).is_none());
+        let (req, _rx) = make_sync_request();
+        let active = waiters.insert(req, Some(3));
+        assert!(waiters.cancel(active));
+        assert!(!waiters.cancel(active));
     }
 }

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -139,7 +139,7 @@ pub enum StageAction {
 
 /// Action produced when handling an operation CQE for a waiter.
 #[allow(clippy::large_enum_variant)]
-pub enum CqeOutcome {
+pub enum CompletionOutcome {
     /// The CQE was stale, referred to a cancel SQE, or otherwise requires no
     /// further loop action.
     Ignore,
@@ -250,7 +250,7 @@ impl Waiters {
     /// When this returns [`StageAction::Submit`], the waiter is marked as
     /// having an operation SQE outstanding immediately. In this implementation,
     /// the caller pushes the SQE right away and treats push failure as fatal.
-    pub fn stage_sqe(&mut self, waiter_id: WaiterId) -> StageAction {
+    pub fn stage(&mut self, waiter_id: WaiterId) -> StageAction {
         let index = waiter_id.index() as usize;
         let should_timeout_locally = {
             let Some(slot) = self.entries.get_mut(index).and_then(Option::as_mut) else {
@@ -286,15 +286,15 @@ impl Waiters {
     ///
     /// Cancel CQEs are handled internally. Operation CQEs drive the request
     /// state machine and return a higher-level loop action.
-    pub fn on_cqe(&mut self, user_data: UserData, result: i32) -> CqeOutcome {
+    pub fn on_completion(&mut self, user_data: UserData, result: i32) -> CompletionOutcome {
         let (waiter_id, is_cancel) = WaiterId::from_user_data(user_data);
         let index = waiter_id.index() as usize;
 
         let Some(slot) = self.entries.get_mut(index).and_then(Option::as_mut) else {
-            return CqeOutcome::Ignore;
+            return CompletionOutcome::Ignore;
         };
         if slot.id != waiter_id {
-            return CqeOutcome::Ignore;
+            return CompletionOutcome::Ignore;
         }
 
         if is_cancel {
@@ -313,7 +313,7 @@ impl Waiters {
             }
 
             // Cancel CQEs acknowledge cancel requests but do not complete waiters.
-            return CqeOutcome::Ignore;
+            return CompletionOutcome::Ignore;
         }
 
         // The operation CQE retires the currently in-flight SQE, regardless of
@@ -326,7 +326,7 @@ impl Waiters {
         };
 
         match action {
-            CqeAction::Requeue => CqeOutcome::Requeue(waiter_id),
+            CqeAction::Requeue => CompletionOutcome::Requeue(waiter_id),
             CqeAction::Complete => {
                 let target_tick = match state {
                     WaiterState::Active { target_tick } => target_tick,
@@ -335,7 +335,7 @@ impl Waiters {
                 let request = self
                     .remove(waiter_id)
                     .expect("completed waiter missing from table");
-                CqeOutcome::Complete {
+                CompletionOutcome::Complete {
                     request,
                     target_tick,
                 }
@@ -445,14 +445,14 @@ mod tests {
         // Completion for a stale generation must be ignored.
         let stale = WaiterId::new(id1.index(), id1.generation().wrapping_add(1));
         assert!(matches!(
-            waiters.on_cqe(stale.user_data(), 0),
-            CqeOutcome::Ignore
+            waiters.on_completion(stale.user_data(), 0),
+            CompletionOutcome::Ignore
         ));
 
         // Complete id1.
         assert!(matches!(
-            waiters.on_cqe(id1.user_data(), 0),
-            CqeOutcome::Complete {
+            waiters.on_completion(id1.user_data(), 0),
+            CompletionOutcome::Complete {
                 target_tick: Some(9),
                 ..
             }
@@ -469,8 +469,8 @@ mod tests {
         );
 
         // All live waiters should still complete and remove cleanly after slot reuse.
-        let _ = waiters.on_cqe(id0.user_data(), 0);
-        let _ = waiters.on_cqe(id2.user_data(), 0);
+        let _ = waiters.on_completion(id0.user_data(), 0);
+        let _ = waiters.on_completion(id2.user_data(), 0);
         assert!(waiters.is_empty());
     }
 
@@ -493,14 +493,14 @@ mod tests {
 
         // Cancel CQE does not complete the waiter.
         assert!(matches!(
-            waiters.on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED),
-            CqeOutcome::Ignore
+            waiters.on_completion(waiter_id.cancel_user_data(), -libc::ECANCELED),
+            CompletionOutcome::Ignore
         ));
 
         // Op CQE completes the waiter.
         assert!(matches!(
-            waiters.on_cqe(waiter_id.user_data(), 0),
-            CqeOutcome::Complete {
+            waiters.on_completion(waiter_id.user_data(), 0),
+            CompletionOutcome::Complete {
                 target_tick: None,
                 ..
             }
@@ -509,10 +509,13 @@ mod tests {
 
         // Late cancel CQE for the already-completed waiter should be ignored.
         assert!(matches!(
-            waiters.on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED),
-            CqeOutcome::Ignore
+            waiters.on_completion(waiter_id.cancel_user_data(), -libc::ECANCELED),
+            CompletionOutcome::Ignore
         ));
-        assert!(matches!(waiters.on_cqe(0, 1), CqeOutcome::Ignore));
+        assert!(matches!(
+            waiters.on_completion(0, 1),
+            CompletionOutcome::Ignore
+        ));
     }
 
     #[test]
@@ -524,15 +527,12 @@ mod tests {
         let waiter_id = waiters.insert(req, Some(4));
 
         assert!(!waiters.is_in_flight(waiter_id));
-        assert!(matches!(
-            waiters.stage_sqe(waiter_id),
-            StageAction::Submit(_)
-        ));
+        assert!(matches!(waiters.stage(waiter_id), StageAction::Submit(_)));
         assert!(waiters.is_in_flight(waiter_id));
 
         assert!(matches!(
-            waiters.on_cqe(waiter_id.user_data(), 0),
-            CqeOutcome::Complete { .. }
+            waiters.on_completion(waiter_id.user_data(), 0),
+            CompletionOutcome::Complete { .. }
         ));
         assert!(!waiters.is_in_flight(waiter_id));
     }
@@ -550,12 +550,9 @@ mod tests {
         let active_id = waiters.insert(req1, Some(2));
         assert_ne!(active_id, stale_id);
 
-        assert!(matches!(waiters.stage_sqe(stale_id), StageAction::Ignore));
+        assert!(matches!(waiters.stage(stale_id), StageAction::Ignore));
         assert!(!waiters.is_in_flight(stale_id));
-        assert!(matches!(
-            waiters.stage_sqe(active_id),
-            StageAction::Submit(_)
-        ));
+        assert!(matches!(waiters.stage(active_id), StageAction::Submit(_)));
         assert!(waiters.is_in_flight(active_id));
     }
 
@@ -566,14 +563,11 @@ mod tests {
         let mut waiters = Waiters::new(1);
         let out_of_range = WaiterId::new(7, 0);
         assert!(!waiters.cancel(out_of_range));
-        assert!(matches!(
-            waiters.stage_sqe(out_of_range),
-            StageAction::Ignore
-        ));
+        assert!(matches!(waiters.stage(out_of_range), StageAction::Ignore));
 
         let empty_slot = WaiterId::new(0, 0);
         assert!(!waiters.cancel(empty_slot));
-        assert!(matches!(waiters.stage_sqe(empty_slot), StageAction::Ignore));
+        assert!(matches!(waiters.stage(empty_slot), StageAction::Ignore));
     }
 
     #[test]
@@ -586,7 +580,7 @@ mod tests {
         // First build a waiter that still has an operation SQE outstanding.
         let (active_req, _active_rx) = make_sync_request();
         let active = waiters.insert(active_req, Some(2));
-        assert!(matches!(waiters.stage_sqe(active), StageAction::Submit(_)));
+        assert!(matches!(waiters.stage(active), StageAction::Submit(_)));
         assert!(waiters.cancel(active));
         assert!(waiters.is_in_flight(active));
         let active_state = waiter_state(&waiters, active).expect("active waiter missing");
@@ -609,15 +603,12 @@ mod tests {
             let mut waiters = Waiters::new(1);
             let (req, _rx) = make_sync_request();
             let waiter_id = waiters.insert(req, Some(2));
-            assert!(matches!(
-                waiters.stage_sqe(waiter_id),
-                StageAction::Submit(_)
-            ));
+            assert!(matches!(waiters.stage(waiter_id), StageAction::Submit(_)));
             assert!(waiters.cancel(waiter_id));
 
             assert!(matches!(
-                waiters.on_cqe(waiter_id.cancel_user_data(), result),
-                CqeOutcome::Ignore
+                waiters.on_completion(waiter_id.cancel_user_data(), result),
+                CompletionOutcome::Ignore
             ));
             let state = waiter_state(&waiters, waiter_id).expect("waiter should remain tracked");
             assert!(matches!(state, WaiterState::CancelRequested));
@@ -631,15 +622,12 @@ mod tests {
         let mut waiters = Waiters::new(1);
         let (req, _rx) = make_sync_request();
         let waiter_id = waiters.insert(req, Some(2));
-        assert!(matches!(
-            waiters.stage_sqe(waiter_id),
-            StageAction::Submit(_)
-        ));
+        assert!(matches!(waiters.stage(waiter_id), StageAction::Submit(_)));
         assert!(waiters.cancel(waiter_id));
 
         assert!(matches!(
-            waiters.on_cqe(waiter_id.cancel_user_data(), -libc::EPERM),
-            CqeOutcome::Ignore
+            waiters.on_completion(waiter_id.cancel_user_data(), -libc::EPERM),
+            CompletionOutcome::Ignore
         ));
         let state = waiter_state(&waiters, waiter_id).expect("waiter should remain tracked");
         assert!(matches!(state, WaiterState::CancelRequested));
@@ -652,14 +640,11 @@ mod tests {
         let mut waiters = Waiters::new(1);
         let (req, _rx) = make_sync_request();
         let waiter_id = waiters.insert(req, Some(2));
-        assert!(matches!(
-            waiters.stage_sqe(waiter_id),
-            StageAction::Submit(_)
-        ));
+        assert!(matches!(waiters.stage(waiter_id), StageAction::Submit(_)));
         assert!(waiters.cancel(waiter_id));
 
         let result = catch_unwind(AssertUnwindSafe(|| {
-            let _ = waiters.on_cqe(waiter_id.cancel_user_data(), -libc::EINVAL);
+            let _ = waiters.on_completion(waiter_id.cancel_user_data(), -libc::EINVAL);
         }));
         assert!(result.is_err());
     }

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -5,7 +5,7 @@
 //! requests are still tracked and whether each currently has an operation SQE
 //! outstanding.
 
-use super::{request::ActiveRequest, Tick, UserData};
+use super::{request::Request, Tick, UserData};
 use io_uring::squeue::Entry as SqueueEntry;
 use tracing::warn;
 
@@ -120,14 +120,14 @@ struct Waiter {
     /// Whether the logical request currently has an operation SQE in flight.
     in_flight: bool,
     /// The active request state machine.
-    request: ActiveRequest,
+    request: Request,
 }
 
 /// Outcome produced when staging the next SQE for a waiter.
 pub enum StageOutcome {
     /// The waiter was canceled while parked in the ready queue and should
     /// complete locally with timeout rather than issuing another SQE.
-    Timeout(ActiveRequest),
+    Timeout(Request),
     /// The waiter is still active and produced an SQE for submission.
     Submit(SqueueEntry),
 }
@@ -143,7 +143,7 @@ pub enum CompletionOutcome {
     /// The logical request completed and was removed from the waiter table.
     Complete {
         /// The completed request, ready to deliver its cached result.
-        request: ActiveRequest,
+        request: Request,
         /// Active deadline tracking to remove from the timeout wheel, when
         /// completion happened before cancellation was requested.
         target_tick: Option<Tick>,
@@ -195,7 +195,7 @@ impl Waiters {
     /// Insert a request and return its assigned id.
     ///
     /// Panics if no free slot is available.
-    pub fn insert(&mut self, request: ActiveRequest, target_tick: Option<Tick>) -> WaiterId {
+    pub fn insert(&mut self, request: Request, target_tick: Option<Tick>) -> WaiterId {
         let id = self
             .free
             .pop()
@@ -217,7 +217,7 @@ impl Waiters {
     /// Panics if `index` is out of bounds or the slot is empty. Callers must
     /// already have validated that the slot still belongs to the expected
     /// waiter.
-    fn take(&mut self, index: usize) -> ActiveRequest {
+    fn take(&mut self, index: usize) -> Request {
         let slot = self.entries[index].take().expect("tracked waiter missing");
         self.free.push(slot.id.next_generation());
         self.len -= 1;
@@ -354,7 +354,7 @@ impl Waiters {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::iouring::request::{ActiveRequest, Request, SyncRequest};
+    use crate::iouring::request::{Request, SyncRequest};
     use commonware_utils::channel::oneshot;
     use std::{
         os::fd::{FromRawFd, IntoRawFd},
@@ -364,16 +364,17 @@ mod tests {
 
     /// Build a `Sync` request backed by a socket fd so waiter tests can
     /// exercise slot lifecycle without touching the filesystem.
-    fn make_sync_request() -> (ActiveRequest, oneshot::Receiver<std::io::Result<()>>) {
+    fn make_sync_request() -> (Request, oneshot::Receiver<std::io::Result<()>>) {
         let (sock_left, _sock_right) =
             std::os::unix::net::UnixStream::pair().expect("failed to create unix socket pair");
         // SAFETY: sock_left is a valid fd that we own.
         let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
         let (tx, rx) = oneshot::channel();
-        let request = ActiveRequest::from_request(Request::Sync(SyncRequest {
+        let request = Request::Sync(SyncRequest {
             file: Arc::new(file),
+            result: None,
             sender: tx,
-        }));
+        });
         (request, rx)
     }
 
@@ -383,7 +384,7 @@ mod tests {
         (slot.id == waiter_id).then_some(slot.state)
     }
 
-    fn remove_waiter(waiters: &mut Waiters, waiter_id: WaiterId) -> ActiveRequest {
+    fn remove_waiter(waiters: &mut Waiters, waiter_id: WaiterId) -> Request {
         let index = waiter_id.index() as usize;
         let slot = waiters
             .entries

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -1,7 +1,9 @@
-//! Waiter identity and lifecycle state for io_uring in-flight requests.
+//! Waiter identity and lifecycle state for tracked io_uring requests.
 //!
-//! This module manages waiter IDs and request lifecycle transitions.
-//! It is the source of truth for in-flight request completion state.
+//! This module manages waiter IDs, request lifecycle transitions, and
+//! outstanding-operation tracking. It is the source of truth for which logical
+//! requests are still tracked and whether each currently has an operation SQE
+//! outstanding.
 
 use super::{
     request::{ActiveRequest, CqeAction},
@@ -87,16 +89,16 @@ impl WaiterId {
     ///
     /// The returned waiter id always has the cancel-tag bit stripped. The
     /// boolean reports whether that bit was set in the input value.
-    pub const fn from_user_data(user_data: UserData) -> (Self, bool) {
+    const fn from_user_data(user_data: UserData) -> (Self, bool) {
         let is_cancel = (user_data & Self::CANCEL_TAG) != 0;
         (Self(user_data & !Self::CANCEL_TAG), is_cancel)
     }
 }
 
-/// Lifecycle state of an in-flight request.
+/// Lifecycle state of a tracked request.
 #[derive(Clone, Copy, Debug)]
 pub enum WaiterState {
-    /// Request is active in the ring.
+    /// Request is still tracked and has not transitioned to cancellation.
     Active {
         /// Absolute wheel tick by which the request must complete.
         ///
@@ -112,7 +114,7 @@ pub enum WaiterState {
     CancelRequested,
 }
 
-/// State for one in-flight logical request.
+/// State for one tracked logical request.
 struct Waiter {
     /// Stable identity of this waiter slot instance.
     id: WaiterId,
@@ -154,7 +156,7 @@ pub enum CqeOutcome {
     },
 }
 
-/// Tracks in-flight logical requests and the state needed to complete them.
+/// Tracks logical requests and the state needed to complete them.
 pub struct Waiters {
     /// Waiters indexed by slot index.
     ///
@@ -162,12 +164,12 @@ pub struct Waiters {
     entries: Vec<Option<Waiter>>,
     /// Stack of reusable waiter ids.
     free: Vec<WaiterId>,
-    /// Number of active waiters currently stored in `entries`.
+    /// Number of tracked waiters currently stored in `entries`.
     len: usize,
 }
 
 impl Waiters {
-    /// Create an empty waiter set that can track at most `capacity` in-flight
+    /// Create an empty waiter set that can track at most `capacity` logical
     /// requests at once.
     pub fn new(capacity: usize) -> Self {
         let mut entries = Vec::with_capacity(capacity);
@@ -186,12 +188,12 @@ impl Waiters {
         }
     }
 
-    /// Return the number of currently in-flight waiters.
+    /// Return the number of currently tracked waiters.
     pub const fn len(&self) -> usize {
         self.len
     }
 
-    /// Return whether there are no in-flight waiters.
+    /// Return whether there are no tracked waiters.
     pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
@@ -245,9 +247,9 @@ impl Waiters {
     /// If the waiter timed out while parked in the ready queue, this removes it
     /// from the table and returns the request for local timeout completion.
     ///
-    /// When this returns [`StageAction::Submit`], the waiter is marked
-    /// in-flight immediately. In this implementation, the caller pushes the SQE
-    /// right away and treats push failure as fatal.
+    /// When this returns [`StageAction::Submit`], the waiter is marked as
+    /// having an operation SQE outstanding immediately. In this implementation,
+    /// the caller pushes the SQE right away and treats push failure as fatal.
     pub fn stage_sqe(&mut self, waiter_id: WaiterId) -> StageAction {
         let index = waiter_id.index() as usize;
         let should_timeout_locally = {

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -126,8 +126,8 @@ struct Waiter {
     request: ActiveRequest,
 }
 
-/// Action produced when staging the next SQE for a waiter.
-pub enum StageAction {
+/// Outcome produced when staging the next SQE for a waiter.
+pub enum StageOutcome {
     /// The waiter id is stale or no longer present.
     Ignore,
     /// The waiter was canceled while parked in the ready queue and should
@@ -137,7 +137,7 @@ pub enum StageAction {
     Submit(SqueueEntry),
 }
 
-/// Action produced when handling an operation CQE for a waiter.
+/// Outcome produced when handling an operation CQE for a waiter.
 #[allow(clippy::large_enum_variant)]
 pub enum CompletionOutcome {
     /// The CQE was stale, referred to a cancel SQE, or otherwise requires no
@@ -247,17 +247,17 @@ impl Waiters {
     /// If the waiter timed out while parked in the ready queue, this removes it
     /// from the table and returns the request for local timeout completion.
     ///
-    /// When this returns [`StageAction::Submit`], the waiter is marked as
+    /// When this returns [`StageOutcome::Submit`], the waiter is marked as
     /// having an operation SQE outstanding immediately. In this implementation,
     /// the caller pushes the SQE right away and treats push failure as fatal.
-    pub fn stage(&mut self, waiter_id: WaiterId) -> StageAction {
+    pub fn stage(&mut self, waiter_id: WaiterId) -> StageOutcome {
         let index = waiter_id.index() as usize;
         let should_timeout_locally = {
             let Some(slot) = self.entries.get_mut(index).and_then(Option::as_mut) else {
-                return StageAction::Ignore;
+                return StageOutcome::Ignore;
             };
             if slot.id != waiter_id {
-                return StageAction::Ignore;
+                return StageOutcome::Ignore;
             }
             matches!(slot.state, WaiterState::CancelRequested)
         };
@@ -266,7 +266,7 @@ impl Waiters {
             let request = self
                 .remove(waiter_id)
                 .expect("cancelled waiter missing from table");
-            return StageAction::Timeout(request);
+            return StageOutcome::Timeout(request);
         }
 
         let sqe = self
@@ -279,7 +279,7 @@ impl Waiters {
                 slot.request.build_sqe(waiter_id)
             });
 
-        sqe.map_or_else(|| StageAction::Ignore, StageAction::Submit)
+        sqe.map_or_else(|| StageOutcome::Ignore, StageOutcome::Submit)
     }
 
     /// Process one CQE for a waiter.
@@ -520,14 +520,14 @@ mod tests {
 
     #[test]
     fn test_waiters_track_in_flight_state() {
-        // Verify `stage_sqe` tracks a staged operation and that the bit is
+        // Verify `stage` tracks a staged operation and that the bit is
         // cleared again when the matching op CQE is processed.
         let mut waiters = Waiters::new(1);
         let (req, _rx) = make_sync_request();
         let waiter_id = waiters.insert(req, Some(4));
 
         assert!(!waiters.is_in_flight(waiter_id));
-        assert!(matches!(waiters.stage(waiter_id), StageAction::Submit(_)));
+        assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
         assert!(waiters.is_in_flight(waiter_id));
 
         assert!(matches!(
@@ -550,9 +550,9 @@ mod tests {
         let active_id = waiters.insert(req1, Some(2));
         assert_ne!(active_id, stale_id);
 
-        assert!(matches!(waiters.stage(stale_id), StageAction::Ignore));
+        assert!(matches!(waiters.stage(stale_id), StageOutcome::Ignore));
         assert!(!waiters.is_in_flight(stale_id));
-        assert!(matches!(waiters.stage(active_id), StageAction::Submit(_)));
+        assert!(matches!(waiters.stage(active_id), StageOutcome::Submit(_)));
         assert!(waiters.is_in_flight(active_id));
     }
 
@@ -563,11 +563,11 @@ mod tests {
         let mut waiters = Waiters::new(1);
         let out_of_range = WaiterId::new(7, 0);
         assert!(!waiters.cancel(out_of_range));
-        assert!(matches!(waiters.stage(out_of_range), StageAction::Ignore));
+        assert!(matches!(waiters.stage(out_of_range), StageOutcome::Ignore));
 
         let empty_slot = WaiterId::new(0, 0);
         assert!(!waiters.cancel(empty_slot));
-        assert!(matches!(waiters.stage(empty_slot), StageAction::Ignore));
+        assert!(matches!(waiters.stage(empty_slot), StageOutcome::Ignore));
     }
 
     #[test]
@@ -580,7 +580,7 @@ mod tests {
         // First build a waiter that still has an operation SQE outstanding.
         let (active_req, _active_rx) = make_sync_request();
         let active = waiters.insert(active_req, Some(2));
-        assert!(matches!(waiters.stage(active), StageAction::Submit(_)));
+        assert!(matches!(waiters.stage(active), StageOutcome::Submit(_)));
         assert!(waiters.cancel(active));
         assert!(waiters.is_in_flight(active));
         let active_state = waiter_state(&waiters, active).expect("active waiter missing");
@@ -603,7 +603,7 @@ mod tests {
             let mut waiters = Waiters::new(1);
             let (req, _rx) = make_sync_request();
             let waiter_id = waiters.insert(req, Some(2));
-            assert!(matches!(waiters.stage(waiter_id), StageAction::Submit(_)));
+            assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
             assert!(waiters.cancel(waiter_id));
 
             assert!(matches!(
@@ -622,7 +622,7 @@ mod tests {
         let mut waiters = Waiters::new(1);
         let (req, _rx) = make_sync_request();
         let waiter_id = waiters.insert(req, Some(2));
-        assert!(matches!(waiters.stage(waiter_id), StageAction::Submit(_)));
+        assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
         assert!(waiters.cancel(waiter_id));
 
         assert!(matches!(
@@ -640,7 +640,7 @@ mod tests {
         let mut waiters = Waiters::new(1);
         let (req, _rx) = make_sync_request();
         let waiter_id = waiters.insert(req, Some(2));
-        assert!(matches!(waiters.stage(waiter_id), StageAction::Submit(_)));
+        assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
         assert!(waiters.cancel(waiter_id));
 
         let result = catch_unwind(AssertUnwindSafe(|| {

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -3,7 +3,11 @@
 //! This module manages waiter IDs and request lifecycle transitions.
 //! It is the source of truth for in-flight request completion state.
 
-use super::{request::ActiveRequest, Tick, UserData};
+use super::{
+    request::{ActiveRequest, CqeAction},
+    Tick, UserData,
+};
+use io_uring::squeue::Entry as SqueueEntry;
 use tracing::warn;
 
 /// Stable waiter identity packed into SQE/CQE `user_data`.
@@ -120,6 +124,35 @@ struct Waiter {
     request: ActiveRequest,
 }
 
+/// Action produced when staging the next SQE for a waiter.
+pub enum StageAction {
+    /// The waiter id is stale or no longer present.
+    Ignore,
+    /// The waiter was canceled while parked in the ready queue and should
+    /// complete locally with timeout rather than issuing another SQE.
+    CompleteTimeout(ActiveRequest),
+    /// The waiter is still active and produced an SQE for submission.
+    Submit(SqueueEntry),
+}
+
+/// Action produced when handling an operation CQE for a waiter.
+pub enum CqeOutcome {
+    /// The CQE was stale, referred to a cancel SQE, or otherwise requires no
+    /// further loop action.
+    Ignore,
+    /// The logical request needs another SQE and should be placed back in the
+    /// ready queue.
+    Requeue(WaiterId),
+    /// The logical request completed and was removed from the waiter table.
+    Complete {
+        /// The completed request, ready to deliver its cached result.
+        request: ActiveRequest,
+        /// Active deadline tracking to remove from the timeout wheel, when
+        /// completion happened before cancellation was requested.
+        target_tick: Option<Tick>,
+    },
+}
+
 /// Tracks in-flight logical requests and the state needed to complete them.
 pub struct Waiters {
     /// Waiters indexed by slot index.
@@ -206,25 +239,62 @@ impl Waiters {
         }
     }
 
-    /// Get mutable access to a request slot by user_data.
+    /// Stage the next SQE for a waiter.
     ///
+    /// If the waiter timed out while parked in the ready queue, this removes it
+    /// from the table and returns the request for local timeout completion.
+    ///
+    /// When this returns [`StageAction::Submit`], the waiter is marked
+    /// in-flight immediately. In this implementation, the caller pushes the SQE
+    /// right away and treats push failure as fatal.
+    pub fn stage_sqe(&mut self, waiter_id: WaiterId) -> StageAction {
+        let index = waiter_id.index() as usize;
+        let should_timeout_locally = {
+            let Some(slot) = self.entries.get_mut(index).and_then(Option::as_mut) else {
+                return StageAction::Ignore;
+            };
+            if slot.id != waiter_id {
+                return StageAction::Ignore;
+            }
+            matches!(slot.state, WaiterState::CancelRequested)
+        };
+
+        if should_timeout_locally {
+            let request = self
+                .remove(waiter_id)
+                .expect("cancelled waiter missing from table");
+            return StageAction::CompleteTimeout(request);
+        }
+
+        let sqe = self
+            .entries
+            .get_mut(index)
+            .and_then(Option::as_mut)
+            .filter(|slot| slot.id == waiter_id)
+            .map(|slot| {
+                slot.in_flight = true;
+                slot.request.build_sqe(waiter_id)
+            });
+
+        match sqe {
+            Some(sqe) => StageAction::Submit(sqe),
+            None => StageAction::Ignore,
+        }
+    }
+
     /// Process one CQE for a waiter.
     ///
-    /// Returns the request, its state, and waiter id if the slot is occupied
-    /// and the generation matches.
-    ///
-    /// Cancel CQEs are handled internally and always return `None`.
-    pub fn on_cqe(
-        &mut self,
-        user_data: UserData,
-        result: i32,
-    ) -> Option<(&mut ActiveRequest, WaiterState, WaiterId)> {
+    /// Cancel CQEs are handled internally. Operation CQEs drive the request
+    /// state machine and return a higher-level loop action.
+    pub fn on_cqe(&mut self, user_data: UserData, result: i32) -> CqeOutcome {
         let (waiter_id, is_cancel) = WaiterId::from_user_data(user_data);
         let index = waiter_id.index() as usize;
 
-        let slot = self.entries[index].as_mut()?;
+        let Some(slot) = self.entries.get_mut(index).and_then(Option::as_mut) else {
+            return CqeOutcome::Ignore;
+        };
         if slot.id != waiter_id {
-            return None;
+            return CqeOutcome::Ignore;
         }
 
         if is_cancel {
@@ -243,14 +313,34 @@ impl Waiters {
             }
 
             // Cancel CQEs acknowledge cancel requests but do not complete waiters.
-            return None;
+            return CqeOutcome::Ignore;
         }
 
         // The operation CQE retires the currently in-flight SQE, regardless of
         // whether the request completes or is requeued for another one.
         slot.in_flight = false;
-        let state = slot.state;
-        Some((&mut slot.request, state, waiter_id))
+        let (state, action) = {
+            let state = slot.state;
+            let action = slot.request.on_cqe(state, result);
+            (state, action)
+        };
+
+        match action {
+            CqeAction::Requeue => CqeOutcome::Requeue(waiter_id),
+            CqeAction::Complete => {
+                let target_tick = match state {
+                    WaiterState::Active { target_tick } => target_tick,
+                    WaiterState::CancelRequested => None,
+                };
+                let request = self
+                    .remove(waiter_id)
+                    .expect("completed waiter missing from table");
+                CqeOutcome::Complete {
+                    request,
+                    target_tick,
+                }
+            }
+        }
     }
 
     /// Get mutable access to a request by waiter id.
@@ -264,21 +354,6 @@ impl Waiters {
             return None;
         }
         Some((&mut slot.request, slot.state))
-    }
-
-    /// Mark a waiter as having an operation SQE in flight.
-    ///
-    /// Returns `true` when the waiter exists and the generation matches.
-    pub fn mark_in_flight(&mut self, waiter_id: WaiterId) -> bool {
-        let index = waiter_id.index() as usize;
-        let Some(slot) = self.entries.get_mut(index).and_then(Option::as_mut) else {
-            return false;
-        };
-        if slot.id != waiter_id {
-            return false;
-        }
-        slot.in_flight = true;
-        true
     }
 
     /// Return whether a waiter currently has an operation SQE in flight.
@@ -376,13 +451,19 @@ mod tests {
 
         // Completion for a stale generation must be ignored.
         let stale = WaiterId::new(id1.index(), id1.generation().wrapping_add(1));
-        assert!(waiters.on_cqe(stale.user_data(), 0).is_none());
+        assert!(matches!(
+            waiters.on_cqe(stale.user_data(), 0),
+            CqeOutcome::Ignore
+        ));
 
         // Complete id1.
-        let result = waiters.on_cqe(id1.user_data(), 0);
-        assert!(result.is_some());
-        let request = waiters.remove(id1);
-        assert!(request.is_some());
+        assert!(matches!(
+            waiters.on_cqe(id1.user_data(), 0),
+            CqeOutcome::Complete {
+                target_tick: Some(9),
+                ..
+            }
+        ));
         assert_eq!(waiters.len(), 1);
 
         // Next allocation reuses the freed slot with incremented generation.
@@ -396,9 +477,7 @@ mod tests {
 
         // All live waiters should still complete and remove cleanly after slot reuse.
         let _ = waiters.on_cqe(id0.user_data(), 0);
-        let _ = waiters.remove(id0);
         let _ = waiters.on_cqe(id2.user_data(), 0);
-        let _ = waiters.remove(id2);
         assert!(waiters.is_empty());
     }
 
@@ -420,40 +499,48 @@ mod tests {
         );
 
         // Cancel CQE does not complete the waiter.
-        assert!(waiters
-            .on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED)
-            .is_none());
+        assert!(matches!(
+            waiters.on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED),
+            CqeOutcome::Ignore
+        ));
 
         // Op CQE completes the waiter.
-        let result = waiters.on_cqe(waiter_id.user_data(), 0);
-        assert!(result.is_some());
-        let (_, state, _) = result.unwrap();
-        assert!(matches!(state, WaiterState::CancelRequested));
-        let _ = waiters.remove(waiter_id);
+        assert!(matches!(
+            waiters.on_cqe(waiter_id.user_data(), 0),
+            CqeOutcome::Complete {
+                target_tick: None,
+                ..
+            }
+        ));
         assert!(waiters.is_empty());
 
         // Late cancel CQE for the already-completed waiter should be ignored.
-        assert!(waiters
-            .on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED)
-            .is_none());
-        assert!(waiters.on_cqe(0, 1).is_none());
+        assert!(matches!(
+            waiters.on_cqe(waiter_id.cancel_user_data(), -libc::ECANCELED),
+            CqeOutcome::Ignore
+        ));
+        assert!(matches!(waiters.on_cqe(0, 1), CqeOutcome::Ignore));
     }
 
     #[test]
     fn test_waiters_track_in_flight_state() {
-        // Verify `mark_in_flight` tracks a staged operation and that the bit is
+        // Verify `stage_sqe` tracks a staged operation and that the bit is
         // cleared again when the matching op CQE is processed.
         let mut waiters = Waiters::new(1);
         let (req, _rx) = make_sync_request();
         let waiter_id = waiters.insert(req, Some(4));
 
         assert!(!waiters.is_in_flight(waiter_id));
-        assert!(waiters.mark_in_flight(waiter_id));
+        assert!(matches!(
+            waiters.stage_sqe(waiter_id),
+            StageAction::Submit(_)
+        ));
         assert!(waiters.is_in_flight(waiter_id));
 
-        let _ = waiters
-            .on_cqe(waiter_id.user_data(), 0)
-            .expect("missing op completion");
+        assert!(matches!(
+            waiters.on_cqe(waiter_id.user_data(), 0),
+            CqeOutcome::Complete { .. }
+        ));
         assert!(!waiters.is_in_flight(waiter_id));
     }
 
@@ -470,9 +557,12 @@ mod tests {
         let active_id = waiters.insert(req1, Some(2));
         assert_ne!(active_id, stale_id);
 
-        assert!(!waiters.mark_in_flight(stale_id));
+        assert!(matches!(waiters.stage_sqe(stale_id), StageAction::Ignore));
         assert!(!waiters.is_in_flight(stale_id));
-        assert!(waiters.mark_in_flight(active_id));
+        assert!(matches!(
+            waiters.stage_sqe(active_id),
+            StageAction::Submit(_)
+        ));
         assert!(waiters.is_in_flight(active_id));
     }
 
@@ -483,11 +573,14 @@ mod tests {
         let mut waiters = Waiters::new(1);
         let out_of_range = WaiterId::new(7, 0);
         assert!(!waiters.cancel(out_of_range));
-        assert!(!waiters.mark_in_flight(out_of_range));
+        assert!(matches!(
+            waiters.stage_sqe(out_of_range),
+            StageAction::Ignore
+        ));
 
         let empty_slot = WaiterId::new(0, 0);
         assert!(!waiters.cancel(empty_slot));
-        assert!(!waiters.mark_in_flight(empty_slot));
+        assert!(matches!(waiters.stage_sqe(empty_slot), StageAction::Ignore));
     }
 
     #[test]
@@ -500,7 +593,7 @@ mod tests {
         // First build a waiter that still has an operation SQE outstanding.
         let (active_req, _active_rx) = make_sync_request();
         let active = waiters.insert(active_req, Some(2));
-        assert!(waiters.mark_in_flight(active));
+        assert!(matches!(waiters.stage_sqe(active), StageAction::Submit(_)));
         assert!(waiters.cancel(active));
         assert!(waiters.is_in_flight(active));
         let (_, active_state) = waiters.get_mut(active).expect("active waiter missing");
@@ -523,12 +616,16 @@ mod tests {
             let mut waiters = Waiters::new(1);
             let (req, _rx) = make_sync_request();
             let waiter_id = waiters.insert(req, Some(2));
-            assert!(waiters.mark_in_flight(waiter_id));
+            assert!(matches!(
+                waiters.stage_sqe(waiter_id),
+                StageAction::Submit(_)
+            ));
             assert!(waiters.cancel(waiter_id));
 
-            assert!(waiters
-                .on_cqe(waiter_id.cancel_user_data(), result)
-                .is_none());
+            assert!(matches!(
+                waiters.on_cqe(waiter_id.cancel_user_data(), result),
+                CqeOutcome::Ignore
+            ));
             let (_, state) = waiters
                 .get_mut(waiter_id)
                 .expect("waiter should remain tracked");
@@ -543,12 +640,16 @@ mod tests {
         let mut waiters = Waiters::new(1);
         let (req, _rx) = make_sync_request();
         let waiter_id = waiters.insert(req, Some(2));
-        assert!(waiters.mark_in_flight(waiter_id));
+        assert!(matches!(
+            waiters.stage_sqe(waiter_id),
+            StageAction::Submit(_)
+        ));
         assert!(waiters.cancel(waiter_id));
 
-        assert!(waiters
-            .on_cqe(waiter_id.cancel_user_data(), -libc::EPERM)
-            .is_none());
+        assert!(matches!(
+            waiters.on_cqe(waiter_id.cancel_user_data(), -libc::EPERM),
+            CqeOutcome::Ignore
+        ));
         let (_, state) = waiters
             .get_mut(waiter_id)
             .expect("waiter should remain tracked");
@@ -562,7 +663,10 @@ mod tests {
         let mut waiters = Waiters::new(1);
         let (req, _rx) = make_sync_request();
         let waiter_id = waiters.insert(req, Some(2));
-        assert!(waiters.mark_in_flight(waiter_id));
+        assert!(matches!(
+            waiters.stage_sqe(waiter_id),
+            StageAction::Submit(_)
+        ));
         assert!(waiters.cancel(waiter_id));
 
         let result = catch_unwind(AssertUnwindSafe(|| {

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -5,10 +5,7 @@
 //! requests are still tracked and whether each currently has an operation SQE
 //! outstanding.
 
-use super::{
-    request::{ActiveRequest, CqeAction},
-    Tick, UserData,
-};
+use super::{request::ActiveRequest, Tick, UserData};
 use io_uring::squeue::Entry as SqueueEntry;
 use tracing::warn;
 
@@ -96,7 +93,7 @@ impl WaiterId {
 }
 
 /// Lifecycle state of a tracked request.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WaiterState {
     /// Request is still tracked and has not transitioned to cancellation.
     Active {
@@ -128,8 +125,6 @@ struct Waiter {
 
 /// Outcome produced when staging the next SQE for a waiter.
 pub enum StageOutcome {
-    /// The waiter id is stale or no longer present.
-    Ignore,
     /// The waiter was canceled while parked in the ready queue and should
     /// complete locally with timeout rather than issuing another SQE.
     Timeout(ActiveRequest),
@@ -140,9 +135,8 @@ pub enum StageOutcome {
 /// Outcome produced when handling an operation CQE for a waiter.
 #[allow(clippy::large_enum_variant)]
 pub enum CompletionOutcome {
-    /// The CQE was stale, referred to a cancel SQE, or otherwise requires no
-    /// further loop action.
-    Ignore,
+    /// The CQE belonged to an async cancel SQE and was handled internally.
+    Cancel,
     /// The logical request needs another SQE and should be placed back in the
     /// ready queue.
     Requeue(WaiterId),
@@ -218,6 +212,18 @@ impl Waiters {
         id
     }
 
+    /// Remove the waiter stored at `index`, returning its owned request.
+    ///
+    /// Panics if `index` is out of bounds or the slot is empty. Callers must
+    /// already have validated that the slot still belongs to the expected
+    /// waiter.
+    fn take(&mut self, index: usize) -> ActiveRequest {
+        let slot = self.entries[index].take().expect("tracked waiter missing");
+        self.free.push(slot.id.next_generation());
+        self.len -= 1;
+        slot.request
+    }
+
     /// Request cancellation for an active waiter.
     ///
     /// Returns `true` when the waiter was successfully transitioned to
@@ -231,6 +237,7 @@ impl Waiters {
             return false;
         };
         if slot.id != waiter_id {
+            // Slot was reused, this CQE belongs to an older waiter generation.
             return false;
         }
         match slot.state {
@@ -248,53 +255,50 @@ impl Waiters {
     /// from the table and returns the request for local timeout completion.
     ///
     /// When this returns [`StageOutcome::Submit`], the waiter is marked as
-    /// having an operation SQE outstanding immediately. In this implementation,
-    /// the caller pushes the SQE right away and treats push failure as fatal.
+    /// having an operation SQE outstanding immediately.
+    ///
+    /// Panics if `waiter_id` does not refer to a currently tracked waiter or if
+    /// the waiter already has an operation SQE outstanding.
     pub fn stage(&mut self, waiter_id: WaiterId) -> StageOutcome {
         let index = waiter_id.index() as usize;
-        let should_timeout_locally = {
-            let Some(slot) = self.entries.get_mut(index).and_then(Option::as_mut) else {
-                return StageOutcome::Ignore;
-            };
-            if slot.id != waiter_id {
-                return StageOutcome::Ignore;
-            }
-            matches!(slot.state, WaiterState::CancelRequested)
-        };
-
-        if should_timeout_locally {
-            let request = self
-                .remove(waiter_id)
-                .expect("cancelled waiter missing from table");
-            return StageOutcome::Timeout(request);
-        }
-
-        let sqe = self
+        let slot = self
             .entries
             .get_mut(index)
             .and_then(Option::as_mut)
-            .filter(|slot| slot.id == waiter_id)
-            .map(|slot| {
-                slot.in_flight = true;
-                slot.request.build_sqe(waiter_id)
-            });
+            .expect("stage called for untracked waiter");
+        assert_eq!(slot.id, waiter_id, "stage called with stale waiter id");
 
-        sqe.map_or_else(|| StageOutcome::Ignore, StageOutcome::Submit)
+        if slot.state == WaiterState::CancelRequested {
+            StageOutcome::Timeout(self.take(index))
+        } else {
+            assert!(
+                !slot.in_flight,
+                "stage called for waiter with op already in flight"
+            );
+            slot.in_flight = true;
+            StageOutcome::Submit(slot.request.build_sqe(waiter_id))
+        }
     }
 
     /// Process one CQE for a waiter.
     ///
     /// Cancel CQEs are handled internally. Operation CQEs drive the request
-    /// state machine and return a higher-level loop action.
+    /// state machine and return a high-level loop action.
+    ///
+    /// Panics if a non-cancel CQE does not refer to a currently tracked waiter,
+    /// if it uses a stale waiter generation, or if the waiter has no operation
+    /// SQE outstanding.
     pub fn on_completion(&mut self, user_data: UserData, result: i32) -> CompletionOutcome {
         let (waiter_id, is_cancel) = WaiterId::from_user_data(user_data);
         let index = waiter_id.index() as usize;
 
         let Some(slot) = self.entries.get_mut(index).and_then(Option::as_mut) else {
-            return CompletionOutcome::Ignore;
+            assert!(is_cancel, "operation CQE for untracked waiter");
+            return CompletionOutcome::Cancel;
         };
         if slot.id != waiter_id {
-            return CompletionOutcome::Ignore;
+            assert!(is_cancel, "operation CQE for stale waiter generation");
+            return CompletionOutcome::Cancel;
         }
 
         if is_cancel {
@@ -313,33 +317,27 @@ impl Waiters {
             }
 
             // Cancel CQEs acknowledge cancel requests but do not complete waiters.
-            return CompletionOutcome::Ignore;
+            return CompletionOutcome::Cancel;
         }
 
         // The operation CQE retires the currently in-flight SQE, regardless of
         // whether the request completes or is requeued for another one.
+        assert!(slot.in_flight);
         slot.in_flight = false;
-        let (state, action) = {
-            let state = slot.state;
-            let action = slot.request.on_cqe(state, result);
-            (state, action)
+
+        let completed = slot.request.on_cqe(slot.state, result);
+        if !completed {
+            return CompletionOutcome::Requeue(waiter_id);
+        }
+
+        let target_tick = match slot.state {
+            WaiterState::Active { target_tick } => target_tick,
+            WaiterState::CancelRequested => None,
         };
 
-        match action {
-            CqeAction::Requeue => CompletionOutcome::Requeue(waiter_id),
-            CqeAction::Complete => {
-                let target_tick = match state {
-                    WaiterState::Active { target_tick } => target_tick,
-                    WaiterState::CancelRequested => None,
-                };
-                let request = self
-                    .remove(waiter_id)
-                    .expect("completed waiter missing from table");
-                CompletionOutcome::Complete {
-                    request,
-                    target_tick,
-                }
-            }
+        CompletionOutcome::Complete {
+            request: self.take(index),
+            target_tick,
         }
     }
 
@@ -350,24 +348,6 @@ impl Waiters {
             .get(index)
             .and_then(Option::as_ref)
             .is_some_and(|slot| slot.id == waiter_id && slot.in_flight)
-    }
-
-    /// Remove a completed request slot by waiter id.
-    ///
-    /// Returns the `ActiveRequest` so the caller can finish it. The slot is
-    /// freed and its generation incremented for reuse.
-    ///
-    /// Returns `None` if the slot is empty or the generation doesn't match.
-    pub fn remove(&mut self, waiter_id: WaiterId) -> Option<ActiveRequest> {
-        let index = waiter_id.index() as usize;
-        let slot = self.entries[index].as_ref()?;
-        if slot.id != waiter_id {
-            return None;
-        }
-        let slot = self.entries[index].take().expect("missing waiter");
-        self.free.push(slot.id.next_generation());
-        self.len -= 1;
-        Some(slot.request)
     }
 }
 
@@ -401,6 +381,20 @@ mod tests {
         let index = waiter_id.index() as usize;
         let slot = waiters.entries.get(index)?.as_ref()?;
         (slot.id == waiter_id).then_some(slot.state)
+    }
+
+    fn remove_waiter(waiters: &mut Waiters, waiter_id: WaiterId) -> ActiveRequest {
+        let index = waiter_id.index() as usize;
+        let slot = waiters
+            .entries
+            .get(index)
+            .and_then(Option::as_ref)
+            .expect("remove_waiter called for untracked waiter");
+        assert_eq!(
+            slot.id, waiter_id,
+            "remove_waiter called with stale waiter id"
+        );
+        waiters.take(index)
     }
 
     #[test]
@@ -442,14 +436,16 @@ mod tests {
         assert_eq!((id0.index(), id1.index()), (0, 1));
         assert_eq!(waiters.len(), 2);
 
-        // Completion for a stale generation must be ignored.
+        // A stale operation CQE should panic because only cancel CQEs are
+        // expected to arrive after slot reuse.
         let stale = WaiterId::new(id1.index(), id1.generation().wrapping_add(1));
-        assert!(matches!(
-            waiters.on_completion(stale.user_data(), 0),
-            CompletionOutcome::Ignore
-        ));
+        let stale_completion = catch_unwind(AssertUnwindSafe(|| {
+            let _ = waiters.on_completion(stale.user_data(), 0);
+        }));
+        assert!(stale_completion.is_err());
 
         // Complete id1.
+        assert!(matches!(waiters.stage(id1), StageOutcome::Submit(_)));
         assert!(matches!(
             waiters.on_completion(id1.user_data(), 0),
             CompletionOutcome::Complete {
@@ -469,7 +465,9 @@ mod tests {
         );
 
         // All live waiters should still complete and remove cleanly after slot reuse.
+        assert!(matches!(waiters.stage(id0), StageOutcome::Submit(_)));
         let _ = waiters.on_completion(id0.user_data(), 0);
+        assert!(matches!(waiters.stage(id2), StageOutcome::Submit(_)));
         let _ = waiters.on_completion(id2.user_data(), 0);
         assert!(waiters.is_empty());
     }
@@ -486,6 +484,7 @@ mod tests {
         let stale = WaiterId::new(waiter_id.index(), waiter_id.generation().wrapping_add(1));
         assert!(!waiters.cancel(stale));
 
+        assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
         assert!(
             waiters.cancel(waiter_id),
             "cancel should transition active waiter"
@@ -494,7 +493,7 @@ mod tests {
         // Cancel CQE does not complete the waiter.
         assert!(matches!(
             waiters.on_completion(waiter_id.cancel_user_data(), -libc::ECANCELED),
-            CompletionOutcome::Ignore
+            CompletionOutcome::Cancel
         ));
 
         // Op CQE completes the waiter.
@@ -510,12 +509,12 @@ mod tests {
         // Late cancel CQE for the already-completed waiter should be ignored.
         assert!(matches!(
             waiters.on_completion(waiter_id.cancel_user_data(), -libc::ECANCELED),
-            CompletionOutcome::Ignore
+            CompletionOutcome::Cancel
         ));
-        assert!(matches!(
-            waiters.on_completion(0, 1),
-            CompletionOutcome::Ignore
-        ));
+        let missing_op_cqe = catch_unwind(AssertUnwindSafe(|| {
+            let _ = waiters.on_completion(0, 1);
+        }));
+        assert!(missing_op_cqe.is_err());
     }
 
     #[test]
@@ -539,35 +538,54 @@ mod tests {
 
     #[test]
     fn test_waiters_reject_stale_in_flight_queries() {
-        // Verify stale waiter ids cannot mark or observe in-flight state after
+        // Verify stale waiter ids cannot observe in-flight state after
         // their slot has been recycled to a new generation.
         let mut waiters = Waiters::new(1);
         let (req0, _rx0) = make_sync_request();
         let stale_id = waiters.insert(req0, Some(1));
-        let _ = waiters.remove(stale_id).expect("missing original waiter");
+        let _ = remove_waiter(&mut waiters, stale_id);
 
         let (req1, _rx1) = make_sync_request();
         let active_id = waiters.insert(req1, Some(2));
         assert_ne!(active_id, stale_id);
 
-        assert!(matches!(waiters.stage(stale_id), StageOutcome::Ignore));
         assert!(!waiters.is_in_flight(stale_id));
         assert!(matches!(waiters.stage(active_id), StageOutcome::Submit(_)));
         assert!(waiters.is_in_flight(active_id));
     }
 
     #[test]
-    fn test_waiters_reject_out_of_range_and_empty_slot_operations() {
+    fn test_waiters_stage_panics_for_out_of_range_and_empty_slots() {
+        // Verify `stage` treats impossible waiter ids as invariant failures,
+        // while the tolerant query/cancel paths still reject them cleanly.
+        let mut waiters = Waiters::new(1);
+        let out_of_range = WaiterId::new(7, 0);
+        assert!(!waiters.cancel(out_of_range));
+        let out_of_range_stage = catch_unwind(AssertUnwindSafe(|| {
+            let _ = waiters.stage(out_of_range);
+        }));
+        assert!(out_of_range_stage.is_err());
+
+        let empty_slot = WaiterId::new(0, 0);
+        assert!(!waiters.cancel(empty_slot));
+        let empty_slot_stage = catch_unwind(AssertUnwindSafe(|| {
+            let _ = waiters.stage(empty_slot);
+        }));
+        assert!(empty_slot_stage.is_err());
+    }
+
+    #[test]
+    fn test_waiters_cancel_and_in_flight_reject_out_of_range_and_empty_slots() {
         // Verify cancel and in-flight tracking reject waiter ids that point
         // outside the table or at currently empty slots.
         let mut waiters = Waiters::new(1);
         let out_of_range = WaiterId::new(7, 0);
         assert!(!waiters.cancel(out_of_range));
-        assert!(matches!(waiters.stage(out_of_range), StageOutcome::Ignore));
+        assert!(!waiters.is_in_flight(out_of_range));
 
         let empty_slot = WaiterId::new(0, 0);
         assert!(!waiters.cancel(empty_slot));
-        assert!(matches!(waiters.stage(empty_slot), StageOutcome::Ignore));
+        assert!(!waiters.is_in_flight(empty_slot));
     }
 
     #[test]
@@ -608,7 +626,7 @@ mod tests {
 
             assert!(matches!(
                 waiters.on_completion(waiter_id.cancel_user_data(), result),
-                CompletionOutcome::Ignore
+                CompletionOutcome::Cancel
             ));
             let state = waiter_state(&waiters, waiter_id).expect("waiter should remain tracked");
             assert!(matches!(state, WaiterState::CancelRequested));
@@ -627,7 +645,7 @@ mod tests {
 
         assert!(matches!(
             waiters.on_completion(waiter_id.cancel_user_data(), -libc::EPERM),
-            CompletionOutcome::Ignore
+            CompletionOutcome::Cancel
         ));
         let state = waiter_state(&waiters, waiter_id).expect("waiter should remain tracked");
         assert!(matches!(state, WaiterState::CancelRequested));
@@ -650,18 +668,21 @@ mod tests {
     }
 
     #[test]
-    fn test_waiters_ignore_stale_state_and_remove() {
+    fn test_waiters_stale_ids_cannot_remove_reused_slots() {
         // Verify stale waiter ids cannot observe state or remove a reused slot.
         let mut waiters = Waiters::new(1);
         let (req0, _rx0) = make_sync_request();
         let waiter_id = waiters.insert(req0, Some(1));
-        let _ = waiters.remove(waiter_id).expect("missing waiter");
+        let _ = remove_waiter(&mut waiters, waiter_id);
 
         let (req1, _rx1) = make_sync_request();
         let reused_id = waiters.insert(req1, Some(2));
         assert_ne!(reused_id, waiter_id);
         assert!(waiter_state(&waiters, waiter_id).is_none());
-        assert!(waiters.remove(waiter_id).is_none());
+        let stale_remove = catch_unwind(AssertUnwindSafe(|| {
+            let _ = remove_waiter(&mut waiters, waiter_id);
+        }));
+        assert!(stale_remove.is_err());
     }
 
     #[test]

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -130,12 +130,13 @@ pub enum StageAction {
     Ignore,
     /// The waiter was canceled while parked in the ready queue and should
     /// complete locally with timeout rather than issuing another SQE.
-    CompleteTimeout(ActiveRequest),
+    Timeout(ActiveRequest),
     /// The waiter is still active and produced an SQE for submission.
     Submit(SqueueEntry),
 }
 
 /// Action produced when handling an operation CQE for a waiter.
+#[allow(clippy::large_enum_variant)]
 pub enum CqeOutcome {
     /// The CQE was stale, referred to a cancel SQE, or otherwise requires no
     /// further loop action.
@@ -263,7 +264,7 @@ impl Waiters {
             let request = self
                 .remove(waiter_id)
                 .expect("cancelled waiter missing from table");
-            return StageAction::CompleteTimeout(request);
+            return StageAction::Timeout(request);
         }
 
         let sqe = self
@@ -276,10 +277,7 @@ impl Waiters {
                 slot.request.build_sqe(waiter_id)
             });
 
-        match sqe {
-            Some(sqe) => StageAction::Submit(sqe),
-            None => StageAction::Ignore,
-        }
+        sqe.map_or_else(|| StageAction::Ignore, StageAction::Submit)
     }
 
     /// Process one CQE for a waiter.
@@ -343,19 +341,6 @@ impl Waiters {
         }
     }
 
-    /// Get mutable access to a request by waiter id.
-    ///
-    /// Used by the loop to build SQEs for requests that are already in the
-    /// waiter table (e.g., from the ready queue).
-    pub fn get_mut(&mut self, waiter_id: WaiterId) -> Option<(&mut ActiveRequest, WaiterState)> {
-        let index = waiter_id.index() as usize;
-        let slot = self.entries[index].as_mut()?;
-        if slot.id != waiter_id {
-            return None;
-        }
-        Some((&mut slot.request, slot.state))
-    }
-
     /// Return whether a waiter currently has an operation SQE in flight.
     pub fn is_in_flight(&self, waiter_id: WaiterId) -> bool {
         let index = waiter_id.index() as usize;
@@ -408,6 +393,12 @@ mod tests {
             sender: tx,
         }));
         (request, rx)
+    }
+
+    fn waiter_state(waiters: &Waiters, waiter_id: WaiterId) -> Option<WaiterState> {
+        let index = waiter_id.index() as usize;
+        let slot = waiters.entries.get(index)?.as_ref()?;
+        (slot.id == waiter_id).then_some(slot.state)
     }
 
     #[test]
@@ -596,7 +587,7 @@ mod tests {
         assert!(matches!(waiters.stage_sqe(active), StageAction::Submit(_)));
         assert!(waiters.cancel(active));
         assert!(waiters.is_in_flight(active));
-        let (_, active_state) = waiters.get_mut(active).expect("active waiter missing");
+        let active_state = waiter_state(&waiters, active).expect("active waiter missing");
         assert!(matches!(active_state, WaiterState::CancelRequested));
 
         // Then build a waiter that has been canceled before any SQE was staged.
@@ -604,7 +595,7 @@ mod tests {
         let ready = waiters.insert(ready_req, Some(3));
         assert!(waiters.cancel(ready));
         assert!(!waiters.is_in_flight(ready));
-        let (_, ready_state) = waiters.get_mut(ready).expect("ready waiter missing");
+        let ready_state = waiter_state(&waiters, ready).expect("ready waiter missing");
         assert!(matches!(ready_state, WaiterState::CancelRequested));
     }
 
@@ -626,9 +617,7 @@ mod tests {
                 waiters.on_cqe(waiter_id.cancel_user_data(), result),
                 CqeOutcome::Ignore
             ));
-            let (_, state) = waiters
-                .get_mut(waiter_id)
-                .expect("waiter should remain tracked");
+            let state = waiter_state(&waiters, waiter_id).expect("waiter should remain tracked");
             assert!(matches!(state, WaiterState::CancelRequested));
         }
     }
@@ -650,9 +639,7 @@ mod tests {
             waiters.on_cqe(waiter_id.cancel_user_data(), -libc::EPERM),
             CqeOutcome::Ignore
         ));
-        let (_, state) = waiters
-            .get_mut(waiter_id)
-            .expect("waiter should remain tracked");
+        let state = waiter_state(&waiters, waiter_id).expect("waiter should remain tracked");
         assert!(matches!(state, WaiterState::CancelRequested));
     }
 
@@ -676,8 +663,8 @@ mod tests {
     }
 
     #[test]
-    fn test_waiters_ignore_stale_get_mut_and_remove() {
-        // Verify stale waiter ids cannot observe or remove a reused slot.
+    fn test_waiters_ignore_stale_state_and_remove() {
+        // Verify stale waiter ids cannot observe state or remove a reused slot.
         let mut waiters = Waiters::new(1);
         let (req0, _rx0) = make_sync_request();
         let waiter_id = waiters.insert(req0, Some(1));
@@ -686,7 +673,7 @@ mod tests {
         let (req1, _rx1) = make_sync_request();
         let reused_id = waiters.insert(req1, Some(2));
         assert_ne!(reused_id, waiter_id);
-        assert!(waiters.get_mut(waiter_id).is_none());
+        assert!(waiter_state(&waiters, waiter_id).is_none());
         assert!(waiters.remove(waiter_id).is_none());
     }
 

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -100,7 +100,11 @@ pub enum WaiterState {
         /// requested. `None` means this request has no timeout deadline.
         target_tick: Option<Tick>,
     },
-    /// Cancellation was requested and cancel SQE was submitted.
+    /// Cancellation was requested.
+    ///
+    /// If the request still has an operation SQE in flight, the loop stages an
+    /// async cancel. If the request is only parked in the ready queue, the loop
+    /// completes it locally with timeout when that entry is revisited.
     CancelRequested,
 }
 
@@ -108,7 +112,10 @@ pub enum WaiterState {
 struct Waiter {
     /// Stable identity of this waiter slot instance.
     id: WaiterId,
+    /// Lifecycle state for the logical request stored in this slot.
     state: WaiterState,
+    /// Whether the logical request currently has an operation SQE in flight.
+    in_flight: bool,
     /// The active request state machine.
     request: ActiveRequest,
 }
@@ -167,6 +174,7 @@ impl Waiters {
         let replaced = self.entries[index].replace(Waiter {
             id,
             state: WaiterState::Active { target_tick },
+            in_flight: false,
             request,
         });
         assert!(replaced.is_none(), "free slot should not contain waiter");
@@ -238,6 +246,9 @@ impl Waiters {
             return None;
         }
 
+        // The operation CQE retires the currently in-flight SQE, regardless of
+        // whether the request completes or is requeued for another one.
+        slot.in_flight = false;
         let state = slot.state;
         Some((&mut slot.request, state, waiter_id))
     }
@@ -253,6 +264,30 @@ impl Waiters {
             return None;
         }
         Some((&mut slot.request, slot.state))
+    }
+
+    /// Mark a waiter as having an operation SQE in flight.
+    ///
+    /// Returns `true` when the waiter exists and the generation matches.
+    pub fn mark_in_flight(&mut self, waiter_id: WaiterId) -> bool {
+        let index = waiter_id.index() as usize;
+        let Some(slot) = self.entries.get_mut(index).and_then(Option::as_mut) else {
+            return false;
+        };
+        if slot.id != waiter_id {
+            return false;
+        }
+        slot.in_flight = true;
+        true
+    }
+
+    /// Return whether a waiter currently has an operation SQE in flight.
+    pub fn is_in_flight(&self, waiter_id: WaiterId) -> bool {
+        let index = waiter_id.index() as usize;
+        self.entries
+            .get(index)
+            .and_then(Option::as_ref)
+            .is_some_and(|slot| slot.id == waiter_id && slot.in_flight)
     }
 
     /// Remove a completed request slot by waiter id.
@@ -285,6 +320,8 @@ mod tests {
         sync::Arc,
     };
 
+    /// Build a `Sync` request backed by a socket fd so waiter tests can
+    /// exercise slot lifecycle without touching the filesystem.
     fn make_sync_request() -> (ActiveRequest, oneshot::Receiver<std::io::Result<()>>) {
         let (sock_left, _sock_right) =
             std::os::unix::net::UnixStream::pair().expect("failed to create unix socket pair");
@@ -300,6 +337,8 @@ mod tests {
 
     #[test]
     fn test_waiter_id_encoding_and_generation_wrap() {
+        // Verify waiter ids round-trip through user_data encoding and wrap their generation field
+        // without corrupting the slot index bits.
         let wrapped = WaiterId::new(7, (WaiterId::GENERATION_MASK as u32).wrapping_add(5));
         assert_eq!(wrapped.generation(), 4);
 
@@ -321,11 +360,13 @@ mod tests {
 
     #[test]
     fn test_waiters_lifecycle_and_slot_reuse() {
+        // Verify waiter insertion, completion, removal, and slot reuse all preserve generations.
         let mut waiters = Waiters::new(3);
         assert_eq!(waiters.entries.len(), 3);
         assert_eq!(waiters.len(), 0);
         assert!(waiters.is_empty());
 
+        // Populate two slots so the test can later free and reuse one of them.
         let (req0, _rx0) = make_sync_request();
         let (req1, _rx1) = make_sync_request();
         let id0 = waiters.insert(req0, Some(5));
@@ -353,6 +394,7 @@ mod tests {
             id1.generation().wrapping_add(1) & (WaiterId::GENERATION_MASK as u32)
         );
 
+        // All live waiters should still complete and remove cleanly after slot reuse.
         let _ = waiters.on_cqe(id0.user_data(), 0);
         let _ = waiters.remove(id0);
         let _ = waiters.on_cqe(id2.user_data(), 0);
@@ -362,6 +404,8 @@ mod tests {
 
     #[test]
     fn test_waiters_cancel_paths() {
+        // Verify cancel requests transition waiter state, ignore cancel CQEs for completion, and
+        // discard late cancel CQEs once the original operation has already completed.
         let mut waiters = Waiters::new(3);
 
         let (req, _rx) = make_sync_request();
@@ -396,7 +440,156 @@ mod tests {
     }
 
     #[test]
+    fn test_waiters_track_in_flight_state() {
+        // Verify `mark_in_flight` tracks a staged operation and that the bit is
+        // cleared again when the matching op CQE is processed.
+        let mut waiters = Waiters::new(1);
+        let (req, _rx) = make_sync_request();
+        let waiter_id = waiters.insert(req, Some(4));
+
+        assert!(!waiters.is_in_flight(waiter_id));
+        assert!(waiters.mark_in_flight(waiter_id));
+        assert!(waiters.is_in_flight(waiter_id));
+
+        let _ = waiters
+            .on_cqe(waiter_id.user_data(), 0)
+            .expect("missing op completion");
+        assert!(!waiters.is_in_flight(waiter_id));
+    }
+
+    #[test]
+    fn test_waiters_reject_stale_in_flight_queries() {
+        // Verify stale waiter ids cannot mark or observe in-flight state after
+        // their slot has been recycled to a new generation.
+        let mut waiters = Waiters::new(1);
+        let (req0, _rx0) = make_sync_request();
+        let stale_id = waiters.insert(req0, Some(1));
+        let _ = waiters.remove(stale_id).expect("missing original waiter");
+
+        let (req1, _rx1) = make_sync_request();
+        let active_id = waiters.insert(req1, Some(2));
+        assert_ne!(active_id, stale_id);
+
+        assert!(!waiters.mark_in_flight(stale_id));
+        assert!(!waiters.is_in_flight(stale_id));
+        assert!(waiters.mark_in_flight(active_id));
+        assert!(waiters.is_in_flight(active_id));
+    }
+
+    #[test]
+    fn test_waiters_reject_out_of_range_and_empty_slot_operations() {
+        // Verify cancel and in-flight tracking reject waiter ids that point
+        // outside the table or at currently empty slots.
+        let mut waiters = Waiters::new(1);
+        let out_of_range = WaiterId::new(7, 0);
+        assert!(!waiters.cancel(out_of_range));
+        assert!(!waiters.mark_in_flight(out_of_range));
+
+        let empty_slot = WaiterId::new(0, 0);
+        assert!(!waiters.cancel(empty_slot));
+        assert!(!waiters.mark_in_flight(empty_slot));
+    }
+
+    #[test]
+    fn test_waiters_cancel_stage_only_when_in_flight() {
+        // Verify timeout processing can distinguish between:
+        // - a waiter whose current SQE is still in flight
+        // - a waiter that is only parked in the ready queue
+        let mut waiters = Waiters::new(2);
+
+        // First build a waiter that still has an operation SQE outstanding.
+        let (active_req, _active_rx) = make_sync_request();
+        let active = waiters.insert(active_req, Some(2));
+        assert!(waiters.mark_in_flight(active));
+        assert!(waiters.cancel(active));
+        assert!(waiters.is_in_flight(active));
+        let (_, active_state) = waiters.get_mut(active).expect("active waiter missing");
+        assert!(matches!(active_state, WaiterState::CancelRequested));
+
+        // Then build a waiter that has been canceled before any SQE was staged.
+        let (ready_req, _ready_rx) = make_sync_request();
+        let ready = waiters.insert(ready_req, Some(3));
+        assert!(waiters.cancel(ready));
+        assert!(!waiters.is_in_flight(ready));
+        let (_, ready_state) = waiters.get_mut(ready).expect("ready waiter missing");
+        assert!(matches!(ready_state, WaiterState::CancelRequested));
+    }
+
+    #[test]
+    fn test_waiters_accept_expected_cancel_cqe_results() {
+        // Verify the expected kernel cancel CQE results leave the waiter alive
+        // for the original operation CQE to finish it later.
+        for result in [0, -libc::EALREADY, -libc::ENOENT] {
+            let mut waiters = Waiters::new(1);
+            let (req, _rx) = make_sync_request();
+            let waiter_id = waiters.insert(req, Some(2));
+            assert!(waiters.mark_in_flight(waiter_id));
+            assert!(waiters.cancel(waiter_id));
+
+            assert!(waiters
+                .on_cqe(waiter_id.cancel_user_data(), result)
+                .is_none());
+            let (_, state) = waiters
+                .get_mut(waiter_id)
+                .expect("waiter should remain tracked");
+            assert!(matches!(state, WaiterState::CancelRequested));
+        }
+    }
+
+    #[test]
+    fn test_waiters_tolerate_unexpected_negative_cancel_result() {
+        // Verify unexpected negative cancel CQEs are ignored rather than
+        // corrupting waiter state.
+        let mut waiters = Waiters::new(1);
+        let (req, _rx) = make_sync_request();
+        let waiter_id = waiters.insert(req, Some(2));
+        assert!(waiters.mark_in_flight(waiter_id));
+        assert!(waiters.cancel(waiter_id));
+
+        assert!(waiters
+            .on_cqe(waiter_id.cancel_user_data(), -libc::EPERM)
+            .is_none());
+        let (_, state) = waiters
+            .get_mut(waiter_id)
+            .expect("waiter should remain tracked");
+        assert!(matches!(state, WaiterState::CancelRequested));
+    }
+
+    #[test]
+    fn test_waiters_cancel_cqe_einval_panics() {
+        // Verify `EINVAL` remains a hard invariant failure because the kernel
+        // rejected our async cancel SQE.
+        let mut waiters = Waiters::new(1);
+        let (req, _rx) = make_sync_request();
+        let waiter_id = waiters.insert(req, Some(2));
+        assert!(waiters.mark_in_flight(waiter_id));
+        assert!(waiters.cancel(waiter_id));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _ = waiters.on_cqe(waiter_id.cancel_user_data(), -libc::EINVAL);
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_waiters_ignore_stale_get_mut_and_remove() {
+        // Verify stale waiter ids cannot observe or remove a reused slot.
+        let mut waiters = Waiters::new(1);
+        let (req0, _rx0) = make_sync_request();
+        let waiter_id = waiters.insert(req0, Some(1));
+        let _ = waiters.remove(waiter_id).expect("missing waiter");
+
+        let (req1, _rx1) = make_sync_request();
+        let reused_id = waiters.insert(req1, Some(2));
+        assert_ne!(reused_id, waiter_id);
+        assert!(waiters.get_mut(waiter_id).is_none());
+        assert!(waiters.remove(waiter_id).is_none());
+    }
+
+    #[test]
     fn test_waiters_insert_and_cancel_invariants() {
+        // Verify waiter capacity is enforced and that cancel remains valid even for waiters that
+        // were inserted without a deadline.
         let mut waiters = Waiters::new(2);
 
         // Inserting beyond configured capacity should panic.

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -260,6 +260,8 @@ mod tests {
 
     #[test]
     fn test_publish_arm_disarm_and_submitted() {
+        // Verify the packed wake state tracks submission sequence separately
+        // from sleep intent across the normal publish and acknowledge flow.
         let waker = Waker::new().expect("eventfd creation should succeed");
         assert_eq!(waker.submitted(), 0);
 
@@ -287,9 +289,13 @@ mod tests {
 
     #[test]
     fn test_ring_and_acknowledge_empty_paths_keep_sequence_stable() {
+        // Verify ringing and draining the eventfd does not perturb the
+        // logical submission sequence, even when the counter is already empty.
         let waker = Waker::new().expect("eventfd creation should succeed");
         let before = waker.submitted();
 
+        // Drive one normal wake cycle, then immediately drain again to hit the
+        // non-blocking empty-read path.
         waker.ring();
         waker.acknowledge();
         // Second acknowledge should take the non-blocking empty path.
@@ -301,6 +307,7 @@ mod tests {
 
     #[test]
     fn test_reinstall_pushes_wake_poll() {
+        // Verify reinstall contributes exactly one multishot wake poll SQE.
         let waker = Waker::new().expect("eventfd creation should succeed");
         let mut ring = IoUring::new(8).expect("io_uring creation should succeed");
 
@@ -313,10 +320,13 @@ mod tests {
 
     #[test]
     fn test_ring_and_acknowledge_error_branches() {
+        // Verify the explicit EAGAIN and generic error branches leave the
+        // logical submission sequence unchanged.
         let mut waker = Waker::new().expect("eventfd creation should succeed");
         let before = waker.submitted();
 
-        // Saturate counter near max so `ring` hits the non-blocking EAGAIN path.
+        // Saturate the eventfd counter near its maximum so `ring` takes the
+        // non-blocking EAGAIN path and `acknowledge` drains the queued wake.
         let fd = waker.inner.wake_fd.as_raw_fd();
         let value = u64::MAX - 1;
         // SAFETY: `fd` is a valid eventfd and `value` points to initialized memory.
@@ -331,7 +341,8 @@ mod tests {
         waker.ring();
         waker.acknowledge();
 
-        // Close the wake fd so `ring`/`acknowledge` hit the generic error branch.
+        // Then close the descriptor so both helpers exercise their generic
+        // error-logging paths.
         // SAFETY: closing a valid fd is safe.
         let closed = unsafe { libc::close(fd) };
         assert_eq!(closed, 0);

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -505,9 +505,8 @@ mod tests {
             iouring::{Config, Network},
             tests,
         },
-        thread, BufferPool, BufferPoolConfig, Error, IoBuf, IoBufMut, IoBufs, Listener as _, Network as _,
-        Sink as _,
-        Stream as _,
+        thread, BufferPool, BufferPoolConfig, Error, IoBuf, IoBufMut, IoBufs, Listener as _,
+        Network as _, Sink as _, Stream as _,
     };
     use commonware_macros::{select, test_group};
     use prometheus_client::registry::Registry;
@@ -901,7 +900,7 @@ mod tests {
         let network = Network::start(
             Config {
                 tcp_nodelay: Some(true),
-                so_linger: Some(Duration::ZERO),
+                zero_linger: true,
                 ..Default::default()
             },
             &mut Registry::default(),

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -41,6 +41,7 @@ use tracing::warn;
 /// Default read buffer size (64 KB).
 const DEFAULT_READ_BUFFER_SIZE: usize = 64 * 1024;
 
+/// Configuration for the io_uring network backend.
 #[derive(Clone, Debug)]
 pub struct Config {
     /// If Some, explicitly sets TCP_NODELAY on the socket.
@@ -84,8 +85,8 @@ impl Default for Config {
     }
 }
 
-#[derive(Clone)]
 /// [crate::Network] implementation that uses io_uring to do async I/O.
+#[derive(Clone)]
 pub struct Network {
     /// If Some, explicitly sets TCP_NODELAY on the socket.
     /// Otherwise uses system default.
@@ -306,6 +307,7 @@ pub struct Sink {
 }
 
 impl Sink {
+    /// Construct a sink that submits logical send requests through one io_uring loop.
     const fn new(fd: Arc<OwnedFd>, submitter: iouring::Submitter, timeout: Duration) -> Self {
         Self {
             fd,
@@ -360,6 +362,7 @@ pub struct Stream {
 }
 
 impl Stream {
+    /// Construct a stream with an optional internal read buffer.
     fn new(
         fd: Arc<OwnedFd>,
         submitter: iouring::Submitter,
@@ -383,7 +386,8 @@ impl Stream {
     /// `offset` is the byte offset into `buffer` where received data should
     /// start. `len` is the number of bytes to read starting at that offset.
     ///
-    /// Returns the buffer and either total bytes written (from offset 0) or an error.
+    /// Returns the buffer and either the number of bytes read for this
+    /// invocation or an error.
     async fn submit_recv(
         &self,
         buffer: IoBufMut,
@@ -400,8 +404,8 @@ impl Stream {
                 fd: self.fd.clone(),
                 buf: buffer,
                 // The active request tracks progress with `received` starting
-                // at `offset`, so `len` is the total target (offset + bytes to read).
-                len: offset + len,
+                // at `offset`, so `target_len` is the total target.
+                target_len: offset + len,
                 received: offset,
                 exact,
                 deadline: Some(deadline),

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -3,11 +3,9 @@
 //!
 //! ## Architecture
 //!
-//! Network operations are sent as high-level [Request][crate::iouring::IoUringRequest]s via a
-//! [commonware_utils::channel::mpsc] channel to a dedicated io_uring event loop running in a
-//! separate thread. Operation results are returned via typed [commonware_utils::channel::oneshot]
-//! channels. This implementation uses two separate io_uring instances: one for send operations and
-//! one for receive operations.
+//! Network operations are submitted through an io_uring [Handle][crate::iouring::Handle] to a
+//! dedicated event loop running in a separate thread. This implementation uses two separate
+//! io_uring instances: one for send operations and one for receive operations.
 //!
 //! ## Memory Safety
 //!
@@ -24,10 +22,9 @@
 //! It requires Linux kernel 6.1 or newer. See [crate::iouring] for details.
 
 use crate::{
-    iouring::{self, IoUringRequest, RecvRequest, SendRequest},
+    iouring::{self},
     utils, Buf, BufferPool, Error, IoBufMut, IoBufs,
 };
-use commonware_utils::channel::oneshot;
 use prometheus_client::registry::Registry;
 use std::{
     net::SocketAddr,
@@ -94,9 +91,9 @@ pub struct Network {
     /// Whether to set `SO_LINGER` to zero on the socket.
     zero_linger: bool,
     /// Used to submit send operations to the send io_uring event loop.
-    send_submitter: iouring::Submitter,
+    send_handle: iouring::Handle,
     /// Used to submit recv operations to the recv io_uring event loop.
-    recv_submitter: iouring::Submitter,
+    recv_handle: iouring::Handle,
     /// Timeout budget applied to each send/recv call.
     read_write_timeout: Duration,
     /// Size of the read buffer for batching network reads.
@@ -131,21 +128,21 @@ impl Network {
 
         // Create an io_uring instance to handle send operations.
         let sender_registry = registry.sub_registry_with_prefix("iouring_sender");
-        let (send_submitter, send_loop) =
+        let (send_handle, send_loop) =
             iouring::IoUringLoop::new(cfg.iouring_config.clone(), sender_registry);
         utils::thread::spawn(cfg.thread_stack_size, move || send_loop.run());
 
         // Create an io_uring instance to handle receive operations.
         let receiver_registry = registry.sub_registry_with_prefix("iouring_receiver");
-        let (recv_submitter, recv_loop) =
+        let (recv_handle, recv_loop) =
             iouring::IoUringLoop::new(cfg.iouring_config, receiver_registry);
         utils::thread::spawn(cfg.thread_stack_size, move || recv_loop.run());
 
         Ok(Self {
             tcp_nodelay: cfg.tcp_nodelay,
             zero_linger: cfg.zero_linger,
-            send_submitter,
-            recv_submitter,
+            send_handle,
+            recv_handle,
             read_write_timeout: cfg.read_write_timeout,
             read_buffer_size: cfg.read_buffer_size,
             pool,
@@ -164,8 +161,8 @@ impl crate::Network for Network {
             tcp_nodelay: self.tcp_nodelay,
             zero_linger: self.zero_linger,
             inner: listener,
-            send_submitter: self.send_submitter.clone(),
-            recv_submitter: self.recv_submitter.clone(),
+            send_handle: self.send_handle.clone(),
+            recv_handle: self.recv_handle.clone(),
             read_write_timeout: self.read_write_timeout,
             read_buffer_size: self.read_buffer_size,
             pool: self.pool.clone(),
@@ -206,12 +203,12 @@ impl crate::Network for Network {
         Ok((
             Sink::new(
                 fd.clone(),
-                self.send_submitter.clone(),
+                self.send_handle.clone(),
                 self.read_write_timeout,
             ),
             Stream::new(
                 fd,
-                self.recv_submitter.clone(),
+                self.recv_handle.clone(),
                 self.read_write_timeout,
                 self.read_buffer_size,
                 self.pool.clone(),
@@ -229,9 +226,9 @@ pub struct Listener {
     zero_linger: bool,
     inner: TcpListener,
     /// Used to submit send operations to the send io_uring event loop.
-    send_submitter: iouring::Submitter,
+    send_handle: iouring::Handle,
     /// Used to submit recv operations to the recv io_uring event loop.
-    recv_submitter: iouring::Submitter,
+    recv_handle: iouring::Handle,
     /// Timeout budget applied to each send/recv call.
     read_write_timeout: Duration,
     /// Size of the read buffer for batching network reads.
@@ -279,12 +276,12 @@ impl crate::Listener for Listener {
             remote_addr,
             Sink::new(
                 fd.clone(),
-                self.send_submitter.clone(),
+                self.send_handle.clone(),
                 self.read_write_timeout,
             ),
             Stream::new(
                 fd,
-                self.recv_submitter.clone(),
+                self.recv_handle.clone(),
                 self.read_write_timeout,
                 self.read_buffer_size,
                 self.pool.clone(),
@@ -301,17 +298,17 @@ impl crate::Listener for Listener {
 pub struct Sink {
     fd: Arc<OwnedFd>,
     /// Used to submit send operations to the io_uring event loop.
-    submitter: iouring::Submitter,
+    handle: iouring::Handle,
     /// Timeout budget for a top-level send call.
     timeout: Duration,
 }
 
 impl Sink {
     /// Construct a sink that submits logical send requests through one io_uring loop.
-    const fn new(fd: Arc<OwnedFd>, submitter: iouring::Submitter, timeout: Duration) -> Self {
+    const fn new(fd: Arc<OwnedFd>, handle: iouring::Handle, timeout: Duration) -> Self {
         Self {
             fd,
-            submitter,
+            handle,
             timeout,
         }
     }
@@ -324,20 +321,9 @@ impl crate::Sink for Sink {
             return Ok(());
         }
 
-        let deadline = Instant::now() + self.timeout;
-        let (tx, rx) = oneshot::channel();
-
-        self.submitter
-            .send(IoUringRequest::Send(SendRequest {
-                fd: self.fd.clone(),
-                bufs,
-                deadline: Some(deadline),
-                sender: tx,
-            }))
+        self.handle
+            .send(self.fd.clone(), bufs, Instant::now() + self.timeout)
             .await
-            .map_err(|_| Error::SendFailed)?;
-
-        rx.await.map_err(|_| Error::SendFailed)?
     }
 }
 
@@ -348,7 +334,7 @@ impl crate::Sink for Sink {
 pub struct Stream {
     fd: Arc<OwnedFd>,
     /// Used to submit recv operations to the io_uring event loop.
-    submitter: iouring::Submitter,
+    handle: iouring::Handle,
     /// Timeout budget for a top-level recv call.
     timeout: Duration,
     /// Internal read buffer.
@@ -365,14 +351,14 @@ impl Stream {
     /// Construct a stream with an optional internal read buffer.
     fn new(
         fd: Arc<OwnedFd>,
-        submitter: iouring::Submitter,
+        handle: iouring::Handle,
         timeout: Duration,
         buffer_capacity: usize,
         pool: BufferPool,
     ) -> Self {
         Self {
             fd,
-            submitter,
+            handle,
             timeout,
             buffer: IoBufMut::with_capacity(buffer_capacity),
             buffer_pos: 0,
@@ -395,41 +381,21 @@ impl Stream {
         len: usize,
         exact: bool,
         deadline: Instant,
-    ) -> (IoBufMut, Result<usize, Error>) {
-        let (tx, rx) = oneshot::channel();
-
-        if self
-            .submitter
-            .send(IoUringRequest::Recv(RecvRequest {
-                fd: self.fd.clone(),
-                buf: buffer,
-                // The request appends into an already-partially-filled
-                // destination buffer, so `offset` is the current write cursor
-                // and `len` is the final target bound for this logical recv.
+    ) -> Result<(IoBufMut, usize), (IoBufMut, Error)> {
+        self.handle
+            .recv(
+                self.fd.clone(),
+                buffer,
                 offset,
-                len: offset + len,
+                offset + len,
                 exact,
-                deadline: Some(deadline),
-                sender: tx,
-            }))
+                deadline,
+            )
             .await
-            .is_err()
-        {
-            // Channel closed - io_uring thread died, buffer is lost
-            return (IoBufMut::default(), Err(Error::RecvFailed));
-        }
-
-        match rx.await {
-            Ok((buf, result)) => {
+            .map(|(buf, total)| {
                 // Translate the total-bytes-received into bytes-read-in-this-call.
-                let result = result.map(|total| total - offset);
-                (buf, result)
-            }
-            Err(_) => {
-                // Channel closed - io_uring thread died, buffer is lost
-                (IoBufMut::default(), Err(Error::RecvFailed))
-            }
-        }
+                (buf, total - offset)
+            })
     }
 
     /// Fills the internal buffer by reading from the socket via io_uring.
@@ -440,9 +406,16 @@ impl Stream {
         let buffer = std::mem::take(&mut self.buffer);
         let len = buffer.capacity();
 
-        let (buffer, result) = self.submit_recv(buffer, 0, len, false, deadline).await;
-        self.buffer = buffer;
-        self.buffer_len = result?;
+        self.buffer_len = match self.submit_recv(buffer, 0, len, false, deadline).await {
+            Ok((buffer, read)) => {
+                self.buffer = buffer;
+                read
+            }
+            Err((buffer, err)) => {
+                self.buffer = buffer;
+                return Err(err);
+            }
+        };
         // SAFETY: The kernel has written exactly `buffer_len` bytes into the buffer.
         unsafe { self.buffer.set_len(self.buffer_len) };
         Ok(self.buffer_len)
@@ -476,11 +449,16 @@ impl crate::Stream for Stream {
             let buffer_capacity = self.buffer.capacity();
             if buffer_capacity == 0 || remaining >= buffer_capacity {
                 // Direct recv into the result buffer with exact=true.
-                let (returned_buf, result) = self
+                match self
                     .submit_recv(owned_buf, bytes_received, remaining, true, deadline)
-                    .await;
-                owned_buf = returned_buf;
-                bytes_received += result?;
+                    .await
+                {
+                    Ok((buf, read)) => {
+                        owned_buf = buf;
+                        bytes_received += read;
+                    }
+                    Err((_, err)) => return Err(err),
+                }
             } else {
                 // Fill internal buffer, then loop will copy
                 self.fill_buffer(deadline).await?;
@@ -802,14 +780,15 @@ mod tests {
         // three more bytes from the socket.
         let writer = tokio::task::spawn_blocking(move || right.write_all(b"abc"));
         let buffer = IoBufMut::with_capacity(5);
-        let (_buffer, result) = stream
+        let result = stream
             .submit_recv(buffer, 2, 3, true, Instant::now() + Duration::from_secs(1))
             .await;
 
         // The wrapper should report only the bytes read by this invocation,
         // not the cumulative total tracked inside the request state.
         writer.await.unwrap().unwrap();
-        assert_eq!(result.unwrap(), 3);
+        let (_buffer, read) = result.expect("submit_recv should succeed");
+        assert_eq!(read, 3);
 
         drop(stream);
         handle.join().unwrap();
@@ -854,7 +833,7 @@ mod tests {
             iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
         drop(io_loop);
 
-        // Construct a sink whose submitter would fail immediately if the wrapper
+        // Construct a sink whose handle would fail immediately if the wrapper
         // tried to hand work to the loop.
         let (left, _right) = UnixStream::pair().unwrap();
         let mut sink = Sink::new(Arc::new(left.into()), submitter, Duration::from_secs(1));
@@ -928,7 +907,7 @@ mod tests {
         let mut registry = Registry::default();
         let (submitter, io_loop) =
             iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
-        let recv_submitter = submitter.clone();
+        let recv_handle = submitter.clone();
         drop(io_loop);
 
         // Send should fail locally once the submission channel has been
@@ -945,7 +924,7 @@ mod tests {
         let (recv_left, _recv_right) = UnixStream::pair().unwrap();
         let mut stream = Stream::new(
             Arc::new(recv_left.into()),
-            recv_submitter,
+            recv_handle,
             Duration::from_secs(1),
             0,
             test_pool(),

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -3,16 +3,16 @@
 //!
 //! ## Architecture
 //!
-//! Network operations are sent via a [commonware_utils::channel::mpsc] channel to a dedicated io_uring event
-//! loop running in a separate thread. Operation results are returned via a [commonware_utils::channel::oneshot]
-//! channel. This implementation uses two separate io_uring instances: one for send operations and
+//! Network operations are sent as high-level [Request][crate::iouring::IoUringRequest]s via a
+//! [commonware_utils::channel::mpsc] channel to a dedicated io_uring event loop running in a
+//! separate thread. Operation results are returned via typed [commonware_utils::channel::oneshot]
+//! channels. This implementation uses two separate io_uring instances: one for send operations and
 //! one for receive operations.
 //!
 //! ## Memory Safety
 //!
-//! We pass to the kernel, via io_uring, a pointer to the buffer being read from/written into.
-//! Therefore, we ensure that the memory location is valid for the duration of the operation.
-//! That is, it doesn't move or go out of scope until the operation completes.
+//! Buffers and file descriptors are owned by the active request state machine inside the io_uring
+//! loop, ensuring that the memory location is valid for the duration of the operation.
 //!
 //! ## Feature Flag
 //!
@@ -24,15 +24,14 @@
 //! It requires Linux kernel 6.1 or newer. See [crate::iouring] for details.
 
 use crate::{
-    iouring::{self, should_retry, OpBuffer, OpFd, OpIovecs},
-    utils, Buf, BufferPool, Error, IoBuf, IoBufMut, IoBufs,
+    iouring::{self, IoUringRequest, RecvRequest, SendRequest},
+    utils, Buf, BufferPool, Error, IoBufMut, IoBufs,
 };
 use commonware_utils::channel::oneshot;
-use io_uring::{opcode, types::Fd};
 use prometheus_client::registry::Registry;
 use std::{
     net::SocketAddr,
-    os::fd::{AsRawFd, OwnedFd},
+    os::fd::OwnedFd,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -41,10 +40,6 @@ use tracing::warn;
 
 /// Default read buffer size (64 KB).
 const DEFAULT_READ_BUFFER_SIZE: usize = 64 * 1024;
-
-/// Cap iovec batch size: larger iovecs reduce syscall count but increase
-/// per-write kernel setup overhead.
-const IOVEC_BATCH_SIZE: usize = 32;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -62,7 +57,7 @@ pub struct Config {
     ///
     /// This is a network-level policy and is independent from io_uring loop
     /// tuning. At startup, the loop timeout horizon is raised as needed so this
-    /// value is never clamped by `iouring_config.max_op_timeout`.
+    /// value is never clamped by `iouring_config.max_request_timeout`.
     pub read_write_timeout: Duration,
     /// Size of the read buffer for batching network reads.
     ///
@@ -81,7 +76,7 @@ impl Default for Config {
         Self {
             tcp_nodelay: Some(true),
             zero_linger: true,
-            read_write_timeout: iouring_config.max_op_timeout,
+            read_write_timeout: iouring_config.max_request_timeout,
             iouring_config,
             read_buffer_size: DEFAULT_READ_BUFFER_SIZE,
             thread_stack_size: utils::thread::system_thread_stack_size(),
@@ -128,9 +123,9 @@ impl Network {
         // dedicated thread, which guarantees that the same thread that creates
         // the ring is the only thread submitting work to it.
         cfg.iouring_config.single_issuer = true;
-        cfg.iouring_config.max_op_timeout = cfg
+        cfg.iouring_config.max_request_timeout = cfg
             .iouring_config
-            .max_op_timeout
+            .max_request_timeout
             .max(cfg.read_write_timeout);
 
         // Create an io_uring instance to handle send operations.
@@ -318,167 +313,29 @@ impl Sink {
             timeout,
         }
     }
-
-    fn as_raw_fd(&self) -> Fd {
-        Fd(self.fd.as_raw_fd())
-    }
-
-    async fn send_single(&self, mut buf: IoBuf) -> Result<(), Error> {
-        let mut bytes_sent = 0;
-        let buf_len = buf.len();
-        let deadline = Instant::now() + self.timeout;
-
-        while bytes_sent < buf_len {
-            // Figure out how much is left to send and where to send from.
-            //
-            // SAFETY: `buf` is an `IoBuf` guaranteeing the memory won't move.
-            // `bytes_sent` is always < `buf_len` due to the loop condition, so
-            // `add(bytes_sent)` stays within bounds and `buf_len - bytes_sent`
-            // correctly represents the remaining valid bytes.
-            let ptr = unsafe { buf.as_ptr().add(bytes_sent) };
-            let remaining_len = buf_len - bytes_sent;
-
-            // Create the io_uring send operation
-            let op = opcode::Send::new(self.as_raw_fd(), ptr, remaining_len as u32).build();
-
-            // Submit the operation to the io_uring event loop
-            let (sender, receiver) = oneshot::channel();
-            self.submitter
-                .send(iouring::Op {
-                    work: op,
-                    sender,
-                    buffer: Some(OpBuffer::Write(buf)),
-                    fd: Some(OpFd::Fd(self.fd.clone())),
-                    iovecs: None,
-                    deadline: Some(deadline),
-                })
-                .await
-                .map_err(|_| Error::SendFailed)?;
-
-            // Wait for the operation to complete and get the buffer back
-            let (return_value, return_buf) = receiver.await.map_err(|_| Error::SendFailed)?;
-            buf = match return_buf {
-                Some(OpBuffer::Write(b)) => b,
-                _ => unreachable!("io_uring loop returns the same OpBuffer that was submitted"),
-            };
-            if should_retry(return_value) {
-                continue;
-            }
-
-            // Retryable error paths are handled above. From here:
-            // - ETIMEDOUT maps to caller-visible timeout
-            // - any other negative or zero result is treated as send failure
-            if return_value <= 0 {
-                if return_value == -libc::ETIMEDOUT {
-                    return Err(Error::Timeout);
-                } else {
-                    return Err(Error::SendFailed);
-                };
-            }
-
-            // Mark bytes as sent.
-            bytes_sent += return_value as usize;
-        }
-
-        Ok(())
-    }
-
-    async fn send_vectored(&self, mut bufs: IoBufs) -> Result<(), Error> {
-        let deadline = Instant::now() + self.timeout;
-        while bufs.has_remaining() {
-            let (iovecs, iovecs_len) = {
-                // Figure out how much is left to send and where to send from.
-                //
-                // Use one pre-initialized `libc::iovec` array as scratch space and
-                // view it as `IoSlice` to fill via `chunks_vectored`, since
-                // `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
-                let max_iovecs = bufs.chunk_count().min(IOVEC_BATCH_SIZE);
-                assert!(
-                    max_iovecs > 0,
-                    "chunk_count should be > 0 if bufs.has_remaining() is true"
-                );
-                let mut iovecs: Box<[libc::iovec]> = std::iter::repeat_n(
-                    libc::iovec {
-                        iov_base: std::ptr::NonNull::<u8>::dangling().as_ptr().cast(),
-                        iov_len: 0,
-                    },
-                    max_iovecs,
-                )
-                .collect();
-
-                // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
-                // `iovecs` is initialized with valid empty entries, so `io_slices`
-                // starts in a valid state for `chunks_vectored` to overwrite.
-                let io_slices: &mut [std::io::IoSlice<'_>] = unsafe {
-                    std::slice::from_raw_parts_mut(
-                        iovecs.as_mut_ptr().cast::<std::io::IoSlice<'_>>(),
-                        iovecs.len(),
-                    )
-                };
-                let io_slices_len = bufs.chunks_vectored(io_slices);
-                assert!(
-                    io_slices_len > 0,
-                    "chunks_vectored should produce at least one slice when bufs has remaining"
-                );
-                (OpIovecs::new(iovecs), io_slices_len)
-            };
-
-            // Create an operation to do the writev.
-            //
-            // For this payload send path, `writev` is sufficient since we don't need
-            // per-send flags, destination addresses, or cmsgs. This keeps the operation
-            // simpler and avoids building an `msghdr` that's required for `sendmsg`.
-            let op =
-                opcode::Writev::new(self.as_raw_fd(), iovecs.as_ptr(), iovecs_len as _).build();
-
-            // Submit the operation.
-            let (sender, receiver) = oneshot::channel();
-            self.submitter
-                .send(iouring::Op {
-                    work: op,
-                    sender,
-                    buffer: Some(OpBuffer::WriteVectored(bufs)),
-                    fd: Some(OpFd::Fd(self.fd.clone())),
-                    iovecs: Some(iovecs),
-                    deadline: Some(deadline),
-                })
-                .await
-                .map_err(|_| Error::SendFailed)?;
-
-            // Wait for the result.
-            let (return_value, return_bufs) = receiver.await.map_err(|_| Error::SendFailed)?;
-            bufs = match return_bufs {
-                Some(OpBuffer::WriteVectored(b)) => b,
-                _ => unreachable!("io_uring loop returns the same OpBuffer that was submitted"),
-            };
-            if should_retry(return_value) {
-                continue;
-            }
-
-            // Retryable error paths are handled above. From here:
-            // - ETIMEDOUT maps to caller-visible timeout
-            // - any other negative or zero result is treated as send failure
-            if return_value <= 0 {
-                if return_value == -libc::ETIMEDOUT {
-                    return Err(Error::Timeout);
-                } else {
-                    return Err(Error::SendFailed);
-                };
-            }
-
-            bufs.advance(return_value as usize);
-        }
-
-        Ok(())
-    }
 }
 
 impl crate::Sink for Sink {
     async fn send(&mut self, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
-        match bufs.into().try_into_single() {
-            Ok(buf) => self.send_single(buf).await,
-            Err(bufs) => self.send_vectored(bufs).await,
+        let bufs = bufs.into();
+        if !bufs.has_remaining() {
+            return Ok(());
         }
+
+        let deadline = Instant::now() + self.timeout;
+        let (tx, rx) = oneshot::channel();
+
+        self.submitter
+            .send(IoUringRequest::Send(SendRequest {
+                fd: self.fd.clone(),
+                bufs,
+                deadline: Some(deadline),
+                sender: tx,
+            }))
+            .await
+            .map_err(|_| Error::SendFailed)?;
+
+        rx.await.map_err(|_| Error::SendFailed)?
     }
 }
 
@@ -521,75 +378,52 @@ impl Stream {
         }
     }
 
-    fn as_raw_fd(&self) -> Fd {
-        Fd(self.fd.as_raw_fd())
-    }
-
-    /// Submits a recv operation to io_uring.
+    /// Submit a recv request to io_uring and wait for completion.
     ///
-    /// # Arguments
-    /// * `buffer` - Buffer for receiving data (kernel writes into this)
-    /// * `offset` - Offset into buffer to write received data
-    /// * `len` - Maximum bytes to receive
+    /// `offset` is the byte offset into `buffer` where received data should
+    /// start. `len` is the number of bytes to read starting at that offset.
     ///
-    /// # Returns
-    /// The buffer and either bytes received or an error.
+    /// Returns the buffer and either total bytes written (from offset 0) or an error.
     async fn submit_recv(
-        &mut self,
-        mut buffer: IoBufMut,
+        &self,
+        buffer: IoBufMut,
         offset: usize,
         len: usize,
+        exact: bool,
         deadline: Instant,
     ) -> (IoBufMut, Result<usize, Error>) {
-        loop {
-            // SAFETY: offset + len <= buffer.capacity() as guaranteed by callers.
-            // `buffer` is an `IoBufMut` guaranteeing the memory won't move.
-            let ptr = unsafe { buffer.as_mut_ptr().add(offset) };
-            let op = opcode::Recv::new(self.as_raw_fd(), ptr, len as u32).build();
+        let (tx, rx) = oneshot::channel();
 
-            let (sender, receiver) = oneshot::channel();
-            if self
-                .submitter
-                .send(iouring::Op {
-                    work: op,
-                    sender,
-                    buffer: Some(OpBuffer::Read(buffer)),
-                    fd: Some(OpFd::Fd(self.fd.clone())),
-                    iovecs: None,
-                    deadline: Some(deadline),
-                })
-                .await
-                .is_err()
-            {
+        if self
+            .submitter
+            .send(IoUringRequest::Recv(RecvRequest {
+                fd: self.fd.clone(),
+                buf: buffer,
+                // The active request tracks progress with `received` starting
+                // at `offset`, so `len` is the total target (offset + bytes to read).
+                len: offset + len,
+                received: offset,
+                exact,
+                deadline: Some(deadline),
+                sender: tx,
+            }))
+            .await
+            .is_err()
+        {
+            // Channel closed - io_uring thread died, buffer is lost
+            return (IoBufMut::default(), Err(Error::RecvFailed));
+        }
+
+        match rx.await {
+            Ok((buf, result)) => {
+                // Translate the total-bytes-received into bytes-read-in-this-call.
+                let result = result.map(|total| total - offset);
+                (buf, result)
+            }
+            Err(_) => {
                 // Channel closed - io_uring thread died, buffer is lost
-                return (IoBufMut::default(), Err(Error::RecvFailed));
+                (IoBufMut::default(), Err(Error::RecvFailed))
             }
-
-            let Ok((return_value, return_buf)) = receiver.await else {
-                // Channel closed - io_uring thread died, buffer is lost
-                return (IoBufMut::default(), Err(Error::RecvFailed));
-            };
-            buffer = match return_buf {
-                Some(OpBuffer::Read(b)) => b,
-                _ => unreachable!("io_uring loop returns the same OpBuffer that was submitted"),
-            };
-            if should_retry(return_value) {
-                continue;
-            }
-
-            // Retryable error paths are handled above. From here:
-            // - ETIMEDOUT maps to caller-visible timeout
-            // - any other negative or zero result is treated as recv failure
-            if return_value <= 0 {
-                let err = if return_value == -libc::ETIMEDOUT {
-                    Error::Timeout
-                } else {
-                    Error::RecvFailed
-                };
-                return (buffer, Err(err));
-            }
-
-            return (buffer, Ok(return_value as usize));
         }
     }
 
@@ -601,9 +435,7 @@ impl Stream {
         let buffer = std::mem::take(&mut self.buffer);
         let len = buffer.capacity();
 
-        // If the buffer is lost due to a channel error, we don't restore it.
-        // Channel errors mean the io_uring thread died, so the stream is unusable anyway.
-        let (buffer, result) = self.submit_recv(buffer, 0, len, deadline).await;
+        let (buffer, result) = self.submit_recv(buffer, 0, len, false, deadline).await;
         self.buffer = buffer;
         self.buffer_len = result?;
         // SAFETY: The kernel has written exactly `buffer_len` bytes into the buffer.
@@ -638,8 +470,9 @@ impl crate::Stream for Stream {
             // to fill the buffer and immediately drain it
             let buffer_capacity = self.buffer.capacity();
             if buffer_capacity == 0 || remaining >= buffer_capacity {
+                // Direct recv into the result buffer with exact=true.
                 let (returned_buf, result) = self
-                    .submit_recv(owned_buf, bytes_received, remaining, deadline)
+                    .submit_recv(owned_buf, bytes_received, remaining, true, deadline)
                     .await;
                 owned_buf = returned_buf;
                 bytes_received += result?;
@@ -841,9 +674,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_op_fd_keeps_descriptor_alive() {
-        // When a recv future is cancelled (e.g. via select!) after the Op has
+        // When a recv future is cancelled (e.g. via select!) after the Request has
         // been sent to the io_uring channel, the Stream can be dropped while
-        // the Op is still queued. The Op's `fd` field keeps the socket alive
+        // the request is still queued. The request's fd field keeps the socket alive
         // so the OS cannot reuse the FD number.
         let op_timeout = Duration::from_millis(200);
         let network = Network::start(
@@ -867,22 +700,20 @@ mod tests {
         assert_eq!(Arc::strong_count(&fd), 3);
 
         // Cancel a recv mid-flight (blocks because no data arrives).
-        // Polling the future submits the Op (with an fd clone) to the
-        // io_uring channel, the timeout then cancels the future.
         select! {
             _ = client_stream.recv(1) => unreachable!("no data was sent"),
             _ = tokio::time::sleep(Duration::from_millis(50)) => {},
         }
 
-        // The queued Op holds an additional clone.
+        // The queued request holds an additional clone.
         assert_eq!(Arc::strong_count(&fd), 4);
 
-        // Drop all handles. The queued Op still retains the fd.
+        // Drop all handles. The queued request still retains the fd.
         drop(client_sink);
         drop(client_stream);
-        assert_eq!(Arc::strong_count(&fd), 2); // our clone + Op
+        assert_eq!(Arc::strong_count(&fd), 2); // our clone + request
 
-        // After op_timeout, the Op completes and releases its fd clone.
+        // After op_timeout, the request completes and releases its fd clone.
         tokio::time::sleep(op_timeout).await;
         assert_eq!(Arc::strong_count(&fd), 1);
     }

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -498,18 +498,22 @@ impl crate::Stream for Stream {
 
 #[cfg(test)]
 mod tests {
+    use super::{Sink, Stream};
     use crate::{
         iouring,
         network::{
             iouring::{Config, Network},
             tests,
         },
-        thread, BufferPool, BufferPoolConfig, Error, Listener as _, Network as _, Sink as _,
+        thread, BufferPool, BufferPoolConfig, Error, IoBuf, IoBufMut, IoBufs, Listener as _, Network as _,
+        Sink as _,
         Stream as _,
     };
     use commonware_macros::{select, test_group};
     use prometheus_client::registry::Registry;
     use std::{
+        io::{Read, Write},
+        os::unix::net::UnixStream,
         sync::Arc,
         time::{Duration, Instant},
     };
@@ -528,6 +532,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_trait() {
+        // Verify the io_uring backend satisfies the shared network trait suite.
         tests::test_network_trait(|| {
             Network::start(Config::default(), &mut Registry::default(), test_pool())
                 .expect("Failed to start io_uring")
@@ -538,6 +543,7 @@ mod tests {
     #[test_group("slow")]
     #[tokio::test]
     async fn test_stress_trait() {
+        // Exercise the io_uring backend under the shared stress suite.
         tests::stress_test_network_trait(|| {
             Network::start(
                 Config {
@@ -557,6 +563,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_small_send_read_quickly() {
+        // Verify a small message is delivered promptly through the buffered recv path.
         let network = Network::start(Config::default(), &mut Registry::default(), test_pool())
             .expect("Failed to start io_uring");
 
@@ -586,6 +593,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_timeout_with_partial_data() {
+        // Verify a top-level recv returns timeout after partial progress stalls.
         // Use a short timeout to make the test fast
         let op_timeout = Duration::from_millis(100);
         let network = Network::start(
@@ -629,7 +637,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_unbuffered_mode() {
-        // Set read_buffer_size to 0 to disable buffering
+        // Verify disabling the internal read buffer preserves direct recv behavior.
+        // Set `read_buffer_size` to zero so every recv goes straight to the caller buffer.
         let network = Network::start(
             Config {
                 read_buffer_size: 0,
@@ -644,7 +653,8 @@ mod tests {
         let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        // Spawn a task to accept and read
+        // Accept one connection and verify that peeking never observes buffered
+        // bytes because the wrapper should not retain any internal read state.
         let reader = tokio::spawn(async move {
             let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
 
@@ -663,21 +673,21 @@ mod tests {
             (buf1, buf2)
         });
 
-        // Connect and send two messages
+        // Send two independent messages so the reader exercises repeated direct recvs.
         let (mut sink, _stream) = network.dial(addr).await.unwrap();
         sink.send([1u8, 2, 3, 4, 5].as_slice()).await.unwrap();
         sink.send([6u8, 7, 8, 9, 10].as_slice()).await.unwrap();
 
-        // Wait for the reader to complete
+        // Both messages should arrive exactly as sent, with no extra bytes hidden in `peek`.
         let (buf1, buf2) = reader.await.unwrap();
 
-        // Verify we got the right data
         assert_eq!(buf1.coalesce(), &[1u8, 2, 3, 4, 5]);
         assert_eq!(buf2.coalesce(), &[6u8, 7, 8, 9, 10]);
     }
 
     #[tokio::test]
     async fn test_op_fd_keeps_descriptor_alive() {
+        // Verify queued recv requests keep their socket fd alive after caller cancellation.
         // When a recv future is cancelled (e.g. via select!) after the Request has
         // been sent to the io_uring channel, the Stream can be dropped while
         // the request is still queued. The request's fd field keeps the socket alive
@@ -724,6 +734,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_peek_with_buffered_data() {
+        // Verify buffered recv calls leave unread bytes visible via peek().
         // Use default buffer size to enable buffering
         let network = Network::start(Config::default(), &mut Registry::default(), test_pool())
             .expect("Failed to start io_uring");
@@ -765,5 +776,184 @@ mod tests {
         sink.send(b"hello world").await.unwrap();
 
         reader.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_submit_recv_returns_bytes_for_this_call() {
+        // Verify `submit_recv` translates the request state's cumulative total
+        // back into the per-call byte count expected by the higher-level recv loop.
+        let mut registry = Registry::default();
+        let (submitter, io_loop) =
+            iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
+        let handle = std::thread::spawn(move || io_loop.run());
+
+        // Build the wrapper directly so the test exercises `submit_recv`
+        // without involving the higher-level buffered recv machinery.
+        let (left, mut right) = UnixStream::pair().unwrap();
+        let stream = Stream::new(
+            Arc::new(left.into()),
+            submitter,
+            Duration::from_secs(1),
+            0,
+            test_pool(),
+        );
+
+        // Pretend the caller already filled two bytes, then complete exactly
+        // three more bytes from the socket.
+        let writer = tokio::task::spawn_blocking(move || right.write_all(b"abc"));
+        let buffer = IoBufMut::with_capacity(5);
+        let (_buffer, result) = stream
+            .submit_recv(buffer, 2, 3, true, Instant::now() + Duration::from_secs(1))
+            .await;
+
+        // The wrapper should report only the bytes read by this invocation,
+        // not the cumulative total tracked inside the request state.
+        writer.await.unwrap().unwrap();
+        assert_eq!(result.unwrap(), 3);
+
+        drop(stream);
+        handle.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_vectored_send_path() {
+        // Verify the network send wrapper drives the vectored `Writev` path end-to-end.
+        let mut registry = Registry::default();
+        let (submitter, io_loop) =
+            iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
+        let handle = std::thread::spawn(move || io_loop.run());
+
+        let (left, mut right) = UnixStream::pair().unwrap();
+        let mut sink = Sink::new(Arc::new(left.into()), submitter, Duration::from_secs(1));
+
+        // Queue two buffers so the wrapper must preserve vectored ordering.
+        let mut bufs = IoBufs::default();
+        bufs.append(IoBuf::from(b"ab"));
+        bufs.append(IoBuf::from(b"cd"));
+
+        // Read from the peer in one shot so the final payload ordering is unambiguous.
+        let reader = tokio::task::spawn_blocking(move || {
+            let mut buf = [0u8; 4];
+            right.read_exact(&mut buf).unwrap();
+            buf
+        });
+
+        // The peer should observe the concatenated payload in-order.
+        sink.send(bufs).await.unwrap();
+        assert_eq!(&reader.await.unwrap(), b"abcd");
+
+        drop(sink);
+        handle.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_zero_length_send_short_circuits_before_submit() {
+        // Verify empty sends return locally without depending on a live io_uring loop.
+        let mut registry = Registry::default();
+        let (submitter, io_loop) =
+            iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
+        drop(io_loop);
+
+        // Construct a sink whose submitter would fail immediately if the wrapper
+        // tried to hand work to the loop.
+        let (left, _right) = UnixStream::pair().unwrap();
+        let mut sink = Sink::new(
+            Arc::new(left.into()),
+            submitter,
+            Duration::from_secs(1),
+        );
+
+        sink.send(IoBufs::default()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_large_recv_skips_internal_buffer() {
+        // Verify reads that are at least as large as the internal buffer go
+        // straight into the caller-owned output buffer.
+        let network = Network::start(
+            Config {
+                read_buffer_size: 8,
+                ..Default::default()
+            },
+            &mut Registry::default(),
+            test_pool(),
+        )
+        .expect("Failed to start io_uring");
+
+        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let expected = *b"abcdefgh";
+
+        // Accept one connection and issue a recv that exactly matches the
+        // internal buffer size, forcing the direct-recv branch.
+        let reader = tokio::spawn(async move {
+            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let received = stream.recv(expected.len()).await.unwrap();
+            assert!(stream.peek(1).is_empty());
+            received
+        });
+
+        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        sink.send(expected.to_vec()).await.unwrap();
+
+        assert_eq!(reader.await.unwrap().coalesce(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_configured_socket_options_cover_accept_and_dial_paths() {
+        // Verify both dial and accept exercise the configured socket-option branches.
+        let network = Network::start(
+            Config {
+                tcp_nodelay: Some(true),
+                so_linger: Some(Duration::ZERO),
+                ..Default::default()
+            },
+            &mut Registry::default(),
+            test_pool(),
+        )
+        .expect("Failed to start io_uring");
+
+        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Accepting the connection covers the listener-side option setters.
+        let accepter = tokio::spawn(async move {
+            let (_addr, _sink, _stream) = listener.accept().await.unwrap();
+        });
+
+        // Dialing the listener covers the client-side option setters.
+        let (_sink, _stream) = network.dial(addr).await.unwrap();
+        accepter.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_channel_close_fallbacks() {
+        // Verify send/recv callers get wrapper-level failures if the io_uring loop disappears.
+        let mut registry = Registry::default();
+        let (submitter, io_loop) =
+            iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
+        let recv_submitter = submitter.clone();
+        drop(io_loop);
+
+        // Send should fail locally once the submission channel has been
+        // disconnected and no loop remains to accept work.
+        let (send_left, _send_right) = UnixStream::pair().unwrap();
+        let mut sink = Sink::new(
+            Arc::new(send_left.into()),
+            submitter,
+            Duration::from_secs(1),
+        );
+        assert!(matches!(sink.send(b"hello").await, Err(Error::SendFailed)));
+
+        // Recv should surface the symmetric wrapper-specific failure.
+        let (recv_left, _recv_right) = UnixStream::pair().unwrap();
+        let mut stream = Stream::new(
+            Arc::new(recv_left.into()),
+            recv_submitter,
+            Duration::from_secs(1),
+            0,
+            test_pool(),
+        );
+        assert!(matches!(stream.recv(1).await, Err(Error::RecvFailed)));
     }
 }

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -857,11 +857,7 @@ mod tests {
         // Construct a sink whose submitter would fail immediately if the wrapper
         // tried to hand work to the loop.
         let (left, _right) = UnixStream::pair().unwrap();
-        let mut sink = Sink::new(
-            Arc::new(left.into()),
-            submitter,
-            Duration::from_secs(1),
-        );
+        let mut sink = Sink::new(Arc::new(left.into()), submitter, Duration::from_secs(1));
 
         sink.send(IoBufs::default()).await.unwrap();
     }

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -839,6 +839,8 @@ mod tests {
         let mut sink = Sink::new(Arc::new(left.into()), submitter, Duration::from_secs(1));
 
         sink.send(IoBufs::default()).await.unwrap();
+        sink.send(IoBuf::default()).await.unwrap();
+        sink.send(Vec::<u8>::new()).await.unwrap();
     }
 
     #[tokio::test]
@@ -897,6 +899,31 @@ mod tests {
         });
 
         // Dialing the listener covers the client-side option setters.
+        let (_sink, _stream) = network.dial(addr).await.unwrap();
+        accepter.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_disabled_socket_options_cover_accept_and_dial_paths() {
+        // Verify both dial and accept also cover the "do not touch socket options" branches.
+        let network = Network::start(
+            Config {
+                tcp_nodelay: None,
+                zero_linger: false,
+                ..Default::default()
+            },
+            &mut Registry::default(),
+            test_pool(),
+        )
+        .expect("Failed to start io_uring");
+
+        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let accepter = tokio::spawn(async move {
+            let (_addr, _sink, _stream) = listener.accept().await.unwrap();
+        });
+
         let (_sink, _stream) = network.dial(addr).await.unwrap();
         accepter.await.unwrap();
     }

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -403,10 +403,11 @@ impl Stream {
             .send(IoUringRequest::Recv(RecvRequest {
                 fd: self.fd.clone(),
                 buf: buffer,
-                // The active request tracks progress with `received` starting
-                // at `offset`, so `target_len` is the total target.
-                target_len: offset + len,
-                received: offset,
+                // The request appends into an already-partially-filled
+                // destination buffer, so `offset` is the current write cursor
+                // and `len` is the final target bound for this logical recv.
+                offset,
+                len: offset + len,
                 exact,
                 deadline: Some(deadline),
                 sender: tx,

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -3,14 +3,14 @@
 //!
 //! ## Architecture
 //!
-//! I/O operations are sent via a [commonware_utils::channel::mpsc] channel to a dedicated io_uring event loop
-//! running in another thread. Operation results are returned via a [commonware_utils::channel::oneshot] channel.
+//! I/O operations are sent as high-level [Request][crate::iouring::IoUringRequest]s via a
+//! [commonware_utils::channel::mpsc] channel to a dedicated io_uring event loop running in another
+//! thread. Operation results are returned via typed [commonware_utils::channel::oneshot] channels.
 //!
 //! ## Memory Safety
 //!
-//! We pass to the kernel, via io_uring, a pointer to the buffer being read from/written into.
-//! Therefore, we ensure that the memory location is valid for the duration of the operation.
-//! That is, it doesn't move or go out of scope until the operation completes.
+//! Buffers and file descriptors are owned by the active request state machine inside the io_uring
+//! loop, ensuring that the memory location is valid for the duration of the operation.
 //!
 //! ## Feature Flag
 //!
@@ -23,25 +23,19 @@
 
 use super::Header;
 use crate::{
-    iouring::{self, should_retry, OpBuffer, OpFd, OpIovecs},
-    utils, Buf, BufferPool, Error, IoBuf, IoBufs, IoBufsMut,
+    iouring::{self, IoUringRequest, ReadAtRequest, SyncRequest, WriteAtRequest},
+    utils, Buf, BufferPool, Error, IoBufs, IoBufsMut,
 };
 use commonware_codec::Encode;
 use commonware_utils::{channel::oneshot, from_hex, hex};
-use io_uring::{opcode, types::Fd};
 use prometheus_client::registry::Registry;
 use std::{
     fs::{self, File},
     io::{Error as IoError, Read, Seek, SeekFrom, Write},
     ops::RangeInclusive,
-    os::fd::AsRawFd,
     path::{Path, PathBuf},
     sync::Arc,
 };
-
-/// Cap iovec batch size: larger iovecs reduce syscall count but increase
-/// per-write kernel setup overhead.
-const IOVEC_BATCH_SIZE: usize = 32;
 
 /// Syncs a directory to ensure directory entry changes are durable.
 /// On Unix, directory metadata (file creation/deletion) must be explicitly fsynced.
@@ -275,149 +269,6 @@ impl Blob {
             pool,
         }
     }
-
-    fn as_raw_fd(&self) -> Fd {
-        Fd(self.file.as_raw_fd())
-    }
-
-    async fn write_single_at(&self, mut offset: u64, mut buf: IoBuf) -> Result<(), Error> {
-        let mut bytes_written = 0;
-        let buf_len = buf.len();
-        while bytes_written < buf_len {
-            // Figure out how much is left to write and where to write from.
-            //
-            // SAFETY: IoBuf wraps Bytes which has stable memory addresses.
-            // `bytes_written` is always < `buf_len` due to the loop condition, so
-            // `add(bytes_written)` stays within bounds and `buf_len - bytes_written`
-            // correctly represents the remaining valid bytes.
-            let ptr = unsafe { buf.as_ptr().add(bytes_written) };
-            let remaining_len = buf_len - bytes_written;
-
-            // Create an operation to do the write
-            let op = opcode::Write::new(self.as_raw_fd(), ptr, remaining_len as _)
-                .offset(offset as _)
-                .build();
-
-            // Submit the operation
-            let (sender, receiver) = oneshot::channel();
-            self.io_submitter
-                .send(iouring::Op {
-                    work: op,
-                    sender,
-                    buffer: Some(OpBuffer::Write(buf)),
-                    fd: Some(OpFd::File(self.file.clone())),
-                    iovecs: None,
-                    deadline: None,
-                })
-                .await
-                .map_err(|_| Error::WriteFailed)?;
-
-            // Wait for the result
-            let (return_value, return_buf) = receiver.await.map_err(|_| Error::WriteFailed)?;
-            buf = match return_buf {
-                Some(OpBuffer::Write(b)) => b,
-                _ => unreachable!("io_uring loop returns the same OpBuffer that was submitted"),
-            };
-            if should_retry(return_value) {
-                continue;
-            }
-
-            // A negative or zero return value indicates an error.
-            let op_bytes_written: usize =
-                return_value.try_into().map_err(|_| Error::WriteFailed)?;
-            if op_bytes_written == 0 {
-                return Err(Error::WriteFailed);
-            }
-
-            bytes_written += op_bytes_written;
-            offset += op_bytes_written as u64;
-        }
-
-        Ok(())
-    }
-
-    async fn write_vectored_at(&self, mut offset: u64, mut bufs: IoBufs) -> Result<(), Error> {
-        while bufs.has_remaining() {
-            let (iovecs, iovecs_len) = {
-                // Figure out how much is left to write and where to write from.
-                //
-                // Use one pre-initialized `libc::iovec` array as scratch space and
-                // view it as `IoSlice` to fill via `chunks_vectored`, since
-                // `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
-                let max_iovecs = bufs.chunk_count().min(IOVEC_BATCH_SIZE);
-                assert!(
-                    max_iovecs > 0,
-                    "chunk_count should be > 0 if bufs.has_remaining() is true"
-                );
-                let mut iovecs: Box<[libc::iovec]> = std::iter::repeat_n(
-                    libc::iovec {
-                        iov_base: std::ptr::NonNull::<u8>::dangling().as_ptr().cast(),
-                        iov_len: 0,
-                    },
-                    max_iovecs,
-                )
-                .collect();
-
-                // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
-                // `raw_iovecs` is initialized with valid empty entries, so `io_slices`
-                // starts in a valid state for `chunks_vectored` to overwrite.
-                let io_slices: &mut [std::io::IoSlice<'_>] = unsafe {
-                    std::slice::from_raw_parts_mut(
-                        iovecs.as_mut_ptr().cast::<std::io::IoSlice<'_>>(),
-                        iovecs.len(),
-                    )
-                };
-                let io_slices_len = bufs.chunks_vectored(io_slices);
-                assert!(
-                    io_slices_len > 0,
-                    "chunks_vectored should produce at least one slice when bufs has remaining"
-                );
-
-                (OpIovecs::new(iovecs), io_slices_len)
-            };
-
-            // Create an operation to do the write
-            let op = opcode::Writev::new(self.as_raw_fd(), iovecs.as_ptr(), iovecs_len as _)
-                .offset(offset as _)
-                .build();
-
-            // Submit the operation
-            let (sender, receiver) = oneshot::channel();
-            self.io_submitter
-                .send(iouring::Op {
-                    work: op,
-                    sender,
-                    buffer: Some(OpBuffer::WriteVectored(bufs)),
-                    fd: Some(OpFd::File(self.file.clone())),
-                    iovecs: Some(iovecs),
-                    deadline: None,
-                })
-                .await
-                .map_err(|_| Error::WriteFailed)?;
-
-            // Wait for the result
-            let (return_value, return_bufs) = receiver.await.map_err(|_| Error::WriteFailed)?;
-            bufs = match return_bufs {
-                Some(OpBuffer::WriteVectored(b)) => b,
-                _ => unreachable!("io_uring loop returns the same OpBuffer that was submitted"),
-            };
-            if should_retry(return_value) {
-                continue;
-            }
-
-            // A negative or zero return value indicates an error.
-            let op_bytes_written: usize =
-                return_value.try_into().map_err(|_| Error::WriteFailed)?;
-            if op_bytes_written == 0 {
-                return Err(Error::WriteFailed);
-            }
-
-            bufs.advance(op_bytes_written);
-            offset += op_bytes_written as u64;
-        }
-
-        Ok(())
-    }
 }
 
 impl crate::Blob for Blob {
@@ -437,7 +288,7 @@ impl crate::Blob for Blob {
 
         // For single buffers, read directly into them (zero-copy).
         // For multi-chunk buffers, use a temporary and copy to preserve the input structure.
-        let (mut io_buf, original_bufs) = if input_bufs.is_single() {
+        let (io_buf, original_bufs) = if input_bufs.is_single() {
             (input_bufs.coalesce(), None)
         } else {
             // SAFETY: `len` bytes are filled via io_uring read loop below.
@@ -445,65 +296,33 @@ impl crate::Blob for Blob {
             (tmp, Some(input_bufs))
         };
 
-        let mut bytes_read = 0;
         let offset = offset
             .checked_add(Header::SIZE_U64)
             .ok_or(Error::OffsetOverflow)?;
-        while bytes_read < len {
-            // Figure out how much is left to read and where to read into.
-            //
-            // SAFETY: IoBufMut wraps BytesMut which has stable memory addresses.
-            // `bytes_read` is always < `len` due to the loop condition, so
-            // `add(bytes_read)` stays within bounds and `len - bytes_read`
-            // correctly represents the remaining valid bytes.
-            let ptr = unsafe { io_buf.as_mut_ptr().add(bytes_read) };
-            let remaining_len = len - bytes_read;
-            let offset = offset + bytes_read as u64;
 
-            // Create an operation to do the read
-            let op = opcode::Read::new(self.as_raw_fd(), ptr, remaining_len as _)
-                .offset(offset as _)
-                .build();
-
-            // Submit the operation
-            let (sender, receiver) = oneshot::channel();
-            self.io_submitter
-                .send(iouring::Op {
-                    work: op,
-                    sender,
-                    buffer: Some(OpBuffer::Read(io_buf)),
-                    fd: Some(OpFd::File(self.file.clone())),
-                    iovecs: None,
-                    deadline: None,
-                })
-                .await
-                .map_err(|_| Error::ReadFailed)?;
-
-            // Wait for the result
-            let (return_value, return_buf) = receiver.await.map_err(|_| Error::ReadFailed)?;
-            io_buf = match return_buf {
-                Some(OpBuffer::Read(b)) => b,
-                _ => unreachable!("io_uring loop returns the same OpBuffer that was submitted"),
-            };
-            if should_retry(return_value) {
-                continue;
-            }
-
-            // A non-positive return value indicates an error.
-            let op_bytes_read: usize = return_value.try_into().map_err(|_| Error::ReadFailed)?;
-            if op_bytes_read == 0 {
-                // A return value of 0 indicates EOF, which shouldn't happen because we
-                // aren't done reading into `buf`. See `man pread`.
-                return Err(Error::BlobInsufficientLength);
-            }
-            bytes_read += op_bytes_read;
+        // Zero-length reads succeed trivially without submitting to the ring.
+        if len == 0 {
+            return Ok(original_bufs.unwrap_or_else(|| io_buf.into()));
         }
 
-        // Return the same buffer structure as input
+        let (tx, rx) = oneshot::channel();
+        self.io_submitter
+            .send(IoUringRequest::ReadAt(ReadAtRequest {
+                file: self.file.clone(),
+                offset,
+                len,
+                buf: io_buf,
+                sender: tx,
+            }))
+            .await
+            .map_err(|_| Error::ReadFailed)?;
+
+        let (io_buf, result) = rx.await.map_err(|_| Error::ReadFailed)?;
+        result?;
+
         match original_bufs {
             None => Ok(io_buf.into()),
             Some(mut bufs) => {
-                // Copy from temporary buffer to the original multi-chunk buffers.
                 bufs.copy_from_slice(io_buf.as_ref());
                 Ok(bufs)
             }
@@ -516,10 +335,22 @@ impl crate::Blob for Blob {
             .checked_add(Header::SIZE_U64)
             .ok_or(Error::OffsetOverflow)?;
 
-        match bufs.try_into_single() {
-            Ok(buf) => self.write_single_at(offset, buf).await,
-            Err(bufs) => self.write_vectored_at(offset, bufs).await,
+        if !bufs.has_remaining() {
+            return Ok(());
         }
+
+        let (tx, rx) = oneshot::channel();
+        self.io_submitter
+            .send(IoUringRequest::WriteAt(WriteAtRequest {
+                file: self.file.clone(),
+                offset,
+                bufs,
+                sender: tx,
+            }))
+            .await
+            .map_err(|_| Error::WriteFailed)?;
+
+        rx.await.map_err(|_| Error::WriteFailed)?
     }
 
     // TODO: Make this async. See https://github.com/commonwarexyz/monorepo/issues/831
@@ -533,53 +364,30 @@ impl crate::Blob for Blob {
     }
 
     async fn sync(&self) -> Result<(), Error> {
-        loop {
-            // Create an operation to do the sync
-            let op = opcode::Fsync::new(self.as_raw_fd()).build();
-
-            // Submit the operation
-            let (sender, receiver) = oneshot::channel();
-            self.io_submitter
-                .send(iouring::Op {
-                    work: op,
-                    sender,
-                    buffer: None,
-                    fd: Some(OpFd::File(self.file.clone())),
-                    iovecs: None,
-                    deadline: None,
-                })
-                .await
-                .map_err(|_| {
-                    Error::BlobSyncFailed(
-                        self.partition.clone(),
-                        hex(&self.name),
-                        IoError::other("failed to send work"),
-                    )
-                })?;
-
-            // Wait for the result
-            let (return_value, _) = receiver.await.map_err(|_| {
+        let (tx, rx) = oneshot::channel();
+        self.io_submitter
+            .send(IoUringRequest::Sync(SyncRequest {
+                file: self.file.clone(),
+                sender: tx,
+            }))
+            .await
+            .map_err(|_| {
                 Error::BlobSyncFailed(
                     self.partition.clone(),
                     hex(&self.name),
-                    IoError::other("failed to read result"),
+                    IoError::other("failed to send work"),
                 )
             })?;
-            if should_retry(return_value) {
-                continue;
-            }
 
-            // If the return value is negative, it indicates an error.
-            if return_value < 0 {
-                return Err(Error::BlobSyncFailed(
-                    self.partition.clone(),
-                    hex(&self.name),
-                    IoError::other(format!("error code: {return_value}")),
-                ));
-            }
+        let result = rx.await.map_err(|_| {
+            Error::BlobSyncFailed(
+                self.partition.clone(),
+                hex(&self.name),
+                IoError::other("failed to read result"),
+            )
+        })?;
 
-            return Ok(());
-        }
+        result.map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
     }
 }
 
@@ -731,6 +539,29 @@ mod tests {
             matches!(result, Err(crate::Error::BlobCorrupt(_, _, reason)) if reason.contains("invalid magic"))
         );
 
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_vectored_write_partial_progress() {
+        let (storage, storage_directory) = create_test_storage();
+
+        let (blob, _) = storage.open("partition", b"vectest").await.unwrap();
+        blob.resize(200).await.unwrap();
+
+        // Write multiple buffers in one vectored call.
+        let mut bufs = crate::IoBufs::default();
+        bufs.append(crate::IoBuf::from(vec![0xAAu8; 80]));
+        bufs.append(crate::IoBuf::from(vec![0xBBu8; 80]));
+        blob.write_at(0, bufs).await.unwrap();
+        blob.sync().await.unwrap();
+
+        // Read back and verify.
+        let data = blob.read_at(0, 160).await.unwrap().coalesce();
+        assert_eq!(&data.as_ref()[..80], &[0xAAu8; 80]);
+        assert_eq!(&data.as_ref()[80..], &[0xBBu8; 80]);
+
+        drop(blob);
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
 }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -358,7 +358,7 @@ mod tests {
     use super::{Header, *};
     use crate::{
         storage::tests::run_storage_tests, utils::thread, Blob as _, BufferPool, BufferPoolConfig,
-        IoBufMut, Storage as _,
+        IoBuf, IoBufMut, Storage as _,
     };
     use std::{
         env,
@@ -523,10 +523,14 @@ mod tests {
         std::fs::write(&bad_magic_path, vec![0u8; Header::SIZE]).unwrap();
 
         // Opening should fail with corrupt error
-        let result = storage.open("partition", b"bad_magic").await;
-        assert!(
-            matches!(result, Err(crate::Error::BlobCorrupt(_, _, reason)) if reason.contains("invalid magic"))
-        );
+        let err = storage
+            .open("partition", b"bad_magic")
+            .await
+            .err()
+            .expect("bad magic should fail");
+        assert!(err
+            .to_string()
+            .starts_with("blob corrupt: partition/6261645f6d61676963 reason: invalid magic"));
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -568,8 +572,8 @@ mod tests {
 
         // The wrapper should surface this as an insufficient-length error instead
         // of silently returning a short buffer.
-        let result = blob.read_at(0, 5).await;
-        assert!(matches!(result, Err(Error::BlobInsufficientLength)));
+        let err = blob.read_at(0, 5).await.unwrap_err();
+        assert_eq!(err.to_string(), "blob insufficient length");
 
         drop(blob);
         let _ = std::fs::remove_dir_all(&storage_directory);
@@ -606,8 +610,14 @@ mod tests {
 
         // Zero-length operations should succeed immediately and preserve the empty blob.
         blob.write_at(0, IoBufs::default()).await.unwrap();
+        blob.write_at(0, IoBuf::default()).await.unwrap();
+        blob.write_at(0, Vec::<u8>::new()).await.unwrap();
         let empty = blob.read_at(0, 0).await.unwrap();
         assert!(empty.is_empty());
+        let _ = blob
+            .read_at_buf(0, 0, IoBufsMut::from(IoBufMut::with_capacity(8)))
+            .await
+            .unwrap();
 
         drop(blob);
         let _ = std::fs::remove_dir_all(&storage_directory);
@@ -623,8 +633,8 @@ mod tests {
         std::fs::create_dir_all(partition.join("nested")).unwrap();
 
         // The wrapper should treat the partition as corrupt rather than silently skipping it.
-        let result = storage.scan("partition").await;
-        assert!(matches!(result, Err(Error::PartitionCorrupt(name)) if name == "partition"));
+        let err = storage.scan("partition").await.unwrap_err();
+        assert_eq!(err.to_string(), "partition corrupt: partition");
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -635,21 +645,17 @@ mod tests {
         let (storage, storage_directory) = create_test_storage();
 
         // Removing a missing partition should fail before any blob-specific path logic runs.
-        let missing_partition = storage.remove("missing", None).await;
-        assert!(matches!(
-            missing_partition,
-            Err(Error::PartitionMissing(name)) if name == "missing"
-        ));
+        let err = storage.remove("missing", None).await.unwrap_err();
+        assert_eq!(err.to_string(), "partition missing: missing");
 
         // Once the partition exists, removing an absent blob should surface the
         // more specific `BlobMissing` error instead.
         std::fs::create_dir_all(storage_directory.join("partition")).unwrap();
-        let missing_blob = storage.remove("partition", Some(b"missing")).await;
-        assert!(matches!(
-            missing_blob,
-            Err(Error::BlobMissing(partition, blob))
-            if partition == "partition" && blob == hex(b"missing")
-        ));
+        let err = storage
+            .remove("partition", Some(b"missing"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.to_string(), "blob missing: partition/6d697373696e67");
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -684,11 +690,8 @@ mod tests {
         // Create a file whose name is valid UTF-8 but not valid hex.
         std::fs::write(partition.join("not-hex"), []).unwrap();
 
-        let scanned = storage.scan("partition").await;
-        assert!(matches!(
-            scanned,
-            Err(Error::PartitionCorrupt(name)) if name == "partition"
-        ));
+        let err = storage.scan("partition").await.unwrap_err();
+        assert_eq!(err.to_string(), "partition corrupt: partition");
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -714,11 +717,12 @@ mod tests {
             pool,
         );
 
-        let opened = storage.open("partition", b"blob").await;
-        assert!(matches!(
-            opened,
-            Err(Error::PartitionCreationFailed(name)) if name == "partition"
-        ));
+        let err = storage
+            .open("partition", b"blob")
+            .await
+            .err()
+            .expect("invalid storage root should fail");
+        assert_eq!(err.to_string(), "partition creation failed: partition");
 
         let _ = std::fs::remove_file(&storage_root);
         let _ = std::fs::remove_dir_all(&storage_directory);
@@ -747,12 +751,14 @@ mod tests {
             pool,
         );
 
-        let opened = storage.open("partition", b"blob").await;
-        assert!(matches!(
-            opened,
-            Err(Error::BlobOpenFailed(partition, name, _))
-            if partition == "partition" && name == blob_name
-        ));
+        let err = storage
+            .open("partition", b"blob")
+            .await
+            .err()
+            .expect("opening a directory as a blob should fail");
+        assert!(err
+            .to_string()
+            .starts_with(&format!("blob open failed: partition/{blob_name} error:")));
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -765,18 +771,21 @@ mod tests {
 
         // Each operation adds the runtime header size internally, so using the
         // maximum logical offset must fail before any request is submitted.
-        assert!(matches!(
-            blob.read_at(u64::MAX, 1).await,
-            Err(Error::OffsetOverflow)
-        ));
-        assert!(matches!(
-            blob.write_at(u64::MAX, b"x".to_vec()).await,
-            Err(Error::OffsetOverflow)
-        ));
-        assert!(matches!(
-            blob.resize(u64::MAX).await,
-            Err(Error::OffsetOverflow)
-        ));
+        assert_eq!(
+            blob.read_at(u64::MAX, 1).await.unwrap_err().to_string(),
+            "offset overflow"
+        );
+        assert_eq!(
+            blob.write_at(u64::MAX, b"x".to_vec())
+                .await
+                .unwrap_err()
+                .to_string(),
+            "offset overflow"
+        );
+        assert_eq!(
+            blob.resize(u64::MAX).await.unwrap_err().to_string(),
+            "offset overflow"
+        );
 
         drop(blob);
         let _ = std::fs::remove_dir_all(&storage_directory);
@@ -802,11 +811,17 @@ mod tests {
 
         // Read and write should fail through their wrapper-specific error enums
         // when the submission channel has already been disconnected.
-        assert!(matches!(blob.read_at(0, 1).await, Err(Error::ReadFailed)));
-        assert!(matches!(
-            blob.write_at(0, b"x".to_vec()).await,
-            Err(Error::WriteFailed)
-        ));
+        assert_eq!(
+            blob.read_at(0, 1).await.unwrap_err().to_string(),
+            "read failed"
+        );
+        assert_eq!(
+            blob.write_at(0, b"x".to_vec())
+                .await
+                .unwrap_err()
+                .to_string(),
+            "write failed"
+        );
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -818,11 +833,10 @@ mod tests {
         let missing = storage_directory.join("missing");
 
         let err = sync_dir(&missing).expect_err("missing directory should fail");
-        assert!(matches!(
-            err,
-            Error::BlobOpenFailed(path, kind, _)
-            if path == missing.to_string_lossy() && kind == "directory"
-        ));
+        assert!(err.to_string().starts_with(&format!(
+            "blob open failed: {}/directory error:",
+            missing.to_string_lossy()
+        )));
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -849,13 +863,13 @@ mod tests {
             .sync()
             .await
             .expect_err("sync should fail without a loop");
-        assert!(matches!(
-            err,
-            Error::BlobSyncFailed(partition, name, inner)
-            if partition == "partition"
-                && name == hex(b"blob")
-                && inner.to_string() == "failed to send work"
-        ));
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "blob sync failed: partition/{} error: failed to send work",
+                hex(b"blob")
+            )
+        );
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -882,12 +896,10 @@ mod tests {
             .resize(0)
             .await
             .expect_err("resize should fail on a socket fd");
-        assert!(matches!(
-            err,
-            Error::BlobResizeFailed(partition, name, _)
-            if partition == "partition"
-                && name == hex(b"blob")
-        ));
+        assert!(err.to_string().starts_with(&format!(
+            "blob resize failed: partition/{} error:",
+            hex(b"blob")
+        )));
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -914,13 +926,18 @@ mod tests {
             .sync()
             .await
             .expect_err("sync should fail on a socket fd");
-        assert!(matches!(
-            err,
-            Error::BlobSyncFailed(partition, name, inner)
-            if partition == "partition"
-                && name == hex(b"blob")
-                && inner.raw_os_error().is_some()
-        ));
+        let message = err.to_string();
+        assert!(message.starts_with(&format!(
+            "blob sync failed: partition/{} error:",
+            hex(b"blob")
+        )));
+        assert_ne!(
+            message,
+            format!(
+                "blob sync failed: partition/{} error: failed to send work",
+                hex(b"blob")
+            )
+        );
 
         drop(blob);
         drop(submitter);

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -396,17 +396,29 @@ impl crate::Blob for Blob {
 mod tests {
     use super::{Header, *};
     use crate::{
-        storage::tests::run_storage_tests, utils::thread, Blob, BufferPool, BufferPoolConfig,
+        storage::tests::run_storage_tests, utils::thread, Blob as _, BufferPool, BufferPoolConfig, IoBufMut,
         Storage as _,
     };
-    use rand::{Rng as _, SeedableRng as _};
-    use std::env;
+    use std::{
+        env,
+        ffi::OsString,
+        os::{
+            fd::{FromRawFd, IntoRawFd},
+            unix::{ffi::OsStringExt, net::UnixStream},
+        },
+        sync::atomic::{AtomicU64, Ordering},
+    };
 
-    // Helper for creating test storage
+    static NEXT_STORAGE_TEST_DIR: AtomicU64 = AtomicU64::new(0);
+
+    /// Build a fresh storage instance rooted in a unique temporary directory.
     fn create_test_storage() -> (Storage, PathBuf) {
-        let mut rng = rand::rngs::StdRng::from_entropy();
-        let storage_directory =
-            env::temp_dir().join(format!("commonware_iouring_storage_{}", rng.gen::<u64>()));
+        let storage_directory = env::temp_dir().join(format!(
+            "commonware_iouring_storage_{}_{}",
+            std::process::id(),
+            NEXT_STORAGE_TEST_DIR.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&storage_directory);
 
         let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut Registry::default());
         let storage = Storage::start(
@@ -421,8 +433,21 @@ mod tests {
         (storage, storage_directory)
     }
 
+    /// Build a fresh temporary directory without starting a storage loop.
+    fn create_test_directory() -> PathBuf {
+        let storage_directory = env::temp_dir().join(format!(
+            "commonware_iouring_storage_{}_{}",
+            std::process::id(),
+            NEXT_STORAGE_TEST_DIR.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&storage_directory);
+        std::fs::create_dir_all(&storage_directory).unwrap();
+        storage_directory
+    }
+
     #[tokio::test]
     async fn test_iouring_storage() {
+        // Verify the io_uring storage backend satisfies the shared storage trait suite.
         let (storage, storage_directory) = create_test_storage();
         run_storage_tests(storage).await;
         let _ = std::fs::remove_dir_all(storage_directory);
@@ -430,6 +455,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_blob_header_handling() {
+        // Verify header creation, logical offsets, resize, reopen, and corruption recovery.
         let (storage, storage_directory) = create_test_storage();
 
         // Test 1: New blob returns logical size 0 and correct application version
@@ -524,6 +550,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_blob_magic_mismatch() {
+        // Verify opening a blob with an invalid runtime header fails as corrupt.
         let (storage, storage_directory) = create_test_storage();
 
         // Create the partition directory
@@ -545,6 +572,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_vectored_write_partial_progress() {
+        // Verify multi-buffer writes survive partial progress and preserve byte order.
         let (storage, storage_directory) = create_test_storage();
 
         let (blob, _) = storage.open("partition", b"vectest").await.unwrap();
@@ -563,6 +591,373 @@ mod tests {
         assert_eq!(&data.as_ref()[80..], &[0xBBu8; 80]);
 
         drop(blob);
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_read_at_reports_eof_when_blob_is_too_short() {
+        // Verify read-at returns `BlobInsufficientLength` when the kernel reports EOF mid-read.
+        let (storage, storage_directory) = create_test_storage();
+
+        // Persist fewer bytes than the upcoming read requests so the wrapper
+        // encounters EOF after the header-adjusted offset has already started reading.
+        let (blob, _) = storage.open("partition", b"short").await.unwrap();
+        blob.write_at(0, b"abc".to_vec()).await.unwrap();
+        blob.sync().await.unwrap();
+
+        // The wrapper should surface this as an insufficient-length error instead
+        // of silently returning a short buffer.
+        let result = blob.read_at(0, 5).await;
+        assert!(matches!(result, Err(Error::BlobInsufficientLength)));
+
+        drop(blob);
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_read_at_buf_preserves_multichunk_layout() {
+        // Verify multi-chunk caller buffers keep their shape after the temporary-buffer fallback.
+        let (storage, storage_directory) = create_test_storage();
+
+        let (blob, _) = storage.open("partition", b"multichunk").await.unwrap();
+        blob.write_at(0, b"hello world".to_vec()).await.unwrap();
+        blob.sync().await.unwrap();
+
+        // Use a two-chunk destination so the read path must rebuild the original
+        // chunk layout after reading through a temporary contiguous buffer.
+        let bufs = IoBufsMut::from(vec![IoBufMut::with_capacity(5), IoBufMut::with_capacity(6)]);
+        let read = blob.read_at_buf(0, 11, bufs).await.unwrap();
+        // The result should keep the split layout rather than collapsing to one buffer.
+        assert!(!read.is_single());
+        assert_eq!(read.coalesce(), b"hello world");
+
+        drop(blob);
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_zero_length_read_and_write_short_circuit() {
+        // Verify zero-length reads and writes complete without touching the ring.
+        let (storage, storage_directory) = create_test_storage();
+
+        let (blob, size) = storage.open("partition", b"empty").await.unwrap();
+        assert_eq!(size, 0);
+
+        // Zero-length operations should succeed immediately and preserve the empty blob.
+        blob.write_at(0, IoBufs::default()).await.unwrap();
+        let empty = blob.read_at(0, 0).await.unwrap();
+        assert!(empty.is_empty());
+
+        drop(blob);
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_scan_rejects_non_file_entries() {
+        // Verify partition scans reject unexpected directory contents as corruption.
+        let (storage, storage_directory) = create_test_storage();
+
+        // Inject a nested directory where `scan` expects only regular blob files.
+        let partition = storage_directory.join("partition");
+        std::fs::create_dir_all(partition.join("nested")).unwrap();
+
+        // The wrapper should treat the partition as corrupt rather than silently skipping it.
+        let result = storage.scan("partition").await;
+        assert!(matches!(result, Err(Error::PartitionCorrupt(name)) if name == "partition"));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_remove_reports_missing_targets() {
+        // Verify wrapper-level remove errors distinguish missing partitions from missing blobs.
+        let (storage, storage_directory) = create_test_storage();
+
+        // Removing a missing partition should fail before any blob-specific path logic runs.
+        let missing_partition = storage.remove("missing", None).await;
+        assert!(matches!(
+            missing_partition,
+            Err(Error::PartitionMissing(name)) if name == "missing"
+        ));
+
+        // Once the partition exists, removing an absent blob should surface the
+        // more specific `BlobMissing` error instead.
+        std::fs::create_dir_all(storage_directory.join("partition")).unwrap();
+        let missing_blob = storage.remove("partition", Some(b"missing")).await;
+        assert!(matches!(
+            missing_blob,
+            Err(Error::BlobMissing(partition, blob))
+            if partition == "partition" && blob == hex(b"missing")
+        ));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_scan_ignores_non_utf8_file_names() {
+        // Verify partition scans ignore entries whose names cannot be represented as UTF-8.
+        let (storage, storage_directory) = create_test_storage();
+
+        let partition = storage_directory.join("partition");
+        std::fs::create_dir_all(&partition).unwrap();
+
+        // Create a valid file entry with a non-UTF8 name so `scan` exercises
+        // the branch that skips names it cannot decode.
+        let invalid_name = OsString::from_vec(vec![0xff, 0xfe, 0xfd]);
+        std::fs::write(partition.join(invalid_name), []).unwrap();
+
+        let scanned = storage.scan("partition").await.unwrap();
+        assert!(scanned.is_empty());
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_scan_rejects_non_hex_file_names() {
+        // Verify partition scans reject UTF-8 entries that are not valid blob names.
+        let (storage, storage_directory) = create_test_storage();
+
+        let partition = storage_directory.join("partition");
+        std::fs::create_dir_all(&partition).unwrap();
+
+        // Create a file whose name is valid UTF-8 but not valid hex.
+        std::fs::write(partition.join("not-hex"), []).unwrap();
+
+        let scanned = storage.scan("partition").await;
+        assert!(matches!(
+            scanned,
+            Err(Error::PartitionCorrupt(name)) if name == "partition"
+        ));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_open_reports_partition_creation_failure() {
+        // Verify opening a blob reports partition-creation failures when the
+        // configured storage root is not a directory.
+        let storage_directory = create_test_directory();
+        let storage_root = storage_directory.join("root-file");
+        std::fs::write(&storage_root, b"not a directory").unwrap();
+
+        // Start storage against the invalid root so `open` reaches the
+        // filesystem setup path under realistic wrapper code.
+        let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut Registry::default());
+        let storage = Storage::start(
+            Config {
+                storage_directory: storage_root.clone(),
+                iouring_config: Default::default(),
+            },
+            &mut Registry::default(),
+            pool,
+        );
+
+        let opened = storage.open("partition", b"blob").await;
+        assert!(matches!(
+            opened,
+            Err(Error::PartitionCreationFailed(name)) if name == "partition"
+        ));
+
+        let _ = std::fs::remove_file(&storage_root);
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_open_reports_blob_open_failure_for_directory_path() {
+        // Verify opening a blob reports `BlobOpenFailed` when the blob path
+        // already exists as a directory instead of a regular file.
+        let storage_directory = create_test_directory();
+        let partition = storage_directory.join("partition");
+        let blob_name = hex(b"blob");
+
+        // Pre-create the would-be blob path as a directory so `OpenOptions`
+        // fails once the wrapper reaches the open call.
+        std::fs::create_dir_all(partition.join(&blob_name)).unwrap();
+
+        let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut Registry::default());
+        let storage = Storage::start(
+            Config {
+                storage_directory: storage_directory.clone(),
+                iouring_config: Default::default(),
+            },
+            &mut Registry::default(),
+            pool,
+        );
+
+        let opened = storage.open("partition", b"blob").await;
+        assert!(matches!(
+            opened,
+            Err(Error::BlobOpenFailed(partition, name, _))
+            if partition == "partition" && name == blob_name
+        ));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_blob_offset_overflow_guards() {
+        // Verify logical offsets are checked before any filesystem or io_uring work.
+        let (storage, storage_directory) = create_test_storage();
+        let (blob, _) = storage.open("partition", b"overflow").await.unwrap();
+
+        // Each operation adds the runtime header size internally, so using the
+        // maximum logical offset must fail before any request is submitted.
+        assert!(matches!(blob.read_at(u64::MAX, 1).await, Err(Error::OffsetOverflow)));
+        assert!(matches!(
+            blob.write_at(u64::MAX, b"x".to_vec()).await,
+            Err(Error::OffsetOverflow)
+        ));
+        assert!(matches!(
+            blob.resize(u64::MAX).await,
+            Err(Error::OffsetOverflow)
+        ));
+
+        drop(blob);
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_read_and_write_report_submitter_disconnect() {
+        // Verify read/write wrappers report channel disconnects before any work
+        // reaches the io_uring loop.
+        let storage_directory = create_test_directory();
+        let path = storage_directory.join("disconnected");
+        let file = File::create(&path).unwrap();
+
+        // Drop the loop immediately so the submitter behaves like a dead
+        // backend while the blob handle still exists.
+        let mut registry = Registry::default();
+        let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut Registry::default());
+        let (submitter, io_loop) =
+            iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
+        drop(io_loop);
+
+        let blob = Blob::new("partition".into(), b"blob", file, submitter, pool);
+
+        // Read and write should fail through their wrapper-specific error enums
+        // when the submission channel has already been disconnected.
+        assert!(matches!(blob.read_at(0, 1).await, Err(Error::ReadFailed)));
+        assert!(matches!(
+            blob.write_at(0, b"x".to_vec()).await,
+            Err(Error::WriteFailed)
+        ));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_sync_dir_reports_missing_directory() {
+        // Verify directory fsync reports missing paths through the open-failure wrapper.
+        let storage_directory = create_test_directory();
+        let missing = storage_directory.join("missing");
+
+        let err = sync_dir(&missing).expect_err("missing directory should fail");
+        assert!(matches!(
+            err,
+            Error::BlobOpenFailed(path, kind, _)
+            if path == missing.to_string_lossy() && kind == "directory"
+        ));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_blob_sync_reports_submitter_disconnect() {
+        // Verify the storage wrapper maps submission-channel disconnects to
+        // `BlobSyncFailed(..., "failed to send work")`.
+        let storage_directory = create_test_directory();
+        let path = storage_directory.join("disconnected");
+        let file = File::create(&path).unwrap();
+
+        // Construct a blob handle whose submitter has already lost its loop so
+        // the wrapper must synthesize the disconnect error locally.
+        let mut registry = Registry::default();
+        let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut Registry::default());
+        let (submitter, io_loop) =
+            iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
+        drop(io_loop);
+
+        let blob = Blob::new("partition".into(), b"blob", file, submitter, pool);
+        // Sync should fail through the blob-specific wrapper before any kernel work is attempted.
+        let err = blob.sync().await.expect_err("sync should fail without a loop");
+        assert!(matches!(
+            err,
+            Error::BlobSyncFailed(partition, name, inner)
+            if partition == "partition"
+                && name == hex(b"blob")
+                && inner.to_string() == "failed to send work"
+        ));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_resize_reports_kernel_error() {
+        // Verify resize preserves its storage-specific wrapper when the
+        // underlying descriptor is a socket rather than a regular file.
+        let storage_directory = create_test_directory();
+        let (socket, _peer) = UnixStream::pair().unwrap();
+        // SAFETY: `into_raw_fd` transfers ownership of the socket fd into `File`.
+        let file = unsafe { File::from_raw_fd(socket.into_raw_fd()) };
+
+        // `set_len` on a socket-backed file descriptor should fail in the
+        // kernel, letting the wrapper expose `BlobResizeFailed`.
+        let mut registry = Registry::default();
+        let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut Registry::default());
+        let (submitter, io_loop) =
+            iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
+        drop(io_loop);
+
+        let blob = Blob::new("partition".into(), b"blob", file, submitter, pool);
+        let err = blob
+            .resize(0)
+            .await
+            .expect_err("resize should fail on a socket fd");
+        assert!(matches!(
+            err,
+            Error::BlobResizeFailed(partition, name, _)
+            if partition == "partition"
+                && name == hex(b"blob")
+        ));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_blob_sync_reports_kernel_error() {
+        // Verify completed sync CQE failures round-trip through the storage wrapper.
+        let storage_directory = create_test_directory();
+        let (socket, _peer) = UnixStream::pair().unwrap();
+        // SAFETY: `into_raw_fd` transfers ownership of the socket fd into `File`.
+        let file = unsafe { File::from_raw_fd(socket.into_raw_fd()) };
+
+        // Run a real loop so the request reaches the kernel and fails there
+        // rather than through the wrapper's disconnected-submit path.
+        let mut registry = Registry::default();
+        let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut Registry::default());
+        let (submitter, io_loop) =
+            iouring::IoUringLoop::new(iouring::Config::default(), &mut registry);
+        let handle = std::thread::spawn(move || io_loop.run());
+
+        let blob = Blob::new("partition".into(), b"blob", file, submitter.clone(), pool);
+        // The request should reach the kernel and come back as a wrapped sync failure.
+        let err = blob
+            .sync()
+            .await
+            .expect_err("sync should fail on a socket fd");
+        assert!(matches!(
+            err,
+            Error::BlobSyncFailed(partition, name, inner)
+            if partition == "partition"
+                && name == hex(b"blob")
+                && inner.raw_os_error().is_some()
+        ));
+
+        drop(blob);
+        drop(submitter);
+        // Joining the loop proves the live backend path shut down cleanly after the error.
+        handle.join().unwrap();
+
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
 }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -3,9 +3,8 @@
 //!
 //! ## Architecture
 //!
-//! I/O operations are sent as high-level [Request][crate::iouring::IoUringRequest]s via a
-//! [commonware_utils::channel::mpsc] channel to a dedicated io_uring event loop running in another
-//! thread. Operation results are returned via typed [commonware_utils::channel::oneshot] channels.
+//! I/O operations are submitted through an io_uring [Handle][crate::iouring::Handle] to a
+//! dedicated event loop running in another thread.
 //!
 //! ## Memory Safety
 //!
@@ -23,11 +22,11 @@
 
 use super::Header;
 use crate::{
-    iouring::{self, IoUringRequest, ReadAtRequest, SyncRequest, WriteAtRequest},
+    iouring::{self},
     utils, Buf, BufferPool, Error, IoBufs, IoBufsMut,
 };
 use commonware_codec::Encode;
-use commonware_utils::{channel::oneshot, from_hex, hex};
+use commonware_utils::{from_hex, hex};
 use prometheus_client::registry::Registry;
 use std::{
     fs::{self, File},
@@ -70,7 +69,7 @@ pub struct Config {
 #[derive(Clone)]
 pub struct Storage {
     storage_directory: PathBuf,
-    io_submitter: iouring::Submitter,
+    io_handle: iouring::Handle,
     pool: BufferPool,
 }
 
@@ -89,11 +88,11 @@ impl Storage {
         // the ring is the only thread submitting work to it.
         iouring_config.single_issuer = true;
 
-        let (io_submitter, iouring_loop) = iouring::IoUringLoop::new(iouring_config, registry);
+        let (io_handle, iouring_loop) = iouring::IoUringLoop::new(iouring_config, registry);
 
         let storage = Self {
             storage_directory,
-            io_submitter,
+            io_handle,
             pool,
         };
 
@@ -175,7 +174,7 @@ impl crate::Storage for Storage {
             partition.into(),
             name,
             file,
-            self.io_submitter.clone(),
+            self.io_handle.clone(),
             self.pool.clone(),
         );
         Ok((blob, logical_len, blob_version))
@@ -236,7 +235,7 @@ pub struct Blob {
     /// The underlying file
     file: Arc<File>,
     /// Where to send IO operations to be executed
-    io_submitter: iouring::Submitter,
+    io_handle: iouring::Handle,
     /// Buffer pool for read allocations
     pool: BufferPool,
 }
@@ -247,7 +246,7 @@ impl Clone for Blob {
             partition: self.partition.clone(),
             name: self.name.clone(),
             file: self.file.clone(),
-            io_submitter: self.io_submitter.clone(),
+            io_handle: self.io_handle.clone(),
             pool: self.pool.clone(),
         }
     }
@@ -259,14 +258,14 @@ impl Blob {
         partition: String,
         name: &[u8],
         file: File,
-        io_submitter: iouring::Submitter,
+        io_handle: iouring::Handle,
         pool: BufferPool,
     ) -> Self {
         Self {
             partition,
             name: name.to_vec(),
             file: Arc::new(file),
-            io_submitter,
+            io_handle,
             pool,
         }
     }
@@ -306,20 +305,11 @@ impl crate::Blob for Blob {
             return Ok(original_bufs.unwrap_or_else(|| io_buf.into()));
         }
 
-        let (tx, rx) = oneshot::channel();
-        self.io_submitter
-            .send(IoUringRequest::ReadAt(ReadAtRequest {
-                file: self.file.clone(),
-                offset,
-                len,
-                buf: io_buf,
-                sender: tx,
-            }))
+        let io_buf = self
+            .io_handle
+            .read_at(self.file.clone(), offset, len, io_buf)
             .await
-            .map_err(|_| Error::ReadFailed)?;
-
-        let (io_buf, result) = rx.await.map_err(|_| Error::ReadFailed)?;
-        result?;
+            .map_err(|(_, err)| err)?;
 
         match original_bufs {
             None => Ok(io_buf.into()),
@@ -340,18 +330,9 @@ impl crate::Blob for Blob {
             return Ok(());
         }
 
-        let (tx, rx) = oneshot::channel();
-        self.io_submitter
-            .send(IoUringRequest::WriteAt(WriteAtRequest {
-                file: self.file.clone(),
-                offset,
-                bufs,
-                sender: tx,
-            }))
+        self.io_handle
+            .write_at(self.file.clone(), offset, bufs)
             .await
-            .map_err(|_| Error::WriteFailed)?;
-
-        rx.await.map_err(|_| Error::WriteFailed)?
     }
 
     // TODO: Make this async. See https://github.com/commonwarexyz/monorepo/issues/831
@@ -365,30 +346,10 @@ impl crate::Blob for Blob {
     }
 
     async fn sync(&self) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        self.io_submitter
-            .send(IoUringRequest::Sync(SyncRequest {
-                file: self.file.clone(),
-                sender: tx,
-            }))
+        self.io_handle
+            .sync(self.file.clone())
             .await
-            .map_err(|_| {
-                Error::BlobSyncFailed(
-                    self.partition.clone(),
-                    hex(&self.name),
-                    IoError::other("failed to send work"),
-                )
-            })?;
-
-        let result = rx.await.map_err(|_| {
-            Error::BlobSyncFailed(
-                self.partition.clone(),
-                hex(&self.name),
-                IoError::other("failed to read result"),
-            )
-        })?;
-
-        result.map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
+            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
     }
 }
 
@@ -822,14 +783,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_and_write_report_submitter_disconnect() {
+    async fn test_read_and_write_report_handle_disconnect() {
         // Verify read/write wrappers report channel disconnects before any work
         // reaches the io_uring loop.
         let storage_directory = create_test_directory();
         let path = storage_directory.join("disconnected");
         let file = File::create(&path).unwrap();
 
-        // Drop the loop immediately so the submitter behaves like a dead
+        // Drop the loop immediately so the handle behaves like a dead
         // backend while the blob handle still exists.
         let mut registry = Registry::default();
         let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut Registry::default());
@@ -867,14 +828,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_blob_sync_reports_submitter_disconnect() {
+    async fn test_blob_sync_reports_handle_disconnect() {
         // Verify the storage wrapper maps submission-channel disconnects to
         // `BlobSyncFailed(..., "failed to send work")`.
         let storage_directory = create_test_directory();
         let path = storage_directory.join("disconnected");
         let file = File::create(&path).unwrap();
 
-        // Construct a blob handle whose submitter has already lost its loop so
+        // Construct a blob handle whose handle has already lost its loop so
         // the wrapper must synthesize the disconnect error locally.
         let mut registry = Registry::default();
         let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut Registry::default());

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -396,8 +396,8 @@ impl crate::Blob for Blob {
 mod tests {
     use super::{Header, *};
     use crate::{
-        storage::tests::run_storage_tests, utils::thread, Blob as _, BufferPool, BufferPoolConfig, IoBufMut,
-        Storage as _,
+        storage::tests::run_storage_tests, utils::thread, Blob as _, BufferPool, BufferPoolConfig,
+        IoBufMut, Storage as _,
     };
     use std::{
         env,
@@ -747,6 +747,7 @@ mod tests {
             Config {
                 storage_directory: storage_root.clone(),
                 iouring_config: Default::default(),
+                thread_stack_size: utils::thread::system_thread_stack_size(),
             },
             &mut Registry::default(),
             pool,
@@ -779,6 +780,7 @@ mod tests {
             Config {
                 storage_directory: storage_directory.clone(),
                 iouring_config: Default::default(),
+                thread_stack_size: utils::thread::system_thread_stack_size(),
             },
             &mut Registry::default(),
             pool,

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -802,7 +802,10 @@ mod tests {
 
         // Each operation adds the runtime header size internally, so using the
         // maximum logical offset must fail before any request is submitted.
-        assert!(matches!(blob.read_at(u64::MAX, 1).await, Err(Error::OffsetOverflow)));
+        assert!(matches!(
+            blob.read_at(u64::MAX, 1).await,
+            Err(Error::OffsetOverflow)
+        ));
         assert!(matches!(
             blob.write_at(u64::MAX, b"x".to_vec()).await,
             Err(Error::OffsetOverflow)
@@ -879,7 +882,10 @@ mod tests {
 
         let blob = Blob::new("partition".into(), b"blob", file, submitter, pool);
         // Sync should fail through the blob-specific wrapper before any kernel work is attempted.
-        let err = blob.sync().await.expect_err("sync should fail without a loop");
+        let err = blob
+            .sync()
+            .await
+            .expect_err("sync should fail without a loop");
         assert!(matches!(
             err,
             Error::BlobSyncFailed(partition, name, inner)

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -56,8 +56,8 @@ fn sync_dir(path: &Path) -> Result<(), Error> {
     })
 }
 
-#[derive(Clone, Debug)]
 /// Configuration for a [Storage].
+#[derive(Clone, Debug)]
 pub struct Config {
     /// Where to store blobs.
     pub storage_directory: PathBuf,
@@ -254,6 +254,7 @@ impl Clone for Blob {
 }
 
 impl Blob {
+    /// Construct a blob handle around an already-open file and shared io_uring loop.
     fn new(
         partition: String,
         name: &[u8],

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -422,7 +422,7 @@ impl crate::Runner for Runner {
                     iouring_config: iouring::Config {
                         // TODO (#1045): make `IOURING_NETWORK_SIZE` configurable
                         size: IOURING_NETWORK_SIZE,
-                        max_op_timeout: self.cfg.network_cfg.read_write_timeout,
+                        max_request_timeout: self.cfg.network_cfg.read_write_timeout,
                         shutdown_timeout: Some(self.cfg.network_cfg.read_write_timeout),
                         ..Default::default()
                     },


### PR DESCRIPTION
Replaces the low-level `Op` (with `OpBuffer`/`OpFd`/`OpIovecs`) submission model with high-level request types (`Send`, `Recv`, `ReadAt`, `WriteAt`, `Sync`). Each request carries its own completion sender and is converted into an `ActiveRequest` state machine inside the loop. The active request owns all resources (buffers, FDs, progress cursors) and handles partial progress, retries, and result delivery internally. This moves the responsibility for building SQEs, interpreting CQE results, and tracking multi-SQE progress from the network/storage frontends into the loop, making the frontends simple one-shot submit-and-await calls.

Depends on #3284.
Related #3319 #2883.