### PR TITLE
Batch Verification of decryption in BTE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,8 +771,7 @@ dependencies = [
 [[package]]
 name = "blst"
 version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+source = "git+https://github.com/guruvamsi-policharla/blst#be004a31595e0ff2ff6b0b765298f69a493b043e"
 dependencies = [
  "cc",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ aws-sdk-ec2 = "1.200.0"
 aws-sdk-s3 = "1.91.0"
 axum = "0.8.1"
 blake3 = { version = "1.8.2", default-features = false }
-blst = { version = "0.3.13", default-features = false }
+blst = { git = "https://github.com/guruvamsi-policharla/blst", default-features = false }
 bytes = { version = "1.7.1", default-features = false }
 cfg-if = "1.0.0"
 chacha20poly1305 = { version = "0.10.1", default-features = false }

--- a/cryptography/src/bls12381/benches/bench.rs
+++ b/cryptography/src/bls12381/benches/bench.rs
@@ -17,6 +17,11 @@ mod signature_verification;
 mod threshold_batch_verify_same_message;
 mod threshold_batch_verify_same_message_precomputed;
 mod threshold_recover;
+mod bte_batch_verify;
+mod bte_breakdown;
+mod bte_decrypt_all;
+mod bte_encrypt;
+mod bte_partial_decrypt;
 mod tle_decrypt;
 mod tle_encrypt;
 
@@ -40,4 +45,9 @@ criterion_main!(
     threshold_batch_verify_same_message_precomputed::benches,
     tle_encrypt::benches,
     tle_decrypt::benches,
+    bte_encrypt::benches,
+    bte_partial_decrypt::benches,
+    bte_decrypt_all::benches,
+    bte_breakdown::benches,
+    bte_batch_verify::benches,
 );

--- a/cryptography/src/bls12381/benches/bte_batch_verify.rs
+++ b/cryptography/src/bls12381/benches/bte_batch_verify.rs
@@ -1,0 +1,68 @@
+use commonware_cryptography::bls12381::primitives::group::{Scalar, G1};
+use commonware_cryptography::bte::{
+    dealer::Dealer,
+    decryption::{aggregate_partial_decryptions, batch_verify, decrypt_all, SecretKey},
+    encryption::encrypt,
+    utils::Domain,
+};
+use commonware_math::algebra::{CryptoGroup, Random};
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{collections::BTreeMap, hint::black_box};
+
+fn bench_bte_batch_verify(c: &mut Criterion) {
+    let n = 1 << 4;
+    let t = n / 2 - 1;
+
+    for size in 2..=10 {
+        let batch_size = 1 << size;
+        let mut rng = StdRng::seed_from_u64(0);
+        let tx_domain = Domain::new(batch_size);
+
+        let mut dealer = Dealer::new(batch_size, n, t, &mut rng);
+        let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+
+        let msgs: Vec<[u8; 32]> = (0..batch_size)
+            .map(|i| {
+                let mut m = [0u8; 32];
+                m[0] = i as u8;
+                m
+            })
+            .collect();
+
+        let ct: Vec<_> = (0..batch_size)
+            .map(|i| encrypt(msgs[i], tx_domain.element(i), hid, &pk, &mut rng))
+            .collect();
+
+        let num_parties = n / 2;
+        let mut partial_decryptions = BTreeMap::new();
+        for i in 0..num_parties {
+            let sk = SecretKey::new(sk_shares[i].clone());
+            let pd = sk.partial_decrypt(&ct, hid, &crs);
+            partial_decryptions.insert(i + 1, pd);
+        }
+
+        let sigma = aggregate_partial_decryptions(&partial_decryptions);
+        let decrypted = decrypt_all(sigma, &ct, &crs);
+
+        // Sanity check
+        assert!(batch_verify(&ct, &decrypted, hid, &pk, &mut rng));
+
+        c.bench_function(
+            &format!("{}/batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(batch_verify(&ct, &decrypted, hid, &pk, &mut rng));
+                });
+            },
+        );
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_bte_batch_verify
+}

--- a/cryptography/src/bls12381/benches/bte_breakdown.rs
+++ b/cryptography/src/bls12381/benches/bte_breakdown.rs
@@ -1,0 +1,230 @@
+use commonware_cryptography::bls12381::primitives::group::{Scalar, G1, G2, GT};
+use commonware_cryptography::bte::{
+    dealer::Dealer,
+    decryption::{aggregate_partial_decryptions, batch_verify, decrypt_all, SecretKey},
+    encryption::encrypt,
+    utils::{open_all_values, Domain},
+};
+use commonware_math::algebra::{CryptoGroup, Random, Space};
+use commonware_parallel::Sequential;
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{collections::BTreeMap, hint::black_box};
+
+fn bench_bte_breakdown(c: &mut Criterion) {
+    let n = 1 << 4;
+    let t = n / 2 - 1;
+
+    for size in [6, 8, 10] {
+        let batch_size = 1 << size;
+        let mut rng = StdRng::seed_from_u64(0);
+        let tx_domain = Domain::new(batch_size);
+
+        let mut dealer = Dealer::new(batch_size, n, t, &mut rng);
+        let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+
+        let msgs: Vec<[u8; 32]> = (0..batch_size)
+            .map(|i| {
+                let mut m = [0u8; 32];
+                m[0] = i as u8;
+                m
+            })
+            .collect();
+
+        let ct: Vec<_> = (0..batch_size)
+            .map(|i| encrypt(msgs[i], tx_domain.element(i), hid, &pk, &mut rng))
+            .collect();
+
+        let fevals: Vec<Scalar> = (0..batch_size)
+            .map(|_| Scalar::random(&mut rng))
+            .collect();
+
+        let fcoeffs = tx_domain.ifft(&fevals);
+
+        let g1_points: Vec<G1> = (0..batch_size)
+            .map(|_| G1::generator() * &Scalar::random(&mut rng))
+            .collect();
+
+        let scalars: Vec<Scalar> = (0..batch_size)
+            .map(|_| Scalar::random(&mut rng))
+            .collect();
+
+        // --- 1. Scalar IFFT ---
+        c.bench_function(
+            &format!("{}/op=scalar_ifft batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(tx_domain.ifft(&fevals));
+                });
+            },
+        );
+
+        // --- 2. Scalar FFT ---
+        c.bench_function(
+            &format!("{}/op=scalar_fft batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(tx_domain.fft(&fcoeffs));
+                });
+            },
+        );
+
+        // --- 3. G1 FFT ---
+        c.bench_function(
+            &format!("{}/op=g1_fft batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(tx_domain.fft(&g1_points));
+                });
+            },
+        );
+
+        // --- 4. G1 IFFT ---
+        let g1_evals = tx_domain.fft(&g1_points);
+        c.bench_function(
+            &format!("{}/op=g1_ifft batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(tx_domain.ifft(&g1_evals));
+                });
+            },
+        );
+
+        // --- 5. G1 MSM ---
+        c.bench_function(
+            &format!("{}/op=g1_msm batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(G1::msm(&crs.powers_of_g, &fcoeffs, &Sequential));
+                });
+            },
+        );
+
+        // --- 6. Pointwise G1 * Scalar ---
+        c.bench_function(
+            &format!(
+                "{}/op=pointwise_g1_scalar batch_size={batch_size}",
+                module_path!()
+            ),
+            |b| {
+                b.iter(|| {
+                    let h: Vec<G1> = g1_points
+                        .iter()
+                        .zip(scalars.iter())
+                        .map(|(&gi, si)| gi * si)
+                        .collect();
+                    black_box(h);
+                });
+            },
+        );
+
+        // --- 7. open_all_values (FK22) ---
+        c.bench_function(
+            &format!("{}/op=open_all_values batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(open_all_values(&crs.y, &fcoeffs, &tx_domain));
+                });
+            },
+        );
+
+        // --- 8. Multi-pairing (2-way, single) ---
+        let g1a = G1::generator() * &Scalar::random(&mut rng);
+        let g1b = G1::generator() * &Scalar::random(&mut rng);
+        let g2a = G2::generator() * &Scalar::random(&mut rng);
+        let g2b = G2::generator() * &Scalar::random(&mut rng);
+        c.bench_function(
+            &format!("{}/op=multi_pairing_2way batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(GT::multi_pairing(&[(g1a, g2a), (g1b, g2b)]));
+                });
+            },
+        );
+
+        // --- 9. Multi-pairing loop (batch_size pairings, as in decrypt_all) ---
+        c.bench_function(
+            &format!(
+                "{}/op=pairing_loop batch_size={batch_size}",
+                module_path!()
+            ),
+            |b| {
+                let pairs: Vec<_> = (0..batch_size)
+                    .map(|_| {
+                        (
+                            G1::generator() * &Scalar::random(&mut rng),
+                            G2::generator() * &Scalar::random(&mut rng),
+                            G1::generator() * &Scalar::random(&mut rng),
+                            G2::generator() * &Scalar::random(&mut rng),
+                        )
+                    })
+                    .collect();
+                b.iter(|| {
+                    for (g1a, g2a, g1b, g2b) in &pairs {
+                        black_box(GT::multi_pairing(&[(*g1a, *g2a), (*g1b, *g2b)]));
+                    }
+                });
+            },
+        );
+
+        // --- 10. Single G1 scalar mul ---
+        let g1_point = G1::generator() * &Scalar::random(&mut rng);
+        let scalar = Scalar::random(&mut rng);
+        c.bench_function(
+            &format!("{}/op=g1_scalar_mul batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(g1_point * &scalar);
+                });
+            },
+        );
+
+        // --- 11. Single G2 scalar mul ---
+        let g2_point = G2::generator() * &Scalar::random(&mut rng);
+        c.bench_function(
+            &format!("{}/op=g2_scalar_mul batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(g2_point * &scalar);
+                });
+            },
+        );
+
+        // --- 12. Full decrypt_all ---
+        let num_parties = n / 2;
+        let mut partial_decryptions = BTreeMap::new();
+        for i in 0..num_parties {
+            let sk = SecretKey::new(sk_shares[i].clone());
+            let pd = sk.partial_decrypt(&ct, hid, &crs);
+            partial_decryptions.insert(i + 1, pd);
+        }
+        let sigma = aggregate_partial_decryptions(&partial_decryptions);
+
+        c.bench_function(
+            &format!("{}/op=full_decrypt_all batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(decrypt_all(sigma, &ct, &crs));
+                });
+            },
+        );
+
+        // --- 13. Batch verify ---
+        let decrypted = decrypt_all(sigma, &ct, &crs);
+        c.bench_function(
+            &format!("{}/op=batch_verify batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(batch_verify(&ct, &decrypted, hid, &pk, &mut rng));
+                });
+            },
+        );
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_bte_breakdown
+}

--- a/cryptography/src/bls12381/benches/bte_decrypt_all.rs
+++ b/cryptography/src/bls12381/benches/bte_decrypt_all.rs
@@ -1,0 +1,73 @@
+use commonware_cryptography::bls12381::primitives::group::{Scalar, G1};
+use commonware_cryptography::bte::{
+    dealer::Dealer,
+    decryption::{aggregate_partial_decryptions, decrypt_all, SecretKey},
+    encryption::encrypt,
+    utils::Domain,
+};
+use commonware_math::algebra::{CryptoGroup, Random};
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{collections::BTreeMap, hint::black_box};
+
+fn bench_bte_decrypt_all(c: &mut Criterion) {
+    let n = 1 << 4;
+    let t = n / 2 - 1;
+
+    for size in 2..=10 {
+        let batch_size = 1 << size;
+        let mut rng = StdRng::seed_from_u64(0);
+        let tx_domain = Domain::new(batch_size);
+
+        let mut dealer = Dealer::new(batch_size, n, t, &mut rng);
+        let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+
+        let msgs: Vec<[u8; 32]> = (0..batch_size)
+            .map(|i| {
+                let mut m = [0u8; 32];
+                m[0] = i as u8;
+                m
+            })
+            .collect();
+
+        let ct: Vec<_> = (0..batch_size)
+            .map(|i| {
+                let x = tx_domain.element(i);
+                encrypt(msgs[i], x, hid, &pk, &mut rng)
+            })
+            .collect();
+
+        let num_parties = n / 2;
+        let mut partial_decryptions = BTreeMap::new();
+        for i in 0..num_parties {
+            let sk = SecretKey::new(sk_shares[i].clone());
+            let pd = sk.partial_decrypt(&ct, hid, &crs);
+            partial_decryptions.insert(i + 1, pd);
+        }
+
+        // Verify correctness once outside the benchmark
+        let sigma = aggregate_partial_decryptions(&partial_decryptions);
+        let decrypted = decrypt_all(sigma, &ct, &crs);
+        for i in 0..batch_size {
+            assert_eq!(decrypted[i].msg, msgs[i], "decryption mismatch at index {i}");
+        }
+
+        c.bench_function(
+            &format!("{}/batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    let sigma = aggregate_partial_decryptions(&partial_decryptions);
+                    black_box(decrypt_all(sigma, &ct, &crs));
+                });
+            },
+        );
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = bench_bte_decrypt_all
+}

--- a/cryptography/src/bls12381/benches/bte_encrypt.rs
+++ b/cryptography/src/bls12381/benches/bte_encrypt.rs
@@ -1,0 +1,39 @@
+use commonware_cryptography::bls12381::primitives::group::{Scalar, G1};
+use commonware_cryptography::bte::{dealer::Dealer, encryption::encrypt, utils::Domain};
+use commonware_math::algebra::{CryptoGroup, Random};
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, SeedableRng};
+use std::hint::black_box;
+
+fn bench_bte_encrypt(c: &mut Criterion) {
+    let n = 1 << 4;
+    let t = n / 2 - 1;
+
+    for size in 2..=5 {
+        let batch_size = 1 << size;
+        let mut rng = StdRng::seed_from_u64(0);
+        let tx_domain = Domain::new(batch_size);
+
+        let mut dealer = Dealer::new(batch_size, n, t, &mut rng);
+        let (_, pk, _) = dealer.setup(&mut rng);
+
+        let msg = [1u8; 32];
+        let x = tx_domain.group_gen();
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+
+        c.bench_function(
+            &format!("{}/batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(encrypt(msg, x.clone(), hid, &pk, &mut rng));
+                });
+            },
+        );
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = bench_bte_encrypt
+}

--- a/cryptography/src/bls12381/benches/bte_partial_decrypt.rs
+++ b/cryptography/src/bls12381/benches/bte_partial_decrypt.rs
@@ -1,0 +1,52 @@
+use commonware_cryptography::bls12381::primitives::group::{Scalar, G1};
+use commonware_cryptography::bte::{
+    dealer::Dealer,
+    decryption::SecretKey,
+    encryption::encrypt,
+    utils::Domain,
+};
+use commonware_math::algebra::{CryptoGroup, Random};
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, SeedableRng};
+use std::hint::black_box;
+
+fn bench_bte_partial_decrypt(c: &mut Criterion) {
+    let n = 1 << 4;
+    let t = n / 2 - 1;
+
+    for size in 2..=10 {
+        let batch_size = 1 << size;
+        let mut rng = StdRng::seed_from_u64(0);
+        let tx_domain = Domain::new(batch_size);
+
+        let mut dealer = Dealer::new(batch_size, n, t, &mut rng);
+        let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+
+        let ct: Vec<_> = (0..batch_size)
+            .map(|i| {
+                let msg = [i as u8; 32];
+                let x = tx_domain.element(i);
+                encrypt(msg, x, hid, &pk, &mut rng)
+            })
+            .collect();
+
+        let secret_key = SecretKey::new(sk_shares[0].clone());
+
+        c.bench_function(
+            &format!("{}/batch_size={batch_size}", module_path!()),
+            |b| {
+                b.iter(|| {
+                    black_box(secret_key.partial_decrypt(&ct, hid, &crs));
+                });
+            },
+        );
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = bench_bte_partial_decrypt
+}

--- a/cryptography/src/bls12381/benches/msm.rs
+++ b/cryptography/src/bls12381/benches/msm.rs
@@ -1,4 +1,7 @@
-use commonware_cryptography::bls12381::primitives::group::{Scalar, G1, G2};
+use commonware_cryptography::bls12381::primitives::{
+    group::{Scalar, G1, G2, GT},
+    variant::{MinPk, Variant},
+};
 use commonware_math::algebra::{CryptoGroup, Random, Space};
 use commonware_parallel::{Rayon, Sequential};
 use criterion::{criterion_group, BatchSize, Criterion};
@@ -84,6 +87,26 @@ fn bench_msm(c: &mut Criterion) {
                         (points, scalars)
                     },
                     |(points, scalars)| black_box(G2::msm(&points, &scalars, &par)),
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        // GT Sequential (conc=1)
+        c.bench_function(
+            &format!("{}/group=gt n={} conc=1", module_path!(), n),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let mut rng = StdRng::seed_from_u64(0);
+                        let gt_gen = MinPk::pairing(&G1::generator(), &G2::generator());
+                        let points: Vec<GT> =
+                            (0..n).map(|_| gt_gen * &Scalar::random(&mut rng)).collect();
+                        let scalars: Vec<Scalar> =
+                            (0..n).map(|_| Scalar::random(&mut rng)).collect();
+                        (points, scalars)
+                    },
+                    |(points, scalars)| black_box(GT::msm(&points, &scalars, &Sequential)),
                     BatchSize::SmallInput,
                 );
             },

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -502,11 +502,13 @@ impl GT {
     /// subgroup (i.e. pairing outputs).
     pub fn scalar_mul(&self, scalar: &Scalar) -> GT {
         let s = scalar.as_blst_scalar();
-        // blst_scalar.b is little-endian
-        let bytes = &s.b;
+        self.scalar_mul_bytes(&s.b)
+    }
 
+    /// Double-and-add over little-endian scalar bytes.
+    fn scalar_mul_bytes(&self, bytes: &[u8]) -> GT {
         // Find the highest set bit
-        let mut top_byte = SCALAR_LENGTH - 1;
+        let mut top_byte = bytes.len() - 1;
         while top_byte > 0 && bytes[top_byte] == 0 {
             top_byte -= 1;
         }
@@ -515,7 +517,7 @@ impl GT {
         }
         let top_bit = 7 - bytes[top_byte].leading_zeros() as usize;
 
-        // Square-and-multiply (MSB to LSB)
+        // Double-and-add (MSB to LSB)
         let mut acc = self.0;
         let base = &self.0;
         let mut started = false;
@@ -588,6 +590,33 @@ impl GT {
         }
         GT(result)
     }
+
+    /// Shared MSM logic: filters identity points and zero scalars, then
+    /// delegates to Pippenger.
+    fn msm_inner<'a>(
+        points: impl Iterator<Item = (&'a Self, &'a [u8])>,
+        nbits: usize,
+    ) -> Self {
+        let nbytes = nbits.div_ceil(8);
+        let (points_filtered, flat_scalars): (Vec<_>, Vec<u8>) = points
+            .filter(|(point, scalar)| {
+                !point.is_identity() && !bool::from(all_zero(&scalar[..nbytes]))
+            })
+            .fold(
+                (Vec::new(), Vec::new()),
+                |(mut pts, mut scs), (point, scalar)| {
+                    pts.push(*point);
+                    scs.extend_from_slice(&scalar[..nbytes]);
+                    (pts, scs)
+                },
+            );
+
+        if points_filtered.is_empty() {
+            return Self::zero();
+        }
+
+        Self::msm_sequential(&points_filtered, &flat_scalars, nbits)
+    }
 }
 
 // GT is treated as an additive group (matching G1/G2). The underlying fp12
@@ -653,44 +682,47 @@ impl<'a> MulAssign<&'a Scalar> for GT {
 impl<'a> Mul<&'a Scalar> for GT {
     type Output = Self;
 
-    fn mul(self, rhs: &'a Scalar) -> Self::Output {
-        self.scalar_mul(rhs)
+    fn mul(mut self, rhs: &'a Scalar) -> Self::Output {
+        self *= rhs;
+        self
+    }
+}
+
+impl<'a> MulAssign<&'a SmallScalar> for GT {
+    fn mul_assign(&mut self, rhs: &'a SmallScalar) {
+        *self = self.scalar_mul_bytes(rhs.as_bytes());
+    }
+}
+
+impl<'a> Mul<&'a SmallScalar> for GT {
+    type Output = Self;
+
+    fn mul(mut self, rhs: &'a SmallScalar) -> Self::Output {
+        self *= rhs;
+        self
     }
 }
 
 impl Space<Scalar> for GT {
     fn msm(points: &[Self], scalars: &[Scalar], _strategy: &impl Strategy) -> Self {
         assert_eq!(points.len(), scalars.len(), "mismatched lengths");
-        let n = points.len();
-        if n == 0 {
-            return Self::zero();
-        }
-
-        // Filter out identity points and zero scalars
         let scalar_bytes: Vec<_> = scalars.iter().map(|s| s.as_blst_scalar()).collect();
-        let (points_filtered, scalars_filtered): (Vec<_>, Vec<_>) = points
-            .iter()
-            .zip(scalar_bytes.iter())
-            .filter_map(|(point, scalar)| {
-                if point.is_identity() || all_zero(&scalar.b).into() {
-                    return None;
-                }
-                Some((*point, scalar))
-            })
-            .unzip();
+        Self::msm_inner(
+            points
+                .iter()
+                .zip(scalar_bytes.iter().map(|s| s.b.as_slice())),
+            SCALAR_BITS,
+        )
+    }
+}
 
-        if points_filtered.is_empty() {
-            return Self::zero();
-        }
-
-        // Flatten scalars into contiguous byte array
-        let nbytes = SCALAR_BITS.div_ceil(8);
-        let flat_scalars: Vec<u8> = scalars_filtered
-            .iter()
-            .flat_map(|s| s.b[..nbytes].iter().copied())
-            .collect();
-
-        Self::msm_sequential(&points_filtered, &flat_scalars, SCALAR_BITS)
+impl Space<SmallScalar> for GT {
+    fn msm(points: &[Self], scalars: &[SmallScalar], _strategy: &impl Strategy) -> Self {
+        assert_eq!(points.len(), scalars.len(), "mismatched lengths");
+        Self::msm_inner(
+            points.iter().zip(scalars.iter().map(|s| s.as_bytes())),
+            SMALL_SCALAR_BITS,
+        )
     }
 }
 
@@ -2373,7 +2405,8 @@ mod tests {
         assert_eq!(msm_result, naive_result, "GT MSM != naive");
 
         // Empty MSM should be identity
-        let empty_result = GT::msm(&[], &[], &Sequential);
+        let empty_scalars: &[Scalar] = &[];
+        let empty_result = GT::msm(&[], empty_scalars, &Sequential);
         assert_eq!(empty_result, GT::zero(), "empty GT MSM should be zero");
 
         // Single element

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -980,6 +980,31 @@ impl From<u64> for Scalar {
     }
 }
 
+impl From<SmallScalar> for Scalar {
+    fn from(small: SmallScalar) -> Self {
+        let mut fr = blst_fr::default();
+        // SAFETY: blst_fr_from_scalar reads a valid blst_scalar.
+        unsafe {
+            blst_fr_from_scalar(&mut fr, &small.inner);
+        }
+        Self(fr)
+    }
+}
+
+impl<'a, 'b> Mul<&'a Scalar> for &'b SmallScalar {
+    type Output = Scalar;
+
+    fn mul(self, rhs: &'a Scalar) -> Scalar {
+        let mut fr = blst_fr::default();
+        // SAFETY: blst_fr_from_scalar reads a valid blst_scalar.
+        unsafe {
+            blst_fr_from_scalar(&mut fr, &self.inner);
+        }
+        let lhs = Scalar(fr);
+        lhs * rhs
+    }
+}
+
 impl<'a> AddAssign<&'a Self> for Scalar {
     fn add_assign(&mut self, rhs: &'a Self) {
         let ptr = &raw mut self.0;

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -15,7 +15,10 @@ use crate::Secret;
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use blst::{
-    blst_bendian_from_fp12, blst_bendian_from_scalar, blst_expand_message_xmd, blst_fp12, blst_fr,
+    blst_bendian_from_fp12, blst_bendian_from_scalar, blst_expand_message_xmd, blst_final_exp,
+    blst_fp12, blst_fp12_conjugate, blst_fp12_cyclotomic_sqr, blst_fp12_is_one,
+    blst_fp12_mul, blst_fp12_one, blst_fp12s_mult_pippenger, blst_miller_loop,
+    blst_fp12s_mult_pippenger_scratch_sizeof, blst_fr,
     blst_fr_add, blst_fr_cneg, blst_fr_from_scalar, blst_fr_from_uint64, blst_fr_inverse,
     blst_fr_mul, blst_fr_rshift, blst_fr_sub, blst_hash_to_g1, blst_hash_to_g2, blst_keygen,
     blst_p1, blst_p1_add_or_double, blst_p1_affine, blst_p1_cneg, blst_p1_compress, blst_p1_double,
@@ -428,9 +431,114 @@ pub struct GT(blst_fp12);
 pub const GT_ELEMENT_BYTE_LENGTH: usize = 576;
 
 impl GT {
-    /// Create GT from blst_fp12.
-    pub(crate) const fn from_blst_fp12(fp12: blst_fp12) -> Self {
-        Self(fp12)
+    /// Compute the pairing e(g1, g2).
+    pub fn pairing(g1: &G1, g2: &G2) -> Self {
+        let p1_affine = g1.as_blst_p1_affine();
+        let p2_affine = g2.as_blst_p2_affine();
+
+        let mut result = blst_fp12::default();
+        let ptr = &raw mut result;
+        // SAFETY: blst_final_exp supports in-place (ret==f). Raw pointer avoids aliased refs.
+        unsafe {
+            blst_miller_loop(ptr, &p2_affine, &p1_affine);
+            blst_final_exp(ptr, ptr);
+        }
+
+        Self(result)
+    }
+
+    /// Compute the sum of multiple pairings: sum(e(g1_i, g2_i)).
+    ///
+    /// Uses a single final exponentiation for efficiency.
+    pub fn multi_pairing(pairs: &[(G1, G2)]) -> Self {
+        assert!(!pairs.is_empty());
+
+        let mut acc = blst_fp12::default();
+        let acc_ptr = &raw mut acc;
+
+        let p1_affine = pairs[0].0.as_blst_p1_affine();
+        let p2_affine = pairs[0].1.as_blst_p2_affine();
+        // SAFETY: Valid affine points; miller_loop writes to acc_ptr.
+        unsafe {
+            blst_miller_loop(acc_ptr, &p2_affine, &p1_affine);
+        }
+
+        for &(ref g1, ref g2) in &pairs[1..] {
+            let p1_affine = g1.as_blst_p1_affine();
+            let p2_affine = g2.as_blst_p2_affine();
+            let mut tmp = blst_fp12::default();
+            // SAFETY: Valid affine points; miller_loop writes to tmp. blst_fp12_mul supports
+            // in-place (ret==a).
+            unsafe {
+                blst_miller_loop(&mut tmp, &p2_affine, &p1_affine);
+                blst_fp12_mul(acc_ptr, acc_ptr, &tmp);
+            }
+        }
+
+        // SAFETY: blst_final_exp supports in-place (ret==f).
+        unsafe {
+            blst_final_exp(acc_ptr, acc_ptr);
+        }
+
+        Self(acc)
+    }
+
+    /// Returns the identity element in GT.
+    fn identity() -> GT {
+        // SAFETY: blst_fp12_one returns a valid pointer to the constant identity element.
+        GT(unsafe { *blst_fp12_one() })
+    }
+
+    /// Returns true if this element is the identity.
+    fn is_identity(&self) -> bool {
+        // SAFETY: blst_fp12_is_one reads from a valid blst_fp12.
+        unsafe { blst_fp12_is_one(&self.0) }
+    }
+
+    /// Computes scalar * self using double-and-add.
+    ///
+    /// Uses cyclotomic squaring (doubling in additive notation), which is
+    /// faster than general fp12 squaring for elements in the cyclotomic
+    /// subgroup (i.e. pairing outputs).
+    pub fn scalar_mul(&self, scalar: &Scalar) -> GT {
+        let s = scalar.as_blst_scalar();
+        // blst_scalar.b is little-endian
+        let bytes = &s.b;
+
+        // Find the highest set bit
+        let mut top_byte = SCALAR_LENGTH - 1;
+        while top_byte > 0 && bytes[top_byte] == 0 {
+            top_byte -= 1;
+        }
+        if bytes[top_byte] == 0 {
+            return GT::identity();
+        }
+        let top_bit = 7 - bytes[top_byte].leading_zeros() as usize;
+
+        // Square-and-multiply (MSB to LSB)
+        let mut acc = self.0;
+        let base = &self.0;
+        let mut started = false;
+        for byte_idx in (0..=top_byte).rev() {
+            let b = bytes[byte_idx];
+            let bit_start = if byte_idx == top_byte { top_bit } else { 7 };
+            for bit in (0..=bit_start).rev() {
+                if started {
+                    // SAFETY: blst_fp12_cyclotomic_sqr supports in-place operation.
+                    unsafe { blst_fp12_cyclotomic_sqr(&mut acc, &acc) };
+                }
+                if (b >> bit) & 1 == 1 {
+                    if started {
+                        // SAFETY: blst_fp12_mul supports in-place when ret aliases a.
+                        unsafe { blst_fp12_mul(&mut acc, &acc, base) };
+                    } else {
+                        started = true;
+                    }
+                }
+            }
+        }
+
+        if started { GT(acc) } else { GT::identity() }
     }
 
     /// Converts the GT element to its canonical big-endian byte representation.
@@ -442,6 +550,147 @@ impl GT {
             blst_bendian_from_fp12(slice.as_mut_ptr(), &self.0);
         }
         slice
+    }
+
+    /// Computes the conjugate of this GT element (negation in the
+    /// cyclotomic subgroup).
+    fn conjugate(&self) -> GT {
+        let mut out = self.0;
+        // SAFETY: blst_fp12_conjugate operates in-place on a valid blst_fp12.
+        unsafe {
+            blst_fp12_conjugate(&mut out);
+        }
+        GT(out)
+    }
+
+    fn msm_sequential(points: &[Self], scalars: &[u8], nbits: usize) -> Self {
+        let npoints = points.len();
+
+        // SAFETY: blst_fp12s_mult_pippenger_scratch_sizeof returns size in bytes.
+        let scratch_size = unsafe { blst_fp12s_mult_pippenger_scratch_sizeof(npoints) };
+        assert_eq!(scratch_size % 8, 0, "scratch_size must be multiple of 8");
+        let mut scratch = vec![0u64; scratch_size / 8];
+
+        let p: [*const blst_fp12; 2] = [&points[0].0 as *const _, ptr::null()];
+        let s: [*const u8; 2] = [scalars.as_ptr(), ptr::null()];
+
+        let mut result = blst_fp12::default();
+        // SAFETY: All pointer arrays are valid and point to data that outlives this call.
+        unsafe {
+            blst_fp12s_mult_pippenger(
+                &mut result,
+                p.as_ptr(),
+                npoints,
+                s.as_ptr(),
+                nbits,
+                scratch.as_mut_ptr(),
+            );
+        }
+        GT(result)
+    }
+}
+
+// GT is treated as an additive group (matching G1/G2). The underlying fp12
+// multiplication is the group operation (+), the fp12 unit is the identity
+// (zero), and conjugation is negation.
+
+impl Object for GT {}
+
+impl AddAssign<&GT> for GT {
+    fn add_assign(&mut self, rhs: &GT) {
+        // SAFETY: blst_fp12_mul supports in-place when ret aliases a.
+        unsafe {
+            blst_fp12_mul(&mut self.0, &self.0, &rhs.0);
+        }
+    }
+}
+
+impl Add<&GT> for GT {
+    type Output = GT;
+
+    fn add(mut self, rhs: &GT) -> GT {
+        self += rhs;
+        self
+    }
+}
+
+impl SubAssign<&GT> for GT {
+    fn sub_assign(&mut self, rhs: &GT) {
+        let inv = rhs.conjugate();
+        *self += &inv;
+    }
+}
+
+impl Sub<&GT> for GT {
+    type Output = GT;
+
+    fn sub(mut self, rhs: &GT) -> GT {
+        self -= rhs;
+        self
+    }
+}
+
+impl Neg for GT {
+    type Output = GT;
+
+    fn neg(self) -> GT {
+        self.conjugate()
+    }
+}
+
+impl Additive for GT {
+    fn zero() -> Self {
+        GT::identity()
+    }
+}
+
+impl<'a> MulAssign<&'a Scalar> for GT {
+    fn mul_assign(&mut self, rhs: &'a Scalar) {
+        *self = self.scalar_mul(rhs);
+    }
+}
+
+impl<'a> Mul<&'a Scalar> for GT {
+    type Output = Self;
+
+    fn mul(self, rhs: &'a Scalar) -> Self::Output {
+        self.scalar_mul(rhs)
+    }
+}
+
+impl Space<Scalar> for GT {
+    fn msm(points: &[Self], scalars: &[Scalar], _strategy: &impl Strategy) -> Self {
+        assert_eq!(points.len(), scalars.len(), "mismatched lengths");
+        let n = points.len();
+        if n == 0 {
+            return Self::zero();
+        }
+
+        // Filter out identity points and zero scalars
+        let scalar_bytes: Vec<_> = scalars.iter().map(|s| s.as_blst_scalar()).collect();
+        let (points_filtered, scalars_filtered): (Vec<_>, Vec<_>) = points
+            .iter()
+            .zip(scalar_bytes.iter())
+            .filter_map(|(point, scalar)| {
+                if point.is_identity() || all_zero(&scalar.b).into() {
+                    return None;
+                }
+                Some((*point, scalar))
+            })
+            .unzip();
+
+        if points_filtered.is_empty() {
+            return Self::zero();
+        }
+
+        // Flatten scalars into contiguous byte array
+        let nbytes = SCALAR_BITS.div_ceil(8);
+        let flat_scalars: Vec<u8> = scalars_filtered
+            .iter()
+            .flat_map(|s| s.b[..nbytes].iter().copied())
+            .collect();
+
+        Self::msm_sequential(&points_filtered, &flat_scalars, SCALAR_BITS)
     }
 }
 
@@ -2042,6 +2291,118 @@ mod tests {
         let expected_g2 = naive_msm(&points_g2, &scalars);
         let result_g2 = G2::msm(&points_g2, &scalars, &Sequential);
         assert_eq!(expected_g2, result_g2, "G2 MSM basic case failed");
+    }
+
+    #[test]
+    fn test_gt_pairing_bilinearity() {
+        let mut rng = test_rng();
+        let a = Scalar::random(&mut rng);
+        let b = Scalar::random(&mut rng);
+
+        let g1 = G1::generator();
+        let g2 = G2::generator();
+
+        // e(aG1, bG2) should equal e(G1, G2)^(ab)
+        let lhs = GT::pairing(&(g1 * &a), &(g2 * &b));
+        let e = GT::pairing(&g1, &g2);
+        let mut ab = a.clone();
+        ab *= &b;
+        let rhs = e.scalar_mul(&ab);
+        assert_eq!(lhs, rhs, "pairing bilinearity failed");
+
+        // e(abG1, G2) should also equal e(G1, G2)^(ab)
+        let lhs2 = GT::pairing(&(g1 * &ab), &g2);
+        assert_eq!(lhs2, rhs, "pairing bilinearity (left) failed");
+
+        // e(G1, abG2) should also equal e(G1, G2)^(ab)
+        let lhs3 = GT::pairing(&g1, &(g2 * &ab));
+        assert_eq!(lhs3, rhs, "pairing bilinearity (right) failed");
+    }
+
+    #[test]
+    fn test_gt_scalar_mul() {
+        let g1 = G1::generator();
+        let g2 = G2::generator();
+        let e = GT::pairing(&g1, &g2);
+
+        // e^5 via scalar_mul should equal e+e+e+e+e via repeated addition
+        let five = Scalar::from_u64(5);
+        let result = e.scalar_mul(&five);
+        let mut acc = GT::zero();
+        for _ in 0..5 {
+            acc += &e;
+        }
+        assert_eq!(result, acc, "scalar_mul(5) != 5 additions");
+
+        // e * 0 should be zero (identity)
+        let zero = Scalar::zero();
+        assert_eq!(e.scalar_mul(&zero), GT::zero(), "scalar_mul(0) != zero");
+
+        // e * 1 should be e
+        let one = Scalar::from_u64(1);
+        assert_eq!(e.scalar_mul(&one), e, "scalar_mul(1) != e");
+    }
+
+    #[test]
+    fn test_gt_conjugate() {
+        let mut rng = test_rng();
+        let a = Scalar::random(&mut rng);
+        let e = GT::pairing(&(G1::generator() * &a), &G2::generator());
+
+        // e + (-e) should be one (identity)
+        let neg_e = -e;
+        let sum = e + &neg_e;
+        assert_eq!(sum, GT::zero(), "e + (-e) should be zero");
+
+        // Double negation
+        assert_eq!(-(-e), e, "double negation should be identity");
+    }
+
+    #[test]
+    fn test_gt_msm() {
+        let mut rng = test_rng();
+        let e = GT::pairing(&G1::generator(), &G2::generator());
+        let n = 10;
+
+        let points: Vec<GT> = (0..n).map(|_| e * &Scalar::random(&mut rng)).collect();
+        let scalars: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
+
+        // MSM should equal naive accumulation
+        let msm_result = GT::msm(&points, &scalars, &Sequential);
+        let naive_result = naive_msm(&points, &scalars);
+        assert_eq!(msm_result, naive_result, "GT MSM != naive");
+
+        // Empty MSM should be identity
+        let empty_result = GT::msm(&[], &[], &Sequential);
+        assert_eq!(empty_result, GT::zero(), "empty GT MSM should be zero");
+
+        // Single element
+        let single_result = GT::msm(&[points[0]], &[scalars[0].clone()], &Sequential);
+        assert_eq!(
+            single_result,
+            points[0] * &scalars[0],
+            "single GT MSM failed"
+        );
+    }
+
+    #[test]
+    fn test_gt_multi_pairing() {
+        let mut rng = test_rng();
+        let g1 = G1::generator();
+        let g2 = G2::generator();
+
+        let a = Scalar::random(&mut rng);
+        let b = Scalar::random(&mut rng);
+
+        let p1 = g1 * &a;
+        let p2 = g1 * &b;
+        let q1 = g2 * &Scalar::random(&mut rng);
+        let q2 = g2 * &Scalar::random(&mut rng);
+
+        // multi_pairing should equal sum of individual pairings
+        let multi = GT::multi_pairing(&[(p1, q1), (p2, q2)]);
+        let individual = GT::pairing(&p1, &q1) + &GT::pairing(&p2, &q2);
+        assert_eq!(multi, individual, "multi_pairing != sum of pairings");
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/variant.rs
+++ b/cryptography/src/bls12381/primitives/variant.rs
@@ -9,7 +9,6 @@ use super::{
 };
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use blst::{blst_final_exp, blst_fp12, blst_miller_loop};
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Error as CodecError, FixedSize, Read, ReadExt as _, Write};
 use commonware_math::algebra::{CryptoGroup, HashToGroup, Space};
@@ -150,18 +149,7 @@ impl Variant for MinPk {
 
     /// Compute the pairing `e(public, signature) -> GT`.
     fn pairing(public: &Self::Public, signature: &Self::Signature) -> GT {
-        let p1_affine = public.as_blst_p1_affine();
-        let p2_affine = signature.as_blst_p2_affine();
-
-        let mut result = blst_fp12::default();
-        let ptr = &raw mut result;
-        // SAFETY: blst_final_exp supports in-place (ret==f). Raw pointer avoids aliased refs.
-        unsafe {
-            blst_miller_loop(ptr, &p2_affine, &p1_affine);
-            blst_final_exp(ptr, ptr);
-        }
-
-        GT::from_blst_fp12(result)
+        GT::pairing(public, signature)
     }
 }
 
@@ -252,18 +240,7 @@ impl Variant for MinSig {
 
     /// Compute the pairing `e(signature, public) -> GT`.
     fn pairing(public: &Self::Public, signature: &Self::Signature) -> GT {
-        let p1_affine = signature.as_blst_p1_affine();
-        let p2_affine = public.as_blst_p2_affine();
-
-        let mut result = blst_fp12::default();
-        let ptr = &raw mut result;
-        // SAFETY: blst_final_exp supports in-place (ret==f). Raw pointer avoids aliased refs.
-        unsafe {
-            blst_miller_loop(ptr, &p2_affine, &p1_affine);
-            blst_final_exp(ptr, ptr);
-        }
-
-        GT::from_blst_fp12(result)
+        GT::pairing(signature, public)
     }
 }
 

--- a/cryptography/src/bte/dealer.rs
+++ b/cryptography/src/bte/dealer.rs
@@ -1,0 +1,156 @@
+use crate::bls12381::primitives::group::{Scalar, G1, G2};
+use commonware_math::algebra::{Additive, CryptoGroup, Random, Ring};
+use rand_core::CryptoRngCore;
+use std::iter;
+
+use super::utils::{lagrange_interp_eval, Domain};
+
+/// Common Reference String (KZG parameters) for batch threshold encryption.
+///
+/// Reusable across different committees/public keys.
+#[derive(Clone)]
+pub struct CRS {
+    /// Powers of g in G1: [g, g*tau, g*tau^2, ...].
+    pub powers_of_g: Vec<G1>,
+    /// h * tau in G2.
+    pub htau: G2,
+    /// Preprocessed Toeplitz matrix for FK22 amortized KZG openings.
+    pub y: Vec<G1>,
+}
+
+/// Committee public key for batch threshold encryption.
+///
+/// Derived from a committee secret key `sk` and the KZG trapdoor `tau`.
+#[derive(Clone, Copy)]
+pub struct PublicKey {
+    /// [sk]_2 = h * sk.
+    pub hsk: G2,
+    /// [sk*tau]_2 = h * (sk * tau).
+    pub hsk_tau: G2,
+}
+
+/// Dealer sets up the CRS and distributes secret shares.
+///
+/// Assumes the shares are evaluated at points (1..=n) and the secret key
+/// is stored at the evaluation point 0.
+#[derive(Clone)]
+pub struct Dealer {
+    batch_size: usize,
+    n: usize,
+    t: usize, // t+1 parties need to agree to decrypt
+    sk: Scalar,
+}
+
+impl Dealer {
+    pub fn new(batch_size: usize, n: usize, t: usize, rng: &mut impl CryptoRngCore) -> Self {
+        Self {
+            batch_size,
+            n,
+            t,
+            sk: Scalar::random(&mut *rng),
+        }
+    }
+
+    pub fn get_pk(&self) -> G2 {
+        G2::generator() * &self.sk
+    }
+
+    pub fn setup(&mut self, rng: &mut impl CryptoRngCore) -> (CRS, PublicKey, Vec<Scalar>) {
+        // Sample tau and compute its powers
+        let tau = Scalar::random(&mut *rng);
+        let powers_of_tau: Vec<Scalar> =
+            iter::successors(Some(Scalar::one()), |p| Some(p.clone() * &tau))
+                .take(self.batch_size)
+                .collect();
+
+        // Generators
+        let g = G1::generator();
+        let h = G2::generator();
+
+        // Compute powers of g: [g*tau^0, g*tau^1, ...]
+        let powers_of_g: Vec<G1> = powers_of_tau.iter().map(|t| g * t).collect();
+
+        // Compute the Toeplitz matrix preprocessing for FK22
+        let mut top_tau = powers_of_tau.clone();
+        top_tau.truncate(self.batch_size);
+        top_tau.reverse();
+        top_tau.resize(2 * self.batch_size, Scalar::zero());
+
+        let top_domain = Domain::new(2 * self.batch_size);
+        let top_tau = top_domain.fft(&top_tau);
+
+        // Compute y = g * top_tau[i] for each i
+        let y: Vec<G1> = top_tau.iter().map(|t| g * t).collect();
+
+        // Generate secret sharing polynomial: sk_poly[0] = sk, rest random
+        let mut sk_poly = vec![Scalar::zero(); self.t + 1];
+        sk_poly[0] = self.sk.clone();
+        for i in 1..self.t {
+            sk_poly[i] = Scalar::random(&mut *rng);
+        }
+
+        // Evaluate at share points (1..=n)
+        let share_domain: Vec<Scalar> = (1..=self.n)
+            .map(|i| Scalar::from_u64(i as u64))
+            .collect();
+
+        // Polynomial is defined at negative indices (0..=t)
+        let eval_domain: Vec<Scalar> = (0..=self.t)
+            .map(|i| -Scalar::from_u64(i as u64))
+            .collect();
+
+        let sk_shares = lagrange_interp_eval(&eval_domain, &share_domain, &sk_poly);
+
+        let hsk = h * &self.sk;
+        let crs = CRS {
+            powers_of_g,
+            htau: h * &tau,
+            y,
+        };
+        let pk = PublicKey {
+            hsk,
+            hsk_tau: hsk * &tau,
+        };
+
+        (crs, pk, sk_shares)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_utils::test_rng;
+
+    #[test]
+    fn test_dealer() {
+        let mut rng = test_rng();
+        let batch_size = 1 << 5;
+        let n = 1 << 4;
+        let t = n / 2 - 1;
+
+        let mut dealer = Dealer::new(batch_size, n, t, &mut rng);
+        let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+
+        let share_domain: Vec<Scalar> = (1..=n)
+            .map(|i| Scalar::from_u64(i as u64))
+            .collect();
+        let should_be_sk =
+            lagrange_interp_eval(&share_domain, &[Scalar::zero()], &sk_shares)[0].clone();
+        assert_eq!(dealer.sk, should_be_sk);
+
+        let should_be_pk = G2::generator() * &should_be_sk;
+        assert_eq!(pk.hsk, should_be_pk);
+
+        let g_sk_shares: Vec<G2> = sk_shares
+            .iter()
+            .map(|ski| G2::generator() * ski)
+            .collect();
+
+        let interp_pk =
+            lagrange_interp_eval(&share_domain, &[Scalar::zero()], &g_sk_shares)[0];
+        assert_eq!(pk.hsk, interp_pk);
+
+        assert_eq!(crs.powers_of_g.len(), batch_size);
+        assert_eq!(sk_shares.len(), n);
+    }
+}

--- a/cryptography/src/bte/decryption.rs
+++ b/cryptography/src/bte/decryption.rs
@@ -1,5 +1,5 @@
-use crate::bls12381::primitives::group::{Scalar, G1, G2, GT};
-use commonware_math::algebra::{Additive, CryptoGroup, Random, Space};
+use crate::bls12381::primitives::group::{Scalar, SmallScalar, G1, G2, GT};
+use commonware_math::algebra::{Additive, CryptoGroup, Space};
 use commonware_parallel::Sequential;
 use rand_core::CryptoRngCore;
 use std::collections::BTreeMap;
@@ -147,22 +147,22 @@ pub fn batch_verify(
         }
     }
 
-    // Step 2: sample r in F^{2B} and batch-check ct2 and ct3
+    // Step 2: sample 128-bit challenges and batch-check ct2 and ct3
     // LHS: sum_i r_i * ct3_i + sum_i r_{B+i} * ct2_i
     // RHS: c1 * h + c2 * hsk_tau - c3 * hsk
-    let r: Vec<Scalar> = (0..2 * batch_size)
-        .map(|_| Scalar::random(&mut *rng))
+    let r: Vec<SmallScalar> = (0..2 * batch_size)
+        .map(|_| SmallScalar::random(&mut *rng))
         .collect();
 
     let mut c1 = Scalar::zero();
     let mut c2 = Scalar::zero();
     let mut c3 = Scalar::zero();
     for i in 0..batch_size {
-        let ri_alpha = r[i].clone() * &alphas[i];
+        let ri_alpha = &r[i] * &alphas[i];
         c1 += &ri_alpha;
-        let rbi_alpha = r[batch_size + i].clone() * &alphas[i];
+        let rbi_alpha = &r[batch_size + i] * &alphas[i];
         c2 += &rbi_alpha;
-        let rbi_alpha_x = rbi_alpha.clone() * &ct[i].x;
+        let rbi_alpha_x = rbi_alpha * &ct[i].x;
         c3 += &rbi_alpha_x;
     }
 
@@ -188,13 +188,13 @@ pub fn batch_verify(
     // RHS: e(c1 * hid - c4 * g, hsk)
     let mut c4 = Scalar::zero();
     for i in 0..batch_size {
-        let ri_alpha_tg = r[i].clone() * &alphas[i] * &tgs[i];
+        let ri_alpha_tg = &r[i] * &alphas[i] * &tgs[i];
         c4 += &ri_alpha_tg;
     }
 
     let gt_hints: Vec<GT> = decrypted.iter().map(|d| d.hint).collect();
-    let r_first_b: Vec<Scalar> = r[..batch_size].to_vec();
-    let lhs_gt = GT::msm(&gt_hints, &r_first_b, &Sequential);
+    let r_first_b = &r[..batch_size];
+    let lhs_gt = GT::msm(&gt_hints, r_first_b, &Sequential);
     let rhs_gt = GT::pairing(&(hid * &c1 - &(g * &c4)), &pk.hsk);
 
     lhs_gt == rhs_gt
@@ -382,7 +382,7 @@ mod tests {
         );
         println!("{}", "-".repeat(70));
 
-        for lg in 13..=16 {
+        for lg in 2..=12 {
             let batch_size = 1 << lg;
             let mut rng = test_rng();
             let tx_domain = Domain::new(batch_size);

--- a/cryptography/src/bte/decryption.rs
+++ b/cryptography/src/bte/decryption.rs
@@ -1,0 +1,462 @@
+use crate::bls12381::primitives::group::{Scalar, G1, G2, GT};
+use commonware_math::algebra::{Additive, CryptoGroup, Random, Space};
+use commonware_parallel::Sequential;
+use rand_core::CryptoRngCore;
+use std::collections::BTreeMap;
+
+use super::{
+    dealer::{PublicKey, CRS},
+    encryption::{compute_tg, hash_hm, hash_hr, Ciphertext},
+    utils::{lagrange_interp_eval, open_all_values, xor, Domain},
+};
+
+/// A secret key share for threshold decryption.
+pub struct SecretKey {
+    sk_share: Scalar,
+}
+
+impl SecretKey {
+    pub fn new(sk_share: Scalar) -> Self {
+        SecretKey { sk_share }
+    }
+
+    pub fn get_pk(&self) -> G2 {
+        G2::generator() * &self.sk_share
+    }
+
+    /// Compute a partial decryption for a batch of ciphertexts.
+    ///
+    /// Returns sigma_j = sk_j * (H_G(eid) - com).
+    pub fn partial_decrypt(&self, ct: &[Ciphertext], hid: G1, crs: &CRS) -> G1 {
+        let batch_size = crs.powers_of_g.len();
+        let tx_domain = Domain::new(batch_size);
+
+        let fevals: Vec<Scalar> = (0..batch_size).map(|i| compute_tg(&ct[i].gs)).collect();
+
+        let fcoeffs = tx_domain.ifft(&fevals);
+        let com = G1::msm(&crs.powers_of_g, &fcoeffs, &Sequential);
+        let delta = hid - &com;
+
+        delta * &self.sk_share
+    }
+}
+
+/// Aggregate partial decryptions into sigma = sk * (H_G(eid) - com).
+pub fn aggregate_partial_decryptions(partial_decryptions: &BTreeMap<usize, G1>) -> G1 {
+    let mut evals = Vec::new();
+    let mut eval_points = Vec::new();
+    for (&key, &value) in partial_decryptions.iter() {
+        evals.push(value);
+        eval_points.push(Scalar::from_u64(key as u64));
+    }
+
+    lagrange_interp_eval(&eval_points, &[Scalar::zero()], &evals)[0]
+}
+
+/// Result of decrypting a single ciphertext, including hints for batch verification.
+pub struct Decrypted {
+    pub msg: [u8; 32],
+    pub key: [u8; 32],
+    pub hint: GT,
+}
+
+/// Decrypt all ciphertexts in a batch using the FO transform.
+///
+/// For each ciphertext, recovers K from ct1, then msg from ct4, verifies
+/// ct3 = [alpha]_2, and returns (msg, K, P) where P is the GT pairing hint
+/// for batch verification.
+pub fn decrypt_all(sigma: G1, ct: &[Ciphertext], crs: &CRS) -> Vec<Decrypted> {
+    let batch_size = ct.len();
+    let h = G2::generator();
+    let tx_domain = Domain::new(batch_size);
+
+    let fevals: Vec<Scalar> = (0..batch_size).map(|i| compute_tg(&ct[i].gs)).collect();
+    let fcoeffs = tx_domain.ifft(&fevals);
+
+    let pi = open_all_values(&crs.y, &fcoeffs, &tx_domain);
+
+    let mut results = Vec::with_capacity(batch_size);
+    for i in 0..batch_size {
+        // P_i = e(pi_i, ct2_i) + e(sigma, ct3_i)
+        let p = GT::multi_pairing(&[(pi[i], ct[i].ct2), (sigma, ct[i].ct3)]);
+
+        // K_i = ct1 XOR H(P_i)
+        let h_p = *blake3::hash(&p.as_slice()).as_bytes();
+        let key: [u8; 32] = xor(&ct[i].ct1, &h_p).as_slice().try_into().unwrap();
+
+        // msg_i = ct4 XOR H_M(K_i)
+        let msg: [u8; 32] = xor(&ct[i].ct4, &hash_hm(&key))
+            .as_slice()
+            .try_into()
+            .unwrap();
+
+        // Verify ct3 = [alpha]_2
+        let alpha = hash_hr(&key, &msg);
+        assert_eq!(ct[i].ct3, h * &alpha, "FO check failed at index {i}");
+
+        results.push(Decrypted {
+            msg,
+            key,
+            hint: p,
+        });
+    }
+
+    results
+}
+
+/// Batch-verify a set of decrypted ciphertexts using the FO transform hints.
+///
+/// Given B ciphertexts and their decryption hints (K_i, P_i), verifies:
+/// 1. Per-ciphertext: ct1_i = H(P_i) XOR K_i
+/// 2. G2 batch check: random linear combination of ct2 and ct3
+/// 3. GT batch check: random linear combination of P_i against a single pairing
+pub fn batch_verify(
+    ct: &[Ciphertext],
+    decrypted: &[Decrypted],
+    hid: G1,
+    pk: &PublicKey,
+    rng: &mut impl CryptoRngCore,
+) -> bool {
+    let batch_size = ct.len();
+    assert_eq!(decrypted.len(), batch_size);
+    let g = G1::generator();
+    let h = G2::generator();
+
+    // Step 1: per-ciphertext scalar checks; recover alpha_i and tg_i
+    let mut alphas = Vec::with_capacity(batch_size);
+    let mut tgs = Vec::with_capacity(batch_size);
+    for i in 0..batch_size {
+        let tg = compute_tg(&ct[i].gs);
+        tgs.push(tg);
+
+        // msg_i = ct4 XOR H_M(K_i)
+        let msg: [u8; 32] = xor(&ct[i].ct4, &hash_hm(&decrypted[i].key))
+            .as_slice()
+            .try_into()
+            .unwrap();
+
+        // alpha_i = H_R(K_i, msg_i)
+        let alpha = hash_hr(&decrypted[i].key, &msg);
+        alphas.push(alpha);
+
+        // Verify ct1_i = H(P_i) XOR K_i
+        let h_p = *blake3::hash(&decrypted[i].hint.as_slice()).as_bytes();
+        let expected_ct1: [u8; 32] = xor(&decrypted[i].key, &h_p).as_slice().try_into().unwrap();
+        if ct[i].ct1 != expected_ct1 {
+            return false;
+        }
+    }
+
+    // Step 2: sample r in F^{2B} and batch-check ct2 and ct3
+    // LHS: sum_i r_i * ct3_i + sum_i r_{B+i} * ct2_i
+    // RHS: c1 * h + c2 * hsk_tau - c3 * hsk
+    let r: Vec<Scalar> = (0..2 * batch_size)
+        .map(|_| Scalar::random(&mut *rng))
+        .collect();
+
+    let mut c1 = Scalar::zero();
+    let mut c2 = Scalar::zero();
+    let mut c3 = Scalar::zero();
+    for i in 0..batch_size {
+        let ri_alpha = r[i].clone() * &alphas[i];
+        c1 += &ri_alpha;
+        let rbi_alpha = r[batch_size + i].clone() * &alphas[i];
+        c2 += &rbi_alpha;
+        let rbi_alpha_x = rbi_alpha.clone() * &ct[i].x;
+        c3 += &rbi_alpha_x;
+    }
+
+    let mut g2_bases = Vec::with_capacity(2 * batch_size);
+    let mut g2_scalars = Vec::with_capacity(2 * batch_size);
+    for i in 0..batch_size {
+        g2_bases.push(ct[i].ct3);
+        g2_scalars.push(r[i].clone());
+    }
+    for i in 0..batch_size {
+        g2_bases.push(ct[i].ct2);
+        g2_scalars.push(r[batch_size + i].clone());
+    }
+    let lhs_g2 = G2::msm(&g2_bases, &g2_scalars, &Sequential);
+    let rhs_g2 = h * &c1 + &(pk.hsk_tau * &c2) - &(pk.hsk * &c3);
+
+    if lhs_g2 != rhs_g2 {
+        return false;
+    }
+
+    // Step 3: batch-check shared secrets in GT
+    // LHS: sum_i r_i * P_i (GT linear combination)
+    // RHS: e(c1 * hid - c4 * g, hsk)
+    let mut c4 = Scalar::zero();
+    for i in 0..batch_size {
+        let ri_alpha_tg = r[i].clone() * &alphas[i] * &tgs[i];
+        c4 += &ri_alpha_tg;
+    }
+
+    let gt_hints: Vec<GT> = decrypted.iter().map(|d| d.hint).collect();
+    let r_first_b: Vec<Scalar> = r[..batch_size].to_vec();
+    let lhs_gt = GT::msm(&gt_hints, &r_first_b, &Sequential);
+    let rhs_gt = GT::pairing(&(hid * &c1 - &(g * &c4)), &pk.hsk);
+
+    lhs_gt == rhs_gt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bte::dealer::Dealer;
+    use crate::bte::encryption::encrypt;
+    use crate::bte::utils::Domain;
+    use commonware_math::algebra::{CryptoGroup, Random};
+    use commonware_utils::test_rng;
+
+    #[test]
+    fn test_end_to_end_decrypt() {
+        let mut rng = test_rng();
+        let batch_size = 1 << 5;
+        let n = 1 << 3;
+
+        let mut dealer = Dealer::new(batch_size, n, n / 2 - 1, &mut rng);
+        let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+
+        let secret_keys: Vec<SecretKey> = sk_shares
+            .iter()
+            .map(|sk| SecretKey::new(sk.clone()))
+            .collect();
+
+        let tx_domain = Domain::new(batch_size);
+
+        let msg = [1u8; 32];
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+
+        let ct: Vec<Ciphertext> = (0..batch_size)
+            .map(|i| encrypt(msg, tx_domain.element(i), hid, &pk, &mut rng))
+            .collect();
+
+        let mut partial_decryptions: BTreeMap<usize, G1> = BTreeMap::new();
+        for i in 0..n / 2 {
+            let partial = secret_keys[i].partial_decrypt(&ct, hid, &crs);
+            partial_decryptions.insert(i + 1, partial);
+        }
+
+        let sigma = aggregate_partial_decryptions(&partial_decryptions);
+        let decrypted = decrypt_all(sigma, &ct, &crs);
+        for i in 0..batch_size {
+            assert_eq!(msg, decrypted[i].msg);
+        }
+    }
+
+    #[test]
+    fn test_end_to_end_distinct_messages() {
+        let mut rng = test_rng();
+        let batch_size = 1 << 4;
+        let n = 1 << 3;
+
+        let mut dealer = Dealer::new(batch_size, n, n / 2 - 1, &mut rng);
+        let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+
+        let secret_keys: Vec<SecretKey> = sk_shares
+            .iter()
+            .map(|sk| SecretKey::new(sk.clone()))
+            .collect();
+
+        let tx_domain = Domain::new(batch_size);
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+
+        let msgs: Vec<[u8; 32]> = (0..batch_size)
+            .map(|i| {
+                let mut m = [0u8; 32];
+                m[0] = i as u8;
+                m[1] = 0xAB;
+                m
+            })
+            .collect();
+
+        let ct: Vec<Ciphertext> = (0..batch_size)
+            .map(|i| encrypt(msgs[i], tx_domain.element(i), hid, &pk, &mut rng))
+            .collect();
+
+        let mut partial_decryptions: BTreeMap<usize, G1> = BTreeMap::new();
+        for i in 0..n / 2 {
+            let partial = secret_keys[i].partial_decrypt(&ct, hid, &crs);
+            partial_decryptions.insert(i + 1, partial);
+        }
+
+        let sigma = aggregate_partial_decryptions(&partial_decryptions);
+        let decrypted = decrypt_all(sigma, &ct, &crs);
+        for i in 0..batch_size {
+            assert_eq!(msgs[i], decrypted[i].msg, "mismatch at index {i}");
+        }
+    }
+
+    #[test]
+    fn test_batch_verify() {
+        let mut rng = test_rng();
+        let batch_size = 1 << 4;
+        let n = 1 << 3;
+
+        let mut dealer = Dealer::new(batch_size, n, n / 2 - 1, &mut rng);
+        let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+
+        let secret_keys: Vec<SecretKey> = sk_shares
+            .iter()
+            .map(|sk| SecretKey::new(sk.clone()))
+            .collect();
+
+        let tx_domain = Domain::new(batch_size);
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+
+        let msgs: Vec<[u8; 32]> = (0..batch_size)
+            .map(|i| {
+                let mut m = [0u8; 32];
+                m[0] = i as u8;
+                m
+            })
+            .collect();
+
+        let ct: Vec<Ciphertext> = (0..batch_size)
+            .map(|i| encrypt(msgs[i], tx_domain.element(i), hid, &pk, &mut rng))
+            .collect();
+
+        let mut partial_decryptions: BTreeMap<usize, G1> = BTreeMap::new();
+        for i in 0..n / 2 {
+            let partial = secret_keys[i].partial_decrypt(&ct, hid, &crs);
+            partial_decryptions.insert(i + 1, partial);
+        }
+
+        let sigma = aggregate_partial_decryptions(&partial_decryptions);
+        let decrypted = decrypt_all(sigma, &ct, &crs);
+
+        // Batch verify should pass
+        assert!(batch_verify(&ct, &decrypted, hid, &pk, &mut rng));
+    }
+
+    #[test]
+    fn test_batch_verify_tampered_key() {
+        let mut rng = test_rng();
+        let batch_size = 1 << 3;
+        let n = 1 << 3;
+
+        let mut dealer = Dealer::new(batch_size, n, n / 2 - 1, &mut rng);
+        let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+
+        let secret_keys: Vec<SecretKey> = sk_shares
+            .iter()
+            .map(|sk| SecretKey::new(sk.clone()))
+            .collect();
+
+        let tx_domain = Domain::new(batch_size);
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+
+        let ct: Vec<Ciphertext> = (0..batch_size)
+            .map(|i| encrypt([i as u8; 32], tx_domain.element(i), hid, &pk, &mut rng))
+            .collect();
+
+        let mut partial_decryptions: BTreeMap<usize, G1> = BTreeMap::new();
+        for i in 0..n / 2 {
+            let partial = secret_keys[i].partial_decrypt(&ct, hid, &crs);
+            partial_decryptions.insert(i + 1, partial);
+        }
+
+        let sigma = aggregate_partial_decryptions(&partial_decryptions);
+        let mut decrypted = decrypt_all(sigma, &ct, &crs);
+
+        // Tamper with one key
+        decrypted[0].key[0] ^= 0xFF;
+
+        // Batch verify should fail
+        assert!(!batch_verify(&ct, &decrypted, hid, &pk, &mut rng));
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_decrypt_vs_verify() {
+        use std::time::Instant;
+
+        let n = 1 << 4;
+        let iters = 3;
+        let h = G2::generator();
+
+        println!(
+            "\n{:>10} {:>10} {:>10} {:>10} | {:>10} {:>8}",
+            "batch", "fk22(ms)", "pair(ms)", "dec(ms)", "verify(ms)", "ratio"
+        );
+        println!("{}", "-".repeat(70));
+
+        for lg in 13..=16 {
+            let batch_size = 1 << lg;
+            let mut rng = test_rng();
+            let tx_domain = Domain::new(batch_size);
+
+            let mut dealer = Dealer::new(batch_size, n, n / 2 - 1, &mut rng);
+            let (crs, pk, sk_shares) = dealer.setup(&mut rng);
+
+            let secret_keys: Vec<SecretKey> = sk_shares
+                .iter()
+                .map(|sk| SecretKey::new(sk.clone()))
+                .collect();
+
+            let hid = G1::generator() * &Scalar::random(&mut rng);
+
+            let ct: Vec<Ciphertext> = (0..batch_size)
+                .map(|i| {
+                    let mut m = [0u8; 32];
+                    m[0] = i as u8;
+                    encrypt(m, tx_domain.element(i), hid, &pk, &mut rng)
+                })
+                .collect();
+
+            let mut partial_decryptions: BTreeMap<usize, G1> = BTreeMap::new();
+            for i in 0..n / 2 {
+                let partial = secret_keys[i].partial_decrypt(&ct, hid, &crs);
+                partial_decryptions.insert(i + 1, partial);
+            }
+            let sigma = aggregate_partial_decryptions(&partial_decryptions);
+
+            // Warmup
+            let decrypted = decrypt_all(sigma, &ct, &crs);
+            assert!(batch_verify(&ct, &decrypted, hid, &pk, &mut rng));
+
+            // Time decrypt_all with breakdown
+            let mut fk22_total = 0.0f64;
+            let mut pair_total = 0.0f64;
+            for _ in 0..iters {
+                let fevals: Vec<Scalar> =
+                    (0..batch_size).map(|i| compute_tg(&ct[i].gs)).collect();
+
+                let start = Instant::now();
+                let fcoeffs = tx_domain.ifft(&fevals);
+                let pi = open_all_values(&crs.y, &fcoeffs, &tx_domain);
+                fk22_total += start.elapsed().as_secs_f64() * 1000.0;
+
+                let start = Instant::now();
+                for i in 0..batch_size {
+                    let p = GT::multi_pairing(&[(pi[i], ct[i].ct2), (sigma, ct[i].ct3)]);
+                    let h_p = *blake3::hash(&p.as_slice()).as_bytes();
+                    let key: [u8; 32] =
+                        xor(&ct[i].ct1, &h_p).as_slice().try_into().unwrap();
+                    let msg: [u8; 32] =
+                        xor(&ct[i].ct4, &hash_hm(&key)).as_slice().try_into().unwrap();
+                    let alpha = hash_hr(&key, &msg);
+                    assert_eq!(ct[i].ct3, h * &alpha);
+                    std::hint::black_box((&key, &msg));
+                }
+                pair_total += start.elapsed().as_secs_f64() * 1000.0;
+            }
+            let fk22_ms = fk22_total / iters as f64;
+            let pair_ms = pair_total / iters as f64;
+            let decrypt_ms = fk22_ms + pair_ms;
+
+            // Time batch_verify
+            let start = Instant::now();
+            for _ in 0..iters {
+                let _ = batch_verify(&ct, &decrypted, hid, &pk, &mut rng);
+            }
+            let verify_ms = start.elapsed().as_secs_f64() * 1000.0 / iters as f64;
+
+            println!(
+                "{:>10} {:>10.2} {:>10.2} {:>10.2} | {:>10.2} {:>8.2}x",
+                batch_size, fk22_ms, pair_ms, decrypt_ms, verify_ms, decrypt_ms / verify_ms
+            );
+        }
+    }
+}

--- a/cryptography/src/bte/encryption.rs
+++ b/cryptography/src/bte/encryption.rs
@@ -1,0 +1,132 @@
+use crate::bls12381::primitives::group::{Scalar, G1, G2, GT};
+use commonware_codec::Encode;
+use commonware_math::algebra::{CryptoGroup, Random};
+use rand_core::CryptoRngCore;
+
+use super::dealer::PublicKey;
+use super::utils::xor;
+
+/// Domain separation tag for hashing to scalar (used for tg computation).
+const DST_HASH_TO_SCALAR: &[u8] = b"_COMMONWARE_CRYPTOGRAPHY_BLS12381_BTE_HASH_TO_SCALAR";
+/// Domain separation for H_M: key -> message mask.
+const DST_HM: &[u8] = b"_COMMONWARE_CRYPTOGRAPHY_BLS12381_BTE_HM";
+/// Domain separation for H_R: (key, msg) -> randomness alpha.
+const DST_HR: &[u8] = b"_COMMONWARE_CRYPTOGRAPHY_BLS12381_BTE_HR";
+
+/// Compute H_M(key): hash a 32-byte key to a 32-byte message mask.
+pub(crate) fn hash_hm(key: &[u8; 32]) -> [u8; 32] {
+    let mut h = blake3::Hasher::new();
+    h.update(DST_HM);
+    h.update(key);
+    *h.finalize().as_bytes()
+}
+
+/// Compute H_R(key, msg): derive the randomness scalar alpha from key and message.
+pub(crate) fn hash_hr(key: &[u8; 32], msg: &[u8; 32]) -> Scalar {
+    let mut h = blake3::Hasher::new();
+    h.update(DST_HR);
+    h.update(key);
+    h.update(msg);
+    let preimage = *h.finalize().as_bytes();
+    Scalar::map(DST_HASH_TO_SCALAR, &preimage)
+}
+
+/// Compute tg = H_F(S) from a G1 commitment S.
+pub(crate) fn compute_tg(gs: &G1) -> Scalar {
+    let hgs = *blake3::hash(gs.encode().as_ref()).as_bytes();
+    Scalar::map(DST_HASH_TO_SCALAR, &hgs)
+}
+
+/// A ciphertext in the batch threshold encryption scheme with FO transform.
+///
+/// ct1 = H(mask) XOR K, ct2 = alpha * [sk*(tau - x)]_2,
+/// ct3 = alpha * h, ct4 = H_M(K) XOR msg.
+#[derive(Clone)]
+pub struct Ciphertext {
+    pub ct1: [u8; 32],
+    pub ct2: G2,
+    pub ct3: G2,
+    pub ct4: [u8; 32],
+    pub gs: G1,
+    pub x: Scalar,
+}
+
+/// Encrypt a 32-byte message using batch threshold encryption with the FO transform.
+///
+/// Samples a random key K, derives alpha = H_R(K, msg), and produces a ciphertext
+/// where ct1 encrypts K (not msg directly) and ct4 = H_M(K) XOR msg.
+pub fn encrypt(
+    msg: [u8; 32],
+    x: Scalar,
+    hid: G1,
+    pk: &PublicKey,
+    rng: &mut impl CryptoRngCore,
+) -> Ciphertext {
+    let g = G1::generator();
+    let h = G2::generator();
+
+    let s = Scalar::random(&mut *rng);
+    let gs = g * &s;
+    let tg = compute_tg(&gs);
+
+    // Sample random key K and derive alpha = H_R(K, msg)
+    let key: [u8; 32] = {
+        let mut k = [0u8; 32];
+        rng.fill_bytes(&mut k);
+        k
+    };
+    let alpha = hash_hr(&key, &msg);
+
+    // mask = e(H_G(eid) - [tg]_1, [sk]_2)^alpha
+    let mask = GT::pairing(&(hid - &(g * &tg)), &pk.hsk).scalar_mul(&alpha);
+    let hmask = *blake3::hash(&mask.as_slice()).as_bytes();
+
+    // ct1 = H(mask) XOR K (encrypts the key, not the message)
+    let ct1: [u8; 32] = xor(&key, &hmask).as_slice().try_into().unwrap();
+    // ct2 = alpha * [sk*(tau - x)]_2
+    let ct2 = (pk.hsk_tau - &(pk.hsk * &x)) * &alpha;
+    // ct3 = alpha * h
+    let ct3 = h * &alpha;
+    // ct4 = H_M(K) XOR msg
+    let ct4: [u8; 32] = xor(&msg, &hash_hm(&key)).as_slice().try_into().unwrap();
+
+    Ciphertext {
+        ct1,
+        ct2,
+        ct3,
+        ct4,
+        gs,
+        x,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bte::dealer::Dealer;
+    use crate::bte::utils::Domain;
+    use commonware_utils::test_rng;
+
+    #[test]
+    fn test_encryption() {
+        let mut rng = test_rng();
+
+        let batch_size = 1 << 5;
+        let n = 1 << 4;
+        let tx_domain = Domain::new(batch_size);
+
+        let mut dealer = Dealer::new(batch_size, n, n / 2 - 1, &mut rng);
+        let (_, pk, _) = dealer.setup(&mut rng);
+
+        let msg = [1u8; 32];
+        let x = tx_domain.group_gen();
+
+        let hid = G1::generator() * &Scalar::random(&mut rng);
+        let ct = encrypt(msg, x, hid, &pk, &mut rng);
+
+        // Verify ct3 = [alpha]_2 by re-deriving alpha from ct
+        // (Not possible without K, but we can at least verify the ciphertext is well-formed)
+        assert_ne!(ct.ct1, [0u8; 32]);
+        assert_ne!(ct.ct4, [0u8; 32]);
+    }
+}

--- a/cryptography/src/bte/mod.rs
+++ b/cryptography/src/bte/mod.rs
@@ -1,0 +1,4 @@
+pub mod dealer;
+pub mod decryption;
+pub mod encryption;
+pub mod utils;

--- a/cryptography/src/bte/utils.rs
+++ b/cryptography/src/bte/utils.rs
@@ -1,0 +1,297 @@
+use crate::bls12381::primitives::group::{Scalar, G1, G2};
+use commonware_codec::Encode;
+use commonware_math::algebra::{Additive, Field, FieldNTT, Ring, Space};
+use commonware_math::ntt::{ntt, Columns};
+
+/// Reverse the first `lg_n` bits of each index; swap elements so that element at `i` moves to `reverse_bits(i)`.
+fn bit_reverse_slice<T>(data: &mut [T], lg_n: u8) {
+    let n = data.len();
+    assert_eq!(n, 1 << lg_n);
+    for i in 0..n {
+        let j = (i as u64).reverse_bits() >> (64 - lg_n as u32);
+        if i < j as usize {
+            data.swap(i, j as usize);
+        }
+    }
+}
+
+/// XOR two byte slices of equal length.
+pub fn xor(a: &[u8], b: &[u8]) -> Vec<u8> {
+    assert_eq!(a.len(), b.len());
+    a.iter().zip(b.iter()).map(|(x, y)| x ^ y).collect()
+}
+
+/// A simple transcript for Fiat-Shamir, wrapping blake3.
+pub struct Transcript {
+    hasher: blake3::Hasher,
+}
+
+impl Transcript {
+    pub fn new() -> Self {
+        Self {
+            hasher: blake3::Hasher::new(),
+        }
+    }
+
+    /// Append labeled data to the transcript.
+    pub fn append(&mut self, label: &[u8], data: &[u8]) {
+        self.hasher.update(label);
+        self.hasher.update(data);
+    }
+
+    /// Append a G1 element to the transcript.
+    pub fn append_g1(&mut self, label: &[u8], g: &G1) {
+        self.append(label, &g.encode());
+    }
+
+    /// Append a G2 element to the transcript.
+    pub fn append_g2(&mut self, label: &[u8], g: &G2) {
+        self.append(label, &g.encode());
+    }
+
+    /// Append a Scalar to the transcript.
+    pub fn append_scalar(&mut self, label: &[u8], s: &Scalar) {
+        self.append(label, &s.encode());
+    }
+
+    /// Derive challenge bytes from the current transcript state.
+    pub fn challenge_bytes(&self, output: &mut [u8]) {
+        let mut reader = self.hasher.clone().finalize_xof();
+        reader.fill(output);
+    }
+}
+
+/// Lagrange interpolation: given evaluations at `given_domain` points,
+/// evaluate the interpolating polynomial at each point in `target_domain`.
+///
+/// Works for any type T that supports addition and scalar multiplication
+/// by Scalar (e.g., Scalar itself, G1, G2).
+pub fn lagrange_interp_eval<T>(
+    given_domain: &[Scalar],
+    target_domain: &[Scalar],
+    evals: &[T],
+) -> Vec<T>
+where
+    T: Additive + Space<Scalar> + Clone,
+{
+    debug_assert_eq!(
+        given_domain.len(),
+        evals.len(),
+        "Evals length does not match given_domain length"
+    );
+
+    let mut result = Vec::new();
+    for point in target_domain.iter() {
+        let mut lagrange_coeffs = vec![Scalar::one(); given_domain.len()];
+
+        for i in 0..given_domain.len() {
+            let mut num = Scalar::one();
+            let mut denom = Scalar::one();
+            for j in 0..given_domain.len() {
+                if given_domain[i] != given_domain[j] {
+                    num = num * &(point.clone() - &given_domain[j]);
+                    denom = denom * &(given_domain[i].clone() - &given_domain[j]);
+                }
+            }
+            lagrange_coeffs[i] = num * &denom.inv();
+        }
+
+        let mut point_eval = T::zero();
+        for i in 0..given_domain.len() {
+            let tmp = evals[i].clone() * &lagrange_coeffs[i];
+            point_eval += &tmp;
+        }
+
+        result.push(point_eval);
+    }
+
+    result
+}
+
+/// Evaluate a polynomial (given as coefficients) at a point using Horner's method.
+pub fn poly_eval(coeffs: &[Scalar], point: &Scalar) -> Scalar {
+    let mut result = Scalar::zero();
+    for c in coeffs.iter().rev() {
+        result = result * point + c;
+    }
+    result
+}
+
+/// An FFT domain over roots of unity in the BLS12-381 scalar field.
+pub struct Domain {
+    lg_size: u8,
+    omega: Scalar,
+}
+
+impl Domain {
+    /// Create a new domain of at least `min_size` elements (rounded up to power of 2).
+    pub fn new(min_size: usize) -> Self {
+        let size = min_size.next_power_of_two();
+        let lg_size = size.ilog2() as u8;
+        let omega = Scalar::root_of_unity(lg_size).expect("domain too large for NTT");
+        Self { lg_size, omega }
+    }
+
+    /// The size of this domain (always a power of 2).
+    pub fn size(&self) -> usize {
+        1 << self.lg_size
+    }
+
+    /// The primitive root of unity (omega) for this domain.
+    pub fn group_gen(&self) -> Scalar {
+        self.omega.clone()
+    }
+
+    /// The i-th element of the domain: omega^i.
+    pub fn element(&self, i: usize) -> Scalar {
+        self.omega.exp(&[i as u64])
+    }
+
+    /// Forward FFT: coefficients -> evaluations at roots of unity.
+    /// Input and output are in natural order (coeff i / eval at omega^i at index i).
+    pub fn fft<T>(&self, input: &[T]) -> Vec<T>
+    where
+        T: Additive + Space<Scalar> + Clone,
+    {
+        let n = self.size();
+        let mut data = Vec::with_capacity(n);
+        data.extend_from_slice(input);
+        data.resize(n, T::zero());
+        bit_reverse_slice(&mut data, self.lg_size);
+        ntt::<true, Scalar, T, _>(n, 1, &mut Columns { data: [data.as_mut_slice()] });
+        data
+    }
+
+    /// Inverse FFT: evaluations at roots of unity -> coefficients.
+    /// Input and output are in natural order.
+    pub fn ifft<T>(&self, input: &[T]) -> Vec<T>
+    where
+        T: Additive + Space<Scalar> + Clone,
+    {
+        let n = self.size();
+        let mut data = Vec::with_capacity(n);
+        data.extend_from_slice(input);
+        data.resize(n, T::zero());
+        ntt::<false, Scalar, T, _>(n, 1, &mut Columns { data: [data.as_mut_slice()] });
+        bit_reverse_slice(&mut data, self.lg_size);
+        data
+    }
+}
+
+/// Computes all KZG opening proofs in O(n log n) time using FK22 amortized technique.
+///
+/// See <https://github.com/khovratovich/Kate/blob/master/Kate_amortized.pdf>
+pub fn open_all_values(y: &[G1], f: &[Scalar], domain: &Domain) -> Vec<G1> {
+    let n = domain.size();
+    let top_domain = Domain::new(2 * n);
+
+    // v = {(n+1 0s), f1, ..., fd}
+    let mut v = vec![Scalar::zero(); n + 1];
+    v.extend_from_slice(&f[1..]);
+    debug_assert_eq!(v.len(), 2 * n);
+    let v = top_domain.fft(&v);
+
+    // h = y * v (pointwise scalar multiplication)
+    let h: Vec<G1> = y.iter().zip(v.iter()).map(|(&yi, vi)| yi * vi).collect();
+
+    // inverse FFT on h
+    let mut h = top_domain.ifft(&h);
+    h.truncate(n);
+
+    // FFT on h to get KZG proofs
+    domain.fft(&h)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bls12381::primitives::group::GT;
+    use commonware_math::algebra::{CryptoGroup, Random};
+    use commonware_parallel::Sequential;
+    use commonware_utils::test_rng;
+
+    #[test]
+    fn open_all_test() {
+        let mut rng = test_rng();
+
+        let domain_size = 1 << 5;
+        let domain = Domain::new(domain_size);
+
+        let mut dealer =
+            super::super::dealer::Dealer::new(domain_size, 1 << 5, domain_size / 2 - 1, &mut rng);
+        let (crs, _, _) = dealer.setup(&mut rng);
+
+        let f: Vec<Scalar> = (0..domain_size).map(|_| Scalar::random(&mut rng)).collect();
+
+        let com = G1::msm(&crs.powers_of_g, &f, &Sequential);
+        let pi = open_all_values(&crs.y, &f, &domain);
+
+        // verify the KZG proofs
+        let g = G1::generator();
+        let h = G2::generator();
+
+        for i in 0..domain_size {
+            let eval = poly_eval(&f, &domain.element(i));
+            let lhs = GT::pairing(&(com - &(g * &eval)), &h);
+            let rhs = GT::pairing(&pi[i], &(crs.htau - &(h * &domain.element(i))));
+            assert_eq!(lhs, rhs);
+        }
+    }
+
+    #[test]
+    fn lagrange_interp_eval_test() {
+        let mut rng = test_rng();
+        let domain_size = 1 << 2;
+        let domain: Vec<Scalar> = (0..domain_size)
+            .map(|i| Scalar::from_u64(i as u64))
+            .collect();
+
+        let points: Vec<Scalar> = (0..domain_size / 2)
+            .map(|i| Scalar::from_u64((domain_size + i) as u64))
+            .collect();
+
+        let f_coeffs: Vec<Scalar> = (0..domain_size).map(|_| Scalar::random(&mut rng)).collect();
+
+        let evals: Vec<Scalar> = domain.iter().map(|e| poly_eval(&f_coeffs, e)).collect();
+
+        let computed_evals = lagrange_interp_eval(&domain, &points, &evals);
+        let should_be_evals: Vec<Scalar> =
+            points.iter().map(|p| poly_eval(&f_coeffs, p)).collect();
+
+        for i in 0..points.len() {
+            assert_eq!(computed_evals[i], should_be_evals[i]);
+        }
+    }
+
+    #[test]
+    fn fft_roundtrip_scalar() {
+        let mut rng = test_rng();
+        let n = 1 << 4;
+        let domain = Domain::new(n);
+
+        let coeffs: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut rng)).collect();
+        let evals = domain.fft(&coeffs);
+        let recovered = domain.ifft(&evals);
+
+        for i in 0..n {
+            assert_eq!(coeffs[i], recovered[i]);
+        }
+    }
+
+    #[test]
+    fn fft_roundtrip_g1() {
+        let mut rng = test_rng();
+        let n = 1 << 4;
+        let domain = Domain::new(n);
+
+        let points: Vec<G1> = (0..n)
+            .map(|_| G1::generator() * &Scalar::random(&mut rng))
+            .collect();
+        let evals = domain.fft(&points);
+        let recovered = domain.ifft(&evals);
+
+        for i in 0..n {
+            assert_eq!(points[i], recovered[i]);
+        }
+    }
+}

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -29,6 +29,13 @@ pub mod bls12381;
     commonware_stability_RESERVED
 )))] // BETA
 pub mod ed25519;
+#[cfg(all(feature = "std", not(any(
+    commonware_stability_GAMMA,
+    commonware_stability_DELTA,
+    commonware_stability_EPSILON,
+    commonware_stability_RESERVED
+))))] // BETA
+pub mod bte;
 #[cfg(not(any(
     commonware_stability_BETA,
     commonware_stability_GAMMA,

--- a/math/src/ntt.rs
+++ b/math/src/ntt.rs
@@ -1,4 +1,4 @@
-use crate::algebra::{Additive, FieldNTT, Ring};
+use crate::algebra::{Additive, FieldNTT, Ring, Space};
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use commonware_codec::{EncodeSize, RangeCfg, Read, Write};
@@ -40,13 +40,18 @@ fn reverse_slice<T>(bit_width: u32, out: &mut [T]) {
 
 /// Calculate an NTT, or an inverse NTT (with FORWARD=false), in place.
 ///
-/// We implement this generically over anything we can index into, which allows
-/// performing NTTs in place.
-fn ntt<const FORWARD: bool, F: FieldNTT, M: IndexMut<(usize, usize), Output = F>>(
-    rows: usize,
-    cols: usize,
-    matrix: &mut M,
-) {
+/// Generic over any element type `T` that is an [`Additive`] [`Space`] over the
+/// scalar field `F`, so it works for both field elements (e.g. [`Scalar`]) and
+/// group elements (e.g. G1, G2). We implement this over anything we can index
+/// into, which allows performing NTTs in place.
+///
+/// For a single column use `rows = data.len()`, `cols = 1`, and a [`Columns`]
+/// with one slice (e.g. `Columns { data: [data] }`).
+pub fn ntt<const FORWARD: bool, F: FieldNTT, T, M>(rows: usize, cols: usize, matrix: &mut M)
+where
+    T: Additive + Space<F> + Clone,
+    M: IndexMut<(usize, usize), Output = T>,
+{
     let lg_rows = rows.ilog2() as usize;
     assert_eq!(1 << lg_rows, rows, "rows should be a power of 2");
     // A number w such that w^(2^lg_rows) = 1.
@@ -60,6 +65,20 @@ fn ntt<const FORWARD: bool, F: FieldNTT, M: IndexMut<(usize, usize), Output = F>
             // making that left-hand term the inverse of w.
             w.exp(&[(1 << lg_rows) - 1])
         }
+    };
+    // For the inverse NTT, we defer normalization (the 1/2 per stage) to a
+    // single 1/n pass at the end. This reduces the inverse butterfly from 3
+    // scalar multiplications to 1 (matching the forward butterfly).
+    let inv_n = if FORWARD {
+        None
+    } else {
+        // rows = 2^lg_rows, so compute n by repeated doubling of 1.
+        let two = F::one() + &F::one();
+        let mut n = F::one();
+        for _ in 0..lg_rows {
+            n *= &two;
+        }
+        Some(n.inv())
     };
     // The inverse algorithm consists of carefully undoing the work of the
     // standard algorithm, so we describe that in detail.
@@ -140,18 +159,16 @@ fn ntt<const FORWARD: bool, F: FieldNTT, M: IndexMut<(usize, usize), Output = F>
                 for k in 0..cols {
                     let (a, b) = (matrix[(index_a, k)].clone(), matrix[(index_b, k)].clone());
                     if FORWARD {
-                        let w_j_b = w_j.clone() * &b;
+                        let w_j_b = b.clone() * &w_j;
                         matrix[(index_a, k)] = a.clone() + &w_j_b;
                         matrix[(index_b, k)] = a - &w_j_b;
                     } else {
-                        // To check the math, convince yourself that applying the forward
-                        // transformation, and then this transformation, with w_j being the
-                        // inverse of the value above, that you get (a, b).
-                        // (a + w_j * b) + (a - w_j * b) = 2 * a
-                        matrix[(index_a, k)] = (a.clone() + &b).div_2();
-                        // (a + w_j * b) - (a - w_j * b) = 2 * w_j * b.
-                        // w_j in this branch is the inverse of w_j in the other branch.
-                        matrix[(index_b, k)] = ((a - &b) * &w_j).div_2();
+                        // Inverse butterfly without per-stage normalization.
+                        // We compute: a' = a + b, b' = (a - b) * w_j^{-1}
+                        // The 1/n normalization is applied once at the end.
+                        let diff_w = (a.clone() - &b) * &w_j;
+                        matrix[(index_a, k)] = a + &b;
+                        matrix[(index_b, k)] = diff_w;
                     }
                 }
                 w_j *= &w;
@@ -159,24 +176,36 @@ fn ntt<const FORWARD: bool, F: FieldNTT, M: IndexMut<(usize, usize), Output = F>
             i += 2 * skip;
         }
     }
+
+    // For inverse NTT, apply the deferred 1/n normalization in a single pass.
+    if !FORWARD {
+        let inv_n_ref = inv_n.as_ref().expect("inv_n set when FORWARD is false");
+        for i in 0..rows {
+            for k in 0..cols {
+                let val = matrix[(i, k)].clone() * inv_n_ref;
+                matrix[(i, k)] = val;
+            }
+        }
+    }
 }
 
 /// Columns of some larger piece of data.
 ///
 /// This allows us to easily do NTTs over partial segments of some bigger matrix.
-struct Columns<'a, const N: usize, F> {
-    data: [&'a mut [F]; N],
+/// For a single column use `Columns { data: [my_slice] }` and call [`ntt`] with `cols = 1`.
+pub struct Columns<'a, const N: usize, T> {
+    pub data: [&'a mut [T]; N],
 }
 
-impl<'a, const N: usize, F> Index<(usize, usize)> for Columns<'a, N, F> {
-    type Output = F;
+impl<'a, const N: usize, T> Index<(usize, usize)> for Columns<'a, N, T> {
+    type Output = T;
 
     fn index(&self, (i, j): (usize, usize)) -> &Self::Output {
         &self.data[j][i]
     }
 }
 
-impl<'a, const N: usize, F> IndexMut<(usize, usize)> for Columns<'a, N, F> {
+impl<'a, const N: usize, T> IndexMut<(usize, usize)> for Columns<'a, N, T> {
     fn index_mut(&mut self, (i, j): (usize, usize)) -> &mut Self::Output {
         &mut self.data[j][i]
     }
@@ -588,7 +617,7 @@ impl<F: FieldNTT> EvaluationColumn<F> {
                             chunk.swap(i, 2 * i);
                         }
                         // Turn the polynomials into evaluations.
-                        ntt::<true, _, _>(
+                        ntt::<true, F, F, _>(
                             next_chunk_size,
                             2,
                             &mut Columns {
@@ -607,9 +636,9 @@ impl<F: FieldNTT> EvaluationColumn<F> {
                 let should_be_evaluated = next_chunk_size >= len;
                 if should_be_evaluated != evaluated {
                     if evaluated {
-                        ntt::<false, _, _>(next_chunk_size, 1, &mut Columns { data: [chunk] });
+                        ntt::<false, F, F, _>(next_chunk_size, 1, &mut Columns { data: [chunk] });
                     } else {
-                        ntt::<true, _, _>(next_chunk_size, 1, &mut Columns { data: [chunk] });
+                        ntt::<true, F, F, _>(next_chunk_size, 1, &mut Columns { data: [chunk] });
                     }
                 }
             }
@@ -621,7 +650,7 @@ impl<F: FieldNTT> EvaluationColumn<F> {
 
     pub fn interpolate(self) -> PolynomialColumn<F> {
         let mut data = self.evaluations;
-        ntt::<false, _, _>(
+        ntt::<false, F, F, _>(
             data.len(),
             1,
             &mut Columns {
@@ -642,7 +671,7 @@ impl<F: FieldNTT> PolynomialColumn<F> {
     /// Evaluate this polynomial over the domain, returning
     pub fn evaluate(self) -> EvaluationColumn<F> {
         let mut data = self.coefficients;
-        ntt::<true, _, _>(
+        ntt::<true, F, F, _>(
             data.len(),
             1,
             &mut Columns {
@@ -829,7 +858,7 @@ impl<F: Additive> Matrix<F> {
 
 impl<F: FieldNTT> Matrix<F> {
     fn ntt<const FORWARD: bool>(&mut self) {
-        ntt::<FORWARD, F, Self>(self.rows, self.cols, self)
+        ntt::<FORWARD, F, F, Self>(self.rows, self.cols, self)
     }
 }
 
@@ -1054,8 +1083,8 @@ impl<F: FieldNTT> PolynomialVector<F> {
         let skew_inv = F::coset_shift_inv();
         self.divide_roots(skew.clone());
         q.divide_roots(skew);
-        ntt::<true, F, _>(self.data.rows, self.data.cols, &mut self.data);
-        ntt::<true, F, _>(
+        ntt::<true, F, F, _>(self.data.rows, self.data.cols, &mut self.data);
+        ntt::<true, F, F, _>(
             q.coefficients.len(),
             1,
             &mut Columns {
@@ -1075,7 +1104,7 @@ impl<F: FieldNTT> PolynomialVector<F> {
             }
         }
         // Interpolate back, using the inverse skew
-        ntt::<false, F, _>(self.data.rows, self.data.cols, &mut self.data);
+        ntt::<false, F, F, _>(self.data.rows, self.data.cols, &mut self.data);
         self.divide_roots(skew_inv);
     }
 }
@@ -1455,6 +1484,7 @@ pub mod fuzz {
         }
     }
 
+    #[commonware_macros::test_group("slow")]
     #[test]
     fn test_fuzz() {
         use commonware_invariants::minifuzz;


### PR DESCRIPTION
## Scheme Description

Implements the batched threshold encryption scheme from [CGPW25] with the Fujisaki-Okamoto (FO) transform from [FPTX25] for CCA security and efficient batch verification of decryptions. A similar strategy is applicable to other batched threshold encryption schemes as well.

The committee uses distributed key generation to sample $(t, n)$-shares of a random field element $\text{sk}$ and publishes the committee's public key $\text{pk} = ([sk]_2, [sk \cdot \tau]_2)$. The dealer also publishes a KZG CRS $crs = ([1]_1, [\tau]_1, \ldots, [\tau^{B-1}]_1, [1]_2, [\tau]_2)$.

**Note:** Currently using a trusted dealer.

### Encryption

$\text{Enc}$: Sample $\hat{x} \leftarrow \Omega = \{1, \omega, \omega^2, \ldots, \omega^{B-1}\}$ (a $B$-th root of unity), $s \leftarrow \mathbb{F}$, and compute $S \leftarrow [s]_1$, $\text{tg} \leftarrow H_F(S)$. Sample $K \leftarrow \mathcal{K}$ and compute $\alpha \leftarrow H_R(K, \text{msg})$. The ciphertext is:

- $\text{ct}^{(1)} := H(\alpha \cdot (H_G(\text{eid}) - [\text{tg}]_1) \circ [\text{sk}]_2) \oplus K$
- $\text{ct}^{(2)} := \alpha \cdot [\text{sk}(\tau - \hat{x})]_2$
- $\text{ct}^{(3)} := \alpha \cdot [1]_2$
- $\text{ct}^{(4)} := H_M(K) \oplus \text{msg}$
- $S, \hat{x}$

### Partial Decryption and Combining

$\text{BatchDec}$: Compute $\text{com} = [p(\tau)]_1$ where $p(X)$ is the degree-$(B-1)$ polynomial such that $p(\hat{x}_i) = \text{tg}_i$ for all $i \in [B]$, where $\text{tg}_i = H_F(\text{ct}_i.S)$. The $j$-th party publishes $\sigma_j = \text{sk}_j \cdot (H_G(\text{eid}) - \text{com})$.

$\text{Combine}$: Recover $\sigma$ via Lagrange interpolation and compute opening proofs $\{\pi_i\}$ via FK22 in $O(B \log B)$ time. For each $i \in [B]$:

1. Compute $P_i \leftarrow \pi_i \circ \text{ct}_i^{(2)} + \sigma \circ \text{ct}_i^{(3)}$
2. Compute $K_i \leftarrow \text{ct}_i^{(1)} \oplus H(P_i)$
3. Compute $\text{msg}_i \leftarrow \text{ct}_i^{(4)} \oplus H_M(K_i)$
4. Compute $\alpha_i \leftarrow H_R(K_i, \text{msg}_i)$ and verify $\text{ct}_i^{(3)} = [\alpha_i]_2$
5. Output $(\text{msg}_i, K_i, P_i)$

### Batch Verification

Given $B$ ciphertexts and hints $\{K_i, P_i\}_{i \in [B]}$ where $P_i := \alpha_i \cdot (H_G(\text{eid}) - [\text{tg}_i]_1) \circ [\text{sk}]_2 \in \mathbb{G}_T$, the verifier:

1. For each $i \in [B]$: compute $\text{tg}_i \leftarrow H_F(\text{ct}_i.S)$, $\text{msg}_i \leftarrow \text{ct}_i^{(4)} \oplus H_M(K_i)$, $\alpha_i \leftarrow H_R(K_i, \text{msg}_i)$, and verify $\text{ct}_i^{(1)} \stackrel{?}{=} H(P_i) \oplus K_i$.

2. Sample $r \leftarrow [0, 2^{128})^{2B}$ and batch-check $\text{ct}^{(2)}$ and $\text{ct}^{(3)}$:

$$\underbrace{\sum_{i=1}^{B} r_i \cdot \text{ct}_i^{(3)} + \sum_{i=1}^{B} r_{B+i} \cdot \text{ct}_i^{(2)}}_{\mathbb{G}_2\text{-MSM}(2B)} \stackrel{?}{=} \underbrace{c_1 \cdot [1]_2 + c_2 \cdot [\text{sk} \cdot \tau]_2 - c_3 \cdot [\text{sk}]_2}_{\mathbb{G}_2\text{-scalar-muls}(3)}$$

where $c_1 = \sum_{i=1}^{B} r_i \cdot \alpha_i$, $c_2 = \sum_{i=1}^{B} r_{B+i} \cdot \alpha_i$, $c_3 = \sum_{i=1}^{B} r_{B+i} \cdot \alpha_i \cdot \hat{x}_i$.

3. Batch-check the shared secrets:

$$\underbrace{\sum_{i=1}^{B} r_i \cdot P_i}_{\mathbb{G}_T\text{-MSM}(B)} \stackrel{?}{=} \left(\underbrace{c_1 \cdot H_G(\text{eid}) - c_4 \cdot [1]_1}_{\mathbb{G}_1\text{-scalar-muls}(2)}\right) \circ [\text{sk}]_2$$

where $c_4 = \sum_{i=1}^{B} r_i \cdot \alpha_i \cdot \text{tg}_i$.

The total verification cost is one $\mathbb{G}_2$-MSM of size $2B$, one $\mathbb{G}_T$-MSM of size $B$, a single pairing, and $O(B)$ hash evaluations and field multiplications. Following [[FGHP09]](https://eprint.iacr.org/2008/015.pdf), challenge scalars are sampled from $[0, 2^{128})$ (`SmallScalar`), halving MSM cost with soundness error $2^{-128}$.

## Benchmark Results (single-threaded, Apple M5 Pro)

Batch verification vs individual decryption (FK22 + $2B$ pairings):

| $B$ | FK22 (ms) | Pairings (ms) | Decrypt total (ms) | Batch verify (ms) | Speedup |
|---|---|---|---|---|---|
| 4 | 2.09 | 3.07 | 5.16 | 1.68 | 3.1x |
| 8 | 3.55 | 4.46 | 8.01 | 1.59 | 5.0x |
| 16 | 7.19 | 7.97 | 15.16 | 2.22 | 6.8x |
| 32 | 16.29 | 15.92 | 32.21 | 3.10 | 10.4x |
| 64 | 36.50 | 31.70 | 68.20 | 4.77 | 14.3x |
| 128 | 80.82 | 63.39 | 144.20 | 7.65 | 18.9x |
| 256 | 176.88 | 126.67 | 303.55 | 12.76 | 23.8x |
| 512 | 385.10 | 254.32 | 639.42 | 22.53 | 28.4x |
| 1,024 | 833.48 | 508.28 | 1,341.75 | 40.04 | 33.5x |
| 2,048 | 1,794.34 | 1,023.02 | 2,817.36 | 72.21 | 39.0x |
| 4,096 | 3,847.39 | 2,053.30 | 5,900.68 | 131.34 | 44.9x |

Batch verification scales sublinearly (Pippenger MSM) while individual decryption scales linearly ($2B$ pairings), yielding increasing speedups at larger batch sizes.
