### PR TITLE
[storage/ordinal] fix panic in get after prune fails mid-removal

### DIFF
--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -371,14 +371,17 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         for section in sections_to_remove {
             if let Some(blob) = self.blobs.remove(&section) {
                 drop(blob);
+
+                // Remove from intervals before attempting disk removal so that
+                // if context.remove fails, blobs and intervals remain consistent.
+                let start_index = section * items_per_blob;
+                let end_index = (section + 1) * items_per_blob - 1;
+                self.intervals.remove(start_index, end_index);
+
                 self.context
                     .remove(&self.config.partition, Some(&section.to_be_bytes()))
                     .await?;
 
-                // Remove the corresponding index range from intervals
-                let start_index = section * items_per_blob;
-                let end_index = (section + 1) * items_per_blob - 1;
-                self.intervals.remove(start_index, end_index);
                 debug!(section, start_index, end_index, "pruned blob");
             }
 


### PR DESCRIPTION
Fixes #2069

## Problem

  `Ordinal::get` assumes that if `self.intervals` contains an index, `self.blobs` must have the corresponding section:

      let blob = self.blobs.get(&section).unwrap();

  `prune` removes a section in three steps:

      1. self.blobs.remove(&section)    -- remove from in-memory map
      2. context.remove(...).await?     -- delete from disk
      3. self.intervals.remove(...)     -- remove from intervals

  If step 2 fails, `?` returns early and step 3 never runs. Now `blobs` is missing the section but `intervals` still has its indices. The next call to `get` for one of those indices passes the intervals check and panics on the unwrap.

  ## Fix

  Move `self.intervals.remove` to before `context.remove`. If the disk deletion fails, both maps are already consistent, and `get` returns `Ok(None)` instead of panicking.