### PR TITLE
[macros] Respect `RUST_LOG` in `test_traced`

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -22,7 +22,7 @@ futures.workspace = true
 futures-timer.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 default = [ "std" ]

--- a/macros/impl/src/lib.rs
+++ b/macros/impl/src/lib.rs
@@ -266,22 +266,15 @@ pub fn test_traced(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
     let input = parse_macro_input!(item as ItemFn);
 
-    // Parse the attribute argument for log level
-    let log_level = if attr.is_empty() {
-        // Default log level is DEBUG
-        quote! { tracing::Level::DEBUG }
+    // Parse the attribute argument for default log level
+    let default_level = if attr.is_empty() {
+        "debug".to_string()
     } else {
-        // Parse the attribute as a string literal
         let level_str = parse_macro_input!(attr as LitStr);
-        let level_ident = level_str.value().to_uppercase();
+        let level_ident = level_str.value().to_lowercase();
         match level_ident.as_str() {
-            "TRACE" => quote! { tracing::Level::TRACE },
-            "DEBUG" => quote! { tracing::Level::DEBUG },
-            "INFO" => quote! { tracing::Level::INFO },
-            "WARN" => quote! { tracing::Level::WARN },
-            "ERROR" => quote! { tracing::Level::ERROR },
+            "trace" | "debug" | "info" | "warn" | "error" => level_ident,
             _ => {
-                // Return a compile error for invalid log levels
                 return Error::new_spanned(
                     level_str,
                     "Invalid log level. Expected one of: TRACE, DEBUG, INFO, WARN, ERROR.",
@@ -303,13 +296,19 @@ pub fn test_traced(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[test]
         #(#attrs)*
         #vis #sig {
-            // Create a subscriber and dispatcher with the specified log level
-            let subscriber = tracing_subscriber::fmt()
-                .with_test_writer()
-                .with_max_level(#log_level)
-                .with_line_number(true)
-                .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
-                .finish();
+            use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+            // Use RUST_LOG if set, otherwise fall back to the macro's default level
+            let filter = EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new(#default_level));
+            let subscriber = tracing_subscriber::Registry::default()
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_test_writer()
+                        .with_line_number(true)
+                        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+                )
+                .with(filter);
             let dispatcher = tracing::Dispatch::new(subscriber);
 
             // Set the subscriber for the scope of the test

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -311,10 +311,13 @@ pub use commonware_macros_impl::test_collect_traces;
 /// This renames `test_some_behavior` into `test_some_behavior_<group>_`, making
 /// it easy to filter tests by group postfixes in nextest.
 pub use commonware_macros_impl::test_group;
-/// Capture logs (based on the provided log level) from a test run using
+/// Capture logs from a test run using
 /// [libtest's output capture functionality](https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output).
 ///
-/// This macro defaults to a log level of `DEBUG` if no level is provided.
+/// The default log level is `DEBUG`, but can be overridden with the macro argument or
+/// the `RUST_LOG` environment variable. When `RUST_LOG` is set, it takes precedence
+/// over the macro argument, enabling per-module filtering (e.g.,
+/// `RUST_LOG=commonware_consensus=trace,warn`).
 ///
 /// This macro is powered by the [tracing](https://docs.rs/tracing) and
 /// [tracing-subscriber](https://docs.rs/tracing-subscriber) crates.
@@ -327,7 +330,7 @@ pub use commonware_macros_impl::test_group;
 /// #[commonware_macros::test_traced("INFO")]
 /// fn test_info_level() {
 ///     info!("This is an info log");
-///     debug!("This is a debug log (won't be shown)");
+///     debug!("This is a debug log (won't be shown unless RUST_LOG overrides)");
 ///     assert_eq!(2 + 2, 4);
 /// }
 /// ```


### PR DESCRIPTION
## Overview

Adds an `EnvFilter` to `test_traced` so that we can filter logs using `RUST_LOG`.
