### PR TITLE
[coding] ZODA reject duplicate shards + interval search

### DIFF
--- a/coding/conformance.toml
+++ b/coding/conformance.toml
@@ -8,7 +8,7 @@ hash = "3ad3a60285f4df6dc4bde8c54d9d85ec37b7aa6af21479ec5b7fbff69dfce94e"
 
 ["commonware_coding::zoda::tests::conformance::CodecConformance<StrongShard<Sha256Digest>>"]
 n_cases = 65536
-hash = "fbf783e8550fe15cd7000f8185e1ca3bc9641ba0baf156ba6365d3b224e2222d"
+hash = "f7f922accdc562bd0058b9b82e66547181d61211f10a1a9e44708dfb2ec79574"
 
 ["commonware_coding::zoda::tests::conformance::CodecConformance<WeakShard<Sha256Digest>>"]
 n_cases = 65536

--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -189,12 +189,13 @@ fn row_digest<H: Hasher>(row: &[F]) -> H::Digest {
 }
 
 mod topology;
-use topology::Topology;
+use topology::{Topology, TopologyHint};
 
 /// A shard of data produced by the encoding scheme.
 #[derive(Clone, Debug)]
 pub struct StrongShard<D: Digest> {
     data_bytes: usize,
+    topology_hint: TopologyHint,
     root: D,
     inclusion_proof: Proof<D>,
     rows: Matrix<F>,
@@ -204,6 +205,7 @@ pub struct StrongShard<D: Digest> {
 impl<D: Digest> PartialEq for StrongShard<D> {
     fn eq(&self, other: &Self) -> bool {
         self.data_bytes == other.data_bytes
+            && self.topology_hint == other.topology_hint
             && self.root == other.root
             && self.inclusion_proof == other.inclusion_proof
             && self.rows == other.rows
@@ -216,6 +218,7 @@ impl<D: Digest> Eq for StrongShard<D> {}
 impl<D: Digest> EncodeSize for StrongShard<D> {
     fn encode_size(&self) -> usize {
         self.data_bytes.encode_size()
+            + self.topology_hint.encode_size()
             + self.root.encode_size()
             + self.inclusion_proof.encode_size()
             + self.rows.encode_size()
@@ -226,6 +229,7 @@ impl<D: Digest> EncodeSize for StrongShard<D> {
 impl<D: Digest> Write for StrongShard<D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.data_bytes.write(buf);
+        self.topology_hint.write(buf);
         self.root.write(buf);
         self.inclusion_proof.write(buf);
         self.rows.write(buf);
@@ -244,6 +248,7 @@ impl<D: Digest> Read for StrongShard<D> {
         let max_els = cfg.maximum_shard_size / F::SIZE;
         Ok(Self {
             data_bytes,
+            topology_hint: ReadExt::read(buf)?,
             root: ReadExt::read(buf)?,
             inclusion_proof: Read::read_cfg(buf, &max_els)?,
             rows: Read::read_cfg(buf, &(max_els, ()))?,
@@ -260,6 +265,7 @@ where
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self {
             data_bytes: u.arbitrary::<u32>()? as usize,
+            topology_hint: u.arbitrary()?,
             root: u.arbitrary()?,
             inclusion_proof: u.arbitrary()?,
             rows: u.arbitrary()?,
@@ -381,28 +387,30 @@ impl<D: Digest> CheckingData<D> {
     /// We're provided with `commitment`, which should hash over `root`,
     /// and `data_bytes`.
     ///
-    /// We're also give a `checksum` matrix used to check the shards we receive.
+    /// We're also given a `checksum` matrix used to check the shards we receive.
     fn reckon(
         namespace: &[u8],
         config: &Config,
         commitment: &Summary,
+        topology_hint: TopologyHint,
         data_bytes: usize,
         root: D,
         checksum: &Matrix<F>,
     ) -> Result<Self, Error> {
-        let topology = Topology::reckon(config, data_bytes);
+        let topology =
+            Topology::reckon(topology_hint, config, data_bytes).ok_or(Error::BadShard)?;
         let mut transcript = Transcript::new(NAMESPACE);
         transcript.commit(namespace);
         transcript.commit((topology.data_bytes as u64).encode());
         transcript.commit(root.encode());
         let expected_commitment = transcript.summarize();
         if *commitment != expected_commitment {
-            return Err(Error::InvalidShard);
+            return Err(Error::BadShard);
         }
         let mut transcript = Transcript::resume(expected_commitment);
         let checking_matrix = checking_matrix(&transcript, &topology);
         if checksum.rows() != topology.data_rows || checksum.cols() != topology.column_samples {
-            return Err(Error::InvalidShard);
+            return Err(Error::BadShard);
         }
         // Commit to the checksum before generating the indices to check.
         //
@@ -436,7 +444,7 @@ impl<D: Digest> CheckingData<D> {
         weak_shard: &WeakShard<D>,
     ) -> Result<CheckedShard, Error> {
         if self.commitment != *commitment {
-            return Err(Error::InvalidShard);
+            return Err(Error::BadShard);
         }
         self.topology.check_index(index)?;
         if weak_shard.shard.rows() != self.topology.samples
@@ -483,8 +491,8 @@ impl<D: Digest> CheckingData<D> {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("invalid shard")]
-    InvalidShard,
+    #[error("bad shard")]
+    BadShard,
     #[error("invalid weak shard")]
     InvalidWeakShard,
     #[error("invalid index {0}")]
@@ -526,7 +534,10 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
     ) -> Result<(Self::Commitment, Vec<Self::StrongShard>), Self::Error> {
         // Step 1: arrange the data as a matrix.
         let data_bytes = data.remaining();
-        let topology = Topology::reckon(config, data_bytes);
+        let topology_hint = TopologyHint::search(config, data_bytes);
+        let topology = Topology::reckon(topology_hint, config, data_bytes)
+            .expect("searched topology hint must be valid");
+        let topology_hint = topology.hint();
         let data = Matrix::init(
             topology.data_rows,
             topology.data_cols,
@@ -586,6 +597,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
                     .map_err(Error::FailedToCreateInclusionProof)?;
                 Ok(StrongShard {
                     data_bytes,
+                    topology_hint,
                     root,
                     inclusion_proof,
                     rows,
@@ -613,6 +625,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
             namespace,
             config,
             commitment,
+            shard.topology_hint,
             shard.data_bytes,
             shard.root,
             shard.checksum.as_ref(),
@@ -639,24 +652,22 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
         _strategy: &impl Strategy,
     ) -> Result<Vec<u8>, Self::Error> {
         if checking_data.commitment != *commitment {
-            return Err(Error::InvalidShard);
+            return Err(Error::BadShard);
         }
 
-        let Topology {
-            encoded_rows,
-            data_cols,
-            samples,
-            data_rows,
-            data_bytes,
-            min_shards,
-            ..
-        } = checking_data.topology;
+        let topology = checking_data.topology;
+        let encoded_rows = topology.encoded_rows;
+        let data_cols = topology.data_cols;
+        let samples = topology.samples;
+        let data_rows = topology.data_rows;
+        let data_bytes = topology.data_bytes;
+        let min_shards = topology.min_shards;
         let mut evaluation = EvaluationVector::<F>::empty(encoded_rows.ilog2() as usize, data_cols);
         let mut shard_count = 0usize;
         for shard in shards {
             shard_count += 1;
             if shard.commitment != *commitment {
-                return Err(Error::InvalidShard);
+                return Err(Error::BadShard);
             }
             let indices =
                 &checking_data.shuffled_indices[shard.index * samples..(shard.index + 1) * samples];
@@ -808,6 +819,23 @@ mod tests {
         assert!(matches!(
             Zoda::<Sha256>::weaken(b"", &config, &commitment, a_i as u16, shards[a_i].clone()),
             Err(Error::InvalidWeakShard)
+        ));
+    }
+
+    #[test]
+    fn weaken_rejects_forged_topology_hint() {
+        let config = Config {
+            minimum_shards: NZU16!(2),
+            extra_shards: NZU16!(1),
+        };
+        let data = vec![0xA5u8; 65_536];
+        let (commitment, mut shards) =
+            Zoda::<Sha256>::encode(&config, &data[..], &STRATEGY).unwrap();
+        shards[0].topology_hint.data_cols = 1;
+
+        assert!(matches!(
+            Zoda::<Sha256>::weaken(&config, &commitment, 0, shards[0].clone()),
+            Err(Error::BadShard)
         ));
     }
 

--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -127,6 +127,7 @@ use commonware_math::{
 };
 use commonware_parallel::Strategy;
 use commonware_storage::bmt::{Builder as BmtBuilder, Error as BmtError, Proof};
+use commonware_utils::bitmap::BitMap;
 use rand::seq::SliceRandom as _;
 use std::{marker::PhantomData, sync::Arc};
 use thiserror::Error;
@@ -663,20 +664,26 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
         let data_bytes = topology.data_bytes;
         let min_shards = topology.min_shards;
         let mut evaluation = EvaluationVector::<F>::empty(encoded_rows.ilog2() as usize, data_cols);
-        let mut shard_count = 0usize;
+        let mut seen_indices: BitMap = BitMap::zeroes(topology.total_shards as u64);
+        let mut unique_shards = 0usize;
         for shard in shards {
-            shard_count += 1;
             if shard.commitment != *commitment {
                 return Err(Error::BadShard);
             }
+            let shard_index = shard.index as u64;
+            if seen_indices.get(shard_index) {
+                continue;
+            }
+            seen_indices.set(shard_index, true);
+            unique_shards += 1;
             let indices =
                 &checking_data.shuffled_indices[shard.index * samples..(shard.index + 1) * samples];
             for (&i, row) in indices.iter().zip(shard.shard.iter()) {
                 evaluation.fill_row(u64::from(i) as usize, row);
             }
         }
-        if shard_count < min_shards {
-            return Err(Error::InsufficientShards(shard_count, min_shards));
+        if unique_shards < min_shards {
+            return Err(Error::InsufficientShards(unique_shards, min_shards));
         }
         // This should never happen, because we check each shard, and the shards
         // should have distinct rows. But, as a sanity check, this doesn't hurt.
@@ -714,7 +721,36 @@ mod tests {
     const STRATEGY: Sequential = Sequential;
 
     #[test]
-    fn decode_rejects_duplicate_indices() {
+    fn decode_ignores_duplicate_indices() {
+        let config = Config {
+            minimum_shards: NZU16!(2),
+            extra_shards: NZU16!(1),
+        };
+        let data = b"duplicate shard coverage";
+        let (commitment, shards) = Zoda::<Sha256>::encode(&config, &data[..], &STRATEGY).unwrap();
+        let shard0 = shards[0].clone();
+        let (checking_data, checked_shard0, _weak_shard0) =
+            Zoda::<Sha256>::weaken(&config, &commitment, 0, shard0).unwrap();
+        let (_, checked_shard1, _weak_shard1) =
+            Zoda::<Sha256>::weaken(&config, &commitment, 1, shards[1].clone()).unwrap();
+        let duplicate = CheckedShard {
+            index: checked_shard0.index,
+            shard: checked_shard0.shard.clone(),
+            commitment: checked_shard0.commitment,
+        };
+        let shards = [checked_shard0, duplicate, checked_shard1];
+        let decoded = Zoda::<Sha256>::decode(
+            &config,
+            &commitment,
+            checking_data,
+            shards.iter(),
+            &STRATEGY,
+        )
+        .unwrap();
+        assert_eq!(decoded, data);
+    }
+    #[test]
+    fn decode_requires_unique_shards() {
         let config = Config {
             minimum_shards: NZU16!(2),
             extra_shards: NZU16!(1),
@@ -738,12 +774,7 @@ mod tests {
             shards.iter(),
             &STRATEGY,
         );
-        match result {
-            Err(Error::InsufficientUniqueRows(actual, expected)) => {
-                assert!(actual < expected);
-            }
-            other => panic!("expected insufficient unique rows error, got {other:?}"),
-        }
+        assert!(matches!(result, Err(Error::InsufficientShards(1, 2))));
     }
 
     #[test]

--- a/coding/src/zoda/topology.rs
+++ b/coding/src/zoda/topology.rs
@@ -1,5 +1,6 @@
 use super::Error;
 use crate::Config;
+use commonware_codec::{EncodeSize, RangeCfg, Read, Write};
 use commonware_math::fields::goldilocks::F;
 use commonware_utils::BigRationalExt as _;
 use num_rational::BigRational;
@@ -9,6 +10,123 @@ const SECURITY_BITS: usize = 126;
 // We use the next power of 2 above SECURITY_BITS (128 = 2^7), which provides
 // 1/128 fractional precision, sufficient for these security calculations.
 const LOG2_PRECISION: usize = SECURITY_BITS.next_power_of_two().trailing_zeros() as usize;
+
+/// Expensive-to-search portion of a ZODA topology.
+///
+/// A hint carries the structural choices that determine the full topology, but
+/// it does not itself prove that those choices meet ZODA's sampling-security
+/// bound. Call [`Topology::reckon`] to derive and validate a full topology.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TopologyHint {
+    pub(crate) data_cols: usize,
+}
+
+impl TopologyHint {
+    const fn new(data_cols: usize) -> Self {
+        Self { data_cols }
+    }
+
+    /// Search for an efficient topology shape for this configuration and data size.
+    pub fn search(config: &Config, data_bytes: usize) -> Self {
+        let min_shards = usize::from(config.minimum_shards.get());
+        let total_shards = config.total_shards() as usize;
+        let data_els = Topology::effective_data_elements(data_bytes);
+
+        // The goal here is to try and maximize the number of columns in the
+        // data. ZODA is more efficient the more columns there are. However,
+        // we need to make sure that every shard has enough samples to guarantee
+        // correct encoding, and that the number of encoded rows can contain
+        // all of the samples in each shard, without overlap.
+        //
+        // To determine if a column configuration is good, we need to choose
+        // the number of encoded rows. To do this, we pick a number of samples
+        // `S` such that `S * n >= data_rows`. Then, our encoded rows will
+        // equal `(N * S).next_power_of_two()`. If the number of required
+        // samples `R` for this configuration satisfies `N * R <= encoded_rows`,
+        // then this configuration is valid, using `R` as the necessary number
+        // of samples.
+        //
+        // We cannot stop at the first invalid column count.
+        //
+        // `data_rows = ceil(data_els / cols)` is a staircase: many adjacent
+        // `cols` values map to the same row count. Everything that matters for
+        // the row-sampling security check depends only on that row count:
+        //
+        // - `samples = ceil(data_rows / n)`
+        // - `encoded_rows = next_power_of_two(N * samples)`
+        // - `required_samples(...)`
+        //
+        // so every `cols` in the same staircase interval has the same validity.
+        //
+        // Write `q = ceil(data_els / cols)`. The interval of column counts that
+        // produce exactly this `q` is:
+        //
+        //   ceil(data_els / q) <= cols <= floor((data_els - 1) / (q - 1))
+        //
+        // for `q > 1`. We are already inside such an interval at the current
+        // `cols`, so we only need its right endpoint:
+        //
+        //   interval_end = floor((data_els - 1) / (q - 1))
+        //
+        // This lets us jump directly from one distinct `data_rows` value to the
+        // next, yielding an exact search over all candidates in about
+        // `O(sqrt(data_els))` intervals instead of `O(data_els)` individual
+        // column counts.
+        //
+        // We cap the search at `data_els`. Beyond that, `data_rows = 1`
+        // forever, meaning we would only be adding guaranteed zero padding to a
+        // single row. That region can never satisfy the 126-bit row-sampling
+        // bound, so it is never an optimal choice.
+        let mut out = Self::new(1);
+        let mut cols = 1usize;
+        while cols <= data_els {
+            let attempt = Topology::with_cols(data_bytes, min_shards, total_shards, cols);
+            let interval_end = if attempt.data_rows == 1 {
+                data_els
+            } else {
+                (data_els - 1) / (attempt.data_rows - 1)
+            };
+            let required_samples = attempt.required_samples();
+            if required_samples.saturating_mul(total_shards) <= attempt.encoded_rows {
+                out = Self::new(interval_end);
+            }
+            cols = interval_end + 1;
+        }
+        out
+    }
+}
+
+impl EncodeSize for TopologyHint {
+    fn encode_size(&self) -> usize {
+        self.data_cols.encode_size()
+    }
+}
+
+impl Write for TopologyHint {
+    fn write(&self, buf: &mut impl bytes::BufMut) {
+        self.data_cols.write(buf);
+    }
+}
+
+impl Read for TopologyHint {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl bytes::Buf, _: &Self::Cfg) -> Result<Self, commonware_codec::Error> {
+        let range = RangeCfg::from(..);
+        Ok(Self {
+            data_cols: usize::read_cfg(buf, &range)?,
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl arbitrary::Arbitrary<'_> for TopologyHint {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            data_cols: u.arbitrary::<u32>()? as usize,
+        })
+    }
+}
 
 /// Contains the sizes of various objects in the protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,19 +150,31 @@ pub struct Topology {
 }
 
 impl Topology {
-    const fn with_cols(data_bytes: usize, n: usize, k: usize, cols: usize) -> Self {
-        let data_els = F::bits_to_elements(8 * data_bytes);
-        let data_rows = data_els.div_ceil(cols);
-        let samples = data_rows.div_ceil(n);
+    const fn effective_data_elements(data_bytes: usize) -> usize {
+        // Model empty input as a single zero-padded row so the sampling and
+        // security calculations still have a non-empty domain.
+        let effective_data_bytes = if data_bytes == 0 { 1 } else { data_bytes };
+        F::bits_to_elements(8 * effective_data_bytes)
+    }
+
+    const fn with_cols(
+        data_bytes: usize,
+        min_shards: usize,
+        total_shards: usize,
+        data_cols: usize,
+    ) -> Self {
+        let data_els = Self::effective_data_elements(data_bytes);
+        let data_rows = data_els.div_ceil(data_cols);
+        let samples = data_rows.div_ceil(min_shards);
         Self {
             data_bytes,
-            data_cols: cols,
+            data_cols,
             data_rows,
-            encoded_rows: ((n + k) * samples).next_power_of_two(),
+            encoded_rows: (total_shards * samples).next_power_of_two(),
             samples,
             column_samples: 0,
-            min_shards: n,
-            total_shards: n + k,
+            min_shards,
+            total_shards,
         }
     }
 
@@ -76,48 +206,35 @@ impl Topology {
             F::bits_to_elements(SECURITY_BITS) * self.required_samples().div_ceil(self.samples);
     }
 
-    /// Figure out what size different values will have, based on the config and the data.
-    pub fn reckon(config: &Config, data_bytes: usize) -> Self {
-        let n = config.minimum_shards.get() as usize;
-        let k = config.extra_shards.get() as usize;
-        // The following calculations don't tolerate data_bytes = 0, so we
-        // temporarily correct that to be at least 1, then make sure to adjust
-        // it back again to 0.
-        let corrected_data_bytes = data_bytes.max(1);
-        // The goal here is to try and maximize the number of columns in the
-        // data. ZODA is more efficient the more columns there are. However,
-        // we need to make sure that every shard has enough samples to guarantee
-        // correct encoding, and that the number of encoded rows can contain
-        // all of the samples in each shard, without overlap.
-        //
-        // To determine if a column configuration is good, we need to choose
-        // the number of encoded rows. To do this, we pick a number of samples
-        // `S` such that `S * n >= data_rows`. Then, our encoded rows will
-        // equal `((n + k) * S).next_power_of_two()`. If the number of required
-        // samples `R` for this configuration satisfies `(n + k) * R <= encoded_rows`,
-        // then this configuration is valid, using `R` as the necessary number
-        // of samples.
-        //
-        // We try increasing column counts, picking the configuration that's good.
-        // It's possible that the first configuration, with one column, is not good.
-        // To correct for that, we need to add extra checksum columns to guarantee
-        // security.
-        let mut out = Self::with_cols(corrected_data_bytes, n, k, 1);
-        loop {
-            let attempt = Self::with_cols(corrected_data_bytes, n, k, out.data_cols + 1);
-            let required_samples = attempt.required_samples();
-            if required_samples.saturating_mul(n + k) <= attempt.encoded_rows {
-                out = Self {
-                    samples: required_samples.max(attempt.samples),
-                    ..attempt
-                };
-            } else {
-                break;
-            }
+    pub const fn hint(&self) -> TopologyHint {
+        TopologyHint::new(self.data_cols)
+    }
+
+    /// Figure out what size different values will have, based on a searched hint
+    /// and the data size. The hint does not need to be optimal, but it must
+    /// still satisfy ZODA's sampling-security bound.
+    pub fn reckon(hint: TopologyHint, config: &Config, data_bytes: usize) -> Option<Self> {
+        if hint.data_cols == 0 || hint.data_cols > Self::effective_data_elements(data_bytes) {
+            return None;
         }
-        out.correct_column_samples();
-        out.data_bytes = data_bytes;
-        out
+
+        let mut topology = Self::with_cols(
+            data_bytes,
+            usize::from(config.minimum_shards.get()),
+            config.total_shards() as usize,
+            hint.data_cols,
+        );
+
+        let required_samples = topology.required_samples();
+        if required_samples.saturating_mul(topology.total_shards) <= topology.encoded_rows {
+            // We might need more samples than required for being able to recover the data,
+            // but if we can fit the required samples, we might as well do that.
+            topology.samples = required_samples.max(topology.samples);
+        }
+
+        // Now we make sure we have enough columns to get the desired security.
+        topology.correct_column_samples();
+        Some(topology)
     }
 
     pub fn check_index(&self, i: u16) -> Result<(), Error> {
@@ -134,17 +251,45 @@ mod tests {
     use commonware_utils::NZU16;
 
     #[test]
+    fn reckon_handles_empty_input() {
+        let config = Config {
+            minimum_shards: NZU16!(2),
+            extra_shards: NZU16!(1),
+        };
+        let data_bytes = 0;
+        let hint = TopologyHint::search(&config, data_bytes);
+        let topology = Topology::reckon(hint, &config, data_bytes)
+            .expect("searched topology hint must be valid");
+        assert_eq!(hint.data_cols, 1);
+        assert_eq!(topology.data_bytes, 0);
+        assert_eq!(topology.data_cols, 1);
+        assert_eq!(topology.data_rows, 1);
+        assert_eq!(topology.samples, 1);
+        assert_eq!(topology.encoded_rows, 4);
+
+        let required = topology.required_samples();
+        let provided = topology.samples * (topology.column_samples / 2);
+        assert!(
+            provided >= required,
+            "security invariant violated: provided {provided} < required {required}"
+        );
+    }
+
+    #[test]
     fn reckon_handles_small_extra_shards() {
         let config = Config {
             minimum_shards: NZU16!(3),
             extra_shards: NZU16!(1),
         };
-        let topology = Topology::reckon(&config, 16);
+        let data_bytes = 16;
+        let hint = TopologyHint::search(&config, data_bytes);
+        let topology = Topology::reckon(hint, &config, data_bytes)
+            .expect("searched topology hint must be valid");
         assert_eq!(topology.min_shards, 3);
         assert_eq!(topology.total_shards, 4);
 
         // Verify we hit the 1-column fallback and the security invariant holds.
-        // When the loop in reckon() exits without finding a multi-column config,
+        // When the search finds no better multi-column configuration,
         // correct_column_samples() must compensate by adding column samples.
         assert_eq!(topology.data_cols, 1);
         let required = topology.required_samples();
@@ -153,5 +298,47 @@ mod tests {
             provided >= required,
             "security invariant violated: provided {provided} < required {required}"
         );
+    }
+
+    #[test]
+    fn reckon_searches_past_invalid_intervals() {
+        let config = Config {
+            minimum_shards: NZU16!(2),
+            extra_shards: NZU16!(1),
+        };
+        let hint = TopologyHint::search(&config, 65_536);
+        let topology =
+            Topology::reckon(hint, &config, 65_536).expect("searched topology hint must be valid");
+
+        // For this payload size, cols=13 and cols=14 are invalid, but
+        // cols=15..24 are valid again. A "stop at first invalid candidate"
+        // search would therefore get stuck at 12, while the exact interval
+        // search should recover the true optimum at 24.
+        assert_eq!(topology.data_cols, 24);
+        assert_eq!(hint.data_cols, 24);
+    }
+
+    #[test]
+    fn reckon_accepts_hints_that_need_extra_column_samples() {
+        let config = Config {
+            minimum_shards: NZU16!(2),
+            extra_shards: NZU16!(1),
+        };
+        let hint = TopologyHint::new(13);
+        let topology =
+            Topology::reckon(hint, &config, 65_536).expect("hint should still be secure");
+        assert_eq!(topology.data_cols, 13);
+        assert!(topology.column_samples > 2);
+    }
+
+    #[test]
+    fn reckon_rejects_malformed_hints() {
+        let config = Config {
+            minimum_shards: NZU16!(2),
+            extra_shards: NZU16!(1),
+        };
+        assert!(Topology::reckon(TopologyHint::new(0), &config, 65_536).is_none());
+        let too_many_cols = Topology::effective_data_elements(65_536) + 1;
+        assert!(Topology::reckon(TopologyHint::new(too_many_cols), &config, 65_536).is_none());
     }
 }


### PR DESCRIPTION
One issue with ZODA is that we would not look at the indices of the shards passed to us, counting several duplicate shards toward the number we need, in case a caller was enough of a nitwit to do this. Now we also de-dup in this method, using only the first shard for a given index, and not counting duplicates towards the requirement.

We also change the Topology calculation to do a more exhaustive interval search, which scales with $O(\sqrt{D})$. This is a bit more expensive (3x for smaller data sizes, 1.2x for larger data sizes, still not a dominant factor at all for encode), so this PR also changes the strategy to create a new `TopologyHint` type, which the leader searches for, and then have the rest of the Topology be calculated using that hint from the followers. The idea is that even a malicious leader can't force an insecure configuration, just one that might be a bit slower to handle. The thinking is that a malicious leader can already delay data transmission in other ways, so this is an acceptable tradeoff in order to accelerate the common honest use case.