### PR TITLE
[cryptography] BLS12381: Allow reading zero scalars

### DIFF
--- a/consensus/conformance.toml
+++ b/consensus/conformance.toml
@@ -1,14 +1,14 @@
 ["commonware_consensus::aggregation::types::tests::conformance::CodecConformance<Ack<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "c28b55d44ff803a04bfc4dbf07e8f94ff7e577dc43cef99c390caf3289706ce4"
+hash = "9fa6d9ec4dd41102c3fefd9c35e65644628824c436ddfc3988bc9392c2a9822f"
 
 ["commonware_consensus::aggregation::types::tests::conformance::CodecConformance<Activity<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "d20fab64a4250b37244b1ce45fa7e062dacefbe56868e063f669f043e40a3d70"
+hash = "e1c7e15c3b28ad5f9820758884c8230359737f74a864bac6e36434444292647c"
 
 ["commonware_consensus::aggregation::types::tests::conformance::CodecConformance<Certificate<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "c7ed824caef05e558858a5566bf3ee8c15658fc3d261d9be73f48086069949b4"
+hash = "848672b1e4a9c0f19a3cf8cb74c509f94ffb06ddd42c077600eaae8019ec16b1"
 
 ["commonware_consensus::aggregation::types::tests::conformance::CodecConformance<Item<Sha256Digest>>"]
 n_cases = 65536
@@ -16,7 +16,7 @@ hash = "55b287b5530fc9ba77c45ec5030ada38f86b2ddf66a1595fde27d4699667b1a3"
 
 ["commonware_consensus::aggregation::types::tests::conformance::CodecConformance<TipAck<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "51b04637257c54cecdc4e5ded4568efccafbc08f20be3fe0951369cab43ba2b6"
+hash = "9e91d17d9f43a6986ad15008464dc3d44316e345b6da4cdad35930f7deb0886b"
 
 ["commonware_consensus::marshal::coding::types::test::conformance::CodecConformance<Shard<ReedSolomon<Sha256>,Sha256>>"]
 n_cases = 65536
@@ -28,11 +28,11 @@ hash = "481cd68f2e6452c0dda512c75d74ddd2e19ac6c9fb19c642c1a152a0d830c1b2"
 
 ["commonware_consensus::ordered_broadcast::types::tests::conformance::CodecConformance<Ack<PublicKey,Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "19a763ac953319b94f4b9c81615eafa99807393198ba398e63270796e72695cd"
+hash = "e240d5459833a95f8088664d7444f187fe0f9f833bf458a2ab31163c87145d25"
 
 ["commonware_consensus::ordered_broadcast::types::tests::conformance::CodecConformance<Activity<PublicKey,Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "2567380ac17bd2e09d0610a7b9c37eeac568536c8dae3823d6d5f5e87d554f04"
+hash = "d004023d2dd45c52ccb6756492173e69f5e7ee925fe07a588f65be0cd7037fc8"
 
 ["commonware_consensus::ordered_broadcast::types::tests::conformance::CodecConformance<Chunk<PublicKey,Sha256Digest>>"]
 n_cases = 65536
@@ -40,15 +40,15 @@ hash = "43624c9e7ce355baebf32ab6e76db21cb5bf08005396ba43dae96b3a86f3a535"
 
 ["commonware_consensus::ordered_broadcast::types::tests::conformance::CodecConformance<Lock<PublicKey,Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "0b501fb047ce26f876bc45041a237a145177bb6a5979bc7ef2a4c26f7531853f"
+hash = "7b930679f48a293e8c61e89f1fc0d6aae996eff5fd551d63dc5cece33c285164"
 
 ["commonware_consensus::ordered_broadcast::types::tests::conformance::CodecConformance<Node<PublicKey,Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "ac52cbf4d43a886454c2008e6c3baf5fc9dbde39a2db8ef3734286aca3746ee4"
+hash = "e3693e1a4482c868466e7c2cac4b583c38b9c93543310d14c70f6f506693d7f4"
 
 ["commonware_consensus::ordered_broadcast::types::tests::conformance::CodecConformance<Parent<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "f1bb7460f40a9b5ffbe2a7db22a491121834771b24503af56338ba1241d7f4fb"
+hash = "04c82ac8f305f88da3002186dbf44aa8c828f5d4a1c8a4cde5ac4d1557d99ebf"
 
 ["commonware_consensus::ordered_broadcast::types::tests::conformance::CodecConformance<Proposal<PublicKey,Sha256Digest>>"]
 n_cases = 65536
@@ -56,7 +56,7 @@ hash = "6fc6f17d8734a14fb841a8acc1a39cda7519bdd025700663e260d3b000c9c5c6"
 
 ["commonware_consensus::simplex::elector::tests::conformance::RandomSelectLeaderConformance"]
 n_cases = 512
-hash = "4df7290375d7ae3b005cfad96dc5fc091bdce4a246665f94b79acf34159a3945"
+hash = "6aac342083d9ad1e9429eb316ee707eb51bd4c5cc223261808c6d0163c5e3c9d"
 
 ["commonware_consensus::simplex::elector::tests::conformance::RoundRobinShuffleConformance"]
 n_cases = 512
@@ -64,39 +64,39 @@ hash = "d6232310a3adc5cc8bf0767d095251f25211f165419372a5fe6b4ed7b06dd765"
 
 ["commonware_consensus::simplex::scheme::bls12381_threshold::vrf::tests::conformance::CodecConformance<Certificate<MinSig>>"]
 n_cases = 65536
-hash = "16b2dec188a1bd12146d62909bffdbb560f5a54e81de57aec8ec4aef2e8a5e88"
+hash = "1397193af32c9f3d5c0eca80fbfa741ca588e189074e4ab4b9c60d97673fdfb8"
 
 ["commonware_consensus::simplex::scheme::bls12381_threshold::vrf::tests::conformance::CodecConformance<Seed<MinSig>>"]
 n_cases = 65536
-hash = "a9fce1350322f848f62aaa67572eb6d510d88ebfa272b6b13371084aae1c3e51"
+hash = "9d21dec64f3333d7eb9455dca51657e28db8358eee173dbe0a86f718138d2342"
 
 ["commonware_consensus::simplex::scheme::bls12381_threshold::vrf::tests::conformance::CodecConformance<Signature<MinSig>>"]
 n_cases = 65536
-hash = "16b2dec188a1bd12146d62909bffdbb560f5a54e81de57aec8ec4aef2e8a5e88"
+hash = "1397193af32c9f3d5c0eca80fbfa741ca588e189074e4ab4b9c60d97673fdfb8"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Activity<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "e65856d6552c849b4a0aca45f794e17968cf18cda7f93e7d1ecab3dbd3958b51"
+hash = "1e25c6dda2b7da4327e5742b1a8b67d68ebd9c34080c8f877ffbd44f38848098"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Artifact<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "a46d1f90f592010bd0af0cf76dcdbf66c84a40ab5687ee36119d2e9f59ace641"
+hash = "f51dd822c99288f77f1557eed3a8c270affba4c484dbb2ef60ac3415f2cc8d03"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Backfiller<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "1aa796eb4f51beab398cdb250179d49045b1facec197d3047efc1785e8dda2f0"
+hash = "3147f69e8e0b4d91927852e19e61f4e0a02bc46fd7ccd97e74d8b859f9f25a4c"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Certificate<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "bc3cd9b7b060514269f06186b180b5a855fbc65af9ddd0e461bfd05aa9c949ef"
+hash = "7ae35fb13f2aa8fb3a13d6fc32a658a6cdd3fdfebd58f2dcccdbbd16dba9910d"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<ConflictingFinalize<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "9b361e8f45bb08e27ded35ffe7800629c9ba8a82f4d2993e154cfb513f528a21"
+hash = "95bb782e73490739bee2dfd0b898a824e450bdb3feeb1e71d9d4a90c6523f0e1"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<ConflictingNotarize<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "9b361e8f45bb08e27ded35ffe7800629c9ba8a82f4d2993e154cfb513f528a21"
+hash = "95bb782e73490739bee2dfd0b898a824e450bdb3feeb1e71d9d4a90c6523f0e1"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Context<Sha256Digest,PublicKey>>"]
 n_cases = 65536
@@ -104,31 +104,31 @@ hash = "5227154cc56a996363e26b0e006515b97a83a8c7ba580b0b5e760132fc620f4d"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Finalization<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "c78e26f7142aed21d0bb8bef88e007baae0fe34b3a2533d1085f7c2b08464e95"
+hash = "eed77fa1bd1ad359dff320a2cdbbe9e1f116dde2feaced367135f748ca5e32d9"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Finalize<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "d115ac2d81886e689a239b6fa8a277d69940876e9bbd1b27964284eb046a99e2"
+hash = "5c6429b2c96c456803271ebcb0be19ca84a040d75b4076378ec0a587bbc19356"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Notarization<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "c78e26f7142aed21d0bb8bef88e007baae0fe34b3a2533d1085f7c2b08464e95"
+hash = "eed77fa1bd1ad359dff320a2cdbbe9e1f116dde2feaced367135f748ca5e32d9"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Notarize<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "d115ac2d81886e689a239b6fa8a277d69940876e9bbd1b27964284eb046a99e2"
+hash = "5c6429b2c96c456803271ebcb0be19ca84a040d75b4076378ec0a587bbc19356"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Nullification<Scheme>>"]
 n_cases = 65536
-hash = "a44138ebc90cfdf8fdce3174ecf08831716245dc20fc666f30b005c6ae2c34d5"
+hash = "ada525d25f10f06d1abbb5956ee33d65ac29038177f637adc4f20f7298831d8d"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Nullify<Scheme>>"]
 n_cases = 65536
-hash = "d8661e9c02a7c5d6578b48297569075adadd608a2e294c695b965125033204ec"
+hash = "d7b8fe05e61a3c0619f02cab3d609a2f96790b8ac70eadfbda7db60b7e785342"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<NullifyFinalize<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "bebb2d2616de0716732a4459600c57cade16ab94952bfa39089104983937ad85"
+hash = "2c682c9ee30ccc8393e5b5e5f38c54ed1a718b6d1a74a4ef22e1bf845dc9ba12"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Proposal<Sha256Digest>>"]
 n_cases = 65536
@@ -140,11 +140,11 @@ hash = "6f852b6ad6e5dd77804d80781b03c808e186e7e7c5611752f124c625c5c3ee17"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Response<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "b9fbf2cfcbc37c87cb7aa8ede95c4ddf93c8bbd9f1a01e86ed72ba14bed920fa"
+hash = "b70a7b65f0d26e695bacfd483d7ed27bd4b78c16811d91227e049f43fbf534f1"
 
 ["commonware_consensus::simplex::types::tests::conformance::CodecConformance<Vote<Scheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "01cc3b0d41d0ef29f02de2729d51b1b31bb96f00c6390e56aadd0fb5117cc7b1"
+hash = "c69ffde4235a13b6a6b70974da030c8c57863d1dae19484f6bc74269528d9683"
 
 ["commonware_consensus::types::tests::conformance::CodecConformance<Commitment>"]
 n_cases = 65536

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -249,7 +249,7 @@ mod tests {
         sha256::Digest as Sha256Digest, Sha256,
     };
     use commonware_parallel::Sequential;
-    use commonware_utils::{test_rng, Faults, N3f1, TryFromIterator};
+    use commonware_utils::{test_rng, test_rng_seeded, Faults, N3f1, TryFromIterator};
 
     const NAMESPACE: &[u8] = b"test";
 
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn random_uses_certificate_randomness() {
-        let mut rng = test_rng();
+        let mut rng = test_rng_seeded(42);
         let Fixture {
             participants,
             schemes,
@@ -464,7 +464,7 @@ mod tests {
         // Different certificates produce different leaders
         //
         // NOTE: In general, different certificates could produce the same leader by chance.
-        // However, for our specific test inputs (rng seed 42, 5 participants), we've
+        // However, for this deterministic fixture (rng seed 42, 5 participants), we've
         // verified these produce different results.
         let leader2 = elector.elect(round1, Some(&cert2));
         assert_ne!(leader1a, leader2);

--- a/cryptography/conformance.toml
+++ b/cryptography/conformance.toml
@@ -12,35 +12,35 @@ hash = "f631238a016fb44fd2dee9eeb5bd20fc5052f33434810599b8ba6535e2ad8e97"
 
 ["commonware_cryptography::bls12381::certificate::multisig::tests::conformance::CodecConformance<Certificate<MinSig>>"]
 n_cases = 65536
-hash = "ad245f64a57c96036599647eaf509937173e9de01503a9e6494f29571191ade1"
+hash = "3d616c654432f4d9edd72c33a6cb8d92e8cd03b33b04265ad24be118e8b40a60"
 
 ["commonware_cryptography::bls12381::certificate::threshold::tests::conformance::CodecConformance<Certificate<MinSig>>"]
 n_cases = 65536
-hash = "ba2d888e6d1050e6a361aa79430c1bb03d90eb8e74b9715b1d7d01c35a495e1d"
+hash = "690ab067abf60a6aa45f71499d6449cc3789d09b319cff990c4d22af77288306"
 
 ["commonware_cryptography::bls12381::dkg::test::conformance::CodecConformance<AckOrReveal<ed25519::PublicKey>>"]
 n_cases = 65536
-hash = "97c266fb7821326e6333be0859025c774220c8d010e488d2fd13a743e4135f64"
+hash = "6d9b0ebc3215cef5e5b1e2629ca06b4be9b766385692db9ddc06c86431c74df7"
 
 ["commonware_cryptography::bls12381::dkg::test::conformance::CodecConformance<DealerLog<MinPk,ed25519::PublicKey>>"]
 n_cases = 65536
-hash = "ef8d69a3cbafc5e3f8f98755337acacc6609e92d3fdee0e4576481190cb421b4"
+hash = "ef75c7729b5f8d126dd514f684caa7df561ddb9a4ddf20e6105ea25551a94a40"
 
 ["commonware_cryptography::bls12381::dkg::test::conformance::CodecConformance<DealerPrivMsg>"]
 n_cases = 65536
-hash = "2d443ed310b383cab74abec888d0637ab81435779e274ed7be84adc7b10e2f86"
+hash = "e3938bbe1394dbdd29d1dcb6e7e02c50cd2ecbbb5e2147c1c48ae00dba281ee7"
 
 ["commonware_cryptography::bls12381::dkg::test::conformance::CodecConformance<DealerPubMsg<MinPk>>"]
 n_cases = 65536
-hash = "0a15ca78d654be68bb78cf58cfd1da568f8f1585878f081735939f02da161b22"
+hash = "ceead4947f5151c47666bb5b297314bcb7bf88e9a3053d5cc1d8c83f2e967ce0"
 
 ["commonware_cryptography::bls12381::dkg::test::conformance::CodecConformance<DealerResult<ed25519::PublicKey>>"]
 n_cases = 65536
-hash = "1a05e4e910dd186bd81189d79eaf1b4c211012d07f534ddaa38ab9705d80fa62"
+hash = "aab01f1b6ca0eff8517484c37ee7ffc965ef94f23f07732da4a0477413f01218"
 
 ["commonware_cryptography::bls12381::dkg::test::conformance::CodecConformance<Output<MinPk,ed25519::PublicKey>>"]
 n_cases = 65536
-hash = "b31f32f62da530fb4861e8a46e5068e0c36ed1b509ee5bc758b6ca90a2568ad7"
+hash = "f5906b9a98350e597a8f85aaf068b4989fef6006e67f938fcf042d20377b1763"
 
 ["commonware_cryptography::bls12381::dkg::test::conformance::CodecConformance<PlayerAck<ed25519::PublicKey>>"]
 n_cases = 65536
@@ -48,15 +48,15 @@ hash = "0cbb8c8644dffe0be78d1307fb5034dd804921d66799c1aaec3d335b44e9616c"
 
 ["commonware_cryptography::bls12381::dkg::test::conformance::CodecConformance<SignedDealerLog<MinPk,ed25519::PrivateKey>>"]
 n_cases = 65536
-hash = "fca94fb3b0df54a6a34edfbb8aeef28490262daf97870e12f869aee6cf7f7e67"
+hash = "e2dd301ea282f20402aaccc7d89bef47019086d6420ce3451e96962c0631cde5"
 
 ["commonware_cryptography::bls12381::primitives::group::tests::conformance::CodecConformance<G1>"]
 n_cases = 65536
-hash = "ba2d888e6d1050e6a361aa79430c1bb03d90eb8e74b9715b1d7d01c35a495e1d"
+hash = "690ab067abf60a6aa45f71499d6449cc3789d09b319cff990c4d22af77288306"
 
 ["commonware_cryptography::bls12381::primitives::group::tests::conformance::CodecConformance<G2>"]
 n_cases = 65536
-hash = "683a309d5fefb8e0ab6778c22e66bd43e139c5f56204df932fd81052792adf4b"
+hash = "2a737e751416393397a9c48b8daf02dc42a69fc5e0d199e2b7a4c31e7b4a4d28"
 
 ["commonware_cryptography::bls12381::primitives::group::tests::conformance::CodecConformance<Private>"]
 n_cases = 65536
@@ -64,7 +64,7 @@ hash = "2d443ed310b383cab74abec888d0637ab81435779e274ed7be84adc7b10e2f86"
 
 ["commonware_cryptography::bls12381::primitives::group::tests::conformance::CodecConformance<Scalar>"]
 n_cases = 65536
-hash = "2d443ed310b383cab74abec888d0637ab81435779e274ed7be84adc7b10e2f86"
+hash = "e3938bbe1394dbdd29d1dcb6e7e02c50cd2ecbbb5e2147c1c48ae00dba281ee7"
 
 ["commonware_cryptography::bls12381::primitives::group::tests::conformance::CodecConformance<Share>"]
 n_cases = 65536
@@ -72,23 +72,23 @@ hash = "7595e042deed41454a74a89e13ecb304a04d0087c9d0760c2ed7940b06a53d78"
 
 ["commonware_cryptography::bls12381::primitives::ops::aggregate::tests::conformance::CodecConformance<Message<MinSig>>"]
 n_cases = 65536
-hash = "ba2d888e6d1050e6a361aa79430c1bb03d90eb8e74b9715b1d7d01c35a495e1d"
+hash = "690ab067abf60a6aa45f71499d6449cc3789d09b319cff990c4d22af77288306"
 
 ["commonware_cryptography::bls12381::primitives::ops::aggregate::tests::conformance::CodecConformance<PublicKey<MinSig>>"]
 n_cases = 65536
-hash = "683a309d5fefb8e0ab6778c22e66bd43e139c5f56204df932fd81052792adf4b"
+hash = "2a737e751416393397a9c48b8daf02dc42a69fc5e0d199e2b7a4c31e7b4a4d28"
 
 ["commonware_cryptography::bls12381::primitives::ops::aggregate::tests::conformance::CodecConformance<Signature<MinSig>>"]
 n_cases = 65536
-hash = "ba2d888e6d1050e6a361aa79430c1bb03d90eb8e74b9715b1d7d01c35a495e1d"
+hash = "690ab067abf60a6aa45f71499d6449cc3789d09b319cff990c4d22af77288306"
 
 ["commonware_cryptography::bls12381::primitives::variant::tests::conformance::CodecConformance<PartialSignature<MinPk>>"]
 n_cases = 65536
-hash = "f022eac985ba0e1cd501cb3988f8d05f0c7e4c491447ff069e0a5ae8e93eac4a"
+hash = "9385ac71405c655cd2c6ed359c38f4c13a68256d88784fcda252049acf7c9a99"
 
 ["commonware_cryptography::bls12381::primitives::variant::tests::conformance::CodecConformance<PartialSignature<MinSig>>"]
 n_cases = 65536
-hash = "7eb431ae7ecc27666f9ca1614f23940fedbc7a49eb59ef2af0d95af422fb73a4"
+hash = "9950477465922ae9a0955491b071d01edeb35c7dd2c0beb84e9345ef0a5cdb8d"
 
 ["commonware_cryptography::bls12381::scheme::tests::conformance::CodecConformance<PrivateKey>"]
 n_cases = 65536
@@ -104,7 +104,7 @@ hash = "dcc604b71699aa675d3f3a033a6975b8fb9e1dde6809ba5c37d516cf13dce75d"
 
 ["commonware_cryptography::bls12381::tle::tests::conformance::CodecConformance<Ciphertext<MinPk>>"]
 n_cases = 65536
-hash = "d764de51d89d256bfd2ffcf39a3497fa3e5e27a60cc7da5363b47f5a9390f655"
+hash = "be8ab6a69a7cfef7a3f77f116d8209af21dc108b691707b28caa4b14f75d212e"
 
 ["commonware_cryptography::certificate::tests::conformance::CodecConformance<Attestation<Scheme>>"]
 n_cases = 65536

--- a/cryptography/fuzz/fuzz_targets/bls12381_primitive_operations.rs
+++ b/cryptography/fuzz/fuzz_targets/bls12381_primitive_operations.rs
@@ -3,7 +3,7 @@
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_codec::{Read, ReadExt, Write};
 use commonware_cryptography::bls12381::primitives::{
-    group::{Private, Scalar, Share, G1, G1_MESSAGE, G2, G2_MESSAGE},
+    group::{Private, Scalar, ScalarReadCfg, Share, G1, G1_MESSAGE, G2, G2_MESSAGE},
     ops,
     variant::{MinPk, MinSig, Variant},
 };
@@ -162,6 +162,7 @@ enum FuzzOperation {
     // Serialization round-trip
     SerializeScalar {
         scalar: Scalar,
+        cfg: ScalarReadCfg,
     },
     SerializeG1 {
         point: G1,
@@ -302,6 +303,7 @@ impl<'a> Arbitrary<'a> for FuzzOperation {
             }),
             30 => Ok(FuzzOperation::SerializeScalar {
                 scalar: u.arbitrary()?,
+                cfg: u.arbitrary()?,
             }),
             31 => Ok(FuzzOperation::SerializeG1 {
                 point: arbitrary_g1(u)?,
@@ -601,12 +603,16 @@ fn fuzz(op: FuzzOperation) {
             }
         }
 
-        FuzzOperation::SerializeScalar { scalar } => {
+        FuzzOperation::SerializeScalar { scalar, cfg } => {
             let mut encoded = Vec::new();
             scalar.write(&mut encoded);
-            if let Ok(decoded) = Scalar::read_cfg(&mut encoded.as_slice(), &Default::default()) {
-                assert_eq!(scalar, decoded);
+            if cfg == ScalarReadCfg::RejectZero && scalar == Scalar::zero() {
+                assert!(Scalar::read_cfg(&mut encoded.as_slice(), &cfg).is_err());
+                return;
             }
+
+            let decoded = Scalar::read_cfg(&mut encoded.as_slice(), &cfg).unwrap();
+            assert_eq!(scalar, decoded);
         }
 
         FuzzOperation::SerializeG1 { point } => {

--- a/cryptography/fuzz/fuzz_targets/bls12381_primitive_operations.rs
+++ b/cryptography/fuzz/fuzz_targets/bls12381_primitive_operations.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use arbitrary::{Arbitrary, Unstructured};
-use commonware_codec::{ReadExt, Write};
+use commonware_codec::{Read, ReadExt, Write};
 use commonware_cryptography::bls12381::primitives::{
     group::{Private, Scalar, Share, G1, G1_MESSAGE, G2, G2_MESSAGE},
     ops,
@@ -604,7 +604,7 @@ fn fuzz(op: FuzzOperation) {
         FuzzOperation::SerializeScalar { scalar } => {
             let mut encoded = Vec::new();
             scalar.write(&mut encoded);
-            if let Ok(decoded) = Scalar::read(&mut encoded.as_slice()) {
+            if let Ok(decoded) = Scalar::read_cfg(&mut encoded.as_slice(), &false) {
                 assert_eq!(scalar, decoded);
             }
         }

--- a/cryptography/fuzz/fuzz_targets/bls12381_primitive_operations.rs
+++ b/cryptography/fuzz/fuzz_targets/bls12381_primitive_operations.rs
@@ -604,7 +604,7 @@ fn fuzz(op: FuzzOperation) {
         FuzzOperation::SerializeScalar { scalar } => {
             let mut encoded = Vec::new();
             scalar.write(&mut encoded);
-            if let Ok(decoded) = Scalar::read_cfg(&mut encoded.as_slice(), &false) {
+            if let Ok(decoded) = Scalar::read_cfg(&mut encoded.as_slice(), &Default::default()) {
                 assert_eq!(scalar, decoded);
             }
         }

--- a/cryptography/src/bls12381/dkg.rs
+++ b/cryptography/src/bls12381/dkg.rs
@@ -305,7 +305,7 @@
 use super::primitives::group::{Private, Share};
 use crate::{
     bls12381::primitives::{
-        group::Scalar,
+        group::{Scalar, ScalarReadCfg},
         sharing::{Mode, ModeVersion, Sharing},
         variant::Variant,
     },
@@ -825,7 +825,13 @@ impl Read for DealerPrivMsg {
         buf: &mut impl bytes::Buf,
         _cfg: &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
-        Ok(Self::new(Scalar::read_cfg(buf, &Default::default())?))
+        // For backwards compatibility, reject zero explicitly.
+        // Ideally, we would allow zero, because that's not an issue in theory.
+        // Honest dealers will never run into this issue.
+        Ok(Self::new(Scalar::read_cfg(
+            buf,
+            &ScalarReadCfg::RejectZero,
+        )?))
     }
 }
 

--- a/cryptography/src/bls12381/dkg.rs
+++ b/cryptography/src/bls12381/dkg.rs
@@ -3648,6 +3648,13 @@ mod test {
         assert!(debug.contains("REDACTED"));
     }
 
+    #[test]
+    fn test_dealer_priv_msg_decode_rejects_zero_scalar() {
+        let mut encoded = Scalar::zero().encode();
+        let decoded: Result<DealerPrivMsg, _> = Read::read_cfg(&mut encoded, &());
+        assert!(decoded.is_err());
+    }
+
     #[cfg(feature = "arbitrary")]
     mod conformance {
         use super::*;

--- a/cryptography/src/bls12381/dkg.rs
+++ b/cryptography/src/bls12381/dkg.rs
@@ -825,7 +825,7 @@ impl Read for DealerPrivMsg {
         buf: &mut impl bytes::Buf,
         _cfg: &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
-        Ok(Self::new(Scalar::read_cfg(buf, &false)?))
+        Ok(Self::new(Scalar::read_cfg(buf, &Default::default())?))
     }
 }
 

--- a/cryptography/src/bls12381/dkg.rs
+++ b/cryptography/src/bls12381/dkg.rs
@@ -825,7 +825,7 @@ impl Read for DealerPrivMsg {
         buf: &mut impl bytes::Buf,
         _cfg: &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
-        Ok(Self::new(ReadExt::read(buf)?))
+        Ok(Self::new(Scalar::read_cfg(buf, &false)?))
     }
 }
 

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -241,8 +241,8 @@ pub struct Scalar(blst_fr);
 #[cfg(any(test, feature = "arbitrary"))]
 impl arbitrary::Arbitrary<'_> for Scalar {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        let ikm = u.arbitrary::<[u8; IKM_LENGTH]>()?;
-        Ok(Self::from_ikm(&ikm))
+        let bytes = u.arbitrary::<[u8; SCALAR_LENGTH + 128 / 8]>()?;
+        Ok(Self::reduce_bytes(&bytes))
     }
 }
 
@@ -518,15 +518,18 @@ impl FixedSize for Private {
 }
 
 impl Random for Private {
-    fn random(rng: impl CryptoRngCore) -> Self {
-        Self::new(Scalar::random(rng))
+    fn random(mut rng: impl CryptoRngCore) -> Self {
+        let mut ikm = Zeroizing::new([0u8; IKM_LENGTH]);
+        rng.fill_bytes(ikm.as_mut());
+        Self::new(Scalar::from_ikm(&ikm))
     }
 }
 
 #[cfg(feature = "arbitrary")]
 impl arbitrary::Arbitrary<'_> for Private {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        Ok(Self::new(u.arbitrary::<Scalar>()?))
+        let ikm = u.arbitrary::<[u8; IKM_LENGTH]>()?;
+        Ok(Self::new(Scalar::from_ikm(&ikm)))
     }
 }
 
@@ -534,6 +537,20 @@ impl arbitrary::Arbitrary<'_> for Private {
 pub const PRIVATE_KEY_LENGTH: usize = SCALAR_LENGTH;
 
 impl Scalar {
+    /// Creates a scalar by reducing a wide big-endian integer modulo `r`.
+    fn reduce_bytes(bytes: &[u8]) -> Self {
+        debug_assert_eq!(bytes.len(), SCALAR_LENGTH + 128 / 8);
+        let mut fr = blst_fr::default();
+        // SAFETY: bytes points to a valid `SCALAR_LENGTH + 128 / 8` byte buffer.
+        unsafe {
+            let mut scalar = blst_scalar::default();
+            blst_scalar_from_be_bytes(&mut scalar, bytes.as_ptr(), bytes.len());
+            blst_fr_from_scalar(&mut fr, &scalar);
+        }
+
+        Self(fr)
+    }
+
     /// Creates a scalar from input key material.
     /// Uses IETF BLS KeyGen which loops internally until a non-zero value is produced.
     fn from_ikm(ikm: &[u8; IKM_LENGTH]) -> Self {
@@ -562,30 +579,19 @@ impl Scalar {
         // These 48 bytes provide sufficient entropy to ensure uniform distribution
         // in the scalar field after modular reduction, maintaining the security
         // properties required by the hash-to-field construction.
-        const L: usize = 48;
-        let mut uniform_bytes = Zeroizing::new([0u8; L]);
+        let mut uniform_bytes = Zeroizing::new([0u8; SCALAR_LENGTH + 128 / 8]);
         // SAFETY: All buffers are valid with correct lengths; blst handles empty inputs.
         unsafe {
             blst_expand_message_xmd(
                 uniform_bytes.as_mut_ptr(),
-                L,
+                SCALAR_LENGTH + 128 / 8,
                 msg.as_ptr(),
                 msg.len(),
                 dst.as_ptr(),
                 dst.len(),
             );
         }
-
-        // Transform expanded bytes with modular reduction
-        let mut fr = blst_fr::default();
-        // SAFETY: uniform_bytes is a valid 48-byte buffer.
-        unsafe {
-            let mut scalar = blst_scalar::default();
-            blst_scalar_from_be_bytes(&mut scalar, uniform_bytes.as_ptr(), L);
-            blst_fr_from_scalar(&mut fr, &scalar);
-        }
-
-        Self(fr)
+        Self::reduce_bytes(uniform_bytes.as_ref())
     }
 
     /// Creates a new scalar from the given limbs in little-endian representation.
@@ -824,11 +830,11 @@ impl Field for Scalar {
 }
 
 impl Random for Scalar {
-    /// Returns a random non-zero scalar.
+    /// Returns a random scalar, including zero.
     fn random(mut rng: impl CryptoRngCore) -> Self {
-        let mut ikm = Zeroizing::new([0u8; IKM_LENGTH]);
-        rng.fill_bytes(ikm.as_mut());
-        Self::from_ikm(&ikm)
+        let mut bytes = Zeroizing::new([0u8; SCALAR_LENGTH + 128 / 8]);
+        rng.fill_bytes(bytes.as_mut());
+        Self::reduce_bytes(bytes.as_ref())
     }
 }
 

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -25,8 +25,8 @@ use blst::{
     blst_p2_cneg, blst_p2_compress, blst_p2_double, blst_p2_from_affine, blst_p2_in_g2,
     blst_p2_is_inf, blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_p2s_mult_pippenger,
     blst_p2s_mult_pippenger_scratch_sizeof, blst_p2s_tile_pippenger, blst_p2s_to_affine,
-    blst_scalar, blst_scalar_from_be_bytes, blst_scalar_from_bendian, blst_scalar_from_fr,
-    blst_sk_check, Pairing, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
+    blst_scalar, blst_scalar_fr_check, blst_scalar_from_be_bytes, blst_scalar_from_bendian,
+    blst_scalar_from_fr, blst_sk_check, Pairing, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
 };
 use bytes::{Buf, BufMut};
 use commonware_codec::{
@@ -497,7 +497,7 @@ impl Read for Private {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
-        let scalar = Scalar::read(buf)?;
+        let scalar = Scalar::read_cfg(buf, &true)?;
         Ok(Self::new(scalar))
     }
 }
@@ -625,14 +625,18 @@ impl Write for Scalar {
 }
 
 impl Read for Scalar {
-    type Cfg = ();
+    /// When `true`, reject zero scalars (use for private keys per IETF BLS spec).
+    /// When `false`, allow zero scalars (only validate in-range).
+    type Cfg = bool;
 
-    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
+    fn read_cfg(buf: &mut impl Buf, reject_zero: &bool) -> Result<Self, Error> {
         let bytes = Zeroizing::new(<[u8; Self::SIZE]>::read(buf)?);
         let mut ret = blst_fr::default();
-        // SAFETY: bytes is a valid 32-byte array. blst_sk_check validates non-zero and in-range.
-        // We use blst_sk_check instead of blst_scalar_fr_check because it also checks non-zero
+        // SAFETY: bytes is a valid 32-byte array.
+        //
+        // When reject_zero is true, blst_sk_check validates non-zero and in-range
         // per IETF BLS12-381 spec (Draft 4+).
+        // When reject_zero is false, blst_scalar_fr_check validates in-range only.
         //
         // References:
         // * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-2.3
@@ -640,7 +644,12 @@ impl Read for Scalar {
         unsafe {
             let mut scalar = blst_scalar::default();
             blst_scalar_from_bendian(&mut scalar, bytes.as_ptr());
-            if !blst_sk_check(&scalar) {
+            let valid = if *reject_zero {
+                blst_sk_check(&scalar)
+            } else {
+                blst_scalar_fr_check(&scalar)
+            };
+            if !valid {
                 return Err(Invalid("Scalar", "Invalid"));
             }
             blst_fr_from_scalar(&mut ret, &scalar);
@@ -1773,7 +1782,7 @@ impl HashToGroup for G2 {
 mod tests {
     use super::*;
     use crate::bls12381::primitives::group::Scalar;
-    use commonware_codec::{DecodeExt, Encode};
+    use commonware_codec::{Decode, DecodeExt, Encode};
     use commonware_invariants::minifuzz;
     use commonware_macros::test_group;
     use commonware_math::algebra::{test_suites, Random};
@@ -1835,8 +1844,21 @@ mod tests {
         let original = Scalar::random(&mut test_rng());
         let mut encoded = original.encode();
         assert_eq!(encoded.len(), Scalar::SIZE);
-        let decoded = Scalar::decode(&mut encoded).unwrap();
+        let decoded = Scalar::decode_cfg(&mut encoded, &true).unwrap();
         assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_zero_scalar_codec() {
+        let zero = Scalar::zero();
+        let encoded = zero.encode();
+
+        // Allow zero: should succeed
+        let decoded = Scalar::decode_cfg(encoded.clone(), &false).unwrap();
+        assert_eq!(zero, decoded);
+
+        // Reject zero: should fail
+        assert!(Scalar::decode_cfg(encoded, &true).is_err());
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -213,6 +213,16 @@ where
 /// Reference: <https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-ciphersuites>
 pub type DST = &'static [u8];
 
+/// Configuration for [`Scalar`]'s [`Read`] implementation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ScalarReadCfg {
+    /// Accept any in-range scalar, including zero.
+    #[default]
+    AllowZero,
+    /// Reject the zero scalar (use for private keys per IETF BLS spec).
+    RejectZero,
+}
+
 /// Wrapper around [blst_fr] that represents an element of the BLS12‑381
 /// scalar field `F_r`.
 ///
@@ -497,7 +507,7 @@ impl Read for Private {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
-        let scalar = Scalar::read_cfg(buf, &true)?;
+        let scalar = Scalar::read_cfg(buf, &ScalarReadCfg::RejectZero)?;
         Ok(Self::new(scalar))
     }
 }
@@ -625,18 +635,16 @@ impl Write for Scalar {
 }
 
 impl Read for Scalar {
-    /// When `true`, reject zero scalars (use for private keys per IETF BLS spec).
-    /// When `false`, allow zero scalars (only validate in-range).
-    type Cfg = bool;
+    type Cfg = ScalarReadCfg;
 
-    fn read_cfg(buf: &mut impl Buf, reject_zero: &bool) -> Result<Self, Error> {
+    fn read_cfg(buf: &mut impl Buf, cfg: &ScalarReadCfg) -> Result<Self, Error> {
         let bytes = Zeroizing::new(<[u8; Self::SIZE]>::read(buf)?);
         let mut ret = blst_fr::default();
         // SAFETY: bytes is a valid 32-byte array.
         //
-        // When reject_zero is true, blst_sk_check validates non-zero and in-range
-        // per IETF BLS12-381 spec (Draft 4+).
-        // When reject_zero is false, blst_scalar_fr_check validates in-range only.
+        // RejectZero: blst_sk_check validates non-zero and in-range per IETF
+        // BLS12-381 spec (Draft 4+).
+        // AllowZero: blst_scalar_fr_check validates in-range only.
         //
         // References:
         // * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-2.3
@@ -644,10 +652,9 @@ impl Read for Scalar {
         unsafe {
             let mut scalar = blst_scalar::default();
             blst_scalar_from_bendian(&mut scalar, bytes.as_ptr());
-            let valid = if *reject_zero {
-                blst_sk_check(&scalar)
-            } else {
-                blst_scalar_fr_check(&scalar)
+            let valid = match cfg {
+                ScalarReadCfg::RejectZero => blst_sk_check(&scalar),
+                ScalarReadCfg::AllowZero => blst_scalar_fr_check(&scalar),
             };
             if !valid {
                 return Err(Invalid("Scalar", "Invalid"));
@@ -1844,7 +1851,7 @@ mod tests {
         let original = Scalar::random(&mut test_rng());
         let mut encoded = original.encode();
         assert_eq!(encoded.len(), Scalar::SIZE);
-        let decoded = Scalar::decode_cfg(&mut encoded, &true).unwrap();
+        let decoded = Scalar::decode_cfg(&mut encoded, &ScalarReadCfg::RejectZero).unwrap();
         assert_eq!(original, decoded);
     }
 
@@ -1854,11 +1861,11 @@ mod tests {
         let encoded = zero.encode();
 
         // Allow zero: should succeed
-        let decoded = Scalar::decode_cfg(encoded.clone(), &false).unwrap();
+        let decoded = Scalar::decode_cfg(encoded.clone(), &ScalarReadCfg::AllowZero).unwrap();
         assert_eq!(zero, decoded);
 
         // Reject zero: should fail
-        assert!(Scalar::decode_cfg(encoded, &true).is_err());
+        assert!(Scalar::decode_cfg(encoded, &ScalarReadCfg::RejectZero).is_err());
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -214,6 +214,7 @@ where
 pub type DST = &'static [u8];
 
 /// Configuration for [`Scalar`]'s [`Read`] implementation.
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum ScalarReadCfg {
     /// Accept any in-range scalar, including zero.

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -26,7 +26,7 @@ use blst::{
     blst_p2_is_inf, blst_p2_mult, blst_p2_to_affine, blst_p2_uncompress, blst_p2s_mult_pippenger,
     blst_p2s_mult_pippenger_scratch_sizeof, blst_p2s_tile_pippenger, blst_p2s_to_affine,
     blst_scalar, blst_scalar_fr_check, blst_scalar_from_be_bytes, blst_scalar_from_bendian,
-    blst_scalar_from_fr, blst_sk_check, Pairing, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
+    blst_scalar_from_fr, Pairing, BLS12_381_G1, BLS12_381_G2, BLST_ERROR,
 };
 use bytes::{Buf, BufMut};
 use commonware_codec::{
@@ -659,16 +659,22 @@ impl Read for Scalar {
         unsafe {
             let mut scalar = blst_scalar::default();
             blst_scalar_from_bendian(&mut scalar, bytes.as_ptr());
-            let valid = match cfg {
-                ScalarReadCfg::RejectZero => blst_sk_check(&scalar),
-                ScalarReadCfg::AllowZero => blst_scalar_fr_check(&scalar),
-            };
-            if !valid {
-                return Err(Invalid("Scalar", "Invalid"));
+            if !blst_scalar_fr_check(&scalar) {
+                return Err(Invalid("Scalar", "invalid scalar"));
             }
             blst_fr_from_scalar(&mut ret, &scalar);
         }
-        Ok(Self(ret))
+        let out = Self(ret);
+        // Some cfgs will have more stringent requirements
+        match cfg {
+            ScalarReadCfg::AllowZero => {}
+            ScalarReadCfg::RejectZero => {
+                if out == Self::zero() {
+                    return Err(Invalid("Scalar", "scalar == 0, cfg = RejectZero"));
+                }
+            }
+        }
+        Ok(out)
     }
 }
 


### PR DESCRIPTION
For backwards compatibility, we introduce a config, allowing to choose whether or not to reject zero scalars.

Private keys reject zero, like before.