### PR TITLE
[storage/qmdb] batch reads in floor raising

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -382,57 +382,6 @@ where
         creates
     }
 
-    /// Scan forward from `floor` to find the next active operation, re-append it at the tip.
-    /// The `scan` parameter controls which locations are considered as potentially active,
-    /// allowing implementations to skip locations known to be inactive without reading them.
-    /// Returns `true` if an active op was found and moved, `false` if the floor reached
-    /// `fixed_tip`.
-    async fn advance_floor_once<E, C, I, S: FloorScan<F>>(
-        &self,
-        floor: &mut Location<F>,
-        fixed_tip: u64,
-        ops: &mut Vec<Operation<F, U>>,
-        diff: &mut BTreeMap<U::Key, DiffEntry<F, U::Value>>,
-        scan: &mut S,
-        db: &Db<F, E, C, I, H, U>,
-    ) -> Result<bool, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        loop {
-            let Some(candidate) = scan.next_candidate(*floor, fixed_tip) else {
-                return Ok(false);
-            };
-            *floor = Location::new(*candidate + 1);
-
-            let op = self.read_op(candidate, ops, db).await?;
-            let Some(key) = op.key().cloned() else {
-                continue; // skip CommitFloor and other non-keyed ops
-            };
-
-            if self.is_active_at(&key, candidate, diff, db) {
-                let new_loc = Location::new(self.base_size + ops.len() as u64);
-                let base_old_loc = diff
-                    .get(&key)
-                    .or_else(|| self.base_diff.get(&key))
-                    .map_or(Some(candidate), DiffEntry::base_old_loc);
-                let value = extract_update_value(&op);
-                ops.push(op);
-                diff.insert(
-                    key,
-                    DiffEntry::Active {
-                        value,
-                        loc: new_loc,
-                        base_old_loc,
-                    },
-                );
-                return Ok(true);
-            }
-        }
-    }
-
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
@@ -458,16 +407,70 @@ where
         let mut floor = self.base_inactivity_floor_loc;
 
         if total_active_keys > 0 {
-            // Floor raise: advance the inactivity floor by `total_steps` active
-            // operations. `fixed_tip` prevents scanning into floor-raise moves
-            // just appended, matching `raise_floor_with_bitmap()` semantics.
+            // Floor raise: advance the inactivity floor by `total_steps` active operations.
+            // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let fixed_tip = self.base_size + ops.len() as u64;
-            for _ in 0..total_steps {
-                if !self
-                    .advance_floor_once(&mut floor, fixed_tip, &mut ops, &mut diff, &mut scan, db)
-                    .await?
-                {
+            let mut moved = 0u64;
+
+            while moved < total_steps {
+                // Collect candidates, capped to bound concurrent I/O.
+                const MAX_BATCH: usize = 64;
+                let mut candidates = Vec::new();
+                let limit = (total_steps - moved).min(MAX_BATCH as u64) as usize;
+                while candidates.len() < limit {
+                    let Some(candidate) = scan.next_candidate(floor, fixed_tip) else {
+                        break;
+                    };
+                    candidates.push(candidate);
+                    floor = Location::new(*candidate + 1);
+                }
+                if candidates.is_empty() {
                     break;
+                }
+
+                // Batch-read on-disk candidates through a single reader.
+                let mut disk_ops = {
+                    let reader = db.log.reader().await;
+                    let futures = candidates
+                        .iter()
+                        .filter(|loc| **loc < self.db_size)
+                        .map(|loc| reader.read(**loc));
+                    try_join_all(futures).await?
+                }
+                .into_iter();
+
+                // Process results sequentially, moving active ops to the tip.
+                for candidate in candidates {
+                    let op = if *candidate < self.db_size {
+                        disk_ops.next().unwrap()
+                    } else {
+                        self.read_op(candidate, &ops, db).await?
+                    };
+                    let Some(key) = op.key().cloned() else {
+                        continue; // skip CommitFloor and other non-keyed ops
+                    };
+                    if !self.is_active_at(&key, candidate, &diff, db) {
+                        continue;
+                    }
+                    let new_loc = Location::new(self.base_size + ops.len() as u64);
+                    let base_old_loc = diff
+                        .get(&key)
+                        .or_else(|| self.base_diff.get(&key))
+                        .map_or(Some(candidate), DiffEntry::base_old_loc);
+                    let value = extract_update_value(&op);
+                    ops.push(op);
+                    diff.insert(
+                        key,
+                        DiffEntry::Active {
+                            value,
+                            loc: new_loc,
+                            base_old_loc,
+                        },
+                    );
+                    moved += 1;
+                    if moved >= total_steps {
+                        break;
+                    }
                 }
             }
         } else {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -23,12 +23,15 @@ use crate::{
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use core::ops::Range;
-use futures::future::try_join_all;
+use futures::{future::try_join_all, stream::FuturesOrdered, StreamExt as _};
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
 use tracing::debug;
+
+/// Maximum number of journal reads to issue concurrently during floor raising.
+const MAX_CONCURRENT_READS: u64 = 64;
 
 /// Strategy for finding the next active location during floor raising.
 pub(crate) trait FloorScan<F: Family> {
@@ -414,9 +417,9 @@ where
 
             while moved < total_steps {
                 // Collect candidates, capped to bound concurrent I/O.
-                const MAX_BATCH: usize = 64;
                 let mut candidates = Vec::new();
-                let limit = (total_steps - moved).min(MAX_BATCH as u64) as usize;
+                let limit =
+                    (total_steps - moved).min(MAX_CONCURRENT_READS) as usize;
                 while candidates.len() < limit {
                     let Some(candidate) = scan.next_candidate(floor, fixed_tip) else {
                         break;
@@ -428,21 +431,19 @@ where
                     break;
                 }
 
-                // Batch-read on-disk candidates through a single reader.
-                let mut disk_ops = {
-                    let reader = db.log.reader().await;
-                    let futures = candidates
-                        .iter()
-                        .filter(|loc| **loc < self.db_size)
-                        .map(|loc| reader.read(**loc));
-                    try_join_all(futures).await?
-                }
-                .into_iter();
+                // Perform on-disk reads concurrently via FuturesOrdered so results are yielded in
+                // insertion order as they resolve.
+                let reader = db.log.reader().await;
+                let mut disk_reads: FuturesOrdered<_> = candidates
+                    .iter()
+                    .filter(|loc| **loc < self.db_size)
+                    .map(|loc| reader.read(**loc))
+                    .collect();
 
-                // Process results sequentially, moving active ops to the tip.
+                // Process results in order, moving active ops to the tip.
                 for candidate in candidates {
                     let op = if *candidate < self.db_size {
-                        disk_ops.next().unwrap()
+                        disk_reads.next().await.unwrap()?
                     } else {
                         self.read_op(candidate, &ops, db).await?
                     };


### PR DESCRIPTION
Optimizes the floor raising process by batch-reading active operation candidates, instead of reading them sequentially.