### PR TITLE
[storage] Batch floor raise w/ cached reads

### DIFF
--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -394,6 +394,22 @@ impl<B: Blob> Append<B> {
         buffer.size()
     }
 
+    /// Try to read exactly `len` bytes starting at `offset` from the page cache only.
+    ///
+    /// Returns `Some(buf)` if all bytes were in the cache, `None` on any cache miss.
+    /// Does not perform any async I/O. The caller must have already validated that
+    /// `offset + len` is within the blob's logical size.
+    pub fn try_read_cached(&self, offset: u64, len: usize) -> Option<IoBufs> {
+        // SAFETY: if all bytes are cached, read_cached fills all `len` bytes.
+        let mut buf = unsafe { self.cache_ref.pool().alloc_len(len) };
+        let cached = self.cache_ref.read_cached(self.id, buf.as_mut(), offset);
+        if cached == len {
+            Some(buf.into())
+        } else {
+            None
+        }
+    }
+
     /// Read exactly `len` immutable bytes starting at `offset`.
     pub async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, Error> {
         // Read into a temporary contiguous buffer and copy back to preserve structure.

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -155,6 +155,18 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
                 }
             })
     }
+
+    /// Try to read an item from the page cache only. Returns `None` on cache miss.
+    fn try_read_cached(&self, pos: u64, items_per_blob: u64) -> Option<A> {
+        if pos >= self.size || pos < self.pruning_boundary {
+            return None;
+        }
+        let section = pos / items_per_blob;
+        let section_start = section * items_per_blob;
+        let first_in_section = self.pruning_boundary.max(section_start);
+        let pos_in_section = pos - first_in_section;
+        self.journal.try_get_cached(section, pos_in_section)
+    }
 }
 
 /// Implementation of `Journal` storage.
@@ -197,6 +209,10 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
 
     async fn read(&self, pos: u64) -> Result<A, Error> {
         self.guard.read(pos, self.items_per_blob).await
+    }
+
+    fn try_read_cached(&self, pos: u64) -> Option<A> {
+        self.guard.try_read_cached(pos, self.items_per_blob)
     }
 
     async fn replay(

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -35,6 +35,14 @@ pub trait Reader: Send + Sync {
     /// Guaranteed not to return [Error::ItemPruned] for positions within `bounds()`.
     fn read(&self, position: u64) -> impl Future<Output = Result<Self::Item, Error>> + Send;
 
+    /// Try to read an item from the page cache only, without async I/O.
+    ///
+    /// Returns `Some(item)` if all data was in cache, `None` on any miss.
+    /// The default returns `None` (no cache available).
+    fn try_read_cached(&self, _position: u64) -> Option<Self::Item> {
+        None
+    }
+
     /// Return a stream of all items starting from `start_pos`.
     ///
     /// Because the reader holds the lock, validation and stream setup happen

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -181,6 +181,16 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         A::decode(buf.coalesce()).map_err(Error::Codec)
     }
 
+    /// Try to read an item using only the page cache. Returns `None` on any cache miss.
+    ///
+    /// The caller must have already validated that the position is within bounds.
+    pub fn try_get_cached(&self, section: u64, position: u64) -> Option<A> {
+        let blob = self.manager.get(section).ok()??;
+        let offset = position.checked_mul(Self::CHUNK_SIZE_U64)?;
+        let buf = blob.try_read_cached(offset, Self::CHUNK_SIZE)?;
+        A::decode(buf.coalesce()).ok()
+    }
+
     /// Read the last item in a section, if any.
     ///
     /// Returns `Ok(None)` if the section is empty.

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -341,8 +341,29 @@ where
     H: Hasher,
     Operation<F, U>: Codec,
 {
-    /// Try to resolve an operation from in-memory sources (this batch or the ancestor chain).
-    /// Returns `None` for locations in the committed journal that require disk I/O.
+    /// Sync cache check: resolve from this batch's ops or the ancestor chain.
+    /// Returns `None` for committed-journal locations that need disk I/O.
+    fn try_read_cached(
+        &self,
+        loc: Location<F>,
+        batch_ops: &[Operation<F, U>],
+    ) -> Option<Operation<F, U>> {
+        let loc = *loc;
+
+        if loc >= self.base_size {
+            return Some(batch_ops[(loc - self.base_size) as usize].clone());
+        }
+
+        if loc >= self.db_size {
+            return Some(
+                read_chain_item_from_ancestors(&self.ancestors, loc, self.db_size).clone(),
+            );
+        }
+
+        None
+    }
+
+    /// Read a single operation by location.
     ///
     /// The operation space is divided into three contiguous regions:
     ///
@@ -357,43 +378,38 @@ where
     ///
     /// For batches created directly from the DB (no uncommitted ancestors),
     /// the ancestor region is empty (`db_size == base_size`).
-    fn try_read_cached(
+    ///
+    /// In-memory locations are resolved synchronously. Only committed-journal locations
+    /// await the `reader`.
+    async fn read_op<R: Reader<Item = Operation<F, U>>>(
         &self,
         loc: Location<F>,
         batch_ops: &[Operation<F, U>],
-    ) -> Option<Operation<F, U>> {
-        let loc = *loc;
-
-        if loc >= self.base_size {
-            // This batch's own operations (user mutations, or earlier floor-raise ops).
-            return Some(batch_ops[(loc - self.base_size) as usize].clone());
+        reader: &R,
+    ) -> Result<Operation<F, U>, crate::qmdb::Error<F>> {
+        match self.try_read_cached(loc, batch_ops) {
+            Some(op) => Ok(op),
+            None => Ok(reader.read(*loc).await?),
         }
-
-        if loc >= self.db_size {
-            // Parent batch chain's operations (in-memory). Walk the ancestors.
-            return Some(
-                read_chain_item_from_ancestors(&self.ancestors, loc, self.db_size).clone(),
-            );
-        }
-
-        // Committed journal -- needs disk I/O.
-        None
     }
 
     /// Read multiple operations by location.
     ///
-    /// In-memory locations (this batch and ancestor chain) are resolved synchronously.
-    /// Remaining disk locations are read concurrently via the provided `reader`.
+    /// In-memory locations are resolved synchronously. Remaining disk locations
+    /// are read concurrently via `try_join_all` on the provided `reader`.
     async fn read_ops<R: Reader<Item = Operation<F, U>>>(
         &self,
         locations: &[Location<F>],
         batch_ops: &[Operation<F, U>],
         reader: &R,
     ) -> Result<Vec<Operation<F, U>>, crate::qmdb::Error<F>> {
-        // Resolve in-memory hits synchronously.
+        // Resolve hits synchronously: batch/ancestor first, then journal page cache.
         let results: Vec<Option<Operation<F, U>>> = locations
             .iter()
-            .map(|loc| self.try_read_cached(*loc, batch_ops))
+            .map(|loc| {
+                self.try_read_cached(*loc, batch_ops)
+                    .or_else(|| reader.try_read_cached(**loc))
+            })
             .collect();
 
         // Batch-read disk misses concurrently.
@@ -410,9 +426,8 @@ where
         let mut disk_iter = disk_results.into_iter();
         Ok(results
             .into_iter()
-            .map(|r| match r {
-                Some(op) => op,
-                None => disk_iter.next().expect("disk result count mismatch"),
+            .map(|r| {
+                r.unwrap_or_else(|| disk_iter.next().expect("disk result count mismatch"))
             })
             .collect())
     }
@@ -555,26 +570,32 @@ where
             // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let fixed_tip = self.base_size + ops.len() as u64;
             let mut moved = 0u64;
+            let mut scan_from = floor;
 
             while moved < total_steps {
-                // Collect candidates, capped to bound concurrent I/O.
-                let limit = (total_steps - moved).min(MAX_CONCURRENT_READS) as usize;
+                // Collect candidates, capped by the number of active ops still needed.
+                // `scan_from` tracks prefetch progress separately from `floor`, so
+                // early exit cannot leave `floor` past unprocessed candidates.
+                let limit = ((total_steps - moved) as usize).min(MAX_CONCURRENT_READS as usize);
                 let mut candidates = Vec::with_capacity(limit);
                 while candidates.len() < limit {
-                    let Some(candidate) = scan.next_candidate(floor, fixed_tip) else {
+                    let Some(candidate) = scan.next_candidate(scan_from, fixed_tip) else {
                         break;
                     };
                     candidates.push(candidate);
-                    floor = Location::new(*candidate + 1);
+                    scan_from = Location::new(*candidate + 1);
                 }
                 if candidates.is_empty() {
                     break;
                 }
 
-                // Resolve in-memory candidates synchronously.
+                // Resolve cached candidates synchronously: batch/ancestor then page cache.
                 let cached: Vec<Option<Operation<F, U>>> = candidates
                     .iter()
-                    .map(|c| self.try_read_cached(*c, &ops))
+                    .map(|c| {
+                        self.try_read_cached(*c, &ops)
+                            .or_else(|| reader.try_read_cached(**c))
+                    })
                     .collect();
 
                 // Batch-read disk misses concurrently.
@@ -590,10 +611,10 @@ where
                 // Process results in order, moving active ops to the tip.
                 let mut disk_iter = disk_results.into_iter();
                 for (candidate, cached_op) in candidates.into_iter().zip(cached) {
-                    let op = match cached_op {
-                        Some(op) => op,
-                        None => disk_iter.next().expect("disk result count mismatch"),
-                    };
+                    let op = cached_op.unwrap_or_else(|| {
+                        disk_iter.next().expect("disk result count mismatch")
+                    });
+                    floor = Location::new(*candidate + 1);
                     let Some(key) = op.key().cloned() else {
                         continue; // skip CommitFloor and other non-keyed ops
                     };
@@ -1050,10 +1071,7 @@ where
                 continue;
             }
             if let DiffEntry::Active { value, loc, .. } = entry {
-                let op = match m.try_read_cached(*loc, &[]) {
-                    Some(op) => op,
-                    None => reader.read(**loc).await?,
-                };
+                let op = m.read_op(*loc, &[], &reader).await?;
                 let data = match op {
                     Operation::Update(data) => data,
                     _ => unreachable!("ancestor diff Active should reference Update op"),
@@ -1737,6 +1755,36 @@ mod tests {
                     Operation::Update(update::Unordered(key_current, value_current)),
                 ]
             );
+
+            // read_op: single-location reads across all three sources.
+            let reader = db.log.reader().await;
+            let disk_op = merkleizer
+                .read_op(committed_loc, &batch_ops, &reader)
+                .await
+                .unwrap();
+            assert_eq!(
+                disk_op,
+                Operation::Update(update::Unordered(key_db, value_db))
+            );
+
+            let ancestor_op = merkleizer
+                .read_op(parent_loc, &batch_ops, &reader)
+                .await
+                .unwrap();
+            assert_eq!(
+                ancestor_op,
+                Operation::Update(update::Unordered(key_parent, value_parent))
+            );
+
+            let current_op = merkleizer
+                .read_op(current_loc, &batch_ops, &reader)
+                .await
+                .unwrap();
+            assert_eq!(
+                current_op,
+                Operation::Update(update::Unordered(key_current, value_current))
+            );
+            drop(reader);
 
             db.destroy().await.unwrap();
         });


### PR DESCRIPTION
## Summary                                                                                                                                                                           
                                         
  Adds a synchronous page-cache fast path to batch merkleization reads, avoiding async overhead when data is already cached.                                                           
                                                                                                                                                                                       
  During `merkleize`, the batch reads existing operations from the journal to generate mutation ops and raise the inactivity floor. Previously, all committed-journal reads went through the async `reader.read()` path, creating futures even when the data was sitting in the page cache. This adds a `try_read_cached` method that attempts a fully synchronous read through the page cache before falling back to async I/O.                                                                                                                        
                                                            
  ### Changes                                                                                                                                                                          
  
  - **`runtime/buffer/paged/append.rs`**: Add `Append::try_read_cached` — sync page-cache-only blob read.                                                                              
  - **`journal/segmented/fixed.rs`**: Add `SegmentedJournal::try_get_cached` — sync cache-only item decode.
  - **`journal/contiguous/fixed.rs`**: Add `Inner::try_read_cached` and implement `Reader::try_read_cached`.                                                                           
  - **`journal/contiguous/mod.rs`**: Add `try_read_cached` to the `Reader` trait with a default `None`.                                                                                
  - **`qmdb/any/batch.rs`**: `read_ops` and the floor-raise loop now check batch/ancestor memory, then the journal page cache, before building `try_join_all` for remaining misses.    
                                                                                                                                                                                       
  ### Result                                                                                                                                                                           
                                                                                                                                                                                       
  When the working set fits in the page cache (the common case for merkleize benchmarks), all reads resolve synchronously — no futures created, no async state machines, no yield points. Cache misses still run concurrently via `try_join_all`.