### PR TITLE
[Storage] Parallelize leaf hashing in authenticated batch merkleization

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -121,7 +121,10 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync> UnmerkleizedBatch<F, H, I
         );
 
         #[cfg(feature = "std")]
-        if let Some(pool) = self.inner.pool().filter(|_| items.len() >= batch::MIN_TO_PARALLELIZE)
+        if let Some(pool) = self
+            .inner
+            .pool()
+            .filter(|_| items.len() >= batch::MIN_TO_PARALLELIZE)
         {
             // Parallel path: encode items and compute leaf digests on the thread pool,
             // then feed the pre-computed digests sequentially into the MMR batch.

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -11,8 +11,10 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
-        self, batch, hasher::Standard as StandardHasher, journaled::Journaled, Family, Location,
-        Position, Proof, Readable,
+        self, batch,
+        hasher::{Hasher as MerkleHasher, Standard as StandardHasher},
+        journaled::Journaled,
+        Family, Location, Position, Proof, Readable,
     },
     Context, Persistable,
 };
@@ -117,10 +119,44 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync> UnmerkleizedBatch<F, H, I
             self.items.is_empty(),
             "merkleize_with expects no items added via add"
         );
+
+        #[cfg(feature = "std")]
+        if let Some(pool) = self.inner.pool().filter(|_| items.len() >= batch::MIN_TO_PARALLELIZE)
+        {
+            // Parallel path: encode items and compute leaf digests on the thread pool,
+            // then feed the pre-computed digests sequentially into the MMR batch.
+            use rayon::prelude::*;
+            let starting_leaves = self.inner.leaves();
+            let digests: Vec<H::Digest> = pool.install(|| {
+                items
+                    .par_iter()
+                    .enumerate()
+                    .map_init(
+                        || self.hasher.clone(),
+                        |h, (i, item)| {
+                            let loc = Location::<F>::new(*starting_leaves + i as u64);
+                            let pos = Position::try_from(loc).expect("valid leaf location");
+                            h.leaf_digest(pos, &item.encode())
+                        },
+                    )
+                    .collect()
+            });
+            for digest in digests {
+                self.inner = self.inner.add_leaf_digest(digest);
+            }
+        } else {
+            for item in &*items {
+                let encoded = item.encode();
+                self.inner = self.inner.add(&self.hasher, &encoded);
+            }
+        }
+
+        #[cfg(not(feature = "std"))]
         for item in &*items {
             let encoded = item.encode();
             self.inner = self.inner.add(&self.hasher, &encoded);
         }
+
         let merkle = self.inner.merkleize(base, &self.hasher);
         let ancestor_items = Self::collect_ancestor_items(&self.parent);
         Arc::new(MerkleizedBatch {

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -11,8 +11,10 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
-        self, batch, hasher::Standard as StandardHasher, journaled::Journaled, Family, Location,
-        Position, Proof, Readable,
+        self, batch,
+        hasher::{Hasher as _, Standard as StandardHasher},
+        journaled::Journaled,
+        Family, Location, Position, Proof, Readable,
     },
     Context, Persistable,
 };
@@ -126,7 +128,6 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync> UnmerkleizedBatch<F, H, I
         {
             // Parallel path: encode items and compute leaf digests on the thread pool,
             // then feed the pre-computed digests sequentially into the MMR batch.
-            use crate::merkle::hasher::Hasher as _;
             use rayon::prelude::*;
 
             let starting_leaves = self.inner.leaves();

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -11,10 +11,8 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
-        self, batch,
-        hasher::{Hasher as MerkleHasher, Standard as StandardHasher},
-        journaled::Journaled,
-        Family, Location, Position, Proof, Readable,
+        self, batch, hasher::Standard as StandardHasher, journaled::Journaled, Family, Location,
+        Position, Proof, Readable,
     },
     Context, Persistable,
 };
@@ -128,7 +126,9 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync> UnmerkleizedBatch<F, H, I
         {
             // Parallel path: encode items and compute leaf digests on the thread pool,
             // then feed the pre-computed digests sequentially into the MMR batch.
+            use crate::mmr::hasher::Hasher as _;
             use rayon::prelude::*;
+
             let starting_leaves = self.inner.leaves();
             let digests: Vec<H::Digest> = pool.install(|| {
                 items

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -126,7 +126,7 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync> UnmerkleizedBatch<F, H, I
         {
             // Parallel path: encode items and compute leaf digests on the thread pool,
             // then feed the pre-computed digests sequentially into the MMR batch.
-            use crate::mmr::hasher::Hasher as _;
+            use crate::merkle::hasher::Hasher as _;
             use rayon::prelude::*;
 
             let starting_leaves = self.inner.leaves();

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -132,7 +132,7 @@ impl<F: Family, D: Digest> UnmerkleizedBatch<F, D> {
 
     /// Return a reference to the thread pool, if any.
     #[cfg(feature = "std")]
-    pub fn pool(&self) -> Option<&ThreadPool> {
+    pub const fn pool(&self) -> Option<&ThreadPool> {
         self.pool.as_ref()
     }
 

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -130,6 +130,12 @@ impl<F: Family, D: Digest> UnmerkleizedBatch<F, D> {
         self
     }
 
+    /// Return a reference to the thread pool, if any.
+    #[cfg(feature = "std")]
+    pub fn pool(&self) -> Option<&ThreadPool> {
+        self.pool.as_ref()
+    }
+
     /// The total number of nodes visible through this batch.
     pub(crate) fn size(&self) -> Position<F> {
         Position::new(*self.parent.size() + self.appended.len() as u64)


### PR DESCRIPTION
## Summary

Parallelize leaf hashing in `authenticated::UnmerkleizedBatch::merkleize_with` using the rayon thread pool.

Also exposes `UnmerkleizedBatch::pool()` on the inner merkle batch so the authenticated layer can check for a pool without reaching through private fields.

Cherry-picked from @clabby's [`dabecac`](https://github.com/commonwarexyz/monorepo/commit/dabecac453fc43e02534ac1e8e94508a0f5ddd39).