### PR TITLE
[runtime] Avoid recursive supervision teardown

### DIFF
--- a/runtime/src/utils/supervision.rs
+++ b/runtime/src/utils/supervision.rs
@@ -45,7 +45,7 @@ impl Children {
     }
 
     /// Records that one weak child pointer is known-dead.
-    fn mark_stale(&mut self) {
+    const fn mark_stale(&mut self) {
         self.stale = self.stale.saturating_add(1);
     }
 


### PR DESCRIPTION
## Summary
  - Replace recursive supervision abort propagation with an iterative traversal
  - Move supervision parent retention out of the inner node state so ancestry can be detached safely during teardown
  - Drop strong parent ancestry iteratively to avoid recursive Arc destruction on deep clone-only chains
  - Batch supervision child reaping behind a STALE_CHILD_THRESHOLD so clone-heavy parents avoid scanning the entire weak-child list on every
  clone
  - Extract child-list operations (push, mark_stale, drain) into a dedicated Children type
  - Add deep-chain regressions for both aborting and dropping 50,000 supervised descendants
  - Add targeted regressions for batched child compaction and wide sibling-fanout aborts