### PR TITLE
[storage/qmdb] fix panic in find_next when fetch_batch_size overflows MAX_LOCATION

### DIFF
--- a/storage/src/qmdb/sync/gaps.rs
+++ b/storage/src/qmdb/sync/gaps.rs
@@ -40,7 +40,7 @@ pub fn find_next<'a>(
     let mut fetched_ops_iter = fetched_operations
         .iter()
         .map(|(&start_loc, &operation_count)| {
-            let end_loc = start_loc.checked_add(operation_count).unwrap();
+            let end_loc = start_loc.saturating_add(operation_count);
             start_loc..end_loc
         })
         .peekable();
@@ -48,7 +48,7 @@ pub fn find_next<'a>(
     let mut outstanding_reqs_iter = outstanding_requests
         .into_iter()
         .map(|&start_loc| {
-            let end_loc = start_loc.checked_add(fetch_batch_size.get()).unwrap();
+            let end_loc = start_loc.saturating_add(fetch_batch_size.get());
             start_loc..end_loc
         })
         .peekable();


### PR DESCRIPTION
Fixes #2068 

## Problem

  `find_next` in `qmdb/sync/gaps.rs` panics when projecting the end location of an outstanding request:

     let end_loc = start_loc.checked_add(fetch_batch_size.get()).unwrap();

  `Location::checked_add` returns `None` when the result exceeds `MAX_LOCATION` (`2^62 - 1`). With a `start_loc` near `MAX_LOCATION` and a `fetch_batch_size` large enough to overflow that bound, `.unwrap()` panics. `fetch_batch_size` is
  caller-supplied config with no upper-bound validation relative to the target range, so this is reachable in normal sync invocations.

  The same `.unwrap()` pattern exists one line above for `fetched_operations` operation counts and is fixed for consistency.

  ## Fix

  Replace both `.checked_add(...).unwrap()` calls with `.saturating_add(...)`, lamping at `MAX_LOCATION` instead of returning `None`. `end_loc` is only used to determine coverage within the range, and `range.end <= MAX_LOCATION` always holds. 