### PR TITLE
[storage/qmdb/any] bitmap for anydb

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -382,57 +382,6 @@ where
         creates
     }
 
-    /// Scan forward from `floor` to find the next active operation, re-append it at the tip.
-    /// The `scan` parameter controls which locations are considered as potentially active,
-    /// allowing implementations to skip locations known to be inactive without reading them.
-    /// Returns `true` if an active op was found and moved, `false` if the floor reached
-    /// `fixed_tip`.
-    async fn advance_floor_once<E, C, I, S: FloorScan<F>>(
-        &self,
-        floor: &mut Location<F>,
-        fixed_tip: u64,
-        ops: &mut Vec<Operation<F, U>>,
-        diff: &mut BTreeMap<U::Key, DiffEntry<F, U::Value>>,
-        scan: &mut S,
-        db: &Db<F, E, C, I, H, U>,
-    ) -> Result<bool, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        loop {
-            let Some(candidate) = scan.next_candidate(*floor, fixed_tip) else {
-                return Ok(false);
-            };
-            *floor = Location::new(*candidate + 1);
-
-            let op = self.read_op(candidate, ops, db).await?;
-            let Some(key) = op.key().cloned() else {
-                continue; // skip CommitFloor and other non-keyed ops
-            };
-
-            if self.is_active_at(&key, candidate, diff, db) {
-                let new_loc = Location::new(self.base_size + ops.len() as u64);
-                let base_old_loc = diff
-                    .get(&key)
-                    .or_else(|| self.base_diff.get(&key))
-                    .map_or(Some(candidate), DiffEntry::base_old_loc);
-                let value = extract_update_value(&op);
-                ops.push(op);
-                diff.insert(
-                    key,
-                    DiffEntry::Active {
-                        value,
-                        loc: new_loc,
-                        base_old_loc,
-                    },
-                );
-                return Ok(true);
-            }
-        }
-    }
-
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
@@ -458,16 +407,70 @@ where
         let mut floor = self.base_inactivity_floor_loc;
 
         if total_active_keys > 0 {
-            // Floor raise: advance the inactivity floor by `total_steps` active
-            // operations. `fixed_tip` prevents scanning into floor-raise moves
-            // just appended, matching `raise_floor_with_bitmap()` semantics.
+            // Floor raise: advance the inactivity floor by `total_steps` active operations.
+            // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let fixed_tip = self.base_size + ops.len() as u64;
-            for _ in 0..total_steps {
-                if !self
-                    .advance_floor_once(&mut floor, fixed_tip, &mut ops, &mut diff, &mut scan, db)
-                    .await?
-                {
+            let mut moved = 0u64;
+
+            while moved < total_steps {
+                // Collect candidates, capped to bound concurrent I/O.
+                const MAX_BATCH: usize = 64;
+                let mut candidates = Vec::new();
+                let limit = (total_steps - moved).min(MAX_BATCH as u64) as usize;
+                while candidates.len() < limit {
+                    let Some(candidate) = scan.next_candidate(floor, fixed_tip) else {
+                        break;
+                    };
+                    candidates.push(candidate);
+                    floor = Location::new(*candidate + 1);
+                }
+                if candidates.is_empty() {
                     break;
+                }
+
+                // Batch-read on-disk candidates through a single reader.
+                let mut disk_ops = {
+                    let reader = db.log.reader().await;
+                    let futures = candidates
+                        .iter()
+                        .filter(|loc| **loc < self.db_size)
+                        .map(|loc| reader.read(**loc));
+                    try_join_all(futures).await?
+                }
+                .into_iter();
+
+                // Process results sequentially, moving active ops to the tip.
+                for candidate in candidates {
+                    let op = if *candidate < self.db_size {
+                        disk_ops.next().unwrap()
+                    } else {
+                        self.read_op(candidate, &ops, db).await?
+                    };
+                    let Some(key) = op.key().cloned() else {
+                        continue; // skip CommitFloor and other non-keyed ops
+                    };
+                    if !self.is_active_at(&key, candidate, &diff, db) {
+                        continue;
+                    }
+                    let new_loc = Location::new(self.base_size + ops.len() as u64);
+                    let base_old_loc = diff
+                        .get(&key)
+                        .or_else(|| self.base_diff.get(&key))
+                        .map_or(Some(candidate), DiffEntry::base_old_loc);
+                    let value = extract_update_value(&op);
+                    ops.push(op);
+                    diff.insert(
+                        key,
+                        DiffEntry::Active {
+                            value,
+                            loc: new_loc,
+                            base_old_loc,
+                        },
+                    );
+                    moved += 1;
+                    if moved >= total_steps {
+                        break;
+                    }
                 }
             }
         } else {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -57,14 +57,23 @@ impl<F: Family, B: BitmapReadable<N>, const N: usize> FloorScan<F> for BitmapSca
         if loc >= tip {
             return None;
         }
-        debug_assert!(
-            self.bitmap.len() >= tip,
-            "bitmap length ({}) must cover tip ({tip})",
-            self.bitmap.len()
-        );
-        if let Some(idx) = self.bitmap.ones_iter_from(loc).next() {
-            if idx < tip {
-                return Some(Location::new(idx));
+        let bitmap_len = self.bitmap.len();
+        // Within the bitmap: find the next set bit at or after floor.
+        if loc < bitmap_len {
+            let bound = bitmap_len.min(tip);
+            if let Some(idx) = self.bitmap.ones_iter_from(loc).next() {
+                if idx < bound {
+                    return Some(Location::new(idx));
+                }
+            }
+        }
+        // Beyond the bitmap: uncommitted ops from prior batches in the
+        // chain that are not tracked by the bitmap yet. Conservatively
+        // treat them as candidates.
+        if bitmap_len < tip {
+            let candidate = loc.max(bitmap_len);
+            if candidate < tip {
+                return Some(Location::new(candidate));
             }
         }
         None
@@ -176,7 +185,8 @@ where
 
     /// Activity bitmap state from the parent (committed DB or prior batch).
     /// Used for `BitmapScan` during floor raising.
-    bitmap_parent: BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>,
+    /// `None` when the any layer is embedded inside a `current::Db` that provides its own scan.
+    bitmap_parent: Option<BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -210,7 +220,8 @@ where
     pub(crate) db_size: u64,
 
     /// Activity bitmap state after this batch (parent bitmap + this batch's layer).
-    bitmap: BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>,
+    /// `None` when the any layer is embedded inside a `current::Db`.
+    bitmap: Option<BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>>,
 }
 
 /// An owned changeset that can be applied to the database.
@@ -259,7 +270,7 @@ where
     db_size: u64,
     base_inactivity_floor_loc: Location<F>,
     base_active_keys: usize,
-    bitmap_parent: BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>,
+    bitmap_parent: Option<BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>>,
 }
 
 impl<F: Family, H, U> Merkleizer<F, H, U>
@@ -470,13 +481,14 @@ where
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
-    async fn finish<E, C, I>(
+    async fn finish<E, C, I, S: FloorScan<F>>(
         mut self,
         mut ops: Vec<Operation<F, U>>,
         mut diff: BTreeMap<U::Key, DiffEntry<F, U::Value>>,
         active_keys_delta: isize,
         user_steps: u64,
         metadata: Option<U::Value>,
+        mut scan: S,
         db: &Db<F, E, C, I, H, U>,
     ) -> Result<MerkleizedBatch<F, H::Digest, U>, crate::qmdb::Error<F>>
     where
@@ -495,18 +507,6 @@ where
             // operations. `fixed_tip` prevents scanning into floor-raise moves
             // just appended, matching `raise_floor_with_bitmap()` semantics.
             let fixed_tip = self.base_size + ops.len() as u64;
-
-            // Pre-extend the bitmap to cover the user ops so the scan has
-            // accurate bits for the full [0, fixed_tip) range. Updates are
-            // active (they are the latest write for their key at this point);
-            // deletes are inactive.
-            let mut scan_bitmap = self.bitmap_parent.clone();
-            let user_bits: Vec<bool> = ops
-                .iter()
-                .map(|op| matches!(op, Operation::Update(_)))
-                .collect();
-            scan_bitmap.push_changeset(user_bits, ClearSet::default());
-            let mut scan = BitmapScan::new(&scan_bitmap);
 
             for _ in 0..total_steps {
                 if !self
@@ -545,66 +545,71 @@ where
             diff.entry(k).or_insert(v);
         }
 
-        // Compute activity bitmap mutations for this batch.
-        let this_segment = self
-            .base_operations
-            .last()
-            .expect("chain should not be empty");
-        let segment_base = *commit_loc + 1 - this_segment.len() as u64;
-        let mut bitmap_pushes = Vec::with_capacity(this_segment.len());
-        let mut bitmap_clears = ClearSet::default();
+        // Compute activity bitmap mutations for this batch (only when bitmap is maintained
+        // at this layer, i.e. standalone any::Db, not embedded in current::Db).
+        let bitmap = if let Some(mut bitmap_parent) = self.bitmap_parent {
+            let this_segment = self
+                .base_operations
+                .last()
+                .expect("chain should not be empty");
+            let segment_base = *commit_loc + 1 - this_segment.len() as u64;
+            let mut bitmap_pushes = Vec::with_capacity(this_segment.len());
+            let mut bitmap_clears = ClearSet::default();
 
-        // Clear the previous commit bit.
-        bitmap_clears.push(segment_base - 1);
+            // Clear the previous commit bit.
+            bitmap_clears.push(segment_base - 1);
 
-        // Push one bit per operation in this segment.
-        for (i, op) in this_segment.iter().enumerate() {
-            let op_loc = Location::new(segment_base + i as u64);
-            match op {
-                Operation::Update(update) => {
-                    let is_active = diff
-                        .get(update.key())
-                        .is_some_and(|entry| entry.loc() == Some(op_loc));
-                    bitmap_pushes.push(is_active);
-                }
-                Operation::CommitFloor(..) => {
-                    bitmap_pushes.push(true);
-                }
-                Operation::Delete(..) => {
-                    bitmap_pushes.push(false);
+            // Push one bit per operation in this segment.
+            for (i, op) in this_segment.iter().enumerate() {
+                let op_loc = Location::new(segment_base + i as u64);
+                match op {
+                    Operation::Update(update) => {
+                        let is_active = diff
+                            .get(update.key())
+                            .is_some_and(|entry| entry.loc() == Some(op_loc));
+                        bitmap_pushes.push(is_active);
+                    }
+                    Operation::CommitFloor(..) => {
+                        bitmap_pushes.push(true);
+                    }
+                    Operation::Delete(..) => {
+                        bitmap_pushes.push(false);
+                    }
                 }
             }
-        }
 
-        // Clear bits for base-DB operations superseded by this chain's diff.
-        for entry in diff.values() {
-            if let Some(old) = entry.base_old_loc() {
-                bitmap_clears.push(*old);
+            // Clear bits for base-DB operations superseded by this chain's diff.
+            for entry in diff.values() {
+                if let Some(old) = entry.base_old_loc() {
+                    bitmap_clears.push(*old);
+                }
             }
-        }
 
-        // Clear ancestor-segment operations superseded by a later segment (chained batches).
-        let chain = &self.base_operations;
-        if chain.len() > 1 {
-            let mut seg_base = self.db_size;
-            for ancestor_seg in &chain[..chain.len() - 1] {
-                for (j, op) in ancestor_seg.iter().enumerate() {
-                    if let Some(key) = op.key() {
-                        let ancestor_loc = Location::new(seg_base + j as u64);
-                        if let Some(entry) = diff.get(key) {
-                            if entry.loc() != Some(ancestor_loc) {
-                                bitmap_clears.push(*ancestor_loc);
+            // Clear ancestor-segment operations superseded by a later segment (chained batches).
+            let chain = &self.base_operations;
+            if chain.len() > 1 {
+                let mut seg_base = self.db_size;
+                for ancestor_seg in &chain[..chain.len() - 1] {
+                    for (j, op) in ancestor_seg.iter().enumerate() {
+                        if let Some(key) = op.key() {
+                            let ancestor_loc = Location::new(seg_base + j as u64);
+                            if let Some(entry) = diff.get(key) {
+                                if entry.loc() != Some(ancestor_loc) {
+                                    bitmap_clears.push(*ancestor_loc);
+                                }
                             }
                         }
                     }
+                    seg_base += ancestor_seg.len() as u64;
                 }
-                seg_base += ancestor_seg.len() as u64;
             }
-        }
 
-        // Build the bitmap state for this batch by pushing a layer.
-        let mut bitmap = self.bitmap_parent;
-        bitmap.push_changeset(bitmap_pushes, bitmap_clears);
+            // Build the bitmap state for this batch by pushing a layer.
+            bitmap_parent.push_changeset(bitmap_pushes, bitmap_clears);
+            Some(bitmap_parent)
+        } else {
+            None
+        };
 
         debug_assert!(total_active_keys >= 0, "active_keys underflow");
         Ok(MerkleizedBatch {
@@ -691,9 +696,43 @@ where
     Operation<F, update::Unordered<K, V>>: Codec,
 {
     /// Resolve mutations into operations, merkleize, and return a [`MerkleizedBatch`].
+    ///
+    /// Uses the bitmap from `bitmap_parent` (must be `Some`) to create a `BitmapScan` for
+    /// floor raising. For callers that supply their own scan (e.g. `current::Db`), use
+    /// [`merkleize_with_floor_scan`](Self::merkleize_with_floor_scan) instead.
     pub async fn merkleize<E, C, I>(
         self,
         metadata: Option<V::Value>,
+        db: &Db<F, E, C, I, H, update::Unordered<K, V>>,
+    ) -> Result<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
+        I: UnorderedIndex<Value = Location<F>>,
+    {
+        // Pre-extend the bitmap to cover user ops so the scan has accurate bits
+        // for the full [0, fixed_tip) range. The bitmap must be present for
+        // standalone any::Db use.
+        let bitmap_parent = self
+            .bitmap_parent
+            .clone()
+            .expect("standalone any::Db must have bitmap");
+        assert!(
+            bitmap_parent.len() >= self.base_size,
+            "bitmap ({}) must cover committed range [0, {})",
+            bitmap_parent.len(),
+            self.base_size,
+        );
+        let scan = BitmapScan::new(&bitmap_parent);
+        self.merkleize_with_floor_scan(metadata, scan, db).await
+    }
+
+    /// Like [`merkleize`](Self::merkleize) but accepts a custom [`FloorScan`]
+    /// to accelerate floor raising.
+    pub(crate) async fn merkleize_with_floor_scan<E, C, I, S: FloorScan<F>>(
+        self,
+        metadata: Option<V::Value>,
+        scan: S,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>>,
     ) -> Result<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>>, crate::qmdb::Error<F>>
     where
@@ -799,7 +838,7 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, db)
+        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
             .await
     }
 }
@@ -813,9 +852,40 @@ where
     Operation<F, update::Ordered<K, V>>: Codec,
 {
     /// Resolve mutations into operations, merkleize, and return a [`MerkleizedBatch`].
+    ///
+    /// Uses the bitmap from `bitmap_parent` (must be `Some`) to create a `BitmapScan` for
+    /// floor raising. For callers that supply their own scan (e.g. `current::Db`), use
+    /// [`merkleize_with_floor_scan`](Self::merkleize_with_floor_scan) instead.
     pub async fn merkleize<E, C, I>(
         self,
         metadata: Option<V::Value>,
+        db: &Db<F, E, C, I, H, update::Ordered<K, V>>,
+    ) -> Result<MerkleizedBatch<F, H::Digest, update::Ordered<K, V>>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
+        I: OrderedIndex<Value = Location<F>>,
+    {
+        let bitmap_parent = self
+            .bitmap_parent
+            .clone()
+            .expect("standalone any::Db must have bitmap");
+        assert!(
+            bitmap_parent.len() >= self.base_size,
+            "bitmap ({}) must cover committed range [0, {})",
+            bitmap_parent.len(),
+            self.base_size,
+        );
+        let scan = BitmapScan::new(&bitmap_parent);
+        self.merkleize_with_floor_scan(metadata, scan, db).await
+    }
+
+    /// Like [`merkleize`](Self::merkleize) but accepts a custom [`FloorScan`]
+    /// to accelerate floor raising.
+    pub(crate) async fn merkleize_with_floor_scan<E, C, I, S: FloorScan<F>>(
+        self,
+        metadata: Option<V::Value>,
+        scan: S,
         db: &Db<F, E, C, I, H, update::Ordered<K, V>>,
     ) -> Result<MerkleizedBatch<F, H::Digest, update::Ordered<K, V>>, crate::qmdb::Error<F>>
     where
@@ -1055,7 +1125,7 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, db)
+        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
             .await
     }
 }
@@ -1159,7 +1229,11 @@ where
             })
             .sum::<isize>();
 
-        let (bitmap_pushes, bitmap_clears) = self.bitmap.collect_mutations();
+        let (bitmap_pushes, bitmap_clears) = self
+            .bitmap
+            .as_ref()
+            .map(|bm| bm.collect_mutations())
+            .unwrap_or_default();
         Changeset {
             journal_finalized: self.journal_batch.finalize(),
             snapshot_diffs,
@@ -1274,8 +1348,15 @@ where
 
         // Collect bitmap mutations, skipping pushes for already-committed operations.
         // Clears are kept in full since set_bit(loc, false) is idempotent.
-        let (all_pushes, bitmap_clears) = self.bitmap.collect_mutations();
-        let bitmap_pushes = all_pushes[items_to_skip as usize..].to_vec();
+        // When bitmap is None (embedded in current::Db), the any layer has no bitmap
+        // mutations -- the current layer manages its own bitmap.
+        let (bitmap_pushes, bitmap_clears) =
+            self.bitmap
+                .as_ref()
+                .map_or_else(Default::default, |bm| {
+                    let (all_pushes, clears) = bm.collect_mutations();
+                    (all_pushes[items_to_skip as usize..].to_vec(), clears)
+                });
 
         let mmr_base = crate::merkle::Position::try_from(Location::new(current_db_size))
             .expect("valid leaf count");
@@ -1386,9 +1467,10 @@ where
         self.inactivity_floor_loc = batch.new_inactivity_floor_loc;
         self.last_commit_loc = batch.new_last_commit_loc;
 
-        // 4. Apply bitmap mutations.
-        self.status
-            .push_changeset(batch.bitmap_pushes, batch.bitmap_clears);
+        // 4. Apply bitmap mutations (only when maintaining a bitmap at this layer).
+        if let Some(status) = &mut self.status {
+            status.push_changeset(batch.bitmap_pushes, batch.bitmap_clears);
+        }
 
         // 5. Return range of operations that were written to the log.
         let end_loc = Location::new(*self.last_commit_loc + 1);

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -14,6 +14,7 @@ use crate::{
             ordered::{find_next_key, find_prev_key},
             ValueEncoding,
         },
+        bitmap::{BitmapBatch, ClearSet},
         delete_known_loc,
         operation::{Key, Operation as OperationTrait},
         update_known_loc,
@@ -22,6 +23,7 @@ use crate::{
 };
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
+use commonware_utils::bitmap::{self, Readable as BitmapReadable};
 use core::ops::Range;
 use futures::future::try_join_all;
 use std::{
@@ -37,17 +39,35 @@ pub(crate) trait FloorScan<F: Family> {
     fn next_candidate(&mut self, floor: Location<F>, tip: u64) -> Option<Location<F>>;
 }
 
-/// Sequential scan: every location is a candidate.
-// TODO(#1829): Always use bitmap for floor raising.
-pub(crate) struct SequentialScan;
+/// Bitmap-accelerated floor scan. Skips locations where the bitmap bit is
+/// unset, avoiding I/O reads for inactive operations.
+pub(crate) struct BitmapScan<'a, B, const N: usize> {
+    bitmap: &'a B,
+}
 
-impl<F: Family> FloorScan<F> for SequentialScan {
+impl<'a, B: BitmapReadable<N>, const N: usize> BitmapScan<'a, B, N> {
+    pub(crate) const fn new(bitmap: &'a B) -> Self {
+        Self { bitmap }
+    }
+}
+
+impl<F: Family, B: BitmapReadable<N>, const N: usize> FloorScan<F> for BitmapScan<'_, B, N> {
     fn next_candidate(&mut self, floor: Location<F>, tip: u64) -> Option<Location<F>> {
-        if *floor < tip {
-            Some(floor)
-        } else {
-            None
+        let loc = *floor;
+        if loc >= tip {
+            return None;
         }
+        debug_assert!(
+            self.bitmap.len() >= tip,
+            "bitmap length ({}) must cover tip ({tip})",
+            self.bitmap.len()
+        );
+        if let Some(idx) = self.bitmap.ones_iter_from(loc).next() {
+            if idx < tip {
+                return Some(Location::new(idx));
+            }
+        }
+        None
     }
 }
 
@@ -153,6 +173,10 @@ where
 
     /// Active key count before this batch.
     base_active_keys: usize,
+
+    /// Activity bitmap state from the parent (committed DB or prior batch).
+    /// Used for `BitmapScan` during floor raising.
+    bitmap_parent: BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -184,6 +208,9 @@ where
 
     /// The database size when the initial batch was created.
     pub(crate) db_size: u64,
+
+    /// Activity bitmap state after this batch (parent bitmap + this batch's layer).
+    bitmap: BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>,
 }
 
 /// An owned changeset that can be applied to the database.
@@ -205,6 +232,12 @@ pub struct Changeset<F: Family, K, D: Digest, Item: Send> {
 
     /// The database size when the batch was created. Used to detect stale changesets.
     db_size: u64,
+
+    /// Activity bitmap: bits pushed by this batch chain.
+    pub(crate) bitmap_pushes: Vec<bool>,
+
+    /// Activity bitmap: bit indices cleared by this batch chain, with per-chunk masks.
+    pub(crate) bitmap_clears: ClearSet<{ bitmap::DEFAULT_CHUNK_SIZE }>,
 }
 
 /// Batch-infrastructure state used during merkleization.
@@ -226,6 +259,7 @@ where
     db_size: u64,
     base_inactivity_floor_loc: Location<F>,
     base_active_keys: usize,
+    bitmap_parent: BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>,
 }
 
 impl<F: Family, H, U> Merkleizer<F, H, U>
@@ -436,14 +470,13 @@ where
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
-    async fn finish<E, C, I, S: FloorScan<F>>(
+    async fn finish<E, C, I>(
         mut self,
         mut ops: Vec<Operation<F, U>>,
         mut diff: BTreeMap<U::Key, DiffEntry<F, U::Value>>,
         active_keys_delta: isize,
         user_steps: u64,
         metadata: Option<U::Value>,
-        mut scan: S,
         db: &Db<F, E, C, I, H, U>,
     ) -> Result<MerkleizedBatch<F, H::Digest, U>, crate::qmdb::Error<F>>
     where
@@ -462,6 +495,19 @@ where
             // operations. `fixed_tip` prevents scanning into floor-raise moves
             // just appended, matching `raise_floor_with_bitmap()` semantics.
             let fixed_tip = self.base_size + ops.len() as u64;
+
+            // Pre-extend the bitmap to cover the user ops so the scan has
+            // accurate bits for the full [0, fixed_tip) range. Updates are
+            // active (they are the latest write for their key at this point);
+            // deletes are inactive.
+            let mut scan_bitmap = self.bitmap_parent.clone();
+            let user_bits: Vec<bool> = ops
+                .iter()
+                .map(|op| matches!(op, Operation::Update(_)))
+                .collect();
+            scan_bitmap.push_changeset(user_bits, ClearSet::default());
+            let mut scan = BitmapScan::new(&scan_bitmap);
+
             for _ in 0..total_steps {
                 if !self
                     .advance_floor_once(&mut floor, fixed_tip, &mut ops, &mut diff, &mut scan, db)
@@ -499,6 +545,67 @@ where
             diff.entry(k).or_insert(v);
         }
 
+        // Compute activity bitmap mutations for this batch.
+        let this_segment = self
+            .base_operations
+            .last()
+            .expect("chain should not be empty");
+        let segment_base = *commit_loc + 1 - this_segment.len() as u64;
+        let mut bitmap_pushes = Vec::with_capacity(this_segment.len());
+        let mut bitmap_clears = ClearSet::default();
+
+        // Clear the previous commit bit.
+        bitmap_clears.push(segment_base - 1);
+
+        // Push one bit per operation in this segment.
+        for (i, op) in this_segment.iter().enumerate() {
+            let op_loc = Location::new(segment_base + i as u64);
+            match op {
+                Operation::Update(update) => {
+                    let is_active = diff
+                        .get(update.key())
+                        .is_some_and(|entry| entry.loc() == Some(op_loc));
+                    bitmap_pushes.push(is_active);
+                }
+                Operation::CommitFloor(..) => {
+                    bitmap_pushes.push(true);
+                }
+                Operation::Delete(..) => {
+                    bitmap_pushes.push(false);
+                }
+            }
+        }
+
+        // Clear bits for base-DB operations superseded by this chain's diff.
+        for entry in diff.values() {
+            if let Some(old) = entry.base_old_loc() {
+                bitmap_clears.push(*old);
+            }
+        }
+
+        // Clear ancestor-segment operations superseded by a later segment (chained batches).
+        let chain = &self.base_operations;
+        if chain.len() > 1 {
+            let mut seg_base = self.db_size;
+            for ancestor_seg in &chain[..chain.len() - 1] {
+                for (j, op) in ancestor_seg.iter().enumerate() {
+                    if let Some(key) = op.key() {
+                        let ancestor_loc = Location::new(seg_base + j as u64);
+                        if let Some(entry) = diff.get(key) {
+                            if entry.loc() != Some(ancestor_loc) {
+                                bitmap_clears.push(*ancestor_loc);
+                            }
+                        }
+                    }
+                }
+                seg_base += ancestor_seg.len() as u64;
+            }
+        }
+
+        // Build the bitmap state for this batch by pushing a layer.
+        let mut bitmap = self.bitmap_parent;
+        bitmap.push_changeset(bitmap_pushes, bitmap_clears);
+
         debug_assert!(total_active_keys >= 0, "active_keys underflow");
         Ok(MerkleizedBatch {
             journal_batch: journal,
@@ -508,6 +615,7 @@ where
             total_size: *commit_loc + 1,
             total_active_keys: total_active_keys as usize,
             db_size: self.db_size,
+            bitmap,
         })
     }
 }
@@ -540,6 +648,7 @@ where
                 db_size: self.db_size,
                 base_inactivity_floor_loc: self.base_inactivity_floor_loc,
                 base_active_keys: self.base_active_keys,
+                bitmap_parent: self.bitmap_parent,
             },
         )
     }
@@ -585,23 +694,6 @@ where
     pub async fn merkleize<E, C, I>(
         self,
         metadata: Option<V::Value>,
-        db: &Db<F, E, C, I, H, update::Unordered<K, V>>,
-    ) -> Result<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>>, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        self.merkleize_with_floor_scan(metadata, SequentialScan, db)
-            .await
-    }
-
-    /// Like [`merkleize`](Self::merkleize) but accepts a custom [`FloorScan`]
-    /// to accelerate floor raising.
-    pub(crate) async fn merkleize_with_floor_scan<E, C, I, S: FloorScan<F>>(
-        self,
-        metadata: Option<V::Value>,
-        scan: S,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>>,
     ) -> Result<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>>, crate::qmdb::Error<F>>
     where
@@ -707,7 +799,7 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
+        m.finish(ops, diff, active_keys_delta, user_steps, metadata, db)
             .await
     }
 }
@@ -724,23 +816,6 @@ where
     pub async fn merkleize<E, C, I>(
         self,
         metadata: Option<V::Value>,
-        db: &Db<F, E, C, I, H, update::Ordered<K, V>>,
-    ) -> Result<MerkleizedBatch<F, H::Digest, update::Ordered<K, V>>, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
-        I: OrderedIndex<Value = Location<F>>,
-    {
-        self.merkleize_with_floor_scan(metadata, SequentialScan, db)
-            .await
-    }
-
-    /// Like [`merkleize`](Self::merkleize) but accepts a custom [`FloorScan`]
-    /// to accelerate floor raising.
-    pub(crate) async fn merkleize_with_floor_scan<E, C, I, S: FloorScan<F>>(
-        self,
-        metadata: Option<V::Value>,
-        scan: S,
         db: &Db<F, E, C, I, H, update::Ordered<K, V>>,
     ) -> Result<MerkleizedBatch<F, H::Digest, update::Ordered<K, V>>, crate::qmdb::Error<F>>
     where
@@ -980,7 +1055,7 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
+        m.finish(ops, diff, active_keys_delta, user_steps, metadata, db)
             .await
     }
 }
@@ -1013,6 +1088,7 @@ where
             db_size: self.db_size,
             base_inactivity_floor_loc: self.new_inactivity_floor_loc,
             base_active_keys: self.total_active_keys,
+            bitmap_parent: self.bitmap.clone(),
         }
     }
 
@@ -1083,6 +1159,7 @@ where
             })
             .sum::<isize>();
 
+        let (bitmap_pushes, bitmap_clears) = self.bitmap.collect_mutations();
         Changeset {
             journal_finalized: self.journal_batch.finalize(),
             snapshot_diffs,
@@ -1090,6 +1167,8 @@ where
             new_inactivity_floor_loc: self.new_inactivity_floor_loc,
             new_last_commit_loc: self.new_last_commit_loc,
             db_size: self.db_size,
+            bitmap_pushes,
+            bitmap_clears,
         }
     }
 
@@ -1193,6 +1272,11 @@ where
             })
             .sum::<isize>();
 
+        // Collect bitmap mutations, skipping pushes for already-committed operations.
+        // Clears are kept in full since set_bit(loc, false) is idempotent.
+        let (all_pushes, bitmap_clears) = self.bitmap.collect_mutations();
+        let bitmap_pushes = all_pushes[items_to_skip as usize..].to_vec();
+
         let mmr_base = crate::merkle::Position::try_from(Location::new(current_db_size))
             .expect("valid leaf count");
         Changeset {
@@ -1202,6 +1286,8 @@ where
             new_inactivity_floor_loc: self.new_inactivity_floor_loc,
             new_last_commit_loc: self.new_last_commit_loc,
             db_size: current_db_size,
+            bitmap_pushes,
+            bitmap_clears,
         }
     }
 }
@@ -1229,6 +1315,7 @@ where
             db_size: journal_size,
             base_inactivity_floor_loc: self.inactivity_floor_loc,
             base_active_keys: self.active_keys,
+            bitmap_parent: self.status.clone(),
         }
     }
 }
@@ -1299,7 +1386,11 @@ where
         self.inactivity_floor_loc = batch.new_inactivity_floor_loc;
         self.last_commit_loc = batch.new_last_commit_loc;
 
-        // 4. Return range of operations that were written to the log.
+        // 4. Apply bitmap mutations.
+        self.status
+            .push_changeset(batch.bitmap_pushes, batch.bitmap_clears);
+
+        // 5. Return range of operations that were written to the log.
         let end_loc = Location::new(*self.last_commit_loc + 1);
         Ok(start_loc..end_loc)
     }
@@ -1327,6 +1418,7 @@ where
             total_size: journal_size,
             total_active_keys: self.active_keys,
             db_size: journal_size,
+            bitmap: self.status.clone(),
         }
     }
 }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1232,7 +1232,7 @@ where
         let (bitmap_pushes, bitmap_clears) = self
             .bitmap
             .as_ref()
-            .map(|bm| bm.collect_mutations())
+            .map(|bm| bm.collect_mutations_since(self.db_size))
             .unwrap_or_default();
         Changeset {
             journal_finalized: self.journal_batch.finalize(),
@@ -1354,7 +1354,7 @@ where
             self.bitmap
                 .as_ref()
                 .map_or_else(Default::default, |bm| {
-                    let (all_pushes, clears) = bm.collect_mutations();
+                    let (all_pushes, clears) = bm.collect_mutations_since(self.db_size);
                     (all_pushes[items_to_skip as usize..].to_vec(), clears)
                 });
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -186,7 +186,7 @@ where
     /// Activity bitmap state from the parent (committed DB or prior batch).
     /// Used for `BitmapScan` during floor raising.
     /// `None` when the any layer is embedded inside a `current::Db` that provides its own scan.
-    bitmap_parent: Option<BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>>,
+    bitmap_parent: Option<BitmapBatch<F, { bitmap::DEFAULT_CHUNK_SIZE }>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -221,7 +221,7 @@ where
 
     /// Activity bitmap state after this batch (parent bitmap + this batch's layer).
     /// `None` when the any layer is embedded inside a `current::Db`.
-    bitmap: Option<BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>>,
+    bitmap: Option<BitmapBatch<F, { bitmap::DEFAULT_CHUNK_SIZE }>>,
 }
 
 /// An owned changeset that can be applied to the database.
@@ -230,7 +230,7 @@ pub struct Changeset<F: Family, K, D: Digest, Item: Send> {
     journal_finalized: authenticated::Changeset<F, D, Item>,
 
     /// Snapshot mutations to apply, in order.
-    snapshot_diffs: Vec<SnapshotDiff<F, K>>,
+    pub(crate) snapshot_diffs: Vec<SnapshotDiff<F, K>>,
 
     /// Net change in active key count.
     active_keys_delta: isize,
@@ -239,16 +239,10 @@ pub struct Changeset<F: Family, K, D: Digest, Item: Send> {
     new_inactivity_floor_loc: Location<F>,
 
     /// Location of the CommitFloor operation appended by this batch.
-    new_last_commit_loc: Location<F>,
+    pub(crate) new_last_commit_loc: Location<F>,
 
     /// The database size when the batch was created. Used to detect stale changesets.
-    db_size: u64,
-
-    /// Activity bitmap: bits pushed by this batch chain.
-    pub(crate) bitmap_pushes: Vec<bool>,
-
-    /// Activity bitmap: bit indices cleared by this batch chain, with per-chunk masks.
-    pub(crate) bitmap_clears: ClearSet<{ bitmap::DEFAULT_CHUNK_SIZE }>,
+    pub(crate) db_size: u64,
 }
 
 /// Batch-infrastructure state used during merkleization.
@@ -270,7 +264,7 @@ where
     db_size: u64,
     base_inactivity_floor_loc: Location<F>,
     base_active_keys: usize,
-    bitmap_parent: Option<BitmapBatch<{ bitmap::DEFAULT_CHUNK_SIZE }>>,
+    bitmap_parent: Option<BitmapBatch<F, { bitmap::DEFAULT_CHUNK_SIZE }>>,
 }
 
 impl<F: Family, H, U> Merkleizer<F, H, U>
@@ -554,10 +548,10 @@ where
                 .expect("chain should not be empty");
             let segment_base = *commit_loc + 1 - this_segment.len() as u64;
             let mut bitmap_pushes = Vec::with_capacity(this_segment.len());
-            let mut bitmap_clears = ClearSet::default();
+            let mut bitmap_clears: ClearSet<F, { bitmap::DEFAULT_CHUNK_SIZE }> = ClearSet::default();
 
             // Clear the previous commit bit.
-            bitmap_clears.push(segment_base - 1);
+            bitmap_clears.push(Location::new(segment_base - 1));
 
             // Push one bit per operation in this segment.
             for (i, op) in this_segment.iter().enumerate() {
@@ -581,7 +575,7 @@ where
             // Clear bits for base-DB operations superseded by this chain's diff.
             for entry in diff.values() {
                 if let Some(old) = entry.base_old_loc() {
-                    bitmap_clears.push(*old);
+                    bitmap_clears.push(old);
                 }
             }
 
@@ -595,7 +589,7 @@ where
                             let ancestor_loc = Location::new(seg_base + j as u64);
                             if let Some(entry) = diff.get(key) {
                                 if entry.loc() != Some(ancestor_loc) {
-                                    bitmap_clears.push(*ancestor_loc);
+                                    bitmap_clears.push(ancestor_loc);
                                 }
                             }
                         }
@@ -1229,11 +1223,6 @@ where
             })
             .sum::<isize>();
 
-        let (bitmap_pushes, bitmap_clears) = self
-            .bitmap
-            .as_ref()
-            .map(|bm| bm.collect_mutations_since(self.db_size))
-            .unwrap_or_default();
         Changeset {
             journal_finalized: self.journal_batch.finalize(),
             snapshot_diffs,
@@ -1241,8 +1230,6 @@ where
             new_inactivity_floor_loc: self.new_inactivity_floor_loc,
             new_last_commit_loc: self.new_last_commit_loc,
             db_size: self.db_size,
-            bitmap_pushes,
-            bitmap_clears,
         }
     }
 
@@ -1346,18 +1333,6 @@ where
             })
             .sum::<isize>();
 
-        // Collect bitmap mutations, skipping pushes for already-committed operations.
-        // Clears are kept in full since set_bit(loc, false) is idempotent.
-        // When bitmap is None (embedded in current::Db), the any layer has no bitmap
-        // mutations -- the current layer manages its own bitmap.
-        let (bitmap_pushes, bitmap_clears) =
-            self.bitmap
-                .as_ref()
-                .map_or_else(Default::default, |bm| {
-                    let (all_pushes, clears) = bm.collect_mutations_since(self.db_size);
-                    (all_pushes[items_to_skip as usize..].to_vec(), clears)
-                });
-
         let mmr_base = crate::merkle::Position::try_from(Location::new(current_db_size))
             .expect("valid leaf count");
         Changeset {
@@ -1367,8 +1342,6 @@ where
             new_inactivity_floor_loc: self.new_inactivity_floor_loc,
             new_last_commit_loc: self.new_last_commit_loc,
             db_size: current_db_size,
-            bitmap_pushes,
-            bitmap_clears,
         }
     }
 }
@@ -1436,7 +1409,18 @@ where
         // 1. Write all operations to the authenticated journal + apply Merkle changeset.
         self.log.apply_batch(batch.journal_finalized).await?;
 
-        // 2. Apply snapshot diffs to the in-memory index.
+        // 2. Derive and apply bitmap changes (only when maintaining a bitmap at this layer).
+        if let Some(status) = &mut self.status {
+            let (pushed_bits, clears) = derive_bitmap_changes::<F, U, { bitmap::DEFAULT_CHUNK_SIZE }>(
+                self.last_commit_loc,
+                journal_size,
+                batch.new_last_commit_loc,
+                &batch.snapshot_diffs,
+            );
+            status.push_changeset(pushed_bits, clears);
+        }
+
+        // 3. Apply snapshot diffs to the in-memory index.
         for diff in batch.snapshot_diffs {
             match diff {
                 SnapshotDiff::Update {
@@ -1455,7 +1439,7 @@ where
             }
         }
 
-        // 3. Update DB metadata.
+        // 4. Update DB metadata.
         let new_active_keys = self.active_keys as isize + batch.active_keys_delta;
         debug_assert!(
             new_active_keys >= 0,
@@ -1467,12 +1451,7 @@ where
         self.inactivity_floor_loc = batch.new_inactivity_floor_loc;
         self.last_commit_loc = batch.new_last_commit_loc;
 
-        // 4. Apply bitmap mutations (only when maintaining a bitmap at this layer).
-        if let Some(status) = &mut self.status {
-            status.push_changeset(batch.bitmap_pushes, batch.bitmap_clears);
-        }
-
-        // 5. Return range of operations that were written to the log.
+        // 4. Return range of operations that were written to the log.
         let end_loc = Location::new(*self.last_commit_loc + 1);
         Ok(start_loc..end_loc)
     }
@@ -1662,6 +1641,61 @@ mod trait_impls {
             self.apply_batch(batch)
         }
     }
+}
+
+/// Derives the bitmap changes (pushed bits and clears) from a batch's snapshot diffs.
+///
+/// Each new operation in the batch gets a pushed bit (true for active updates/inserts,
+/// false otherwise). Historical locations that are superseded get cleared.
+///
+/// # Panics
+///
+/// This function assumes `batch_start` exactly matches the base size against which `snapshot_diffs`
+/// and `new_last_commit_loc` were derived, and may panic or produce incorrect results otherwise.
+pub(crate) fn derive_bitmap_changes<F: Family, U: update::Update, const N: usize>(
+    previous_commit_loc: Location<F>,
+    batch_start: u64,
+    new_last_commit_loc: Location<F>,
+    snapshot_diffs: &[SnapshotDiff<F, U::Key>],
+) -> (Vec<bool>, ClearSet<F, N>) {
+    let mut clears = ClearSet::default();
+
+    let num_ops = (*new_last_commit_loc)
+        .checked_sub(batch_start)
+        .expect("batch start exceeds new last commit loc") as usize
+        + 1;
+    let mut pushed_bits = vec![false; num_ops];
+
+    // The last operation is the new CommitFloor, always active.
+    pushed_bits[num_ops - 1] = true;
+
+    // The previous CommitFloor stops being current once this batch is applied.
+    clears.push(previous_commit_loc);
+
+    for diff in snapshot_diffs {
+        match diff {
+            SnapshotDiff::Update {
+                old_loc, new_loc, ..
+            } => {
+                let offset = (**new_loc)
+                    .checked_sub(batch_start)
+                    .expect("new_loc is before batch start") as usize;
+                pushed_bits[offset] = true;
+                clears.push(*old_loc);
+            }
+            SnapshotDiff::Insert { new_loc, .. } => {
+                let offset = (**new_loc)
+                    .checked_sub(batch_start)
+                    .expect("new_loc is before batch start") as usize;
+                pushed_bits[offset] = true;
+            }
+            SnapshotDiff::Delete { old_loc, .. } => {
+                clears.push(*old_loc);
+            }
+        }
+    }
+
+    (pushed_bits, clears)
 }
 
 #[cfg(test)]
@@ -1922,5 +1956,104 @@ mod tests {
 
             db.destroy().await.unwrap();
         });
+    }
+
+    mod derive_bitmap {
+        use super::*;
+        use crate::qmdb::any::operation::update;
+        use crate::qmdb::any::value::FixedEncoding;
+        use commonware_codec::FixedSize;
+        use commonware_utils::{bitmap::Prunable as PrunableBitMap, sequence::FixedBytes};
+        use std::sync::Arc;
+
+        const N: usize = sha256::Digest::SIZE;
+        type TestKey = FixedBytes<4>;
+        type TestUpdate = update::Unordered<TestKey, FixedEncoding<u64>>;
+        type Loc = crate::merkle::mmr::Location;
+
+        fn key(byte: u8) -> TestKey {
+            FixedBytes::from([byte, 0, 0, 0])
+        }
+
+        fn all_true_bitmap(len: u64) -> PrunableBitMap<N> {
+            let mut bitmap = PrunableBitMap::<N>::new();
+            for _ in 0..len {
+                bitmap.push(true);
+            }
+            bitmap
+        }
+
+        #[test]
+        fn mixed_diffs() {
+            let diffs = vec![
+                SnapshotDiff::Insert {
+                    key: key(1),
+                    new_loc: Loc::new(10),
+                },
+                SnapshotDiff::Update {
+                    key: key(2),
+                    old_loc: Loc::new(3),
+                    new_loc: Loc::new(11),
+                },
+                SnapshotDiff::Delete {
+                    key: key(3),
+                    old_loc: Loc::new(8),
+                },
+            ];
+
+            let (pushed_bits, clears) =
+                derive_bitmap_changes::<mmr::Family, TestUpdate, N>(
+                    Loc::new(9), 10, Loc::new(13), &diffs,
+                );
+
+            assert_eq!(pushed_bits, vec![true, true, false, true]);
+
+            let mut bitmap = BitmapBatch::Base(Arc::new(all_true_bitmap(10)));
+            bitmap.push_changeset(pushed_bits, clears);
+
+            assert!(!bitmap.get_bit(3));
+            assert!(!bitmap.get_bit(8));
+            assert!(!bitmap.get_bit(9));
+            assert!(bitmap.get_bit(10));
+            assert!(bitmap.get_bit(11));
+            assert!(!bitmap.get_bit(12));
+            assert!(bitmap.get_bit(13));
+        }
+
+        #[test]
+        fn delete_only_batch() {
+            let diffs = vec![SnapshotDiff::Delete {
+                key: key(7),
+                old_loc: Loc::new(4),
+            }];
+
+            let (pushed_bits, clears) =
+                derive_bitmap_changes::<mmr::Family, TestUpdate, N>(
+                    Loc::new(19), 20, Loc::new(21), &diffs,
+                );
+
+            assert_eq!(pushed_bits, vec![false, true]);
+
+            let mut bitmap = BitmapBatch::Base(Arc::new(all_true_bitmap(20)));
+            bitmap.push_changeset(pushed_bits, clears);
+
+            assert!(!bitmap.get_bit(4));
+            assert!(!bitmap.get_bit(19));
+            assert!(!bitmap.get_bit(20));
+            assert!(bitmap.get_bit(21));
+        }
+
+        #[test]
+        #[should_panic(expected = "new_loc is before batch start")]
+        fn panics_when_new_loc_precedes_batch_start() {
+            let diffs = vec![SnapshotDiff::Insert {
+                key: key(9),
+                new_loc: Loc::new(9),
+            }];
+
+            let _ = derive_bitmap_changes::<mmr::Family, TestUpdate, N>(
+                Loc::new(9), 10, Loc::new(10), &diffs,
+            );
+        }
     }
 }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -23,12 +23,15 @@ use crate::{
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use core::ops::Range;
-use futures::future::try_join_all;
+use futures::{future::try_join_all, stream::FuturesOrdered, StreamExt as _};
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
 use tracing::debug;
+
+/// Maximum number of journal reads to issue concurrently during floor raising.
+const MAX_CONCURRENT_READS: u64 = 64;
 
 /// Strategy for finding the next active location during floor raising.
 pub(crate) trait FloorScan<F: Family> {
@@ -414,9 +417,9 @@ where
 
             while moved < total_steps {
                 // Collect candidates, capped to bound concurrent I/O.
-                const MAX_BATCH: usize = 64;
                 let mut candidates = Vec::new();
-                let limit = (total_steps - moved).min(MAX_BATCH as u64) as usize;
+                let limit =
+                    (total_steps - moved).min(MAX_CONCURRENT_READS) as usize;
                 while candidates.len() < limit {
                     let Some(candidate) = scan.next_candidate(floor, fixed_tip) else {
                         break;
@@ -428,21 +431,19 @@ where
                     break;
                 }
 
-                // Batch-read on-disk candidates through a single reader.
-                let mut disk_ops = {
-                    let reader = db.log.reader().await;
-                    let futures = candidates
-                        .iter()
-                        .filter(|loc| **loc < self.db_size)
-                        .map(|loc| reader.read(**loc));
-                    try_join_all(futures).await?
-                }
-                .into_iter();
+                // Perform on-disk reads concurrently via FuturesOrdered so results are yielded in
+                // insertion order as they resolve.
+                let reader = db.log.reader().await;
+                let mut disk_reads: FuturesOrdered<_> = candidates
+                    .iter()
+                    .filter(|loc| **loc < self.db_size)
+                    .map(|loc| reader.read(**loc))
+                    .collect();
 
-                // Process results sequentially, moving active ops to the tip.
+                // Process results in order, moving active ops to the tip.
                 for candidate in candidates {
                     let op = if *candidate < self.db_size {
-                        disk_ops.next().unwrap()
+                        disk_reads.next().await.unwrap()?
                     } else {
                         self.read_op(candidate, &ops, db).await?
                     };

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -12,15 +12,16 @@ use crate::{
     },
     merkle::{Family, Location, Proof},
     qmdb::{
-        build_snapshot_from_log, delete_known_loc, operation::Operation as OperationTrait,
-        update_known_loc, Error,
+        bitmap::BitmapBatch, build_snapshot_from_log, delete_known_loc,
+        operation::Operation as OperationTrait, update_known_loc, Error,
     },
     Context, Persistable,
 };
 use commonware_codec::{Codec, CodecShared};
 use commonware_cryptography::Hasher;
+use commonware_utils::bitmap::{Prunable as PrunableBitMap, Readable as BitmapReadable};
 use core::num::NonZeroU64;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 /// Type alias for the authenticated journal used by [Db].
 pub(crate) type AuthenticatedLog<F, E, C, H> = authenticated::Journal<F, E, C, H>;
@@ -82,6 +83,11 @@ pub struct Db<
 
     /// The number of active keys in the snapshot.
     pub(crate) active_keys: usize,
+
+    /// Activity bitmap for optimized floor raising. Tracks which operations are active (bit=1)
+    /// or inactive (bit=0), allowing `BitmapScan` to skip inactive operations during floor
+    /// raising instead of reading them from the journal.
+    pub(crate) status: BitmapBatch<{ commonware_utils::bitmap::DEFAULT_CHUNK_SIZE }>,
 
     /// Marker for the update type parameter.
     pub(crate) _update: core::marker::PhantomData<U>,
@@ -192,6 +198,13 @@ where
             ));
         }
 
+        // Flatten bitmap layers and prune chunks below the inactivity floor.
+        self.status.flatten();
+        let BitmapBatch::Base(base) = &mut self.status else {
+            unreachable!("flatten() guarantees Base");
+        };
+        Arc::make_mut(base).prune_to_bit(*self.inactivity_floor_loc);
+
         self.log.prune(prune_loc).await?;
 
         Ok(())
@@ -265,6 +278,17 @@ where
                 return Err(Error::UnexpectedData(rewind_last_loc));
             };
             if *rewind_floor < bounds.start {
+                return Err(Error::<F>::Journal(JournalError::ItemPruned(*rewind_floor)));
+            }
+
+            // Ensure the rewind target is above the bitmap pruning boundary.
+            let pruned_bits = self.status.pruned_bits();
+            if rewind_size < pruned_bits {
+                return Err(Error::<F>::Journal(JournalError::ItemPruned(
+                    rewind_size - 1,
+                )));
+            }
+            if *rewind_floor < pruned_bits {
                 return Err(Error::<F>::Journal(JournalError::ItemPruned(*rewind_floor)));
             }
 
@@ -363,6 +387,19 @@ where
         self.last_commit_loc = Location::new(rewind_size - 1);
         self.inactivity_floor_loc = rewind_floor;
 
+        // Patch the activity bitmap: truncate to rewound size, mark restored locs as active.
+        self.status.flatten();
+        let BitmapBatch::Base(base) = &mut self.status else {
+            unreachable!("flatten() guarantees Base");
+        };
+        let bm = Arc::make_mut(base);
+        bm.truncate(rewind_size);
+        for loc in &restored_locs {
+            bm.set_bit(**loc, true);
+        }
+        // Mark the new tip commit as active.
+        bm.set_bit(rewind_size - 1, true);
+
         Ok(restored_locs)
     }
 }
@@ -393,6 +430,10 @@ where
     where
         Cb: FnMut(bool, Option<Location<F>>),
     {
+        // Initialize the activity bitmap. If a known inactivity floor is provided,
+        // start the bitmap at that point (matching current/mod.rs:340-349 pattern).
+        let mut status = PrunableBitMap::new();
+
         // If the last-known inactivity floor is behind the current floor, then invoke the callback
         // appropriately to report the inactive bits.
         let (last_commit_loc, inactivity_floor_loc, active_keys) = {
@@ -405,13 +446,25 @@ where
             let last_commit = reader.read(last_commit_loc).await?;
             let inactivity_floor_loc = last_commit.has_floor().expect("should be a commit");
             if let Some(known_inactivity_floor) = known_inactivity_floor {
-                (*known_inactivity_floor..*inactivity_floor_loc)
-                    .for_each(|_| callback(false, None));
+                (*known_inactivity_floor..*inactivity_floor_loc).for_each(|_| {
+                    status.push(false);
+                    callback(false, None);
+                });
             }
 
-            let active_keys =
-                build_snapshot_from_log(inactivity_floor_loc, &reader, &mut index, callback)
-                    .await?;
+            let active_keys = build_snapshot_from_log(
+                inactivity_floor_loc,
+                &reader,
+                &mut index,
+                |active, old_loc| {
+                    status.push(active);
+                    if let Some(loc) = old_loc {
+                        status.set_bit(*loc, false);
+                    }
+                    callback(active, old_loc);
+                },
+            )
+            .await?;
             (
                 Location::new(last_commit_loc),
                 inactivity_floor_loc,
@@ -425,6 +478,7 @@ where
             snapshot: index,
             last_commit_loc,
             active_keys,
+            status: BitmapBatch::Base(Arc::new(status)),
             _update: core::marker::PhantomData,
         })
     }

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -87,7 +87,11 @@ pub struct Db<
     /// Activity bitmap for optimized floor raising. Tracks which operations are active (bit=1)
     /// or inactive (bit=0), allowing `BitmapScan` to skip inactive operations during floor
     /// raising instead of reading them from the journal.
-    pub(crate) status: BitmapBatch<{ commonware_utils::bitmap::DEFAULT_CHUNK_SIZE }>,
+    ///
+    /// `None` when this `any::Db` is embedded inside a `current::Db`, which maintains its own
+    /// bitmap with a different chunk size (for authenticated proofs). In that case the caller
+    /// injects a floor scan externally via [`crate::qmdb::any::batch::UnmerkleizedBatch::merkleize_with_floor_scan`].
+    pub(crate) status: Option<BitmapBatch<{ commonware_utils::bitmap::DEFAULT_CHUNK_SIZE }>>,
 
     /// Marker for the update type parameter.
     pub(crate) _update: core::marker::PhantomData<U>,
@@ -199,11 +203,13 @@ where
         }
 
         // Flatten bitmap layers and prune chunks below the inactivity floor.
-        self.status.flatten();
-        let BitmapBatch::Base(base) = &mut self.status else {
-            unreachable!("flatten() guarantees Base");
-        };
-        Arc::make_mut(base).prune_to_bit(*self.inactivity_floor_loc);
+        if let Some(status) = &mut self.status {
+            status.flatten();
+            let BitmapBatch::Base(base) = status else {
+                unreachable!("flatten() guarantees Base");
+            };
+            Arc::make_mut(base).prune_to_bit(*self.inactivity_floor_loc);
+        }
 
         self.log.prune(prune_loc).await?;
 
@@ -282,14 +288,18 @@ where
             }
 
             // Ensure the rewind target is above the bitmap pruning boundary.
-            let pruned_bits = self.status.pruned_bits();
-            if rewind_size < pruned_bits {
-                return Err(Error::<F>::Journal(JournalError::ItemPruned(
-                    rewind_size - 1,
-                )));
-            }
-            if *rewind_floor < pruned_bits {
-                return Err(Error::<F>::Journal(JournalError::ItemPruned(*rewind_floor)));
+            if let Some(status) = &self.status {
+                let pruned_bits = status.pruned_bits();
+                if rewind_size < pruned_bits {
+                    return Err(Error::<F>::Journal(JournalError::ItemPruned(
+                        rewind_size - 1,
+                    )));
+                }
+                if *rewind_floor < pruned_bits {
+                    return Err(Error::<F>::Journal(JournalError::ItemPruned(
+                        *rewind_floor,
+                    )));
+                }
             }
 
             let mut undos = Vec::with_capacity((current_size - rewind_size) as usize);
@@ -388,17 +398,19 @@ where
         self.inactivity_floor_loc = rewind_floor;
 
         // Patch the activity bitmap: truncate to rewound size, mark restored locs as active.
-        self.status.flatten();
-        let BitmapBatch::Base(base) = &mut self.status else {
-            unreachable!("flatten() guarantees Base");
-        };
-        let bm = Arc::make_mut(base);
-        bm.truncate(rewind_size);
-        for loc in &restored_locs {
-            bm.set_bit(**loc, true);
+        if let Some(status) = &mut self.status {
+            status.flatten();
+            let BitmapBatch::Base(base) = status else {
+                unreachable!("flatten() guarantees Base");
+            };
+            let bm = Arc::make_mut(base);
+            bm.truncate(rewind_size);
+            for loc in &restored_locs {
+                bm.set_bit(**loc, true);
+            }
+            // Mark the new tip commit as active.
+            bm.set_bit(rewind_size - 1, true);
         }
-        // Mark the new tip commit as active.
-        bm.set_bit(rewind_size - 1, true);
 
         Ok(restored_locs)
     }
@@ -445,12 +457,15 @@ where
                 .expect("commit should exist");
             let last_commit = reader.read(last_commit_loc).await?;
             let inactivity_floor_loc = last_commit.has_floor().expect("should be a commit");
-            if let Some(known_inactivity_floor) = known_inactivity_floor {
-                (*known_inactivity_floor..*inactivity_floor_loc).for_each(|_| {
-                    status.push(false);
-                    callback(false, None);
-                });
-            }
+            // Push inactive bits for the range [0, inactivity_floor_loc). When a known
+            // inactivity floor is provided (e.g. from a persisted bitmap pruning boundary),
+            // only the gap between it and the current floor needs to be filled. Otherwise,
+            // the full prefix must be initialized.
+            let bitmap_start = known_inactivity_floor.map_or(0, |loc| *loc);
+            (bitmap_start..*inactivity_floor_loc).for_each(|_| {
+                status.push(false);
+                callback(false, None);
+            });
 
             let active_keys = build_snapshot_from_log(
                 inactivity_floor_loc,
@@ -478,7 +493,7 @@ where
             snapshot: index,
             last_commit_loc,
             active_keys,
-            status: BitmapBatch::Base(Arc::new(status)),
+            status: Some(BitmapBatch::Base(Arc::new(status))),
             _update: core::marker::PhantomData,
         })
     }

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -91,7 +91,7 @@ pub struct Db<
     /// `None` when this `any::Db` is embedded inside a `current::Db`, which maintains its own
     /// bitmap with a different chunk size (for authenticated proofs). In that case the caller
     /// injects a floor scan externally via [`crate::qmdb::any::batch::UnmerkleizedBatch::merkleize_with_floor_scan`].
-    pub(crate) status: Option<BitmapBatch<{ commonware_utils::bitmap::DEFAULT_CHUNK_SIZE }>>,
+    pub(crate) status: Option<BitmapBatch<F, { commonware_utils::bitmap::DEFAULT_CHUNK_SIZE }>>,
 
     /// Marker for the update type parameter.
     pub(crate) _update: core::marker::PhantomData<U>,

--- a/storage/src/qmdb/any/unordered/mod.rs
+++ b/storage/src/qmdb/any/unordered/mod.rs
@@ -99,6 +99,9 @@ impl<
             snapshot,
             last_commit_loc,
             active_keys,
+            status: crate::qmdb::bitmap::BitmapBatch::Base(std::sync::Arc::new(
+                commonware_utils::bitmap::Prunable::new(),
+            )),
             _update: core::marker::PhantomData,
         })
     }

--- a/storage/src/qmdb/any/unordered/mod.rs
+++ b/storage/src/qmdb/any/unordered/mod.rs
@@ -77,11 +77,25 @@ impl<
         log: AuthenticatedLog<F, E, C, H>,
         mut snapshot: I,
     ) -> Result<Self, crate::qmdb::Error<F>> {
+        let mut status = commonware_utils::bitmap::Prunable::new();
+        // Push inactive bits for the range [0, inactivity_floor_loc).
+        for _ in 0..*inactivity_floor_loc {
+            status.push(false);
+        }
         let (active_keys, last_commit_loc) = {
             let reader = log.reader().await;
-            let active_keys =
-                build_snapshot_from_log(inactivity_floor_loc, &reader, &mut snapshot, |_, _| {})
-                    .await?;
+            let active_keys = build_snapshot_from_log(
+                inactivity_floor_loc,
+                &reader,
+                &mut snapshot,
+                |active, old_loc| {
+                    status.push(active);
+                    if let Some(loc) = old_loc {
+                        status.set_bit(*loc, false);
+                    }
+                },
+            )
+            .await?;
             let last_commit_loc = Location::new(
                 reader
                     .bounds()
@@ -99,9 +113,7 @@ impl<
             snapshot,
             last_commit_loc,
             active_keys,
-            status: crate::qmdb::bitmap::BitmapBatch::Base(std::sync::Arc::new(
-                commonware_utils::bitmap::Prunable::new(),
-            )),
+            status: Some(crate::qmdb::bitmap::BitmapBatch::Base(std::sync::Arc::new(status))),
             _update: core::marker::PhantomData,
         })
     }

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -1,0 +1,263 @@
+//! Shared layered bitmap types for speculative batch chains.
+//!
+//! `BitmapBatch` provides an immutable, layered bitmap that allows speculative batches to
+//! push thin diff layers (pushed bits + cleared bits) on top of a parent's bitmap without
+//! cloning. Reads walk the layer chain.
+
+use commonware_utils::bitmap::{Prunable as PrunableBitMap, Readable as BitmapReadable};
+use std::{collections::BTreeMap, sync::Arc};
+
+/// Cleared bitmap bits tracked in two synchronized views.
+///
+/// `locations` preserves the original clear operations so batch chaining, flattening, and
+/// finalization can replay them in order. `masks` indexes the same clears by chunk, allowing
+/// [`apply_push_clear`] to zero an entire chunk without rescanning every cleared location.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ClearSet<const N: usize> {
+    locations: Vec<u64>,
+    masks: BTreeMap<usize, [u8; N]>,
+}
+
+impl<const N: usize> ClearSet<N> {
+    /// Push a location to the clear set.
+    pub(crate) fn push(&mut self, loc: u64) {
+        self.locations.push(loc);
+
+        let chunk_idx = PrunableBitMap::<N>::to_chunk_index(loc);
+        let rel = (loc % PrunableBitMap::<N>::CHUNK_SIZE_BITS) as usize;
+        let chunk = self.masks.entry(chunk_idx).or_insert([0u8; N]);
+        chunk[rel / 8] |= 1 << (rel % 8);
+    }
+
+    /// Merge another clear set into this one.
+    pub(crate) fn merge(&mut self, other: &Self) {
+        self.locations.extend_from_slice(&other.locations);
+        for (&idx, other_mask) in &other.masks {
+            let chunk = self.masks.entry(idx).or_insert([0u8; N]);
+            for (byte, &m) in chunk.iter_mut().zip(other_mask) {
+                *byte |= m;
+            }
+        }
+    }
+
+    /// Return the locations in the clear set.
+    pub(crate) fn locations(&self) -> &[u64] {
+        &self.locations
+    }
+
+    /// Return the mask for the given chunk index.
+    fn mask(&self, idx: usize) -> Option<&[u8; N]> {
+        self.masks.get(&idx)
+    }
+}
+
+/// Apply pushed bits and cleared bits to `chunk` at absolute position `chunk_start`.
+///
+/// `push_start` is the absolute bit index where pushes begin (i.e. the parent's length).
+/// `clear_mask` is the chunk-local view returned by [`ClearSet::mask`].
+fn apply_push_clear<const N: usize>(
+    chunk: &mut [u8; N],
+    chunk_start: u64,
+    push_start: u64,
+    pushed_bits: &[bool],
+    clear_mask: Option<&[u8; N]>,
+) {
+    let chunk_end = chunk_start + PrunableBitMap::<N>::CHUNK_SIZE_BITS;
+
+    let push_end = push_start + pushed_bits.len() as u64;
+    if push_start < chunk_end && push_end > chunk_start {
+        let abs_start = push_start.max(chunk_start);
+        let abs_end = push_end.min(chunk_end);
+        let from = (abs_start - push_start) as usize;
+        let to = (abs_end - push_start) as usize;
+        let rel_offset = (abs_start - chunk_start) as usize;
+        for (j, &bit) in pushed_bits[from..to].iter().enumerate() {
+            if bit {
+                let rel = rel_offset + j;
+                chunk[rel / 8] |= 1 << (rel % 8);
+            }
+        }
+    }
+
+    if let Some(clear_mask) = clear_mask {
+        for (byte, mask) in chunk.iter_mut().zip(clear_mask) {
+            *byte &= !mask;
+        }
+    }
+}
+
+/// Immutable bitmap state at any point in a batch chain.
+///
+/// Mirrors the [`crate::merkle::mmr::batch::MerkleizedBatch`] pattern.
+#[derive(Clone, Debug)]
+pub(crate) enum BitmapBatch<const N: usize> {
+    /// Committed bitmap (chain terminal).
+    Base(Arc<PrunableBitMap<N>>),
+    /// Speculative layer on top of a parent batch.
+    Layer(Arc<BitmapBatchLayer<N>>),
+}
+
+/// The data behind a [`BitmapBatch::Layer`].
+#[derive(Debug)]
+pub(crate) struct BitmapBatchLayer<const N: usize> {
+    parent: BitmapBatch<N>,
+    /// Cached `parent.len()` at layer creation time.
+    parent_len: u64,
+    /// New bits appended contiguously from `parent_len`.
+    pushed_bits: Arc<Vec<bool>>,
+    /// Bit indices of parent bits that were deactivated, with per-chunk masks.
+    clears: Arc<ClearSet<N>>,
+}
+
+impl<const N: usize> BitmapBatch<N> {
+    const CHUNK_SIZE_BITS: u64 = PrunableBitMap::<N>::CHUNK_SIZE_BITS;
+}
+
+impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
+    fn complete_chunks(&self) -> usize {
+        (self.len() / Self::CHUNK_SIZE_BITS) as usize
+    }
+
+    fn get_chunk(&self, idx: usize) -> [u8; N] {
+        match self {
+            Self::Base(bm) => *bm.get_chunk(idx),
+            Self::Layer(layer) => {
+                let chunk_start = idx as u64 * Self::CHUNK_SIZE_BITS;
+
+                // Start with parent's data, or zeroed if this chunk is
+                // entirely beyond the parent's range (created by pushes).
+                let parent_chunks = layer.parent_len.div_ceil(Self::CHUNK_SIZE_BITS);
+                let mut chunk = if (idx as u64) < parent_chunks {
+                    layer.parent.get_chunk(idx)
+                } else {
+                    [0u8; N]
+                };
+
+                apply_push_clear(
+                    &mut chunk,
+                    chunk_start,
+                    layer.parent_len,
+                    &layer.pushed_bits,
+                    layer.clears.mask(idx),
+                );
+                chunk
+            }
+        }
+    }
+
+    fn last_chunk(&self) -> ([u8; N], u64) {
+        let total = self.len();
+        if total == 0 {
+            return ([0u8; N], 0);
+        }
+        let rem = total % Self::CHUNK_SIZE_BITS;
+        let bits_in_last = if rem == 0 { Self::CHUNK_SIZE_BITS } else { rem };
+        let idx = if rem == 0 {
+            self.complete_chunks().saturating_sub(1)
+        } else {
+            self.complete_chunks()
+        };
+        (self.get_chunk(idx), bits_in_last)
+    }
+
+    fn pruned_chunks(&self) -> usize {
+        match self {
+            Self::Base(bm) => bm.pruned_chunks(),
+            Self::Layer(layer) => layer.parent.pruned_chunks(),
+        }
+    }
+
+    fn len(&self) -> u64 {
+        match self {
+            Self::Base(bm) => BitmapReadable::<N>::len(bm.as_ref()),
+            Self::Layer(layer) => layer.parent_len + layer.pushed_bits.len() as u64,
+        }
+    }
+}
+
+impl<const N: usize> BitmapBatch<N> {
+    /// Push a changeset as a new layer on top of this bitmap, mutating `self` in place.
+    ///
+    /// The old value becomes the parent of the new layer.
+    pub(crate) fn push_changeset(&mut self, pushed_bits: Vec<bool>, clears: ClearSet<N>) {
+        if pushed_bits.is_empty() && clears.locations().is_empty() {
+            return;
+        }
+        let parent_len = self.len();
+        let parent = self.clone();
+        *self = Self::Layer(Arc::new(BitmapBatchLayer {
+            parent,
+            parent_len,
+            pushed_bits: Arc::new(pushed_bits),
+            clears: Arc::new(clears),
+        }));
+    }
+
+    /// Collect all layer pushes and clears from this batch down to the Base.
+    /// Returns `(pushed_bits, clear_set)` in base-to-tip order.
+    pub(crate) fn collect_mutations(&self) -> (Vec<bool>, ClearSet<N>) {
+        let mut layers = Vec::new();
+        let mut current = self;
+        loop {
+            match current {
+                Self::Base(_) => break,
+                Self::Layer(layer) => {
+                    layers.push((&*layer.pushed_bits, &*layer.clears));
+                    current = &layer.parent;
+                }
+            }
+        }
+        layers.reverse();
+        let mut pushes = Vec::new();
+        let mut clears = ClearSet::default();
+        for (p, c) in layers {
+            pushes.extend_from_slice(p);
+            clears.merge(c);
+        }
+        (pushes, clears)
+    }
+
+    /// Flatten all layers back to a single `Base(Arc<PrunableBitMap<N>>)`.
+    ///
+    /// After flattening, the new `Base` Arc has refcount 1 (assuming no external clones
+    /// are held).
+    pub(crate) fn flatten(&mut self) {
+        if matches!(self, Self::Base(_)) {
+            return;
+        }
+
+        // Take ownership of the chain so that Arc refcounts are not
+        // artificially inflated by a clone.
+        let mut owned = std::mem::replace(self, Self::Base(Arc::new(PrunableBitMap::default())));
+
+        // Collect layers from tip to base.
+        let mut layers: Vec<(Arc<Vec<bool>>, Arc<ClearSet<N>>)> = Vec::new();
+        let base = loop {
+            match owned {
+                Self::Base(bm) => break bm,
+                Self::Layer(layer) => match Arc::try_unwrap(layer) {
+                    Ok(inner) => {
+                        layers.push((inner.pushed_bits, inner.clears));
+                        owned = inner.parent;
+                    }
+                    Err(arc) => {
+                        layers.push((arc.pushed_bits.clone(), arc.clears.clone()));
+                        owned = arc.parent.clone();
+                    }
+                },
+            }
+        };
+
+        // Replay mutations from base to tip.
+        let mut bitmap = Arc::try_unwrap(base).unwrap_or_else(|arc| (*arc).clone());
+        for (pushed, clears) in layers.into_iter().rev() {
+            for &bit in pushed.iter() {
+                bitmap.push(bit);
+            }
+            for &bit_idx in clears.locations() {
+                bitmap.set_bit(bit_idx, false);
+            }
+        }
+        *self = Self::Base(Arc::new(bitmap));
+    }
+}

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -193,15 +193,21 @@ impl<const N: usize> BitmapBatch<N> {
         }));
     }
 
-    /// Collect all layer pushes and clears from this batch down to the Base.
+    /// Collect layer pushes and clears added after the bitmap reached length
+    /// `cutoff`. Layers whose `parent_len < cutoff` (i.e. pre-existing DB
+    /// layers) are excluded.
+    ///
     /// Returns `(pushed_bits, clear_set)` in base-to-tip order.
-    pub(crate) fn collect_mutations(&self) -> (Vec<bool>, ClearSet<N>) {
+    pub(crate) fn collect_mutations_since(&self, cutoff: u64) -> (Vec<bool>, ClearSet<N>) {
         let mut layers = Vec::new();
         let mut current = self;
         loop {
             match current {
                 Self::Base(_) => break,
                 Self::Layer(layer) => {
+                    if layer.parent_len < cutoff {
+                        break;
+                    }
                     layers.push((&*layer.pushed_bits, &*layer.clears));
                     current = &layer.parent;
                 }

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -4,6 +4,7 @@
 //! push thin diff layers (pushed bits + cleared bits) on top of a parent's bitmap without
 //! cloning. Reads walk the layer chain.
 
+use crate::merkle::{Family, Location};
 use commonware_utils::bitmap::{Prunable as PrunableBitMap, Readable as BitmapReadable};
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -12,41 +13,45 @@ use std::{collections::BTreeMap, sync::Arc};
 /// `locations` preserves the original clear operations so batch chaining, flattening, and
 /// finalization can replay them in order. `masks` indexes the same clears by chunk, allowing
 /// [`apply_push_clear`] to zero an entire chunk without rescanning every cleared location.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct ClearSet<const N: usize> {
-    locations: Vec<u64>,
+#[derive(Clone, Debug)]
+pub(crate) struct ClearSet<F: Family, const N: usize> {
+    locations: Vec<Location<F>>,
     masks: BTreeMap<usize, [u8; N]>,
 }
 
-impl<const N: usize> ClearSet<N> {
+impl<F: Family, const N: usize> Default for ClearSet<F, N> {
+    fn default() -> Self {
+        Self {
+            locations: Vec::new(),
+            masks: BTreeMap::new(),
+        }
+    }
+}
+
+impl<F: Family, const N: usize> ClearSet<F, N> {
     /// Push a location to the clear set.
-    pub(crate) fn push(&mut self, loc: u64) {
+    pub(crate) fn push(&mut self, loc: Location<F>) {
+        let raw = *loc;
         self.locations.push(loc);
 
-        let chunk_idx = PrunableBitMap::<N>::to_chunk_index(loc);
-        let rel = (loc % PrunableBitMap::<N>::CHUNK_SIZE_BITS) as usize;
+        let chunk_idx = PrunableBitMap::<N>::to_chunk_index(raw);
+        let rel = (raw % PrunableBitMap::<N>::CHUNK_SIZE_BITS) as usize;
         let chunk = self.masks.entry(chunk_idx).or_insert([0u8; N]);
         chunk[rel / 8] |= 1 << (rel % 8);
     }
 
-    /// Merge another clear set into this one.
-    pub(crate) fn merge(&mut self, other: &Self) {
-        self.locations.extend_from_slice(&other.locations);
-        for (&idx, other_mask) in &other.masks {
-            let chunk = self.masks.entry(idx).or_insert([0u8; N]);
-            for (byte, &m) in chunk.iter_mut().zip(other_mask) {
-                *byte |= m;
-            }
-        }
+    /// Whether the clear set is empty.
+    pub(crate) const fn is_empty(&self) -> bool {
+        self.locations.is_empty()
     }
 
     /// Return the locations in the clear set.
-    pub(crate) fn locations(&self) -> &[u64] {
+    pub(crate) fn locations(&self) -> &[Location<F>] {
         &self.locations
     }
 
     /// Return the mask for the given chunk index.
-    fn mask(&self, idx: usize) -> Option<&[u8; N]> {
+    pub(crate) fn mask(&self, idx: usize) -> Option<&[u8; N]> {
         self.masks.get(&idx)
     }
 }
@@ -90,30 +95,30 @@ fn apply_push_clear<const N: usize>(
 ///
 /// Mirrors the [`crate::merkle::mmr::batch::MerkleizedBatch`] pattern.
 #[derive(Clone, Debug)]
-pub(crate) enum BitmapBatch<const N: usize> {
+pub(crate) enum BitmapBatch<F: Family, const N: usize> {
     /// Committed bitmap (chain terminal).
     Base(Arc<PrunableBitMap<N>>),
     /// Speculative layer on top of a parent batch.
-    Layer(Arc<BitmapBatchLayer<N>>),
+    Layer(Arc<BitmapBatchLayer<F, N>>),
 }
 
 /// The data behind a [`BitmapBatch::Layer`].
 #[derive(Debug)]
-pub(crate) struct BitmapBatchLayer<const N: usize> {
-    parent: BitmapBatch<N>,
+pub(crate) struct BitmapBatchLayer<F: Family, const N: usize> {
+    parent: BitmapBatch<F, N>,
     /// Cached `parent.len()` at layer creation time.
     parent_len: u64,
     /// New bits appended contiguously from `parent_len`.
     pushed_bits: Arc<Vec<bool>>,
     /// Bit indices of parent bits that were deactivated, with per-chunk masks.
-    clears: Arc<ClearSet<N>>,
+    clears: Arc<ClearSet<F, N>>,
 }
 
-impl<const N: usize> BitmapBatch<N> {
+impl<F: Family, const N: usize> BitmapBatch<F, N> {
     const CHUNK_SIZE_BITS: u64 = PrunableBitMap::<N>::CHUNK_SIZE_BITS;
 }
 
-impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
+impl<F: Family, const N: usize> BitmapReadable<N> for BitmapBatch<F, N> {
     fn complete_chunks(&self) -> usize {
         (self.len() / Self::CHUNK_SIZE_BITS) as usize
     }
@@ -175,11 +180,11 @@ impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
     }
 }
 
-impl<const N: usize> BitmapBatch<N> {
+impl<F: Family, const N: usize> BitmapBatch<F, N> {
     /// Push a changeset as a new layer on top of this bitmap, mutating `self` in place.
     ///
     /// The old value becomes the parent of the new layer.
-    pub(crate) fn push_changeset(&mut self, pushed_bits: Vec<bool>, clears: ClearSet<N>) {
+    pub(crate) fn push_changeset(&mut self, pushed_bits: Vec<bool>, clears: ClearSet<F, N>) {
         if pushed_bits.is_empty() && clears.locations().is_empty() {
             return;
         }
@@ -191,36 +196,6 @@ impl<const N: usize> BitmapBatch<N> {
             pushed_bits: Arc::new(pushed_bits),
             clears: Arc::new(clears),
         }));
-    }
-
-    /// Collect layer pushes and clears added after the bitmap reached length
-    /// `cutoff`. Layers whose `parent_len < cutoff` (i.e. pre-existing DB
-    /// layers) are excluded.
-    ///
-    /// Returns `(pushed_bits, clear_set)` in base-to-tip order.
-    pub(crate) fn collect_mutations_since(&self, cutoff: u64) -> (Vec<bool>, ClearSet<N>) {
-        let mut layers = Vec::new();
-        let mut current = self;
-        loop {
-            match current {
-                Self::Base(_) => break,
-                Self::Layer(layer) => {
-                    if layer.parent_len < cutoff {
-                        break;
-                    }
-                    layers.push((&*layer.pushed_bits, &*layer.clears));
-                    current = &layer.parent;
-                }
-            }
-        }
-        layers.reverse();
-        let mut pushes = Vec::new();
-        let mut clears = ClearSet::default();
-        for (p, c) in layers {
-            pushes.extend_from_slice(p);
-            clears.merge(c);
-        }
-        (pushes, clears)
     }
 
     /// Flatten all layers back to a single `Base(Arc<PrunableBitMap<N>>)`.
@@ -237,7 +212,7 @@ impl<const N: usize> BitmapBatch<N> {
         let mut owned = std::mem::replace(self, Self::Base(Arc::new(PrunableBitMap::default())));
 
         // Collect layers from tip to base.
-        let mut layers: Vec<(Arc<Vec<bool>>, Arc<ClearSet<N>>)> = Vec::new();
+        let mut layers = Vec::new();
         let base = loop {
             match owned {
                 Self::Base(bm) => break bm,
@@ -261,7 +236,7 @@ impl<const N: usize> BitmapBatch<N> {
                 bitmap.push(bit);
             }
             for &bit_idx in clears.locations() {
-                bitmap.set_bit(bit_idx, false);
+                bitmap.set_bit(*bit_idx, false);
             }
         }
         *self = Self::Base(Arc::new(bitmap));

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -12,7 +12,7 @@ use crate::{
     qmdb::{
         any::{
             self,
-            batch::DiffEntry,
+            batch::{BitmapScan, DiffEntry},
             operation::{update, Operation},
             ValueEncoding,
         },
@@ -431,7 +431,16 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let inner = inner.merkleize(metadata, &db.any).await?;
+        assert!(
+            bitmap_parent.len() > *db.any.last_commit_loc,
+            "bitmap ({}) must cover committed range [0, {}]",
+            bitmap_parent.len(),
+            *db.any.last_commit_loc,
+        );
+        let scan = BitmapScan::new(&bitmap_parent);
+        let inner = inner
+            .merkleize_with_floor_scan(metadata, scan, &db.any)
+            .await?;
         compute_current_layer(
             inner,
             db,
@@ -485,7 +494,16 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let inner = inner.merkleize(metadata, &db.any).await?;
+        assert!(
+            bitmap_parent.len() > *db.any.last_commit_loc,
+            "bitmap ({}) must cover committed range [0, {}]",
+            bitmap_parent.len(),
+            *db.any.last_commit_loc,
+        );
+        let scan = BitmapScan::new(&bitmap_parent);
+        let inner = inner
+            .merkleize_with_floor_scan(metadata, scan, &db.any)
+            .await?;
         compute_current_layer(
             inner,
             db,
@@ -1649,8 +1667,32 @@ mod tests {
         let bm = Bm::new();
         let mut scan = BitmapScan::<Bm, N>::new(&bm);
 
+        // Empty bitmap, but tip > 0: all locations are beyond bitmap.
+        assert_eq!(
+            scan.next_candidate(Location::new(0), 5),
+            Some(Location::new(0))
+        );
         // Empty bitmap, tip = 0: no candidates.
         assert_eq!(scan.next_candidate(Location::new(0), 0), None);
+    }
+
+    #[test]
+    fn bitmap_scan_beyond_bitmap_len_returns_candidate() {
+        // Bitmap has 4 bits, but tip is 8. Locations 4..8 are beyond the
+        // bitmap and should be returned as candidates.
+        let bm = make_bitmap(&[false; 4]);
+        let mut scan = BitmapScan::<Bm, N>::new(&bm);
+
+        // All bitmap bits are unset, so 0..4 are skipped.
+        // Location 4 is beyond bitmap -> candidate.
+        assert_eq!(
+            scan.next_candidate(Location::new(0), 8),
+            Some(Location::new(4))
+        );
+        assert_eq!(
+            scan.next_candidate(Location::new(6), 8),
+            Some(Location::new(6))
+        );
     }
 
     #[test]

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -12,7 +12,7 @@ use crate::{
     qmdb::{
         any::{
             self,
-            batch::{DiffEntry, FloorScan},
+            batch::DiffEntry,
             operation::{update, Operation},
             ValueEncoding,
         },
@@ -127,52 +127,6 @@ fn apply_push_clear<const N: usize>(
         for (byte, mask) in chunk.iter_mut().zip(clear_mask) {
             *byte &= !mask;
         }
-    }
-}
-
-/// Bitmap-accelerated floor scan. Skips locations where the bitmap bit is
-/// unset, avoiding I/O reads for inactive operations.
-pub(crate) struct BitmapScan<'a, B, const N: usize> {
-    bitmap: &'a B,
-}
-
-impl<'a, B: BitmapReadable<N>, const N: usize> BitmapScan<'a, B, N> {
-    pub(crate) const fn new(bitmap: &'a B) -> Self {
-        Self { bitmap }
-    }
-}
-
-impl<B: BitmapReadable<N>, const N: usize> FloorScan<mmr::Family> for BitmapScan<'_, B, N> {
-    fn next_candidate(&mut self, floor: Location, tip: u64) -> Option<Location> {
-        let loc = *floor;
-        if loc >= tip {
-            return None;
-        }
-        let bitmap_len = self.bitmap.len();
-        // Within the bitmap: find the next set bit at or after floor.
-        // ones_iter_from returns set indices in ascending order so the
-        // first result is the only possible candidate below bound.
-        // tip >= bitmap_len always holds (base_size ==
-        // bitmap_parent.len()), so bound == bitmap_len and the
-        // length check inside the iterator prevents scanning past bound.
-        if loc < bitmap_len {
-            let bound = bitmap_len.min(tip);
-            if let Some(idx) = self.bitmap.ones_iter_from(loc).next() {
-                if idx < bound {
-                    return Some(Location::new(idx));
-                }
-            }
-        }
-        // Beyond the bitmap: uncommitted ops from prior batches in the
-        // chain that aren't tracked by the bitmap yet. Conservatively
-        // treat them as candidates.
-        if bitmap_len < tip {
-            let candidate = loc.max(bitmap_len);
-            if candidate < tip {
-                return Some(Location::new(candidate));
-            }
-        }
-        None
     }
 }
 
@@ -477,10 +431,7 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let scan = BitmapScan::new(&bitmap_parent);
-        let inner = inner
-            .merkleize_with_floor_scan(metadata, scan, &db.any)
-            .await?;
+        let inner = inner.merkleize(metadata, &db.any).await?;
         compute_current_layer(
             inner,
             db,
@@ -534,10 +485,7 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let scan = BitmapScan::new(&bitmap_parent);
-        let inner = inner
-            .merkleize_with_floor_scan(metadata, scan, &db.any)
-            .await?;
+        let inner = inner.merkleize(metadata, &db.any).await?;
         compute_current_layer(
             inner,
             db,
@@ -1636,23 +1584,7 @@ mod tests {
 
     // ---- FloorScan tests ----
 
-    use crate::qmdb::any::batch::{FloorScan, SequentialScan};
-
-    #[test]
-    fn sequential_scan_returns_floor_when_below_tip() {
-        let mut scan = SequentialScan;
-        assert_eq!(
-            scan.next_candidate(Location::new(5), 10),
-            Some(Location::new(5))
-        );
-    }
-
-    #[test]
-    fn sequential_scan_returns_none_at_tip() {
-        let mut scan = SequentialScan;
-        assert_eq!(scan.next_candidate(Location::new(10), 10), None);
-        assert_eq!(scan.next_candidate(Location::new(11), 10), None);
-    }
+    use crate::qmdb::any::batch::{BitmapScan, FloorScan};
 
     #[test]
     fn bitmap_scan_all_active() {
@@ -1692,25 +1624,6 @@ mod tests {
     }
 
     #[test]
-    fn bitmap_scan_beyond_bitmap_len_returns_candidate() {
-        // Bitmap has 4 bits, but tip is 8. Locations 4..8 are beyond the
-        // bitmap and should be returned as candidates.
-        let bm = make_bitmap(&[false; 4]);
-        let mut scan = BitmapScan::<Bm, N>::new(&bm);
-
-        // All bitmap bits are unset, so 0..4 are skipped.
-        // Location 4 is beyond bitmap -> candidate.
-        assert_eq!(
-            scan.next_candidate(Location::new(0), 8),
-            Some(Location::new(4))
-        );
-        assert_eq!(
-            scan.next_candidate(Location::new(6), 8),
-            Some(Location::new(6))
-        );
-    }
-
-    #[test]
     fn bitmap_scan_respects_tip() {
         let bm = make_bitmap(&[false, false, false, true]);
         let mut scan = BitmapScan::<Bm, N>::new(&bm);
@@ -1736,11 +1649,6 @@ mod tests {
         let bm = Bm::new();
         let mut scan = BitmapScan::<Bm, N>::new(&bm);
 
-        // Empty bitmap, but tip > 0: all locations are beyond bitmap.
-        assert_eq!(
-            scan.next_candidate(Location::new(0), 5),
-            Some(Location::new(0))
-        );
         // Empty bitmap, tip = 0: no candidates.
         assert_eq!(scan.next_candidate(Location::new(0), 0), None);
     }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -16,6 +16,7 @@ use crate::{
             operation::{update, Operation},
             ValueEncoding,
         },
+        bitmap::ClearSet,
         current::{
             db::{compute_db_root, compute_grafted_leaves, partial_chunk},
             grafting,
@@ -33,67 +34,6 @@ use std::{
 };
 
 type Error = crate::qmdb::Error<mmr::Family>;
-
-/// Cleared bitmap bits tracked in two synchronized views.
-///
-/// `locations` preserves the original clear operations so batch chaining, flattening, and
-/// finalization can replay them in order. `masks` indexes the same clears by chunk, allowing
-/// [`apply_push_clear`] to zero an entire chunk without rescanning every cleared location.
-#[derive(Clone, Debug, Default)]
-pub(super) struct ClearSet<const N: usize> {
-    locations: Vec<Location>,
-    masks: BTreeMap<usize, [u8; N]>,
-}
-
-impl<const N: usize> ClearSet<N> {
-    /// Create a clear set with a given capacity.
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            locations: Vec::with_capacity(capacity),
-            masks: BTreeMap::new(),
-        }
-    }
-
-    /// Push a location to the clear set.
-    fn push(&mut self, loc: Location) {
-        self.locations.push(loc);
-
-        let chunk_idx = BitMap::<N>::to_chunk_index(*loc);
-        let rel = (*loc % BitMap::<N>::CHUNK_SIZE_BITS) as usize;
-        let chunk = self.masks.entry(chunk_idx).or_insert([0u8; N]);
-        chunk[rel / 8] |= 1 << (rel % 8);
-    }
-
-    /// Merge another clear set into this one.
-    fn merge(&mut self, other: &Self) {
-        self.locations.extend_from_slice(&other.locations);
-        for (&idx, other_mask) in &other.masks {
-            let chunk = self.masks.entry(idx).or_insert([0u8; N]);
-            for (byte, &m) in chunk.iter_mut().zip(other_mask) {
-                *byte |= m;
-            }
-        }
-    }
-
-    /// Return the number of locations in the clear set.
-    const fn len(&self) -> usize {
-        self.locations.len()
-    }
-
-    const fn is_empty(&self) -> bool {
-        self.locations.is_empty()
-    }
-
-    /// Return the locations in the clear set.
-    fn locations(&self) -> &[Location] {
-        &self.locations
-    }
-
-    /// Return the mask for the given chunk index.
-    fn mask(&self, idx: usize) -> Option<&[u8; N]> {
-        self.masks.get(&idx)
-    }
-}
 
 /// Apply pushed bits and cleared bits to `chunk` at absolute position `chunk_start`.
 ///
@@ -140,7 +80,7 @@ pub struct BitmapDiff<'a, B: BitmapReadable<N>, const N: usize> {
     /// New bits appended beyond the base bitmap.
     pushed_bits: Vec<bool>,
     /// Base bits that have been deactivated, plus chunk masks derived from them.
-    clears: ClearSet<N>,
+    clears: ClearSet<mmr::Family, N>,
     /// Chunk indices containing cleared bits that need grafted MMR recomputation.
     dirty_chunks: HashSet<usize>,
     /// Number of complete chunks in the base bitmap at diff creation time.
@@ -174,7 +114,7 @@ impl<'a, B: BitmapReadable<N>, const N: usize> BitmapDiff<'a, B, N> {
     }
 
     /// Consume the diff, returning the parts needed for a [`BitmapBatchLayer`].
-    fn into_parts(self) -> (u64, Vec<bool>, ClearSet<N>) {
+    fn into_parts(self) -> (u64, Vec<bool>, ClearSet<mmr::Family, N>) {
         (self.base_len, self.pushed_bits, self.clears)
     }
 }
@@ -299,12 +239,6 @@ where
     /// The inner any-layer batch that handles mutations, journal, and floor raise.
     inner: any::batch::UnmerkleizedBatch<mmr::Family, H, U>,
 
-    /// Bitmap pushes accumulated by prior batches in the chain.
-    base_bitmap_pushes: Vec<Arc<Vec<bool>>>,
-
-    /// Bitmap clears accumulated by prior batches in the chain.
-    base_bitmap_clears: Vec<Arc<ClearSet<N>>>,
-
     /// Parent's grafted MMR state (owned, Arc-based internally).
     grafted_parent: mmr::batch::MerkleizedBatch<H::Digest>,
 
@@ -324,12 +258,6 @@ where
     /// Inner any-layer batch (ops MMR, diff, floor, commit loc, sizes).
     inner: any::batch::MerkleizedBatch<mmr::Family, D, U>,
 
-    /// Accumulated bitmap pushes from all batches in the chain.
-    bitmap_pushes: Vec<Arc<Vec<bool>>>,
-
-    /// Accumulated bitmap clears from all batches in the chain.
-    bitmap_clears: Vec<Arc<ClearSet<N>>>,
-
     /// Grafted MMR state.
     grafted: mmr::batch::MerkleizedBatch<D>,
 
@@ -344,12 +272,6 @@ where
 pub struct Changeset<K, D: Digest, Item: Send, const N: usize> {
     /// The inner any-layer changeset.
     pub(super) inner: any::batch::Changeset<mmr::Family, K, D, Item>,
-
-    /// One bool per operation in the batch chain (pushes applied before clears).
-    pub(super) bitmap_pushes: Vec<bool>,
-
-    /// Cleared bitmap locations, plus per-chunk masks cached for fast reapplication.
-    pub(super) bitmap_clears: ClearSet<N>,
 
     /// Changeset for the grafted MMR.
     pub(super) grafted_changeset: mmr::Changeset<D>,
@@ -366,15 +288,11 @@ where
 {
     pub(super) const fn new(
         inner: any::batch::UnmerkleizedBatch<mmr::Family, H, U>,
-        base_bitmap_pushes: Vec<Arc<Vec<bool>>>,
-        base_bitmap_clears: Vec<Arc<ClearSet<N>>>,
         grafted_parent: mmr::batch::MerkleizedBatch<H::Digest>,
         bitmap_parent: BitmapBatch<N>,
     ) -> Self {
         Self {
             inner,
-            base_bitmap_pushes,
-            base_bitmap_clears,
             grafted_parent,
             bitmap_parent,
         }
@@ -426,8 +344,6 @@ where
     {
         let Self {
             inner,
-            base_bitmap_pushes,
-            base_bitmap_clears,
             grafted_parent,
             bitmap_parent,
         } = self;
@@ -441,15 +357,7 @@ where
         let inner = inner
             .merkleize_with_floor_scan(metadata, scan, &db.any)
             .await?;
-        compute_current_layer(
-            inner,
-            db,
-            base_bitmap_pushes,
-            base_bitmap_clears,
-            &grafted_parent,
-            &bitmap_parent,
-        )
-        .await
+        compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }
 }
 
@@ -489,8 +397,6 @@ where
     {
         let Self {
             inner,
-            base_bitmap_pushes,
-            base_bitmap_clears,
             grafted_parent,
             bitmap_parent,
         } = self;
@@ -504,15 +410,7 @@ where
         let inner = inner
             .merkleize_with_floor_scan(metadata, scan, &db.any)
             .await?;
-        compute_current_layer(
-            inner,
-            db,
-            base_bitmap_pushes,
-            base_bitmap_clears,
-            &grafted_parent,
-            &bitmap_parent,
-        )
-        .await
+        compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }
 }
 
@@ -596,14 +494,10 @@ fn clear_ancestor_superseded<U, B, const N: usize>(
 /// any batch.
 ///
 /// Creates a `BitmapDiff` and grafted MMR batch from the immediate parent's state, and
-/// produces the [`MerkleizedBatch`] directly. The ancestor chain's accumulated bitmap
-/// pushes/clears are stored alongside the batch so that `finalize()` can concatenate them
-/// without recomputation.
+/// produces the [`MerkleizedBatch`] directly.
 async fn compute_current_layer<E, U, C, I, H, const N: usize>(
     inner: any::batch::MerkleizedBatch<mmr::Family, H::Digest, U>,
     current_db: &super::db::Db<E, C, I, H, U, N>,
-    base_bitmap_pushes: Vec<Arc<Vec<bool>>>,
-    base_bitmap_clears: Vec<Arc<ClearSet<N>>>,
     grafted_parent: &mmr::batch::MerkleizedBatch<H::Digest>,
     bitmap_parent: &BitmapBatch<N>,
 ) -> Result<MerkleizedBatch<H::Digest, U, N>, Error>
@@ -621,6 +515,7 @@ where
     let chain = &inner.journal_batch.items;
     let this_segment = chain.last().expect("operation chain should not be empty");
     let segment_base = *inner.new_last_commit_loc + 1 - this_segment.len() as u64;
+    bitmap.pushed_bits.reserve(this_segment.len());
 
     // 1. Inactivate previous commit.
     let prev_commit_loc = Location::new(segment_base - 1);
@@ -689,28 +584,18 @@ where
     let canonical_root =
         compute_db_root::<H, _, _, N>(&hasher, &grafted_storage, partial, &ops_root).await?;
 
-    // 8. Extract diff data and build COW bitmap layer + push/clear chain.
+    // 8. Extract diff data and build COW bitmap layer.
     let (parent_len, pushed_bits, clears) = bitmap.into_parts();
-
-    let pushed_bits = Arc::new(pushed_bits);
-    let clears = Arc::new(clears);
-
-    let mut bitmap_pushes = base_bitmap_pushes;
-    bitmap_pushes.push(Arc::clone(&pushed_bits));
-    let mut bitmap_clears = base_bitmap_clears;
-    bitmap_clears.push(Arc::clone(&clears));
 
     let bitmap_batch = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
         parent: bitmap_parent.clone(),
         parent_len,
-        pushed_bits,
-        clears,
+        pushed_bits: Arc::new(pushed_bits),
+        clears: Arc::new(clears),
     }));
 
     Ok(MerkleizedBatch {
         inner,
-        bitmap_pushes,
-        bitmap_clears,
         grafted: grafted_batch,
         bitmap: bitmap_batch,
         canonical_root,
@@ -721,7 +606,7 @@ where
 ///
 /// Mirrors the [`crate::mmr::batch::MerkleizedBatch`] pattern.
 #[derive(Clone, Debug)]
-pub(crate) enum BitmapBatch<const N: usize> {
+pub(super) enum BitmapBatch<const N: usize> {
     /// Committed bitmap (chain terminal).
     Base(Arc<BitMap<N>>),
     /// Speculative layer on top of a parent batch.
@@ -730,14 +615,14 @@ pub(crate) enum BitmapBatch<const N: usize> {
 
 /// The data behind a [`BitmapBatch::Layer`].
 #[derive(Debug)]
-pub(crate) struct BitmapBatchLayer<const N: usize> {
+pub(super) struct BitmapBatchLayer<const N: usize> {
     parent: BitmapBatch<N>,
     /// Cached `parent.len()` at layer creation time.
     parent_len: u64,
     /// New bits appended contiguously from `parent_len`.
     pushed_bits: Arc<Vec<bool>>,
     /// Parent bits that were deactivated, plus chunk masks derived from them.
-    clears: Arc<ClearSet<N>>,
+    clears: Arc<ClearSet<mmr::Family, N>>,
 }
 
 impl<const N: usize> BitmapBatch<N> {
@@ -807,13 +692,29 @@ impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
 }
 
 impl<const N: usize> BitmapBatch<N> {
-    /// Push a changeset as a new layer on top of this bitmap, mutating `self` in place.
+    /// Push a changeset on top of this bitmap, mutating `self` in place.
     ///
-    /// The old value becomes the parent of the new layer.
-    pub(super) fn push_changeset(&mut self, pushed_bits: Vec<bool>, clears: ClearSet<N>) {
+    /// When the bitmap is a [Self::Base] variant with no outstanding clones (typical for sequential
+    /// commit patterns), mutations are applied directly in place, keeping the bitmap flat and
+    /// `get_chunk` O(1). Otherwise a new [Self::Layer] is created. `pushed_bits[i]` corresponds to
+    /// the operation at `parent_len + i` in the new committed range.
+    pub(super) fn push_changeset(&mut self, pushed_bits: Vec<bool>, clears: ClearSet<mmr::Family, N>) {
         if pushed_bits.is_empty() && clears.is_empty() {
             return;
         }
+
+        if let Self::Base(base) = self {
+            if let Some(bitmap) = Arc::get_mut(base) {
+                for &bit in &pushed_bits {
+                    bitmap.push(bit);
+                }
+                for loc in clears.locations() {
+                    bitmap.set_bit(**loc, false);
+                }
+                return;
+            }
+        }
+
         let parent_len = self.len();
         let parent = self.clone();
         *self = Self::Layer(Arc::new(BitmapBatchLayer {
@@ -893,13 +794,8 @@ where
     where
         H: Hasher<Digest = D>,
     {
-        let pushes = self.bitmap_pushes.clone();
-        let clears = self.bitmap_clears.clone();
-
         UnmerkleizedBatch::new(
             self.inner.new_batch::<H>(),
-            pushes,
-            clears,
             self.grafted.clone(),
             self.bitmap.clone(),
         )
@@ -925,23 +821,8 @@ where
     where
         U: 'static,
     {
-        // Flatten accumulated bitmap pushes + clears into flat Vecs.
-        let total_pushes: usize = self.bitmap_pushes.iter().map(|s| s.len()).sum();
-        let mut bitmap_pushes = Vec::with_capacity(total_pushes);
-        for seg in &self.bitmap_pushes {
-            bitmap_pushes.extend_from_slice(seg);
-        }
-
-        let total_clears: usize = self.bitmap_clears.iter().map(|s| s.len()).sum();
-        let mut bitmap_clears = ClearSet::with_capacity(total_clears);
-        for seg in &self.bitmap_clears {
-            bitmap_clears.merge(seg);
-        }
-
         Changeset {
             inner: self.inner.finalize(),
-            bitmap_pushes,
-            bitmap_clears,
             grafted_changeset: self.grafted.finalize(),
             canonical_root: self.canonical_root,
         }
@@ -951,13 +832,12 @@ where
     /// instead of the original DB size when this batch chain was created.
     ///
     /// Use this when an ancestor batch in the chain has already been committed, advancing
-    /// the DB's operation count past the original fork point. Skips bitmap pushes/clears
-    /// and grafted MMR entries from ancestor batches that have already been committed.
+    /// the DB's operation count past the original fork point. Skips grafted MMR entries
+    /// from ancestor batches that have already been committed.
     ///
     /// # Panics
     ///
-    /// Panics if `current_db_size` is less than the DB size when this batch was created,
-    /// or if `items_to_skip` does not align with push segment boundaries.
+    /// Panics if `current_db_size` is less than the DB size when this batch was created.
     pub fn finalize_from(
         self,
         current_db_size: u64,
@@ -970,43 +850,6 @@ where
             "current_db_size ({current_db_size}) < batch db_size ({})",
             self.inner.db_size
         );
-        let items_to_skip = (current_db_size - self.inner.db_size) as usize;
-
-        // Determine how many complete batch segments have been committed.
-        // Push segments have one entry per operation, so their cumulative
-        // length maps directly to items_to_skip. Committed batches are
-        // always committed as whole units, so items_to_skip always aligns
-        // with segment boundaries.
-        let mut remaining = items_to_skip;
-        let mut segments_to_skip = 0;
-        for seg in &self.bitmap_pushes {
-            if remaining == 0 {
-                break;
-            }
-            assert!(
-                remaining >= seg.len(),
-                "items_to_skip does not align with push segment boundary"
-            );
-            remaining -= seg.len();
-            segments_to_skip += 1;
-        }
-
-        // Flatten uncommitted push segments.
-        let mut bitmap_pushes = Vec::new();
-        for seg in &self.bitmap_pushes[segments_to_skip..] {
-            bitmap_pushes.extend_from_slice(seg);
-        }
-
-        // Flatten uncommitted clear segments (1:1 with push segments).
-        let mut bitmap_clears = ClearSet::with_capacity(
-            self.bitmap_clears[segments_to_skip..]
-                .iter()
-                .map(|s| s.len())
-                .sum(),
-        );
-        for seg in &self.bitmap_clears[segments_to_skip..] {
-            bitmap_clears.merge(seg);
-        }
 
         // The grafted MMR base must reflect the current committed bitmap's
         // complete chunk count (after committed ancestors' pushes).
@@ -1016,9 +859,9 @@ where
         let grafted_changeset = self.grafted.finalize_from(grafted_base);
 
         Changeset {
+            // Bitmap rebasing happens later in current::Db::apply_batch(), derived from the rebased
+            // inner snapshot diffs.
             inner: self.inner.finalize_from(current_db_size),
-            bitmap_pushes,
-            bitmap_clears,
             grafted_changeset,
             canonical_root: self.canonical_root,
         }
@@ -1038,8 +881,6 @@ where
     pub fn to_batch(&self) -> MerkleizedBatch<H::Digest, U, N> {
         MerkleizedBatch {
             inner: self.any.to_batch(),
-            bitmap_pushes: Vec::new(),
-            bitmap_clears: Vec::new(),
             grafted: self.grafted_snapshot(),
             bitmap: self.status.clone(),
             canonical_root: self.root,
@@ -1353,112 +1194,6 @@ mod tests {
     }
 
     #[test]
-    fn clear_set_merge_empty_into_empty() {
-        let mut a = ClearSet::<N>::default();
-        let b = ClearSet::<N>::default();
-        a.merge(&b);
-        assert_eq!(a.len(), 0);
-        assert!(a.is_empty());
-    }
-
-    #[test]
-    fn clear_set_merge_non_empty_into_empty() {
-        let mut a = ClearSet::<N>::default();
-        let mut b = ClearSet::<N>::default();
-        b.push(Location::new(3));
-        b.push(Location::new(7));
-
-        a.merge(&b);
-        assert_eq!(a.len(), 2);
-        assert_eq!(a.locations(), &[Location::new(3), Location::new(7)]);
-        // Both bits in chunk 0.
-        let mask = a.mask(0).unwrap();
-        assert_eq!(mask[0], (1 << 3) | (1 << 7));
-    }
-
-    #[test]
-    fn clear_set_merge_empty_into_non_empty() {
-        let mut a = ClearSet::<N>::default();
-        a.push(Location::new(5));
-        let b = ClearSet::<N>::default();
-
-        a.merge(&b);
-        assert_eq!(a.len(), 1);
-        assert_eq!(a.locations(), &[Location::new(5)]);
-        let mask = a.mask(0).unwrap();
-        assert_eq!(mask[0], 1 << 5);
-    }
-
-    #[test]
-    fn clear_set_merge_disjoint_chunks() {
-        // N=4 -> CHUNK_SIZE_BITS = 32. Bit 2 is in chunk 0, bit 33 is in chunk 1.
-        let mut a = ClearSet::<N>::default();
-        a.push(Location::new(2));
-
-        let mut b = ClearSet::<N>::default();
-        b.push(Location::new(33));
-
-        a.merge(&b);
-        assert_eq!(a.len(), 2);
-        assert_eq!(a.locations(), &[Location::new(2), Location::new(33)]);
-        // Chunk 0: only bit 2.
-        let m0 = a.mask(0).unwrap();
-        assert_eq!(m0[0], 1 << 2);
-        // Chunk 1: bit 33 -> relative bit 1 -> byte 0, bit 1.
-        let m1 = a.mask(1).unwrap();
-        assert_eq!(m1[0], 1 << 1);
-    }
-
-    #[test]
-    fn clear_set_merge_overlapping_chunk() {
-        // Both sets clear bits in the same chunk; masks must be OR'd.
-        let mut a = ClearSet::<N>::default();
-        a.push(Location::new(1));
-        a.push(Location::new(4));
-
-        let mut b = ClearSet::<N>::default();
-        b.push(Location::new(4)); // duplicate with a
-        b.push(Location::new(6));
-
-        a.merge(&b);
-        assert_eq!(a.len(), 4);
-        let mask = a.mask(0).unwrap();
-        // bits 1, 4, 6 (4 appears in both but OR is idempotent for mask)
-        assert_eq!(mask[0], (1 << 1) | (1 << 4) | (1 << 6));
-    }
-
-    #[test]
-    fn clear_set_merge_matches_sequential_push() {
-        // Verify merge produces the same masks as pushing each location individually.
-        let locs_a: Vec<Location> = (0..5).map(Location::new).collect();
-        let locs_b: Vec<Location> = (30..36).map(Location::new).collect(); // spans chunks 0 and 1
-
-        // Build via merge.
-        let mut via_merge = ClearSet::<N>::default();
-        let mut part_a = ClearSet::<N>::default();
-        for &loc in &locs_a {
-            part_a.push(loc);
-        }
-        let mut part_b = ClearSet::<N>::default();
-        for &loc in &locs_b {
-            part_b.push(loc);
-        }
-        via_merge.merge(&part_a);
-        via_merge.merge(&part_b);
-
-        // Build via sequential push.
-        let mut via_push = ClearSet::<N>::default();
-        for &loc in locs_a.iter().chain(&locs_b) {
-            via_push.push(loc);
-        }
-
-        assert_eq!(via_merge.locations(), via_push.locations());
-        for idx in 0..2 {
-            assert_eq!(via_merge.mask(idx), via_push.mask(idx));
-        }
-    }
-
-    #[test]
     fn bitmap_diff_clear_set_tracks_chunk_bits() {
         let base = make_bitmap(&[true; 96]);
         let mut diff = BitmapDiff::<Bm, N>::new(&base, 3);
@@ -1480,12 +1215,7 @@ mod tests {
         clears.push(Location::new(40));
         batch.push_changeset(Vec::new(), clears);
 
-        let BitmapBatch::Layer(layer) = &batch else {
-            panic!("expected layer");
-        };
-        assert_eq!(layer.clears.mask(0).unwrap()[0], 1 << 3);
-        assert_eq!(layer.clears.mask(1).unwrap()[1], 0x01);
-
+        // Verify the cleared bits are reflected in the chunks.
         let chunk0 = batch.get_chunk(0);
         let chunk1 = batch.get_chunk(1);
         assert_eq!(chunk0[0] & (1 << 3), 0);
@@ -1588,7 +1318,7 @@ mod tests {
 
         clear_base_old_locs::<K, u64, Bm, N>(&mut bitmap, &diff);
 
-        assert_eq!(bitmap.clears.len(), 2);
+        assert_eq!(bitmap.clears.locations().len(), 2);
 
         // Verify bits 5 and 10 are cleared.
         let c0 = bitmap.get_chunk(0);

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -19,6 +19,7 @@ use crate::{
     qmdb::{
         any::{
             self,
+            batch::derive_bitmap_changes,
             operation::{update::Update, Operation},
         },
         current::{
@@ -200,8 +201,6 @@ where
     pub fn new_batch(&self) -> super::batch::UnmerkleizedBatch<H, U, N> {
         super::batch::UnmerkleizedBatch::new(
             self.any.new_batch(),
-            Vec::new(),
-            Vec::new(),
             self.grafted_snapshot(),
             self.status.clone(),
         )
@@ -446,7 +445,7 @@ where
             let BitmapBatch::Base(base) = &mut self.status else {
                 unreachable!("flatten() guarantees Base");
             };
-            let status = Arc::get_mut(base).expect("flatten ensures sole owner");
+            let status = Arc::make_mut(base);
             status.truncate(rewind_size);
             for loc in &restored_locs {
                 status.set_bit(**loc, true);
@@ -481,7 +480,7 @@ where
     }
 
     /// Sync the metadata to disk.
-    pub(crate) async fn sync_metadata(&self) -> Result<(), Error> {
+    pub(super) async fn sync_metadata(&self) -> Result<(), Error> {
         let mut metadata = self.metadata.lock().await;
         metadata.clear();
 
@@ -573,12 +572,32 @@ where
         &mut self,
         batch: super::batch::Changeset<U::Key, H::Digest, Operation<mmr::Family, U>, N>,
     ) -> Result<Range<Location>, Error> {
+        // Check for staleness before trying to derive the bitmap changes, otherwise it could panic.
+        let batch_start = *self.any.last_commit_loc + 1;
+        if batch.inner.db_size != batch_start {
+            return Err(crate::qmdb::Error::StaleChangeset {
+                expected: batch.inner.db_size,
+                actual: batch_start,
+            });
+        }
+
+        // Zero-op changeset (e.g. from to_batch().finalize()) — nothing to apply.
+        let start_loc = Location::new(batch_start);
+        if *batch.inner.new_last_commit_loc < batch_start {
+            return Ok(start_loc..start_loc);
+        }
+
+        let (active_bits, clears) = derive_bitmap_changes::<mmr::Family, U, N>(
+            self.any.last_commit_loc,
+            batch_start,
+            batch.inner.new_last_commit_loc,
+            &batch.inner.snapshot_diffs,
+        );
+
         // Apply inner any batch (writes ops, updates snapshot).
         let range = self.any.apply_batch(batch.inner).await?;
 
-        // Push bitmap mutations as a layer (O(changeset), no deep clone).
-        self.status
-            .push_changeset(batch.bitmap_pushes, batch.bitmap_clears);
+        self.status.push_changeset(active_bits, clears);
 
         // Push grafted changeset as a layer (O(changeset), no deep clone).
         self.grafted_mmr.push_changeset(batch.grafted_changeset);
@@ -959,4 +978,5 @@ mod tests {
         let r2 = combine_roots(&h2, &ops_b, &grafted, None);
         assert_ne!(r1, r2);
     }
+
 }

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -52,7 +52,7 @@ use core::{cmp::Ordering, marker::PhantomData};
 use tracing::debug;
 
 /// Get the grafting height for a bitmap with chunk size determined by N.
-pub(crate) const fn height<const N: usize>() -> u32 {
+pub(super) const fn height<const N: usize>() -> u32 {
     BitMap::<N>::CHUNK_SIZE_BITS.trailing_zeros()
 }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -338,7 +338,7 @@ where
 
     // Initialize the anydb with a callback that populates the status bitmap.
     let last_known_inactivity_floor = Location::new(status.len());
-    let any = any::init(
+    let mut any = any::init(
         context.with_label("any"),
         config.into(),
         Some(last_known_inactivity_floor),
@@ -350,6 +350,10 @@ where
         },
     )
     .await?;
+
+    // When embedded inside a current::Db, the any layer does not need its own bitmap --
+    // current maintains its own bitmap with a different chunk size for authenticated proofs.
+    any.status = None;
 
     // Build the grafted MMR from the bitmap and ops MMR.
     let hasher = StandardHasher::<H>::new();

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1673,6 +1673,74 @@ pub mod tests {
         });
     }
 
+    /// Regression: rewind must not panic when a live snapshot (new_batch/to_batch)
+    /// shares the committed Base bitmap Arc.
+    #[test_traced("INFO")]
+    fn test_current_rewind_with_live_snapshot() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let partition = "current-rewind-live-snapshot";
+            let ctx = context.with_label("db");
+            let mut db: UnorderedVariableDb =
+                UnorderedVariableDb::init(ctx.clone(), variable_config::<OneCap>(partition, &ctx))
+                    .await
+                    .unwrap();
+
+            commit_writes_with_metadata(
+                &mut db,
+                [(key(0), Some(val(0))), (key(1), Some(val(1)))],
+                None,
+            )
+            .await;
+            let size_before = db.bounds().await.end;
+            let root_before = db.root();
+
+            commit_writes_with_metadata(&mut db, [(key(0), Some(val(100)))], None).await;
+
+            // Hold a live snapshot that shares the Base bitmap Arc.
+            let _live_batch = db.new_batch();
+
+            // Rewind while the snapshot is alive. Before the fix this panicked
+            // because flatten() was a no-op on Base and Arc::get_mut failed.
+            db.rewind(size_before).await.unwrap();
+            assert_eq!(db.bounds().await.end, size_before);
+            assert_eq!(db.root(), root_before);
+            assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
+            assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Regression: applying a finalized committed snapshot (to_batch().finalize())
+    /// must not panic. It is a zero-op changeset and should return an empty range.
+    #[test_traced("INFO")]
+    fn test_current_apply_zero_op_changeset() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let partition = "current-zero-op-changeset";
+            let ctx = context.with_label("db");
+            let mut db: UnorderedVariableDb =
+                UnorderedVariableDb::init(ctx.clone(), variable_config::<OneCap>(partition, &ctx))
+                    .await
+                    .unwrap();
+
+            commit_writes_with_metadata(&mut db, [(key(0), Some(val(0)))], None).await;
+            let size_before = db.bounds().await.end;
+            let root_before = db.root();
+
+            let snapshot = db.to_batch();
+            let changeset = snapshot.finalize();
+            let range = db.apply_batch(changeset).await.unwrap();
+
+            assert!(range.is_empty());
+            assert_eq!(db.bounds().await.end, size_before);
+            assert_eq!(db.root(), root_before);
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// MerkleizedBatch::root() returns the canonical root that matches db.root()
     /// after apply. ops_root() differs from root() because the canonical root
     /// includes the bitmap/grafted MMR layers.

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -145,7 +145,7 @@ where
     // init_from_log replays the operations, building the snapshot (index) and invoking
     // our callback for each operation to populate the bitmap.
     let known_inactivity_floor = Location::new(status.len());
-    let any: AnyDb<mmr::Family, E, J, I, H, U> = AnyDb::init_from_log(
+    let mut any: AnyDb<mmr::Family, E, J, I, H, U> = AnyDb::init_from_log(
         index,
         log,
         Some(known_inactivity_floor),
@@ -157,6 +157,10 @@ where
         },
     )
     .await?;
+
+    // When embedded inside a current::Db, the any layer does not need its own bitmap --
+    // current maintains its own bitmap with a different chunk size for authenticated proofs.
+    any.status = None;
 
     // Extract grafted pinned nodes from the ops MMR.
     //

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -58,6 +58,7 @@ use futures::{pin_mut, StreamExt as _};
 use thiserror::Error;
 
 pub mod any;
+pub(crate) mod bitmap;
 pub mod current;
 pub mod immutable;
 pub mod keyless;


### PR DESCRIPTION
Adds an activity bitmap to the anydb for optimized floor raising.

Resolves: https://github.com/commonwarexyz/monorepo/issues/1829