### PR TITLE
[consensus/marshal] Avoid materializing blocks for availability checks

### DIFF
--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -16,7 +16,7 @@ use commonware_utils::{
     channel::{fallible::OneshotExt, mpsc, oneshot},
     ordered::Set,
 };
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use tracing::{debug, error, trace, warn};
 
 /// A responder waiting for a message.
@@ -30,6 +30,12 @@ enum InsertMessageResult {
     Inserted,
     Duplicate,
     Ineligible,
+}
+
+/// A responder waiting for message availability.
+struct AvailabilityWaiter {
+    /// The responder to notify when the digest is available.
+    responder: oneshot::Sender<()>,
 }
 
 /// Instance of the main engine for the module.
@@ -74,6 +80,9 @@ where
 
     /// Pending requests from the application.
     waiters: BTreeMap<M::Digest, Vec<Waiter<M>>>,
+
+    /// Pending requests waiting only for digest availability.
+    availability_waiters: BTreeMap<M::Digest, Vec<AvailabilityWaiter>>,
 
     /// Provider for peer set changes.
     peer_provider: D,
@@ -131,6 +140,7 @@ where
             codec_config: cfg.codec_config,
             mailbox_receiver,
             waiters: BTreeMap::new(),
+            availability_waiters: BTreeMap::new(),
             deques: BTreeMap::new(),
             items: BTreeMap::new(),
             counts: BTreeMap::new(),
@@ -165,7 +175,7 @@ where
             on_start => {
                 // Cleanup waiters
                 self.cleanup_waiters();
-                let _ = self.metrics.waiters.try_set(self.waiters.len());
+                let _ = self.metrics.waiters.try_set(self.waiter_digests());
             },
             on_stopped => {
                 debug!("shutdown");
@@ -196,9 +206,17 @@ where
                     trace!("mailbox: subscribe");
                     self.handle_subscribe(digest, responder);
                 }
+                Message::SubscribeAvailable { digest, responder } => {
+                    trace!("mailbox: subscribe available");
+                    self.handle_subscribe_available(digest, responder);
+                }
                 Message::Get { digest, responder } => {
                     trace!("mailbox: get");
                     self.handle_get(digest, responder);
+                }
+                Message::Has { digest, responder } => {
+                    trace!("mailbox: has");
+                    self.handle_has(digest, responder);
                 }
             },
             // Handle incoming messages
@@ -277,10 +295,40 @@ where
             .push(Waiter { responder });
     }
 
+    /// Handles a `subscribe available` request from the application.
+    ///
+    /// If the message is already in the cache, the responder is immediately notified.
+    /// Otherwise, the responder is stored in the availability waiters list.
+    fn handle_subscribe_available(&mut self, digest: M::Digest, responder: oneshot::Sender<()>) {
+        if self.items.contains_key(&digest) {
+            self.respond_subscribe_available(responder);
+            return;
+        }
+
+        self.availability_waiters
+            .entry(digest)
+            .or_default()
+            .push(AvailabilityWaiter { responder });
+    }
+
     /// Handles a `get` request from the application.
     fn handle_get(&mut self, digest: M::Digest, responder: oneshot::Sender<Option<M>>) {
         let item = self.items.get(&digest).cloned();
         self.respond_get(responder, item);
+    }
+
+    /// Handles a `has` request from the application.
+    fn handle_has(&mut self, digest: M::Digest, responder: oneshot::Sender<bool>) {
+        let found = self.items.contains_key(&digest);
+        self.metrics.get.inc(if responder.send_lossy(found) {
+            if found {
+                Status::Success
+            } else {
+                Status::Failure
+            }
+        } else {
+            Status::Dropped
+        });
     }
 
     /// Handles a message that was received from a peer.
@@ -314,6 +362,11 @@ where
         if let Some(waiters) = self.waiters.remove(&digest) {
             for waiter in waiters {
                 self.respond_subscribe(waiter.responder, msg.clone());
+            }
+        }
+        if let Some(waiters) = self.availability_waiters.remove(&digest) {
+            for waiter in waiters {
+                self.respond_subscribe_available(waiter.responder);
             }
         }
 
@@ -394,12 +447,41 @@ where
 
             !waiters.is_empty()
         });
+        self.availability_waiters.retain(|_, waiters| {
+            let initial_len = waiters.len();
+            waiters.retain(|waiter| !waiter.responder.is_closed());
+            let dropped_count = initial_len - waiters.len();
+
+            for _ in 0..dropped_count {
+                self.metrics.subscribe.inc(Status::Dropped);
+            }
+
+            !waiters.is_empty()
+        });
+    }
+
+    /// Count the number of digests with at least one pending waiter.
+    fn waiter_digests(&self) -> usize {
+        self.waiters
+            .keys()
+            .chain(self.availability_waiters.keys())
+            .collect::<BTreeSet<_>>()
+            .len()
     }
 
     /// Respond to a waiter with a message.
     /// Increments the appropriate metric based on the result.
     fn respond_subscribe(&mut self, responder: oneshot::Sender<M>, msg: M) {
         self.metrics.subscribe.inc(if responder.send_lossy(msg) {
+            Status::Success
+        } else {
+            Status::Dropped
+        });
+    }
+
+    /// Respond to an availability waiter.
+    fn respond_subscribe_available(&mut self, responder: oneshot::Sender<()>) {
+        self.metrics.subscribe.inc(if responder.send_lossy(()) {
             Status::Success
         } else {
             Status::Dropped

--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -16,13 +16,16 @@ use commonware_utils::{
     channel::{fallible::OneshotExt, mpsc, oneshot},
     ordered::Set,
 };
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use tracing::{debug, error, trace, warn};
 
-/// A responder waiting for a message.
-struct Waiter<M> {
-    /// The responder to send the message to.
-    responder: oneshot::Sender<M>,
+/// A responder waiting for a digest.
+enum Waiter<M> {
+    /// A subscriber waiting for the full message.
+    Message(oneshot::Sender<M>),
+
+    /// A subscriber waiting only for digest availability.
+    Availability(oneshot::Sender<()>),
 }
 
 /// Result of buffering an incoming or locally sent digest (inserted, duplicate, or ineligible).
@@ -30,12 +33,6 @@ enum InsertMessageResult {
     Inserted,
     Duplicate,
     Ineligible,
-}
-
-/// A responder waiting for message availability.
-struct AvailabilityWaiter {
-    /// The responder to notify when the digest is available.
-    responder: oneshot::Sender<()>,
 }
 
 /// Instance of the main engine for the module.
@@ -78,11 +75,8 @@ where
     /// The mailbox for receiving messages.
     mailbox_receiver: mpsc::Receiver<Message<P, M>>,
 
-    /// Pending requests from the application.
+    /// Pending subscriptions from the application.
     waiters: BTreeMap<M::Digest, Vec<Waiter<M>>>,
-
-    /// Pending requests waiting only for digest availability.
-    availability_waiters: BTreeMap<M::Digest, Vec<AvailabilityWaiter>>,
 
     /// Provider for peer set changes.
     peer_provider: D,
@@ -140,7 +134,6 @@ where
             codec_config: cfg.codec_config,
             mailbox_receiver,
             waiters: BTreeMap::new(),
-            availability_waiters: BTreeMap::new(),
             deques: BTreeMap::new(),
             items: BTreeMap::new(),
             counts: BTreeMap::new(),
@@ -292,23 +285,23 @@ where
         self.waiters
             .entry(digest)
             .or_default()
-            .push(Waiter { responder });
+            .push(Waiter::Message(responder));
     }
 
     /// Handles a `subscribe available` request from the application.
     ///
     /// If the message is already in the cache, the responder is immediately notified.
-    /// Otherwise, the responder is stored in the availability waiters list.
+    /// Otherwise, the responder is stored in the waiters list.
     fn handle_subscribe_available(&mut self, digest: M::Digest, responder: oneshot::Sender<()>) {
         if self.items.contains_key(&digest) {
             self.respond_subscribe_available(responder);
             return;
         }
 
-        self.availability_waiters
+        self.waiters
             .entry(digest)
             .or_default()
-            .push(AvailabilityWaiter { responder });
+            .push(Waiter::Availability(responder));
     }
 
     /// Handles a `get` request from the application.
@@ -361,12 +354,14 @@ where
         // Send the message to the waiters, if any
         if let Some(waiters) = self.waiters.remove(&digest) {
             for waiter in waiters {
-                self.respond_subscribe(waiter.responder, msg.clone());
-            }
-        }
-        if let Some(waiters) = self.availability_waiters.remove(&digest) {
-            for waiter in waiters {
-                self.respond_subscribe_available(waiter.responder);
+                match waiter {
+                    Waiter::Message(responder) => {
+                        self.respond_subscribe(responder, msg.clone());
+                    }
+                    Waiter::Availability(responder) => {
+                        self.respond_subscribe_available(responder);
+                    }
+                }
             }
         }
 
@@ -436,23 +431,23 @@ where
     /// Remove all waiters that have dropped receivers.
     fn cleanup_waiters(&mut self) {
         self.waiters.retain(|_, waiters| {
-            let initial_len = waiters.len();
-            waiters.retain(|waiter| !waiter.responder.is_closed());
-            let dropped_count = initial_len - waiters.len();
+            let mut dropped_message_waiters = 0;
+            let mut dropped_availability_waiters = 0;
+            waiters.retain(|waiter| {
+                let is_closed = waiter.is_closed();
+                if is_closed {
+                    match waiter {
+                        Waiter::Message(_) => dropped_message_waiters += 1,
+                        Waiter::Availability(_) => dropped_availability_waiters += 1,
+                    }
+                }
+                !is_closed
+            });
 
-            // Increment metrics for each dropped waiter
-            for _ in 0..dropped_count {
+            for _ in 0..dropped_message_waiters {
                 self.metrics.get.inc(Status::Dropped);
             }
-
-            !waiters.is_empty()
-        });
-        self.availability_waiters.retain(|_, waiters| {
-            let initial_len = waiters.len();
-            waiters.retain(|waiter| !waiter.responder.is_closed());
-            let dropped_count = initial_len - waiters.len();
-
-            for _ in 0..dropped_count {
+            for _ in 0..dropped_availability_waiters {
                 self.metrics.subscribe.inc(Status::Dropped);
             }
 
@@ -462,11 +457,7 @@ where
 
     /// Count the number of digests with at least one pending waiter.
     fn waiter_digests(&self) -> usize {
-        self.waiters
-            .keys()
-            .chain(self.availability_waiters.keys())
-            .collect::<BTreeSet<_>>()
-            .len()
+        self.waiters.len()
     }
 
     /// Respond to a waiter with a message.
@@ -501,6 +492,16 @@ where
         } else {
             Status::Dropped
         });
+    }
+}
+
+impl<M> Waiter<M> {
+    /// Whether the waiter has already dropped its receiver.
+    fn is_closed(&self) -> bool {
+        match self {
+            Self::Message(responder) => responder.is_closed(),
+            Self::Availability(responder) => responder.is_closed(),
+        }
     }
 }
 

--- a/broadcast/src/buffered/ingress.rs
+++ b/broadcast/src/buffered/ingress.rs
@@ -25,10 +25,26 @@ pub enum Message<P: PublicKey, M: Digestible> {
         responder: oneshot::Sender<M>,
     },
 
+    /// Subscribe to receive availability for a message by digest.
+    ///
+    /// The responder will be notified when the digest is available; either
+    /// instantly (if cached) or when it is received from the network. The request can be canceled
+    /// by dropping the responder.
+    SubscribeAvailable {
+        digest: M::Digest,
+        responder: oneshot::Sender<()>,
+    },
+
     /// Get a message by digest.
     Get {
         digest: M::Digest,
         responder: oneshot::Sender<Option<M>>,
+    },
+
+    /// Check whether a message is already cached by digest.
+    Has {
+        digest: M::Digest,
+        responder: oneshot::Sender<bool>,
     },
 }
 
@@ -58,6 +74,21 @@ impl<P: PublicKey, M: Digestible + Codec> Mailbox<P, M> {
         receiver
     }
 
+    /// Subscribe to message availability by digest.
+    ///
+    /// The responder will be notified when the message is available; either
+    /// instantly (if cached) or when it is received from the network. The request can be canceled
+    /// by dropping the responder.
+    ///
+    /// If the engine has shut down, the returned receiver will resolve to `Canceled`.
+    pub async fn subscribe_available(&self, digest: M::Digest) -> oneshot::Receiver<()> {
+        let (responder, receiver) = oneshot::channel();
+        self.sender
+            .send_lossy(Message::SubscribeAvailable { digest, responder })
+            .await;
+        receiver
+    }
+
     /// Subscribe to a message by digest with an externally prepared responder.
     ///
     /// The responder will be sent the message when it is available; either
@@ -79,6 +110,16 @@ impl<P: PublicKey, M: Digestible + Codec> Mailbox<P, M> {
             .request(|responder| Message::Get { digest, responder })
             .await
             .unwrap_or_default()
+    }
+
+    /// Check whether a message is already cached by digest.
+    ///
+    /// If the engine has shut down, returns `false`.
+    pub async fn has(&self, digest: M::Digest) -> bool {
+        self.sender
+            .request(|responder| Message::Has { digest, responder })
+            .await
+            .unwrap_or(false)
     }
 }
 

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -279,7 +279,7 @@ mod tests {
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
                 initialize_simulation(context.clone(), 1, 1.0).await;
-            let mailboxes = spawn_peer_engines(context.clone(), &oracle, &mut registrations);
+            let mailboxes = spawn_peer_engines(context.clone(), &oracle, &mut registrations).await;
             let mailbox = mailboxes.get(&peers[0]).unwrap().clone();
 
             let message = TestMessage::shared(b"availability");
@@ -303,6 +303,33 @@ mod tests {
                 .expect("post-broadcast availability subscription failed");
             let duration = context.current().duration_since(start).unwrap();
             assert!(duration < A_JIFFY, "availability should resolve immediately");
+        });
+    }
+
+    #[test_traced]
+    fn test_message_and_availability_subscriptions_share_digest_waiters() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(5));
+        runner.start(|context| async move {
+            let (peers, mut registrations, oracle) =
+                initialize_simulation(context.clone(), 1, 1.0).await;
+            let mailboxes = spawn_peer_engines(context.clone(), &oracle, &mut registrations).await;
+            let mailbox = mailboxes.get(&peers[0]).unwrap().clone();
+
+            let message = TestMessage::shared(b"message-and-availability");
+            let digest = message.digest();
+
+            let available = mailbox.subscribe_available(digest).await;
+            let subscribed = mailbox.subscribe(digest).await;
+            let result = mailbox.broadcast(Recipients::All, message.clone()).await;
+            assert_eq!(result.await.unwrap().len(), peers.len() - 1);
+
+            available
+                .await
+                .expect("availability subscription should resolve");
+            let resolved = subscribed
+                .await
+                .expect("message subscription should resolve");
+            assert_eq!(resolved, message);
         });
     }
 

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -274,6 +274,39 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_availability_subscription() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(5));
+        runner.start(|context| async move {
+            let (peers, mut registrations, oracle) =
+                initialize_simulation(context.clone(), 1, 1.0).await;
+            let mailboxes = spawn_peer_engines(context.clone(), &oracle, &mut registrations);
+            let mailbox = mailboxes.get(&peers[0]).unwrap().clone();
+
+            let message = TestMessage::shared(b"availability");
+            let digest = message.digest();
+
+            assert!(!mailbox.has(digest).await);
+
+            let available_before = mailbox.subscribe_available(digest).await;
+            let result = mailbox.broadcast(Recipients::All, message).await;
+            assert_eq!(result.await.unwrap().len(), peers.len() - 1);
+
+            available_before
+                .await
+                .expect("pre-broadcast availability subscription failed");
+            assert!(mailbox.has(digest).await);
+
+            let available_after = mailbox.subscribe_available(digest).await;
+            let start = context.current();
+            available_after
+                .await
+                .expect("post-broadcast availability subscription failed");
+            let duration = context.current().duration_since(start).unwrap();
+            assert!(duration < A_JIFFY, "availability should resolve immediately");
+        });
+    }
+
+    #[test_traced]
     fn test_packet_loss() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|context| async move {

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -352,6 +352,9 @@ where
     block_subscriptions:
         BTreeMap<BlockSubscriptionKey<B::Digest>, Vec<oneshot::Sender<Arc<CodedBlock<B, C, H>>>>>,
 
+    /// Open subscriptions waiting only for block availability by digest.
+    available_by_digest_subscriptions: BTreeMap<B::Digest, Vec<oneshot::Sender<()>>>,
+
     /// Metrics for the shard engine.
     metrics: ShardMetrics,
 }
@@ -392,6 +395,7 @@ where
                 reconstructed_blocks: BTreeMap::new(),
                 assigned_shard_verified_subscriptions: BTreeMap::new(),
                 block_subscriptions: BTreeMap::new(),
+                available_by_digest_subscriptions: BTreeMap::new(),
                 metrics,
             },
             Mailbox::new(sender),
@@ -450,6 +454,11 @@ where
                         subscribers.retain(|tx| !tx.is_closed());
                         !subscribers.is_empty()
                     });
+                self.available_by_digest_subscriptions
+                    .retain(|_, subscribers| {
+                        subscribers.retain(|tx| !tx.is_closed());
+                        !subscribers.is_empty()
+                    });
             },
             on_stopped => {
                 debug!("received shutdown signal, stopping shard engine");
@@ -492,6 +501,13 @@ where
                         .cloned();
                     response.send_lossy(block);
                 }
+                Message::HasByDigest { digest, response } => {
+                    let available = self
+                        .reconstructed_blocks
+                        .values()
+                        .any(|block| block.digest() == digest);
+                    response.send_lossy(available);
+                }
                 Message::SubscribeAssignedShardVerified {
                     commitment,
                     response,
@@ -509,6 +525,9 @@ where
                 }
                 Message::SubscribeByDigest { digest, response } => {
                     self.handle_block_subscription(BlockSubscriptionKey::Digest(digest), response);
+                }
+                Message::SubscribeAvailableByDigest { digest, response } => {
+                    self.handle_available_by_digest_subscription(digest, response);
                 }
                 Message::Prune { through } => {
                     self.prune(through);
@@ -961,6 +980,27 @@ where
             .push(response);
     }
 
+    /// Handles the registry of a block-availability subscription by digest.
+    fn handle_available_by_digest_subscription(
+        &mut self,
+        digest: B::Digest,
+        response: oneshot::Sender<()>,
+    ) {
+        if self
+            .reconstructed_blocks
+            .values()
+            .any(|block| block.digest() == digest)
+        {
+            response.send_lossy(());
+            return;
+        }
+
+        self.available_by_digest_subscriptions
+            .entry(digest)
+            .or_default()
+            .push(response);
+    }
+
     /// Notifies and cleans up any subscriptions waiting for assigned shard
     /// verification.
     fn notify_assigned_shard_verified_subscribers(&mut self, commitment: Commitment) {
@@ -974,10 +1014,21 @@ where
         }
     }
 
+    /// Notifies and cleans up any subscriptions waiting for block availability by digest.
+    fn notify_available_by_digest_subscribers(&mut self, digest: B::Digest) {
+        if let Some(mut subscribers) = self.available_by_digest_subscriptions.remove(&digest) {
+            for subscriber in subscribers.drain(..) {
+                subscriber.send_lossy(());
+            }
+        }
+    }
+
     /// Notifies and cleans up any subscriptions for a reconstructed block.
     fn notify_block_subscribers(&mut self, block: Arc<CodedBlock<B, C, H>>) {
         let commitment = block.commitment();
         let digest = block.digest();
+
+        self.notify_available_by_digest_subscribers(digest);
 
         // Notify by-commitment subscribers.
         if let Some(mut subscribers) = self
@@ -1009,10 +1060,10 @@ where
             .remove(&commitment);
         self.block_subscriptions
             .remove(&BlockSubscriptionKey::Commitment(commitment));
+        let digest = commitment.block::<B::Digest>();
         self.block_subscriptions
-            .remove(&BlockSubscriptionKey::Digest(
-                commitment.block::<B::Digest>(),
-            ));
+            .remove(&BlockSubscriptionKey::Digest(digest));
+        self.available_by_digest_subscriptions.remove(&digest);
     }
 
     /// Prunes all blocks in the reconstructed block cache that are older than the block

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -50,6 +50,13 @@ where
         /// The response channel.
         response: oneshot::Sender<Option<Arc<CodedBlock<B, C, H>>>>,
     },
+    /// A request to check whether a reconstructed block is already available by digest.
+    HasByDigest {
+        /// The digest of the block to check.
+        digest: B::Digest,
+        /// The response channel.
+        response: oneshot::Sender<bool>,
+    },
     /// A request to open a subscription for assigned shard verification.
     ///
     /// For participants, this resolves once the leader-delivered shard for
@@ -81,6 +88,13 @@ where
         digest: B::Digest,
         /// The response channel.
         response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
+    },
+    /// A request to open a subscription for block availability by digest.
+    SubscribeAvailableByDigest {
+        /// The block's digest.
+        digest: B::Digest,
+        /// The response channel.
+        response: oneshot::Sender<()>,
     },
     /// A request to prune all caches at and below the given commitment.
     Prune {
@@ -153,6 +167,17 @@ where
             .flatten()
     }
 
+    /// Check whether a reconstructed block is already available by digest.
+    pub async fn has_by_digest(&self, digest: B::Digest) -> bool {
+        self.sender
+            .request(|tx| Message::HasByDigest {
+                digest,
+                response: tx,
+            })
+            .await
+            .unwrap_or(false)
+    }
+
     /// Subscribe to assigned shard verification for a commitment.
     ///
     /// For participants, this resolves once the leader-delivered shard for
@@ -197,6 +222,20 @@ where
     ) -> oneshot::Receiver<Arc<CodedBlock<B, C, H>>> {
         let (responder, receiver) = oneshot::channel();
         let msg = Message::SubscribeByDigest {
+            digest,
+            response: responder,
+        };
+        self.sender.send_lossy(msg).await;
+        receiver
+    }
+
+    /// Subscribe to block availability by digest.
+    pub async fn subscribe_available_by_digest(
+        &self,
+        digest: B::Digest,
+    ) -> oneshot::Receiver<()> {
+        let (responder, receiver) = oneshot::channel();
+        let msg = Message::SubscribeAvailableByDigest {
             digest,
             response: responder,
         };

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -77,6 +77,13 @@ where
         self.get_by_digest(digest).await
     }
 
+    async fn has_by_digest(
+        &self,
+        digest: <CodedBlock<B, C, H> as Digestible>::Digest,
+    ) -> bool {
+        self.has_by_digest(digest).await
+    }
+
     async fn find_by_commitment(&self, commitment: Commitment) -> Option<Self::CachedBlock> {
         self.get(commitment).await
     }
@@ -86,6 +93,13 @@ where
         digest: <CodedBlock<B, C, H> as Digestible>::Digest,
     ) -> oneshot::Receiver<Self::CachedBlock> {
         self.subscribe_by_digest(digest).await
+    }
+
+    async fn subscribe_available_by_digest(
+        &self,
+        digest: <CodedBlock<B, C, H> as Digestible>::Digest,
+    ) -> oneshot::Receiver<()> {
+        self.subscribe_available_by_digest(digest).await
     }
 
     async fn subscribe_by_commitment(

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -173,6 +173,14 @@ struct BlockSubscription<V: Variant> {
     _aborter: Aborter,
 }
 
+/// A struct that holds multiple subscriptions waiting only for block availability.
+struct AvailabilitySubscription {
+    // The subscribers that are waiting for the digest to become available.
+    subscribers: Vec<oneshot::Sender<()>>,
+    // Aborter that aborts the waiter future when dropped.
+    _aborter: Aborter,
+}
+
 /// The key used to track block subscriptions.
 ///
 /// Digest-scoped and commitment-scoped subscriptions are intentionally distinct
@@ -185,6 +193,10 @@ enum BlockSubscriptionKey<C, D> {
 
 type BlockSubscriptionKeyFor<V> =
     BlockSubscriptionKey<<V as Variant>::Commitment, <<V as Variant>::Block as Digestible>::Digest>;
+
+type AvailabilityDigestFor<V> = <<V as Variant>::Block as Digestible>::Digest;
+type AvailabilityWaiterResultFor<V> = Result<AvailabilityDigestFor<V>, AvailabilityDigestFor<V>>;
+type AvailabilityWaitersFor<V> = AbortablePool<AvailabilityWaiterResultFor<V>>;
 
 /// The [Actor] is responsible for receiving uncertified blocks from the broadcast mechanism,
 /// receiving notarizations and finalizations from consensus, and reconstructing a total order
@@ -245,6 +257,8 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: BTreeMap<BlockSubscriptionKeyFor<V>, BlockSubscription<V>>,
+    // Outstanding subscriptions waiting only for digest availability
+    availability_subscriptions: BTreeMap<<V::Block as Digestible>::Digest, AvailabilitySubscription>,
 
     // ---------- Storage ----------
     // Prunable cache
@@ -348,6 +362,7 @@ where
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
                 tip: Height::zero(),
                 block_subscriptions: BTreeMap::new(),
+                availability_subscriptions: BTreeMap::new(),
                 cache,
                 application_metadata,
                 finalizations_by_height,
@@ -392,6 +407,7 @@ where
     {
         // Create a local pool for waiter futures.
         let mut waiters = AbortablePool::<Result<V::Block, BlockSubscriptionKeyFor<V>>>::default();
+        let mut availability_waiters = AvailabilityWaitersFor::<V>::default();
 
         // Get tip and send to application
         let tip = self.get_latest().await;
@@ -424,6 +440,10 @@ where
                     bs.subscribers.retain(|tx| !tx.is_closed());
                     !bs.subscribers.is_empty()
                 });
+                self.availability_subscriptions.retain(|_, subscription| {
+                    subscription.subscribers.retain(|tx| !tx.is_closed());
+                    !subscription.subscribers.is_empty()
+                });
             },
             on_stopped => {
                 debug!("context shutdown, stopping marshal");
@@ -447,6 +467,16 @@ where
                         }
                     }
                     self.block_subscriptions.remove(&key);
+                }
+            },
+            Ok(completion) = availability_waiters.next_completed() else continue => match completion {
+                Ok(digest) => self.notify_available_subscribers(digest),
+                Err(digest) => {
+                    debug!(
+                        ?digest,
+                        "buffer availability subscription closed, canceling local subscribers"
+                    );
+                    self.availability_subscriptions.remove(&digest);
                 }
             },
             // Handle application acknowledgements (drain all ready acks, sync once)
@@ -674,6 +704,21 @@ where
                             response,
                             &mut resolver,
                             &mut waiters,
+                            &mut buffer,
+                        )
+                        .await;
+                    }
+                    Message::SubscribeAvailableByDigest {
+                        round,
+                        digest,
+                        response,
+                    } => {
+                        self.handle_subscribe_available(
+                            round,
+                            digest,
+                            response,
+                            &mut resolver,
+                            &mut availability_waiters,
                             &mut buffer,
                         )
                         .await;
@@ -927,6 +972,50 @@ where
                         .map_or_else(|_| Err(waiter_key), |block| Ok(block.into_block()))
                 });
                 entry.insert(BlockSubscription {
+                    subscribers: vec![response],
+                    _aborter: aborter,
+                });
+            }
+        }
+    }
+
+    /// Handle a local subscription request for block availability by digest.
+    async fn handle_subscribe_available<Buf: Buffer<V>>(
+        &mut self,
+        round: Option<Round>,
+        digest: <V::Block as Digestible>::Digest,
+        response: oneshot::Sender<()>,
+        resolver: &mut impl Resolver<Key = Request<V::Commitment>>,
+        waiters: &mut AvailabilityWaitersFor<V>,
+        buffer: &mut Buf,
+    ) {
+        if self.is_block_available(buffer, digest).await {
+            response.send_lossy(());
+            return;
+        }
+
+        if let Some(round) = round {
+            if round < self.last_processed_round {
+                return;
+            }
+
+            debug!(?round, ?digest, "requested block availability missing");
+            resolver
+                .fetch(Request::<V::Commitment>::Notarized { round })
+                .await;
+        }
+
+        debug!(?round, ?digest, "registering availability subscriber");
+        match self.availability_subscriptions.entry(digest) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().subscribers.push(response);
+            }
+            Entry::Vacant(entry) => {
+                let rx = buffer.subscribe_available_by_digest(digest).await;
+                let aborter = waiters.push(async move {
+                    rx.await.map_or_else(|_| Err(digest), |_| Ok(digest))
+                });
+                entry.insert(AvailabilitySubscription {
                     subscribers: vec![response],
                     _aborter: aborter,
                 });
@@ -1201,8 +1290,18 @@ where
 
     // -------------------- Waiters --------------------
 
+    /// Notify any subscribers waiting only for digest availability.
+    fn notify_available_subscribers(&mut self, digest: <V::Block as Digestible>::Digest) {
+        if let Some(mut subscription) = self.availability_subscriptions.remove(&digest) {
+            for subscriber in subscription.subscribers.drain(..) {
+                subscriber.send_lossy(());
+            }
+        }
+    }
+
     /// Notify any subscribers for the given digest with the provided block.
     fn notify_subscribers(&mut self, block: &V::Block) {
+        self.notify_available_subscribers(block.digest());
         if let Some(mut bs) = self
             .block_subscriptions
             .remove(&BlockSubscriptionKey::Digest(block.digest()))
@@ -1503,6 +1602,18 @@ where
 
     // -------------------- Mixed Storage --------------------
 
+    /// Checks whether a block is available in cache or finalized storage.
+    async fn has_block_in_storage(&self, digest: <V::Block as Digestible>::Digest) -> bool {
+        if self.cache.has_block(digest).await {
+            return true;
+        }
+
+        match self.finalized_blocks.has(ArchiveID::Key(&digest)).await {
+            Ok(found) => found,
+            Err(e) => panic!("failed to check block: {e}"),
+        }
+    }
+
     /// Looks for a block in cache and finalized storage by digest.
     async fn find_block_in_storage(
         &self,
@@ -1517,6 +1628,15 @@ where
             Ok(stored) => stored.map(|stored| stored.into()),
             Err(e) => panic!("failed to get block: {e}"),
         }
+    }
+
+    /// Checks whether a block is available anywhere locally using only the digest.
+    async fn is_block_available<Buf: Buffer<V>>(
+        &self,
+        buffer: &Buf,
+        digest: <V::Block as Digestible>::Digest,
+    ) -> bool {
+        buffer.has_by_digest(digest).await || self.has_block_in_storage(digest).await
     }
 
     /// Looks for a block anywhere in local storage using only the digest.

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -430,6 +430,30 @@ where
         None
     }
 
+    /// Check whether a verified or notarized block is cached by digest.
+    pub(crate) async fn has_block(&self, digest: <V::Block as Digestible>::Digest) -> bool {
+        for cache in self.caches.values().rev() {
+            if cache
+                .verified_blocks
+                .has(Identifier::Key(&digest))
+                .await
+                .expect("failed to check verified block")
+            {
+                return true;
+            }
+
+            if cache
+                .notarized_blocks
+                .has(Identifier::Key(&digest))
+                .await
+                .expect("failed to check notarized block")
+            {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Prune the caches below the given round.
     pub(crate) async fn prune(&mut self, round: Round) {
         // Remove and close prunable archives from older epochs

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -76,6 +76,16 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// A channel to send the retrieved block.
         response: oneshot::Sender<V::Block>,
     },
+    /// A request to subscribe to block availability by digest.
+    SubscribeAvailableByDigest {
+        /// The round in which the block was notarized. This is an optimization
+        /// to help locate the block.
+        round: Option<Round>,
+        /// The digest of the block to check.
+        digest: <V::Block as Digestible>::Digest,
+        /// A channel to notify once the block is available.
+        response: oneshot::Sender<()>,
+    },
     /// A request to subscribe to a block by its commitment.
     SubscribeByCommitment {
         /// The round in which the block was notarized. This is an optimization
@@ -248,6 +258,30 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         let (tx, rx) = oneshot::channel();
         self.sender
             .send_lossy(Message::SubscribeByDigest {
+                round,
+                digest,
+                response: tx,
+            })
+            .await;
+        rx
+    }
+
+    /// Subscribe to block availability by its digest.
+    ///
+    /// If the block is already available locally, the receiver resolves immediately.
+    /// Otherwise, the request will be registered and the caller will be notified when the
+    /// block becomes available. If the block is not finalized, it's possible that it may
+    /// never become available.
+    ///
+    /// The oneshot receiver should be dropped to cancel the subscription.
+    pub async fn subscribe_available_by_digest(
+        &self,
+        round: Option<Round>,
+        digest: <V::Block as Digestible>::Digest,
+    ) -> oneshot::Receiver<()> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send_lossy(Message::SubscribeAvailableByDigest {
                 round,
                 digest,
                 response: tx,

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -98,6 +98,17 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
         digest: <V::Block as Digestible>::Digest,
     ) -> impl Future<Output = Option<Self::CachedBlock>> + Send;
 
+    /// Check whether a block is immediately available by digest.
+    ///
+    /// This is a non-blocking existence check that does not materialize the block
+    /// when the buffer can answer more cheaply than `find_by_digest`.
+    fn has_by_digest(
+        &self,
+        digest: <V::Block as Digestible>::Digest,
+    ) -> impl Future<Output = bool> + Send {
+        async move { self.find_by_digest(digest).await.is_some() }
+    }
+
     /// Attempt to find a block by its commitment.
     ///
     /// Returns `Some(block)` if the block is immediately available in the buffer,
@@ -121,6 +132,17 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
         &self,
         digest: <V::Block as Digestible>::Digest,
     ) -> impl Future<Output = oneshot::Receiver<Self::CachedBlock>> + Send;
+
+    /// Subscribe to a block's availability by its digest without fetching the block.
+    ///
+    /// Returns a receiver that will resolve when the block becomes available.
+    /// If the block is already cached, the receiver may resolve immediately.
+    ///
+    /// The returned receiver can be dropped to cancel the subscription.
+    fn subscribe_available_by_digest(
+        &self,
+        digest: <V::Block as Digestible>::Digest,
+    ) -> impl Future<Output = oneshot::Receiver<()>> + Send;
 
     /// Subscribe to a block's availability by its commitment.
     ///

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -483,14 +483,26 @@ where
             return rx;
         }
 
-        // Otherwise, subscribe to marshal for block availability.
-        let block_rx = self.marshal.subscribe_by_digest(Some(round), digest).await;
+        // Otherwise, wait for marshal to observe the digest before
+        // materializing the block for the certified slow path.
+        let availability_rx = self
+            .marshal
+            .subscribe_available_by_digest(Some(round), digest)
+            .await;
         let marshal = self.marshal.clone();
         let (mut tx, rx) = oneshot::channel();
         self.context
             .with_label("inline_certify")
             .with_attribute("round", round)
             .spawn(move |_| async move {
+                if await_block_subscription(&mut tx, availability_rx, &digest, "certification")
+                    .await
+                    .is_none()
+                {
+                    return;
+                }
+
+                let block_rx = marshal.subscribe_by_digest(Some(round), digest).await;
                 let Some(block) =
                     await_block_subscription(&mut tx, block_rx, &digest, "certification").await
                 else {

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -60,6 +60,10 @@ where
         self.get(digest).await
     }
 
+    async fn has_by_digest(&self, digest: B::Digest) -> bool {
+        self.has(digest).await
+    }
+
     async fn find_by_commitment(&self, commitment: B::Digest) -> Option<Self::CachedBlock> {
         self.find_by_digest(commitment).await
     }
@@ -68,6 +72,10 @@ where
         let (tx, rx) = oneshot::channel();
         self.subscribe_prepared(digest, tx).await;
         rx
+    }
+
+    async fn subscribe_available_by_digest(&self, digest: B::Digest) -> oneshot::Receiver<()> {
+        self.subscribe_available(digest).await
     }
 
     async fn subscribe_by_commitment(

--- a/consensus/src/marshal/store.rs
+++ b/consensus/src/marshal/store.rs
@@ -130,6 +130,16 @@ pub trait Blocks: Send + Sync + 'static {
         id: Identifier<'_, <Self::Block as Digestible>::Digest>,
     ) -> impl Future<Output = Result<Option<Self::Block>, Self::Error>> + Send;
 
+    /// Check whether a finalized block exists by height or block digest.
+    ///
+    /// Implementations may answer this more cheaply than [`Self::get`].
+    fn has(
+        &self,
+        id: Identifier<'_, <Self::Block as Digestible>::Digest>,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send {
+        async move { self.get(id).await.map(|block| block.is_some()) }
+    }
+
     /// Prune the store to the provided minimum height (inclusive).
     ///
     /// # Arguments
@@ -258,6 +268,13 @@ where
         <Self as Archive>::get(self, id).await
     }
 
+    async fn has(
+        &self,
+        id: Identifier<'_, <Self::Block as Digestible>::Digest>,
+    ) -> Result<bool, Self::Error> {
+        <Self as Archive>::has(self, id).await
+    }
+
     async fn prune(&mut self, _: Height) -> Result<(), Self::Error> {
         // Pruning is a no-op for immutable archives.
         Ok(())
@@ -349,6 +366,13 @@ where
         id: Identifier<'_, <Self::Block as Digestible>::Digest>,
     ) -> Result<Option<Self::Block>, Self::Error> {
         <Self as Archive>::get(self, id).await
+    }
+
+    async fn has(
+        &self,
+        id: Identifier<'_, <Self::Block as Digestible>::Digest>,
+    ) -> Result<bool, Self::Error> {
+        <Self as Archive>::has(self, id).await
     }
 
     async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {


### PR DESCRIPTION
Closes: #3393

## Summary

- add an availability-only marshal subscription by digest
- teach marshal storage and buffer backends to answer cheap availability checks without materializing blocks
- update `standard::Inline::certify` to wait on block availability instead of fetching the full block
- add a focused buffered availability test

## Detail

`Inline::certify` only needs to know whether marshal has a block, not the block contents. This change adds a lightweight availability path through marshal core and the backing buffer implementations so certification can wait on availability without materializing the block.

To support that path cleanly, marshal now keeps separate availability subscriptions, cache/finalized storage can answer existence checks via `has(...)`, and both the standard buffered backend and coding shards backend expose availability-only subscriptions by digest.
