### PR TITLE
[runtime/tokio] flush Rayon buffer-pool caches on idle

### DIFF
--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -138,13 +138,6 @@ pub(crate) enum BufferPoolThreadCacheConfig {
     Disabled,
 }
 
-impl BufferPoolThreadCacheConfig {
-    /// Returns true if thread-local caching is enabled for this config.
-    pub const fn is_enabled(&self) -> bool {
-        matches!(self, Self::Fixed(_) | Self::ForParallelism(_))
-    }
-}
-
 /// Configuration for a buffer pool.
 #[derive(Debug, Clone)]
 pub struct BufferPoolConfig {
@@ -309,6 +302,14 @@ impl BufferPoolConfig {
         self.max_per_class =
             NonZeroU32::new(max_per_class).expect("max_per_class must be non-zero");
         self
+    }
+
+    /// Returns true if thread-local caching is enabled.
+    pub const fn thread_cache_enabled(&self) -> bool {
+        matches!(
+            self.thread_cache_config,
+            BufferPoolThreadCacheConfig::Fixed(_) | BufferPoolThreadCacheConfig::ForParallelism(_)
+        )
     }
 
     /// Validates the configuration, panicking on invalid values.

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -726,6 +726,7 @@ impl BufferPoolThreadCache {
     /// paths. A push or pop sets the bit. The first check after activity clears
     /// it and keeps the cache warm, a later check that finds it still clear
     /// drops the cache, returning entries to the global freelists.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn flush_idle() {
         Self::TLS_SIZE_CLASS_CACHES.with(|bins| {
             // SAFETY: this TLS value is only ever accessed by the current thread.

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -138,6 +138,13 @@ pub(crate) enum BufferPoolThreadCacheConfig {
     Disabled,
 }
 
+impl BufferPoolThreadCacheConfig {
+    /// Returns true if thread-local caching is enabled for this config.
+    pub const fn is_enabled(&self) -> bool {
+        matches!(self, Self::Fixed(_) | Self::ForParallelism(_))
+    }
+}
+
 /// Configuration for a buffer pool.
 #[derive(Debug, Clone)]
 pub struct BufferPoolConfig {

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -305,7 +305,7 @@ impl BufferPoolConfig {
     }
 
     /// Returns true if thread-local caching is enabled.
-    pub fn thread_cache_enabled(&self) -> bool {
+    pub(crate) fn thread_cache_enabled(&self) -> bool {
         self.resolve_thread_cache_capacity() > 0
     }
 

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -305,8 +305,8 @@ impl BufferPoolConfig {
     }
 
     /// Returns true if thread-local caching is enabled.
-    pub const fn thread_cache_enabled(&self) -> bool {
-        matches!(self.thread_cache_config, BufferPoolThreadCacheConfig::Enabled(_))
+    pub fn thread_cache_enabled(&self) -> bool {
+        self.resolve_thread_cache_capacity() > 0
     }
 
     /// Validates the configuration, panicking on invalid values.
@@ -1239,6 +1239,26 @@ mod tests {
         let page = page_size();
         let config = test_config(page, page * 4, 10).with_thread_cache_capacity(NZUsize!(11));
         config.validate();
+    }
+
+    #[test]
+    fn test_thread_cache_enabled_uses_resolved_capacity() {
+        let page = page_size();
+
+        // Automatic sizing can resolve to zero for small class budgets.
+        let auto_zero = test_config(page, page, 1);
+        assert_eq!(auto_zero.resolve_thread_cache_capacity(), 0);
+        assert!(!auto_zero.thread_cache_enabled());
+
+        let auto_nonzero = test_config(page, page, 4);
+        assert!(auto_nonzero.resolve_thread_cache_capacity() > 0);
+        assert!(auto_nonzero.thread_cache_enabled());
+
+        let explicit = test_config(page, page, 1).with_thread_cache_capacity(NZUsize!(1));
+        assert!(explicit.thread_cache_enabled());
+
+        let disabled = test_config(page, page, 4).with_thread_cache_disabled();
+        assert!(!disabled.thread_cache_enabled());
     }
 
     #[test]

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -305,6 +305,7 @@ impl BufferPoolConfig {
     }
 
     /// Returns true if thread-local caching is enabled.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn thread_cache_enabled(&self) -> bool {
         self.resolve_thread_cache_capacity() > 0
     }

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -559,6 +559,7 @@ struct TlsSizeClassCacheEntry {
 struct TlsSizeClassCache {
     entries: Vec<TlsSizeClassCacheEntry>,
     capacity: usize,
+    recently_used: bool,
 }
 
 impl TlsSizeClassCache {
@@ -567,6 +568,7 @@ impl TlsSizeClassCache {
         Self {
             entries: Vec::with_capacity(capacity),
             capacity,
+            recently_used: false,
         }
     }
 
@@ -578,6 +580,9 @@ impl TlsSizeClassCache {
     /// and retain the rest locally for future allocations.
     #[inline]
     fn pop(&mut self, class: &Arc<SizeClass>) -> Option<TlsSizeClassCacheEntry> {
+        // Record activity for the next reclamation pass.
+        self.recently_used = true;
+
         // Serve local hits without touching shared state.
         if let Some(entry) = self.entries.pop() {
             return Some(entry);
@@ -631,6 +636,9 @@ impl TlsSizeClassCache {
     /// queue traffic across future returns.
     #[inline]
     fn push(&mut self, entry: TlsSizeClassCacheEntry) {
+        // Record activity for the next reclamation pass.
+        self.recently_used = true;
+
         // Preserve same-thread locality while the cache still has room.
         if self.entries.len() < self.capacity {
             self.entries.push(entry);
@@ -708,6 +716,29 @@ impl BufferPoolThreadCache {
             let bins = unsafe { &mut *bins.get() };
             for cache in bins.iter_mut() {
                 let _ = cache.take();
+            }
+        });
+    }
+
+    /// Flushes local caches that were inactive across two consecutive checks.
+    ///
+    /// This uses a single activity bit instead of timestamping allocator hot
+    /// paths. A push or pop sets the bit. The first check after activity clears
+    /// it and keeps the cache warm, a later check that finds it still clear
+    /// drops the cache, returning entries to the global freelists.
+    pub(crate) fn flush_idle() {
+        Self::TLS_SIZE_CLASS_CACHES.with(|bins| {
+            // SAFETY: this TLS value is only ever accessed by the current thread.
+            let bins = unsafe { &mut *bins.get() };
+            for cache in bins.iter_mut() {
+                let Some(local) = cache.as_mut() else {
+                    continue;
+                };
+                if local.recently_used {
+                    local.recently_used = false;
+                } else {
+                    let _ = cache.take();
+                }
             }
         });
     }
@@ -1697,6 +1728,46 @@ mod tests {
     }
 
     #[test]
+    fn test_thread_cache_flush_idle_skips_recently_used_cache_once() {
+        let page = page_size();
+        let pool =
+            test_pool(test_config(page, page * 2, 8).with_thread_cache_capacity(NZUsize!(4)));
+
+        // Use two distinct size classes so the idle pass walks the whole TLS
+        // registry and applies the same policy to each populated bin.
+        let small_index = pool.inner.config.class_index(page).unwrap();
+        let large_index = pool.inner.config.class_index(page + 1).unwrap();
+        let small_class = &pool.inner.classes[small_index];
+        let large_class = &pool.inner.classes[large_index];
+
+        let small = pool.try_alloc(page).expect("tracked allocation");
+        let large = pool.try_alloc(page + 1).expect("tracked allocation");
+        drop(small);
+        drop(large);
+
+        assert_eq!(get_local_len(small_class), 1);
+        assert_eq!(get_local_len(large_class), 1);
+        assert_eq!(get_global_len(small_class), 0);
+        assert_eq!(get_global_len(large_class), 0);
+
+        // The first idle pass sees recent use, preserves local cache locality,
+        // and arms each cache to be flushed if it remains untouched.
+        BufferPoolThreadCache::flush_idle();
+        assert_eq!(get_local_len(small_class), 1);
+        assert_eq!(get_local_len(large_class), 1);
+        assert_eq!(get_global_len(small_class), 0);
+        assert_eq!(get_global_len(large_class), 0);
+
+        // A second pass with no intervening use moves the cached buffers back
+        // to the global freelists.
+        BufferPoolThreadCache::flush_idle();
+        assert_eq!(get_local_len(small_class), 0);
+        assert_eq!(get_local_len(large_class), 0);
+        assert_eq!(get_global_len(small_class), 1);
+        assert_eq!(get_global_len(large_class), 1);
+    }
+
+    #[test]
     fn test_config_with_budget_bytes() {
         // Classes: 4, 8, 16 (sum = 28). Budget 280 => max_per_class = 10.
         let config = BufferPoolConfig {
@@ -1900,6 +1971,7 @@ mod tests {
         let mut cache = TlsSizeClassCache {
             entries: Vec::new(),
             capacity: 0,
+            recently_used: false,
         };
 
         // Small local capacities should bypass batching and push straight to global.

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -306,10 +306,7 @@ impl BufferPoolConfig {
 
     /// Returns true if thread-local caching is enabled.
     pub const fn thread_cache_enabled(&self) -> bool {
-        matches!(
-            self.thread_cache_config,
-            BufferPoolThreadCacheConfig::Fixed(_) | BufferPoolThreadCacheConfig::ForParallelism(_)
-        )
+        matches!(self.thread_cache_config, BufferPoolThreadCacheConfig::Enabled(_))
     }
 
     /// Validates the configuration, panicking on invalid values.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -858,7 +858,7 @@ mod tests {
         pin::Pin,
         str::FromStr,
         sync::{
-            atomic::{AtomicU32, Ordering},
+            atomic::{AtomicBool, AtomicU32, Ordering},
             Arc,
         },
         task::{Context as TContext, Poll, Waker},
@@ -3984,26 +3984,32 @@ mod tests {
                 .create_thread_pool(NZUsize!(2))
                 .unwrap();
             let buffer_pool = context.network_buffer_pool().clone();
-            let flush_interval = tokio::RAYON_BUFFER_POOL_CACHE_FLUSH_INTERVAL;
 
             // Ask each Rayon worker to allocate and then drop one tracked
             // buffer. Because TLS caching is enabled, each worker parks that
             // buffer in its thread-local cache instead of returning it to the
-            // shared freelist immediately.
+            // shared freelist immediately. Keep the workers occupied after
+            // parking so the background flush broadcast cannot run before the
+            // pre-flush exhaustion assertion.
             let parked = Arc::new(AtomicU32::new(0));
+            let release = Arc::new(AtomicBool::new(false));
             pool.spawn_broadcast({
                 let buffer_pool = buffer_pool.clone();
                 let parked = parked.clone();
+                let release = release.clone();
                 move |_| {
                     let buf = buffer_pool.try_alloc(1024).expect("tracked buffer");
                     drop(buf);
-                    parked.fetch_add(1, Ordering::Relaxed);
+                    parked.fetch_add(1, Ordering::Release);
+                    while !release.load(Ordering::Acquire) {
+                        std::thread::yield_now();
+                    }
                 }
             });
 
             // Wait until both workers report that they have parked one
             // buffer in their TLS caches.
-            while parked.load(Ordering::Relaxed) != 2 {
+            while parked.load(Ordering::Acquire) != 2 {
                 context.sleep(Duration::from_millis(10)).await;
             }
 
@@ -4014,18 +4020,31 @@ mod tests {
                 PoolError::Exhausted
             );
 
-            // Give the runtime's background flush loop time to inject its
-            // broadcast and let both idle workers flush their TLS caches.
-            context.sleep(flush_interval.saturating_mul(2)).await;
+            // Release the workers so they can observe the flush broadcast.
+            release.store(true, Ordering::Release);
 
             // After the flush loop runs, both buffers should be visible to the
             // main thread again via the shared freelist.
-            let _buf1 = buffer_pool
-                .try_alloc(1024)
-                .expect("first flushed buffer should be visible to the main thread");
-            let _buf2 = buffer_pool
-                .try_alloc(1024)
-                .expect("second flushed buffer should be visible to the main thread");
+            let wait_for_flush = {
+                let context = context.clone();
+                let buffer_pool = buffer_pool.clone();
+                async move {
+                    loop {
+                        if let Ok(buf1) = buffer_pool.try_alloc(1024) {
+                            if let Ok(buf2) = buffer_pool.try_alloc(1024) {
+                                break (buf1, buf2);
+                            }
+                        }
+                        context.sleep(Duration::from_millis(10)).await;
+                    }
+                }
+            };
+
+            let (_buf1, _buf2) = context
+                .timeout(Duration::from_secs(5), wait_for_flush)
+                .await
+                .expect("workers should flush TLS caches before timeout");
+
             assert_eq!(
                 buffer_pool.try_alloc(1024).unwrap_err(),
                 PoolError::Exhausted

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3968,7 +3968,7 @@ mod tests {
             tokio::Config::default()
                 .with_network_buffer_pool_config(
                     BufferPoolConfig::for_network()
-                        .with_max_per_class(NZUsize!(2))
+                        .with_max_per_class(NZU32!(2))
                         .with_thread_cache_capacity(NZUsize!(1)),
                 )
                 .with_storage_buffer_pool_config(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3958,6 +3958,82 @@ mod tests {
     }
 
     #[test]
+    fn test_tokio_rayon_workers_flush_buffer_pool_tls_cache() {
+        // Give the network buffer pool exactly two tracked buffers in the
+        // 1024-byte size class and let each worker keep at most one in its
+        // TLS cache. That makes it easy to observe both buffers becoming
+        // invisible to the main thread, then visible again after the idle
+        // flush loop runs.
+        let executor = tokio::Runner::new(
+            tokio::Config::default()
+                .with_network_buffer_pool_config(
+                    BufferPoolConfig::for_network()
+                        .with_max_per_class(NZUsize!(2))
+                        .with_thread_cache_capacity(NZUsize!(1)),
+                )
+                .with_storage_buffer_pool_config(
+                    BufferPoolConfig::for_storage().with_thread_cache_disabled(),
+                ),
+        );
+
+        executor.start(|context| async move {
+            // Use two Rayon workers so the broadcast must fan out to multiple
+            // long-lived worker threads.
+            let pool = context
+                .with_label("pool")
+                .create_thread_pool(NZUsize!(2))
+                .unwrap();
+            let buffer_pool = context.network_buffer_pool().clone();
+            let flush_interval = tokio::RAYON_BUFFER_POOL_CACHE_FLUSH_INTERVAL;
+
+            // Ask each Rayon worker to allocate and then drop one tracked
+            // buffer. Because TLS caching is enabled, each worker parks that
+            // buffer in its thread-local cache instead of returning it to the
+            // shared freelist immediately.
+            let parked = Arc::new(AtomicU32::new(0));
+            pool.spawn_broadcast({
+                let buffer_pool = buffer_pool.clone();
+                let parked = parked.clone();
+                move |_| {
+                    let buf = buffer_pool.try_alloc(1024).expect("tracked buffer");
+                    drop(buf);
+                    parked.fetch_add(1, Ordering::Relaxed);
+                }
+            });
+
+            // Wait until both workers report that they have parked one
+            // buffer in their TLS caches.
+            while parked.load(Ordering::Relaxed) != 2 {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            // The main thread cannot allocate from this size class now,
+            // because both free buffers are hidden in worker-local caches.
+            assert_eq!(
+                buffer_pool.try_alloc(1024).unwrap_err(),
+                PoolError::Exhausted
+            );
+
+            // Give the runtime's background flush loop time to inject its
+            // broadcast and let both idle workers flush their TLS caches.
+            context.sleep(flush_interval.saturating_mul(2)).await;
+
+            // After the flush loop runs, both buffers should be visible to the
+            // main thread again via the shared freelist.
+            let _buf1 = buffer_pool
+                .try_alloc(1024)
+                .expect("first flushed buffer should be visible to the main thread");
+            let _buf2 = buffer_pool
+                .try_alloc(1024)
+                .expect("second flushed buffer should be visible to the main thread");
+            assert_eq!(
+                buffer_pool.try_alloc(1024).unwrap_err(),
+                PoolError::Exhausted
+            );
+        });
+    }
+
+    #[test]
     fn test_create_thread_pool_deterministic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -53,7 +53,11 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 // How often the background Rayon buffer-pool cache flush loop asks workers to
 // flush their thread-local caches.
-const RAYON_BUFFER_POOL_CACHE_FLUSH_INTERVAL: Duration = Duration::from_secs(10);
+pub(crate) const RAYON_BUFFER_POOL_CACHE_FLUSH_INTERVAL: Duration = if cfg!(test) {
+    Duration::from_millis(100)
+} else {
+    Duration::from_secs(10)
+};
 
 #[cfg(feature = "iouring-network")]
 cfg_if::cfg_if! {

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -56,7 +56,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 pub(crate) const RAYON_BUFFER_POOL_CACHE_FLUSH_INTERVAL: Duration = if cfg!(test) {
     Duration::from_millis(100)
 } else {
-    Duration::from_secs(10)
+    Duration::from_secs(2)
 };
 
 #[cfg(feature = "iouring-network")]

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -737,16 +737,8 @@ impl crate::ThreadPooler for Context {
 
         // If any buffer pool has thread-local caching enabled, we must periodically
         // ask Rayon workers to flush their thread-local caches.
-        if self
-            .network_buffer_pool
-            .config()
-            .thread_cache_config
-            .is_enabled()
-            || self
-                .storage_buffer_pool
-                .config()
-                .thread_cache_config
-                .is_enabled()
+        if self.network_buffer_pool.config().thread_cache_enabled()
+            || self.storage_buffer_pool.config().thread_cache_enabled()
         {
             self.spawn_rayon_buffer_pool_thread_cache_flush(&pool);
         }

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -577,7 +577,7 @@ impl Context {
     fn spawn_rayon_buffer_pool_thread_cache_flush(&self, pool: &ThreadPool) {
         let pool = Arc::downgrade(pool);
         let pending = Arc::new(AtomicBool::new(false));
-        self.with_label("rayon-buffer-pool-thread-cache-flush")
+        self.with_label("rayon_buffer_pool_thread_cache_flush")
             .spawn(move |context| async move {
                 loop {
                     context.sleep(RAYON_BUFFER_POOL_CACHE_FLUSH_INTERVAL).await;

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -567,13 +567,14 @@ impl Context {
         &self.executor.metrics
     }
 
-    /// Spawn a task that periodically asks Rayon workers to flush their
+    /// Spawn a task that periodically asks Rayon workers to flush idle
     /// thread-local buffer pool caches.
     ///
     /// Rayon worker threads are long-lived, so without periodic flushes they
     /// could retain cached buffers indefinitely. Each pass injects a broadcast
-    /// task that runs once per worker after it drains local work, allowing the
-    /// worker to release any cached buffers back to the global freelists.
+    /// task that runs once per worker after it drains local work. Caches used
+    /// since the previous pass are retained for locality, caches untouched for
+    /// a full interval are released back to the global freelists.
     fn spawn_rayon_buffer_pool_thread_cache_flush(&self, pool: &ThreadPool) {
         let pool = Arc::downgrade(pool);
         let pending = Arc::new(AtomicBool::new(false));
@@ -602,7 +603,7 @@ impl Context {
                     let remaining = AtomicUsize::new(pool.current_num_threads());
                     let pending = pending.clone();
                     pool.spawn_broadcast(move |_| {
-                        BufferPoolThreadCache::flush();
+                        BufferPoolThreadCache::flush_idle();
 
                         if remaining.fetch_sub(1, Ordering::Relaxed) == 1 {
                             pending.store(false, Ordering::Relaxed);

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -18,8 +18,8 @@ use crate::{
         Registry,
     },
     utils::{self, signal::Stopper, supervision::Tree, Panicker},
-    BufferPool, BufferPoolConfig, Clock, Error, Execution, Handle, Metrics as _, SinkOf,
-    Spawner as _, StreamOf, METRICS_PREFIX,
+    BufferPool, BufferPoolConfig, BufferPoolThreadCache, Clock, Error, Execution, Handle,
+    Metrics as _, SinkOf, Spawner as _, StreamOf, METRICS_PREFIX,
 };
 #[cfg(feature = "iouring-network")]
 use crate::{
@@ -41,12 +41,19 @@ use std::{
     net::{IpAddr, SocketAddr},
     num::NonZeroUsize,
     path::PathBuf,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Weak,
+    },
     time::{Duration, SystemTime},
 };
 use tokio::runtime::{Builder, Runtime};
 use tracing::{info_span, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+// How often the background Rayon buffer-pool cache flush loop asks workers to
+// flush their thread-local caches.
+const RAYON_BUFFER_POOL_CACHE_FLUSH_INTERVAL: Duration = Duration::from_secs(10);
 
 #[cfg(feature = "iouring-network")]
 cfg_if::cfg_if! {
@@ -555,6 +562,51 @@ impl Context {
     fn metrics(&self) -> &Metrics {
         &self.executor.metrics
     }
+
+    /// Spawn a task that periodically asks Rayon workers to flush their
+    /// thread-local buffer pool caches.
+    ///
+    /// Rayon worker threads are long-lived, so without periodic flushes they
+    /// could retain cached buffers indefinitely. Each pass injects a broadcast
+    /// task that runs once per worker after it drains local work, allowing the
+    /// worker to release any cached buffers back to the global freelists.
+    fn spawn_rayon_buffer_pool_thread_cache_flush(&self, pool: &ThreadPool) {
+        let pool = Arc::downgrade(pool);
+        let pending = Arc::new(AtomicBool::new(false));
+        self.with_label("rayon-buffer-pool-thread-cache-flush")
+            .spawn(move |context| async move {
+                loop {
+                    context.sleep(RAYON_BUFFER_POOL_CACHE_FLUSH_INTERVAL).await;
+
+                    // Stop maintenance once the caller has dropped the pool.
+                    let Some(pool) = Weak::upgrade(&pool) else {
+                        break;
+                    };
+
+                    // At most one broadcast may be pending, otherwise slow or busy
+                    // workers could accumulate maintenance jobs indefinitely.
+                    if pending
+                        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                        .is_err()
+                    {
+                        continue;
+                    }
+
+                    // Rayon only runs this on workers after they have drained
+                    // their local work, so the flush happens during an idle
+                    // maintenance pass rather than interrupting active tasks.
+                    let remaining = AtomicUsize::new(pool.current_num_threads());
+                    let pending = pending.clone();
+                    pool.spawn_broadcast(move |_| {
+                        BufferPoolThreadCache::flush();
+
+                        if remaining.fetch_sub(1, Ordering::Relaxed) == 1 {
+                            pending.store(false, Ordering::Relaxed);
+                        }
+                    });
+                }
+            });
+    }
 }
 
 impl crate::Spawner for Context {
@@ -666,7 +718,7 @@ impl crate::ThreadPooler for Context {
         &self,
         concurrency: NonZeroUsize,
     ) -> Result<ThreadPool, ThreadPoolBuildError> {
-        ThreadPoolBuilder::new()
+        let pool = ThreadPoolBuilder::new()
             .num_threads(concurrency.get())
             .spawn_handler(move |thread| {
                 // Tasks spawned in a thread pool are expected to run longer than any single
@@ -677,7 +729,25 @@ impl crate::ThreadPooler for Context {
                 Ok(())
             })
             .build()
-            .map(Arc::new)
+            .map(Arc::new)?;
+
+        // If any buffer pool has thread-local caching enabled, we must periodically
+        // ask Rayon workers to flush their thread-local caches.
+        if self
+            .network_buffer_pool
+            .config()
+            .thread_cache_config
+            .is_enabled()
+            || self
+                .storage_buffer_pool
+                .config()
+                .thread_cache_config
+                .is_enabled()
+        {
+            self.spawn_rayon_buffer_pool_thread_cache_flush(&pool);
+        }
+
+        Ok(pool)
     }
 }
 

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -511,6 +511,25 @@ impl crate::Runner for Runner {
     }
 }
 
+/// Marks one worker's Rayon broadcast maintenance task as complete on drop.
+///
+/// The maintenance loop allows only one broadcast to be in flight at a time by
+/// holding a `pending` latch until every worker has run the broadcast closure.
+/// Keep the accounting in a guard so an unwind from maintenance code cannot
+/// leave that latch set forever and silently disable future flush passes.
+struct RayonBroadcastGuard<'a> {
+    remaining: &'a AtomicUsize,
+    pending: &'a AtomicBool,
+}
+
+impl Drop for RayonBroadcastGuard<'_> {
+    fn drop(&mut self) {
+        if self.remaining.fetch_sub(1, Ordering::Relaxed) == 1 {
+            self.pending.store(false, Ordering::Relaxed);
+        }
+    }
+}
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "iouring-storage")] {
         type Storage = MeteredStorage<IoUringStorage>;
@@ -603,11 +622,12 @@ impl Context {
                     let remaining = AtomicUsize::new(pool.current_num_threads());
                     let pending = pending.clone();
                     pool.spawn_broadcast(move |_| {
-                        BufferPoolThreadCache::flush_idle();
+                        let _guard = RayonBroadcastGuard {
+                            remaining: &remaining,
+                            pending: pending.as_ref(),
+                        };
 
-                        if remaining.fetch_sub(1, Ordering::Relaxed) == 1 {
-                            pending.store(false, Ordering::Relaxed);
-                        }
+                        BufferPoolThreadCache::flush_idle();
                     });
                 }
             });


### PR DESCRIPTION
Rayon worker threads in our runtime are long-lived. That interacts poorly with the buffer pool's thread-local cache: once a rayon worker touches the buffer pool, it can retain cached buffers indefinitely. Tokio blocking workers do not have this problem since they shut down when idle and naturally release their thread-local state.

This PR adds a small background flush loop for rayon thread pools created by the tokio runtime. When thread-local buffer caching is enabled for either runtime buffer pool, we periodically schedule a `spawn_broadcast` on the rayon pool so each worker gets a chance to flush its thread-local buffer cache back into the global freelists. The important detail is that the broadcast only runs once a worker has drained its local work, so this behaves like an idle-time cleanup pass rather than interrupting active rayon work. That lets us keep the fast path benefits of TLS caching while avoiding indefinite hoarding on long-lived worker threads.

Depends on #3458.