### PR TITLE
[Storage] Implement state sync for `qmdb::keyless`

### DIFF
--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -10,8 +10,8 @@ use commonware_runtime::{
 };
 use commonware_storage::qmdb::sync;
 use commonware_sync::{
-    any, crate_version, current, databases::DatabaseType, immutable, net::Resolver, Digest, Error,
-    Key,
+    any, crate_version, current, databases::DatabaseType, immutable, keyless, net::Resolver,
+    Digest, Error, Key,
 };
 use commonware_utils::{
     channel::mpsc::{self, error::TrySendError},
@@ -299,6 +299,69 @@ where
     }
 }
 
+/// Repeatedly sync a Keyless database to the server's state.
+async fn run_keyless<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
+where
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
+{
+    info!("starting Keyless database sync process");
+    let mut iteration = 0u32;
+    loop {
+        let resolver = Resolver::<keyless::Operation, Key>::connect(
+            context.with_label("resolver"),
+            config.server,
+        )
+        .await?;
+
+        let initial_target = resolver.get_sync_target().await?;
+
+        let db_config = keyless::create_config(&context);
+        let (update_sender, update_receiver) = mpsc::channel(UPDATE_CHANNEL_SIZE);
+
+        let target_update_handle = {
+            let resolver = resolver.clone();
+            let initial_target_clone = initial_target.clone();
+            let target_update_interval = config.target_update_interval;
+            context.with_label("target_update").spawn(move |context| {
+                target_update_task(
+                    context,
+                    resolver,
+                    update_sender,
+                    target_update_interval,
+                    initial_target_clone,
+                )
+            })
+        };
+
+        let sync_config =
+            sync::engine::Config::<keyless::Database<_>, Resolver<keyless::Operation, Key>> {
+                context: context.with_label("sync"),
+                db_config,
+                fetch_batch_size: config.batch_size,
+                target: initial_target,
+                resolver,
+                apply_batch_size: 1024,
+                max_outstanding_requests: config.max_outstanding_requests,
+                update_rx: Some(update_receiver),
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
+
+        let database: keyless::Database<_> = sync::sync(sync_config).await?;
+        let got_root = database.root();
+        info!(
+            sync_iteration = iteration,
+            root = %got_root,
+            sync_interval = ?config.sync_interval,
+            "✅ Keyless sync completed successfully"
+        );
+        target_update_handle.abort();
+        context.sleep(config.sync_interval).await;
+        iteration += 1;
+    }
+}
+
 fn parse_config() -> Result<Config, Box<dyn std::error::Error>> {
     // Parse command line arguments
     let matches = Command::new("Sync Client")
@@ -307,8 +370,8 @@ fn parse_config() -> Result<Config, Box<dyn std::error::Error>> {
         .arg(
             Arg::new("db")
                 .long("db")
-                .value_name("any|current|immutable")
-                .help("Database type to use. Must be `any`, `current`, or `immutable`.")
+                .value_name("any|current|immutable|keyless")
+                .help("Database type to use. Must be `any`, `current`, `immutable`, or `keyless`.")
                 .default_value("any"),
         )
         .arg(
@@ -468,6 +531,7 @@ fn main() {
             DatabaseType::Any => run_any(context.with_label("sync"), config).await,
             DatabaseType::Current => run_current(context.with_label("sync"), config).await,
             DatabaseType::Immutable => run_immutable(context.with_label("sync"), config).await,
+            DatabaseType::Keyless => run_keyless(context.with_label("sync"), config).await,
         };
 
         if let Err(err) = result {

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -1,5 +1,5 @@
 //! Server that serves operations and proofs to clients attempting to sync an
-//! `any`, `current`, or `immutable` database.
+//! `any`, `current`, `immutable`, or `keyless` database.
 
 use clap::{Arg, Command};
 use commonware_codec::{DecodeExt, Encode, Read};
@@ -13,7 +13,7 @@ use commonware_stream::utils::codec::{recv_frame, send_frame};
 use commonware_sync::{
     any, crate_version, current,
     databases::{DatabaseType, Syncable},
-    immutable,
+    immutable, keyless,
     net::{wire, ErrorCode, ErrorResponse, MAX_MESSAGE_SIZE},
     Error, Key,
 };
@@ -537,6 +537,17 @@ where
     run_helper(context, config, database).await
 }
 
+/// Run the Keyless database server.
+async fn run_keyless<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
+where
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Clone,
+{
+    let db_config = keyless::create_config(&context);
+    let database = keyless::Database::init(context.with_label("database"), db_config).await?;
+
+    run_helper(context, config, database).await
+}
+
 /// Parse command line arguments and return configuration.
 fn parse_config() -> Result<Config, Box<dyn std::error::Error>> {
     // Parse command line arguments
@@ -546,8 +557,8 @@ fn parse_config() -> Result<Config, Box<dyn std::error::Error>> {
         .arg(
             Arg::new("db")
                 .long("db")
-                .value_name("any|current|immutable")
-                .help("Database type to use. Must be `any`, `current`, or `immutable`.")
+                .value_name("any|current|immutable|keyless")
+                .help("Database type to use. Must be `any`, `current`, `immutable`, or `keyless`.")
                 .default_value("any"),
         )
         .arg(
@@ -680,6 +691,7 @@ fn main() {
             DatabaseType::Any => run_any(context, config).await,
             DatabaseType::Current => run_current(context, config).await,
             DatabaseType::Immutable => run_immutable(context, config).await,
+            DatabaseType::Keyless => run_keyless(context, config).await,
         };
 
         if let Err(err) = result {

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -1,0 +1,185 @@
+//! Keyless database types and helpers for the sync example.
+//!
+//! A `keyless` database is append-only: operations are stored by location rather than by key.
+//! It supports `Append(value)` and `Commit(metadata)` operations. For sync, the engine targets
+//! the Merkle root over all operations, and the client reconstructs the same state by replaying
+//! the fetched operations.
+
+use crate::{Hasher, Value};
+use commonware_cryptography::{Hasher as CryptoHasher, Sha256};
+use commonware_runtime::{buffer, BufferPooler, Clock, Metrics, Storage};
+use commonware_storage::{
+    journal::contiguous::fixed::Config as FConfig,
+    merkle::{
+        journaled::Config as MmrConfig,
+        mmr::{self, Location, Proof},
+    },
+    qmdb::{
+        self,
+        keyless::{self, fixed},
+        operation::Committable,
+    },
+};
+use commonware_utils::{NZUsize, NZU16, NZU64};
+use std::{future::Future, num::NonZeroU64};
+use tracing::error;
+
+/// Database type alias.
+pub type Database<E> = fixed::Db<mmr::Family, E, Value, Hasher>;
+
+/// Operation type alias.
+pub type Operation = fixed::Operation<Value>;
+
+/// Create a database configuration for the keyless variant.
+pub fn create_config(context: &impl BufferPooler) -> fixed::Config {
+    let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
+    keyless::Config {
+        merkle: MmrConfig {
+            journal_partition: "mmr-journal".into(),
+            metadata_partition: "mmr-metadata".into(),
+            items_per_blob: NZU64!(4096),
+            write_buffer: NZUsize!(4096),
+            thread_pool: None,
+            page_cache: page_cache.clone(),
+        },
+        log: FConfig {
+            partition: "log-journal".into(),
+            items_per_blob: NZU64!(4096),
+            write_buffer: NZUsize!(4096),
+            page_cache,
+        },
+    }
+}
+
+/// Create deterministic test operations for demonstration purposes.
+/// Generates Append operations and periodic Commit operations.
+pub fn create_test_operations(count: usize, seed: u64) -> Vec<Operation> {
+    let mut operations = Vec::new();
+    let mut hasher = <Hasher as CryptoHasher>::new();
+
+    for i in 0..count {
+        let value = {
+            hasher.update(&i.to_be_bytes());
+            hasher.update(&seed.to_be_bytes());
+            hasher.finalize()
+        };
+
+        operations.push(Operation::Append(value));
+
+        if (i + 1) % 10 == 0 {
+            operations.push(Operation::Commit(None));
+        }
+    }
+
+    // Always end with a commit
+    operations.push(Operation::Commit(Some(Sha256::fill(1))));
+    operations
+}
+
+impl<E> super::Syncable for Database<E>
+where
+    E: Storage + Clock + Metrics,
+{
+    type Family = mmr::Family;
+    type Operation = Operation;
+
+    fn create_test_operations(count: usize, seed: u64) -> Vec<Self::Operation> {
+        create_test_operations(count, seed)
+    }
+
+    async fn add_operations(
+        &mut self,
+        operations: Vec<Self::Operation>,
+    ) -> Result<(), qmdb::Error<mmr::Family>> {
+        if operations.last().is_none() || !operations.last().unwrap().is_commit() {
+            // Ignore bad inputs rather than return errors.
+            error!("operations must end with a commit");
+            return Ok(());
+        }
+
+        let mut batch = self.new_batch();
+        for operation in operations {
+            match operation {
+                Operation::Append(value) => {
+                    batch = batch.append(value);
+                }
+                Operation::Commit(metadata) => {
+                    let merkleized = batch.merkleize(self, metadata);
+                    self.apply_batch(merkleized).await?;
+                    self.commit().await?;
+                    batch = self.new_batch();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn root(&self) -> crate::Key {
+        self.root()
+    }
+
+    async fn size(&self) -> Location {
+        self.bounds().await.end
+    }
+
+    async fn inactivity_floor(&self) -> Location {
+        // Keyless databases have no inactivity floor concept.
+        // Use the pruning boundary, same as immutable.
+        self.bounds().await.start
+    }
+
+    fn historical_proof(
+        &self,
+        op_count: Location,
+        start_loc: Location,
+        max_ops: NonZeroU64,
+    ) -> impl Future<
+        Output = Result<(Proof<crate::Key>, Vec<Self::Operation>), qmdb::Error<mmr::Family>>,
+    > + Send {
+        self.historical_proof(op_count, start_loc, max_ops)
+    }
+
+    fn pinned_nodes_at(
+        &self,
+        loc: Location,
+    ) -> impl Future<Output = Result<Vec<crate::Key>, qmdb::Error<mmr::Family>>> + Send {
+        self.pinned_nodes_at(loc)
+    }
+
+    fn name() -> &'static str {
+        "keyless"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::databases::Syncable;
+    use commonware_runtime::deterministic;
+
+    type KeylessDb = Database<deterministic::Context>;
+
+    #[test]
+    fn test_create_test_operations() {
+        let ops = <KeylessDb as Syncable>::create_test_operations(5, 12345);
+        assert_eq!(ops.len(), 6); // 5 operations + 1 commit
+
+        if let Operation::Commit(Some(_)) = &ops[5] {
+            // ok
+        } else {
+            panic!("last operation should be a commit with metadata");
+        }
+    }
+
+    #[test]
+    fn test_deterministic_operations() {
+        // Operations should be deterministic based on seed
+        let ops1 = <KeylessDb as Syncable>::create_test_operations(3, 12345);
+        let ops2 = <KeylessDb as Syncable>::create_test_operations(3, 12345);
+        assert_eq!(ops1, ops2);
+
+        // Different seeds should produce different operations
+        let ops3 = <KeylessDb as Syncable>::create_test_operations(3, 54321);
+        assert_ne!(ops1, ops3);
+    }
+}

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -5,7 +5,7 @@
 //! the Merkle root over all operations, and the client reconstructs the same state by replaying
 //! the fetched operations.
 
-use crate::{Hasher, Value};
+use crate::{Hasher, Key, Value};
 use commonware_cryptography::{Hasher as CryptoHasher, Sha256};
 use commonware_runtime::{buffer, BufferPooler, Clock, Metrics, Storage};
 use commonware_storage::{
@@ -114,7 +114,7 @@ where
         Ok(())
     }
 
-    fn root(&self) -> crate::Key {
+    fn root(&self) -> Key {
         self.root()
     }
 
@@ -134,7 +134,7 @@ where
         start_loc: Location,
         max_ops: NonZeroU64,
     ) -> impl Future<
-        Output = Result<(Proof<crate::Key>, Vec<Self::Operation>), qmdb::Error<mmr::Family>>,
+        Output = Result<(Proof<Key>, Vec<Self::Operation>), qmdb::Error<mmr::Family>>,
     > + Send {
         self.historical_proof(op_count, start_loc, max_ops)
     }
@@ -142,7 +142,7 @@ where
     fn pinned_nodes_at(
         &self,
         loc: Location,
-    ) -> impl Future<Output = Result<Vec<crate::Key>, qmdb::Error<mmr::Family>>> + Send {
+    ) -> impl Future<Output = Result<Vec<Key>, qmdb::Error<mmr::Family>>> + Send {
         self.pinned_nodes_at(loc)
     }
 

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -21,7 +21,7 @@ use commonware_storage::{
     },
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
-use std::{future::Future, num::NonZeroU64};
+use std::num::NonZeroU64;
 use tracing::error;
 
 /// Database type alias.
@@ -128,21 +128,20 @@ where
         self.bounds().await.start
     }
 
-    fn historical_proof(
+    async fn historical_proof(
         &self,
         op_count: Location,
         start_loc: Location,
         max_ops: NonZeroU64,
-    ) -> impl Future<Output = Result<(Proof<Key>, Vec<Self::Operation>), qmdb::Error<mmr::Family>>> + Send
-    {
-        self.historical_proof(op_count, start_loc, max_ops)
+    ) -> Result<(Proof<Key>, Vec<Self::Operation>), qmdb::Error<mmr::Family>> {
+        self.historical_proof(op_count, start_loc, max_ops).await
     }
 
-    fn pinned_nodes_at(
+    async fn pinned_nodes_at(
         &self,
         loc: Location,
-    ) -> impl Future<Output = Result<Vec<Key>, qmdb::Error<mmr::Family>>> + Send {
-        self.pinned_nodes_at(loc)
+    ) -> Result<Vec<Key>, qmdb::Error<mmr::Family>> {
+        self.pinned_nodes_at(loc).await
     }
 
     fn name() -> &'static str {

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -31,8 +31,12 @@ pub type Database<E> = fixed::Db<mmr::Family, E, Value, Hasher>;
 pub type Operation = fixed::Operation<Value>;
 
 /// Create a database configuration for the keyless variant.
-pub fn create_config(context: &impl BufferPooler) -> fixed::Config {
-    let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
+pub fn create_config(context: &(impl BufferPooler + commonware_runtime::Metrics)) -> fixed::Config {
+    let page_cache = buffer::paged::CacheRef::from_pooler(
+        &context.with_label("page_cache"),
+        NZU16!(2048),
+        NZUsize!(10),
+    );
     keyless::Config {
         merkle: MmrConfig {
             journal_partition: "mmr-journal".into(),
@@ -137,10 +141,7 @@ where
         self.historical_proof(op_count, start_loc, max_ops).await
     }
 
-    async fn pinned_nodes_at(
-        &self,
-        loc: Location,
-    ) -> Result<Vec<Key>, qmdb::Error<mmr::Family>> {
+    async fn pinned_nodes_at(&self, loc: Location) -> Result<Vec<Key>, qmdb::Error<mmr::Family>> {
         self.pinned_nodes_at(loc).await
     }
 

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -133,9 +133,8 @@ where
         op_count: Location,
         start_loc: Location,
         max_ops: NonZeroU64,
-    ) -> impl Future<
-        Output = Result<(Proof<Key>, Vec<Self::Operation>), qmdb::Error<mmr::Family>>,
-    > + Send {
+    ) -> impl Future<Output = Result<(Proof<Key>, Vec<Self::Operation>), qmdb::Error<mmr::Family>>> + Send
+    {
         self.historical_proof(op_count, start_loc, max_ops)
     }
 

--- a/examples/sync/src/databases/mod.rs
+++ b/examples/sync/src/databases/mod.rs
@@ -4,13 +4,14 @@ use crate::Key;
 use commonware_codec::Encode;
 use commonware_storage::{
     merkle::{self, Location, Proof},
-    qmdb::{self, operation::Operation},
+    qmdb,
 };
 use std::{future::Future, num::NonZeroU64};
 
 pub mod any;
 pub mod current;
 pub mod immutable;
+pub mod keyless;
 
 /// Database type to sync.
 #[derive(Debug, Clone, Copy)]
@@ -18,6 +19,7 @@ pub enum DatabaseType {
     Any,
     Current,
     Immutable,
+    Keyless,
 }
 
 impl std::str::FromStr for DatabaseType {
@@ -28,8 +30,9 @@ impl std::str::FromStr for DatabaseType {
             "any" => Ok(Self::Any),
             "current" => Ok(Self::Current),
             "immutable" => Ok(Self::Immutable),
+            "keyless" => Ok(Self::Keyless),
             _ => Err(format!(
-                "Invalid database type: '{s}'. Must be 'any', 'current', or 'immutable'",
+                "Invalid database type: '{s}'. Must be 'any', 'current', 'immutable', or 'keyless'",
             )),
         }
     }
@@ -41,6 +44,7 @@ impl DatabaseType {
             Self::Any => "any",
             Self::Current => "current",
             Self::Immutable => "immutable",
+            Self::Keyless => "keyless",
         }
     }
 }
@@ -52,7 +56,7 @@ pub trait Syncable: Sized {
     type Family: merkle::Family;
 
     /// The type of operations in the database.
-    type Operation: Operation<Self::Family> + Encode + Sync + 'static;
+    type Operation: Encode + Sync + 'static;
 
     /// Create test operations with the given count and seed.
     /// The returned operations must end with a commit operation.

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -1,8 +1,8 @@
 //! Synchronize state between a server and client.
 //!
 //! This example shows how to synchronize a client database to a remote server's database
-//! using [commonware_storage::qmdb::any], [commonware_storage::qmdb::current], or
-//! [commonware_storage::qmdb::immutable].
+//! using [commonware_storage::qmdb::any], [commonware_storage::qmdb::current],
+//! [commonware_storage::qmdb::immutable], or [commonware_storage::qmdb::keyless].
 //!
 //! It includes network protocols, database configuration, and utilities for creating test data.
 
@@ -15,7 +15,7 @@ pub mod error;
 pub use error::Error;
 pub mod databases;
 pub mod net;
-pub use databases::{any, current, immutable};
+pub use databases::{any, current, immutable, keyless};
 
 /// Returns the version of the crate.
 pub const fn crate_version() -> &'static str {

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -59,7 +59,7 @@ use tracing::{debug, warn};
 pub mod batch;
 pub mod fixed;
 mod operation;
-pub mod sync;
+pub(crate) mod sync;
 pub mod variable;
 pub use operation::Operation;
 

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -59,6 +59,7 @@ use tracing::{debug, warn};
 pub mod batch;
 pub mod fixed;
 mod operation;
+pub mod sync;
 pub mod variable;
 pub use operation::Operation;
 
@@ -209,6 +210,23 @@ where
             .journal
             .historical_proof(op_count, start_loc, max_ops)
             .await?)
+    }
+
+    /// Return the pinned Merkle nodes for a lower operation boundary of `loc`.
+    pub async fn pinned_nodes_at(&self, loc: Location<F>) -> Result<Vec<H::Digest>, Error<F>> {
+        if !loc.is_valid() {
+            return Err(crate::merkle::Error::LocationOverflow(loc).into());
+        }
+        let futs: Vec<_> = F::nodes_to_pin(loc)
+            .map(|p| async move {
+                self.journal
+                    .merkle
+                    .get_node(p)
+                    .await?
+                    .ok_or(crate::merkle::Error::ElementPruned(p).into())
+            })
+            .collect();
+        futures::future::try_join_all(futs).await
     }
 
     /// Prune historical operations prior to `loc`. This does not affect the db's root.

--- a/storage/src/qmdb/keyless/sync.rs
+++ b/storage/src/qmdb/keyless/sync.rs
@@ -11,7 +11,8 @@ use crate::{
     qmdb::{
         self,
         any::value::ValueEncoding,
-        keyless::{Keyless, Operation},
+        keyless::{operation::Codec, Keyless, Operation},
+        operation::Committable as _,
         sync,
     },
     Context, Persistable,
@@ -23,7 +24,7 @@ use std::ops::Range;
 impl<E, V, C, H> sync::Database for Keyless<mmr::Family, E, V, C, H>
 where
     E: Context,
-    V: ValueEncoding,
+    V: ValueEncoding + Codec,
     C: Mutable<Item = Operation<V>>
         + Persistable<Error = JournalError>
         + sync::Journal<Context = E, Op = Operation<V>>,
@@ -38,6 +39,21 @@ where
     type Digest = H::Digest;
     type Context = E;
 
+    /// Returns a [Keyless] db initialized from data collected in the sync process.
+    ///
+    /// # Behavior
+    ///
+    /// This method handles different initialization scenarios based on existing data:
+    /// - If the Merkle journal is empty or the last item is before the range start, it creates
+    ///   a fresh Merkle structure from the provided `pinned_nodes`
+    /// - If the Merkle journal has data but is incomplete (has length < range end), missing
+    ///   operations from the log are applied to bring it up to the target state
+    /// - If the Merkle journal has data beyond the range end, it is rewound to match the sync
+    ///   target
+    ///
+    /// # Returns
+    ///
+    /// A [Keyless] db populated with the state from the given range.
     async fn from_sync_result(
         context: Self::Context,
         config: Self::Config,
@@ -69,13 +85,14 @@ where
 
         let last_commit_loc = {
             let reader = journal.reader().await;
-            Location::new(
-                reader
-                    .bounds()
-                    .end
-                    .checked_sub(1)
-                    .expect("commit should exist"),
-            )
+            let loc = reader
+                .bounds()
+                .end
+                .checked_sub(1)
+                .expect("journal should not be empty");
+            let op = reader.read(loc).await?;
+            assert!(op.is_commit(), "last operation should be a commit");
+            Location::new(loc)
         };
 
         let db = Self {
@@ -102,6 +119,7 @@ mod tests {
             sync::{
                 self,
                 engine::{Config, NextStep},
+                resolver::tests::FailResolver,
                 Engine, Target,
             },
         },
@@ -121,15 +139,22 @@ mod tests {
         sync::Arc,
     };
 
+    /// Type alias for sync tests with variable-length values.
     type KeylessSyncTest = variable::Db<mmr::Family, deterministic::Context, Vec<u8>, Sha256>;
 
+    type VariableOp = Operation<crate::qmdb::any::value::VariableEncoding<Vec<u8>>>;
+
+    // Used by both `create_sync_config` and `test_sync_fixed`.
     const PAGE_SIZE: NonZeroU16 = NZU16!(77);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
 
+    /// Create a simple config for sync tests.
     fn create_sync_config(
         suffix: &str,
         pooler: &impl BufferPooler,
     ) -> variable::Config<(commonware_codec::RangeCfg<usize>, ())> {
+        const ITEMS_PER_SECTION: NonZeroU64 = NZU64!(5);
+
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         keyless::Config {
             merkle: crate::merkle::journaled::Config {
@@ -142,7 +167,7 @@ mod tests {
             },
             log: crate::journal::contiguous::variable::Config {
                 partition: format!("log-{suffix}"),
-                items_per_section: NZU64!(5),
+                items_per_section: ITEMS_PER_SECTION,
                 compression: None,
                 codec_config: ((0..=10000).into(), ()),
                 page_cache,
@@ -151,22 +176,22 @@ mod tests {
         }
     }
 
+    /// Create a test database with unique partition names.
     async fn create_test_db(mut context: deterministic::Context) -> KeylessSyncTest {
         let seed = context.next_u64();
         let config = create_sync_config(&format!("sync-test-{seed}"), &context);
         KeylessSyncTest::init(context, config).await.unwrap()
     }
 
-    fn create_test_ops(
-        n: usize,
-    ) -> Vec<Operation<crate::qmdb::any::value::VariableEncoding<Vec<u8>>>> {
+    /// Create n random Append operations using the default seed (0).
+    /// create_test_ops(n) is a prefix of create_test_ops(n') for n < n'.
+    fn create_test_ops(n: usize) -> Vec<VariableOp> {
         create_test_ops_seeded(n, 0)
     }
 
-    fn create_test_ops_seeded(
-        n: usize,
-        seed: u64,
-    ) -> Vec<Operation<crate::qmdb::any::value::VariableEncoding<Vec<u8>>>> {
+    /// Create n random Append operations using a specific seed.
+    /// Use different seeds when you need non-overlapping values in the same test.
+    fn create_test_ops_seeded(n: usize, seed: u64) -> Vec<VariableOp> {
         let mut rng = test_rng_seeded(seed);
         let mut ops = Vec::with_capacity(n);
         for _ in 0..n {
@@ -178,11 +203,8 @@ mod tests {
         ops
     }
 
-    async fn apply_ops(
-        db: &mut KeylessSyncTest,
-        ops: Vec<Operation<crate::qmdb::any::value::VariableEncoding<Vec<u8>>>>,
-        metadata: Option<Vec<u8>>,
-    ) {
+    /// Applies the given operations and commits the database.
+    async fn apply_ops(db: &mut KeylessSyncTest, ops: Vec<VariableOp>, metadata: Option<Vec<u8>>) {
         let mut batch = db.new_batch();
         for op in ops {
             match op {
@@ -198,14 +220,44 @@ mod tests {
         db.apply_batch(merkleized).await.unwrap();
     }
 
+    /// Test that resolver failure is handled correctly.
+    #[test_traced("WARN")]
+    fn test_sync_resolver_fails() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let resolver = FailResolver::<VariableOp, sha256::Digest>::new();
+            let db_config = create_sync_config(&context.next_u64().to_string(), &context);
+            let config = Config {
+                context: context.with_label("client"),
+                target: Target {
+                    root: sha256::Digest::from([0; 32]),
+                    range: non_empty_range!(Location::new(0), Location::new(5)),
+                },
+                resolver,
+                apply_batch_size: 2,
+                max_outstanding_requests: 2,
+                fetch_batch_size: NZU64!(2),
+                db_config,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
+
+            let result: Result<KeylessSyncTest, _> = sync::sync(config).await;
+            assert!(result.is_err());
+        });
+    }
+
     #[rstest]
     #[case::singleton_batch_size_one(1, NZU64!(1))]
     #[case::singleton_batch_size_gt_db_size(1, NZU64!(2))]
-    #[case::batch_size_one(100, NZU64!(1))]
-    #[case::floor_div_db_batch_size(100, NZU64!(3))]
-    #[case::div_db_batch_size(100, NZU64!(10))]
-    #[case::db_size_eq_batch_size(100, NZU64!(100))]
-    #[case::batch_size_gt_db_size(100, NZU64!(200))]
+    #[case::batch_size_one(1000, NZU64!(1))]
+    #[case::floor_div_db_batch_size(1000, NZU64!(3))]
+    #[case::floor_div_db_batch_size_2(1000, NZU64!(999))]
+    #[case::div_db_batch_size(1000, NZU64!(100))]
+    #[case::db_size_eq_batch_size(1000, NZU64!(1000))]
+    #[case::batch_size_gt_db_size(1000, NZU64!(1001))]
     fn test_sync(#[case] target_db_ops: usize, #[case] fetch_batch_size: NonZeroU64) {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
@@ -861,7 +913,8 @@ mod tests {
         });
     }
 
-    // Verify fixed-size keyless DB also syncs correctly.
+    // Extra test verifying the generic sync::Database impl works for fixed-size journals.
+    // Not present in immutable (which only tests variable).
     #[test_traced("WARN")]
     fn test_sync_fixed() {
         use crate::qmdb::keyless::fixed;

--- a/storage/src/qmdb/keyless/sync.rs
+++ b/storage/src/qmdb/keyless/sync.rs
@@ -1,0 +1,964 @@
+use crate::{
+    journal::{
+        authenticated,
+        contiguous::{Contiguous as _, Mutable, Reader as _},
+        Error as JournalError,
+    },
+    merkle::{
+        journaled::{self, Journaled},
+        mmr::{self, Location, StandardHasher},
+    },
+    qmdb::{
+        self,
+        any::value::ValueEncoding,
+        keyless::{Keyless, Operation},
+        sync,
+    },
+    Context, Persistable,
+};
+use commonware_codec::EncodeShared;
+use commonware_cryptography::Hasher;
+use std::ops::Range;
+
+impl<E, V, C, H> sync::Database for Keyless<mmr::Family, E, V, C, H>
+where
+    E: Context,
+    V: ValueEncoding,
+    C: Mutable<Item = Operation<V>>
+        + Persistable<Error = JournalError>
+        + sync::Journal<Context = E, Op = Operation<V>>,
+    C::Config: Clone + Send,
+    H: Hasher,
+    Operation<V>: EncodeShared,
+{
+    type Op = Operation<V>;
+    type Journal = C;
+    type Hasher = H;
+    type Config = super::Config<C::Config>;
+    type Digest = H::Digest;
+    type Context = E;
+
+    async fn from_sync_result(
+        context: Self::Context,
+        config: Self::Config,
+        log: Self::Journal,
+        pinned_nodes: Option<Vec<Self::Digest>>,
+        range: Range<Location>,
+        apply_batch_size: usize,
+    ) -> Result<Self, qmdb::Error<mmr::Family>> {
+        let hasher = StandardHasher::<H>::new();
+
+        let merkle = Journaled::init_sync(
+            context.with_label("merkle"),
+            journaled::SyncConfig {
+                config: config.merkle.clone(),
+                range,
+                pinned_nodes,
+            },
+            &hasher,
+        )
+        .await?;
+
+        let journal = authenticated::Journal::<mmr::Family, _, _, _>::from_components(
+            merkle,
+            log,
+            hasher,
+            apply_batch_size as u64,
+        )
+        .await?;
+
+        let last_commit_loc = {
+            let reader = journal.reader().await;
+            Location::new(
+                reader
+                    .bounds()
+                    .end
+                    .checked_sub(1)
+                    .expect("commit should exist"),
+            )
+        };
+
+        let db = Self {
+            journal,
+            last_commit_loc,
+        };
+
+        db.sync().await?;
+        Ok(db)
+    }
+
+    fn root(&self) -> Self::Digest {
+        self.root()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        journal::contiguous::Contiguous,
+        merkle::mmr::{self, Location},
+        qmdb::{
+            keyless::{self, variable, Operation},
+            sync::{
+                self,
+                engine::{Config, NextStep},
+                Engine, Target,
+            },
+        },
+    };
+    use commonware_cryptography::{sha256, Sha256};
+    use commonware_macros::test_traced;
+    use commonware_runtime::{
+        buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner as _,
+    };
+    use commonware_utils::{
+        channel::mpsc, non_empty_range, test_rng_seeded, NZUsize, NZU16, NZU64,
+    };
+    use rand::RngCore as _;
+    use rstest::rstest;
+    use std::{
+        num::{NonZeroU16, NonZeroU64, NonZeroUsize},
+        sync::Arc,
+    };
+
+    type KeylessSyncTest = variable::Db<mmr::Family, deterministic::Context, Vec<u8>, Sha256>;
+
+    const PAGE_SIZE: NonZeroU16 = NZU16!(77);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
+
+    fn create_sync_config(
+        suffix: &str,
+        pooler: &impl BufferPooler,
+    ) -> variable::Config<(commonware_codec::RangeCfg<usize>, ())> {
+        let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
+        keyless::Config {
+            merkle: crate::merkle::journaled::Config {
+                journal_partition: format!("journal-{suffix}"),
+                metadata_partition: format!("metadata-{suffix}"),
+                items_per_blob: NZU64!(11),
+                write_buffer: NZUsize!(1024),
+                thread_pool: None,
+                page_cache: page_cache.clone(),
+            },
+            log: crate::journal::contiguous::variable::Config {
+                partition: format!("log-{suffix}"),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: ((0..=10000).into(), ()),
+                page_cache,
+                write_buffer: NZUsize!(1024),
+            },
+        }
+    }
+
+    async fn create_test_db(mut context: deterministic::Context) -> KeylessSyncTest {
+        let seed = context.next_u64();
+        let config = create_sync_config(&format!("sync-test-{seed}"), &context);
+        KeylessSyncTest::init(context, config).await.unwrap()
+    }
+
+    fn create_test_ops(
+        n: usize,
+    ) -> Vec<Operation<crate::qmdb::any::value::VariableEncoding<Vec<u8>>>> {
+        create_test_ops_seeded(n, 0)
+    }
+
+    fn create_test_ops_seeded(
+        n: usize,
+        seed: u64,
+    ) -> Vec<Operation<crate::qmdb::any::value::VariableEncoding<Vec<u8>>>> {
+        let mut rng = test_rng_seeded(seed);
+        let mut ops = Vec::with_capacity(n);
+        for _ in 0..n {
+            let len = (rng.next_u32() % 100 + 1) as usize;
+            let mut value = vec![0u8; len];
+            rng.fill_bytes(&mut value);
+            ops.push(Operation::Append(value));
+        }
+        ops
+    }
+
+    async fn apply_ops(
+        db: &mut KeylessSyncTest,
+        ops: Vec<Operation<crate::qmdb::any::value::VariableEncoding<Vec<u8>>>>,
+        metadata: Option<Vec<u8>>,
+    ) {
+        let mut batch = db.new_batch();
+        for op in ops {
+            match op {
+                Operation::Append(value) => {
+                    batch = batch.append(value);
+                }
+                Operation::Commit(_) => {
+                    panic!("Commit operation not supported in apply_ops");
+                }
+            }
+        }
+        let merkleized = batch.merkleize(db, metadata);
+        db.apply_batch(merkleized).await.unwrap();
+    }
+
+    #[rstest]
+    #[case::singleton_batch_size_one(1, NZU64!(1))]
+    #[case::singleton_batch_size_gt_db_size(1, NZU64!(2))]
+    #[case::batch_size_one(100, NZU64!(1))]
+    #[case::floor_div_db_batch_size(100, NZU64!(3))]
+    #[case::div_db_batch_size(100, NZU64!(10))]
+    #[case::db_size_eq_batch_size(100, NZU64!(100))]
+    #[case::batch_size_gt_db_size(100, NZU64!(200))]
+    fn test_sync(#[case] target_db_ops: usize, #[case] fetch_batch_size: NonZeroU64) {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let target_ops = create_test_ops(target_db_ops);
+            apply_ops(&mut target_db, target_ops.clone(), Some(vec![42])).await;
+            let bounds = target_db.bounds().await;
+            let target_op_count = bounds.end;
+            let target_oldest_retained_loc = bounds.start;
+            let target_root = target_db.root();
+
+            let db_config =
+                create_sync_config(&format!("sync_client_{}", context.next_u64()), &context);
+
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                db_config: db_config.clone(),
+                fetch_batch_size,
+                target: Target {
+                    root: target_root,
+                    range: non_empty_range!(target_oldest_retained_loc, target_op_count),
+                },
+                context: context.with_label("client"),
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 1,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
+            let got_db: KeylessSyncTest = sync::sync(config).await.unwrap();
+
+            // Verify database state
+            let bounds = got_db.bounds().await;
+            assert_eq!(bounds.end, target_op_count);
+            assert_eq!(bounds.start, target_oldest_retained_loc);
+            assert_eq!(got_db.root(), target_root);
+
+            // Verify values match
+            for (i, op) in target_ops.iter().enumerate() {
+                if let Operation::Append(value) = op {
+                    // +1 because location 0 is the initial commit
+                    let got = got_db.get(Location::new(i as u64 + 1)).await.unwrap();
+                    assert_eq!(got.as_ref(), Some(value));
+                }
+            }
+
+            // Apply more operations to both databases and verify they remain consistent
+            let new_ops = create_test_ops_seeded(target_db_ops, 1);
+            let mut got_db = got_db;
+            apply_ops(&mut got_db, new_ops.clone(), None).await;
+            let mut target_db = Arc::try_unwrap(target_db)
+                .unwrap_or_else(|_| panic!("target_db should have no other references"));
+            apply_ops(&mut target_db, new_ops, None).await;
+
+            assert_eq!(got_db.root(), target_db.root());
+
+            got_db.destroy().await.unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_sync_empty_to_nonempty() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            apply_ops(&mut target_db, vec![], Some(vec![1, 2, 3])).await;
+
+            let bounds = target_db.bounds().await;
+            let target_op_count = bounds.end;
+            let target_oldest_retained_loc = bounds.start;
+            let target_root = target_db.root();
+
+            let db_config =
+                create_sync_config(&format!("empty_sync_{}", context.next_u64()), &context);
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                db_config,
+                fetch_batch_size: NZU64!(10),
+                target: Target {
+                    root: target_root,
+                    range: non_empty_range!(target_oldest_retained_loc, target_op_count),
+                },
+                context: context.with_label("client"),
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 1,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
+            let got_db: KeylessSyncTest = sync::sync(config).await.unwrap();
+
+            let bounds = got_db.bounds().await;
+            assert_eq!(bounds.end, target_op_count);
+            assert_eq!(bounds.start, target_oldest_retained_loc);
+            assert_eq!(got_db.root(), target_root);
+            assert_eq!(got_db.get_metadata().await.unwrap(), Some(vec![1, 2, 3]));
+
+            got_db.destroy().await.unwrap();
+            let target_db =
+                Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("Failed to unwrap Arc"));
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_sync_database_persistence() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let target_ops = create_test_ops(10);
+            apply_ops(&mut target_db, target_ops.clone(), Some(vec![0])).await;
+
+            let target_root = target_db.root();
+            let bounds = target_db.bounds().await;
+            let lower_bound = bounds.start;
+            let op_count = bounds.end;
+
+            let db_config = create_sync_config("persistence-test", &context);
+            let client_context = context.with_label("client");
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                db_config: db_config.clone(),
+                fetch_batch_size: NZU64!(5),
+                target: Target {
+                    root: target_root,
+                    range: non_empty_range!(lower_bound, op_count),
+                },
+                context: client_context.clone(),
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 1,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
+            let synced_db: KeylessSyncTest = sync::sync(config).await.unwrap();
+
+            assert_eq!(synced_db.root(), target_root);
+            let expected_root = synced_db.root();
+            let bounds = synced_db.bounds().await;
+            let expected_op_count = bounds.end;
+            let expected_oldest_retained_loc = bounds.start;
+
+            // Drop and reopen
+            synced_db.sync().await.unwrap();
+            drop(synced_db);
+            let reopened_db = KeylessSyncTest::init(context.with_label("reopened"), db_config)
+                .await
+                .unwrap();
+
+            assert_eq!(reopened_db.root(), expected_root);
+            let bounds = reopened_db.bounds().await;
+            assert_eq!(bounds.end, expected_op_count);
+            assert_eq!(bounds.start, expected_oldest_retained_loc);
+
+            // Verify data integrity
+            for (i, op) in target_ops.iter().enumerate() {
+                if let Operation::Append(value) = op {
+                    let got = reopened_db.get(Location::new(i as u64 + 1)).await.unwrap();
+                    assert_eq!(got.as_ref(), Some(value));
+                }
+            }
+
+            reopened_db.destroy().await.unwrap();
+            let target_db =
+                Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("Failed to unwrap Arc"));
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_target_update_during_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let initial_ops = create_test_ops(50);
+            apply_ops(&mut target_db, initial_ops, None).await;
+
+            let bounds = target_db.bounds().await;
+            let initial_lower_bound = bounds.start;
+            let initial_upper_bound = bounds.end;
+            let initial_root = target_db.root();
+
+            let additional_ops = create_test_ops_seeded(25, 1);
+            apply_ops(&mut target_db, additional_ops, None).await;
+            let final_upper_bound = target_db.bounds().await.end;
+            let final_root = target_db.root();
+
+            let target_db = Arc::new(target_db);
+
+            let (update_sender, update_receiver) = mpsc::channel(1);
+            let client = {
+                let config = Config {
+                    context: context.with_label("client"),
+                    db_config: create_sync_config(
+                        &format!("update_test_{}", context.next_u64()),
+                        &context,
+                    ),
+                    target: Target {
+                        root: initial_root,
+                        range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                    },
+                    resolver: target_db.clone(),
+                    fetch_batch_size: NZU64!(2),
+                    max_outstanding_requests: 10,
+                    apply_batch_size: 1024,
+                    update_rx: Some(update_receiver),
+                    finish_rx: None,
+                    reached_target_tx: None,
+                    max_retained_roots: 1,
+                };
+                let mut client: Engine<KeylessSyncTest, _> = Engine::new(config).await.unwrap();
+                loop {
+                    client = match client.step().await.unwrap() {
+                        NextStep::Continue(new_client) => new_client,
+                        NextStep::Complete(_) => panic!("client should not be complete"),
+                    };
+                    let log_size = Contiguous::size(client.journal()).await;
+                    if log_size > initial_lower_bound {
+                        break client;
+                    }
+                }
+            };
+
+            update_sender
+                .send(Target {
+                    root: final_root,
+                    range: non_empty_range!(initial_lower_bound, final_upper_bound),
+                })
+                .await
+                .unwrap();
+
+            let synced_db = client.sync().await.unwrap();
+            assert_eq!(synced_db.root(), final_root);
+
+            let target_db =
+                Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("Failed to unwrap Arc"));
+            {
+                let bounds = synced_db.bounds().await;
+                let target_bounds = target_db.bounds().await;
+                assert_eq!(bounds.end, target_bounds.end);
+                assert_eq!(bounds.start, target_bounds.start);
+                assert_eq!(synced_db.root(), target_db.root());
+            }
+
+            synced_db.destroy().await.unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn test_sync_subset_of_target_database() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let target_ops = create_test_ops(30);
+            // Apply all but the last operation
+            apply_ops(&mut target_db, target_ops[..29].to_vec(), None).await;
+
+            let target_root = target_db.root();
+            let bounds = target_db.bounds().await;
+            let lower_bound = bounds.start;
+            let op_count = bounds.end;
+
+            // Add final op after capturing the range
+            apply_ops(&mut target_db, target_ops[29..].to_vec(), None).await;
+
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                db_config: create_sync_config(&format!("subset_{}", context.next_u64()), &context),
+                fetch_batch_size: NZU64!(10),
+                target: Target {
+                    root: target_root,
+                    range: non_empty_range!(lower_bound, op_count),
+                },
+                context: context.with_label("client"),
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 1,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
+            let synced_db: KeylessSyncTest = sync::sync(config).await.unwrap();
+
+            assert_eq!(synced_db.root(), target_root);
+            assert_eq!(synced_db.bounds().await.end, op_count);
+
+            synced_db.destroy().await.unwrap();
+            let target_db =
+                Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("failed to unwrap Arc"));
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn test_sync_use_existing_db_partial_match() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let original_ops = create_test_ops(50);
+
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let sync_db_config =
+                create_sync_config(&format!("partial_{}", context.next_u64()), &context);
+            let client_context = context.with_label("client");
+            let mut sync_db: KeylessSyncTest =
+                KeylessSyncTest::init(client_context.clone(), sync_db_config.clone())
+                    .await
+                    .unwrap();
+
+            // Apply same operations to both
+            apply_ops(&mut target_db, original_ops.clone(), None).await;
+            apply_ops(&mut sync_db, original_ops, None).await;
+
+            drop(sync_db);
+
+            // Add one more op to target
+            let last_op = create_test_ops_seeded(1, 1);
+            apply_ops(&mut target_db, last_op, None).await;
+            let root = target_db.root();
+            let bounds = target_db.bounds().await;
+            let lower_bound = bounds.start;
+            let upper_bound = bounds.end;
+
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                db_config: sync_db_config,
+                fetch_batch_size: NZU64!(10),
+                target: Target {
+                    root,
+                    range: non_empty_range!(lower_bound, upper_bound),
+                },
+                context: context.with_label("sync"),
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 1,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
+            let sync_db: KeylessSyncTest = sync::sync(config).await.unwrap();
+
+            assert_eq!(sync_db.bounds().await.end, upper_bound);
+            assert_eq!(sync_db.root(), root);
+
+            sync_db.destroy().await.unwrap();
+            let target_db =
+                Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("failed to unwrap Arc"));
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn test_sync_use_existing_db_exact_match() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let target_ops = create_test_ops(40);
+
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let sync_config =
+                create_sync_config(&format!("exact_{}", context.next_u64()), &context);
+            let client_context = context.with_label("client");
+            let mut sync_db: KeylessSyncTest =
+                KeylessSyncTest::init(client_context.clone(), sync_config.clone())
+                    .await
+                    .unwrap();
+
+            apply_ops(&mut target_db, target_ops.clone(), None).await;
+            apply_ops(&mut sync_db, target_ops, None).await;
+
+            drop(sync_db);
+
+            let root = target_db.root();
+            let bounds = target_db.bounds().await;
+            let lower_bound = bounds.start;
+            let upper_bound = bounds.end;
+
+            let resolver = Arc::new(target_db);
+            let config = Config {
+                db_config: sync_config,
+                fetch_batch_size: NZU64!(10),
+                target: Target {
+                    root,
+                    range: non_empty_range!(lower_bound, upper_bound),
+                },
+                context: context.with_label("sync"),
+                resolver: resolver.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 1,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
+            let sync_db: KeylessSyncTest = sync::sync(config).await.unwrap();
+
+            assert_eq!(sync_db.bounds().await.end, upper_bound);
+            assert_eq!(sync_db.root(), root);
+
+            sync_db.destroy().await.unwrap();
+            let target_db =
+                Arc::try_unwrap(resolver).unwrap_or_else(|_| panic!("failed to unwrap Arc"));
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_target_update_lower_bound_decrease() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let target_ops = create_test_ops(100);
+            apply_ops(&mut target_db, target_ops, None).await;
+
+            target_db.prune(Location::new(10)).await.unwrap();
+
+            let bounds = target_db.bounds().await;
+            let initial_lower_bound = bounds.start;
+            let initial_upper_bound = bounds.end;
+            let initial_root = target_db.root();
+
+            let (update_sender, update_receiver) = mpsc::channel(1);
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                context: context.with_label("client"),
+                db_config: create_sync_config(&format!("lb-dec-{}", context.next_u64()), &context),
+                fetch_batch_size: NZU64!(5),
+                target: Target {
+                    root: initial_root,
+                    range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                },
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 10,
+                update_rx: Some(update_receiver),
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 1,
+            };
+            let client: Engine<KeylessSyncTest, _> = Engine::new(config).await.unwrap();
+
+            update_sender
+                .send(Target {
+                    root: initial_root,
+                    range: non_empty_range!(
+                        initial_lower_bound.checked_sub(1).unwrap(),
+                        initial_upper_bound
+                    ),
+                })
+                .await
+                .unwrap();
+
+            let result = client.step().await;
+            assert!(matches!(
+                result,
+                Err(sync::Error::Engine(
+                    sync::EngineError::SyncTargetMovedBackward { .. }
+                ))
+            ));
+
+            let target_db =
+                Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("failed to unwrap Arc"));
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_target_update_upper_bound_decrease() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let target_ops = create_test_ops(50);
+            apply_ops(&mut target_db, target_ops, None).await;
+
+            let bounds = target_db.bounds().await;
+            let initial_lower_bound = bounds.start;
+            let initial_upper_bound = bounds.end;
+            let initial_root = target_db.root();
+
+            let (update_sender, update_receiver) = mpsc::channel(1);
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                context: context.with_label("client"),
+                db_config: create_sync_config(&format!("ub-dec-{}", context.next_u64()), &context),
+                fetch_batch_size: NZU64!(5),
+                target: Target {
+                    root: initial_root,
+                    range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                },
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 10,
+                update_rx: Some(update_receiver),
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 1,
+            };
+            let client: Engine<KeylessSyncTest, _> = Engine::new(config).await.unwrap();
+
+            update_sender
+                .send(Target {
+                    root: initial_root,
+                    range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
+                })
+                .await
+                .unwrap();
+
+            let result = client.step().await;
+            assert!(matches!(
+                result,
+                Err(sync::Error::Engine(
+                    sync::EngineError::SyncTargetMovedBackward { .. }
+                ))
+            ));
+
+            let target_db =
+                Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("failed to unwrap Arc"));
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_target_update_bounds_increase() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let target_ops = create_test_ops(100);
+            apply_ops(&mut target_db, target_ops, None).await;
+
+            let bounds = target_db.bounds().await;
+            let initial_lower_bound = bounds.start;
+            let initial_upper_bound = bounds.end;
+            let initial_root = target_db.root();
+
+            let more_ops = create_test_ops_seeded(5, 1);
+            apply_ops(&mut target_db, more_ops, None).await;
+
+            target_db.prune(Location::new(10)).await.unwrap();
+            apply_ops(&mut target_db, vec![], None).await;
+
+            let bounds = target_db.bounds().await;
+            let final_lower_bound = bounds.start;
+            let final_upper_bound = bounds.end;
+            let final_root = target_db.root();
+
+            assert_ne!(final_lower_bound, initial_lower_bound);
+            assert_ne!(final_upper_bound, initial_upper_bound);
+
+            let (update_sender, update_receiver) = mpsc::channel(1);
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                context: context.with_label("client"),
+                db_config: create_sync_config(
+                    &format!("bounds_inc_{}", context.next_u64()),
+                    &context,
+                ),
+                fetch_batch_size: NZU64!(1),
+                target: Target {
+                    root: initial_root,
+                    range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                },
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 1,
+                update_rx: Some(update_receiver),
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 1,
+            };
+
+            update_sender
+                .send(Target {
+                    root: final_root,
+                    range: non_empty_range!(final_lower_bound, final_upper_bound),
+                })
+                .await
+                .unwrap();
+
+            let synced_db: KeylessSyncTest = sync::sync(config).await.unwrap();
+
+            assert_eq!(synced_db.root(), final_root);
+            let bounds = synced_db.bounds().await;
+            assert_eq!(bounds.end, final_upper_bound);
+            assert_eq!(bounds.start, final_lower_bound);
+
+            synced_db.destroy().await.unwrap();
+            let target_db =
+                Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("Failed to unwrap Arc"));
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_target_update_on_done_client() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let mut target_db = create_test_db(context.with_label("target")).await;
+            let target_ops = create_test_ops(10);
+            apply_ops(&mut target_db, target_ops, None).await;
+
+            let bounds = target_db.bounds().await;
+            let lower_bound = bounds.start;
+            let upper_bound = bounds.end;
+            let root = target_db.root();
+
+            let (update_sender, update_receiver) = mpsc::channel(1);
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                context: context.with_label("client"),
+                db_config: create_sync_config(&format!("done_{}", context.next_u64()), &context),
+                fetch_batch_size: NZU64!(20),
+                target: Target {
+                    root,
+                    range: non_empty_range!(lower_bound, upper_bound),
+                },
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 10,
+                update_rx: Some(update_receiver),
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 1,
+            };
+
+            let synced_db: KeylessSyncTest = sync::sync(config).await.unwrap();
+
+            let _ = update_sender
+                .send(Target {
+                    root: sha256::Digest::from([2u8; 32]),
+                    range: non_empty_range!(lower_bound + 1, upper_bound + 1),
+                })
+                .await;
+
+            assert_eq!(synced_db.root(), root);
+            let bounds = synced_db.bounds().await;
+            assert_eq!(bounds.end, upper_bound);
+            assert_eq!(bounds.start, lower_bound);
+
+            synced_db.destroy().await.unwrap();
+            Arc::try_unwrap(target_db)
+                .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+                .destroy()
+                .await
+                .unwrap();
+        });
+    }
+
+    // Verify fixed-size keyless DB also syncs correctly.
+    #[test_traced("WARN")]
+    fn test_sync_fixed() {
+        use crate::qmdb::keyless::fixed;
+        use commonware_utils::sequence::U64;
+
+        type FixedSyncTest = fixed::Db<mmr::Family, deterministic::Context, U64, Sha256>;
+
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+            let target_config = fixed::Config {
+                merkle: crate::merkle::journaled::Config {
+                    journal_partition: format!("fixed-journal-target-{}", context.next_u64()),
+                    metadata_partition: format!("fixed-metadata-target-{}", context.next_u64()),
+                    items_per_blob: NZU64!(11),
+                    write_buffer: NZUsize!(1024),
+                    thread_pool: None,
+                    page_cache: page_cache.clone(),
+                },
+                log: crate::journal::contiguous::fixed::Config {
+                    partition: format!("fixed-log-target-{}", context.next_u64()),
+                    items_per_blob: NZU64!(7),
+                    page_cache: page_cache.clone(),
+                    write_buffer: NZUsize!(1024),
+                },
+            };
+
+            let mut target_db: FixedSyncTest =
+                FixedSyncTest::init(context.with_label("target"), target_config)
+                    .await
+                    .unwrap();
+
+            // Add some values
+            let mut batch = target_db.new_batch();
+            for i in 0..20u64 {
+                batch = batch.append(U64::new(i * 10 + 1));
+            }
+            let merkleized = batch.merkleize(&target_db, None);
+            target_db.apply_batch(merkleized).await.unwrap();
+
+            let target_root = target_db.root();
+            let bounds = target_db.bounds().await;
+            let lower_bound = bounds.start;
+            let upper_bound = bounds.end;
+
+            let client_page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+            let client_config = fixed::Config {
+                merkle: crate::merkle::journaled::Config {
+                    journal_partition: format!("fixed-journal-client-{}", context.next_u64()),
+                    metadata_partition: format!("fixed-metadata-client-{}", context.next_u64()),
+                    items_per_blob: NZU64!(11),
+                    write_buffer: NZUsize!(1024),
+                    thread_pool: None,
+                    page_cache: client_page_cache.clone(),
+                },
+                log: crate::journal::contiguous::fixed::Config {
+                    partition: format!("fixed-log-client-{}", context.next_u64()),
+                    items_per_blob: NZU64!(7),
+                    page_cache: client_page_cache,
+                    write_buffer: NZUsize!(1024),
+                },
+            };
+
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                db_config: client_config,
+                fetch_batch_size: NZU64!(5),
+                target: Target {
+                    root: target_root,
+                    range: non_empty_range!(lower_bound, upper_bound),
+                },
+                context: context.with_label("client"),
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 1,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
+            let synced_db: FixedSyncTest = sync::sync(config).await.unwrap();
+
+            assert_eq!(synced_db.root(), target_root);
+            let bounds = synced_db.bounds().await;
+            assert_eq!(bounds.end, upper_bound);
+            assert_eq!(bounds.start, lower_bound);
+
+            // Verify values
+            for i in 0..20u64 {
+                let got = synced_db.get(Location::new(i + 1)).await.unwrap();
+                assert_eq!(got, Some(U64::new(i * 10 + 1)));
+            }
+
+            synced_db.destroy().await.unwrap();
+            let target_db =
+                Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("failed to unwrap Arc"));
+            target_db.destroy().await.unwrap();
+        });
+    }
+}

--- a/storage/src/qmdb/keyless/sync.rs
+++ b/storage/src/qmdb/keyless/sync.rs
@@ -151,11 +151,12 @@ mod tests {
     /// Create a simple config for sync tests.
     fn create_sync_config(
         suffix: &str,
-        pooler: &impl BufferPooler,
+        pooler: &(impl BufferPooler + commonware_runtime::Metrics),
     ) -> variable::Config<(commonware_codec::RangeCfg<usize>, ())> {
         const ITEMS_PER_SECTION: NonZeroU64 = NZU64!(5);
 
-        let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
+        let page_cache =
+            CacheRef::from_pooler(&pooler.with_label("page_cache"), PAGE_SIZE, PAGE_CACHE_SIZE);
         keyless::Config {
             merkle: crate::merkle::journaled::Config {
                 journal_partition: format!("journal-{suffix}"),
@@ -924,7 +925,11 @@ mod tests {
 
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
-            let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+            let page_cache = CacheRef::from_pooler(
+                &context.with_label("page_cache"),
+                PAGE_SIZE,
+                PAGE_CACHE_SIZE,
+            );
             let target_config = fixed::Config {
                 merkle: crate::merkle::journaled::Config {
                     journal_partition: format!("fixed-journal-target-{}", context.next_u64()),
@@ -960,7 +965,11 @@ mod tests {
             let lower_bound = bounds.start;
             let upper_bound = bounds.end;
 
-            let client_page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+            let client_page_cache = CacheRef::from_pooler(
+                &context.with_label("client_page_cache"),
+                PAGE_SIZE,
+                PAGE_CACHE_SIZE,
+            );
             let client_config = fixed::Config {
                 merkle: crate::merkle::journaled::Config {
                     journal_partition: format!("fixed-journal-client-{}", context.next_u64()),

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -22,6 +22,14 @@ impl<T: Translator, C: Clone> Config for crate::qmdb::immutable::Config<T, C> {
         self.log.clone()
     }
 }
+
+impl<J: Clone> Config for crate::qmdb::keyless::Config<J> {
+    type JournalConfig = J;
+
+    fn journal_config(&self) -> Self::JournalConfig {
+        self.log.clone()
+    }
+}
 pub trait Database: Sized + Send {
     type Op: Send;
     type Journal: Journal<Context = Self::Context, Op = Self::Op>;

--- a/storage/src/qmdb/sync/resolver.rs
+++ b/storage/src/qmdb/sync/resolver.rs
@@ -17,6 +17,10 @@ use crate::{
             fixed::{Db as ImmutableFixedDb, Operation as ImmutableFixedOp},
             variable::{Db as ImmutableVariableDb, Operation as ImmutableVariableOp},
         },
+        keyless::{
+            fixed::{Db as KeylessFixedDb, Operation as KeylessFixedOp},
+            variable::{Db as KeylessVariableDb, Operation as KeylessVariableOp},
+        },
         operation::Key,
     },
     translator::Translator,
@@ -333,6 +337,120 @@ impl_resolver_immutable!(ImmutableFixedDb, ImmutableFixedOp, FixedValue, Array);
 
 // Immutable Variable
 impl_resolver_immutable!(ImmutableVariableDb, ImmutableVariableOp, VariableValue, Key);
+
+// Keyless types have no key or translator, so they need their own macro.
+macro_rules! impl_resolver_keyless {
+    ($db:ident, $op:ident, $val_bound:ident) => {
+        impl<E, V, H> Resolver for Arc<$db<mmr::Family, E, V, H>>
+        where
+            E: Context,
+            V: $val_bound + Send + Sync + 'static,
+            H: Hasher,
+        {
+            type Digest = H::Digest;
+            type Op = $op<V>;
+            type Error = qmdb::Error<mmr::Family>;
+
+            async fn get_operations(
+                &self,
+                op_count: Location,
+                start_loc: Location,
+                max_ops: NonZeroU64,
+                include_pinned_nodes: bool,
+                _cancel_rx: oneshot::Receiver<()>,
+            ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+                let (proof, operations) =
+                    self.historical_proof(op_count, start_loc, max_ops).await?;
+                let pinned_nodes = if include_pinned_nodes {
+                    Some(self.pinned_nodes_at(start_loc).await?)
+                } else {
+                    None
+                };
+                Ok(FetchResult {
+                    proof,
+                    operations,
+                    success_tx: oneshot::channel().0,
+                    pinned_nodes,
+                })
+            }
+        }
+
+        impl<E, V, H> Resolver for Arc<AsyncRwLock<$db<mmr::Family, E, V, H>>>
+        where
+            E: Context,
+            V: $val_bound + Send + Sync + 'static,
+            H: Hasher,
+        {
+            type Digest = H::Digest;
+            type Op = $op<V>;
+            type Error = qmdb::Error<mmr::Family>;
+
+            async fn get_operations(
+                &self,
+                op_count: Location,
+                start_loc: Location,
+                max_ops: NonZeroU64,
+                include_pinned_nodes: bool,
+                _cancel_rx: oneshot::Receiver<()>,
+            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+                let db = self.read().await;
+                let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
+                let pinned_nodes = if include_pinned_nodes {
+                    Some(db.pinned_nodes_at(start_loc).await?)
+                } else {
+                    None
+                };
+                Ok(FetchResult {
+                    proof,
+                    operations,
+                    success_tx: oneshot::channel().0,
+                    pinned_nodes,
+                })
+            }
+        }
+
+        impl<E, V, H> Resolver for Arc<AsyncRwLock<Option<$db<mmr::Family, E, V, H>>>>
+        where
+            E: Context,
+            V: $val_bound + Send + Sync + 'static,
+            H: Hasher,
+        {
+            type Digest = H::Digest;
+            type Op = $op<V>;
+            type Error = qmdb::Error<mmr::Family>;
+
+            async fn get_operations(
+                &self,
+                op_count: Location,
+                start_loc: Location,
+                max_ops: NonZeroU64,
+                include_pinned_nodes: bool,
+                _cancel_rx: oneshot::Receiver<()>,
+            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+                let guard = self.read().await;
+                let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
+                let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
+                let pinned_nodes = if include_pinned_nodes {
+                    Some(db.pinned_nodes_at(start_loc).await?)
+                } else {
+                    None
+                };
+                Ok(FetchResult {
+                    proof,
+                    operations,
+                    success_tx: oneshot::channel().0,
+                    pinned_nodes,
+                })
+            }
+        }
+    };
+}
+
+// Keyless Fixed
+impl_resolver_keyless!(KeylessFixedDb, KeylessFixedOp, FixedValue);
+
+// Keyless Variable
+impl_resolver_keyless!(KeylessVariableDb, KeylessVariableOp, VariableValue);
 
 #[cfg(test)]
 pub(crate) mod tests {


### PR DESCRIPTION
## Summary

Add state sync support for `qmdb::keyless`, matching the existing sync implementations for `qmdb::immutable`, `qmdb::any`, and `qmdb::current`.

## Storage crate

**`sync::Database` impl** (`storage/src/qmdb/keyless/sync.rs`): A single generic impl on `Keyless<mmr::Family, E, V, C, H>` covers both fixed and variable keyless databases. `from_sync_result` initializes the Merkle structure from sync components, builds the authenticated journal, and verifies the last operation is a commit. Simpler than `immutable`'s impl because there is no key-value index to rebuild.

**`pinned_nodes_at`** (`storage/src/qmdb/keyless/mod.rs`): New method on `Keyless` that returns the Merkle nodes needed to reconstruct the tree from a pruning boundary. Required by the resolver. Follows the same pattern as `any::Db::pinned_nodes_at` and `immutable::Immutable::pinned_nodes_at`.

**`sync::Config`** (`storage/src/qmdb/sync/database.rs`): Impl for `keyless::Config<J>` so the sync engine can extract the journal config.

**`sync::Resolver`** (`storage/src/qmdb/sync/resolver.rs`): New `impl_resolver_keyless!` macro generating resolver impls for both fixed and variable keyless DB types (3 Arc/Lock wrapper variants each). Keyless needs its own macro because its type parameters differ from the keyed variants (no `K`/`T`).

**Tests**: 20 tests covering basic sync at various batch sizes, persistence after sync, target updates (increase, decrease, during sync, after completion), partial/exact match with existing data, resolver failure, and a fixed-variant test.

## Sync example

**`examples/sync/src/databases/keyless.rs`**: New module implementing the `Syncable` trait for keyless using `keyless::fixed` (since the example's `Value` type is fixed-size `sha256::Digest`). Includes `create_config`, deterministic test operation generation, and the `Syncable` impl.

**Server/client**: Added `run_keyless` functions and `--db keyless` CLI support in both binaries.

**`Syncable` trait bound**: Weakened `type Operation` bound from `Operation<Self::Family> + Encode + Sync + 'static` to `Encode + Sync + 'static`. The `Operation<F>` trait requires key-related methods (`key()`, `is_update()`, `is_delete()`, `has_floor()`) that don't apply to keyless operations and were never called through the `Syncable` interface.


Partially resolves #3538