### PR TITLE
[Storage] Sync cache resolution + concurrent disk reads in   merkleization 

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -341,7 +341,8 @@ where
     H: Hasher,
     Operation<F, U>: Codec,
 {
-    /// Read an operation at a given location from the correct source.
+    /// Try to resolve an operation from in-memory sources (this batch or the ancestor chain).
+    /// Returns `None` for locations in the committed journal that require disk I/O.
     ///
     /// The operation space is divided into three contiguous regions:
     ///
@@ -350,35 +351,70 @@ where
     ///   committed (on disk)     ancestors (in mem)          this batch (in mem)
     /// ```
     ///
-    /// `db_size` here is the Merkleizer's effective boundary between disk and in-memory
-    /// ancestors. It equals the original DB size when the full ancestor chain is alive, or a
-    /// higher value if ancestors were freed (see `into_parts`).
+    /// `db_size` is the boundary between disk and in-memory ancestors. It equals the
+    /// original DB size when the full ancestor chain is alive, or a higher value if
+    /// ancestors were freed (see `into_parts`).
     ///
-    /// For top-level batches, the ancestor region is empty (`db_size == base_size`).
-    async fn read_op<E, C, I>(
+    /// For batches created directly from the DB (no uncommitted ancestors),
+    /// the ancestor region is empty (`db_size == base_size`).
+    fn try_read_cached(
         &self,
         loc: Location<F>,
-        current_ops: &[Operation<F, U>],
-        db: &Db<F, E, C, I, H, U>,
-    ) -> Result<Operation<F, U>, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        let loc_val = *loc;
+        batch_ops: &[Operation<F, U>],
+    ) -> Option<Operation<F, U>> {
+        let loc = *loc;
 
-        if loc_val >= self.base_size {
+        if loc >= self.base_size {
             // This batch's own operations (user mutations, or earlier floor-raise ops).
-            Ok(current_ops[(loc_val - self.base_size) as usize].clone())
-        } else if loc_val >= self.db_size {
-            // Parent batch chain's operations (in-memory). Walk the ancestors.
-            Ok(read_chain_item_from_ancestors(&self.ancestors, loc_val, self.db_size).clone())
-        } else {
-            // Base DB's journal (on-disk async read).
-            let reader = db.log.reader().await;
-            Ok(reader.read(loc_val).await?)
+            return Some(batch_ops[(loc - self.base_size) as usize].clone());
         }
+
+        if loc >= self.db_size {
+            // Parent batch chain's operations (in-memory). Walk the ancestors.
+            return Some(
+                read_chain_item_from_ancestors(&self.ancestors, loc, self.db_size).clone(),
+            );
+        }
+
+        // Committed journal -- needs disk I/O.
+        None
+    }
+
+    /// Read multiple operations by location.
+    ///
+    /// In-memory locations (this batch and ancestor chain) are resolved synchronously.
+    /// Remaining disk locations are read concurrently via the provided `reader`.
+    async fn read_ops<R: Reader<Item = Operation<F, U>>>(
+        &self,
+        locations: &[Location<F>],
+        batch_ops: &[Operation<F, U>],
+        reader: &R,
+    ) -> Result<Vec<Operation<F, U>>, crate::qmdb::Error<F>> {
+        // Resolve in-memory hits synchronously.
+        let results: Vec<Option<Operation<F, U>>> = locations
+            .iter()
+            .map(|loc| self.try_read_cached(*loc, batch_ops))
+            .collect();
+
+        // Batch-read disk misses concurrently.
+        let disk_results = try_join_all(
+            locations
+                .iter()
+                .zip(results.iter())
+                .filter(|(_, cached)| cached.is_none())
+                .map(|(loc, _)| reader.read(**loc)),
+        )
+        .await?;
+
+        // Merge disk results back in order.
+        let mut disk_iter = disk_results.into_iter();
+        Ok(results
+            .into_iter()
+            .map(|r| match r {
+                Some(op) => op,
+                None => disk_iter.next().expect("disk result count mismatch"),
+            })
+            .collect())
     }
 
     /// Gather existing-key locations for all keys in `mutations`.
@@ -490,7 +526,7 @@ where
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
-    async fn finish<E, C, I, S: FloorScan<F>>(
+    async fn finish<E, C, I, S, R>(
         self,
         mut ops: Vec<Operation<F, U>>,
         mut diff: BTreeMap<U::Key, DiffEntry<F, U::Value>>,
@@ -498,12 +534,15 @@ where
         user_steps: u64,
         metadata: Option<U::Value>,
         mut scan: S,
+        reader: &R,
         db: &Db<F, E, C, I, H, U>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U>>, crate::qmdb::Error<F>>
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>>,
+        S: FloorScan<F>,
+        R: Reader<Item = Operation<F, U>>,
     {
         // Floor raise.
         // Steps = user_steps + 1 (+1 for previous commit becoming inactive).
@@ -516,7 +555,6 @@ where
             // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let fixed_tip = self.base_size + ops.len() as u64;
             let mut moved = 0u64;
-            let reader = db.log.reader().await;
 
             while moved < total_steps {
                 // Collect candidates, capped to bound concurrent I/O.
@@ -533,25 +571,28 @@ where
                     break;
                 }
 
-                // Perform on-disk reads concurrently via try_join_all, yielding results
-                // in insertion order.
+                // Resolve in-memory candidates synchronously.
+                let cached: Vec<Option<Operation<F, U>>> = candidates
+                    .iter()
+                    .map(|c| self.try_read_cached(*c, &ops))
+                    .collect();
+
+                // Batch-read disk misses concurrently.
                 let disk_results = try_join_all(
                     candidates
                         .iter()
-                        .filter(|loc| **loc < self.db_size)
-                        .map(|loc| reader.read(**loc)),
+                        .zip(cached.iter())
+                        .filter(|(_, c)| c.is_none())
+                        .map(|(loc, _)| reader.read(**loc)),
                 )
                 .await?;
 
                 // Process results in order, moving active ops to the tip.
-                let mut disk_idx = 0;
-                for candidate in candidates {
-                    let op = if *candidate < self.db_size {
-                        let op = disk_results[disk_idx].clone();
-                        disk_idx += 1;
-                        op
-                    } else {
-                        self.read_op(candidate, &ops, db).await?
+                let mut disk_iter = disk_results.into_iter();
+                for (candidate, cached_op) in candidates.into_iter().zip(cached) {
+                    let op = match cached_op {
+                        Some(op) => op,
+                        None => disk_iter.next().expect("disk result count mismatch"),
                     };
                     let Some(key) = op.key().cloned() else {
                         continue; // skip CommitFloor and other non-keyed ops
@@ -647,7 +688,7 @@ where
         // oldest alive ancestor's items don't start at db_size. Example: chain A -> B -> C,
         // A committed and dropped. ancestors() yields [B] (A's Weak is dead). B's items start
         // at A.size(), not db_size. We use the journal (strong Arcs, always intact) to compute
-        // the actual base so read_op falls through to disk for locations in the gap.
+        // the actual base so reads fall through to disk for locations in the gap.
         let db_size = self.base.db_size();
         let effective_db_size = ancestors.last().map_or(db_size, |oldest| {
             let oldest_base =
@@ -741,10 +782,10 @@ where
     {
         let (mut mutations, m) = self.into_parts();
 
-        // Resolve existing keys (async I/O, parallelized).
+        // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, false);
-        let futures = locations.iter().map(|&loc| m.read_op(loc, &[], db));
-        let results = try_join_all(futures).await?;
+        let reader = db.log.reader().await;
+        let results = m.read_ops(&locations, &[], &reader).await?;
 
         // Generate user mutation operations.
         let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
@@ -843,8 +884,17 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
-            .await
+        m.finish(
+            ops,
+            diff,
+            active_keys_delta,
+            user_steps,
+            metadata,
+            scan,
+            &reader,
+            db,
+        )
+        .await
     }
 }
 
@@ -886,12 +936,13 @@ where
     {
         let (mut mutations, m) = self.into_parts();
 
-        // Resolve existing keys (async I/O).
+        // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);
+        let reader = db.log.reader().await;
 
         // Read and unwrap Update operations (snapshot only references Updates).
-        let futures = locations.iter().map(|&loc| m.read_op(loc, &[], db));
-        let update_results: Vec<_> = try_join_all(futures)
+        let update_results: Vec<_> = m
+            .read_ops(&locations, &[], &reader)
             .await?
             .into_iter()
             .map(|op| match op {
@@ -965,11 +1016,7 @@ where
         prev_locations.sort();
         prev_locations.dedup();
 
-        let prev_results = {
-            let reader = db.log.reader().await;
-            let futures = prev_locations.iter().map(|loc| reader.read(**loc));
-            try_join_all(futures).await?
-        };
+        let prev_results = m.read_ops(&prev_locations, &[], &reader).await?;
 
         for (op, &old_loc) in prev_results.into_iter().zip(&prev_locations) {
             let data = match op {
@@ -1003,7 +1050,10 @@ where
                 continue;
             }
             if let DiffEntry::Active { value, loc, .. } = entry {
-                let op: Operation<F, update::Ordered<K, V>> = m.read_op(*loc, &[], db).await?;
+                let op = match m.try_read_cached(*loc, &[]) {
+                    Some(op) => op,
+                    None => reader.read(**loc).await?,
+                };
                 let data = match op {
                     Operation::Update(data) => data,
                     _ => unreachable!("ancestor diff Active should reference Update op"),
@@ -1129,8 +1179,17 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
-            .await
+        m.finish(
+            ops,
+            diff,
+            active_keys_delta,
+            user_steps,
+            metadata,
+            scan,
+            &reader,
+            db,
+        )
+        .await
     }
 }
 
@@ -1600,6 +1659,87 @@ mod tests {
         // Mutation unchanged.
         assert_eq!(mutations.len(), 1);
         assert!(mutations.contains_key(&1));
+    }
+
+    #[test]
+    fn read_ops_resolves_committed_ancestor_and_current_sources() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = UnorderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+            >;
+
+            let config = fixed_db_config::<OneCap>("read-locations-all-sources", &context);
+            let mut db = TestDb::init(context, config).await.unwrap();
+
+            let key_db = colliding_digest(0x30, 0);
+            let value_db = colliding_digest(0x30, 1);
+            let key_parent = colliding_digest(0x31, 0);
+            let value_parent = colliding_digest(0x31, 1);
+            let key_current = colliding_digest(0x32, 0);
+            let value_current = colliding_digest(0x32, 1);
+
+            // Commit one key to the DB so it's on disk.
+            let seed = db
+                .new_batch()
+                .write(key_db, Some(value_db))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            let committed_loc = db.snapshot.get(&key_db).next().copied().unwrap();
+
+            // Create a parent batch with a second key (in-memory ancestor).
+            let parent = db
+                .new_batch()
+                .write(key_parent, Some(value_parent))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let parent_loc = parent.diff.get(&key_parent).unwrap().loc().unwrap();
+
+            // Create a child batch with a third key (current ops).
+            let child = parent
+                .new_batch::<Sha256>()
+                .write(key_current, Some(value_current));
+            let (_mutations, merkleizer) = child.into_parts();
+
+            let current_loc = Location::new(merkleizer.base_size);
+            let batch_ops = vec![Operation::Update(update::Unordered(
+                key_current,
+                value_current,
+            ))];
+
+            // read_ops should resolve all three sources correctly.
+            let reader = db.log.reader().await;
+            let ops = merkleizer
+                .read_ops(
+                    &[committed_loc, parent_loc, current_loc],
+                    &batch_ops,
+                    &reader,
+                )
+                .await
+                .unwrap();
+            drop(reader);
+
+            assert_eq!(
+                ops,
+                vec![
+                    Operation::Update(update::Unordered(key_db, value_db)),
+                    Operation::Update(update::Unordered(key_parent, value_parent)),
+                    Operation::Update(update::Unordered(key_current, value_current)),
+                ]
+            );
+
+            db.destroy().await.unwrap();
+        });
     }
 
     #[test]

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -568,17 +568,19 @@ where
             // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let fixed_tip = self.base_size + ops.len() as u64;
             let mut moved = 0u64;
+            let mut scan_from = floor;
 
             while moved < total_steps {
-                // Collect candidates, capped to bound concurrent I/O.
-                let limit = (total_steps - moved).min(MAX_CONCURRENT_READS) as usize;
-                let mut candidates = Vec::with_capacity(limit);
-                while candidates.len() < limit {
-                    let Some(candidate) = scan.next_candidate(floor, fixed_tip) else {
+                // Collect candidates. The batch size is always MAX_CONCURRENT_READS
+                // because floor advances during processing (not collection), so
+                // early exit cannot leave floor past unprocessed candidates.
+                let mut candidates = Vec::with_capacity(MAX_CONCURRENT_READS as usize);
+                while candidates.len() < MAX_CONCURRENT_READS as usize {
+                    let Some(candidate) = scan.next_candidate(scan_from, fixed_tip) else {
                         break;
                     };
                     candidates.push(candidate);
-                    floor = Location::new(*candidate + 1);
+                    scan_from = Location::new(*candidate + 1);
                 }
                 if candidates.is_empty() {
                     break;
@@ -589,6 +591,7 @@ where
 
                 // Process results in order, moving active ops to the tip.
                 for (candidate, op) in candidates.into_iter().zip(results) {
+                    floor = Location::new(*candidate + 1);
                     let Some(key) = op.key().cloned() else {
                         continue; // skip CommitFloor and other non-keyed ops
                     };
@@ -1732,14 +1735,32 @@ mod tests {
 
             // read_op: single-location reads across all three sources.
             let reader = db.log.reader().await;
-            let disk_op = merkleizer.read_op(committed_loc, &batch_ops, &reader).await.unwrap();
-            assert_eq!(disk_op, Operation::Update(update::Unordered(key_db, value_db)));
+            let disk_op = merkleizer
+                .read_op(committed_loc, &batch_ops, &reader)
+                .await
+                .unwrap();
+            assert_eq!(
+                disk_op,
+                Operation::Update(update::Unordered(key_db, value_db))
+            );
 
-            let ancestor_op = merkleizer.read_op(parent_loc, &batch_ops, &reader).await.unwrap();
-            assert_eq!(ancestor_op, Operation::Update(update::Unordered(key_parent, value_parent)));
+            let ancestor_op = merkleizer
+                .read_op(parent_loc, &batch_ops, &reader)
+                .await
+                .unwrap();
+            assert_eq!(
+                ancestor_op,
+                Operation::Update(update::Unordered(key_parent, value_parent))
+            );
 
-            let current_op = merkleizer.read_op(current_loc, &batch_ops, &reader).await.unwrap();
-            assert_eq!(current_op, Operation::Update(update::Unordered(key_current, value_current)));
+            let current_op = merkleizer
+                .read_op(current_loc, &batch_ops, &reader)
+                .await
+                .unwrap();
+            assert_eq!(
+                current_op,
+                Operation::Update(update::Unordered(key_current, value_current))
+            );
             drop(reader);
 
             db.destroy().await.unwrap();

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -341,8 +341,29 @@ where
     H: Hasher,
     Operation<F, U>: Codec,
 {
-    /// Try to resolve an operation from in-memory sources (this batch or the ancestor chain).
-    /// Returns `None` for locations in the committed journal that require disk I/O.
+    /// Sync cache check: resolve from this batch's ops or the ancestor chain.
+    /// Returns `None` for committed-journal locations that need disk I/O.
+    fn try_read_cached(
+        &self,
+        loc: Location<F>,
+        batch_ops: &[Operation<F, U>],
+    ) -> Option<Operation<F, U>> {
+        let loc = *loc;
+
+        if loc >= self.base_size {
+            return Some(batch_ops[(loc - self.base_size) as usize].clone());
+        }
+
+        if loc >= self.db_size {
+            return Some(
+                read_chain_item_from_ancestors(&self.ancestors, loc, self.db_size).clone(),
+            );
+        }
+
+        None
+    }
+
+    /// Read a single operation by location.
     ///
     /// The operation space is divided into three contiguous regions:
     ///
@@ -357,33 +378,25 @@ where
     ///
     /// For batches created directly from the DB (no uncommitted ancestors),
     /// the ancestor region is empty (`db_size == base_size`).
-    fn try_read_cached(
+    ///
+    /// In-memory locations are resolved synchronously. Only committed-journal locations
+    /// await the `reader`.
+    async fn read_op<R: Reader<Item = Operation<F, U>>>(
         &self,
         loc: Location<F>,
         batch_ops: &[Operation<F, U>],
-    ) -> Option<Operation<F, U>> {
-        let loc = *loc;
-
-        if loc >= self.base_size {
-            // This batch's own operations (user mutations, or earlier floor-raise ops).
-            return Some(batch_ops[(loc - self.base_size) as usize].clone());
+        reader: &R,
+    ) -> Result<Operation<F, U>, crate::qmdb::Error<F>> {
+        match self.try_read_cached(loc, batch_ops) {
+            Some(op) => Ok(op),
+            None => Ok(reader.read(*loc).await?),
         }
-
-        if loc >= self.db_size {
-            // Parent batch chain's operations (in-memory). Walk the ancestors.
-            return Some(
-                read_chain_item_from_ancestors(&self.ancestors, loc, self.db_size).clone(),
-            );
-        }
-
-        // Committed journal -- needs disk I/O.
-        None
     }
 
     /// Read multiple operations by location.
     ///
-    /// In-memory locations (this batch and ancestor chain) are resolved synchronously.
-    /// Remaining disk locations are read concurrently via the provided `reader`.
+    /// In-memory locations are resolved synchronously. Remaining disk locations
+    /// are read concurrently via `try_join_all` on the provided `reader`.
     async fn read_ops<R: Reader<Item = Operation<F, U>>>(
         &self,
         locations: &[Location<F>],
@@ -571,29 +584,11 @@ where
                     break;
                 }
 
-                // Resolve in-memory candidates synchronously.
-                let cached: Vec<Option<Operation<F, U>>> = candidates
-                    .iter()
-                    .map(|c| self.try_read_cached(*c, &ops))
-                    .collect();
-
-                // Batch-read disk misses concurrently.
-                let disk_results = try_join_all(
-                    candidates
-                        .iter()
-                        .zip(cached.iter())
-                        .filter(|(_, c)| c.is_none())
-                        .map(|(loc, _)| reader.read(**loc)),
-                )
-                .await?;
+                // Resolve cached in-memory ops synchronously, batch disk misses.
+                let results = self.read_ops(&candidates, &ops, reader).await?;
 
                 // Process results in order, moving active ops to the tip.
-                let mut disk_iter = disk_results.into_iter();
-                for (candidate, cached_op) in candidates.into_iter().zip(cached) {
-                    let op = match cached_op {
-                        Some(op) => op,
-                        None => disk_iter.next().expect("disk result count mismatch"),
-                    };
+                for (candidate, op) in candidates.into_iter().zip(results) {
                     let Some(key) = op.key().cloned() else {
                         continue; // skip CommitFloor and other non-keyed ops
                     };
@@ -1050,10 +1045,7 @@ where
                 continue;
             }
             if let DiffEntry::Active { value, loc, .. } = entry {
-                let op = match m.try_read_cached(*loc, &[]) {
-                    Some(op) => op,
-                    None => reader.read(**loc).await?,
-                };
+                let op = m.read_op(*loc, &[], &reader).await?;
                 let data = match op {
                     Operation::Update(data) => data,
                     _ => unreachable!("ancestor diff Active should reference Update op"),
@@ -1737,6 +1729,18 @@ mod tests {
                     Operation::Update(update::Unordered(key_current, value_current)),
                 ]
             );
+
+            // read_op: single-location reads across all three sources.
+            let reader = db.log.reader().await;
+            let disk_op = merkleizer.read_op(committed_loc, &batch_ops, &reader).await.unwrap();
+            assert_eq!(disk_op, Operation::Update(update::Unordered(key_db, value_db)));
+
+            let ancestor_op = merkleizer.read_op(parent_loc, &batch_ops, &reader).await.unwrap();
+            assert_eq!(ancestor_op, Operation::Update(update::Unordered(key_parent, value_parent)));
+
+            let current_op = merkleizer.read_op(current_loc, &batch_ops, &reader).await.unwrap();
+            assert_eq!(current_op, Operation::Update(update::Unordered(key_current, value_current)));
+            drop(reader);
 
             db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -423,9 +423,11 @@ where
         let mut disk_iter = disk_results.into_iter();
         Ok(results
             .into_iter()
-            .map(|r| match r {
-                Some(op) => op,
-                None => disk_iter.next().expect("disk result count mismatch"),
+            .map(|r| {
+                r.map_or_else(
+                    || disk_iter.next().expect("disk result count mismatch"),
+                    |op| op,
+                )
             })
             .collect())
     }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -382,57 +382,6 @@ where
         creates
     }
 
-    /// Scan forward from `floor` to find the next active operation, re-append it at the tip.
-    /// The `scan` parameter controls which locations are considered as potentially active,
-    /// allowing implementations to skip locations known to be inactive without reading them.
-    /// Returns `true` if an active op was found and moved, `false` if the floor reached
-    /// `fixed_tip`.
-    async fn advance_floor_once<E, C, I, S: FloorScan<F>>(
-        &self,
-        floor: &mut Location<F>,
-        fixed_tip: u64,
-        ops: &mut Vec<Operation<F, U>>,
-        diff: &mut BTreeMap<U::Key, DiffEntry<F, U::Value>>,
-        scan: &mut S,
-        db: &Db<F, E, C, I, H, U>,
-    ) -> Result<bool, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        loop {
-            let Some(candidate) = scan.next_candidate(*floor, fixed_tip) else {
-                return Ok(false);
-            };
-            *floor = Location::new(*candidate + 1);
-
-            let op = self.read_op(candidate, ops, db).await?;
-            let Some(key) = op.key().cloned() else {
-                continue; // skip CommitFloor and other non-keyed ops
-            };
-
-            if self.is_active_at(&key, candidate, diff, db) {
-                let new_loc = Location::new(self.base_size + ops.len() as u64);
-                let base_old_loc = diff
-                    .get(&key)
-                    .or_else(|| self.base_diff.get(&key))
-                    .map_or(Some(candidate), DiffEntry::base_old_loc);
-                let value = extract_update_value(&op);
-                ops.push(op);
-                diff.insert(
-                    key,
-                    DiffEntry::Active {
-                        value,
-                        loc: new_loc,
-                        base_old_loc,
-                    },
-                );
-                return Ok(true);
-            }
-        }
-    }
-
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
@@ -458,16 +407,70 @@ where
         let mut floor = self.base_inactivity_floor_loc;
 
         if total_active_keys > 0 {
-            // Floor raise: advance the inactivity floor by `total_steps` active
-            // operations. `fixed_tip` prevents scanning into floor-raise moves
-            // just appended, matching `raise_floor_with_bitmap()` semantics.
+            // Floor raise: advance the inactivity floor by `total_steps` active operations.
+            // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let fixed_tip = self.base_size + ops.len() as u64;
-            for _ in 0..total_steps {
-                if !self
-                    .advance_floor_once(&mut floor, fixed_tip, &mut ops, &mut diff, &mut scan, db)
-                    .await?
-                {
+            let mut moved = 0u64;
+
+            while moved < total_steps {
+                // Collect candidates, capped to bound concurrent I/O.
+                const MAX_BATCH: usize = 64;
+                let mut candidates = Vec::new();
+                let limit = (total_steps - moved).min(MAX_BATCH as u64) as usize;
+                while candidates.len() < limit {
+                    let Some(candidate) = scan.next_candidate(floor, fixed_tip) else {
+                        break;
+                    };
+                    candidates.push(candidate);
+                    floor = Location::new(*candidate + 1);
+                }
+                if candidates.is_empty() {
                     break;
+                }
+
+                // Batch-read on-disk candidates through a single reader.
+                let mut disk_ops = {
+                    let reader = db.log.reader().await;
+                    let futures = candidates
+                        .iter()
+                        .filter(|loc| **loc < self.db_size)
+                        .map(|loc| reader.read(**loc));
+                    try_join_all(futures).await?
+                }
+                .into_iter();
+
+                // Process results sequentially, moving active ops to the tip.
+                for candidate in candidates {
+                    let op = if *candidate < self.db_size {
+                        disk_ops.next().unwrap()
+                    } else {
+                        self.read_op(candidate, &ops, db).await?
+                    };
+                    let Some(key) = op.key().cloned() else {
+                        continue; // skip CommitFloor and other non-keyed ops
+                    };
+                    if !self.is_active_at(&key, candidate, &diff, db) {
+                        continue;
+                    }
+                    let new_loc = Location::new(self.base_size + ops.len() as u64);
+                    let base_old_loc = diff
+                        .get(&key)
+                        .or_else(|| self.base_diff.get(&key))
+                        .map_or(Some(candidate), DiffEntry::base_old_loc);
+                    let value = extract_update_value(&op);
+                    ops.push(op);
+                    diff.insert(
+                        key,
+                        DiffEntry::Active {
+                            value,
+                            loc: new_loc,
+                            base_old_loc,
+                        },
+                    );
+                    moved += 1;
+                    if moved >= total_steps {
+                        break;
+                    }
                 }
             }
         } else {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -23,12 +23,15 @@ use crate::{
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use core::ops::Range;
-use futures::future::try_join_all;
+use futures::{future::try_join_all, stream::FuturesOrdered, StreamExt as _};
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
 use tracing::debug;
+
+/// Maximum number of journal reads to issue concurrently during floor raising.
+const MAX_CONCURRENT_READS: u64 = 64;
 
 /// Strategy for finding the next active location during floor raising.
 pub(crate) trait FloorScan<F: Family> {
@@ -414,9 +417,9 @@ where
 
             while moved < total_steps {
                 // Collect candidates, capped to bound concurrent I/O.
-                const MAX_BATCH: usize = 64;
                 let mut candidates = Vec::new();
-                let limit = (total_steps - moved).min(MAX_BATCH as u64) as usize;
+                let limit =
+                    (total_steps - moved).min(MAX_CONCURRENT_READS) as usize;
                 while candidates.len() < limit {
                     let Some(candidate) = scan.next_candidate(floor, fixed_tip) else {
                         break;
@@ -428,21 +431,19 @@ where
                     break;
                 }
 
-                // Batch-read on-disk candidates through a single reader.
-                let mut disk_ops = {
-                    let reader = db.log.reader().await;
-                    let futures = candidates
-                        .iter()
-                        .filter(|loc| **loc < self.db_size)
-                        .map(|loc| reader.read(**loc));
-                    try_join_all(futures).await?
-                }
-                .into_iter();
+                // Perform on-disk reads concurrently via FuturesOrdered so results are yielded in
+                // insertion order as they resolve.
+                let reader = db.log.reader().await;
+                let mut disk_reads: FuturesOrdered<_> = candidates
+                    .iter()
+                    .filter(|loc| **loc < self.db_size)
+                    .map(|loc| reader.read(**loc))
+                    .collect();
 
-                // Process results sequentially, moving active ops to the tip.
+                // Process results in order, moving active ops to the tip.
                 for candidate in candidates {
                     let op = if *candidate < self.db_size {
-                        disk_ops.next().unwrap()
+                        disk_reads.next().await.unwrap()?
                     } else {
                         self.read_op(candidate, &ops, db).await?
                     };


### PR DESCRIPTION
Combines #3552 and #3539 changes.

## Summary

Optimizes operation reads during QMDB batch merkleization by separating
in-memory cache resolution from disk I/O and batching the disk reads.

Previously, `read_op` was a single async method that independently acquired
the journal reader lock on every disk read, and floor raising issued one
read at a time via `advance_floor_once`. This PR restructures reads around
two primitives:

- **`try_read_cached`** (sync): Resolves operations from in-memory sources
  (current batch ops, ancestor chain) with no async overhead. Returns `None`
  for committed-journal locations that require disk I/O.

- **`read_ops`** (async, batched): Resolves a batch of locations by calling
  `try_read_cached` for each, then issuing a single `try_join_all` for
  the remaining disk misses. The journal reader is acquired once per
  merkleization and threaded through all read sites.

### Key-resolution phase

Both the unordered and ordered `merkleize_with_floor_scan` paths now call
`db.log.reader().await` once and pass the reader to `read_ops` and `finish`.
This replaces the previous pattern where each `read_op` call independently
acquired the reader lock.

### Floor-raise phase

Replaces the sequential `advance_floor_once` loop with a batched approach:

1. Collect up to `MAX_CONCURRENT_READS` (64) candidate locations per batch.
2. Resolve in-memory candidates synchronously via `try_read_cached`.
3. Issue remaining disk reads concurrently via `try_join_all`.
4. Process results in order, moving active ops to the tip.

This reuses the reader already acquired during the key-resolution phase.