### PR TITLE
[storage] Optimize `merkleize_with_floor_scan`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,3 +194,7 @@ debug = true
 # Although overflow checks are enabled by default in "test", we explicitly
 # enable them here for clarity.
 overflow-checks = true
+
+[profile.samply]
+inherits = "release"
+debug = true

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -434,6 +434,91 @@ impl<B: Blob> Append<B> {
         Ok((bufs, available))
     }
 
+    /// Read multiple fixed-size items at sorted byte offsets into a contiguous caller buffer.
+    ///
+    /// `buf` must be exactly `offsets.len() * item_size` bytes. All offsets must be sorted,
+    /// non-overlapping, and within bounds. This amortizes lock acquisition and avoids
+    /// per-item buffer allocation compared to calling [`read_at`](Self::read_at) in a loop.
+    pub async fn read_many_into(
+        &self,
+        buf: &mut [u8],
+        offsets: &[u64],
+        item_size: usize,
+    ) -> Result<(), Error> {
+        debug_assert_eq!(buf.len(), offsets.len() * item_size);
+        if offsets.is_empty() {
+            return Ok(());
+        }
+
+        let last_end = offsets[offsets.len() - 1]
+            .checked_add(item_size as u64)
+            .ok_or(Error::OffsetOverflow)?;
+
+        // Acquire the buffer lock once for all items.
+        let buffer = self.buffer.read().await;
+        if last_end > buffer.size() {
+            return Err(Error::BlobInsufficientLength);
+        }
+
+        // Resolve tip-buffer overlap for all items, tracking which indices need cache reads.
+        // cache_indices stores (item_index, byte_len, offset) for items needing cache reads.
+        let mut cache_indices: Vec<(usize, usize, u64)> = Vec::new();
+        for (i, &offset) in offsets.iter().enumerate() {
+            let item_buf = &mut buf[i * item_size..(i + 1) * item_size];
+            let end = offset + item_size as u64;
+
+            if end <= buffer.offset {
+                // Entirely below tip -- needs cache read.
+                cache_indices.push((i, item_size, offset));
+            } else if offset >= buffer.offset {
+                // Entirely in tip buffer.
+                let src = (offset - buffer.offset) as usize;
+                item_buf.copy_from_slice(&buffer.as_ref()[src..src + item_size]);
+            } else {
+                // Straddles tip boundary.
+                let prefix_len = (buffer.offset - offset) as usize;
+                item_buf[prefix_len..].copy_from_slice(&buffer.as_ref()[..item_size - prefix_len]);
+                cache_indices.push((i, prefix_len, offset));
+            }
+        }
+
+        drop(buffer);
+
+        if cache_indices.is_empty() {
+            return Ok(());
+        }
+
+        // Build mutable slices for the cache read. We split buf into non-overlapping
+        // sub-slices using raw pointer arithmetic (items are at fixed strides).
+        // SAFETY: Each (index, len) pair refers to a disjoint region of buf since
+        // indices are unique and item_size-aligned.
+        let mut cache_ranges: Vec<(&mut [u8], u64)> = cache_indices
+            .iter()
+            .map(|&(idx, len, offset)| {
+                let start = idx * item_size;
+                let ptr = unsafe { buf.as_mut_ptr().add(start) };
+                let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
+                (slice, offset)
+            })
+            .collect();
+
+        // Fast path: try page cache for all ranges in a single lock acquisition.
+        let fully_cached = self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
+
+        if fully_cached == cache_ranges.len() {
+            return Ok(());
+        }
+
+        // Slow path: cache miss on some ranges. Fall back to per-range reads.
+        let blob_guard = self.blob_state.read().await;
+        for (item_buf, offset) in &mut cache_ranges[fully_cached..] {
+            self.cache_ref
+                .read(&blob_guard.blob, self.id, item_buf, *offset)
+                .await?;
+        }
+        Ok(())
+    }
+
     /// Reads bytes starting at `logical_offset` into `buf`.
     ///
     /// This method allows reading directly into a mutable slice without taking ownership of the

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -237,6 +237,32 @@ impl CacheRef {
         original_len - buf.len()
     }
 
+    /// Read multiple disjoint byte ranges from the page cache in a single lock acquisition.
+    ///
+    /// Each element of `ranges` is `(logical_offset, dest_slice)`. Returns the number of
+    /// ranges that were *fully* read from cache before encountering a miss. Ranges must be
+    /// sorted by offset and non-overlapping.
+    pub(super) fn read_cached_many(&self, blob_id: u64, ranges: &mut [(&mut [u8], u64)]) -> usize {
+        let page_cache = self.cache.read();
+        let mut fully_read = 0;
+        for (buf, logical_offset) in ranges.iter_mut() {
+            let mut remaining = buf.len();
+            let mut offset = *logical_offset;
+            let mut dst = 0;
+            while remaining > 0 {
+                let count = page_cache.read_at(blob_id, &mut buf[dst..], offset);
+                if count == 0 {
+                    return fully_read;
+                }
+                offset += count as u64;
+                dst += count;
+                remaining -= count;
+            }
+            fully_read += 1;
+        }
+        fully_read
+    }
+
     /// Read the specified bytes, preferentially from the page cache. Bytes not found in the cache
     /// will be read from the provided `blob` and cached for future reads.
     pub(super) async fn read<B: Blob>(

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -84,6 +84,12 @@ path = "src/qmdb/benches/bench.rs"
 required-features = ["test-traits"]
 
 [[bench]]
+name = "qmdb-merkleize"
+harness = false
+path = "src/qmdb/benches/bench_merkleize.rs"
+required-features = ["test-traits"]
+
+[[bench]]
 name="archive"
 harness = false
 path = "src/archive/benches/bench.rs"

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -121,7 +121,10 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync> UnmerkleizedBatch<F, H, I
         );
 
         #[cfg(feature = "std")]
-        if let Some(pool) = self.inner.pool().filter(|_| items.len() >= batch::MIN_TO_PARALLELIZE)
+        if let Some(pool) = self
+            .inner
+            .pool()
+            .filter(|_| items.len() >= batch::MIN_TO_PARALLELIZE)
         {
             // Parallel path: encode items and compute leaf digests on the thread pool,
             // then feed the pre-computed digests sequentially into the MMR batch.

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -11,8 +11,10 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
-        self, batch, hasher::Standard as StandardHasher, journaled::Journaled, Family, Location,
-        Position, Proof, Readable,
+        self, batch,
+        hasher::{Hasher as MerkleHasher, Standard as StandardHasher},
+        journaled::Journaled,
+        Family, Location, Position, Proof, Readable,
     },
     Context, Persistable,
 };
@@ -117,10 +119,44 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync> UnmerkleizedBatch<F, H, I
             self.items.is_empty(),
             "merkleize_with expects no items added via add"
         );
+
+        #[cfg(feature = "std")]
+        if let Some(pool) = self.inner.pool().filter(|_| items.len() >= batch::MIN_TO_PARALLELIZE)
+        {
+            // Parallel path: encode items and compute leaf digests on the thread pool,
+            // then feed the pre-computed digests sequentially into the MMR batch.
+            use rayon::prelude::*;
+            let starting_leaves = self.inner.leaves();
+            let digests: Vec<H::Digest> = pool.install(|| {
+                items
+                    .par_iter()
+                    .enumerate()
+                    .map_init(
+                        || self.hasher.clone(),
+                        |h, (i, item)| {
+                            let loc = Location::<F>::new(*starting_leaves + i as u64);
+                            let pos = Position::try_from(loc).expect("valid leaf location");
+                            h.leaf_digest(pos, &item.encode())
+                        },
+                    )
+                    .collect()
+            });
+            for digest in digests {
+                self.inner = self.inner.add_leaf_digest(digest);
+            }
+        } else {
+            for item in &*items {
+                let encoded = item.encode();
+                self.inner = self.inner.add(&self.hasher, &encoded);
+            }
+        }
+
+        #[cfg(not(feature = "std"))]
         for item in &*items {
             let encoded = item.encode();
             self.inner = self.inner.add(&self.hasher, &encoded);
         }
+
         let merkle = self.inner.merkleize(base, &self.hasher);
         let ancestor_items = Self::collect_ancestor_items(&self.parent);
         Arc::new(MerkleizedBatch {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -199,6 +199,68 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         self.guard.read(pos, self.items_per_blob).await
     }
 
+    async fn read_many(&self, positions: &[u64]) -> Result<Vec<A>, Error> {
+        if positions.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Validate all positions.
+        for &pos in positions {
+            if pos >= self.guard.size {
+                return Err(Error::ItemOutOfRange(pos));
+            }
+            if pos < self.guard.pruning_boundary {
+                return Err(Error::ItemPruned(pos));
+            }
+        }
+
+        let items_per_blob = self.items_per_blob;
+        let pruning_boundary = self.guard.pruning_boundary;
+        let chunk_size = SegmentedJournal::<E, A>::CHUNK_SIZE;
+
+        // Group positions by section and translate to section-local positions.
+        let mut result = Vec::with_capacity(positions.len());
+        let mut reusable_buf = vec![0u8; positions.len() * chunk_size];
+
+        let mut group_start = 0;
+        while group_start < positions.len() {
+            let section = positions[group_start] / items_per_blob;
+            let section_start = section * items_per_blob;
+            let first_in_section = pruning_boundary.max(section_start);
+
+            // Find the end of this section group (positions are sorted).
+            let mut group_end = group_start + 1;
+            while group_end < positions.len() && positions[group_end] / items_per_blob == section {
+                group_end += 1;
+            }
+
+            let group_len = group_end - group_start;
+            let section_positions: Vec<u64> = positions[group_start..group_end]
+                .iter()
+                .map(|&pos| pos - first_in_section)
+                .collect();
+
+            let buf = &mut reusable_buf[..group_len * chunk_size];
+            let items = self
+                .guard
+                .journal
+                .get_many(section, &section_positions, buf)
+                .await
+                .map_err(|e| match e {
+                    Error::SectionOutOfRange(e)
+                    | Error::AlreadyPrunedToSection(e)
+                    | Error::ItemOutOfRange(e) => {
+                        Error::Corruption(format!("section/item should be found, but got: {e}"))
+                    }
+                    other => other,
+                })?;
+
+            result.extend(items);
+            group_start = group_end;
+        }
+
+        Ok(result)
+    }
+
     async fn replay(
         &self,
         buffer: NonZeroUsize,

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -35,6 +35,27 @@ pub trait Reader: Send + Sync {
     /// Guaranteed not to return [Error::ItemPruned] for positions within `bounds()`.
     fn read(&self, position: u64) -> impl Future<Output = Result<Self::Item, Error>> + Send;
 
+    /// Read multiple items at sorted positions.
+    ///
+    /// The default implementation calls [`read`](Self::read) in a loop.
+    /// Fixed-size journal implementations override this to amortize lock
+    /// acquisition and avoid per-item buffer allocation.
+    fn read_many(
+        &self,
+        positions: &[u64],
+    ) -> impl Future<Output = Result<Vec<Self::Item>, Error>> + Send
+    where
+        Self::Item: Send,
+    {
+        async move {
+            let mut items = Vec::with_capacity(positions.len());
+            for &pos in positions {
+                items.push(self.read(pos).await?);
+            }
+            Ok(items)
+        }
+    }
+
     /// Return a stream of all items starting from `start_pos`.
     ///
     /// Because the reader holds the lock, validation and stream setup happen

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -176,6 +176,42 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         A::decode(buf.coalesce()).map_err(Error::Codec)
     }
 
+    /// Read multiple items from the same section at sorted positions into a caller buffer.
+    ///
+    /// `buf` must be at least `positions.len() * CHUNK_SIZE` bytes. All positions must be
+    /// within the section's bounds.
+    pub async fn get_many(
+        &self,
+        section: u64,
+        positions: &[u64],
+        buf: &mut [u8],
+    ) -> Result<Vec<A>, Error> {
+        if positions.is_empty() {
+            return Ok(Vec::new());
+        }
+        let blob = self
+            .manager
+            .get(section)?
+            .ok_or(Error::SectionOutOfRange(section))?;
+
+        let offsets: Vec<u64> = positions
+            .iter()
+            .map(|&p| {
+                p.checked_mul(Self::CHUNK_SIZE_U64)
+                    .ok_or(Error::ItemOutOfRange(p))
+            })
+            .collect::<Result<_, _>>()?;
+
+        blob.read_many_into(buf, &offsets, Self::CHUNK_SIZE).await?;
+
+        let mut items = Vec::with_capacity(positions.len());
+        for i in 0..positions.len() {
+            let slice = &buf[i * Self::CHUNK_SIZE..(i + 1) * Self::CHUNK_SIZE];
+            items.push(A::decode(bytes::Bytes::copy_from_slice(slice)).map_err(Error::Codec)?);
+        }
+        Ok(items)
+    }
+
     /// Read the last item in a section, if any.
     ///
     /// Returns `Ok(None)` if the section is empty.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -130,6 +130,12 @@ impl<F: Family, D: Digest> UnmerkleizedBatch<F, D> {
         self
     }
 
+    /// Return a reference to the thread pool, if any.
+    #[cfg(feature = "std")]
+    pub fn pool(&self) -> Option<&ThreadPool> {
+        self.pool.as_ref()
+    }
+
     /// The total number of nodes visible through this batch.
     pub(crate) fn size(&self) -> Position<F> {
         Position::new(*self.parent.size() + self.appended.len() as u64)

--- a/storage/src/merkle/journaled.rs
+++ b/storage/src/merkle/journaled.rs
@@ -786,9 +786,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Journaled<F, E, D> {
         let mut batch = batch::MerkleizedBatch::from_mem(&inner.mem);
         #[cfg(feature = "std")]
         if let Some(pool) = &self.pool {
-            Arc::get_mut(&mut batch)
-                .expect("just created")
-                .pool = Some(pool.clone());
+            Arc::get_mut(&mut batch).expect("just created").pool = Some(pool.clone());
         }
         batch
     }

--- a/storage/src/merkle/journaled.rs
+++ b/storage/src/merkle/journaled.rs
@@ -783,7 +783,14 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Journaled<F, E, D> {
     /// This is the starting point for building owned batch chains.
     pub(crate) fn to_batch(&self) -> Arc<batch::MerkleizedBatch<F, D>> {
         let inner = self.inner.read();
-        batch::MerkleizedBatch::from_mem(&inner.mem)
+        let mut batch = batch::MerkleizedBatch::from_mem(&inner.mem);
+        #[cfg(feature = "std")]
+        if let Some(pool) = &self.pool {
+            Arc::get_mut(&mut batch)
+                .expect("just created")
+                .pool = Some(pool.clone());
+        }
+        batch
     }
 
     /// Borrow the committed Mem through the read lock. Holds the lock for

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -23,7 +23,6 @@ use crate::{
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use core::{iter, ops::Range};
-use futures::future::try_join_all;
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::{Arc, Weak},
@@ -338,7 +337,7 @@ where
     H: Hasher,
     Operation<F, U>: Codec,
 {
-    /// Read an operation at a given location from the correct source.
+    /// Return an operation immediately when it is already in memory.
     ///
     /// The operation space is divided into three contiguous regions:
     ///
@@ -352,30 +351,57 @@ where
     /// higher value if ancestors were freed (see `into_parts`).
     ///
     /// For top-level batches, the ancestor region is empty (`db_size == base_size`).
-    async fn read_op<E, C, I>(
+    fn read_cached_op(
         &self,
         loc: Location<F>,
         current_ops: &[Operation<F, U>],
-        db: &Db<F, E, C, I, H, U>,
-    ) -> Result<Operation<F, U>, crate::qmdb::Error<F>>
+    ) -> Option<Operation<F, U>>
     where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
+        Operation<F, U>: Clone,
     {
         let loc_val = *loc;
 
         if loc_val >= self.base_size {
             // This batch's own operations (user mutations, or earlier floor-raise ops).
-            Ok(current_ops[(loc_val - self.base_size) as usize].clone())
-        } else if loc_val >= self.db_size {
-            // Parent batch chain's operations (in-memory). Walk the ancestors.
-            Ok(read_chain_item_from_ancestors(&self.ancestors, loc_val, self.db_size).clone())
-        } else {
-            // Base DB's journal (on-disk async read).
-            let reader = db.log.reader().await;
-            Ok(reader.read(loc_val).await?)
+            return Some(current_ops[(loc_val - self.base_size) as usize].clone());
         }
+
+        if loc_val >= self.db_size {
+            // Parent batch chain's operations (in-memory). Walk the ancestors.
+            return Some(
+                read_chain_item_from_ancestors(&self.ancestors, loc_val, self.db_size).clone(),
+            );
+        }
+
+        None
+    }
+
+    /// Read operations from committed storage and in-memory sources in location order.
+    ///
+    /// `reader` is acquired once by the caller and reused for every committed-DB read. This
+    /// avoids building a future per location and repeatedly reacquiring the journal reader.
+    async fn read_locations<R>(
+        &self,
+        locations: &[Location<F>],
+        current_ops: &[Operation<F, U>],
+        reader: &R,
+    ) -> Result<Vec<Operation<F, U>>, crate::qmdb::Error<F>>
+    where
+        R: Reader<Item = Operation<F, U>>,
+    {
+        if locations.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut ops = Vec::with_capacity(locations.len());
+        for &loc in locations {
+            if let Some(op) = self.read_cached_op(loc, current_ops) {
+                ops.push(op);
+                continue;
+            }
+            ops.push(reader.read(*loc).await?);
+        }
+        Ok(ops)
     }
 
     /// Gather existing-key locations for all keys in `mutations`.
@@ -489,19 +515,22 @@ where
     /// allowing implementations to skip locations known to be inactive without reading them.
     /// Returns `true` if an active op was found and moved, `false` if the floor reached
     /// `fixed_tip`.
-    async fn advance_floor_once<E, C, I, S: FloorScan<F>>(
+    async fn advance_floor_once<E, C, I, S, R>(
         &self,
         floor: &mut Location<F>,
         fixed_tip: u64,
         ops: &mut Vec<Operation<F, U>>,
         diff: &mut BTreeMap<U::Key, DiffEntry<F, U::Value>>,
         scan: &mut S,
+        reader: &R,
         db: &Db<F, E, C, I, H, U>,
     ) -> Result<bool, crate::qmdb::Error<F>>
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>>,
+        S: FloorScan<F>,
+        R: Reader<Item = Operation<F, U>>,
     {
         loop {
             let Some(candidate) = scan.next_candidate(*floor, fixed_tip) else {
@@ -509,7 +538,11 @@ where
             };
             *floor = Location::new(*candidate + 1);
 
-            let op = self.read_op(candidate, ops, db).await?;
+            let op = if let Some(op) = self.read_cached_op(candidate, ops) {
+                op
+            } else {
+                reader.read(*candidate).await?
+            };
             let Some(key) = op.key().cloned() else {
                 continue; // skip CommitFloor and other non-keyed ops
             };
@@ -538,7 +571,7 @@ where
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
-    async fn finish<E, C, I, S: FloorScan<F>>(
+    async fn finish<E, C, I, S, R>(
         self,
         mut ops: Vec<Operation<F, U>>,
         mut diff: BTreeMap<U::Key, DiffEntry<F, U::Value>>,
@@ -546,12 +579,15 @@ where
         user_steps: u64,
         metadata: Option<U::Value>,
         mut scan: S,
+        reader: &R,
         db: &Db<F, E, C, I, H, U>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U>>, crate::qmdb::Error<F>>
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>>,
+        S: FloorScan<F>,
+        R: Reader<Item = Operation<F, U>>,
     {
         // Floor raise.
         // Steps = user_steps + 1 (+1 for previous commit becoming inactive).
@@ -566,7 +602,9 @@ where
             let fixed_tip = self.base_size + ops.len() as u64;
             for _ in 0..total_steps {
                 if !self
-                    .advance_floor_once(&mut floor, fixed_tip, &mut ops, &mut diff, &mut scan, db)
+                    .advance_floor_once(
+                        &mut floor, fixed_tip, &mut ops, &mut diff, &mut scan, reader, db,
+                    )
                     .await?
                 {
                     break;
@@ -639,7 +677,7 @@ where
         // oldest alive ancestor's items don't start at db_size. Example: chain A -> B -> C,
         // A committed and dropped. ancestors() yields [B] (A's Weak is dead). B's items start
         // at A.size(), not db_size. We use the journal (strong Arcs, always intact) to compute
-        // the actual base so read_op falls through to disk for locations in the gap.
+        // the actual base so reads fall through to disk for locations in the gap.
         let db_size = self.base.db_size();
         let effective_db_size = ancestors.last().map_or(db_size, |oldest| {
             let oldest_base =
@@ -732,11 +770,11 @@ where
         I: UnorderedIndex<Value = Location<F>>,
     {
         let (mut mutations, m) = self.into_parts();
+        let reader = db.log.reader().await;
 
-        // Resolve existing keys (async I/O, parallelized).
+        // Resolve existing keys with a single committed-journal reader.
         let locations = m.gather_existing_locations(&mutations, db, false);
-        let futures = locations.iter().map(|&loc| m.read_op(loc, &[], db));
-        let results = try_join_all(futures).await?;
+        let results = m.read_locations(&locations, &[], &reader).await?;
 
         // Generate user mutation operations.
         let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
@@ -835,8 +873,17 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
-            .await
+        m.finish(
+            ops,
+            diff,
+            active_keys_delta,
+            user_steps,
+            metadata,
+            scan,
+            &reader,
+            db,
+        )
+        .await
     }
 }
 
@@ -877,13 +924,14 @@ where
         I: OrderedIndex<Value = Location<F>>,
     {
         let (mut mutations, m) = self.into_parts();
+        let reader = db.log.reader().await;
 
-        // Resolve existing keys (async I/O).
+        // Resolve existing keys with a single committed-journal reader.
         let locations = m.gather_existing_locations(&mutations, db, true);
 
         // Read and unwrap Update operations (snapshot only references Updates).
-        let futures = locations.iter().map(|&loc| m.read_op(loc, &[], db));
-        let update_results: Vec<_> = try_join_all(futures)
+        let update_results: Vec<_> = m
+            .read_locations(&locations, &[], &reader)
             .await?
             .into_iter()
             .map(|op| match op {
@@ -957,11 +1005,7 @@ where
         prev_locations.sort();
         prev_locations.dedup();
 
-        let prev_results = {
-            let reader = db.log.reader().await;
-            let futures = prev_locations.iter().map(|loc| reader.read(**loc));
-            try_join_all(futures).await?
-        };
+        let prev_results = m.read_locations(&prev_locations, &[], &reader).await?;
 
         for (op, &old_loc) in prev_results.into_iter().zip(&prev_locations) {
             let data = match op {
@@ -995,7 +1039,11 @@ where
                 continue;
             }
             if let DiffEntry::Active { value, loc, .. } = entry {
-                let op: Operation<F, update::Ordered<K, V>> = m.read_op(*loc, &[], db).await?;
+                let op = if let Some(op) = m.read_cached_op(*loc, &[]) {
+                    op
+                } else {
+                    reader.read(**loc).await?
+                };
                 let data = match op {
                     Operation::Update(data) => data,
                     _ => unreachable!("ancestor diff Active should reference Update op"),
@@ -1121,8 +1169,17 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
-            .await
+        m.finish(
+            ops,
+            diff,
+            active_keys_delta,
+            user_steps,
+            metadata,
+            scan,
+            &reader,
+            db,
+        )
+        .await
     }
 }
 
@@ -1592,6 +1649,83 @@ mod tests {
         // Mutation unchanged.
         assert_eq!(mutations.len(), 1);
         assert!(mutations.contains_key(&1));
+    }
+
+    #[test]
+    fn read_locations_resolves_committed_ancestor_and_current_sources() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = UnorderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+            >;
+
+            let config = fixed_db_config::<OneCap>("read-locations-all-sources", &context);
+            let mut db = TestDb::init(context, config).await.unwrap();
+
+            let key_db = colliding_digest(0x30, 0);
+            let value_db = colliding_digest(0x30, 1);
+            let key_parent = colliding_digest(0x31, 0);
+            let value_parent = colliding_digest(0x31, 1);
+            let key_current = colliding_digest(0x32, 0);
+            let value_current = colliding_digest(0x32, 1);
+
+            let seed = db
+                .new_batch()
+                .write(key_db, Some(value_db))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            let committed_loc = db.snapshot.get(&key_db).next().copied().unwrap();
+
+            let parent = db
+                .new_batch()
+                .write(key_parent, Some(value_parent))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let parent_loc = parent.diff.get(&key_parent).unwrap().loc().unwrap();
+
+            let child = parent
+                .new_batch::<Sha256>()
+                .write(key_current, Some(value_current));
+            let (_mutations, merkleizer) = child.into_parts();
+
+            let current_loc = Location::new(merkleizer.base_size);
+            let current_ops = vec![Operation::Update(update::Unordered(
+                key_current,
+                value_current,
+            ))];
+
+            let reader = db.log.reader().await;
+            let ops = merkleizer
+                .read_locations(
+                    &[committed_loc, parent_loc, current_loc],
+                    &current_ops,
+                    &reader,
+                )
+                .await
+                .unwrap();
+            drop(reader);
+
+            assert_eq!(
+                ops,
+                vec![
+                    Operation::Update(update::Unordered(key_db, value_db)),
+                    Operation::Update(update::Unordered(key_parent, value_parent)),
+                    Operation::Update(update::Unordered(key_current, value_current)),
+                ]
+            );
+
+            db.destroy().await.unwrap();
+        });
     }
 
     #[test]

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -393,15 +393,29 @@ where
             return Ok(Vec::new());
         }
 
-        let mut ops = Vec::with_capacity(locations.len());
-        for &loc in locations {
+        // Separate in-memory ops from committed-journal positions for batch reading.
+        let mut ops: Vec<Option<Operation<F, U>>> = Vec::with_capacity(locations.len());
+        let mut committed: Vec<(usize, u64)> = Vec::new();
+        for (i, &loc) in locations.iter().enumerate() {
             if let Some(op) = self.read_cached_op(loc, current_ops) {
-                ops.push(op);
-                continue;
+                ops.push(Some(op));
+            } else {
+                ops.push(None);
+                committed.push((i, *loc));
             }
-            ops.push(reader.read(*loc).await?);
         }
-        Ok(ops)
+
+        if committed.is_empty() {
+            return Ok(ops.into_iter().map(|o| o.unwrap()).collect());
+        }
+
+        // Batch read all committed positions in a single call.
+        let positions: Vec<u64> = committed.iter().map(|&(_, pos)| pos).collect();
+        let read_ops = reader.read_many(&positions).await?;
+        for ((idx, _), op) in committed.into_iter().zip(read_ops) {
+            ops[idx] = Some(op);
+        }
+        Ok(ops.into_iter().map(|o| o.unwrap()).collect())
     }
 
     /// Gather existing-key locations for all keys in `mutations`.

--- a/storage/src/qmdb/benches/bench.rs
+++ b/storage/src/qmdb/benches/bench.rs
@@ -1,6 +1,4 @@
-//! Benchmark entry point for all QMDB benchmarks.
-//!
-//! Run with: `cargo bench --bench qmdb`
+//! Benchmark entry point for the generate & init QMDB benchmarks.
 
 use criterion::criterion_main;
 

--- a/storage/src/qmdb/benches/bench_merkleize.rs
+++ b/storage/src/qmdb/benches/bench_merkleize.rs
@@ -1,0 +1,13 @@
+//! Benchmark entry point for QMDB merkleize benchmarks.
+//!
+//! This is a separate binary from the other QMDB benchmarks so they don't block waiting on the
+//! time-consuming setup of the QMDB init benchmarks.
+
+use criterion::criterion_main;
+
+#[path = "common.rs"]
+#[allow(unused_imports, unused_macros, dead_code)]
+mod common;
+mod merkleize;
+
+criterion_main!(merkleize::benches);

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -45,7 +45,7 @@ type AnyUVar = commonware_storage::qmdb::any::unordered::variable::Db<
     Sha256,
     EightCap,
 >;
-type CurUFix = commonware_storage::qmdb::current::unordered::fixed::Db<
+type CurUFix32 = commonware_storage::qmdb::current::unordered::fixed::Db<
     Context,
     Digest,
     Digest,
@@ -53,13 +53,32 @@ type CurUFix = commonware_storage::qmdb::current::unordered::fixed::Db<
     EightCap,
     CHUNK_SIZE,
 >;
-type CurUVar = commonware_storage::qmdb::current::unordered::variable::Db<
+type CurUVar32 = commonware_storage::qmdb::current::unordered::variable::Db<
     Context,
     Digest,
     Digest,
     Sha256,
     EightCap,
     CHUNK_SIZE,
+>;
+
+const LARGE_CHUNK_SIZE: usize = 256;
+
+type CurUFix256 = commonware_storage::qmdb::current::unordered::fixed::Db<
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    LARGE_CHUNK_SIZE,
+>;
+type CurUVar256 = commonware_storage::qmdb::current::unordered::variable::Db<
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    LARGE_CHUNK_SIZE,
 >;
 
 const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(100_000);
@@ -171,8 +190,10 @@ async fn run_bench<
 enum Variant {
     AnyFixed,
     AnyVariable,
-    CurrentFixed,
-    CurrentVariable,
+    CurrentFixed32,
+    CurrentVariable32,
+    CurrentFixed256,
+    CurrentVariable256,
 }
 
 impl Variant {
@@ -180,17 +201,21 @@ impl Variant {
         match self {
             Self::AnyFixed => "any::unordered::fixed",
             Self::AnyVariable => "any::unordered::variable",
-            Self::CurrentFixed => "current::unordered::fixed",
-            Self::CurrentVariable => "current::unordered::variable",
+            Self::CurrentFixed32 => "current::unordered::fixed::chunk=32",
+            Self::CurrentVariable32 => "current::unordered::variable::chunk=32",
+            Self::CurrentFixed256 => "current::unordered::fixed::chunk=256",
+            Self::CurrentVariable256 => "current::unordered::variable::chunk=256",
         }
     }
 }
 
-const VARIANTS: [Variant; 4] = [
+const VARIANTS: [Variant; 6] = [
     Variant::AnyFixed,
     Variant::AnyVariable,
-    Variant::CurrentFixed,
-    Variant::CurrentVariable,
+    Variant::CurrentFixed32,
+    Variant::CurrentVariable32,
+    Variant::CurrentFixed256,
+    Variant::CurrentVariable256,
 ];
 
 fn bench_merkleize(c: &mut Criterion) {
@@ -226,7 +251,7 @@ fn bench_merkleize(c: &mut Criterion) {
                                 let db = AnyUVar::init(ctx, cfg).await.unwrap();
                                 run_bench(db, num_keys, iters).await
                             }
-                            Variant::CurrentFixed => {
+                            Variant::CurrentFixed32 => {
                                 let cfg = commonware_storage::qmdb::current::FixedConfig {
                                     mmr_config: mmr_cfg(&ctx, pc.clone()),
                                     journal_config: fix_log_cfg(pc),
@@ -235,10 +260,10 @@ fn bench_merkleize(c: &mut Criterion) {
                                     ),
                                     translator: EightCap,
                                 };
-                                let db = CurUFix::init(ctx, cfg).await.unwrap();
+                                let db = CurUFix32::init(ctx, cfg).await.unwrap();
                                 run_bench(db, num_keys, iters).await
                             }
-                            Variant::CurrentVariable => {
+                            Variant::CurrentVariable32 => {
                                 let cfg = commonware_storage::qmdb::current::VariableConfig {
                                     mmr_config: mmr_cfg(&ctx, pc.clone()),
                                     journal_config: var_log_cfg(pc),
@@ -247,7 +272,31 @@ fn bench_merkleize(c: &mut Criterion) {
                                     ),
                                     translator: EightCap,
                                 };
-                                let db = CurUVar::init(ctx, cfg).await.unwrap();
+                                let db = CurUVar32::init(ctx, cfg).await.unwrap();
+                                run_bench(db, num_keys, iters).await
+                            }
+                            Variant::CurrentFixed256 => {
+                                let cfg = commonware_storage::qmdb::current::FixedConfig {
+                                    mmr_config: mmr_cfg(&ctx, pc.clone()),
+                                    journal_config: fix_log_cfg(pc),
+                                    grafted_mmr_metadata_partition: format!(
+                                        "grafted-mmr-metadata-{PARTITION}"
+                                    ),
+                                    translator: EightCap,
+                                };
+                                let db = CurUFix256::init(ctx, cfg).await.unwrap();
+                                run_bench(db, num_keys, iters).await
+                            }
+                            Variant::CurrentVariable256 => {
+                                let cfg = commonware_storage::qmdb::current::VariableConfig {
+                                    mmr_config: mmr_cfg(&ctx, pc.clone()),
+                                    journal_config: var_log_cfg(pc),
+                                    grafted_mmr_metadata_partition: format!(
+                                        "grafted-mmr-metadata-{PARTITION}"
+                                    ),
+                                    translator: EightCap,
+                                };
+                                let db = CurUVar256::init(ctx, cfg).await.unwrap();
                                 run_bench(db, num_keys, iters).await
                             }
                         }

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -1,0 +1,265 @@
+//! Benchmarks for speculative batch merkleization.
+//!
+//! Measures the time required to create a speculative batch (applying random updates equal to 10%
+//! of the total key count, sampled with replacement), merkleize it, and compute its root. The
+//! database is initialized with N unique keys having random digests as values. Database
+//! initialization time is not included in the benchmark. The page cache is large enough to hold the
+//! entire active key set to eliminate disk access delays from affecting the results.
+
+use crate::common::{make_fixed_value, Digest, CHUNK_SIZE, WRITE_BUFFER_SIZE};
+use commonware_cryptography::{Hasher, Sha256};
+use commonware_runtime::{
+    benchmarks::{context, tokio},
+    buffer::paged::CacheRef,
+    tokio::{Config, Context},
+    BufferPooler, ThreadPooler,
+};
+use commonware_storage::{
+    journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
+    merkle::mmr::journaled::Config as MmrConfig,
+    qmdb::any::traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
+    translator::EightCap,
+};
+use commonware_utils::{NZUsize, NZU16, NZU64};
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use std::{
+    hint::black_box,
+    num::{NonZeroU16, NonZeroU64, NonZeroUsize},
+    time::{Duration, Instant},
+};
+
+type AnyUFix = commonware_storage::qmdb::any::unordered::fixed::Db<
+    commonware_storage::merkle::mmr::Family,
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+>;
+type AnyUVar = commonware_storage::qmdb::any::unordered::variable::Db<
+    commonware_storage::merkle::mmr::Family,
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+>;
+type CurUFix = commonware_storage::qmdb::current::unordered::fixed::Db<
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    CHUNK_SIZE,
+>;
+type CurUVar = commonware_storage::qmdb::current::unordered::variable::Db<
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    CHUNK_SIZE,
+>;
+
+const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(100_000);
+const THREADS: NonZeroUsize = NZUsize!(8);
+
+/// Configure a large (512MB) page cache that can hold all active keys in RAM.
+const PAGE_SIZE: NonZeroU16 = NZU16!(4096);
+const LARGE_PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(131_072);
+const PARTITION: &str = "bench-merkleize";
+
+fn mmr_cfg(ctx: &(impl BufferPooler + ThreadPooler), page_cache: CacheRef) -> MmrConfig {
+    MmrConfig {
+        journal_partition: format!("journal-{PARTITION}"),
+        metadata_partition: format!("metadata-{PARTITION}"),
+        items_per_blob: ITEMS_PER_BLOB,
+        write_buffer: WRITE_BUFFER_SIZE,
+        thread_pool: Some(ctx.create_thread_pool(THREADS).unwrap()),
+        page_cache,
+    }
+}
+
+fn fix_log_cfg(page_cache: CacheRef) -> FConfig {
+    FConfig {
+        partition: format!("log-journal-{PARTITION}"),
+        items_per_blob: ITEMS_PER_BLOB,
+        page_cache,
+        write_buffer: WRITE_BUFFER_SIZE,
+    }
+}
+
+fn var_log_cfg(page_cache: CacheRef) -> VConfig<((), ())> {
+    VConfig {
+        partition: format!("log-journal-{PARTITION}"),
+        items_per_section: ITEMS_PER_BLOB,
+        compression: None,
+        codec_config: ((), ()),
+        page_cache,
+        write_buffer: WRITE_BUFFER_SIZE,
+    }
+}
+
+fn large_page_cache(ctx: &impl BufferPooler) -> CacheRef {
+    CacheRef::from_pooler(ctx, PAGE_SIZE, LARGE_PAGE_CACHE_SIZE)
+}
+
+/// Pre-populate the database with `num_keys` unique keys, commit, and sync.
+async fn seed_db<
+    C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest, Value = Digest>,
+>(
+    db: &mut C,
+    num_keys: u64,
+) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut batch = db.new_batch();
+    for i in 0u64..num_keys {
+        let k = Sha256::hash(&i.to_be_bytes());
+        batch = batch.write(k, Some(make_fixed_value(&mut rng)));
+    }
+    let merkleized = batch.merkleize(db, None).await.unwrap();
+    db.apply_batch(merkleized).await.unwrap();
+    db.commit().await.unwrap();
+    db.sync().await.unwrap();
+}
+
+/// Create a speculative batch by applying random updates equal to 10% of the key count
+/// (sampled with replacement), then merkleize & retrieve its root.
+/// Returns elapsed time for the batch+merkleize+root cycle.
+async fn bench_speculative_merkleize<
+    C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest, Value = Digest>,
+>(
+    db: &C,
+    num_keys: u64,
+) -> Duration {
+    let mut rng = StdRng::seed_from_u64(99);
+    let num_updates = num_keys / 10;
+
+    let start = Instant::now();
+
+    let mut batch = db.new_batch();
+    for _ in 0..num_updates {
+        let idx = rng.next_u64() % num_keys;
+        let k = Sha256::hash(&idx.to_be_bytes());
+        batch = batch.write(k, Some(make_fixed_value(&mut rng)));
+    }
+    let merkleized = batch.merkleize(db, None).await.unwrap();
+    black_box(merkleized.root());
+
+    start.elapsed()
+}
+
+/// Run the benchmark for a concrete DB type.
+async fn run_bench<
+    C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest, Value = Digest>,
+>(
+    mut db: C,
+    num_keys: u64,
+    iters: u64,
+) -> Duration {
+    seed_db(&mut db, num_keys).await;
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        total += bench_speculative_merkleize(&db, num_keys).await;
+    }
+    db.destroy().await.unwrap();
+    total
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Variant {
+    AnyFixed,
+    AnyVariable,
+    CurrentFixed,
+    CurrentVariable,
+}
+
+impl Variant {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::AnyFixed => "any::unordered::fixed",
+            Self::AnyVariable => "any::unordered::variable",
+            Self::CurrentFixed => "current::unordered::fixed",
+            Self::CurrentVariable => "current::unordered::variable",
+        }
+    }
+}
+
+const VARIANTS: [Variant; 4] = [
+    Variant::AnyFixed,
+    Variant::AnyVariable,
+    Variant::CurrentFixed,
+    Variant::CurrentVariable,
+];
+
+fn bench_merkleize(c: &mut Criterion) {
+    let runner = tokio::Runner::new(Config::default());
+    for num_keys in [10_000u64, 100_000, 1_000_000] {
+        for variant in VARIANTS {
+            c.bench_function(
+                &format!(
+                    "{}/variant={} num_keys={num_keys}",
+                    module_path!(),
+                    variant.name(),
+                ),
+                |b| {
+                    b.to_async(&runner).iter_custom(|iters| async move {
+                        let ctx = context::get::<Context>();
+                        let pc = large_page_cache(&ctx);
+                        match variant {
+                            Variant::AnyFixed => {
+                                let cfg = commonware_storage::qmdb::any::FixedConfig {
+                                    merkle_config: mmr_cfg(&ctx, pc.clone()),
+                                    journal_config: fix_log_cfg(pc),
+                                    translator: EightCap,
+                                };
+                                let db = AnyUFix::init(ctx, cfg).await.unwrap();
+                                run_bench(db, num_keys, iters).await
+                            }
+                            Variant::AnyVariable => {
+                                let cfg = commonware_storage::qmdb::any::VariableConfig {
+                                    merkle_config: mmr_cfg(&ctx, pc.clone()),
+                                    journal_config: var_log_cfg(pc),
+                                    translator: EightCap,
+                                };
+                                let db = AnyUVar::init(ctx, cfg).await.unwrap();
+                                run_bench(db, num_keys, iters).await
+                            }
+                            Variant::CurrentFixed => {
+                                let cfg = commonware_storage::qmdb::current::FixedConfig {
+                                    mmr_config: mmr_cfg(&ctx, pc.clone()),
+                                    journal_config: fix_log_cfg(pc),
+                                    grafted_mmr_metadata_partition: format!(
+                                        "grafted-mmr-metadata-{PARTITION}"
+                                    ),
+                                    translator: EightCap,
+                                };
+                                let db = CurUFix::init(ctx, cfg).await.unwrap();
+                                run_bench(db, num_keys, iters).await
+                            }
+                            Variant::CurrentVariable => {
+                                let cfg = commonware_storage::qmdb::current::VariableConfig {
+                                    mmr_config: mmr_cfg(&ctx, pc.clone()),
+                                    journal_config: var_log_cfg(pc),
+                                    grafted_mmr_metadata_partition: format!(
+                                        "grafted-mmr-metadata-{PARTITION}"
+                                    ),
+                                    translator: EightCap,
+                                };
+                                let db = CurUVar::init(ctx, cfg).await.unwrap();
+                                run_bench(db, num_keys, iters).await
+                            }
+                        }
+                    });
+                },
+            );
+        }
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_merkleize
+}

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -29,6 +29,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+// -- Type aliases --
+
 type AnyUFix = commonware_storage::qmdb::any::unordered::fixed::Db<
     commonware_storage::merkle::mmr::Family,
     Context,
@@ -81,48 +83,98 @@ type CurUVar256 = commonware_storage::qmdb::current::unordered::variable::Db<
     LARGE_CHUNK_SIZE,
 >;
 
+// -- Config --
+
 const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(100_000);
 const THREADS: NonZeroUsize = NZUsize!(8);
-
-/// Configure a large (512MB) page cache that can hold all active keys in RAM.
 const PAGE_SIZE: NonZeroU16 = NZU16!(4096);
 const LARGE_PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(131_072);
 const PARTITION: &str = "bench-merkleize";
 
-fn mmr_cfg(ctx: &(impl BufferPooler + ThreadPooler), page_cache: CacheRef) -> MmrConfig {
+fn mmr_cfg(ctx: &(impl BufferPooler + ThreadPooler), pc: CacheRef) -> MmrConfig {
     MmrConfig {
         journal_partition: format!("journal-{PARTITION}"),
         metadata_partition: format!("metadata-{PARTITION}"),
         items_per_blob: ITEMS_PER_BLOB,
         write_buffer: WRITE_BUFFER_SIZE,
         thread_pool: Some(ctx.create_thread_pool(THREADS).unwrap()),
-        page_cache,
+        page_cache: pc,
     }
 }
 
-fn fix_log_cfg(page_cache: CacheRef) -> FConfig {
+fn fix_log_cfg(pc: CacheRef) -> FConfig {
     FConfig {
         partition: format!("log-journal-{PARTITION}"),
         items_per_blob: ITEMS_PER_BLOB,
-        page_cache,
+        page_cache: pc,
         write_buffer: WRITE_BUFFER_SIZE,
     }
 }
 
-fn var_log_cfg(page_cache: CacheRef) -> VConfig<((), ())> {
+fn var_log_cfg(pc: CacheRef) -> VConfig<((), ())> {
     VConfig {
         partition: format!("log-journal-{PARTITION}"),
         items_per_section: ITEMS_PER_BLOB,
         compression: None,
         codec_config: ((), ()),
-        page_cache,
+        page_cache: pc,
         write_buffer: WRITE_BUFFER_SIZE,
     }
 }
 
-fn large_page_cache(ctx: &impl BufferPooler) -> CacheRef {
+fn pc(ctx: &impl BufferPooler) -> CacheRef {
     CacheRef::from_pooler(ctx, PAGE_SIZE, LARGE_PAGE_CACHE_SIZE)
 }
+
+// -- DB constructors (eliminates repeated config boilerplate in match arms) --
+
+fn any_fix_cfg(
+    ctx: &(impl BufferPooler + ThreadPooler),
+) -> commonware_storage::qmdb::any::FixedConfig<EightCap> {
+    let pc = pc(ctx);
+    commonware_storage::qmdb::any::FixedConfig {
+        merkle_config: mmr_cfg(ctx, pc.clone()),
+        journal_config: fix_log_cfg(pc),
+        translator: EightCap,
+    }
+}
+
+fn any_var_cfg(
+    ctx: &(impl BufferPooler + ThreadPooler),
+) -> commonware_storage::qmdb::any::VariableConfig<EightCap, ((), ())> {
+    let pc = pc(ctx);
+    commonware_storage::qmdb::any::VariableConfig {
+        merkle_config: mmr_cfg(ctx, pc.clone()),
+        journal_config: var_log_cfg(pc),
+        translator: EightCap,
+    }
+}
+
+fn cur_fix_cfg(
+    ctx: &(impl BufferPooler + ThreadPooler),
+) -> commonware_storage::qmdb::current::FixedConfig<EightCap> {
+    let pc = pc(ctx);
+    commonware_storage::qmdb::current::FixedConfig {
+        mmr_config: mmr_cfg(ctx, pc.clone()),
+        journal_config: fix_log_cfg(pc),
+        grafted_mmr_metadata_partition: format!("grafted-mmr-metadata-{PARTITION}"),
+        translator: EightCap,
+    }
+}
+
+fn cur_var_cfg(
+    ctx: &(impl BufferPooler + ThreadPooler),
+) -> commonware_storage::qmdb::current::VariableConfig<EightCap, ((), ())> {
+    let pc = pc(ctx);
+    commonware_storage::qmdb::current::VariableConfig {
+        mmr_config: mmr_cfg(ctx, pc.clone()),
+        journal_config: var_log_cfg(pc),
+        grafted_mmr_metadata_partition: format!("grafted-mmr-metadata-{PARTITION}"),
+        translator: EightCap,
+    }
+}
+
+// -- Benchmark helpers --
 
 /// Pre-populate the database with `num_keys` unique keys, commit, and sync.
 async fn seed_db<
@@ -143,33 +195,30 @@ async fn seed_db<
     db.sync().await.unwrap();
 }
 
-/// Create a speculative batch by applying random updates equal to 10% of the key count
-/// (sampled with replacement), then merkleize & retrieve its root.
-/// Returns elapsed time for the batch+merkleize+root cycle.
-async fn bench_speculative_merkleize<
-    C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest, Value = Digest>,
+/// Write `num_updates` random key updates into a batch.
+fn write_random_updates<
+    B: commonware_storage::qmdb::any::traits::UnmerkleizedBatch<
+        Db,
+        Family = commonware_storage::merkle::mmr::Family,
+        K = Digest,
+        V = Digest,
+    >,
+    Db: ?Sized,
 >(
-    db: &C,
+    mut batch: B,
+    num_updates: u64,
     num_keys: u64,
-) -> Duration {
-    let mut rng = StdRng::seed_from_u64(99);
-    let num_updates = num_keys / 10;
-
-    let start = Instant::now();
-
-    let mut batch = db.new_batch();
+    rng: &mut StdRng,
+) -> B {
     for _ in 0..num_updates {
         let idx = rng.next_u64() % num_keys;
         let k = Sha256::hash(&idx.to_be_bytes());
-        batch = batch.write(k, Some(make_fixed_value(&mut rng)));
+        batch = batch.write(k, Some(make_fixed_value(rng)));
     }
-    let merkleized = batch.merkleize(db, None).await.unwrap();
-    black_box(merkleized.root());
-
-    start.elapsed()
+    batch
 }
 
-/// Run the benchmark for a concrete DB type.
+/// Single-batch benchmark: create batch, write updates, merkleize, read root.
 async fn run_bench<
     C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest, Value = Digest>,
 >(
@@ -178,13 +227,56 @@ async fn run_bench<
     iters: u64,
 ) -> Duration {
     seed_db(&mut db, num_keys).await;
+    let num_updates = num_keys / 10;
+    let mut rng = StdRng::seed_from_u64(99);
     let mut total = Duration::ZERO;
     for _ in 0..iters {
-        total += bench_speculative_merkleize(&db, num_keys).await;
+        let start = Instant::now();
+        let batch = write_random_updates(db.new_batch(), num_updates, num_keys, &mut rng);
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        black_box(merkleized.root());
+        total += start.elapsed();
     }
     db.destroy().await.unwrap();
     total
 }
+
+/// Chained benchmark: merkleize a parent (not timed), then create a child from
+/// the parent, write updates, merkleize the child, and read its root (timed).
+///
+/// `fork_child` bridges the gap between the generic trait and the concrete
+/// `MerkleizedBatch::new_batch` method.
+async fn run_chained_bench<
+    C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest, Value = Digest>,
+    F: Fn(&C::Merkleized) -> C::Batch,
+>(
+    mut db: C,
+    num_keys: u64,
+    iters: u64,
+    fork_child: F,
+) -> Duration {
+    seed_db(&mut db, num_keys).await;
+    let num_updates = num_keys / 10;
+    let mut rng = StdRng::seed_from_u64(99);
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        // Build and merkleize parent (not timed).
+        let parent_batch = write_random_updates(db.new_batch(), num_updates, num_keys, &mut rng);
+        let parent = parent_batch.merkleize(&db, None).await.unwrap();
+
+        // Build and merkleize child (timed).
+        let start = Instant::now();
+        let child_batch =
+            write_random_updates(fork_child(&parent), num_updates, num_keys, &mut rng);
+        let child = child_batch.merkleize(&db, None).await.unwrap();
+        black_box(child.root());
+        total += start.elapsed();
+    }
+    db.destroy().await.unwrap();
+    total
+}
+
+// -- Variant dispatch --
 
 #[derive(Debug, Clone, Copy)]
 enum Variant {
@@ -231,73 +323,146 @@ fn bench_merkleize(c: &mut Criterion) {
                 |b| {
                     b.to_async(&runner).iter_custom(|iters| async move {
                         let ctx = context::get::<Context>();
-                        let pc = large_page_cache(&ctx);
                         match variant {
                             Variant::AnyFixed => {
-                                let cfg = commonware_storage::qmdb::any::FixedConfig {
-                                    merkle_config: mmr_cfg(&ctx, pc.clone()),
-                                    journal_config: fix_log_cfg(pc),
-                                    translator: EightCap,
-                                };
-                                let db = AnyUFix::init(ctx, cfg).await.unwrap();
-                                run_bench(db, num_keys, iters).await
+                                run_bench(
+                                    AnyUFix::init(ctx.clone(), any_fix_cfg(&ctx)).await.unwrap(),
+                                    num_keys,
+                                    iters,
+                                )
+                                .await
                             }
                             Variant::AnyVariable => {
-                                let cfg = commonware_storage::qmdb::any::VariableConfig {
-                                    merkle_config: mmr_cfg(&ctx, pc.clone()),
-                                    journal_config: var_log_cfg(pc),
-                                    translator: EightCap,
-                                };
-                                let db = AnyUVar::init(ctx, cfg).await.unwrap();
-                                run_bench(db, num_keys, iters).await
+                                run_bench(
+                                    AnyUVar::init(ctx.clone(), any_var_cfg(&ctx)).await.unwrap(),
+                                    num_keys,
+                                    iters,
+                                )
+                                .await
                             }
                             Variant::CurrentFixed32 => {
-                                let cfg = commonware_storage::qmdb::current::FixedConfig {
-                                    mmr_config: mmr_cfg(&ctx, pc.clone()),
-                                    journal_config: fix_log_cfg(pc),
-                                    grafted_mmr_metadata_partition: format!(
-                                        "grafted-mmr-metadata-{PARTITION}"
-                                    ),
-                                    translator: EightCap,
-                                };
-                                let db = CurUFix32::init(ctx, cfg).await.unwrap();
-                                run_bench(db, num_keys, iters).await
+                                run_bench(
+                                    CurUFix32::init(ctx.clone(), cur_fix_cfg(&ctx))
+                                        .await
+                                        .unwrap(),
+                                    num_keys,
+                                    iters,
+                                )
+                                .await
                             }
                             Variant::CurrentVariable32 => {
-                                let cfg = commonware_storage::qmdb::current::VariableConfig {
-                                    mmr_config: mmr_cfg(&ctx, pc.clone()),
-                                    journal_config: var_log_cfg(pc),
-                                    grafted_mmr_metadata_partition: format!(
-                                        "grafted-mmr-metadata-{PARTITION}"
-                                    ),
-                                    translator: EightCap,
-                                };
-                                let db = CurUVar32::init(ctx, cfg).await.unwrap();
-                                run_bench(db, num_keys, iters).await
+                                run_bench(
+                                    CurUVar32::init(ctx.clone(), cur_var_cfg(&ctx))
+                                        .await
+                                        .unwrap(),
+                                    num_keys,
+                                    iters,
+                                )
+                                .await
                             }
                             Variant::CurrentFixed256 => {
-                                let cfg = commonware_storage::qmdb::current::FixedConfig {
-                                    mmr_config: mmr_cfg(&ctx, pc.clone()),
-                                    journal_config: fix_log_cfg(pc),
-                                    grafted_mmr_metadata_partition: format!(
-                                        "grafted-mmr-metadata-{PARTITION}"
-                                    ),
-                                    translator: EightCap,
-                                };
-                                let db = CurUFix256::init(ctx, cfg).await.unwrap();
-                                run_bench(db, num_keys, iters).await
+                                run_bench(
+                                    CurUFix256::init(ctx.clone(), cur_fix_cfg(&ctx))
+                                        .await
+                                        .unwrap(),
+                                    num_keys,
+                                    iters,
+                                )
+                                .await
                             }
                             Variant::CurrentVariable256 => {
-                                let cfg = commonware_storage::qmdb::current::VariableConfig {
-                                    mmr_config: mmr_cfg(&ctx, pc.clone()),
-                                    journal_config: var_log_cfg(pc),
-                                    grafted_mmr_metadata_partition: format!(
-                                        "grafted-mmr-metadata-{PARTITION}"
-                                    ),
-                                    translator: EightCap,
-                                };
-                                let db = CurUVar256::init(ctx, cfg).await.unwrap();
-                                run_bench(db, num_keys, iters).await
+                                run_bench(
+                                    CurUVar256::init(ctx.clone(), cur_var_cfg(&ctx))
+                                        .await
+                                        .unwrap(),
+                                    num_keys,
+                                    iters,
+                                )
+                                .await
+                            }
+                        }
+                    });
+                },
+            );
+        }
+    }
+}
+
+fn bench_chained_merkleize(c: &mut Criterion) {
+    let runner = tokio::Runner::new(Config::default());
+    for num_keys in [10_000u64, 100_000, 1_000_000] {
+        for variant in VARIANTS {
+            c.bench_function(
+                &format!(
+                    "{}/chained variant={} num_keys={num_keys}",
+                    module_path!(),
+                    variant.name(),
+                ),
+                |b| {
+                    b.to_async(&runner).iter_custom(|iters| async move {
+                        let ctx = context::get::<Context>();
+                        match variant {
+                            Variant::AnyFixed => {
+                                run_chained_bench(
+                                    AnyUFix::init(ctx.clone(), any_fix_cfg(&ctx)).await.unwrap(),
+                                    num_keys,
+                                    iters,
+                                    |p| p.new_batch(),
+                                )
+                                .await
+                            }
+                            Variant::AnyVariable => {
+                                run_chained_bench(
+                                    AnyUVar::init(ctx.clone(), any_var_cfg(&ctx)).await.unwrap(),
+                                    num_keys,
+                                    iters,
+                                    |p| p.new_batch(),
+                                )
+                                .await
+                            }
+                            Variant::CurrentFixed32 => {
+                                run_chained_bench(
+                                    CurUFix32::init(ctx.clone(), cur_fix_cfg(&ctx))
+                                        .await
+                                        .unwrap(),
+                                    num_keys,
+                                    iters,
+                                    |p| p.new_batch(),
+                                )
+                                .await
+                            }
+                            Variant::CurrentVariable32 => {
+                                run_chained_bench(
+                                    CurUVar32::init(ctx.clone(), cur_var_cfg(&ctx))
+                                        .await
+                                        .unwrap(),
+                                    num_keys,
+                                    iters,
+                                    |p| p.new_batch(),
+                                )
+                                .await
+                            }
+                            Variant::CurrentFixed256 => {
+                                run_chained_bench(
+                                    CurUFix256::init(ctx.clone(), cur_fix_cfg(&ctx))
+                                        .await
+                                        .unwrap(),
+                                    num_keys,
+                                    iters,
+                                    |p| p.new_batch(),
+                                )
+                                .await
+                            }
+                            Variant::CurrentVariable256 => {
+                                run_chained_bench(
+                                    CurUVar256::init(ctx.clone(), cur_var_cfg(&ctx))
+                                        .await
+                                        .unwrap(),
+                                    num_keys,
+                                    iters,
+                                    |p| p.new_batch(),
+                                )
+                                .await
                             }
                         }
                     });
@@ -310,5 +475,5 @@ fn bench_merkleize(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = bench_merkleize
+    targets = bench_merkleize, bench_chained_merkleize
 }


### PR DESCRIPTION
## Overview

Several optimizations for `merkleize_with_floor_scan`

### Standard (single batch from DB)

  | Variant | num_keys | Time | Change |
  |---------|----------|------|--------|
  | any::unordered::fixed | 10K | 1.26 ms | -40.0% |
  | any::unordered::variable | 10K | 1.74 ms | -31.1% |
  | current::unordered::fixed::chunk=32 | 10K | 1.88 ms | -34.7% |
  | current::unordered::variable::chunk=32 | 10K | 2.43 ms | -27.0% |
  | current::unordered::fixed::chunk=256 | 10K | 5.24 ms | -14.4% |
  | current::unordered::variable::chunk=256 | 10K | 5.75 ms | -12.7% |
  | any::unordered::fixed | 100K | 12.04 ms | -46.7% |
  | any::unordered::variable | 100K | 16.91 ms | -36.9% |
  | current::unordered::fixed::chunk=32 | 100K | 17.77 ms | -37.9% |
  | current::unordered::variable::chunk=32 | 100K | 22.94 ms | -30.9% |
  | current::unordered::fixed::chunk=256 | 100K | 51.49 ms | -17.1% |
  | current::unordered::variable::chunk=256 | 100K | 55.95 ms | -15.0% |
  | any::unordered::fixed | 1M | 138.07 ms | -46.0% |
  | any::unordered::variable | 1M | 186.44 ms | -38.5% |
  | current::unordered::fixed::chunk=32 | 1M | 200.51 ms | -37.2% |
  | current::unordered::variable::chunk=32 | 1M | 248.53 ms | -32.2% |
  | current::unordered::fixed::chunk=256 | 1M | 527.39 ms | -18.2% |
  | current::unordered::variable::chunk=256 | 1M | 579.04 ms | -15.9% |

  ### Chained (batch on top of pending parent)

  | Variant | num_keys | Time | Change |
  |---------|----------|------|--------|
  | any::unordered::fixed | 10K | 1.44 ms | -36.1% |
  | any::unordered::variable | 10K | 1.89 ms | -30.7% |
  | current::unordered::fixed::chunk=32 | 10K | 2.12 ms | -28.6% |
  | current::unordered::variable::chunk=32 | 10K | 2.55 ms | -24.3% |
  | current::unordered::fixed::chunk=256 | 10K | 5.41 ms | -12.6% |
  | current::unordered::variable::chunk=256 | 10K | 5.89 ms | -10.8% |
  | any::unordered::fixed | 100K | 14.04 ms | -42.5% |
  | any::unordered::variable | 100K | 18.67 ms | -35.0% |
  | current::unordered::fixed::chunk=32 | 100K | 20.50 ms | -32.8% |
  | current::unordered::variable::chunk=32 | 100K | 24.84 ms | -29.5% |
  | current::unordered::fixed::chunk=256 | 100K | 52.93 ms | -16.9% |
  | current::unordered::variable::chunk=256 | 100K | 57.37 ms | -15.3% |
  | any::unordered::fixed | 1M | 161.42 ms | -41.9% |
  | any::unordered::variable | 1M | 209.38 ms | -35.0% |
  | current::unordered::fixed::chunk=32 | 1M | 229.46 ms | -33.5% |
  | current::unordered::variable::chunk=32 | 1M | 273.19 ms | -29.5% |
  | current::unordered::fixed::chunk=256 | 1M | 555.63 ms | -17.5% |
  | current::unordered::variable::chunk=256 | 1M | 605.16 ms | -15.5% |