### PR TITLE
[consensus/simplex] Self-Verify Nits

### DIFF
--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -4147,7 +4147,6 @@ mod tests {
         no_self_propose_or_verify_after_restart(secp256r1::fixture);
     }
 
-
     /// After restart, a proposal we already voted on must not be re-verified
     /// when it is re-delivered to the voter (e.g. via the automaton after
     /// peer vote aggregation reconstructs it).

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -3728,6 +3728,424 @@ mod tests {
         no_recertification_after_replay::<_, _, RoundRobin>(secp256r1::fixture);
     }
 
+    /// When the voter is the leader of a view and builds its own proposal, it
+    /// must not subsequently ask the automaton to verify that same proposal.
+    ///
+    /// This is guarded by `Slot::built` (which sets `status = Verified` and
+    /// `requested_verify = true`) and by `Round::verify_ready` short-circuiting
+    /// for leader-owned views. This test asserts the end-to-end invariant on
+    /// the live path (no restart): after calling `automaton.propose`, the voter
+    /// must never call `automaton.verify` for the produced payload.
+    fn no_self_verify_when_proposing<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let quorum = quorum(n);
+        let namespace = b"no_self_verify_when_proposing".to_vec();
+        let partition = "no_self_verify_when_proposing".to_string();
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.clone(), participants.clone(), true).await;
+
+            // RoundRobin with epoch=333, n=5: view 2 -> leader=Participant::new(0) = us.
+            let target_view = View::new(2);
+            let me = participants[0].clone();
+            let elector = RoundRobin::<Sha256>::default();
+            let reporter_cfg = mocks::reporter::Config {
+                participants: participants.clone().try_into().unwrap(),
+                scheme: schemes[0].clone(),
+                elector: elector.clone(),
+            };
+            let reporter =
+                mocks::reporter::Reporter::new(context.with_label("reporter"), reporter_cfg);
+            let relay = Arc::new(mocks::relay::Relay::new());
+
+            // Install propose + verify observers from the start so we can assert the
+            // leader's propose call fires but no verify call is issued for our proposal.
+            let propose_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let verify_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let propose_tracker = propose_calls.clone();
+            let verify_tracker = verify_calls.clone();
+            let app_cfg = mocks::application::Config {
+                hasher: Sha256::default(),
+                relay: relay.clone(),
+                me: me.clone(),
+                propose_latency: (1.0, 0.0),
+                verify_latency: (1.0, 0.0),
+                certify_latency: (1.0, 0.0),
+                should_certify: mocks::application::Certifier::Always,
+            };
+            let (mut app_actor, application) =
+                mocks::application::Application::new(context.with_label("app"), app_cfg);
+            app_actor
+                .set_propose_observer(Box::new(move |ctx| propose_tracker.lock().push(ctx.view())));
+            app_actor.set_verify_observer(Box::new(move |ctx, _| {
+                verify_tracker.lock().push(ctx.view())
+            }));
+            app_actor.start();
+
+            let voter_cfg = Config {
+                scheme: schemes[0].clone(),
+                elector,
+                blocker: oracle.control(me.clone()),
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter,
+                partition,
+                epoch: Epoch::new(333),
+                mailbox_size: 128,
+                leader_timeout: Duration::from_millis(500),
+                certification_timeout: Duration::from_secs(1),
+                timeout_retry: Duration::from_secs(1),
+                activity_timeout: ViewDelta::new(10),
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let (voter, mut mailbox) = Actor::new(context.with_label("voter"), voter_cfg);
+
+            let (resolver_sender, _) = mpsc::channel(8);
+            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
+            let (vote_sender, _) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (cert_sender, _) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            voter.start(
+                batcher::Mailbox::new(batcher_sender),
+                resolver::Mailbox::new(resolver_sender),
+                vote_sender,
+                cert_sender,
+            );
+
+            // Wait for startup, then advance to the leader-owned view.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update { response, .. } => {
+                        response.send(None).unwrap();
+                        break;
+                    }
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+            advance_to_view(
+                &mut mailbox,
+                &mut batcher_receiver,
+                &schemes,
+                quorum,
+                target_view,
+            )
+            .await;
+
+            // Wait for the voter to time out (leader_timeout) and construct a Nullify
+            // for the view. By that point the voter has already run the full propose
+            // flow (so propose_observer should have fired) and any spurious verify for
+            // the same payload would have fired before the timeout.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Constructed(Vote::Nullify(nullify))
+                        if nullify.view() == target_view =>
+                    {
+                        break;
+                    }
+                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            let proposed = propose_calls.lock();
+            let verified = verify_calls.lock();
+            assert!(
+                proposed.contains(&target_view),
+                "test precondition: voter must have called automaton.propose for the leader-owned view (observed: {proposed:?})"
+            );
+            assert!(
+                !verified.contains(&target_view),
+                "voter must not verify its own leader-built proposal (observed: {verified:?})"
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_no_self_verify_when_proposing() {
+        no_self_verify_when_proposing(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        no_self_verify_when_proposing(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        no_self_verify_when_proposing(bls12381_multisig::fixture::<MinPk, _>);
+        no_self_verify_when_proposing(bls12381_multisig::fixture::<MinSig, _>);
+        no_self_verify_when_proposing(ed25519::fixture);
+        no_self_verify_when_proposing(secp256r1::fixture);
+    }
+
+    /// Restart analogue of `no_self_verify_when_proposing`: after the voter has
+    /// proposed and journaled a local notarize as leader, restarting and then
+    /// having the proposal re-delivered (e.g. via peer echo through the
+    /// automaton) must not cause the voter to verify its own proposal.
+    ///
+    /// Replay of the journaled local notarize must restore the slot's proposal
+    /// and verify flags so that subsequent delivery of the same proposal is a
+    /// no-op. Without that restoration, the re-delivered proposal would appear
+    /// as unverified, and the voter could call `automaton.verify` for a
+    /// payload it built itself pre-crash.
+    fn no_self_verify_when_proposing_after_restart<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let quorum = quorum(n);
+        let namespace = b"no_self_verify_when_proposing_after_restart".to_vec();
+        let partition = "no_self_verify_when_proposing_after_restart".to_string();
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.clone(), participants.clone(), true).await;
+
+            // RoundRobin with epoch=333, n=5: view 2 -> leader=Participant::new(0) = us.
+            let target_view = View::new(2);
+            let me = participants[0].clone();
+            let elector = RoundRobin::<Sha256>::default();
+            let reporter_cfg = mocks::reporter::Config {
+                participants: participants.clone().try_into().unwrap(),
+                scheme: schemes[0].clone(),
+                elector: elector.clone(),
+            };
+            let reporter =
+                mocks::reporter::Reporter::new(context.with_label("reporter"), reporter_cfg);
+            let relay = Arc::new(mocks::relay::Relay::new());
+
+            let app_cfg = mocks::application::Config {
+                hasher: Sha256::default(),
+                relay: relay.clone(),
+                me: me.clone(),
+                propose_latency: (1.0, 0.0),
+                verify_latency: (1.0, 0.0),
+                certify_latency: (1.0, 0.0),
+                should_certify: mocks::application::Certifier::Always,
+            };
+            let (app_actor, application) =
+                mocks::application::Application::new(context.with_label("app"), app_cfg);
+            app_actor.start();
+
+            let voter_cfg = Config {
+                scheme: schemes[0].clone(),
+                elector: elector.clone(),
+                blocker: oracle.control(me.clone()),
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter: reporter.clone(),
+                partition: partition.clone(),
+                epoch: Epoch::new(333),
+                mailbox_size: 128,
+                leader_timeout: Duration::from_millis(500),
+                certification_timeout: Duration::from_secs(1),
+                timeout_retry: Duration::from_secs(1),
+                activity_timeout: ViewDelta::new(10),
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let (voter, mut mailbox) = Actor::new(context.with_label("voter"), voter_cfg);
+
+            let (resolver_sender, _) = mpsc::channel(8);
+            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
+            let (vote_sender, _) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (cert_sender, _) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let handle = voter.start(
+                batcher::Mailbox::new(batcher_sender),
+                resolver::Mailbox::new(resolver_sender),
+                vote_sender,
+                cert_sender,
+            );
+
+            // Wait for startup, then advance to the leader-owned view.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update { response, .. } => {
+                        response.send(None).unwrap();
+                        break;
+                    }
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+            advance_to_view(
+                &mut mailbox,
+                &mut batcher_receiver,
+                &schemes,
+                quorum,
+                target_view,
+            )
+            .await;
+
+            // Wait for the voter to emit its own notarize (journaled). The captured
+            // proposal is reused post-restart to exercise the re-delivery path.
+            let proposal = loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Constructed(Vote::Notarize(notarize))
+                        if notarize.view() == target_view =>
+                    {
+                        break notarize.proposal;
+                    }
+                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
+                    batcher::Message::Constructed(_) => {}
+                }
+            };
+
+            // Restart (same partition).
+            handle.abort();
+
+            // Fresh Application with propose + verify observers to catch any spurious
+            // work for the leader-owned view that has already been notarized in the journal.
+            let propose_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let verify_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let propose_tracker = propose_calls.clone();
+            let verify_tracker = verify_calls.clone();
+            let app_cfg = mocks::application::Config {
+                hasher: Sha256::default(),
+                relay: relay.clone(),
+                me: me.clone(),
+                propose_latency: (1.0, 0.0),
+                verify_latency: (1.0, 0.0),
+                certify_latency: (1.0, 0.0),
+                should_certify: mocks::application::Certifier::Always,
+            };
+            let (mut app_actor, application) = mocks::application::Application::new(
+                context.with_label("app_restarted"),
+                app_cfg,
+            );
+            app_actor
+                .set_propose_observer(Box::new(move |ctx| propose_tracker.lock().push(ctx.view())));
+            app_actor.set_verify_observer(Box::new(move |ctx, _| {
+                verify_tracker.lock().push(ctx.view())
+            }));
+            app_actor.start();
+
+            let voter_cfg = Config {
+                scheme: schemes[0].clone(),
+                elector,
+                blocker: oracle.control(me.clone()),
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter,
+                partition,
+                epoch: Epoch::new(333),
+                mailbox_size: 128,
+                leader_timeout: Duration::from_millis(500),
+                certification_timeout: Duration::from_secs(1),
+                timeout_retry: Duration::from_secs(1),
+                activity_timeout: ViewDelta::new(10),
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let (voter, mut mailbox) =
+                Actor::new(context.with_label("voter_restarted"), voter_cfg);
+
+            let (resolver_sender, _) = mpsc::channel(8);
+            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
+            let (vote_sender, _) = oracle
+                .control(me.clone())
+                .register(2, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (cert_sender, _) = oracle
+                .control(me.clone())
+                .register(3, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            voter.start(
+                batcher::Mailbox::new(batcher_sender),
+                resolver::Mailbox::new(resolver_sender),
+                vote_sender,
+                cert_sender,
+            );
+
+            // Wait for replay to complete; confirm we re-entered the leader-owned view.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update {
+                        current,
+                        leader,
+                        response,
+                        ..
+                    } => {
+                        response.send(None).unwrap();
+                        assert_eq!(current, target_view);
+                        assert_eq!(leader, Participant::new(0));
+                        break;
+                    }
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            // Re-deliver the proposal via the automaton, simulating peer echo after
+            // restart. Any spurious propose/verify for this view would fire on the next
+            // run-loop iteration. Then wait for leader_timeout to fire a Nullify,
+            // proving the voter ran its full flow without ever advancing.
+            mailbox.proposal(proposal.clone()).await;
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Constructed(Vote::Nullify(nullify))
+                        if nullify.view() == target_view =>
+                    {
+                        break;
+                    }
+                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            let proposed = propose_calls.lock();
+            let verified = verify_calls.lock();
+            assert!(
+                !verified.contains(&target_view),
+                "voter must not verify its own leader-built proposal after restart (observed: {verified:?})"
+            );
+            assert!(
+                !proposed.contains(&target_view),
+                "voter must not propose for a leader-owned view after restart (observed: {proposed:?})"
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_no_self_verify_when_proposing_after_restart() {
+        no_self_verify_when_proposing_after_restart(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        no_self_verify_when_proposing_after_restart(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        no_self_verify_when_proposing_after_restart(bls12381_multisig::fixture::<MinPk, _>);
+        no_self_verify_when_proposing_after_restart(bls12381_multisig::fixture::<MinSig, _>);
+        no_self_verify_when_proposing_after_restart(ed25519::fixture);
+        no_self_verify_when_proposing_after_restart(secp256r1::fixture);
+    }
+
     /// After restart in a leader-owned view that was already voted on, the
     /// voter must not call `automaton.propose` to build a new payload.
     ///

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -3728,6 +3728,259 @@ mod tests {
         no_recertification_after_replay::<_, _, RoundRobin>(secp256r1::fixture);
     }
 
+    /// After restart in a leader-owned view that was already voted on, the
+    /// voter must not call `automaton.propose` to build a new payload.
+    ///
+    /// Replay of the journaled local notarize must restore the slot's proposal
+    /// (and `requested_build`) so that `should_build` returns false. Without
+    /// that restoration, the voter's main loop would treat the leader-owned
+    /// view as a fresh proposal opportunity and call `automaton.propose` for
+    /// a payload that has already been notarized.
+    fn no_self_propose_after_restart<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let quorum = quorum(n);
+        let namespace = b"no_self_propose_after_restart".to_vec();
+        let partition = "no_self_propose_after_restart".to_string();
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.clone(), participants.clone(), true).await;
+
+            // RoundRobin with epoch=333, n=5: view 2 -> leader=Participant::new(0) = us.
+            let target_view = View::new(2);
+            let me = participants[0].clone();
+            let elector = RoundRobin::<Sha256>::default();
+            let reporter_cfg = mocks::reporter::Config {
+                participants: participants.clone().try_into().unwrap(),
+                scheme: schemes[0].clone(),
+                elector: elector.clone(),
+            };
+            let reporter =
+                mocks::reporter::Reporter::new(context.with_label("reporter"), reporter_cfg);
+            let relay = Arc::new(mocks::relay::Relay::new());
+
+            let app_cfg = mocks::application::Config {
+                hasher: Sha256::default(),
+                relay: relay.clone(),
+                me: me.clone(),
+                propose_latency: (1.0, 0.0),
+                verify_latency: (1.0, 0.0),
+                certify_latency: (1.0, 0.0),
+                should_certify: mocks::application::Certifier::Always,
+            };
+            let (app_actor, application) =
+                mocks::application::Application::new(context.with_label("app"), app_cfg);
+            app_actor.start();
+
+            let voter_cfg = Config {
+                scheme: schemes[0].clone(),
+                elector: elector.clone(),
+                blocker: oracle.control(me.clone()),
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter: reporter.clone(),
+                partition: partition.clone(),
+                epoch: Epoch::new(333),
+                mailbox_size: 128,
+                leader_timeout: Duration::from_millis(500),
+                certification_timeout: Duration::from_secs(1),
+                timeout_retry: Duration::from_secs(1),
+                activity_timeout: ViewDelta::new(10),
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let (voter, mut mailbox) = Actor::new(context.with_label("voter"), voter_cfg);
+
+            let (resolver_sender, _) = mpsc::channel(8);
+            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
+            let (vote_sender, _) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (cert_sender, _) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let handle = voter.start(
+                batcher::Mailbox::new(batcher_sender),
+                resolver::Mailbox::new(resolver_sender),
+                vote_sender,
+                cert_sender,
+            );
+
+            // Wait for startup, then advance to the leader-owned view.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update { response, .. } => {
+                        response.send(None).unwrap();
+                        break;
+                    }
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+            advance_to_view(
+                &mut mailbox,
+                &mut batcher_receiver,
+                &schemes,
+                quorum,
+                target_view,
+            )
+            .await;
+
+            // Wait for our local notarize (journaled) so replay has something to restore.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Constructed(Vote::Notarize(notarize))
+                        if notarize.view() == target_view =>
+                    {
+                        break;
+                    }
+                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            // Restart (same partition).
+            handle.abort();
+
+            // Fresh Application with propose + verify observers to catch any spurious
+            // work for the leader-owned view that has already been notarized in the journal.
+            let propose_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let verify_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let propose_tracker = propose_calls.clone();
+            let verify_tracker = verify_calls.clone();
+            let app_cfg = mocks::application::Config {
+                hasher: Sha256::default(),
+                relay: relay.clone(),
+                me: me.clone(),
+                propose_latency: (1.0, 0.0),
+                verify_latency: (1.0, 0.0),
+                certify_latency: (1.0, 0.0),
+                should_certify: mocks::application::Certifier::Always,
+            };
+            let (mut app_actor, application) = mocks::application::Application::new(
+                context.with_label("app_restarted"),
+                app_cfg,
+            );
+            app_actor
+                .set_propose_observer(Box::new(move |ctx| propose_tracker.lock().push(ctx.view())));
+            app_actor.set_verify_observer(Box::new(move |ctx, _| {
+                verify_tracker.lock().push(ctx.view())
+            }));
+            app_actor.start();
+
+            let voter_cfg = Config {
+                scheme: schemes[0].clone(),
+                elector,
+                blocker: oracle.control(me.clone()),
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter,
+                partition,
+                epoch: Epoch::new(333),
+                mailbox_size: 128,
+                leader_timeout: Duration::from_millis(500),
+                certification_timeout: Duration::from_secs(1),
+                timeout_retry: Duration::from_secs(1),
+                activity_timeout: ViewDelta::new(10),
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let (voter, _mailbox) = Actor::new(context.with_label("voter_restarted"), voter_cfg);
+
+            let (resolver_sender, _) = mpsc::channel(8);
+            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
+            let (vote_sender, _) = oracle
+                .control(me.clone())
+                .register(2, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (cert_sender, _) = oracle
+                .control(me.clone())
+                .register(3, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            voter.start(
+                batcher::Mailbox::new(batcher_sender),
+                resolver::Mailbox::new(resolver_sender),
+                vote_sender,
+                cert_sender,
+            );
+
+            // Wait for replay to complete; confirm we re-entered the leader-owned view.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update {
+                        current,
+                        leader,
+                        response,
+                        ..
+                    } => {
+                        response.send(None).unwrap();
+                        assert_eq!(current, target_view);
+                        assert_eq!(leader, Participant::new(0));
+                        break;
+                    }
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            // Without the replay fix, the voter's main loop would call `automaton.propose`
+            // for the leader-owned view on its first iteration after replay. We wait for
+            // the voter to time out (leader_timeout) and construct a Nullify for the view:
+            // by that point the run loop has had ample opportunity to propose, and
+            // emitting a Nullify proves the voter reached the timeout path without ever
+            // advancing.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Constructed(Vote::Nullify(nullify))
+                        if nullify.view() == target_view =>
+                    {
+                        break;
+                    }
+                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            let proposed = propose_calls.lock();
+            let verified = verify_calls.lock();
+            assert!(
+                !proposed.contains(&target_view),
+                "voter must not propose for a leader-owned view after restart (observed: {proposed:?})"
+            );
+            assert!(
+                !verified.contains(&target_view),
+                "voter must not request verification for a leader-owned view after restart (observed: {verified:?})"
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_no_self_propose_after_restart() {
+        no_self_propose_after_restart(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        no_self_propose_after_restart(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        no_self_propose_after_restart(bls12381_multisig::fixture::<MinPk, _>);
+        no_self_propose_after_restart(bls12381_multisig::fixture::<MinSig, _>);
+        no_self_propose_after_restart(ed25519::fixture);
+        no_self_propose_after_restart(secp256r1::fixture);
+    }
+
     /// After restart, a proposal we already voted on must not be re-verified
     /// when it is re-delivered to the voter (e.g. via the automaton after
     /// peer vote aggregation reconstructs it).
@@ -4000,259 +4253,6 @@ mod tests {
         no_self_verify_after_restart(bls12381_multisig::fixture::<MinSig, _>);
         no_self_verify_after_restart(ed25519::fixture);
         no_self_verify_after_restart(secp256r1::fixture);
-    }
-
-    /// After restart in a leader-owned view that was already voted on, the
-    /// voter must not call `automaton.propose` to build a new payload.
-    ///
-    /// Replay of the journaled local notarize must restore the slot's proposal
-    /// (and `requested_build`) so that `should_build` returns false. Without
-    /// that restoration, the voter's main loop would treat the leader-owned
-    /// view as a fresh proposal opportunity and call `automaton.propose` for
-    /// a payload that has already been notarized.
-    fn no_self_propose_after_restart<S, F>(mut fixture: F)
-    where
-        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
-        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
-    {
-        let n = 5;
-        let quorum = quorum(n);
-        let namespace = b"no_self_propose_after_restart".to_vec();
-        let partition = "no_self_propose_after_restart".to_string();
-        let executor = deterministic::Runner::timed(Duration::from_secs(10));
-        executor.start(|mut context| async move {
-            let Fixture {
-                participants,
-                schemes,
-                ..
-            } = fixture(&mut context, &namespace, n);
-            let oracle =
-                start_test_network_with_peers(context.clone(), participants.clone(), true).await;
-
-            // RoundRobin with epoch=333, n=5: view 2 -> leader=Participant::new(0) = us.
-            let target_view = View::new(2);
-            let me = participants[0].clone();
-            let elector = RoundRobin::<Sha256>::default();
-            let reporter_cfg = mocks::reporter::Config {
-                participants: participants.clone().try_into().unwrap(),
-                scheme: schemes[0].clone(),
-                elector: elector.clone(),
-            };
-            let reporter =
-                mocks::reporter::Reporter::new(context.with_label("reporter"), reporter_cfg);
-            let relay = Arc::new(mocks::relay::Relay::new());
-
-            let app_cfg = mocks::application::Config {
-                hasher: Sha256::default(),
-                relay: relay.clone(),
-                me: me.clone(),
-                propose_latency: (1.0, 0.0),
-                verify_latency: (1.0, 0.0),
-                certify_latency: (1.0, 0.0),
-                should_certify: mocks::application::Certifier::Always,
-            };
-            let (app_actor, application) =
-                mocks::application::Application::new(context.with_label("app"), app_cfg);
-            app_actor.start();
-
-            let voter_cfg = Config {
-                scheme: schemes[0].clone(),
-                elector: elector.clone(),
-                blocker: oracle.control(me.clone()),
-                automaton: application.clone(),
-                relay: application.clone(),
-                reporter: reporter.clone(),
-                partition: partition.clone(),
-                epoch: Epoch::new(333),
-                mailbox_size: 128,
-                leader_timeout: Duration::from_millis(500),
-                certification_timeout: Duration::from_secs(1),
-                timeout_retry: Duration::from_secs(1),
-                activity_timeout: ViewDelta::new(10),
-                replay_buffer: NZUsize!(1024 * 1024),
-                write_buffer: NZUsize!(1024 * 1024),
-                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-            };
-            let (voter, mut mailbox) = Actor::new(context.with_label("voter"), voter_cfg);
-
-            let (resolver_sender, _) = mpsc::channel(8);
-            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
-            let (vote_sender, _) = oracle
-                .control(me.clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-            let (cert_sender, _) = oracle
-                .control(me.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            let handle = voter.start(
-                batcher::Mailbox::new(batcher_sender),
-                resolver::Mailbox::new(resolver_sender),
-                vote_sender,
-                cert_sender,
-            );
-
-            // Wait for startup, then advance to the leader-owned view.
-            loop {
-                match batcher_receiver.recv().await.unwrap() {
-                    batcher::Message::Update { response, .. } => {
-                        response.send(None).unwrap();
-                        break;
-                    }
-                    batcher::Message::Constructed(_) => {}
-                }
-            }
-            advance_to_view(
-                &mut mailbox,
-                &mut batcher_receiver,
-                &schemes,
-                quorum,
-                target_view,
-            )
-            .await;
-
-            // Wait for our local notarize (journaled) so replay has something to restore.
-            loop {
-                match batcher_receiver.recv().await.unwrap() {
-                    batcher::Message::Constructed(Vote::Notarize(notarize))
-                        if notarize.view() == target_view =>
-                    {
-                        break;
-                    }
-                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
-                    batcher::Message::Constructed(_) => {}
-                }
-            }
-
-            // Restart (same partition).
-            handle.abort();
-
-            // Fresh Application with propose + verify observers to catch any spurious
-            // work for the leader-owned view that has already been notarized in the journal.
-            let propose_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
-            let verify_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
-            let propose_tracker = propose_calls.clone();
-            let verify_tracker = verify_calls.clone();
-            let app_cfg = mocks::application::Config {
-                hasher: Sha256::default(),
-                relay: relay.clone(),
-                me: me.clone(),
-                propose_latency: (1.0, 0.0),
-                verify_latency: (1.0, 0.0),
-                certify_latency: (1.0, 0.0),
-                should_certify: mocks::application::Certifier::Always,
-            };
-            let (mut app_actor, application) = mocks::application::Application::new(
-                context.with_label("app_restarted"),
-                app_cfg,
-            );
-            app_actor
-                .set_propose_observer(Box::new(move |ctx| propose_tracker.lock().push(ctx.view())));
-            app_actor.set_verify_observer(Box::new(move |ctx, _| {
-                verify_tracker.lock().push(ctx.view())
-            }));
-            app_actor.start();
-
-            let voter_cfg = Config {
-                scheme: schemes[0].clone(),
-                elector,
-                blocker: oracle.control(me.clone()),
-                automaton: application.clone(),
-                relay: application.clone(),
-                reporter,
-                partition,
-                epoch: Epoch::new(333),
-                mailbox_size: 128,
-                leader_timeout: Duration::from_millis(500),
-                certification_timeout: Duration::from_secs(1),
-                timeout_retry: Duration::from_secs(1),
-                activity_timeout: ViewDelta::new(10),
-                replay_buffer: NZUsize!(1024 * 1024),
-                write_buffer: NZUsize!(1024 * 1024),
-                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-            };
-            let (voter, _mailbox) = Actor::new(context.with_label("voter_restarted"), voter_cfg);
-
-            let (resolver_sender, _) = mpsc::channel(8);
-            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
-            let (vote_sender, _) = oracle
-                .control(me.clone())
-                .register(2, TEST_QUOTA)
-                .await
-                .unwrap();
-            let (cert_sender, _) = oracle
-                .control(me.clone())
-                .register(3, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            voter.start(
-                batcher::Mailbox::new(batcher_sender),
-                resolver::Mailbox::new(resolver_sender),
-                vote_sender,
-                cert_sender,
-            );
-
-            // Wait for replay to complete; confirm we re-entered the leader-owned view.
-            loop {
-                match batcher_receiver.recv().await.unwrap() {
-                    batcher::Message::Update {
-                        current,
-                        leader,
-                        response,
-                        ..
-                    } => {
-                        response.send(None).unwrap();
-                        assert_eq!(current, target_view);
-                        assert_eq!(leader, Participant::new(0));
-                        break;
-                    }
-                    batcher::Message::Constructed(_) => {}
-                }
-            }
-
-            // Without the replay fix, the voter's main loop would call `automaton.propose`
-            // for the leader-owned view on its first iteration after replay. We wait for
-            // the voter to time out (leader_timeout) and construct a Nullify for the view:
-            // by that point the run loop has had ample opportunity to propose, and
-            // emitting a Nullify proves the voter reached the timeout path without ever
-            // advancing.
-            loop {
-                match batcher_receiver.recv().await.unwrap() {
-                    batcher::Message::Constructed(Vote::Nullify(nullify))
-                        if nullify.view() == target_view =>
-                    {
-                        break;
-                    }
-                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
-                    batcher::Message::Constructed(_) => {}
-                }
-            }
-
-            let proposed = propose_calls.lock();
-            let verified = verify_calls.lock();
-            assert!(
-                !proposed.contains(&target_view),
-                "voter must not propose for a leader-owned view after restart (observed: {proposed:?})"
-            );
-            assert!(
-                !verified.contains(&target_view),
-                "voter must not request verification for a leader-owned view after restart (observed: {verified:?})"
-            );
-        });
-    }
-
-    #[test_traced]
-    fn test_no_self_propose_after_restart() {
-        no_self_propose_after_restart(bls12381_threshold_vrf::fixture::<MinPk, _>);
-        no_self_propose_after_restart(bls12381_threshold_vrf::fixture::<MinSig, _>);
-        no_self_propose_after_restart(bls12381_multisig::fixture::<MinPk, _>);
-        no_self_propose_after_restart(bls12381_multisig::fixture::<MinSig, _>);
-        no_self_propose_after_restart(ed25519::fixture);
-        no_self_propose_after_restart(secp256r1::fixture);
     }
 
     /// Test that in-flight certification requests are cancelled when finalization occurs.

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -86,7 +86,6 @@ mod tests {
     };
     use commonware_utils::{channel::mpsc, sync::Mutex, NZUsize, NZU16};
     use futures::FutureExt;
-    use rstest::rstest;
     use std::{
         num::{NonZeroU16, NonZeroU32},
         sync::Arc,
@@ -3729,47 +3728,17 @@ mod tests {
         no_recertification_after_replay::<_, _, RoundRobin>(secp256r1::fixture);
     }
 
-    #[derive(Clone, Copy)]
-    enum RecoveredCertificateKind {
-        Notarization,
-        Finalization,
-    }
-
-    #[derive(Clone, Copy)]
-    enum RestartVerifyCase {
-        ProposalReturns,
-        DurableLocalNotarize,
-        RecoveredCertificate(RecoveredCertificateKind),
-    }
-
-    async fn wait_for_startup_update<S: Scheme<Sha256Digest>>(
-        batcher_receiver: &mut mpsc::Receiver<batcher::Message<S, Sha256Digest>>,
-    ) -> (View, Participant) {
-        loop {
-            match batcher_receiver.recv().await.unwrap() {
-                batcher::Message::Update {
-                    current,
-                    leader,
-                    response,
-                    ..
-                } => {
-                    response.send(None).unwrap();
-                    return (current, leader);
-                }
-                batcher::Message::Constructed(_) => {}
-            }
-        }
-    }
-
-    /// After restart, a leader-owned proposal that was already voted on should
-    /// never trigger application verification. Tests four paths that can
-    /// re-introduce the proposal after restart:
+    /// After restart, a proposal we already voted on must not be re-verified
+    /// when it is re-delivered to the voter (e.g. via the automaton after
+    /// peer vote aggregation reconstructs it).
     ///
-    /// 1. ProposalReturns: proposal re-delivered via mailbox.
-    /// 2. DurableLocalNotarize: local notarize vote observed on the network.
-    /// 3. RecoveredNotarization: notarization certificate recovered.
-    /// 4. RecoveredFinalization: finalization certificate recovered.
-    fn no_self_verify_after_restart<S, F>(mut fixture: F, case: RestartVerifyCase)
+    /// Uses a view where we are a follower (so `verify_ready` does not
+    /// short-circuit). Pre-restart the voter verifies the leader's proposal,
+    /// emits a `Notarize` vote, and journals it. Post-restart the voter
+    /// replays the journaled `Notarize`; the proposal must be restored as
+    /// `Verified` so that re-delivering the proposal does not trigger another
+    /// `automaton.verify` call.
+    fn no_self_verify_after_restart<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
@@ -3785,14 +3754,283 @@ mod tests {
                 schemes,
                 ..
             } = fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.clone(), participants.clone(), true).await;
 
-            let oracle = start_test_network_with_peers(
-                context.clone(),
-                participants.clone(),
-                true,
+            // RoundRobin with epoch=333, n=5: view 3 -> leader=Participant::new(1).
+            // We are Participant::new(0), so view 3 is a follower view.
+            let target_view = View::new(3);
+            let target_leader_idx = 1usize;
+            let me = participants[0].clone();
+            let leader_pk = participants[target_leader_idx].clone();
+            let elector = RoundRobin::<Sha256>::default();
+            let reporter_cfg = mocks::reporter::Config {
+                participants: participants.clone().try_into().unwrap(),
+                scheme: schemes[0].clone(),
+                elector: elector.clone(),
+            };
+            let reporter =
+                mocks::reporter::Reporter::new(context.with_label("reporter"), reporter_cfg);
+            let relay = Arc::new(mocks::relay::Relay::new());
+
+            let app_cfg = mocks::application::Config {
+                hasher: Sha256::default(),
+                relay: relay.clone(),
+                me: me.clone(),
+                propose_latency: (1.0, 0.0),
+                verify_latency: (1.0, 0.0),
+                certify_latency: (1.0, 0.0),
+                should_certify: mocks::application::Certifier::Always,
+            };
+            let (app_actor, application) =
+                mocks::application::Application::new(context.with_label("app"), app_cfg);
+            app_actor.start();
+
+            let voter_cfg = Config {
+                scheme: schemes[0].clone(),
+                elector: elector.clone(),
+                blocker: oracle.control(me.clone()),
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter: reporter.clone(),
+                partition: partition.clone(),
+                epoch: Epoch::new(333),
+                mailbox_size: 128,
+                leader_timeout: Duration::from_millis(500),
+                certification_timeout: Duration::from_secs(1),
+                timeout_retry: Duration::from_secs(1),
+                activity_timeout: ViewDelta::new(10),
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let (voter, mut mailbox) = Actor::new(context.with_label("voter"), voter_cfg);
+
+            let (resolver_sender, _) = mpsc::channel(8);
+            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
+            let (vote_sender, _) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (cert_sender, _) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let handle = voter.start(
+                batcher::Mailbox::new(batcher_sender),
+                resolver::Mailbox::new(resolver_sender),
+                vote_sender,
+                cert_sender,
+            );
+
+            // Wait for startup, then advance to view 3 via a synthetic finalization for
+            // view 2. `advance_to_view` uses Sha256::hash(prev_view.to_be_bytes()) as the
+            // parent payload, which we reuse below.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update { response, .. } => {
+                        response.send(None).unwrap();
+                        break;
+                    }
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+            let parent_payload = advance_to_view(
+                &mut mailbox,
+                &mut batcher_receiver,
+                &schemes,
+                quorum,
+                target_view,
             )
             .await;
 
+            // Simulate the leader's proposal: broadcast its payload contents to the
+            // application via the relay, then deliver the proposal to the voter.
+            let proposal = Proposal::new(
+                Round::new(Epoch::new(333), target_view),
+                target_view.previous().unwrap(),
+                Sha256::hash(b"follower_proposal"),
+            );
+            let contents = (proposal.round, parent_payload, 0u64).encode();
+            relay.broadcast(&leader_pk, (proposal.payload, contents));
+            mailbox.proposal(proposal.clone()).await;
+
+            // Wait for our local notarize (journaled) so replay has something to restore.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Constructed(Vote::Notarize(notarize))
+                        if notarize.view() == target_view =>
+                    {
+                        assert_eq!(notarize.proposal, proposal);
+                        break;
+                    }
+                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            // Restart (same partition).
+            handle.abort();
+
+            // Fresh Application with propose + verify observers to catch any spurious
+            // work for the follower view that has already been notarized in the journal.
+            let propose_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let verify_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let propose_tracker = propose_calls.clone();
+            let verify_tracker = verify_calls.clone();
+            let app_cfg = mocks::application::Config {
+                hasher: Sha256::default(),
+                relay: relay.clone(),
+                me: me.clone(),
+                propose_latency: (1.0, 0.0),
+                verify_latency: (1.0, 0.0),
+                certify_latency: (1.0, 0.0),
+                should_certify: mocks::application::Certifier::Always,
+            };
+            let (mut app_actor, application) = mocks::application::Application::new(
+                context.with_label("app_restarted"),
+                app_cfg,
+            );
+            app_actor
+                .set_propose_observer(Box::new(move |ctx| propose_tracker.lock().push(ctx.view())));
+            app_actor.set_verify_observer(Box::new(move |ctx, _| {
+                verify_tracker.lock().push(ctx.view())
+            }));
+            app_actor.start();
+
+            let voter_cfg = Config {
+                scheme: schemes[0].clone(),
+                elector,
+                blocker: oracle.control(me.clone()),
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter,
+                partition,
+                epoch: Epoch::new(333),
+                mailbox_size: 128,
+                leader_timeout: Duration::from_millis(500),
+                certification_timeout: Duration::from_secs(1),
+                timeout_retry: Duration::from_secs(1),
+                activity_timeout: ViewDelta::new(10),
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+            let (voter, mut mailbox) =
+                Actor::new(context.with_label("voter_restarted"), voter_cfg);
+
+            let (resolver_sender, _) = mpsc::channel(8);
+            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
+            let (vote_sender, _) = oracle
+                .control(me.clone())
+                .register(2, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (cert_sender, _) = oracle
+                .control(me.clone())
+                .register(3, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            voter.start(
+                batcher::Mailbox::new(batcher_sender),
+                resolver::Mailbox::new(resolver_sender),
+                vote_sender,
+                cert_sender,
+            );
+
+            // Wait for replay to complete; confirm we re-entered the follower view.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update {
+                        current,
+                        leader,
+                        response,
+                        ..
+                    } => {
+                        response.send(None).unwrap();
+                        assert_eq!(current, target_view);
+                        assert_eq!(leader, Participant::from_usize(target_leader_idx));
+                        break;
+                    }
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            // Re-deliver the proposal via the automaton (simulating peer echo after restart).
+            // Any spurious verify for the follower view would fire on the next run-loop
+            // iteration after the proposal is processed. We then wait for the voter to time
+            // out (leader_timeout) and construct a Nullify for the view: by that point the
+            // run loop has had ample opportunity to request verification, and emitting a
+            // Nullify proves the voter reached the timeout path without ever advancing.
+            mailbox.proposal(proposal.clone()).await;
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Constructed(Vote::Nullify(nullify))
+                        if nullify.view() == target_view =>
+                    {
+                        break;
+                    }
+                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            let proposed = propose_calls.lock();
+            let verified = verify_calls.lock();
+            assert!(
+                !verified.contains(&target_view),
+                "voter must not request verification for a previously-voted view after restart (observed: {verified:?})"
+            );
+            assert!(
+                !proposed.contains(&target_view),
+                "voter must not propose for a previously-voted view after restart (observed: {proposed:?})"
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_no_self_verify_after_restart() {
+        no_self_verify_after_restart(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        no_self_verify_after_restart(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        no_self_verify_after_restart(bls12381_multisig::fixture::<MinPk, _>);
+        no_self_verify_after_restart(bls12381_multisig::fixture::<MinSig, _>);
+        no_self_verify_after_restart(ed25519::fixture);
+        no_self_verify_after_restart(secp256r1::fixture);
+    }
+
+    /// After restart in a leader-owned view that was already voted on, the
+    /// voter must not call `automaton.propose` to build a new payload.
+    ///
+    /// Replay of the journaled local notarize must restore the slot's proposal
+    /// (and `requested_build`) so that `should_build` returns false. Without
+    /// that restoration, the voter's main loop would treat the leader-owned
+    /// view as a fresh proposal opportunity and call `automaton.propose` for
+    /// a payload that has already been notarized.
+    fn no_self_propose_after_restart<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let quorum = quorum(n);
+        let namespace = b"no_self_propose_after_restart".to_vec();
+        let partition = "no_self_propose_after_restart".to_string();
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.clone(), participants.clone(), true).await;
+
+            // RoundRobin with epoch=333, n=5: view 2 -> leader=Participant::new(0) = us.
+            let target_view = View::new(2);
             let me = participants[0].clone();
             let elector = RoundRobin::<Sha256>::default();
             let reporter_cfg = mocks::reporter::Config {
@@ -3850,26 +4088,6 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Register an observer to intercept broadcasted votes (for DurableLocalNotarize case).
-            let observer = participants[1].clone();
-            let (_, mut observer_vote_receiver) = oracle
-                .control(observer.clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-            oracle
-                .add_link(
-                    me.clone(),
-                    observer,
-                    Link {
-                        latency: Duration::from_millis(0),
-                        jitter: Duration::from_millis(0),
-                        success_rate: 1.0,
-                    },
-                )
-                .await
-                .unwrap();
-
             let handle = voter.start(
                 batcher::Mailbox::new(batcher_sender),
                 resolver::Mailbox::new(resolver_sender),
@@ -3877,11 +4095,16 @@ mod tests {
                 cert_sender,
             );
 
-            // Wait for startup and advance to view 2 where we are the leader.
-            let (_, leader) = wait_for_startup_update(&mut batcher_receiver).await;
-            assert_eq!(leader, Participant::new(4));
-
-            let target_view = View::new(2);
+            // Wait for startup, then advance to the leader-owned view.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update { response, .. } => {
+                        response.send(None).unwrap();
+                        break;
+                    }
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
             advance_to_view(
                 &mut mailbox,
                 &mut batcher_receiver,
@@ -3891,55 +4114,28 @@ mod tests {
             )
             .await;
 
-            // Capture the proposal we produced as leader.
-            let proposal = match case {
-                // Wait for the vote to be sent over the network.
-                RestartVerifyCase::DurableLocalNotarize => loop {
-                    select! {
-                        msg = batcher_receiver.recv() => match msg.unwrap() {
-                            batcher::Message::Update { response, .. } => response.send(None).unwrap(),
-                            batcher::Message::Constructed(_) => {}
-                        },
-                        message = commonware_p2p::Receiver::recv(&mut observer_vote_receiver) => {
-                            let (_, message) = message.unwrap();
-                            let vote: Vote<S, Sha256Digest> = Vote::decode(message).unwrap();
-                            if let Vote::Notarize(notarize) = vote {
-                                if notarize.view() == target_view {
-                                    break notarize.proposal;
-                                }
-                            }
-                        },
-                        _ = context.sleep(Duration::from_secs(1)) => {
-                            panic!("expected durable local notarize vote for leader-owned restart view {target_view}");
-                        },
+            // Wait for our local notarize (journaled) so replay has something to restore.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Constructed(Vote::Notarize(notarize))
+                        if notarize.view() == target_view =>
+                    {
+                        break;
                     }
-                },
-                // Wait for the vote to be constructed locally.
-                RestartVerifyCase::ProposalReturns
-                | RestartVerifyCase::RecoveredCertificate(_) => loop {
-                    select! {
-                        msg = batcher_receiver.recv() => match msg.unwrap() {
-                            batcher::Message::Constructed(Vote::Notarize(notarize))
-                                if notarize.view() == target_view =>
-                            {
-                                break notarize.proposal;
-                            }
-                            batcher::Message::Update { response, .. } => response.send(None).unwrap(),
-                            batcher::Message::Constructed(_) => {}
-                        },
-                        _ = context.sleep(Duration::from_secs(1)) => {
-                            panic!("expected local notarize vote for leader-owned restart view {target_view}");
-                        },
-                    }
-                },
-            };
+                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
 
-            // Restart the voter (reuses the same journal partition).
+            // Restart (same partition).
             handle.abort();
 
-            // Create new application with a verify observer to detect spurious calls.
-            let verify_calls: Arc<Mutex<Vec<Sha256Digest>>> = Arc::new(Mutex::new(Vec::new()));
-            let tracker = verify_calls.clone();
+            // Fresh Application with propose + verify observers to catch any spurious
+            // work for the leader-owned view that has already been notarized in the journal.
+            let propose_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let verify_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
+            let propose_tracker = propose_calls.clone();
+            let verify_tracker = verify_calls.clone();
             let app_cfg = mocks::application::Config {
                 hasher: Sha256::default(),
                 relay: relay.clone(),
@@ -3949,10 +4145,14 @@ mod tests {
                 certify_latency: (1.0, 0.0),
                 should_certify: mocks::application::Certifier::Always,
             };
-            let (mut app_actor, application) =
-                mocks::application::Application::new(context.with_label("app_restarted"), app_cfg);
-            app_actor.set_verify_observer(Box::new(move |digest| {
-                tracker.lock().push(digest);
+            let (mut app_actor, application) = mocks::application::Application::new(
+                context.with_label("app_restarted"),
+                app_cfg,
+            );
+            app_actor
+                .set_propose_observer(Box::new(move |ctx| propose_tracker.lock().push(ctx.view())));
+            app_actor.set_verify_observer(Box::new(move |ctx, _| {
+                verify_tracker.lock().push(ctx.view())
             }));
             app_actor.start();
 
@@ -3974,8 +4174,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
-            let (voter, mut mailbox) =
-                Actor::new(context.with_label("voter_restarted"), voter_cfg);
+            let (voter, _mailbox) = Actor::new(context.with_label("voter_restarted"), voter_cfg);
 
             let (resolver_sender, _) = mpsc::channel(8);
             let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
@@ -3997,105 +4196,63 @@ mod tests {
                 cert_sender,
             );
 
-            // Verify we restarted in the same leader-owned view.
-            let (current, leader) = wait_for_startup_update(&mut batcher_receiver).await;
-            assert_eq!(current, target_view, "restart should stay in the leader-owned view");
-            assert_eq!(
-                leader,
-                Participant::new(0),
-                "restart should remain in a leader-owned view"
-            );
-
-            // Re-introduce the proposal via the path under test.
-            match case {
-                RestartVerifyCase::ProposalReturns | RestartVerifyCase::DurableLocalNotarize => {
-                    // Re-deliver the proposal and allow time for any verify attempt.
-                    mailbox.proposal(proposal).await;
-                    context.sleep(Duration::from_millis(100)).await;
-                }
-                RestartVerifyCase::RecoveredCertificate(RecoveredCertificateKind::Notarization) => {
-                    // Send notarization and wait for the finalize vote.
-                    let (_, notarization) = build_notarization(&schemes, &proposal, quorum);
-                    mailbox
-                        .recovered(Certificate::Notarization(notarization))
-                        .await;
-
-                    loop {
-                        select! {
-                            msg = batcher_receiver.recv() => match msg.unwrap() {
-                                batcher::Message::Constructed(Vote::Finalize(finalize))
-                                    if finalize.view() == target_view =>
-                                {
-                                    break;
-                                }
-                                batcher::Message::Update { response, .. } => response.send(None).unwrap(),
-                                batcher::Message::Constructed(_) => {}
-                            },
-                            _ = context.sleep(Duration::from_secs(1)) => {
-                                panic!("expected local finalize after recovered notarization for view {target_view}");
-                            },
-                        }
+            // Wait for replay to complete; confirm we re-entered the leader-owned view.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update {
+                        current,
+                        leader,
+                        response,
+                        ..
+                    } => {
+                        response.send(None).unwrap();
+                        assert_eq!(current, target_view);
+                        assert_eq!(leader, Participant::new(0));
+                        break;
                     }
-                }
-                RestartVerifyCase::RecoveredCertificate(RecoveredCertificateKind::Finalization) => {
-                    // Send finalization and wait for the view to advance.
-                    let (_, finalization) = build_finalization(&schemes, &proposal, quorum);
-                    mailbox
-                        .recovered(Certificate::Finalization(finalization))
-                        .await;
-
-                    loop {
-                        select! {
-                            msg = batcher_receiver.recv() => match msg.unwrap() {
-                                batcher::Message::Update {
-                                    current,
-                                    finalized,
-                                    response,
-                                    ..
-                                } => {
-                                    response.send(None).unwrap();
-                                    if finalized >= target_view || current > target_view {
-                                        break;
-                                    }
-                                }
-                                batcher::Message::Constructed(_) => {}
-                            },
-                            _ = context.sleep(Duration::from_secs(1)) => {
-                                panic!("expected recovered finalization to advance view {target_view}");
-                            },
-                        }
-                    }
+                    batcher::Message::Constructed(_) => {}
                 }
             }
 
-            // Verify that no application verify calls were made.
+            // Without the replay fix, the voter's main loop would call `automaton.propose`
+            // for the leader-owned view on its first iteration after replay. We wait for
+            // the voter to time out (leader_timeout) and construct a Nullify for the view:
+            // by that point the run loop has had ample opportunity to propose, and
+            // emitting a Nullify proves the voter reached the timeout path without ever
+            // advancing.
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Constructed(Vote::Nullify(nullify))
+                        if nullify.view() == target_view =>
+                    {
+                        break;
+                    }
+                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
+                    batcher::Message::Constructed(_) => {}
+                }
+            }
+
+            let proposed = propose_calls.lock();
+            let verified = verify_calls.lock();
             assert!(
-                verify_calls.lock().is_empty(),
-                "application verify should not run for a leader-owned proposal after restart"
+                !proposed.contains(&target_view),
+                "voter must not propose for a leader-owned view after restart (observed: {proposed:?})"
+            );
+            assert!(
+                !verified.contains(&target_view),
+                "voter must not request verification for a leader-owned view after restart (observed: {verified:?})"
             );
         });
     }
 
-    fn run_no_self_verify_after_restart_case(case: RestartVerifyCase) {
-        no_self_verify_after_restart(bls12381_threshold_vrf::fixture::<MinPk, _>, case);
-        no_self_verify_after_restart(bls12381_threshold_vrf::fixture::<MinSig, _>, case);
-        no_self_verify_after_restart(bls12381_multisig::fixture::<MinPk, _>, case);
-        no_self_verify_after_restart(bls12381_multisig::fixture::<MinSig, _>, case);
-        no_self_verify_after_restart(ed25519::fixture, case);
-        no_self_verify_after_restart(secp256r1::fixture, case);
-    }
-
-    #[rstest]
-    #[case::proposal_returns(RestartVerifyCase::ProposalReturns)]
-    #[case::durable_local_notarize(RestartVerifyCase::DurableLocalNotarize)]
-    #[case::recovered_notarization(RestartVerifyCase::RecoveredCertificate(
-        RecoveredCertificateKind::Notarization,
-    ))]
-    #[case::recovered_finalization(RestartVerifyCase::RecoveredCertificate(
-        RecoveredCertificateKind::Finalization,
-    ))]
-    fn test_no_self_verify_after_restart(#[case] case: RestartVerifyCase) {
-        run_no_self_verify_after_restart_case(case);
+    #[test_traced]
+    fn test_no_self_propose_after_restart() {
+        no_self_propose_after_restart(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        no_self_propose_after_restart(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        no_self_propose_after_restart(bls12381_multisig::fixture::<MinPk, _>);
+        no_self_propose_after_restart(bls12381_multisig::fixture::<MinSig, _>);
+        no_self_propose_after_restart(ed25519::fixture);
+        no_self_propose_after_restart(secp256r1::fixture);
     }
 
     /// Test that in-flight certification requests are cancelled when finalization occurs.

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -3747,6 +3747,7 @@ mod tests {
         let partition = "no_self_verify_when_proposing".to_string();
         let executor = deterministic::Runner::timed(Duration::from_secs(10));
         executor.start(|mut context| async move {
+            // Set up the simulated network.
             let Fixture {
                 participants,
                 schemes,
@@ -3792,6 +3793,7 @@ mod tests {
             }));
             app_actor.start();
 
+            // Build and start the voter wired to the observing application.
             let voter_cfg = Config {
                 scheme: schemes[0].clone(),
                 elector,
@@ -3811,7 +3813,6 @@ mod tests {
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let (voter, mut mailbox) = Actor::new(context.with_label("voter"), voter_cfg);
-
             let (resolver_sender, _) = mpsc::channel(8);
             let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
             let (vote_sender, _) = oracle
@@ -3824,7 +3825,6 @@ mod tests {
                 .register(1, TEST_QUOTA)
                 .await
                 .unwrap();
-
             voter.start(
                 batcher::Mailbox::new(batcher_sender),
                 resolver::Mailbox::new(resolver_sender),
@@ -3867,6 +3867,8 @@ mod tests {
                 }
             }
 
+            // Assert the live invariant: propose fired (precondition proving the leader
+            // flow ran) but verify did not fire for the payload we just built.
             let proposed = propose_calls.lock();
             let verified = verify_calls.lock();
             assert!(
@@ -3898,7 +3900,8 @@ mod tests {
     /// Replay of the journaled local notarize must restore the slot's proposal,
     /// `requested_build`, and `requested_verify` flags so that:
     /// - `should_build` returns false on the next run-loop iteration (no new
-    ///   `automaton.propose` call for a payload already notarized), and
+    ///   `automaton.propose` call for a payload the voter already proposed
+    ///   and voted on pre-crash), and
     /// - subsequent delivery of the same proposal is a no-op (no
     ///   `automaton.verify` call for a payload the voter built itself).
     fn no_self_propose_or_verify_after_restart<S, F>(mut fixture: F)
@@ -3912,6 +3915,7 @@ mod tests {
         let partition = "no_self_propose_or_verify_after_restart".to_string();
         let executor = deterministic::Runner::timed(Duration::from_secs(10));
         executor.start(|mut context| async move {
+            // Set up the simulated network.
             let Fixture {
                 participants,
                 schemes,
@@ -3933,6 +3937,8 @@ mod tests {
                 mocks::reporter::Reporter::new(context.with_label("reporter"), reporter_cfg);
             let relay = Arc::new(mocks::relay::Relay::new());
 
+            // Pre-restart: plain application (no observers) so the voter can
+            // cleanly propose and journal its own notarize vote for view 2.
             let app_cfg = mocks::application::Config {
                 hasher: Sha256::default(),
                 relay: relay.clone(),
@@ -3946,6 +3952,7 @@ mod tests {
                 mocks::application::Application::new(context.with_label("app"), app_cfg);
             app_actor.start();
 
+            // Build and start the pre-restart voter.
             let voter_cfg = Config {
                 scheme: schemes[0].clone(),
                 elector: elector.clone(),
@@ -3965,7 +3972,6 @@ mod tests {
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let (voter, mut mailbox) = Actor::new(context.with_label("voter"), voter_cfg);
-
             let (resolver_sender, _) = mpsc::channel(8);
             let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
             let (vote_sender, _) = oracle
@@ -3978,7 +3984,6 @@ mod tests {
                 .register(1, TEST_QUOTA)
                 .await
                 .unwrap();
-
             let handle = voter.start(
                 batcher::Mailbox::new(batcher_sender),
                 resolver::Mailbox::new(resolver_sender),
@@ -4019,11 +4024,10 @@ mod tests {
                 }
             };
 
-            // Restart (same partition).
+            // Restart: abort the voter and construct a fresh application with
+            // propose + verify observers to catch any spurious work for the
+            // leader-owned view that has a journaled local notarize vote.
             handle.abort();
-
-            // Fresh Application with propose + verify observers to catch any spurious
-            // work for the leader-owned view that has already been notarized in the journal.
             let propose_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
             let verify_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
             let propose_tracker = propose_calls.clone();
@@ -4048,6 +4052,7 @@ mod tests {
             }));
             app_actor.start();
 
+            // Build and start the post-restart voter against the same journal partition.
             let voter_cfg = Config {
                 scheme: schemes[0].clone(),
                 elector,
@@ -4068,7 +4073,6 @@ mod tests {
             };
             let (voter, mut mailbox) =
                 Actor::new(context.with_label("voter_restarted"), voter_cfg);
-
             let (resolver_sender, _) = mpsc::channel(8);
             let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
             let (vote_sender, _) = oracle
@@ -4081,7 +4085,6 @@ mod tests {
                 .register(3, TEST_QUOTA)
                 .await
                 .unwrap();
-
             voter.start(
                 batcher::Mailbox::new(batcher_sender),
                 resolver::Mailbox::new(resolver_sender),
@@ -4124,15 +4127,18 @@ mod tests {
                 }
             }
 
+            // Assert the restart invariant: neither propose nor verify fires post-restart
+            // for a leader-owned view whose journaled notarize replay should have
+            // restored the slot's proposal state.
             let proposed = propose_calls.lock();
             let verified = verify_calls.lock();
             assert!(
-                !verified.contains(&target_view),
-                "voter must not verify its own leader-built proposal after restart (observed: {verified:?})"
-            );
-            assert!(
                 !proposed.contains(&target_view),
                 "voter must not propose for a leader-owned view after restart (observed: {proposed:?})"
+            );
+            assert!(
+                !verified.contains(&target_view),
+                "voter must not verify its own leader-built proposal after restart (observed: {verified:?})"
             );
         });
     }
@@ -4168,6 +4174,7 @@ mod tests {
         let partition = "no_self_verify_after_restart".to_string();
         let executor = deterministic::Runner::timed(Duration::from_secs(10));
         executor.start(|mut context| async move {
+            // Set up the simulated network.
             let Fixture {
                 participants,
                 schemes,
@@ -4192,6 +4199,8 @@ mod tests {
                 mocks::reporter::Reporter::new(context.with_label("reporter"), reporter_cfg);
             let relay = Arc::new(mocks::relay::Relay::new());
 
+            // Pre-restart: plain application (no observers) so the voter can verify
+            // the leader's proposal and journal its own notarize vote for view 3.
             let app_cfg = mocks::application::Config {
                 hasher: Sha256::default(),
                 relay: relay.clone(),
@@ -4205,6 +4214,7 @@ mod tests {
                 mocks::application::Application::new(context.with_label("app"), app_cfg);
             app_actor.start();
 
+            // Build and start the pre-restart voter.
             let voter_cfg = Config {
                 scheme: schemes[0].clone(),
                 elector: elector.clone(),
@@ -4224,7 +4234,6 @@ mod tests {
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let (voter, mut mailbox) = Actor::new(context.with_label("voter"), voter_cfg);
-
             let (resolver_sender, _) = mpsc::channel(8);
             let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
             let (vote_sender, _) = oracle
@@ -4237,7 +4246,6 @@ mod tests {
                 .register(1, TEST_QUOTA)
                 .await
                 .unwrap();
-
             let handle = voter.start(
                 batcher::Mailbox::new(batcher_sender),
                 resolver::Mailbox::new(resolver_sender),
@@ -4291,11 +4299,10 @@ mod tests {
                 }
             }
 
-            // Restart (same partition).
+            // Restart: abort the voter and construct a fresh application with
+            // propose + verify observers to catch any spurious work for the
+            // follower view that has a journaled local notarize vote.
             handle.abort();
-
-            // Fresh Application with propose + verify observers to catch any spurious
-            // work for the follower view that has already been notarized in the journal.
             let propose_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
             let verify_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
             let propose_tracker = propose_calls.clone();
@@ -4320,6 +4327,7 @@ mod tests {
             }));
             app_actor.start();
 
+            // Build and start the post-restart voter against the same journal partition.
             let voter_cfg = Config {
                 scheme: schemes[0].clone(),
                 elector,
@@ -4340,7 +4348,6 @@ mod tests {
             };
             let (voter, mut mailbox) =
                 Actor::new(context.with_label("voter_restarted"), voter_cfg);
-
             let (resolver_sender, _) = mpsc::channel(8);
             let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
             let (vote_sender, _) = oracle
@@ -4353,7 +4360,6 @@ mod tests {
                 .register(3, TEST_QUOTA)
                 .await
                 .unwrap();
-
             voter.start(
                 batcher::Mailbox::new(batcher_sender),
                 resolver::Mailbox::new(resolver_sender),
@@ -4398,6 +4404,9 @@ mod tests {
                 }
             }
 
+            // Assert the restart invariant: verify does not fire for the previously-voted
+            // follower proposal (primary) and propose does not fire for the follower view
+            // (trivially, since we are not its leader).
             let proposed = propose_calls.lock();
             let verified = verify_calls.lock();
             assert!(

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -3891,24 +3891,25 @@ mod tests {
     }
 
     /// Restart analogue of `no_self_verify_when_proposing`: after the voter has
-    /// proposed and journaled a local notarize as leader, restarting and then
-    /// having the proposal re-delivered (e.g. via peer echo through the
-    /// automaton) must not cause the voter to verify its own proposal.
+    /// proposed and journaled a local notarize as leader, restarting must not
+    /// cause the voter to re-propose or to verify its own proposal when it is
+    /// re-delivered (e.g. via peer echo through the automaton).
     ///
-    /// Replay of the journaled local notarize must restore the slot's proposal
-    /// and verify flags so that subsequent delivery of the same proposal is a
-    /// no-op. Without that restoration, the re-delivered proposal would appear
-    /// as unverified, and the voter could call `automaton.verify` for a
-    /// payload it built itself pre-crash.
-    fn no_self_verify_when_proposing_after_restart<S, F>(mut fixture: F)
+    /// Replay of the journaled local notarize must restore the slot's proposal,
+    /// `requested_build`, and `requested_verify` flags so that:
+    /// - `should_build` returns false on the next run-loop iteration (no new
+    ///   `automaton.propose` call for a payload already notarized), and
+    /// - subsequent delivery of the same proposal is a no-op (no
+    ///   `automaton.verify` call for a payload the voter built itself).
+    fn no_self_propose_or_verify_after_restart<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
     {
         let n = 5;
         let quorum = quorum(n);
-        let namespace = b"no_self_verify_when_proposing_after_restart".to_vec();
-        let partition = "no_self_verify_when_proposing_after_restart".to_string();
+        let namespace = b"no_self_propose_or_verify_after_restart".to_vec();
+        let partition = "no_self_propose_or_verify_after_restart".to_string();
         let executor = deterministic::Runner::timed(Duration::from_secs(10));
         executor.start(|mut context| async move {
             let Fixture {
@@ -4137,267 +4138,15 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_no_self_verify_when_proposing_after_restart() {
-        no_self_verify_when_proposing_after_restart(bls12381_threshold_vrf::fixture::<MinPk, _>);
-        no_self_verify_when_proposing_after_restart(bls12381_threshold_vrf::fixture::<MinSig, _>);
-        no_self_verify_when_proposing_after_restart(bls12381_multisig::fixture::<MinPk, _>);
-        no_self_verify_when_proposing_after_restart(bls12381_multisig::fixture::<MinSig, _>);
-        no_self_verify_when_proposing_after_restart(ed25519::fixture);
-        no_self_verify_when_proposing_after_restart(secp256r1::fixture);
+    fn test_no_self_propose_or_verify_after_restart() {
+        no_self_propose_or_verify_after_restart(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        no_self_propose_or_verify_after_restart(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        no_self_propose_or_verify_after_restart(bls12381_multisig::fixture::<MinPk, _>);
+        no_self_propose_or_verify_after_restart(bls12381_multisig::fixture::<MinSig, _>);
+        no_self_propose_or_verify_after_restart(ed25519::fixture);
+        no_self_propose_or_verify_after_restart(secp256r1::fixture);
     }
 
-    /// After restart in a leader-owned view that was already voted on, the
-    /// voter must not call `automaton.propose` to build a new payload.
-    ///
-    /// Replay of the journaled local notarize must restore the slot's proposal
-    /// (and `requested_build`) so that `should_build` returns false. Without
-    /// that restoration, the voter's main loop would treat the leader-owned
-    /// view as a fresh proposal opportunity and call `automaton.propose` for
-    /// a payload that has already been notarized.
-    fn no_self_propose_after_restart<S, F>(mut fixture: F)
-    where
-        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
-        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
-    {
-        let n = 5;
-        let quorum = quorum(n);
-        let namespace = b"no_self_propose_after_restart".to_vec();
-        let partition = "no_self_propose_after_restart".to_string();
-        let executor = deterministic::Runner::timed(Duration::from_secs(10));
-        executor.start(|mut context| async move {
-            let Fixture {
-                participants,
-                schemes,
-                ..
-            } = fixture(&mut context, &namespace, n);
-            let oracle =
-                start_test_network_with_peers(context.clone(), participants.clone(), true).await;
-
-            // RoundRobin with epoch=333, n=5: view 2 -> leader=Participant::new(0) = us.
-            let target_view = View::new(2);
-            let me = participants[0].clone();
-            let elector = RoundRobin::<Sha256>::default();
-            let reporter_cfg = mocks::reporter::Config {
-                participants: participants.clone().try_into().unwrap(),
-                scheme: schemes[0].clone(),
-                elector: elector.clone(),
-            };
-            let reporter =
-                mocks::reporter::Reporter::new(context.with_label("reporter"), reporter_cfg);
-            let relay = Arc::new(mocks::relay::Relay::new());
-
-            let app_cfg = mocks::application::Config {
-                hasher: Sha256::default(),
-                relay: relay.clone(),
-                me: me.clone(),
-                propose_latency: (1.0, 0.0),
-                verify_latency: (1.0, 0.0),
-                certify_latency: (1.0, 0.0),
-                should_certify: mocks::application::Certifier::Always,
-            };
-            let (app_actor, application) =
-                mocks::application::Application::new(context.with_label("app"), app_cfg);
-            app_actor.start();
-
-            let voter_cfg = Config {
-                scheme: schemes[0].clone(),
-                elector: elector.clone(),
-                blocker: oracle.control(me.clone()),
-                automaton: application.clone(),
-                relay: application.clone(),
-                reporter: reporter.clone(),
-                partition: partition.clone(),
-                epoch: Epoch::new(333),
-                mailbox_size: 128,
-                leader_timeout: Duration::from_millis(500),
-                certification_timeout: Duration::from_secs(1),
-                timeout_retry: Duration::from_secs(1),
-                activity_timeout: ViewDelta::new(10),
-                replay_buffer: NZUsize!(1024 * 1024),
-                write_buffer: NZUsize!(1024 * 1024),
-                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-            };
-            let (voter, mut mailbox) = Actor::new(context.with_label("voter"), voter_cfg);
-
-            let (resolver_sender, _) = mpsc::channel(8);
-            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
-            let (vote_sender, _) = oracle
-                .control(me.clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-            let (cert_sender, _) = oracle
-                .control(me.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            let handle = voter.start(
-                batcher::Mailbox::new(batcher_sender),
-                resolver::Mailbox::new(resolver_sender),
-                vote_sender,
-                cert_sender,
-            );
-
-            // Wait for startup, then advance to the leader-owned view.
-            loop {
-                match batcher_receiver.recv().await.unwrap() {
-                    batcher::Message::Update { response, .. } => {
-                        response.send(None).unwrap();
-                        break;
-                    }
-                    batcher::Message::Constructed(_) => {}
-                }
-            }
-            advance_to_view(
-                &mut mailbox,
-                &mut batcher_receiver,
-                &schemes,
-                quorum,
-                target_view,
-            )
-            .await;
-
-            // Wait for our local notarize (journaled) so replay has something to restore.
-            loop {
-                match batcher_receiver.recv().await.unwrap() {
-                    batcher::Message::Constructed(Vote::Notarize(notarize))
-                        if notarize.view() == target_view =>
-                    {
-                        break;
-                    }
-                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
-                    batcher::Message::Constructed(_) => {}
-                }
-            }
-
-            // Restart (same partition).
-            handle.abort();
-
-            // Fresh Application with propose + verify observers to catch any spurious
-            // work for the leader-owned view that has already been notarized in the journal.
-            let propose_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
-            let verify_calls: Arc<Mutex<Vec<View>>> = Arc::new(Mutex::new(Vec::new()));
-            let propose_tracker = propose_calls.clone();
-            let verify_tracker = verify_calls.clone();
-            let app_cfg = mocks::application::Config {
-                hasher: Sha256::default(),
-                relay: relay.clone(),
-                me: me.clone(),
-                propose_latency: (1.0, 0.0),
-                verify_latency: (1.0, 0.0),
-                certify_latency: (1.0, 0.0),
-                should_certify: mocks::application::Certifier::Always,
-            };
-            let (mut app_actor, application) = mocks::application::Application::new(
-                context.with_label("app_restarted"),
-                app_cfg,
-            );
-            app_actor
-                .set_propose_observer(Box::new(move |ctx| propose_tracker.lock().push(ctx.view())));
-            app_actor.set_verify_observer(Box::new(move |ctx, _| {
-                verify_tracker.lock().push(ctx.view())
-            }));
-            app_actor.start();
-
-            let voter_cfg = Config {
-                scheme: schemes[0].clone(),
-                elector,
-                blocker: oracle.control(me.clone()),
-                automaton: application.clone(),
-                relay: application.clone(),
-                reporter,
-                partition,
-                epoch: Epoch::new(333),
-                mailbox_size: 128,
-                leader_timeout: Duration::from_millis(500),
-                certification_timeout: Duration::from_secs(1),
-                timeout_retry: Duration::from_secs(1),
-                activity_timeout: ViewDelta::new(10),
-                replay_buffer: NZUsize!(1024 * 1024),
-                write_buffer: NZUsize!(1024 * 1024),
-                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-            };
-            let (voter, _mailbox) = Actor::new(context.with_label("voter_restarted"), voter_cfg);
-
-            let (resolver_sender, _) = mpsc::channel(8);
-            let (batcher_sender, mut batcher_receiver) = mpsc::channel(8);
-            let (vote_sender, _) = oracle
-                .control(me.clone())
-                .register(2, TEST_QUOTA)
-                .await
-                .unwrap();
-            let (cert_sender, _) = oracle
-                .control(me.clone())
-                .register(3, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            voter.start(
-                batcher::Mailbox::new(batcher_sender),
-                resolver::Mailbox::new(resolver_sender),
-                vote_sender,
-                cert_sender,
-            );
-
-            // Wait for replay to complete; confirm we re-entered the leader-owned view.
-            loop {
-                match batcher_receiver.recv().await.unwrap() {
-                    batcher::Message::Update {
-                        current,
-                        leader,
-                        response,
-                        ..
-                    } => {
-                        response.send(None).unwrap();
-                        assert_eq!(current, target_view);
-                        assert_eq!(leader, Participant::new(0));
-                        break;
-                    }
-                    batcher::Message::Constructed(_) => {}
-                }
-            }
-
-            // Without the replay fix, the voter's main loop would call `automaton.propose`
-            // for the leader-owned view on its first iteration after replay. We wait for
-            // the voter to time out (leader_timeout) and construct a Nullify for the view:
-            // by that point the run loop has had ample opportunity to propose, and
-            // emitting a Nullify proves the voter reached the timeout path without ever
-            // advancing.
-            loop {
-                match batcher_receiver.recv().await.unwrap() {
-                    batcher::Message::Constructed(Vote::Nullify(nullify))
-                        if nullify.view() == target_view =>
-                    {
-                        break;
-                    }
-                    batcher::Message::Update { response, .. } => response.send(None).unwrap(),
-                    batcher::Message::Constructed(_) => {}
-                }
-            }
-
-            let proposed = propose_calls.lock();
-            let verified = verify_calls.lock();
-            assert!(
-                !proposed.contains(&target_view),
-                "voter must not propose for a leader-owned view after restart (observed: {proposed:?})"
-            );
-            assert!(
-                !verified.contains(&target_view),
-                "voter must not request verification for a leader-owned view after restart (observed: {verified:?})"
-            );
-        });
-    }
-
-    #[test_traced]
-    fn test_no_self_propose_after_restart() {
-        no_self_propose_after_restart(bls12381_threshold_vrf::fixture::<MinPk, _>);
-        no_self_propose_after_restart(bls12381_threshold_vrf::fixture::<MinSig, _>);
-        no_self_propose_after_restart(bls12381_multisig::fixture::<MinPk, _>);
-        no_self_propose_after_restart(bls12381_multisig::fixture::<MinSig, _>);
-        no_self_propose_after_restart(ed25519::fixture);
-        no_self_propose_after_restart(secp256r1::fixture);
-    }
 
     /// After restart, a proposal we already voted on must not be re-verified
     /// when it is re-delivered to the voter (e.g. via the automaton after

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -125,6 +125,15 @@ const GENESIS_BYTES: &[u8] = b"genesis";
 
 type Latency = (f64, f64);
 
+/// Observer invoked on every `Message::Propose` request. Used by tests to
+/// detect spurious propose calls.
+type ProposeObserver<H, P> = Box<dyn Fn(Context<<H as Hasher>::Digest, P>) + Send + 'static>;
+
+/// Observer invoked on every `Message::Verify` request. Used by tests to
+/// detect spurious verification calls.
+type VerifyObserver<H, P> =
+    Box<dyn Fn(Context<<H as Hasher>::Digest, P>, <H as Hasher>::Digest) + Send + 'static>;
+
 /// Predicate to determine whether a payload should be certified.
 /// Returning true means certify, false means reject.
 pub enum Certifier<D: Digest> {
@@ -190,12 +199,12 @@ pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
 
     /// Invoked on every `Message::Propose` request received by the application.
     /// Used by tests to detect spurious local-leader propose attempts (e.g. after replay).
-    propose_observer: Option<Box<dyn Fn(Context<H::Digest, P>) + Send + 'static>>,
+    propose_observer: Option<ProposeObserver<H, P>>,
 
     /// Invoked on every `Message::Verify` request received by the application.
     /// Used by tests to detect spurious verification requests (e.g. after replay
     /// of a leader-owned proposal).
-    verify_observer: Option<Box<dyn Fn(Context<H::Digest, P>, H::Digest) + Send + 'static>>,
+    verify_observer: Option<VerifyObserver<H, P>>,
 
     /// Senders held alive to simulate certifications that hang indefinitely
     /// (used by [`Certifier::Pending`]).
@@ -256,17 +265,11 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
         self.drop_verifications = drop;
     }
 
-    pub fn set_propose_observer(
-        &mut self,
-        observer: Box<dyn Fn(Context<H::Digest, P>) + Send + 'static>,
-    ) {
+    pub fn set_propose_observer(&mut self, observer: ProposeObserver<H, P>) {
         self.propose_observer = Some(observer);
     }
 
-    pub fn set_verify_observer(
-        &mut self,
-        observer: Box<dyn Fn(Context<H::Digest, P>, H::Digest) + Send + 'static>,
-    ) {
+    pub fn set_verify_observer(&mut self, observer: VerifyObserver<H, P>) {
         self.verify_observer = Some(observer);
     }
 

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -188,7 +188,14 @@ pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
 
     verified: HashSet<H::Digest>,
 
-    verify_observer: Option<Box<dyn Fn(H::Digest) + Send + 'static>>,
+    /// Invoked on every `Message::Propose` request received by the application.
+    /// Used by tests to detect spurious local-leader propose attempts (e.g. after replay).
+    propose_observer: Option<Box<dyn Fn(Context<H::Digest, P>) + Send + 'static>>,
+
+    /// Invoked on every `Message::Verify` request received by the application.
+    /// Used by tests to detect spurious verification requests (e.g. after replay
+    /// of a leader-owned proposal).
+    verify_observer: Option<Box<dyn Fn(Context<H::Digest, P>, H::Digest) + Send + 'static>>,
 
     /// Senders held alive to simulate certifications that hang indefinitely
     /// (used by [`Certifier::Pending`]).
@@ -229,6 +236,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
 
                 pending: HashMap::new(),
                 verified: HashSet::new(),
+                propose_observer: None,
                 verify_observer: None,
                 pending_certifications: Vec::new(),
             },
@@ -248,7 +256,17 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
         self.drop_verifications = drop;
     }
 
-    pub fn set_verify_observer(&mut self, observer: Box<dyn Fn(H::Digest) + Send + 'static>) {
+    pub fn set_propose_observer(
+        &mut self,
+        observer: Box<dyn Fn(Context<H::Digest, P>) + Send + 'static>,
+    ) {
+        self.propose_observer = Some(observer);
+    }
+
+    pub fn set_verify_observer(
+        &mut self,
+        observer: Box<dyn Fn(Context<H::Digest, P>, H::Digest) + Send + 'static>,
+    ) {
         self.verify_observer = Some(observer);
     }
 
@@ -392,6 +410,9 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                         response.send_lossy(digest);
                     }
                     Message::Propose { context, response } => {
+                        if let Some(observer) = &self.propose_observer {
+                            observer(context.clone());
+                        }
                         if self.drop_proposals {
                             continue;
                         }
@@ -403,11 +424,11 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                         payload,
                         response,
                     } => {
+                        if let Some(observer) = &self.verify_observer {
+                            observer(context.clone(), payload);
+                        }
                         if self.drop_verifications {
                             continue;
-                        }
-                        if let Some(observer) = &self.verify_observer {
-                            observer(payload);
                         }
                         if let Some(contents) = seen.get(&payload) {
                             let verified = self.verify(context, payload, contents.clone()).await;


### PR DESCRIPTION
Related: #3551 

  Where the new tests are clearly better (from Claude):

  1. They actually catch the regression. The original 4-case matrix tested "no verify" for leader-owned views, but verify_ready's leader short-circuit structurally prevents verify from firing there regardless of the fix. All 4
  original cases passed whether the fix was present or not — they were coincidental coverage, not regression tests.
  2. Coverage of the live path. The original only tested restart; test_no_self_verify_when_proposing covers the live leader flow that the original ignored entirely.
  3. Coverage of the follower path. The original only tested leader-owned views (where verify can't fire). test_no_self_verify_after_restart exercises the follower path where verify does fire in the buggy case and the observer
  directly catches it.
  4. Deterministic sync via Nullify. The original used ad-hoc sleeps and matches; new tests use the voter's natural leader_timeout → Nullify path as a clean sync point that guarantees the voter has run its full cycle.