### PR TITLE
[storage/qmdb] Batch reads in floor raising with page-cache fast path (Rebased on main)

### DIFF
--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -403,12 +403,11 @@ impl<B: Blob> Append<B> {
         Some(buffer.size())
     }
 
-    /// Try to read from the page cache only into the provided buffer.
+    /// Read into `buf` if it can be done synchronously (e.g. without I/O), returning `false` otherwise.
     ///
-    /// Returns `true` if all `buf.len()` bytes were in the cache, `false` on any
-    /// cache miss. Does not perform any async I/O. The caller must have already
-    /// validated that `offset + buf.len()` is within the blob's logical size.
-    pub fn try_read_cached(&self, offset: u64, buf: &mut [u8]) -> bool {
+    /// Returns `true` only if all `buf.len()` bytes were satisfied. The caller must have
+    /// already validated that `offset + buf.len()` is within the blob's logical size.
+    pub fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
         self.cache_ref.read_cached(self.id, buf, offset) == buf.len()
     }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -394,6 +394,24 @@ impl<B: Blob> Append<B> {
         buffer.size()
     }
 
+    /// Returns the logical size of the blob if it can be observed without waiting.
+    ///
+    /// This is useful for opportunistic fast paths that should fall back rather than contend with
+    /// concurrent writers.
+    pub fn try_size(&self) -> Option<u64> {
+        let buffer = self.buffer.try_read().ok()?;
+        Some(buffer.size())
+    }
+
+    /// Try to read from the page cache only into the provided buffer.
+    ///
+    /// Returns `true` if all `buf.len()` bytes were in the cache, `false` on any
+    /// cache miss. Does not perform any async I/O. The caller must have already
+    /// validated that `offset + buf.len()` is within the blob's logical size.
+    pub fn try_read_cached(&self, offset: u64, buf: &mut [u8]) -> bool {
+        self.cache_ref.read_cached(self.id, buf, offset) == buf.len()
+    }
+
     /// Read exactly `len` immutable bytes starting at `offset`.
     pub async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, Error> {
         // Read into a temporary contiguous buffer and copy back to preserve structure.

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -155,6 +155,18 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
                 }
             })
     }
+
+    /// Try to read an item from the page cache only. Returns `None` on cache miss.
+    fn try_read_cached(&self, pos: u64, items_per_blob: u64) -> Option<A> {
+        if pos >= self.size || pos < self.pruning_boundary {
+            return None;
+        }
+        let section = pos / items_per_blob;
+        let section_start = section * items_per_blob;
+        let first_in_section = self.pruning_boundary.max(section_start);
+        let pos_in_section = pos - first_in_section;
+        self.journal.try_get_cached(section, pos_in_section)
+    }
 }
 
 /// Implementation of `Journal` storage.
@@ -197,6 +209,10 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
 
     async fn read(&self, pos: u64) -> Result<A, Error> {
         self.guard.read(pos, self.items_per_blob).await
+    }
+
+    fn try_read_cached(&self, pos: u64) -> Option<A> {
+        self.guard.try_read_cached(pos, self.items_per_blob)
     }
 
     async fn replay(

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -156,8 +156,8 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             })
     }
 
-    /// Try to read an item from the page cache only. Returns `None` on cache miss.
-    fn try_read_cached(&self, pos: u64, items_per_blob: u64) -> Option<A> {
+    /// Read an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
+    fn try_read_sync(&self, pos: u64, items_per_blob: u64) -> Option<A> {
         if pos >= self.size || pos < self.pruning_boundary {
             return None;
         }
@@ -165,7 +165,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         let section_start = section * items_per_blob;
         let first_in_section = self.pruning_boundary.max(section_start);
         let pos_in_section = pos - first_in_section;
-        self.journal.try_get_cached(section, pos_in_section)
+        self.journal.try_get_sync(section, pos_in_section)
     }
 }
 
@@ -211,8 +211,8 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         self.guard.read(pos, self.items_per_blob).await
     }
 
-    fn try_read_cached(&self, pos: u64) -> Option<A> {
-        self.guard.try_read_cached(pos, self.items_per_blob)
+    fn try_read_sync(&self, pos: u64) -> Option<A> {
+        self.guard.try_read_sync(pos, self.items_per_blob)
     }
 
     async fn replay(

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -35,10 +35,10 @@ pub trait Reader: Send + Sync {
     /// Guaranteed not to return [Error::ItemPruned] for positions within `bounds()`.
     fn read(&self, position: u64) -> impl Future<Output = Result<Self::Item, Error>> + Send;
 
-    /// Try to read an item from the page cache only, without async I/O.
+    /// Try to read an item from cache (without async I/O).
     ///
-    /// Returns `Some(item)` if all data was in cache, `None` on any miss.
-    /// The default returns `None` (no cache available).
+    /// Returns `Some(item)` if all data was in cache, `None` on any miss. The
+    /// default returns `None` (no cache available).
     fn try_read_cached(&self, _position: u64) -> Option<Self::Item> {
         None
     }

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -35,6 +35,14 @@ pub trait Reader: Send + Sync {
     /// Guaranteed not to return [Error::ItemPruned] for positions within `bounds()`.
     fn read(&self, position: u64) -> impl Future<Output = Result<Self::Item, Error>> + Send;
 
+    /// Try to read an item from the page cache only, without async I/O.
+    ///
+    /// Returns `Some(item)` if all data was in cache, `None` on any miss.
+    /// The default returns `None` (no cache available).
+    fn try_read_cached(&self, _position: u64) -> Option<Self::Item> {
+        None
+    }
+
     /// Return a stream of all items starting from `start_pos`.
     ///
     /// Because the reader holds the lock, validation and stream setup happen

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -35,11 +35,10 @@ pub trait Reader: Send + Sync {
     /// Guaranteed not to return [Error::ItemPruned] for positions within `bounds()`.
     fn read(&self, position: u64) -> impl Future<Output = Result<Self::Item, Error>> + Send;
 
-    /// Try to read an item from cache (without async I/O).
+    /// Read an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
     ///
-    /// Returns `Some(item)` if all data was in cache, `None` on any miss. The
-    /// default returns `None` (no cache available).
-    fn try_read_cached(&self, _position: u64) -> Option<Self::Item> {
+    /// Default implementation always returns `None`.
+    fn try_read_sync(&self, _position: u64) -> Option<Self::Item> {
         None
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -146,8 +146,8 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         self.data.get(section, offset).await
     }
 
-    /// Try to read an item from the page cache only. Returns `None` on cache miss.
-    fn try_read_cached(
+    /// Read an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
+    fn try_read_sync(
         &self,
         position: u64,
         items_per_section: u64,
@@ -156,9 +156,9 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         if position >= self.size || position < self.pruning_boundary {
             return None;
         }
-        let offset = offsets.try_read_cached(position)?;
+        let offset = offsets.try_read_sync(position)?;
         let section = position_to_section(position, items_per_section);
-        self.data.try_get_cached(section, offset)
+        self.data.try_get_sync(section, offset)
     }
 }
 
@@ -242,9 +242,9 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<'_, E, V> {
             .await
     }
 
-    fn try_read_cached(&self, position: u64) -> Option<V> {
+    fn try_read_sync(&self, position: u64) -> Option<V> {
         self.guard
-            .try_read_cached(position, self.items_per_section, &self.offsets)
+            .try_read_sync(position, self.items_per_section, &self.offsets)
     }
 
     async fn replay(

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -145,6 +145,21 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 
         self.data.get(section, offset).await
     }
+
+    /// Try to read an item from the page cache only. Returns `None` on cache miss.
+    fn try_read_cached(
+        &self,
+        position: u64,
+        items_per_section: u64,
+        offsets: &impl super::Reader<Item = u64>,
+    ) -> Option<V> {
+        if position >= self.size || position < self.pruning_boundary {
+            return None;
+        }
+        let offset = offsets.try_read_cached(position)?;
+        let section = position_to_section(position, items_per_section);
+        self.data.try_get_cached(section, offset)
+    }
 }
 
 /// A contiguous journal with variable-size entries.
@@ -225,6 +240,11 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<'_, E, V> {
         self.guard
             .read(position, self.items_per_section, &self.offsets)
             .await
+    }
+
+    fn try_read_cached(&self, position: u64) -> Option<V> {
+        self.guard
+            .try_read_cached(position, self.items_per_section, &self.offsets)
     }
 
     async fn replay(

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -181,9 +181,8 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         A::decode(buf.coalesce()).map_err(Error::Codec)
     }
 
-    /// Try to read an item using only the page cache. Returns `None` on any cache miss
-    /// or if the position cannot be verified as in-bounds without blocking.
-    pub fn try_get_cached(&self, section: u64, position: u64) -> Option<A> {
+    /// Get an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
+    pub fn try_get_sync(&self, section: u64, position: u64) -> Option<A> {
         let blob = self.manager.get(section).ok()??;
         let offset = position.checked_mul(Self::CHUNK_SIZE_U64)?;
         let remaining = blob.try_size()?.checked_sub(offset)?;
@@ -191,7 +190,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
             return None;
         }
         let mut buf = vec![0u8; Self::CHUNK_SIZE];
-        if !blob.try_read_cached(offset, &mut buf) {
+        if !blob.try_read_sync(offset, &mut buf) {
             return None;
         }
         A::decode(&buf[..]).ok()

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -181,6 +181,22 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         A::decode(buf.coalesce()).map_err(Error::Codec)
     }
 
+    /// Try to read an item using only the page cache. Returns `None` on any cache miss
+    /// or if the position cannot be verified as in-bounds without blocking.
+    pub fn try_get_cached(&self, section: u64, position: u64) -> Option<A> {
+        let blob = self.manager.get(section).ok()??;
+        let offset = position.checked_mul(Self::CHUNK_SIZE_U64)?;
+        let remaining = blob.try_size()?.checked_sub(offset)?;
+        if remaining < Self::CHUNK_SIZE_U64 {
+            return None;
+        }
+        let mut buf = vec![0u8; Self::CHUNK_SIZE];
+        if !blob.try_read_cached(offset, &mut buf) {
+            return None;
+        }
+        A::decode(&buf[..]).ok()
+    }
+
     /// Read the last item in a section, if any.
     ///
     /// Returns `Ok(None)` if the section is empty.

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -580,9 +580,8 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         Ok(item)
     }
 
-    /// Try to read an item using only the page cache. Returns `None` on any cache miss
-    /// or if the position cannot be verified as in-bounds without blocking.
-    pub fn try_get_cached(&self, section: u64, offset: u64) -> Option<V> {
+    /// Get an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
+    pub fn try_get_sync(&self, section: u64, offset: u64) -> Option<V> {
         let blob = self.manager.get(section).ok()??;
         let remaining = blob.try_size()?.checked_sub(offset)?;
         let header_len = usize::try_from(remaining.min(MAX_U32_VARINT_SIZE as u64)).ok()?;
@@ -592,7 +591,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
 
         // Read the varint header to determine item size.
         let mut header = [0u8; MAX_U32_VARINT_SIZE];
-        if !blob.try_read_cached(offset, &mut header[..header_len]) {
+        if !blob.try_read_sync(offset, &mut header[..header_len]) {
             return None;
         }
         let mut cursor = Cursor::new(&header[..header_len]);
@@ -626,7 +625,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
 
         // Otherwise try reading the full item from cache.
         let mut full = vec![0u8; item_len];
-        if !blob.try_read_cached(offset, &mut full) {
+        if !blob.try_read_sync(offset, &mut full) {
             return None;
         }
         decode_item::<V>(

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -580,6 +580,63 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         Ok(item)
     }
 
+    /// Try to read an item using only the page cache. Returns `None` on any cache miss
+    /// or if the position cannot be verified as in-bounds without blocking.
+    pub fn try_get_cached(&self, section: u64, offset: u64) -> Option<V> {
+        let blob = self.manager.get(section).ok()??;
+        let remaining = blob.try_size()?.checked_sub(offset)?;
+        let header_len = usize::try_from(remaining.min(MAX_U32_VARINT_SIZE as u64)).ok()?;
+        if header_len == 0 {
+            return None;
+        }
+
+        // Read the varint header to determine item size.
+        let mut header = [0u8; MAX_U32_VARINT_SIZE];
+        if !blob.try_read_cached(offset, &mut header[..header_len]) {
+            return None;
+        }
+        let mut cursor = Cursor::new(&header[..header_len]);
+        let (_, item_info) = find_item(&mut cursor, offset).ok()?;
+
+        let (varint_len, data_len) = match item_info {
+            ItemInfo::Complete {
+                varint_len,
+                data_len,
+            } => (varint_len, data_len),
+            ItemInfo::Incomplete {
+                varint_len,
+                total_len,
+                ..
+            } => (varint_len, total_len),
+        };
+        let item_len = varint_len.checked_add(data_len)?;
+        if item_len > usize::try_from(remaining).ok()? {
+            return None;
+        }
+
+        // If the full item fits in the header read, decode directly.
+        if item_len <= header_len {
+            return decode_item::<V>(
+                &header[varint_len..varint_len + data_len],
+                &self.codec_config,
+                self.compression.is_some(),
+            )
+            .ok();
+        }
+
+        // Otherwise try reading the full item from cache.
+        let mut full = vec![0u8; item_len];
+        if !blob.try_read_cached(offset, &mut full) {
+            return None;
+        }
+        decode_item::<V>(
+            &full[varint_len..varint_len + data_len],
+            &self.codec_config,
+            self.compression.is_some(),
+        )
+        .ok()
+    }
+
     /// Gets the size of the journal for a specific section.
     ///
     /// Returns 0 if the section does not exist.

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -957,30 +957,26 @@ where
         let locations = m.gather_existing_locations(&mutations, db, true);
         let reader = db.log.reader().await;
 
-        // Read and unwrap Update operations (snapshot only references Updates).
-        let update_results: Vec<_> = m
-            .read_ops(&locations, &[], &reader)
-            .await?
-            .into_iter()
-            .map(|op| match op {
-                Operation::Update(data) => data,
-                _ => unreachable!("snapshot should only reference Update operations"),
-            })
-            .collect();
-
         // Classify mutations into deleted, created, updated.
         let mut next_candidates: BTreeSet<K> = BTreeSet::new();
         let mut prev_candidates: BTreeMap<K, (V::Value, Location<F>)> = BTreeMap::new();
-
         let mut deleted: BTreeMap<K, Location<F>> = BTreeMap::new();
         let mut updated: BTreeMap<K, (V::Value, Location<F>)> = BTreeMap::new();
 
-        for (key_data, &old_loc) in update_results.into_iter().zip(&locations) {
+        for (op, &old_loc) in m
+            .read_ops(&locations, &[], &reader)
+            .await?
+            .into_iter()
+            .zip(&locations)
+        {
             let update::Ordered {
                 key,
                 value,
                 next_key,
-            } = key_data;
+            } = match op {
+                Operation::Update(data) => data,
+                _ => unreachable!("snapshot should only reference Update operations"),
+            };
             next_candidates.insert(next_key);
 
             let mutation = mutations.remove(&key);

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -30,6 +30,9 @@ use std::{
 };
 use tracing::debug;
 
+/// Maximum number of journal reads to issue concurrently during floor raising.
+const MAX_CONCURRENT_READS: u64 = 64;
+
 /// Strategy for finding the next active location during floor raising.
 pub(crate) trait FloorScan<F: Family> {
     /// Return the next location at or after `floor` that might be active,
@@ -338,7 +341,29 @@ where
     H: Hasher,
     Operation<F, U>: Codec,
 {
-    /// Read an operation at a given location from the correct source.
+    /// Sync cache check: resolve from this batch's ops or the ancestor chain.
+    /// Returns `None` for committed-journal locations that need disk I/O.
+    fn try_read_cached(
+        &self,
+        loc: Location<F>,
+        batch_ops: &[Operation<F, U>],
+    ) -> Option<Operation<F, U>> {
+        let loc = *loc;
+
+        if loc >= self.base_size {
+            return Some(batch_ops[(loc - self.base_size) as usize].clone());
+        }
+
+        if loc >= self.db_size {
+            return Some(
+                read_chain_item_from_ancestors(&self.ancestors, loc, self.db_size).clone(),
+            );
+        }
+
+        None
+    }
+
+    /// Read a single operation by location.
     ///
     /// The operation space is divided into three contiguous regions:
     ///
@@ -347,35 +372,62 @@ where
     ///   committed (on disk)     ancestors (in mem)          this batch (in mem)
     /// ```
     ///
-    /// `db_size` here is the Merkleizer's effective boundary between disk and in-memory
-    /// ancestors. It equals the original DB size when the full ancestor chain is alive, or a
-    /// higher value if ancestors were freed (see `into_parts`).
+    /// `db_size` is the boundary between disk and in-memory ancestors. It equals the
+    /// original DB size when the full ancestor chain is alive, or a higher value if
+    /// ancestors were freed (see `into_parts`).
     ///
-    /// For top-level batches, the ancestor region is empty (`db_size == base_size`).
-    async fn read_op<E, C, I>(
+    /// For batches created directly from the DB (no uncommitted ancestors),
+    /// the ancestor region is empty (`db_size == base_size`).
+    ///
+    /// In-memory locations are resolved synchronously. Only committed-journal locations
+    /// await the `reader`.
+    async fn read_op<R: Reader<Item = Operation<F, U>>>(
         &self,
         loc: Location<F>,
-        current_ops: &[Operation<F, U>],
-        db: &Db<F, E, C, I, H, U>,
-    ) -> Result<Operation<F, U>, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        let loc_val = *loc;
-
-        if loc_val >= self.base_size {
-            // This batch's own operations (user mutations, or earlier floor-raise ops).
-            Ok(current_ops[(loc_val - self.base_size) as usize].clone())
-        } else if loc_val >= self.db_size {
-            // Parent batch chain's operations (in-memory). Walk the ancestors.
-            Ok(read_chain_item_from_ancestors(&self.ancestors, loc_val, self.db_size).clone())
-        } else {
-            // Base DB's journal (on-disk async read).
-            let reader = db.log.reader().await;
-            Ok(reader.read(loc_val).await?)
+        batch_ops: &[Operation<F, U>],
+        reader: &R,
+    ) -> Result<Operation<F, U>, crate::qmdb::Error<F>> {
+        match self.try_read_cached(loc, batch_ops) {
+            Some(op) => Ok(op),
+            None => Ok(reader.read(*loc).await?),
         }
+    }
+
+    /// Read multiple operations by location.
+    ///
+    /// In-memory locations are resolved synchronously. Remaining disk locations
+    /// are read concurrently via `try_join_all` on the provided `reader`.
+    async fn read_ops<R: Reader<Item = Operation<F, U>>>(
+        &self,
+        locations: &[Location<F>],
+        batch_ops: &[Operation<F, U>],
+        reader: &R,
+    ) -> Result<Vec<Operation<F, U>>, crate::qmdb::Error<F>> {
+        // Resolve hits synchronously: batch/ancestor first, then journal page cache.
+        let results: Vec<Option<Operation<F, U>>> = locations
+            .iter()
+            .map(|loc| {
+                self.try_read_cached(*loc, batch_ops)
+                    .or_else(|| reader.try_read_cached(**loc))
+            })
+            .collect();
+
+        // Batch-read disk misses concurrently.
+        let disk_results = try_join_all(
+            locations
+                .iter()
+                .zip(results.iter())
+                .filter(|(_, cached)| cached.is_none())
+                .map(|(loc, _)| reader.read(**loc)),
+        )
+        .await?;
+
+        // Merge disk results back in order.
+        let mut disk_iter = disk_results.into_iter();
+        Ok(results
+            .into_iter()
+            .map(|r| r.unwrap_or_else(|| disk_iter.next().expect("disk result count mismatch")))
+            .collect())
     }
 
     /// Gather existing-key locations for all keys in `mutations`.
@@ -484,61 +536,10 @@ where
         creates
     }
 
-    /// Scan forward from `floor` to find the next active operation, re-append it at the tip.
-    /// The `scan` parameter controls which locations are considered as potentially active,
-    /// allowing implementations to skip locations known to be inactive without reading them.
-    /// Returns `true` if an active op was found and moved, `false` if the floor reached
-    /// `fixed_tip`.
-    async fn advance_floor_once<E, C, I, S: FloorScan<F>>(
-        &self,
-        floor: &mut Location<F>,
-        fixed_tip: u64,
-        ops: &mut Vec<Operation<F, U>>,
-        diff: &mut BTreeMap<U::Key, DiffEntry<F, U::Value>>,
-        scan: &mut S,
-        db: &Db<F, E, C, I, H, U>,
-    ) -> Result<bool, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        loop {
-            let Some(candidate) = scan.next_candidate(*floor, fixed_tip) else {
-                return Ok(false);
-            };
-            *floor = Location::new(*candidate + 1);
-
-            let op = self.read_op(candidate, ops, db).await?;
-            let Some(key) = op.key().cloned() else {
-                continue; // skip CommitFloor and other non-keyed ops
-            };
-
-            if self.is_active_at(&key, candidate, diff, db) {
-                let new_loc = Location::new(self.base_size + ops.len() as u64);
-                let base_old_loc = diff
-                    .get(&key)
-                    .or_else(|| resolve_in_ancestors(&self.ancestors, &key))
-                    .map_or(Some(candidate), DiffEntry::base_old_loc);
-                let value = extract_update_value(&op);
-                ops.push(op);
-                diff.insert(
-                    key,
-                    DiffEntry::Active {
-                        value,
-                        loc: new_loc,
-                        base_old_loc,
-                    },
-                );
-                return Ok(true);
-            }
-        }
-    }
-
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
-    async fn finish<E, C, I, S: FloorScan<F>>(
+    async fn finish<E, C, I, S, R>(
         self,
         mut ops: Vec<Operation<F, U>>,
         mut diff: BTreeMap<U::Key, DiffEntry<F, U::Value>>,
@@ -546,12 +547,15 @@ where
         user_steps: u64,
         metadata: Option<U::Value>,
         mut scan: S,
+        reader: R,
         db: &Db<F, E, C, I, H, U>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U>>, crate::qmdb::Error<F>>
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>>,
+        S: FloorScan<F>,
+        R: Reader<Item = Operation<F, U>>,
     {
         // Floor raise.
         // Steps = user_steps + 1 (+1 for previous commit becoming inactive).
@@ -560,16 +564,79 @@ where
         let mut floor = self.base_inactivity_floor_loc;
 
         if total_active_keys > 0 {
-            // Floor raise: advance the inactivity floor by `total_steps` active
-            // operations. `fixed_tip` prevents scanning into floor-raise moves
-            // just appended, matching `raise_floor_with_bitmap()` semantics.
+            // Floor raise: advance the inactivity floor by `total_steps` active operations.
+            // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let fixed_tip = self.base_size + ops.len() as u64;
-            for _ in 0..total_steps {
-                if !self
-                    .advance_floor_once(&mut floor, fixed_tip, &mut ops, &mut diff, &mut scan, db)
-                    .await?
-                {
+            let mut moved = 0u64;
+            let mut scan_from = floor;
+
+            while moved < total_steps {
+                // Collect candidates, capped by the number of active ops still needed.
+                // `scan_from` tracks prefetch progress separately from `floor`, so
+                // early exit cannot leave `floor` past unprocessed candidates.
+                let limit = ((total_steps - moved) as usize).min(MAX_CONCURRENT_READS as usize);
+                let mut candidates = Vec::with_capacity(limit);
+                while candidates.len() < limit {
+                    let Some(candidate) = scan.next_candidate(scan_from, fixed_tip) else {
+                        break;
+                    };
+                    candidates.push(candidate);
+                    scan_from = Location::new(*candidate + 1);
+                }
+                if candidates.is_empty() {
                     break;
+                }
+
+                // Resolve cached candidates synchronously: batch/ancestor then page cache.
+                let cached: Vec<Option<Operation<F, U>>> = candidates
+                    .iter()
+                    .map(|c| {
+                        self.try_read_cached(*c, &ops)
+                            .or_else(|| reader.try_read_cached(**c))
+                    })
+                    .collect();
+
+                // Batch-read disk misses concurrently.
+                let disk_results = try_join_all(
+                    candidates
+                        .iter()
+                        .zip(cached.iter())
+                        .filter(|(_, c)| c.is_none())
+                        .map(|(loc, _)| reader.read(**loc)),
+                )
+                .await?;
+
+                // Process results in order, moving active ops to the tip.
+                let mut disk_iter = disk_results.into_iter();
+                for (candidate, cached_op) in candidates.into_iter().zip(cached) {
+                    let op = cached_op
+                        .unwrap_or_else(|| disk_iter.next().expect("disk result count mismatch"));
+                    floor = Location::new(*candidate + 1);
+                    let Some(key) = op.key().cloned() else {
+                        continue; // skip CommitFloor and other non-keyed ops
+                    };
+                    if !self.is_active_at(&key, candidate, &diff, db) {
+                        continue;
+                    }
+                    let new_loc = Location::new(self.base_size + ops.len() as u64);
+                    let base_old_loc = diff
+                        .get(&key)
+                        .or_else(|| resolve_in_ancestors(&self.ancestors, &key))
+                        .map_or(Some(candidate), DiffEntry::base_old_loc);
+                    let value = extract_update_value(&op);
+                    ops.push(op);
+                    diff.insert(
+                        key,
+                        DiffEntry::Active {
+                            value,
+                            loc: new_loc,
+                            base_old_loc,
+                        },
+                    );
+                    moved += 1;
+                    if moved >= total_steps {
+                        break;
+                    }
                 }
             }
         } else {
@@ -577,6 +644,10 @@ where
             floor = Location::new(self.base_size + ops.len() as u64);
             debug!(tip = ?floor, "db is empty, raising floor to tip");
         }
+
+        // Release the reader guard before CPU-only work (merkleization) so
+        // concurrent writers are not blocked.
+        drop(reader);
 
         // CommitFloor operation.
         let commit_loc = Location::new(self.base_size + ops.len() as u64);
@@ -639,7 +710,7 @@ where
         // oldest alive ancestor's items don't start at db_size. Example: chain A -> B -> C,
         // A committed and dropped. ancestors() yields [B] (A's Weak is dead). B's items start
         // at A.size(), not db_size. We use the journal (strong Arcs, always intact) to compute
-        // the actual base so read_op falls through to disk for locations in the gap.
+        // the actual base so reads fall through to disk for locations in the gap.
         let db_size = self.base.db_size();
         let effective_db_size = ancestors.last().map_or(db_size, |oldest| {
             let oldest_base =
@@ -733,10 +804,10 @@ where
     {
         let (mut mutations, m) = self.into_parts();
 
-        // Resolve existing keys (async I/O, parallelized).
+        // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, false);
-        let futures = locations.iter().map(|&loc| m.read_op(loc, &[], db));
-        let results = try_join_all(futures).await?;
+        let reader = db.log.reader().await;
+        let results = m.read_ops(&locations, &[], &reader).await?;
 
         // Generate user mutation operations.
         let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
@@ -835,8 +906,17 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
-            .await
+        m.finish(
+            ops,
+            diff,
+            active_keys_delta,
+            user_steps,
+            metadata,
+            scan,
+            reader,
+            db,
+        )
+        .await
     }
 }
 
@@ -878,12 +958,13 @@ where
     {
         let (mut mutations, m) = self.into_parts();
 
-        // Resolve existing keys (async I/O).
+        // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);
+        let reader = db.log.reader().await;
 
         // Read and unwrap Update operations (snapshot only references Updates).
-        let futures = locations.iter().map(|&loc| m.read_op(loc, &[], db));
-        let update_results: Vec<_> = try_join_all(futures)
+        let update_results: Vec<_> = m
+            .read_ops(&locations, &[], &reader)
             .await?
             .into_iter()
             .map(|op| match op {
@@ -957,11 +1038,7 @@ where
         prev_locations.sort();
         prev_locations.dedup();
 
-        let prev_results = {
-            let reader = db.log.reader().await;
-            let futures = prev_locations.iter().map(|loc| reader.read(**loc));
-            try_join_all(futures).await?
-        };
+        let prev_results = m.read_ops(&prev_locations, &[], &reader).await?;
 
         for (op, &old_loc) in prev_results.into_iter().zip(&prev_locations) {
             let data = match op {
@@ -995,7 +1072,7 @@ where
                 continue;
             }
             if let DiffEntry::Active { value, loc, .. } = entry {
-                let op: Operation<F, update::Ordered<K, V>> = m.read_op(*loc, &[], db).await?;
+                let op = m.read_op(*loc, &[], &reader).await?;
                 let data = match op {
                     Operation::Update(data) => data,
                     _ => unreachable!("ancestor diff Active should reference Update op"),
@@ -1121,8 +1198,17 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(ops, diff, active_keys_delta, user_steps, metadata, scan, db)
-            .await
+        m.finish(
+            ops,
+            diff,
+            active_keys_delta,
+            user_steps,
+            metadata,
+            scan,
+            reader,
+            db,
+        )
+        .await
     }
 }
 
@@ -1592,6 +1678,117 @@ mod tests {
         // Mutation unchanged.
         assert_eq!(mutations.len(), 1);
         assert!(mutations.contains_key(&1));
+    }
+
+    #[test]
+    fn read_ops_resolves_committed_ancestor_and_current_sources() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = UnorderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+            >;
+
+            let config = fixed_db_config::<OneCap>("read-locations-all-sources", &context);
+            let mut db = TestDb::init(context, config).await.unwrap();
+
+            let key_db = colliding_digest(0x30, 0);
+            let value_db = colliding_digest(0x30, 1);
+            let key_parent = colliding_digest(0x31, 0);
+            let value_parent = colliding_digest(0x31, 1);
+            let key_current = colliding_digest(0x32, 0);
+            let value_current = colliding_digest(0x32, 1);
+
+            // Commit one key to the DB so it's on disk.
+            let seed = db
+                .new_batch()
+                .write(key_db, Some(value_db))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            let committed_loc = db.snapshot.get(&key_db).next().copied().unwrap();
+
+            // Create a parent batch with a second key (in-memory ancestor).
+            let parent = db
+                .new_batch()
+                .write(key_parent, Some(value_parent))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let parent_loc = parent.diff.get(&key_parent).unwrap().loc().unwrap();
+
+            // Create a child batch with a third key (current ops).
+            let child = parent
+                .new_batch::<Sha256>()
+                .write(key_current, Some(value_current));
+            let (_mutations, merkleizer) = child.into_parts();
+
+            let current_loc = Location::new(merkleizer.base_size);
+            let batch_ops = vec![Operation::Update(update::Unordered(
+                key_current,
+                value_current,
+            ))];
+
+            // read_ops should resolve all three sources correctly.
+            let reader = db.log.reader().await;
+            let ops = merkleizer
+                .read_ops(
+                    &[committed_loc, parent_loc, current_loc],
+                    &batch_ops,
+                    &reader,
+                )
+                .await
+                .unwrap();
+            drop(reader);
+
+            assert_eq!(
+                ops,
+                vec![
+                    Operation::Update(update::Unordered(key_db, value_db)),
+                    Operation::Update(update::Unordered(key_parent, value_parent)),
+                    Operation::Update(update::Unordered(key_current, value_current)),
+                ]
+            );
+
+            // read_op: single-location reads across all three sources.
+            let reader = db.log.reader().await;
+            let disk_op = merkleizer
+                .read_op(committed_loc, &batch_ops, &reader)
+                .await
+                .unwrap();
+            assert_eq!(
+                disk_op,
+                Operation::Update(update::Unordered(key_db, value_db))
+            );
+
+            let ancestor_op = merkleizer
+                .read_op(parent_loc, &batch_ops, &reader)
+                .await
+                .unwrap();
+            assert_eq!(
+                ancestor_op,
+                Operation::Update(update::Unordered(key_parent, value_parent))
+            );
+
+            let current_op = merkleizer
+                .read_op(current_loc, &batch_ops, &reader)
+                .await
+                .unwrap();
+            assert_eq!(
+                current_op,
+                Operation::Update(update::Unordered(key_current, value_current))
+            );
+            drop(reader);
+
+            db.destroy().await.unwrap();
+        });
     }
 
     #[test]

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -308,11 +308,15 @@ fn apply_snapshot_diff<F: Family, V, I: UnorderedIndex<Value = Location<F>>>(
     }
 }
 
-/// Read a single operation item from the ancestor chain at the given location.
+/// Resolve `loc` to an op within the in-memory ancestor region
+/// `[db_size, ancestors[0].journal_batch.size())`, walked parent-first.
 ///
-/// `db_size` is the number of committed operations in the DB. The location must be in
-/// `[db_size, tip)` where `tip = ancestors[0].journal_batch.size()`.
-fn read_chain_item_from_ancestors<F: Family, D: Digest, U: update::Update + Send + Sync>(
+/// # Panics
+///
+/// Panics if `loc` cannot be located in the chain: either it falls outside the region (including
+/// when `ancestors` is empty), or the ancestor spans are non-contiguous (a bookkeeping invariant
+/// violation).
+fn read_op_from_ancestors<F: Family, D: Digest, U: update::Update + Send + Sync>(
     ancestors: &[Arc<MerkleizedBatch<F, D, U>>],
     loc: u64,
     db_size: u64,
@@ -335,15 +339,37 @@ where
     unreachable!("location {loc} not found in ancestor chain (db_size={db_size})")
 }
 
+/// Read helpers on [`Merkleizer`].
+///
+/// # Operation-location model
+///
+/// The operation space is divided into three contiguous regions:
+///
+/// ```text
+///  [0 ........... db_size)  [db_size ..... base_size)  [base_size .. base_size+len)
+///   committed (on disk)     ancestors (in mem)          this batch (in mem)
+/// ```
+///
+/// `db_size` is the boundary between disk and in-memory ancestors. It equals the original DB size
+/// when the full ancestor chain is alive, or a higher value if ancestors were freed (see
+/// `into_parts`). For batches created directly from the DB (no uncommitted ancestors), the ancestor
+/// region is empty (`db_size == base_size`).
+///
+/// # Contract for all read methods
+///
+/// Callers must pass a `loc` that is a valid operation location: specifically `loc < base_size +
+/// batch_ops.len()` (i.e., within one of the three regions). Passing an out-of-range `loc` may
+/// panic (via `batch_ops` indexing or the ancestor-chain walk) or result in a disk-read error.
+/// In-memory locations are resolved synchronously; only disk locations await the `reader`.
 impl<F: Family, H, U> Merkleizer<F, H, U>
 where
     U: update::Update + Send + Sync,
     H: Hasher,
     Operation<F, U>: Codec,
 {
-    /// Sync cache check: resolve from this batch's ops or the ancestor chain.
-    /// Returns `None` for committed-journal locations that need disk I/O.
-    fn try_read_cached(
+    /// Returns `Some(op)` if `loc` falls in the batch or ancestor regions, and `None` when `loc` is
+    /// in the committed region (`loc < db_size`).
+    fn try_read_op_from_uncommitted(
         &self,
         loc: Location<F>,
         batch_ops: &[Operation<F, U>],
@@ -355,48 +381,38 @@ where
         }
 
         if loc >= self.db_size {
-            return Some(
-                read_chain_item_from_ancestors(&self.ancestors, loc, self.db_size).clone(),
-            );
+            return Some(read_op_from_ancestors(&self.ancestors, loc, self.db_size).clone());
         }
 
         None
     }
 
+    /// Resolve an operation by its location `loc` if it can be done synchronously (e.g. without
+    /// I/O), or return `None` otherwise.
+    fn try_read_op_sync<R: Reader<Item = Operation<F, U>>>(
+        &self,
+        loc: Location<F>,
+        batch_ops: &[Operation<F, U>],
+        reader: &R,
+    ) -> Option<Operation<F, U>> {
+        self.try_read_op_from_uncommitted(loc, batch_ops)
+            .or_else(|| reader.try_read_cached(*loc))
+    }
+
     /// Read a single operation by location.
-    ///
-    /// The operation space is divided into three contiguous regions:
-    ///
-    /// ```text
-    ///  [0 ........... db_size)  [db_size ..... base_size)  [base_size .. base_size+len)
-    ///   committed (on disk)     ancestors (in mem)          this batch (in mem)
-    /// ```
-    ///
-    /// `db_size` is the boundary between disk and in-memory ancestors. It equals the
-    /// original DB size when the full ancestor chain is alive, or a higher value if
-    /// ancestors were freed (see `into_parts`).
-    ///
-    /// For batches created directly from the DB (no uncommitted ancestors),
-    /// the ancestor region is empty (`db_size == base_size`).
-    ///
-    /// In-memory locations are resolved synchronously. Only committed-journal locations
-    /// await the `reader`.
     async fn read_op<R: Reader<Item = Operation<F, U>>>(
         &self,
         loc: Location<F>,
         batch_ops: &[Operation<F, U>],
         reader: &R,
     ) -> Result<Operation<F, U>, crate::qmdb::Error<F>> {
-        match self.try_read_cached(loc, batch_ops) {
+        match self.try_read_op_sync(loc, batch_ops, reader) {
             Some(op) => Ok(op),
             None => Ok(reader.read(*loc).await?),
         }
     }
 
     /// Read multiple operations by location.
-    ///
-    /// In-memory locations are resolved synchronously. Remaining disk locations
-    /// are read concurrently via `try_join_all` on the provided `reader`.
     async fn read_ops<R: Reader<Item = Operation<F, U>>>(
         &self,
         locations: &[Location<F>],
@@ -406,10 +422,7 @@ where
         // Resolve hits synchronously: batch/ancestor first, then journal page cache.
         let results: Vec<Option<Operation<F, U>>> = locations
             .iter()
-            .map(|loc| {
-                self.try_read_cached(*loc, batch_ops)
-                    .or_else(|| reader.try_read_cached(**loc))
-            })
+            .map(|loc| self.try_read_op_sync(*loc, batch_ops, reader))
             .collect();
 
         // Batch-read disk misses concurrently.
@@ -587,30 +600,12 @@ where
                     break;
                 }
 
-                // Resolve cached candidates synchronously: batch/ancestor then page cache.
-                let cached: Vec<Option<Operation<F, U>>> = candidates
-                    .iter()
-                    .map(|c| {
-                        self.try_read_cached(*c, &ops)
-                            .or_else(|| reader.try_read_cached(**c))
-                    })
-                    .collect();
-
-                // Batch-read disk misses concurrently.
-                let disk_results = try_join_all(
-                    candidates
-                        .iter()
-                        .zip(cached.iter())
-                        .filter(|(_, c)| c.is_none())
-                        .map(|(loc, _)| reader.read(**loc)),
-                )
-                .await?;
+                // Batch-read candidates: cache hits resolve synchronously, disk misses
+                // are fetched concurrently.
+                let resolved = self.read_ops(&candidates, &ops, &reader).await?;
 
                 // Process results in order, moving active ops to the tip.
-                let mut disk_iter = disk_results.into_iter();
-                for (candidate, cached_op) in candidates.into_iter().zip(cached) {
-                    let op = cached_op
-                        .unwrap_or_else(|| disk_iter.next().expect("disk result count mismatch"));
+                for (candidate, op) in candidates.into_iter().zip(resolved) {
                     floor = Location::new(*candidate + 1);
                     let Some(key) = op.key().cloned() else {
                         continue; // skip CommitFloor and other non-keyed ops

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -396,7 +396,7 @@ where
         reader: &R,
     ) -> Option<Operation<F, U>> {
         self.try_read_op_from_uncommitted(loc, batch_ops)
-            .or_else(|| reader.try_read_cached(*loc))
+            .or_else(|| reader.try_read_sync(*loc))
     }
 
     /// Read a single operation by location.


### PR DESCRIPTION
## Summary                                                                                                                                                                           
                                         
  Adds a synchronous page-cache fast path to batch merkleization reads, avoiding async overhead when data is already cached.                                                           
                                                                                                                                                                                       
  During `merkleize`, the batch reads existing operations from the journal to generate mutation ops and raise the inactivity floor. Previously, all committed-journal reads went through the async `reader.read()` path, creating futures even when the data was sitting in the page cache. This adds a `try_read_sync` method that attempts a fully synchronous read through the page cache before falling back to async I/O.                                                                                                                        
                                                            
  ### Changes                                                                                                                                                                          
  
  - **`runtime/buffer/paged/append.rs`**: Add `Append::try_read_sync` — sync page-cache-only blob read.                                                                              
  - **`journal/segmented/fixed.rs`**: Add `SegmentedJournal::try_get_sync` — sync cache-only item decode.
  - **`journal/contiguous/variable+fixed.rs`**: Add `Inner::try_read_sync` and implement `Reader::try_read_cached`.                                                                           
  - **`journal/contiguous/mod.rs`**: Add `try_read_sync` to the `Reader` trait with a default `None`.                                                                                
  - **`qmdb/any/batch.rs`**: `read_ops` and the floor-raise loop now check batch/ancestor memory, then the journal page cache, before building `try_join_all` for remaining misses.    

 ### Future Work

 Each cached read results in a vector allocation plus copy, and in the variable record case, may result in a vector being allocated then not used should the result not be cached.  Future work (e.g. https://github.com/commonwarexyz/monorepo/pull/3185) may allow us to remove or reduce this overhead which should yield significant additional performance gains.
                                                                                                                                                                                       
  ### Result                                                                                                                                                                           
                                                                                                                                                                                       
  When the working set fits in the page cache (the common case for merkleize benchmarks), all reads resolve synchronously — no futures created, no async state machines, no yield points. Cache misses still run concurrently via `try_join_all`.
  
  Performance on merkleize benchmark is ~20+% faster on fixed, 30% faster on variable.
  ```
qmdb_merkleize::merkleize/variant=any::unordered::fixed::mmr num_keys=1000000
                        time:   [119.02 ms 119.29 ms 119.59 ms]
                        change: [−21.912% −21.447% −21.004%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking qmdb_merkleize::merkleize/variant=any::unordered::variable::mmr num_keys=1000000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 11.3s.
qmdb_merkleize::merkleize/variant=any::unordered::variable::mmr num_keys=1000000
                        time:   [131.78 ms 133.61 ms 135.87 ms]
                        change: [−34.049% −33.047% −31.871%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

Benchmarking qmdb_merkleize::merkleize/variant=any::unordered::fixed::mmb num_keys=1000000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.0s.
qmdb_merkleize::merkleize/variant=any::unordered::fixed::mmb num_keys=1000000
                        time:   [117.36 ms 119.21 ms 120.96 ms]
                        change: [−22.366% −21.199% −19.961%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking qmdb_merkleize::merkleize/variant=any::unordered::variable::mmb num_keys=1000000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 10.8s.
qmdb_merkleize::merkleize/variant=any::unordered::variable::mmb num_keys=1000000
                        time:   [128.42 ms 130.63 ms 133.63 ms]
                        change: [−35.023% −33.817% −32.360%] (p = 0.00 < 0.05)
                        Performance has improved.
```