### PR TITLE
[cryptography] reject ed25519 signatures with non-canonical S at decode time

### DIFF
--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -31,15 +31,15 @@ const L: [u8; 32] = [
 ];
 
 fn is_canonical_s(s: &[u8; 32]) -> bool {
-    for i in (0..32).rev() {
-        if s[i] < L[i] {
-            return true;
-        }
-        if s[i] > L[i] {
-            return false;
-        }
+    // Constant-time s < L via subtraction with borrow (little-endian, LSB first).
+    // borrow is 1 when the subtraction at position i underflowed, 0 otherwise.
+    // After all 32 bytes, a non-zero borrow means s < L.
+    let mut borrow: u16 = 0;
+    for i in 0..32 {
+        let diff = (s[i] as u16).wrapping_sub(L[i] as u16).wrapping_sub(borrow);
+        borrow = (diff >> 8) & 1;
     }
-    false
+    borrow != 0
 }
 
 /// Ed25519 Private Key.

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -30,7 +30,6 @@ const L: [u8; 32] = [
     0x00, 0x10,
 ];
 
-// Returns true iff s < l (canonical scalar).
 fn is_canonical_s(s: &[u8; 32]) -> bool {
     for i in (0..32).rev() {
         if s[i] < L[i] {
@@ -40,7 +39,7 @@ fn is_canonical_s(s: &[u8; 32]) -> bool {
             return false;
         }
     }
-    false // s == l
+    false
 }
 
 /// Ed25519 Private Key.
@@ -814,7 +813,6 @@ mod tests {
 
     #[test]
     fn test_s_equal_to_l_rejected_at_decode() {
-        // S == l is not canonical (must be in [0, l-1])
         let mut bad_signature = vec![0u8; SIGNATURE_LENGTH];
         bad_signature[32..].copy_from_slice(&L);
         assert!(Signature::decode(bad_signature.as_ref()).is_err());
@@ -822,10 +820,9 @@ mod tests {
 
     #[test]
     fn test_s_above_l_rejected_at_decode() {
-        // S == l + 1
         let mut bad_signature = vec![0u8; SIGNATURE_LENGTH];
         bad_signature[32..].copy_from_slice(&L);
-        bad_signature[32] = bad_signature[32].wrapping_add(1); // increment LSB
+        bad_signature[32] = bad_signature[32].wrapping_add(1);
         assert!(Signature::decode(bad_signature.as_ref()).is_err());
     }
 

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -23,6 +23,26 @@ const PRIVATE_KEY_LENGTH: usize = 32;
 const PUBLIC_KEY_LENGTH: usize = 32;
 const SIGNATURE_LENGTH: usize = 64;
 
+// Group order l = 2^252 + 27742317777372353535851937790883648493, little-endian.
+const L: [u8; 32] = [
+    0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde,
+    0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x10,
+];
+
+// Returns true iff s < l (canonical scalar).
+fn is_canonical_s(s: &[u8; 32]) -> bool {
+    for i in (0..32).rev() {
+        if s[i] < L[i] {
+            return true;
+        }
+        if s[i] > L[i] {
+            return false;
+        }
+    }
+    false // s == l
+}
+
 /// Ed25519 Private Key.
 #[derive(Clone, Debug)]
 pub struct PrivateKey {
@@ -260,6 +280,10 @@ impl Read for Signature {
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let raw = <[u8; Self::SIZE]>::read(buf)?;
+        let s: &[u8; 32] = raw[32..].try_into().unwrap();
+        if !is_canonical_s(s) {
+            return Err(CodecError::Invalid(CURVE_NAME, "non-canonical S"));
+        }
         Ok(Self { raw })
     }
 }
@@ -781,12 +805,28 @@ mod tests {
     }
 
     #[test]
-    fn test_high_s_fails() {
-        let (_, public_key, message, signature) = vector_1();
+    fn test_high_s_rejected_at_decode() {
+        let (_, _, _, signature) = vector_1();
         let mut bad_signature = signature.to_vec();
-        bad_signature[63] |= 0x80; // make S non-canonical
-        let bad_signature = Signature::decode(bad_signature.as_ref()).unwrap();
-        assert!(!public_key.verify_inner(None, &message, &bad_signature));
+        bad_signature[63] |= 0x80; // set high bit of S — makes S >= 2^255 > l
+        assert!(Signature::decode(bad_signature.as_ref()).is_err());
+    }
+
+    #[test]
+    fn test_s_equal_to_l_rejected_at_decode() {
+        // S == l is not canonical (must be in [0, l-1])
+        let mut bad_signature = vec![0u8; SIGNATURE_LENGTH];
+        bad_signature[32..].copy_from_slice(&L);
+        assert!(Signature::decode(bad_signature.as_ref()).is_err());
+    }
+
+    #[test]
+    fn test_s_above_l_rejected_at_decode() {
+        // S == l + 1
+        let mut bad_signature = vec![0u8; SIGNATURE_LENGTH];
+        bad_signature[32..].copy_from_slice(&L);
+        bad_signature[32] = bad_signature[32].wrapping_add(1); // increment LSB
+        assert!(Signature::decode(bad_signature.as_ref()).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`ed25519::Signature::read_cfg` accepted any 64-byte sequence without validation. A signature with S >= l (the ed25519 group order) would decode successfully but fail verification later. This is inconsistent with the rest of the codebase:

- `ed25519::PublicKey::read_cfg` calls `VerificationKey::try_from` — validates the compressed Edwards point at decode time
- `secp256r1::Signature::read_cfg` calls `p256::ecdsa::Signature::from_slice` — validates R and S at decode time
- `ed25519::Signature::read_cfg` — previously did nothing beyond confirming 64 bytes were present

Non-canonical S values introduce signature malleability: two different byte sequences (S and S mod l) decode to logically equivalent signatures since verification reduces S mod l. In adversarial environments this matters — a valid signature can be transformed into a "different" one that also passes verification.

## Fix

Add a canonicality check for S (bytes 32..63 of the signature) in `read_cfg`. S must be in [0, l-1] where:

```
l = 2^252 + 27742317777372353535851937790883648493
```

The check compares S against l byte-by-byte from the most significant byte down (required because S is stored little-endian — index 0 is the LSB, so Rust's default lexicographic array comparison would be incorrect here).

The `ed25519_consensus` library does not expose standalone signature validation without a message, so the R component (bytes 0..31) cannot be validated at decode time without adding a dependency on `curve25519-dalek`. Only S canonicality is checkable, which is the primary malleability concern.

## Tests

- `test_high_s_rejected_at_decode`: S with high bit set (S >= 2^255 >> l)
- `test_s_equal_to_l_rejected_at_decode`: S == l exactly (boundary — valid range is [0, l-1])
- `test_s_above_l_rejected_at_decode`: S == l+1

Closes #1070