### PR TITLE
[Storage/qmdb/current] fix MMB prune + growth root computation bug by bounding pruning

### DIFF
--- a/storage/fuzz/Cargo.toml
+++ b/storage/fuzz/Cargo.toml
@@ -118,6 +118,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "current_mmb_prune_grow"
+path = "fuzz_targets/current_mmb_prune_grow.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "current_unordered_batch_root"
 path = "fuzz_targets/current_unordered_batch_root.rs"
 test = false

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -270,6 +270,8 @@ async fn bootstrap_pruned_state(
     pending_expected: &mut HashMap<LogicalKey, Option<RawValue>>,
     all_keys: &mut HashSet<LogicalKey>,
 ) {
+    // `step as u8` intentionally wraps for step >= 256; uniqueness is not required here,
+    // we just need to drive the inactivity floor forward.
     for step in 0..BOOTSTRAP_COMMITS {
         let key = (step as u8) % LOGICAL_KEY_SPACE;
         let mut value = [0u8; 32];
@@ -301,7 +303,6 @@ struct ReopenEnv<'a> {
     count: &'a mut usize,
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn drive_post_prune_window(
     mut db: Db,
     reference_db: &mut Db,
@@ -344,8 +345,14 @@ async fn drive_post_prune_window(
         // delayed merges are still in progress.
         if step == midpoint {
             *reopen.count += 1;
-            db = reopen_pruned_db(db, reopen.context, reopen.config, reference_db, *reopen.count)
-                .await;
+            db = reopen_pruned_db(
+                db,
+                reopen.context,
+                reopen.config,
+                reference_db,
+                *reopen.count,
+            )
+            .await;
         }
     }
     db

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -295,13 +295,22 @@ async fn bootstrap_pruned_state(
     panic!("bootstrap should create a genuinely pruned state");
 }
 
+struct ReopenEnv<'a> {
+    context: &'a deterministic::Context,
+    config: &'a Config<TwoCap>,
+    count: &'a mut usize,
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn drive_post_prune_window(
-    db: &mut Db,
+    mut db: Db,
     reference_db: &mut Db,
     committed_state: &mut HashMap<LogicalKey, Option<RawValue>>,
     pending_expected: &mut HashMap<LogicalKey, Option<RawValue>>,
     all_keys: &mut HashSet<LogicalKey>,
-) {
+    reopen: &mut ReopenEnv<'_>,
+) -> Db {
+    let midpoint = POST_PRUNE_WINDOW_STEPS / 2;
     for step in 0..POST_PRUNE_WINDOW_STEPS {
         let key = step % LOGICAL_KEY_SPACE;
         let current_value = expected_value_for_key(key, committed_state, pending_expected);
@@ -322,15 +331,24 @@ async fn drive_post_prune_window(
 
         let mut writes = vec![write];
         commit_pending(
-            db,
+            &mut db,
             reference_db,
             &mut writes,
             committed_state,
             pending_expected,
         )
         .await;
-        prune_to_floor(db, reference_db, "forced-post-prune-window").await;
+        prune_to_floor(&mut db, reference_db, "forced-post-prune-window").await;
+
+        // Reopen midway through the window to exercise the metadata round-trip while
+        // delayed merges are still in progress.
+        if step == midpoint {
+            *reopen.count += 1;
+            db = reopen_pruned_db(db, reopen.context, reopen.config, reference_db, *reopen.count)
+                .await;
+        }
     }
+    db
 }
 
 fn fuzz(data: FuzzInput) {
@@ -359,7 +377,11 @@ fn fuzz(data: FuzzInput) {
         let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
         let mut issued_writes = 0usize;
         let mut forced_window_ran = false;
-        let mut reopen_count = 0usize;
+        let mut reopen_env = ReopenEnv {
+            context: &context,
+            config: &pruned_config,
+            count: &mut 0usize,
+        };
 
         bootstrap_pruned_state(
             &mut db,
@@ -425,7 +447,7 @@ fn fuzz(data: FuzzInput) {
                         issued_writes += 1;
                     }
                 }
-                CurrentOperation::Commit => {
+                CurrentOperation::Commit | CurrentOperation::Root => {
                     commit_pending(
                         &mut db,
                         &mut reference_db,
@@ -437,12 +459,13 @@ fn fuzz(data: FuzzInput) {
                     prune_to_floor(&mut db, &reference_db, "commit+prune").await;
                     if db.pruned_bits() > 0 && !forced_window_ran {
                         forced_window_ran = true;
-                        drive_post_prune_window(
-                            &mut db,
+                        db = drive_post_prune_window(
+                            db,
                             &mut reference_db,
                             &mut committed_state,
                             &mut pending_expected,
                             &mut all_keys,
+                            &mut reopen_env,
                         )
                         .await;
                     }
@@ -457,32 +480,15 @@ fn fuzz(data: FuzzInput) {
                     )
                     .await;
                     prune_to_floor(&mut db, &reference_db, "close-reopen-prep").await;
-                    reopen_count += 1;
-                    db =
-                        reopen_pruned_db(db, &context, &pruned_config, &reference_db, reopen_count)
-                            .await;
-                }
-                CurrentOperation::Root => {
-                    commit_pending(
-                        &mut db,
-                        &mut reference_db,
-                        &mut pending_writes,
-                        &mut committed_state,
-                        &mut pending_expected,
+                    *reopen_env.count += 1;
+                    db = reopen_pruned_db(
+                        db,
+                        reopen_env.context,
+                        reopen_env.config,
+                        &reference_db,
+                        *reopen_env.count,
                     )
                     .await;
-                    prune_to_floor(&mut db, &reference_db, "root").await;
-                    if db.pruned_bits() > 0 && !forced_window_ran {
-                        forced_window_ran = true;
-                        drive_post_prune_window(
-                            &mut db,
-                            &mut reference_db,
-                            &mut committed_state,
-                            &mut pending_expected,
-                            &mut all_keys,
-                        )
-                        .await;
-                    }
                 }
             }
         }

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -1,0 +1,553 @@
+#![no_main]
+
+//! Focused fuzzer for Current QMDB prune/grow divergence under MMB Merkle family. The test is MMB
+//! specific since grafted MMR root witnesses are stable as the tree grows.
+//!
+//! This target intentionally avoids proof generation and broader API coverage. It concentrates on
+//! the narrow state shape that previously caused canonical root drift in live pruned MMB state:
+//! deterministically bootstrap into a pruned state, then force a short post-prune growth window
+//! with root comparisons after every commit. That keeps the corpus focused on the delayed-settle
+//! region without relying on libFuzzer to randomly discover the first successful prune. It also
+//! performs pruned-side close/reopen steps, because this bug family is especially interesting when
+//! compacted grafted state must survive a metadata round-trip without changing the canonical root.
+
+use arbitrary::Arbitrary;
+use commonware_cryptography::Sha256;
+use commonware_runtime::{buffer::paged::CacheRef, deterministic, Metrics as _, Runner};
+use commonware_storage::{
+    journal::contiguous::fixed::Config as FConfig,
+    merkle::{journaled::Config as MerkleConfig, mmb},
+    qmdb::current::{unordered::fixed::Db as CurrentDb, BitmapPrunedBits, FixedConfig as Config},
+    translator::TwoCap,
+};
+use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
+use libfuzzer_sys::fuzz_target;
+use std::{
+    collections::{HashMap, HashSet},
+    num::NonZeroU16,
+};
+
+// We use a tiny keyspace to ensure plenty of key updates, which force floor raising.
+type Key = FixedBytes<1>;
+type Value = FixedBytes<32>;
+type LogicalKey = u8;
+type RawValue = [u8; 32];
+type Db = CurrentDb<mmb::Family, deterministic::Context, Key, Value, Sha256, TwoCap, 32>;
+
+#[derive(Arbitrary, Debug, Clone)]
+enum CurrentOperation {
+    Update {
+        #[arbitrary(with = bounded_logical_key)]
+        key: LogicalKey,
+        value: RawValue,
+    },
+    UpdateBurst {
+        #[arbitrary(with = bounded_logical_key)]
+        key: LogicalKey,
+        value: RawValue,
+        #[arbitrary(with = bounded_burst_count)]
+        count: u8,
+    },
+    Delete {
+        #[arbitrary(with = bounded_logical_key)]
+        key: LogicalKey,
+    },
+    DeleteBurst {
+        #[arbitrary(with = bounded_logical_key)]
+        key: LogicalKey,
+        #[arbitrary(with = bounded_burst_count)]
+        count: u8,
+    },
+    Commit,
+    CloseReopen,
+    Root,
+}
+
+const MAX_OPERATIONS: usize = 100;
+const MAX_ACTUAL_WRITES: usize = 64;
+const LOGICAL_KEY_SPACE: u8 = 8;
+const POST_PRUNE_WINDOW_STEPS: u8 = 127;
+
+// With SHA-256, N=32 means one bitmap chunk covers 256 ops. Bootstrap commits one hot-key mutation
+// at a time, so we intentionally go comfortably past one full chunk before expecting the inactivity
+// floor to advance into genuinely pruned territory. The extra 64 commits are deterministic
+// headroom.
+const BOOTSTRAP_COMMITS: u16 = 320;
+
+#[derive(Debug, Clone)]
+struct FuzzInput {
+    operations: Vec<CurrentOperation>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
+        let operations = (0..num_ops)
+            .map(|_| CurrentOperation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(FuzzInput { operations })
+    }
+}
+
+fn bounded_burst_count(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<u8> {
+    u.int_in_range(1..=8)
+}
+
+fn bounded_logical_key(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<LogicalKey> {
+    u.int_in_range(0..=(LOGICAL_KEY_SPACE - 1))
+}
+
+fn encode_key(key: LogicalKey) -> Key {
+    Key::new([key])
+}
+
+fn burst_key(key: LogicalKey, offset: u8) -> LogicalKey {
+    let span = u16::from(LOGICAL_KEY_SPACE);
+    let sum = u16::from(key) + u16::from(offset);
+    let reduced = sum % span;
+    reduced as u8
+}
+
+fn burst_value(mut value: RawValue, offset: u8) -> RawValue {
+    value[31] = value[31].wrapping_add(offset);
+    value
+}
+
+fn expected_value_for_key(
+    key: LogicalKey,
+    committed_state: &HashMap<LogicalKey, Option<RawValue>>,
+    pending_expected: &HashMap<LogicalKey, Option<RawValue>>,
+) -> Option<RawValue> {
+    match pending_expected.get(&key).copied() {
+        Some(value) => value,
+        None => committed_state.get(&key).copied().flatten(),
+    }
+}
+
+fn find_live_key(
+    preferred: LogicalKey,
+    committed_state: &HashMap<LogicalKey, Option<RawValue>>,
+    pending_expected: &HashMap<LogicalKey, Option<RawValue>>,
+) -> Option<LogicalKey> {
+    for offset in 0..LOGICAL_KEY_SPACE {
+        let candidate = burst_key(preferred, offset);
+        if expected_value_for_key(candidate, committed_state, pending_expected).is_some() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+const PAGE_SIZE: NonZeroU16 = NZU16!(88);
+const PAGE_CACHE_SIZE: usize = 2;
+const MERKLE_ITEMS_PER_BLOB: u64 = 11;
+const LOG_ITEMS_PER_BLOB: u64 = 7;
+const WRITE_BUFFER_SIZE: usize = 1024;
+
+fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap> {
+    Config {
+        merkle_config: MerkleConfig {
+            journal_partition: format!("fuzz-current-mmb-pruning-{name}-merkle-journal"),
+            metadata_partition: format!("fuzz-current-mmb-pruning-{name}-merkle-metadata"),
+            items_per_blob: NZU64!(MERKLE_ITEMS_PER_BLOB),
+            write_buffer: NZUsize!(WRITE_BUFFER_SIZE),
+            thread_pool: None,
+            page_cache: page_cache.clone(),
+        },
+        journal_config: FConfig {
+            partition: format!("fuzz-current-mmb-pruning-{name}-log-journal"),
+            items_per_blob: NZU64!(LOG_ITEMS_PER_BLOB),
+            write_buffer: NZUsize!(WRITE_BUFFER_SIZE),
+            page_cache,
+        },
+        grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
+        translator: TwoCap,
+    }
+}
+
+async fn apply_pending(db: &mut Db, writes: &[(Key, Option<Value>)]) {
+    let mut batch = db.new_batch();
+    for (key, value) in writes.iter().cloned() {
+        batch = batch.write(key, value);
+    }
+    let merkleized = batch.merkleize(db, None).await.unwrap();
+    db.apply_batch(merkleized)
+        .await
+        .expect("commit should not fail");
+    db.commit().await.expect("commit fsync should not fail");
+}
+
+async fn assert_matches_reference(db: &Db, reference_db: &Db, context: &str) {
+    assert_eq!(
+        db.bounds().await.end,
+        reference_db.bounds().await.end,
+        "op count mismatch after {context}"
+    );
+    assert_eq!(
+        db.ops_root(),
+        reference_db.ops_root(),
+        "ops root mismatch after {context}"
+    );
+    assert_eq!(
+        db.root(),
+        reference_db.root(),
+        "canonical root mismatch after {context}"
+    );
+}
+
+async fn commit_pending(
+    db: &mut Db,
+    reference_db: &mut Db,
+    pending_writes: &mut Vec<(Key, Option<Value>)>,
+    committed_state: &mut HashMap<LogicalKey, Option<RawValue>>,
+    pending_expected: &mut HashMap<LogicalKey, Option<RawValue>>,
+) {
+    if pending_writes.is_empty() {
+        assert_matches_reference(db, reference_db, "empty commit").await;
+        return;
+    }
+
+    let writes = std::mem::take(pending_writes);
+    apply_pending(db, &writes).await;
+    apply_pending(reference_db, &writes).await;
+    committed_state.extend(pending_expected.drain());
+    assert_matches_reference(db, reference_db, "commit").await;
+}
+
+async fn prune_to_floor(db: &mut Db, reference_db: &Db, context: &str) {
+    db.prune(db.inactivity_floor_loc())
+        .await
+        .expect("prune should not fail");
+    assert_matches_reference(db, reference_db, context).await;
+}
+
+async fn reopen_pruned_db(
+    db: Db,
+    context: &deterministic::Context,
+    config: &Config<TwoCap>,
+    reference_db: &Db,
+    reopen_count: usize,
+) -> Db {
+    let root_before = db.root();
+    let ops_root_before = db.ops_root();
+    let bounds_before = db.bounds().await;
+    let pruned_bits_before = db.pruned_bits();
+    drop(db);
+
+    let reopen_label = format!("pruned_reopen_{reopen_count}");
+    let reopen_context = context.with_label(&reopen_label);
+    let reopened = Db::init(reopen_context, config.clone())
+        .await
+        .expect("reopen pruned current db");
+    assert_eq!(
+        reopened.root(),
+        root_before,
+        "canonical root changed after reopen"
+    );
+    assert_eq!(
+        reopened.ops_root(),
+        ops_root_before,
+        "ops root changed after reopen"
+    );
+    assert_eq!(
+        reopened.bounds().await,
+        bounds_before,
+        "bounds changed after reopen"
+    );
+    assert_eq!(
+        reopened.pruned_bits(),
+        pruned_bits_before,
+        "pruned bits changed after reopen"
+    );
+    assert_matches_reference(&reopened, reference_db, "reopen").await;
+    reopened
+}
+
+async fn bootstrap_pruned_state(
+    db: &mut Db,
+    reference_db: &mut Db,
+    committed_state: &mut HashMap<LogicalKey, Option<RawValue>>,
+    pending_expected: &mut HashMap<LogicalKey, Option<RawValue>>,
+    all_keys: &mut HashSet<LogicalKey>,
+) {
+    for step in 0..BOOTSTRAP_COMMITS {
+        let key = (step as u8) % LOGICAL_KEY_SPACE;
+        let mut value = [0u8; 32];
+        value[0] = 0xB0;
+        value[1] = step as u8;
+        value[31] = key;
+        let mut pending_writes = vec![(encode_key(key), Some(Value::new(value)))];
+        pending_expected.insert(key, Some(value));
+        all_keys.insert(key);
+        commit_pending(
+            db,
+            reference_db,
+            &mut pending_writes,
+            committed_state,
+            pending_expected,
+        )
+        .await;
+        prune_to_floor(db, reference_db, "bootstrap").await;
+        if db.pruned_bits() > 0 {
+            return;
+        }
+    }
+    panic!("bootstrap should create a genuinely pruned state");
+}
+
+async fn drive_post_prune_window(
+    db: &mut Db,
+    reference_db: &mut Db,
+    committed_state: &mut HashMap<LogicalKey, Option<RawValue>>,
+    pending_expected: &mut HashMap<LogicalKey, Option<RawValue>>,
+    all_keys: &mut HashSet<LogicalKey>,
+) {
+    for step in 0..POST_PRUNE_WINDOW_STEPS {
+        let key = step % LOGICAL_KEY_SPACE;
+        let current_value = expected_value_for_key(key, committed_state, pending_expected);
+        let write = if current_value.is_some() && step % 2 == 1 {
+            (encode_key(key), None)
+        } else {
+            let mut value = [0u8; 32];
+            value[0] = step;
+            value[31] = key;
+            pending_expected.insert(key, Some(value));
+            (encode_key(key), Some(Value::new(value)))
+        };
+
+        if write.1.is_none() {
+            pending_expected.insert(key, None);
+        }
+        all_keys.insert(key);
+
+        let mut writes = vec![write];
+        commit_pending(
+            db,
+            reference_db,
+            &mut writes,
+            committed_state,
+            pending_expected,
+        )
+        .await;
+        prune_to_floor(db, reference_db, "forced-post-prune-window").await;
+    }
+}
+
+fn fuzz(data: FuzzInput) {
+    let runner = deterministic::Runner::default();
+
+    runner.start(|context| async move {
+        let pruned_context = context.with_label("pruned");
+        let pruned_cache =
+            CacheRef::from_pooler(&pruned_context, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE));
+        let pruned_config = test_config("pruned", pruned_cache);
+        let mut db = Db::init(pruned_context, pruned_config.clone())
+            .await
+            .expect("init pruned current db");
+
+        let reference_context = context.with_label("reference");
+        let reference_cache =
+            CacheRef::from_pooler(&reference_context, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE));
+        let mut reference_db =
+            Db::init(reference_context, test_config("reference", reference_cache))
+                .await
+                .expect("init reference current db");
+
+        let mut committed_state: HashMap<LogicalKey, Option<RawValue>> = HashMap::new();
+        let mut pending_expected: HashMap<LogicalKey, Option<RawValue>> = HashMap::new();
+        let mut all_keys = HashSet::new();
+        let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
+        let mut issued_writes = 0usize;
+        let mut forced_window_ran = false;
+        let mut reopen_count = 0usize;
+
+        bootstrap_pruned_state(
+            &mut db,
+            &mut reference_db,
+            &mut committed_state,
+            &mut pending_expected,
+            &mut all_keys,
+        )
+        .await;
+
+        for op in &data.operations {
+            match op {
+                CurrentOperation::Update { key, value } => {
+                    if issued_writes >= MAX_ACTUAL_WRITES {
+                        continue;
+                    }
+                    pending_writes.push((encode_key(*key), Some(Value::new(*value))));
+                    pending_expected.insert(*key, Some(*value));
+                    all_keys.insert(*key);
+                    issued_writes += 1;
+                }
+                CurrentOperation::UpdateBurst { key, value, count } => {
+                    for offset in 0..*count {
+                        if issued_writes >= MAX_ACTUAL_WRITES {
+                            break;
+                        }
+                        let derived_key = burst_key(*key, offset);
+                        let derived_value = burst_value(*value, offset);
+                        pending_writes
+                            .push((encode_key(derived_key), Some(Value::new(derived_value))));
+                        pending_expected.insert(derived_key, Some(derived_value));
+                        all_keys.insert(derived_key);
+                        issued_writes += 1;
+                    }
+                }
+                CurrentOperation::Delete { key } => {
+                    if issued_writes >= MAX_ACTUAL_WRITES {
+                        continue;
+                    }
+                    let Some(live_key) = find_live_key(*key, &committed_state, &pending_expected)
+                    else {
+                        continue;
+                    };
+                    pending_writes.push((encode_key(live_key), None));
+                    pending_expected.insert(live_key, None);
+                    all_keys.insert(live_key);
+                    issued_writes += 1;
+                }
+                CurrentOperation::DeleteBurst { key, count } => {
+                    for offset in 0..*count {
+                        if issued_writes >= MAX_ACTUAL_WRITES {
+                            break;
+                        }
+                        let preferred = burst_key(*key, offset);
+                        let Some(live_key) =
+                            find_live_key(preferred, &committed_state, &pending_expected)
+                        else {
+                            break;
+                        };
+                        pending_writes.push((encode_key(live_key), None));
+                        pending_expected.insert(live_key, None);
+                        all_keys.insert(live_key);
+                        issued_writes += 1;
+                    }
+                }
+                CurrentOperation::Commit => {
+                    commit_pending(
+                        &mut db,
+                        &mut reference_db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
+                    prune_to_floor(&mut db, &reference_db, "commit+prune").await;
+                    if db.pruned_bits() > 0 && !forced_window_ran {
+                        forced_window_ran = true;
+                        drive_post_prune_window(
+                            &mut db,
+                            &mut reference_db,
+                            &mut committed_state,
+                            &mut pending_expected,
+                            &mut all_keys,
+                        )
+                        .await;
+                    }
+                }
+                CurrentOperation::CloseReopen => {
+                    commit_pending(
+                        &mut db,
+                        &mut reference_db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
+                    prune_to_floor(&mut db, &reference_db, "close-reopen-prep").await;
+                    reopen_count += 1;
+                    db =
+                        reopen_pruned_db(db, &context, &pruned_config, &reference_db, reopen_count)
+                            .await;
+                }
+                CurrentOperation::Root => {
+                    commit_pending(
+                        &mut db,
+                        &mut reference_db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
+                    prune_to_floor(&mut db, &reference_db, "root").await;
+                    if db.pruned_bits() > 0 && !forced_window_ran {
+                        forced_window_ran = true;
+                        drive_post_prune_window(
+                            &mut db,
+                            &mut reference_db,
+                            &mut committed_state,
+                            &mut pending_expected,
+                            &mut all_keys,
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+
+        if !pending_writes.is_empty() {
+            commit_pending(
+                &mut db,
+                &mut reference_db,
+                &mut pending_writes,
+                &mut committed_state,
+                &mut pending_expected,
+            )
+            .await;
+        }
+
+        prune_to_floor(&mut db, &reference_db, "final").await;
+        assert_eq!(
+            db.bounds().await.end,
+            reference_db.bounds().await.end,
+            "final op count mismatch"
+        );
+
+        for key in &all_keys {
+            let k = encode_key(*key);
+            let result = db.get(&k).await.expect("final get should not fail");
+            let reference_result = reference_db
+                .get(&k)
+                .await
+                .expect("reference final get should not fail");
+            assert_eq!(
+                result, reference_result,
+                "final get diverged for key {key:?}"
+            );
+
+            match committed_state.get(key) {
+                Some(Some(expected_value)) => {
+                    assert!(result.is_some(), "Lost value for key {key:?} at end");
+                    let actual_value = result.expect("Should have value");
+                    let actual_bytes: &[u8; 32] = actual_value
+                        .as_ref()
+                        .try_into()
+                        .expect("Value should be 32 bytes");
+                    assert_eq!(
+                        actual_bytes, expected_value,
+                        "Final value mismatch for key {key:?}"
+                    );
+                }
+                Some(None) => {
+                    assert!(
+                        result.is_none(),
+                        "Deleted key {key:?} should remain deleted"
+                    );
+                }
+                None => {
+                    assert!(result.is_none(), "Unset key {key:?} should not exist");
+                }
+            }
+        }
+
+        db.destroy().await.expect("destroy should not fail");
+        reference_db
+            .destroy()
+            .await
+            .expect("reference destroy should not fail");
+    });
+}
+
+fuzz_target!(|input: FuzzInput| fuzz(input));

--- a/storage/src/merkle/journaled.rs
+++ b/storage/src/merkle/journaled.rs
@@ -151,9 +151,9 @@ pub struct Journaled<F: Family, E: RStorage + Clock + Metrics, D: Digest> {
     /// Stores all unpruned nodes.
     pub(crate) journal: Journal<E, D>,
 
-    /// Stores all "pinned nodes" (pruned nodes required for proving & root generation), and the
-    /// corresponding pruning boundary used to generate them. The metadata remains empty until
-    /// pruning is invoked, and its contents change only when the pruning boundary moves.
+    /// Stores the pinned nodes for the current pruning boundary, and the corresponding pruning
+    /// boundary used to generate them. The metadata remains empty until pruning is invoked, and its
+    /// contents change only when the pruning boundary moves.
     pub(crate) metadata: Metadata<E, U64, Vec<u8>>,
 
     /// Serializes concurrent sync calls.
@@ -815,10 +815,10 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Journaled<F, E, D> {
     /// Rewind the structure by the given number of leaves.
     ///
     /// Adds go through the batch API ([`Self::new_batch`] / [`Self::apply_batch`]), but removing
-    /// leaves requires `rewind`. After `init` or `sync`, the in-memory structure is pruned to
-    /// O(log n) pinned peaks. A batch pop would expose new peaks that are not in memory, and
-    /// `merkleize` cannot load them because [`Readable::get_node`] is synchronous. `rewind`
-    /// performs async journal I/O to rebuild state at the target position.
+    /// leaves requires `rewind`. After `init` or `sync`, the in-memory structure is pruned to O(log
+    /// n) pinned nodes. A batch pop would expose new peaks that are not in memory, and `merkleize`
+    /// cannot load them because [`Readable::get_node`] is synchronous. `rewind` performs async
+    /// journal I/O to rebuild state at the target position.
     pub(crate) async fn rewind(
         &mut self,
         leaves_to_remove: usize,

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -29,10 +29,9 @@ pub struct Config<F: Family, D: Digest> {
 
 /// A basic, `no_std`-compatible Merkle structure where all nodes are stored in-memory.
 ///
-/// Nodes are either _retained_, _pruned_, or _pinned_. Retained nodes are stored in the main
-/// deque. Pruned nodes precede `pruning_boundary` and are no longer stored unless they are still
-/// required for root computation or proof generation, in which case they are kept in
-/// `pinned_nodes`.
+/// Nodes are either _retained_, _pruned_, or _pinned_. Retained nodes are stored in the main deque.
+/// Pruned nodes precede `pruning_boundary` and are no longer stored unless they are part of the
+/// pruning-boundary pinned-node set, in which case they are kept in `pinned_nodes`.
 ///
 /// The structure is always merkleized (its root is always computed). Mutations go through the
 /// batch API: create an [`UnmerkleizedBatch`](batch::UnmerkleizedBatch) via [`Self::new_batch`],

--- a/storage/src/merkle/mmb/mod.rs
+++ b/storage/src/merkle/mmb/mod.rs
@@ -225,6 +225,26 @@ impl merkle::Family for Family {
 }
 
 impl Graftable for Family {
+    fn peak_birth_size(pos: Position, height: u32) -> u64 {
+        let width = 1u64.checked_shl(height).expect("height excessively large");
+        // `base` is the leaf count at which all leaves in the subtree have been appended.
+        let base = <Self as Graftable>::leftmost_leaf(pos, height)
+            .checked_add(width)
+            .expect("birth size overflow");
+        if height == 0 {
+            return *base; // Leaves have no merge delay.
+        }
+
+        // In MMB, a parent at height h is not created when its last leaf is appended.
+        // Instead it is delayed by 2^(h-1) - 1 additional leaf insertions (the
+        // "1-merge-per-leaf" budget). So the node is born at `base + delay` total leaves.
+        let delay = 1u64
+            .checked_shl(height - 1)
+            .and_then(|v| v.checked_sub(1))
+            .expect("height excessively large");
+        *base.checked_add(delay).expect("birth size overflow")
+    }
+
     fn leftmost_leaf(pos: Position, height: u32) -> Location {
         if height == 0 {
             return Self::position_to_location(pos).expect("height-0 node must be a leaf");

--- a/storage/src/merkle/mmb/mod.rs
+++ b/storage/src/merkle/mmb/mod.rs
@@ -226,14 +226,16 @@ impl merkle::Family for Family {
 
 impl Graftable for Family {
     fn peak_birth_size(pos: Position, height: u32) -> u64 {
+        if height == 0 {
+            // Leaves have no merge delay; born as soon as appended.
+            return *<Self as Graftable>::leftmost_leaf(pos, 0) + 1;
+        }
+
         let width = 1u64.checked_shl(height).expect("height excessively large");
         // `base` is the leaf count at which all leaves in the subtree have been appended.
         let base = <Self as Graftable>::leftmost_leaf(pos, height)
             .checked_add(width)
             .expect("birth size overflow");
-        if height == 0 {
-            return *base; // Leaves have no merge delay.
-        }
 
         // In MMB, a parent at height h is not created when its last leaf is appended.
         // Instead it is delayed by 2^(h-1) - 1 additional leaf insertions (the

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -159,6 +159,27 @@ pub trait Graftable: Family {
     /// Panics if `height` is excessively large (e.g., `>= 63`), or if an invalid combination of
     /// `pos` and `height` results in arithmetic underflow/overflow.
     fn leftmost_leaf(pos: Position<Self>, height: u32) -> Location<Self>;
+
+    /// Return the minimum leaf count at which the node at `pos` with `height` exists in the
+    /// structure.
+    ///
+    /// For families without delayed merging (e.g. MMR), a node exists as soon as all leaves
+    /// in its span have been appended. For families with delayed merging (e.g. MMB), the
+    /// node is created some number of leaf insertions _after_ its last leaf, so the birth
+    /// size is larger. The MMB override accounts for this delay.
+    ///
+    /// This is used by the grafted-tree pruning logic to determine when a chunk-pair's
+    /// parent has been born in the ops tree, which controls when it is safe to prune the
+    /// pair's individual grafted leaves.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `height` is excessively large (e.g., `>= 63`), or if arithmetic overflows.
+    fn peak_birth_size(pos: Position<Self>, height: u32) -> u64 {
+        let leftmost = *Self::leftmost_leaf(pos, height);
+        let width = 1u64.checked_shl(height).expect("height excessively large");
+        leftmost.checked_add(width).expect("birth size overflow")
+    }
 }
 
 /// Errors that can occur when interacting with a Merkle-family data structure.

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -71,11 +71,11 @@ pub trait Family: Copy + Clone + Debug + Default + Send + Sync + 'static {
 
     /// Compute positions of nodes that must be pinned when pruning to `prune_loc`.
     ///
-    /// The default implementation returns the peaks of the sub-structure at `prune_loc`,
-    /// which is sufficient for both root computation and re-merkleization of retained leaves.
-    /// Implementations may override to return a conservative superset of the minimally
-    /// required nodes. Callers must therefore treat the result as "safe to retain" rather
-    /// than assuming it is minimal or canonical.
+    /// Pinned nodes are the minimal set of pruned digests required to continue growing the
+    /// structure and recomputing its root after pruning. The default implementation returns the
+    /// peaks of the sub-structure at `prune_loc`, which is sufficient for both root computation and
+    /// re-merkleization of retained leaves. Implementations may override this if their family
+    /// requires a different canonical pinned-node set for the pruning boundary.
     ///
     /// # Panics
     ///

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -543,7 +543,7 @@ where
         let chunk_pos = F::subtree_root_position(Location::<F>::new(chunk_start), grafting_height);
         let stable_after = F::peak_birth_size(chunk_pos, grafting_height);
         if stable_after > chunk_end
-            && last_complete_chunk >= pruned_chunks
+            && last_complete_chunk >= pruned_chunks // skip already-pruned chunks
             && base_ops_leaves < stable_after
         {
             chunk_indices_to_update.insert(last_complete_chunk);

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -531,6 +531,7 @@ where
         .filter(|(&idx, _)| idx < new_grafted_leaves)
         .map(|(&idx, _)| idx)
         .collect();
+    // Both are chunk indices (not bit positions); cast to u64 only for the shift arithmetic.
     let pruned_chunks = bitmap_parent.pruned_chunks();
     if new_grafted_leaves > 0 {
         let last_complete_chunk = new_grafted_leaves - 1;

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -28,7 +28,10 @@ use crate::{
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 /// Speculative chunk-level bitmap overlay.
 ///
@@ -513,16 +516,47 @@ where
         &inner.ancestor_diffs,
     );
 
-    // Grafted MMR recomputation: iterate complete chunks in the overlay.
-    // This covers both new chunks and dirty existing chunks in a single pass.
+    let grafting_height = grafting::height::<N>();
+    let ops_tree_adapter =
+        BatchStorageAdapter::new(&inner.journal_batch, &current_db.any.log.merkle);
+    let base_ops_leaves = Location::<F>::try_from(current_db.any.log.merkle.size())?.as_u64();
+
+    // Recompute grafted leaves for dirty complete chunks. For MMB, the last complete chunk can
+    // still change while delayed merges finalize its grafting-height digest, so we force-refresh
+    // that chunk until its peak birth threshold is reached.
     let new_grafted_leaves = overlay.complete_chunks();
-    let chunks_to_update = overlay
+    let mut chunk_indices_to_update: BTreeSet<usize> = overlay
         .chunks
         .iter()
         .filter(|(&idx, _)| idx < new_grafted_leaves)
-        .map(|(&idx, &chunk)| (idx, chunk));
-    let ops_tree_adapter =
-        BatchStorageAdapter::new(&inner.journal_batch, &current_db.any.log.merkle);
+        .map(|(&idx, _)| idx)
+        .collect();
+    let pruned_chunks = bitmap_parent.pruned_chunks();
+    if new_grafted_leaves > 0 {
+        let last_complete_chunk = new_grafted_leaves - 1;
+        let chunk_start = (last_complete_chunk as u64)
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("chunk start overflow"))?;
+        let chunk_end = ((last_complete_chunk + 1) as u64)
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("chunk end overflow"))?;
+        let chunk_pos = F::subtree_root_position(Location::<F>::new(chunk_start), grafting_height);
+        let stable_after = F::peak_birth_size(chunk_pos, grafting_height);
+        if stable_after > chunk_end
+            && last_complete_chunk >= pruned_chunks
+            && base_ops_leaves < stable_after
+        {
+            chunk_indices_to_update.insert(last_complete_chunk);
+        }
+    }
+    let chunks_to_update = chunk_indices_to_update.into_iter().map(|idx| {
+        let chunk = overlay
+            .get(idx)
+            .copied()
+            .unwrap_or_else(|| bitmap_parent.get_chunk(idx));
+        (idx, chunk)
+    });
+
     let hasher = StandardHasher::<H>::new();
     let new_leaves = compute_grafted_leaves::<F, H, N>(
         &hasher,
@@ -533,7 +567,6 @@ where
     .await?;
 
     // Build grafted MMR from parent batch.
-    let grafting_height = grafting::height::<N>();
     let grafted_batch = {
         let mut grafted_batch = grafted_parent
             .new_batch()
@@ -567,7 +600,8 @@ where
         batch: &grafted_batch,
         mem: &current_db.grafted_tree,
     };
-    let grafted_storage = grafting::Storage::new(&layered, grafting_height, &ops_tree_adapter);
+    let grafted_storage =
+        grafting::Storage::new(&layered, grafting_height, &ops_tree_adapter, hasher.clone());
     // Compute partial chunk (last incomplete chunk, if any).
     let partial = {
         let rem = bitmap_batch.len() % BitmapBatch::<N>::CHUNK_SIZE_BITS;
@@ -579,7 +613,7 @@ where
             Some((chunk, rem))
         }
     };
-    let canonical_root = compute_db_root::<F, H, _, _, _, N>(
+    let canonical_root = compute_db_root::<F, H, _, _, N>(
         &hasher,
         &bitmap_batch,
         &grafted_storage,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -321,60 +321,33 @@ where
     fn settled_bitmap_prune_loc(&self) -> Result<Location<F>, Error<F>> {
         let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
         let mut pruned_chunks = *self.any.inactivity_floor_loc / chunk_bits;
-        if pruned_chunks == 0 {
-            return Ok(Location::new(0));
-        }
 
         let ops_leaves = (*self.any.last_commit_loc)
             .checked_add(1)
             .ok_or(Error::DataCorrupted("ops size overflow"))?;
         let grafting_height = grafting::height::<N>();
 
-        loop {
-            if pruned_chunks == 0 {
-                return Ok(Location::new(0));
+        while pruned_chunks > 0 {
+            let required_ops =
+                Self::pair_absorption_threshold(pruned_chunks)?.unwrap_or_else(|| {
+                    let youngest_start = (pruned_chunks - 1) * chunk_bits;
+                    let pos = F::subtree_root_position(
+                        Location::<F>::new(youngest_start),
+                        grafting_height,
+                    );
+                    F::peak_birth_size(pos, grafting_height)
+                });
+
+            if ops_leaves >= required_ops {
+                break;
             }
-
-            let youngest = pruned_chunks - 1;
-            let chunk_start = youngest
-                .checked_shl(grafting_height)
-                .ok_or(Error::DataCorrupted("chunk start overflow"))?;
-            let chunk_pos =
-                F::subtree_root_position(Location::<F>::new(chunk_start), grafting_height);
-
-            // Condition 1: youngest chunk's height-gh subtree root is born.
-            let settled_after = F::peak_birth_size(chunk_pos, grafting_height);
-            if ops_leaves < settled_after {
-                pruned_chunks -= 1;
-                continue;
-            }
-
-            // Fast path: families without delayed merges (birth_size == chunk_end) need
-            // only condition 1. Return the inactivity floor unchanged.
-            let chunk_end = (youngest + 1)
-                .checked_shl(grafting_height)
-                .ok_or(Error::DataCorrupted("chunk end overflow"))?;
-            if settled_after <= chunk_end {
-                let settled_bits = pruned_chunks
-                    .checked_mul(chunk_bits)
-                    .ok_or(Error::DataCorrupted("bitmap prune boundary overflow"))?;
-                return Ok(Location::new(settled_bits));
-            }
-
-            // Condition 2 (delayed-merge only): youngest chunk-pair's height-(gh+1)
-            // parent is born.
-            let absorbed_after = Self::pair_absorption_threshold(pruned_chunks)?
-                .expect("delayed-merge family must have absorption threshold");
-            if ops_leaves < absorbed_after {
-                pruned_chunks -= 1;
-                continue;
-            }
-
-            let settled_bits = pruned_chunks
-                .checked_mul(chunk_bits)
-                .ok_or(Error::DataCorrupted("bitmap prune boundary overflow"))?;
-            return Ok(Location::new(settled_bits));
+            pruned_chunks -= 1;
         }
+
+        let settled_bits = pruned_chunks
+            .checked_mul(chunk_bits)
+            .ok_or(Error::DataCorrupted("bitmap prune boundary overflow"))?;
+        Ok(Location::new(settled_bits))
     }
 
     /// Returns the minimum rewind target that keeps delayed-merge grafting queries valid

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -264,6 +264,41 @@ where
         self.any.pinned_nodes_at(loc).await
     }
 
+    /// For the youngest of `pruned_chunks` chunks, return the `peak_birth_size` of its
+    /// chunk-pair parent at height `gh+1`. Returns `None` for families without delayed merges
+    /// (where `peak_birth_size` at height `gh` equals the chunk boundary).
+    fn pair_absorption_threshold(
+        pruned_chunks: u64,
+    ) -> Result<Option<u64>, Error<F>> {
+        if pruned_chunks == 0 {
+            return Ok(None);
+        }
+
+        let grafting_height = grafting::height::<N>();
+        let youngest = pruned_chunks - 1;
+        let youngest_start = youngest
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("chunk start overflow"))?;
+        let youngest_end = (youngest + 1)
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("chunk end overflow"))?;
+        let youngest_pos =
+            F::subtree_root_position(Location::<F>::new(youngest_start), grafting_height);
+
+        // Families without delayed merges: birth_size == chunk_end.
+        if F::peak_birth_size(youngest_pos, grafting_height) <= youngest_end {
+            return Ok(None);
+        }
+
+        let pair_chunk = youngest & !1;
+        let pair_start = pair_chunk
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("pair start overflow"))?;
+        let pair_pos =
+            F::subtree_root_position(Location::<F>::new(pair_start), grafting_height + 1);
+        Ok(Some(F::peak_birth_size(pair_pos, grafting_height + 1)))
+    }
+
     /// Returns the most aggressive bitmap prune boundary that is safe for the current ops
     /// tree size, accounting for delayed-merge settlement.
     ///
@@ -279,7 +314,8 @@ where
     ///
     /// Because older chunk-pairs have strictly earlier birth times, checking only the youngest
     /// pair is sufficient: if the youngest pair's parent is born, all older pairs' parents are
-    /// too.
+    /// too. In the worst case the loop decrements twice (once past the unsettled chunk, once
+    /// to land on the older pair boundary).
     ///
     /// For families without delayed merges (e.g. MMR), `peak_birth_size` at height `gh`
     /// equals the chunk's last leaf, so condition (1) always holds and the function returns
@@ -305,22 +341,21 @@ where
             let chunk_start = youngest
                 .checked_shl(grafting_height)
                 .ok_or(Error::DataCorrupted("chunk start overflow"))?;
-            let chunk_end = (youngest + 1)
-                .checked_shl(grafting_height)
-                .ok_or(Error::DataCorrupted("chunk end overflow"))?;
             let chunk_pos =
                 F::subtree_root_position(Location::<F>::new(chunk_start), grafting_height);
 
             // Condition 1: youngest chunk's height-gh subtree root is born.
-            // For families without delayed merges, birth_size == chunk_end so this always
-            // holds and the function returns the inactivity floor unchanged.
             let settled_after = F::peak_birth_size(chunk_pos, grafting_height);
             if ops_leaves < settled_after {
                 pruned_chunks -= 1;
                 continue;
             }
 
-            // For families without delayed merges, condition 1 is sufficient.
+            // Fast path: families without delayed merges (birth_size == chunk_end) need
+            // only condition 1. Return the inactivity floor unchanged.
+            let chunk_end = (youngest + 1)
+                .checked_shl(grafting_height)
+                .ok_or(Error::DataCorrupted("chunk end overflow"))?;
             if settled_after <= chunk_end {
                 let settled_bits = pruned_chunks
                     .checked_mul(chunk_bits)
@@ -330,13 +365,8 @@ where
 
             // Condition 2 (delayed-merge only): youngest chunk-pair's height-(gh+1)
             // parent is born.
-            let pair_chunk = youngest & !1;
-            let pair_start = pair_chunk
-                .checked_shl(grafting_height)
-                .ok_or(Error::DataCorrupted("pair start overflow"))?;
-            let pair_pos =
-                F::subtree_root_position(Location::<F>::new(pair_start), grafting_height + 1);
-            let absorbed_after = F::peak_birth_size(pair_pos, grafting_height + 1);
+            let absorbed_after = Self::pair_absorption_threshold(pruned_chunks)?
+                .expect("delayed-merge family must have absorption threshold");
             if ops_leaves < absorbed_after {
                 pruned_chunks -= 1;
                 continue;
@@ -360,35 +390,7 @@ where
     ///
     /// Returns `None` for families without delayed merges.
     fn delayed_merge_rewind_floor(&self) -> Result<Option<u64>, Error<F>> {
-        let pruned_chunks = self.status.pruned_chunks() as u64;
-        if pruned_chunks == 0 {
-            return Ok(None);
-        }
-
-        let grafting_height = grafting::height::<N>();
-        let youngest = pruned_chunks - 1;
-        let youngest_start = youngest
-            .checked_shl(grafting_height)
-            .ok_or(Error::DataCorrupted("chunk start overflow"))?;
-        let youngest_end = (youngest + 1)
-            .checked_shl(grafting_height)
-            .ok_or(Error::DataCorrupted("chunk end overflow"))?;
-        let youngest_pos =
-            F::subtree_root_position(Location::<F>::new(youngest_start), grafting_height);
-
-        // Families without delayed merges: birth_size == chunk_end, so no additional
-        // rewind floor is needed (same detection as in `settled_bitmap_prune_loc`).
-        if F::peak_birth_size(youngest_pos, grafting_height) <= youngest_end {
-            return Ok(None);
-        }
-
-        let pair_chunk = youngest & !1;
-        let pair_start = pair_chunk
-            .checked_shl(grafting_height)
-            .ok_or(Error::DataCorrupted("pair start overflow"))?;
-        let pair_pos =
-            F::subtree_root_position(Location::<F>::new(pair_start), grafting_height + 1);
-        Ok(Some(F::peak_birth_size(pair_pos, grafting_height + 1)))
+        Self::pair_absorption_threshold(self.status.pruned_chunks() as u64)
     }
 
     /// Collapse the accumulated bitmap `Layer` chain into a flat `Base`.
@@ -406,8 +408,8 @@ where
     /// Prunes historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
     ///
-    /// `prune_loc` controls ops-log pruning only. Bitmap pruning always advances to the
-    /// settled inactivity floor regardless of `prune_loc`.
+    /// `prune_loc` controls ops-log pruning only. Bitmap pruning advances to the settled
+    /// portion of the inactivity floor, independent of `prune_loc`.
     ///
     /// # Errors
     ///

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -267,9 +267,7 @@ where
     /// For the youngest of `pruned_chunks` chunks, return the `peak_birth_size` of its
     /// chunk-pair parent at height `gh+1`. Returns `None` for families without delayed merges
     /// (where `peak_birth_size` at height `gh` equals the chunk boundary).
-    fn pair_absorption_threshold(
-        pruned_chunks: u64,
-    ) -> Result<Option<u64>, Error<F>> {
+    fn pair_absorption_threshold(pruned_chunks: u64) -> Result<Option<u64>, Error<F>> {
         if pruned_chunks == 0 {
             return Ok(None);
         }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -296,44 +296,40 @@ where
             .ok_or(Error::DataCorrupted("ops size overflow"))?;
         let grafting_height = grafting::height::<N>();
 
-        // Fast path for families without delayed merges: the youngest chunk's subtree root
-        // is born as soon as its leaves are appended, so no settlement wait is needed.
-        let youngest = pruned_chunks - 1;
-        let youngest_start = youngest
-            .checked_shl(grafting_height)
-            .ok_or(Error::DataCorrupted("chunk start overflow"))?;
-        let youngest_end = (youngest + 1)
-            .checked_shl(grafting_height)
-            .ok_or(Error::DataCorrupted("chunk end overflow"))?;
-        let youngest_pos =
-            F::subtree_root_position(Location::<F>::new(youngest_start), grafting_height);
-        if F::peak_birth_size(youngest_pos, grafting_height) <= youngest_end {
-            let settled_bits = pruned_chunks
-                .checked_mul(chunk_bits)
-                .ok_or(Error::DataCorrupted("bitmap prune boundary overflow"))?;
-            return Ok(Location::new(settled_bits));
-        }
-
-        // Delayed-merge path: walk backward until both conditions hold.
         loop {
             if pruned_chunks == 0 {
                 return Ok(Location::new(0));
             }
 
-            // Condition 1: youngest chunk's height-gh subtree root is born.
             let youngest = pruned_chunks - 1;
             let chunk_start = youngest
                 .checked_shl(grafting_height)
                 .ok_or(Error::DataCorrupted("chunk start overflow"))?;
+            let chunk_end = (youngest + 1)
+                .checked_shl(grafting_height)
+                .ok_or(Error::DataCorrupted("chunk end overflow"))?;
             let chunk_pos =
                 F::subtree_root_position(Location::<F>::new(chunk_start), grafting_height);
+
+            // Condition 1: youngest chunk's height-gh subtree root is born.
+            // For families without delayed merges, birth_size == chunk_end so this always
+            // holds and the function returns the inactivity floor unchanged.
             let settled_after = F::peak_birth_size(chunk_pos, grafting_height);
             if ops_leaves < settled_after {
                 pruned_chunks -= 1;
                 continue;
             }
 
-            // Condition 2: youngest chunk-pair's height-(gh+1) parent is born.
+            // For families without delayed merges, condition 1 is sufficient.
+            if settled_after <= chunk_end {
+                let settled_bits = pruned_chunks
+                    .checked_mul(chunk_bits)
+                    .ok_or(Error::DataCorrupted("bitmap prune boundary overflow"))?;
+                return Ok(Location::new(settled_bits));
+            }
+
+            // Condition 2 (delayed-merge only): youngest chunk-pair's height-(gh+1)
+            // parent is born.
             let pair_chunk = youngest & !1;
             let pair_start = pair_chunk
                 .checked_shl(grafting_height)
@@ -380,7 +376,8 @@ where
         let youngest_pos =
             F::subtree_root_position(Location::<F>::new(youngest_start), grafting_height);
 
-        // Families without delayed merges do not need an additional rewind floor.
+        // Families without delayed merges: birth_size == chunk_end, so no additional
+        // rewind floor is needed (same detection as in `settled_bitmap_prune_loc`).
         if F::peak_birth_size(youngest_pos, grafting_height) <= youngest_end {
             return Ok(None);
         }
@@ -408,6 +405,9 @@ where
 
     /// Prunes historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
+    ///
+    /// `prune_loc` controls ops-log pruning only. Bitmap pruning always advances to the
+    /// settled inactivity floor regardless of `prune_loc`.
     ///
     /// # Errors
     ///

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     merkle::{
         self, batch::MIN_TO_PARALLELIZE, hasher::Standard as StandardHasher, mem::Mem,
-        storage::Storage as MerkleStorage, Location, Position, Readable,
+        storage::Storage as MerkleStorage, Location, Position,
     },
     metadata::{Config as MConfig, Metadata},
     qmdb::{
@@ -155,6 +155,7 @@ where
             &self.grafted_tree,
             grafting::height::<N>(),
             &self.any.log.merkle,
+            StandardHasher::<H>::new(),
         )
     }
 
@@ -263,6 +264,136 @@ where
         self.any.pinned_nodes_at(loc).await
     }
 
+    /// Returns the most aggressive bitmap prune boundary that is safe for the current ops
+    /// tree size, accounting for delayed-merge settlement.
+    ///
+    /// Starts from the inactivity floor (the most chunks we could possibly prune) and walks
+    /// backward until two conditions hold for the youngest chunk that would be pruned:
+    ///
+    /// 1. **Settled**: the chunk's ops subtree root at height `gh` has been born in the ops
+    ///    tree (its `peak_birth_size <= ops_leaves`).
+    ///
+    /// 2. **Absorbed**: the chunk-pair parent at height `gh+1` has been born. This guarantees
+    ///    that the ops tree has no individual height-`gh` peaks for pruned chunks, so
+    ///    `compute_grafted_root` never queries a discarded grafted leaf.
+    ///
+    /// Because older chunk-pairs have strictly earlier birth times, checking only the youngest
+    /// pair is sufficient: if the youngest pair's parent is born, all older pairs' parents are
+    /// too.
+    ///
+    /// For families without delayed merges (e.g. MMR), `peak_birth_size` at height `gh`
+    /// equals the chunk's last leaf, so condition (1) always holds and the function returns
+    /// the inactivity floor unchanged.
+    fn settled_bitmap_prune_loc(&self) -> Result<Location<F>, Error<F>> {
+        let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
+        let mut pruned_chunks = *self.any.inactivity_floor_loc / chunk_bits;
+        if pruned_chunks == 0 {
+            return Ok(Location::new(0));
+        }
+
+        let ops_leaves = (*self.any.last_commit_loc)
+            .checked_add(1)
+            .ok_or(Error::DataCorrupted("ops size overflow"))?;
+        let grafting_height = grafting::height::<N>();
+
+        // Fast path for families without delayed merges: the youngest chunk's subtree root
+        // is born as soon as its leaves are appended, so no settlement wait is needed.
+        let youngest = pruned_chunks - 1;
+        let youngest_start = youngest
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("chunk start overflow"))?;
+        let youngest_end = (youngest + 1)
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("chunk end overflow"))?;
+        let youngest_pos =
+            F::subtree_root_position(Location::<F>::new(youngest_start), grafting_height);
+        if F::peak_birth_size(youngest_pos, grafting_height) <= youngest_end {
+            let settled_bits = pruned_chunks
+                .checked_mul(chunk_bits)
+                .ok_or(Error::DataCorrupted("bitmap prune boundary overflow"))?;
+            return Ok(Location::new(settled_bits));
+        }
+
+        // Delayed-merge path: walk backward until both conditions hold.
+        loop {
+            if pruned_chunks == 0 {
+                return Ok(Location::new(0));
+            }
+
+            // Condition 1: youngest chunk's height-gh subtree root is born.
+            let youngest = pruned_chunks - 1;
+            let chunk_start = youngest
+                .checked_shl(grafting_height)
+                .ok_or(Error::DataCorrupted("chunk start overflow"))?;
+            let chunk_pos =
+                F::subtree_root_position(Location::<F>::new(chunk_start), grafting_height);
+            let settled_after = F::peak_birth_size(chunk_pos, grafting_height);
+            if ops_leaves < settled_after {
+                pruned_chunks -= 1;
+                continue;
+            }
+
+            // Condition 2: youngest chunk-pair's height-(gh+1) parent is born.
+            let pair_chunk = youngest & !1;
+            let pair_start = pair_chunk
+                .checked_shl(grafting_height)
+                .ok_or(Error::DataCorrupted("pair start overflow"))?;
+            let pair_pos =
+                F::subtree_root_position(Location::<F>::new(pair_start), grafting_height + 1);
+            let absorbed_after = F::peak_birth_size(pair_pos, grafting_height + 1);
+            if ops_leaves < absorbed_after {
+                pruned_chunks -= 1;
+                continue;
+            }
+
+            let settled_bits = pruned_chunks
+                .checked_mul(chunk_bits)
+                .ok_or(Error::DataCorrupted("bitmap prune boundary overflow"))?;
+            return Ok(Location::new(settled_bits));
+        }
+    }
+
+    /// Returns the minimum rewind target that keeps delayed-merge grafting queries valid
+    /// for the current bitmap pruning boundary.
+    ///
+    /// This is the same absorption threshold used by [`Self::settled_bitmap_prune_loc`]:
+    /// the `peak_birth_size` of the youngest pruned chunk-pair's height-(gh+1) parent.
+    /// Rewinding below this size would put the ops tree in a state where the parent has not
+    /// been born, re-exposing individual height-`gh` ops peaks for pruned chunks whose
+    /// grafted leaves are no longer available.
+    ///
+    /// Returns `None` for families without delayed merges.
+    fn delayed_merge_rewind_floor(&self) -> Result<Option<u64>, Error<F>> {
+        let pruned_chunks = self.status.pruned_chunks() as u64;
+        if pruned_chunks == 0 {
+            return Ok(None);
+        }
+
+        let grafting_height = grafting::height::<N>();
+        let youngest = pruned_chunks - 1;
+        let youngest_start = youngest
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("chunk start overflow"))?;
+        let youngest_end = (youngest + 1)
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("chunk end overflow"))?;
+        let youngest_pos =
+            F::subtree_root_position(Location::<F>::new(youngest_start), grafting_height);
+
+        // Families without delayed merges do not need an additional rewind floor.
+        if F::peak_birth_size(youngest_pos, grafting_height) <= youngest_end {
+            return Ok(None);
+        }
+
+        let pair_chunk = youngest & !1;
+        let pair_start = pair_chunk
+            .checked_shl(grafting_height)
+            .ok_or(Error::DataCorrupted("pair start overflow"))?;
+        let pair_pos =
+            F::subtree_root_position(Location::<F>::new(pair_start), grafting_height + 1);
+        Ok(Some(F::peak_birth_size(pair_pos, grafting_height + 1)))
+    }
+
     /// Collapse the accumulated bitmap `Layer` chain into a flat `Base`.
     ///
     /// Each [`Db::apply_batch`] pushes a new `Layer` on the bitmap. These layers are cheap
@@ -283,13 +414,20 @@ where
     /// - Returns [Error::PruneBeyondMinRequired] if `prune_loc` > inactivity floor.
     /// - Returns [`crate::merkle::Error::LocationOverflow`] if `prune_loc` > [crate::merkle::Family::MAX_LEAVES].
     pub async fn prune(&mut self, prune_loc: Location<F>) -> Result<(), Error<F>> {
+        let inactivity_floor = self.inactivity_floor_loc();
+        if prune_loc > inactivity_floor {
+            return Err(Error::PruneBeyondMinRequired(prune_loc, inactivity_floor));
+        }
+
         self.flatten();
 
-        // Prune bitmap chunks below the inactivity floor.
+        // Prune bitmap chunks below the inactivity floor, but for delayed-merge families only
+        // advance to a rewind-safe settled boundary.
+        let settled_bitmap_floor = self.settled_bitmap_prune_loc()?;
         let BitmapBatch::<N>::Base(base) = &mut self.status else {
             unreachable!("flatten() guarantees Base");
         };
-        Arc::make_mut(base).prune_to_bit(*self.any.inactivity_floor_loc);
+        Arc::make_mut(base).prune_to_bit(*settled_bitmap_floor);
 
         // Prune the grafted tree to match the bitmap's pruned chunks.
         let pruned_chunks = self.status.pruned_chunks() as u64;
@@ -373,6 +511,11 @@ where
         if rewind_size < pruned_bits {
             return Err(Error::Journal(JournalError::ItemPruned(rewind_size - 1)));
         }
+        if let Some(rewind_floor) = self.delayed_merge_rewind_floor()? {
+            if rewind_size < rewind_floor {
+                return Err(Error::Journal(JournalError::ItemPruned(rewind_size - 1)));
+            }
+        }
 
         // Ensure the target commit's logical range is fully representable with the current
         // bitmap pruning boundary. Even if the ops log still retains older entries, rewinding
@@ -437,8 +580,12 @@ where
             self.thread_pool.as_ref(),
         )
         .await?;
-        let storage =
-            grafting::Storage::new(&grafted_tree, grafting::height::<N>(), &self.any.log.merkle);
+        let storage = grafting::Storage::new(
+            &grafted_tree,
+            grafting::height::<N>(),
+            &self.any.log.merkle,
+            hasher.clone(),
+        );
         let partial_chunk = partial_chunk(status);
         let ops_root = self.any.log.root();
         let root = compute_db_root(&hasher, status, &storage, partial_chunk, &ops_root).await?;
@@ -637,13 +784,12 @@ pub(super) async fn compute_db_root<
     F: merkle::Graftable,
     H: Hasher,
     B: BitmapReadable<N>,
-    G: Readable<Family = F, Digest = H::Digest, Error = merkle::Error<F>>,
     S: MerkleStorage<F, Digest = H::Digest>,
     const N: usize,
 >(
     hasher: &StandardHasher<H>,
     status: &B,
-    storage: &grafting::Storage<'_, F, H::Digest, G, S>,
+    storage: &S,
     partial_chunk: Option<([u8; N], u64)>,
     ops_root: &H::Digest,
 ) -> Result<H::Digest, Error<F>> {
@@ -673,13 +819,12 @@ pub(super) async fn compute_grafted_root<
     F: merkle::Graftable,
     H: Hasher,
     B: BitmapReadable<N>,
-    G: Readable<Family = F, Digest = H::Digest, Error = merkle::Error<F>>,
     S: MerkleStorage<F, Digest = H::Digest>,
     const N: usize,
 >(
     hasher: &StandardHasher<H>,
     status: &B,
-    storage: &grafting::Storage<'_, F, H::Digest, G, S>,
+    storage: &S,
 ) -> Result<H::Digest, Error<F>> {
     let size = storage.size().await;
     let leaves = Location::try_from(size)?;
@@ -690,7 +835,7 @@ pub(super) async fn compute_grafted_root<
         let digest = storage
             .get_node(peak_pos)
             .await?
-            .ok_or(merkle::Error::<F>::MissingNode(peak_pos))?;
+            .ok_or_else(|| merkle::Error::<F>::MissingNode(peak_pos))?;
         peaks.push(digest);
     }
 

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -387,10 +387,12 @@ pub(super) struct Storage<
     D: Digest,
     G: Readable<Family = F, Digest = D, Error = merkle::Error<F>>,
     S: StorageTrait<F, Digest = D>,
+    H: HasherTrait<F, Digest = D> + Clone,
 > {
     grafted_tree: &'a G,
     grafting_height: u32,
     ops_tree: &'a S,
+    grafted_hasher: GraftedHasher<F, H>,
     _phantom: PhantomData<(F, D)>,
 }
 
@@ -400,16 +402,53 @@ impl<
         D: Digest,
         G: Readable<Family = F, Digest = D, Error = merkle::Error<F>>,
         S: StorageTrait<F, Digest = D>,
-    > Storage<'a, F, D, G, S>
+        H: HasherTrait<F, Digest = D> + Clone,
+    > Storage<'a, F, D, G, S, H>
 {
     /// Creates a new [Storage] instance.
-    pub(super) const fn new(grafted_tree: &'a G, grafting_height: u32, ops_tree: &'a S) -> Self {
+    pub(super) const fn new(
+        grafted_tree: &'a G,
+        grafting_height: u32,
+        ops_tree: &'a S,
+        hasher: H,
+    ) -> Self {
         Self {
             grafted_tree,
             grafting_height,
             ops_tree,
+            grafted_hasher: GraftedHasher::new(hasher, grafting_height),
             _phantom: PhantomData,
         }
+    }
+
+    /// Reconstruct a grafted node that is missing from the pruned grafted tree.
+    ///
+    /// After pruning, only the grafted tree's pinned peaks and retained nodes are available.
+    /// As the ops tree grows, delayed merges create new ops peaks that map to grafted nodes
+    /// above the pinned peaks (ancestors). This function reconstructs those ancestors by
+    /// recursing into their children and hashing upward until it reaches available nodes
+    /// (pinned peaks or retained nodes).
+    ///
+    /// Returns `None` at height 0 (a grafted leaf), since leaves encode bitmap data and
+    /// cannot be recomputed from the tree structure alone. The settlement guard in
+    /// [`super::db::Db::settled_bitmap_prune_loc`] ensures this case is unreachable for
+    /// pruned chunks.
+    fn reconstruct_grafted_node(&self, pos: Position<F>) -> Option<D> {
+        if let Some(node) = self.grafted_tree.get_node(pos) {
+            return Some(node);
+        }
+
+        let height = F::pos_to_height(pos);
+        if height == 0 {
+            return None;
+        }
+        let (left, right) = F::children(pos, height);
+        let left_digest = self.reconstruct_grafted_node(left)?;
+        let right_digest = self.reconstruct_grafted_node(right)?;
+        Some(
+            self.grafted_hasher
+                .node_digest(pos, &left_digest, &right_digest),
+        )
     }
 }
 
@@ -418,7 +457,8 @@ impl<
         D: Digest,
         G: Readable<Family = F, Digest = D, Error = merkle::Error<F>>,
         S: StorageTrait<F, Digest = D>,
-    > StorageTrait<F> for Storage<'_, F, D, G, S>
+        H: HasherTrait<F, Digest = D> + Clone + Send + Sync,
+    > StorageTrait<F> for Storage<'_, F, D, G, S, H>
 {
     type Digest = D;
 
@@ -431,9 +471,8 @@ impl<
         if ops_height < self.grafting_height {
             return self.ops_tree.get_node(pos).await;
         }
-        // Convert the ops-family position to a grafted position (same family F).
         let grafted_pos = ops_to_grafted_pos::<F>(pos, self.grafting_height);
-        Ok(self.grafted_tree.get_node(grafted_pos))
+        Ok(self.reconstruct_grafted_node(grafted_pos))
     }
 }
 
@@ -762,7 +801,7 @@ mod tests {
             let ops_root = *ops_mmr.root();
 
             {
-                let combined = Storage::new(&grafted, GRAFTING_HEIGHT, &ops_mmr);
+                let combined = Storage::new(&grafted, GRAFTING_HEIGHT, &ops_mmr, hasher.clone());
                 assert_eq!(combined.size().await, ops_mmr.size());
 
                 // Compute the grafted root by iterating ops peaks.
@@ -891,7 +930,7 @@ mod tests {
 
             ops_mmr.apply_batch(&batch).unwrap();
 
-            let combined = Storage::new(&grafted, GRAFTING_HEIGHT, &ops_mmr);
+            let combined = Storage::new(&grafted, GRAFTING_HEIGHT, &ops_mmr, hasher.clone());
             assert_eq!(combined.size().await, ops_mmr.size());
 
             // Compute the grafted root.
@@ -1029,7 +1068,8 @@ mod tests {
                     &chunks,
                     grafting_height,
                 );
-                let combined = Storage::<F, _, _, _>::new(&grafted, grafting_height, &ops);
+                let combined =
+                    Storage::<F, _, _, _, _>::new(&grafted, grafting_height, &ops, hasher.clone());
 
                 let leaves = merkle::Location::<F>::try_from(size).unwrap();
                 let mut peaks = Vec::new();

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -430,9 +430,9 @@ impl<
     /// (pinned peaks or retained nodes).
     ///
     /// Recursion depth is bounded by the height difference between the queried node and the
-    /// nearest available descendant (a pinned peak or retained node). In practice this is at
-    /// most 1 level above the pinned peaks because the settlement guard limits how far ahead
-    /// the ops tree can grow before bitmap pruning advances.
+    /// nearest available descendant (a pinned peak or retained node). In practice it remains
+    /// small because the settlement guard limits how far ahead the ops tree can grow before
+    /// bitmap pruning advances.
     ///
     /// Returns `None` at height 0 (a grafted leaf), since leaves encode bitmap data and
     /// cannot be recomputed from the tree structure alone. The settlement guard in

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -429,6 +429,11 @@ impl<
     /// recursing into their children and hashing upward until it reaches available nodes
     /// (pinned peaks or retained nodes).
     ///
+    /// Recursion depth is bounded by the height difference between the queried node and the
+    /// nearest available descendant (a pinned peak or retained node). In practice this is at
+    /// most 1 level above the pinned peaks because the settlement guard limits how far ahead
+    /// the ops tree can grow before bitmap pruning advances.
+    ///
     /// Returns `None` at height 0 (a grafted leaf), since leaves encode bitmap data and
     /// cannot be recomputed from the tree structure alone. The settlement guard in
     /// [`super::db::Db::settled_bitmap_prune_loc`] ensures this case is unreachable for

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -162,10 +162,10 @@
 //!
 //! To avoid this, [`Db::prune`](db::Db::prune) defers bitmap pruning for chunks whose
 //! chunk-pair parent has not yet been born in the ops tree (see
-//! `settled_bitmap_prune_loc`). Once the parent is born, every ops peak within
+//! `Db::settled_bitmap_prune_loc`). Once the parent is born, every ops peak within
 //! the pruned region is at height `gh+1` or above, and maps to a pinned peak or an
 //! ancestor of pinned peaks that can be reconstructed by hashing children (see
-//! `reconstruct_grafted_node`).
+//! `grafting::Storage::reconstruct_grafted_node`).
 //!
 //! The same birth threshold also defines a _rewind floor_: rewinding the database to a size
 //! where the chunk-pair parent has not been born would re-expose the individual ops peaks and
@@ -1857,6 +1857,7 @@ pub mod tests {
             .unwrap();
 
             let k = key(0);
+            // Always assigned before the loop breaks.
             let mut expected;
 
             // Keep growing until the settle guard allows 2+ pruned chunks.

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -174,8 +174,8 @@
 //! not need to be persisted; it is recomputed on startup from the pruned chunk count stored
 //! in metadata.
 //!
-//! The pruning lag is small: at most `3 * 2^(gh-1) - 2` ops beyond the chunk boundary
-//! (about 1.5 chunks for the default chunk size).
+//! The pruning lag is small: at most `2^(gh+1) - 1` ops beyond the chunk boundary
+//! (just under 2 chunks for the default chunk size).
 //!
 //! # Root structure
 //!

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -138,9 +138,45 @@
 //! ## Pruning
 //!
 //! Old bitmap chunks (below the inactivity floor) can be pruned. Before pruning, the grafted
-//! digest peaks covering the pruned region are persisted to metadata as "pinned nodes". On
-//! recovery, these pinned nodes are loaded and serve as opaque siblings during upward propagation,
-//! allowing the grafted tree to be rebuilt without the pruned chunks.
+//! tree's peak digests covering the pruned region are persisted to metadata as "pinned nodes".
+//! On recovery, these pinned nodes are loaded and serve as opaque siblings during upward
+//! propagation, allowing the grafted tree to be rebuilt without the pruned chunks.
+//!
+//! ### Delayed-merge settlement
+//!
+//! For families with delayed merges (e.g. MMB), pruning is slightly more conservative than
+//! the inactivity floor alone would allow.
+//!
+//! The grafted root is computed by iterating the _ops tree's_ peaks and looking up the
+//! corresponding nodes in the grafted tree. After pruning, only the grafted tree's pinned
+//! peaks are available in the pruned region; interior nodes (including individual grafted
+//! leaves) are discarded. If the ops tree has a peak that maps to a discarded grafted node,
+//! root computation fails.
+//!
+//! In an MMR the ops tree's peaks within the pruned region always coincide with the grafted
+//! tree's pinned peaks, so this is never a problem. In an MMB, delayed merges cause the ops
+//! tree's peak structure to lag behind: a chunk pair's parent node at height `gh+1` is not
+//! created until some number of leaves after the pair's last leaf. Until that merge happens,
+//! the ops tree still has individual height-`gh` peaks for each chunk in the pair, and those
+//! map to grafted _leaves_ (height 0 in the grafted tree) -- which are not pinned peaks.
+//!
+//! To avoid this, [`Db::prune`](db::Db::prune) defers bitmap pruning for chunks whose
+//! chunk-pair parent has not yet been born in the ops tree (see
+//! [`settled_bitmap_prune_loc`](db::Db::settled_bitmap_prune_loc) in db.rs). Once the
+//! parent is born, every ops peak within the pruned region is at height `gh+1` or above,
+//! and maps to a pinned peak or an ancestor of pinned peaks that can be reconstructed by
+//! hashing children (see [`reconstruct_grafted_node`](grafting::Storage::reconstruct_grafted_node)
+//! in grafting.rs).
+//!
+//! The same birth threshold also defines a _rewind floor_: rewinding the database to a size
+//! where the chunk-pair parent has not been born would re-expose the individual ops peaks and
+//! break reconstruction. [`Db::rewind`](db::Db::rewind) rejects targets below this floor.
+//! The floor is a pure function of the pruned chunk count and the family geometry, so it does
+//! not need to be persisted -- it is recomputed on startup from the pruned chunk count stored
+//! in metadata.
+//!
+//! The pruning lag is small: at most `3 * 2^(gh-1) - 2` ops beyond the chunk boundary
+//! (about 1.5 chunks for the default chunk size).
 //!
 //! # Root structure
 //!
@@ -309,7 +345,12 @@ where
     .await?;
 
     // Compute and cache the root.
-    let storage = grafting::Storage::new(&grafted_tree, grafting::height::<N>(), &any.log.merkle);
+    let storage = grafting::Storage::new(
+        &grafted_tree,
+        grafting::height::<N>(),
+        &any.log.merkle,
+        hasher.clone(),
+    );
     let partial_chunk = db::partial_chunk(&status);
     let ops_root = any.log.root();
     let root = db::compute_db_root(&hasher, &status, &storage, partial_chunk, &ops_root).await?;
@@ -1585,13 +1626,8 @@ pub mod tests {
         });
     }
 
-    /// Verify that reopening and proving a pruned MMB database does not panic when the pruned
-    /// prefix contains sub-grafting-height peaks that require chunk regrouping.
-    ///
-    /// With 100 single-key commits the MMB has 301 leaves (100 writes + 100 commit floors +
-    /// 101 internal nodes). The first 256 leaves span three sub-grafting-height ops peaks
-    /// (128 + 64 + 64), so grafted root recomposition must regroup them as chunk 0. After
-    /// pruning, chunk 0 is gone and get_chunk(0) would panic without the pruned-chunk guard.
+    /// Verify that a delayed-merge settle guard can defer bitmap pruning while reopen/proof paths
+    /// remain stable.
     #[test_traced("INFO")]
     fn test_current_mmb_reopen_and_prove_after_prune_multi_peak_chunk() {
         let executor = deterministic::Runner::default();
@@ -1625,7 +1661,7 @@ pub mod tests {
             );
 
             db.prune(Location::<mmb::Family>::new(1)).await.unwrap();
-            assert_eq!(db.pruned_bits(), 256);
+            assert_eq!(db.pruned_bits(), 0);
             db.sync().await.unwrap();
             drop(db);
 
@@ -1644,6 +1680,88 @@ pub mod tests {
             let mut hasher = commonware_cryptography::Sha256::new();
             let _proof = reopened.key_value_proof(&mut hasher, k).await.unwrap();
 
+            reopened.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_current_mmb_rewind_rejects_unsettled_pruned_window() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const COMMITS: u64 = 320;
+            const N: usize = 32;
+
+            let partition = "current-mmb-rewind-unsettled-window";
+            let ctx = context.with_label("db");
+            let mut db: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                ctx.clone(),
+                variable_config::<OneCap>(partition, &ctx),
+            )
+            .await
+            .unwrap();
+
+            let key0 = key(0);
+            let mut history = Vec::new();
+            for round in 0..COMMITS {
+                let mut batch = db.new_batch();
+                batch = batch.write(key0, Some(val(60_000 + round)));
+                let merkleized = batch.merkleize(&db, None).await.unwrap();
+                db.apply_batch(merkleized).await.unwrap();
+                db.commit().await.unwrap();
+                history.push((db.bounds().await.end, db.inactivity_floor_loc()));
+            }
+
+            db.prune(db.inactivity_floor_loc()).await.unwrap();
+            let pruned_bits = db.pruned_bits();
+            assert!(pruned_bits > 0, "expected MMB bitmap pruning to be active");
+            db.sync().await.unwrap();
+
+            let chunk_bits = commonware_utils::bitmap::BitMap::<N>::CHUNK_SIZE_BITS;
+            let pruned_chunks = (pruned_bits / chunk_bits) as u64;
+            let gh = super::grafting::height::<N>();
+            let youngest = pruned_chunks - 1;
+            let pair_chunk = youngest & !1;
+            let pair_start = pair_chunk << gh;
+            let pair_pos = <mmb::Family as merkle::Graftable>::subtree_root_position(
+                merkle::Location::<mmb::Family>::new(pair_start),
+                gh + 1,
+            );
+            let absorbed_after =
+                <mmb::Family as merkle::Graftable>::peak_birth_size(pair_pos, gh + 1);
+
+            let unsafe_target = history
+                .iter()
+                .filter_map(|(size, floor)| {
+                    let s = **size;
+                    if s >= pruned_bits && s < absorbed_after && **floor >= pruned_bits {
+                        Some(s)
+                    } else {
+                        None
+                    }
+                })
+                .max()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "expected rewind target in unsettled window: pruned_bits={pruned_bits}, absorbed_after={absorbed_after}, history={history:?}"
+                    )
+                });
+
+            let err = db
+                .rewind(merkle::Location::<mmb::Family>::new(unsafe_target))
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),
+                "unexpected rewind error for unsettled delayed-merge window: {err:?}"
+            );
+            drop(db);
+
+            let reopened: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                context.with_label("reopen"),
+                variable_config::<OneCap>(partition, &context),
+            )
+            .await
+            .unwrap();
             reopened.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -162,10 +162,10 @@
 //!
 //! To avoid this, [`Db::prune`](db::Db::prune) defers bitmap pruning for chunks whose
 //! chunk-pair parent has not yet been born in the ops tree (see
-//! `settled_bitmap_prune_loc` in db.rs). Once the parent is born, every ops peak within
+//! `settled_bitmap_prune_loc`). Once the parent is born, every ops peak within
 //! the pruned region is at height `gh+1` or above, and maps to a pinned peak or an
 //! ancestor of pinned peaks that can be reconstructed by hashing children (see
-//! `reconstruct_grafted_node` in grafting.rs).
+//! `reconstruct_grafted_node`).
 //!
 //! The same birth threshold also defines a _rewind floor_: rewinding the database to a size
 //! where the chunk-pair parent has not been born would re-expose the individual ops peaks and
@@ -1677,7 +1677,7 @@ pub mod tests {
             db.sync().await.unwrap();
             drop(db);
 
-            // Reopen: compute_grafted_root must handle pruned chunk 0.
+            // Reopen: settlement guard deferred pruning, so state is unchanged.
             let reopened: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
                 context.with_label("reopen"),
                 variable_config::<OneCap>(partition, &context),
@@ -1933,6 +1933,8 @@ pub mod tests {
                 assert_eq!(db.get(&k).await.unwrap(), expected);
                 drop(prev_db);
             }
+
+            db.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -158,7 +158,7 @@
 //! tree's peak structure to lag behind: a chunk pair's parent node at height `gh+1` is not
 //! created until some number of leaves after the pair's last leaf. Until that merge happens,
 //! the ops tree still has individual height-`gh` peaks for each chunk in the pair, and those
-//! map to grafted _leaves_ (height 0 in the grafted tree) -- which are not pinned peaks.
+//! map to grafted _leaves_ (height 0 in the grafted tree), which are not pinned peaks.
 //!
 //! To avoid this, [`Db::prune`](db::Db::prune) defers bitmap pruning for chunks whose
 //! chunk-pair parent has not yet been born in the ops tree (see
@@ -171,7 +171,7 @@
 //! where the chunk-pair parent has not been born would re-expose the individual ops peaks and
 //! break reconstruction. [`Db::rewind`](db::Db::rewind) rejects targets below this floor.
 //! The floor is a pure function of the pruned chunk count and the family geometry, so it does
-//! not need to be persisted -- it is recomputed on startup from the pruned chunk count stored
+//! not need to be persisted; it is recomputed on startup from the pruned chunk count stored
 //! in metadata.
 //!
 //! The pruning lag is small: at most `3 * 2^(gh-1) - 2` ops beyond the chunk boundary
@@ -1638,10 +1638,10 @@ pub mod tests {
         });
     }
 
-    /// Verify that a delayed-merge settle guard can defer bitmap pruning while reopen/proof paths
-    /// remain stable.
+    /// Verify that the delayed-merge settlement guard defers bitmap pruning while reopen/proof
+    /// paths remain stable.
     #[test_traced("INFO")]
-    fn test_current_mmb_reopen_and_prove_after_prune_multi_peak_chunk() {
+    fn test_current_mmb_settlement_guard_defers_pruning() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             const COMMITS: u64 = 100;

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1386,6 +1386,19 @@ pub mod tests {
         Sha256::hash(&(i + 10000).to_be_bytes())
     }
 
+    async fn mmb_commit(
+        db: &mut UnorderedVariableMmbDb,
+        writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
+    ) {
+        let mut batch = db.new_batch();
+        for (k, v) in writes {
+            batch = batch.write(k, v);
+        }
+        let merkleized = batch.merkleize(db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+    }
+
     async fn commit_writes_with_metadata(
         db: &mut UnorderedVariableDb,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
@@ -1762,6 +1775,392 @@ pub mod tests {
             )
             .await
             .unwrap();
+            reopened.destroy().await.unwrap();
+        });
+    }
+
+    /// Prune, then grow without pruning again so delayed MMB merges occur inside the
+    /// already-pruned region. Verify proof + reopen correctness.
+    #[test_traced]
+    fn test_current_mmb_reopen_and_prove_after_prune_delayed_merge() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let db_ctx = context.with_label("db_init");
+            let mut db: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                db_ctx.clone(),
+                variable_config::<OneCap>("test_prune_delayed_merge", &db_ctx),
+            )
+            .await
+            .unwrap();
+
+            let k = key(0);
+
+            for round in 0..200u64 {
+                mmb_commit(&mut db, [(k, Some(val(60_000 + round)))]).await;
+            }
+
+            db.prune(db.inactivity_floor_loc()).await.unwrap();
+            db.sync().await.unwrap();
+
+            // Keep growing without pruning: delayed merges now occur in the pruned region.
+            for round in 200..300u64 {
+                mmb_commit(&mut db, [(key(1), Some(val(round)))]).await;
+            }
+
+            let mut hasher = commonware_cryptography::Sha256::new();
+            let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+            assert!(UnorderedVariableMmbDb::verify_key_value_proof(
+                &mut hasher,
+                k,
+                val(60_000 + 199),
+                &proof,
+                &db.root()
+            ));
+
+            let target_root = db.root();
+            drop(db);
+
+            let reopen_ctx = context.with_label("db_reopen");
+            let reopened: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                reopen_ctx.clone(),
+                variable_config::<OneCap>("test_prune_delayed_merge", &reopen_ctx),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(reopened.root(), target_root);
+
+            let mut hasher = commonware_cryptography::Sha256::new();
+            let proof = reopened.key_value_proof(&mut hasher, k).await.unwrap();
+            assert!(UnorderedVariableMmbDb::verify_key_value_proof(
+                &mut hasher,
+                k,
+                val(60_000 + 199),
+                &proof,
+                &reopened.root()
+            ));
+
+            reopened.destroy().await.unwrap();
+        });
+    }
+
+    /// Grow past 2 full pruned chunks, prune, reopen, verify root + value.
+    #[test_traced]
+    fn test_current_mmb_reopen_after_prune_two_chunks() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let db_ctx = context.with_label("db");
+            let mut db: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                db_ctx.clone(),
+                variable_config::<OneCap>("test_prune_two", &db_ctx),
+            )
+            .await
+            .unwrap();
+
+            let k = key(0);
+            let mut expected;
+
+            // Keep growing until the settle guard allows 2+ pruned chunks.
+            // The absorber for chunk pair [0,1] at gh=8 needs ~766 ops leaves.
+            let mut round = 0u64;
+            loop {
+                expected = Some(val(60_000 + round));
+                mmb_commit(&mut db, [(k, expected)]).await;
+                round += 1;
+                db.prune(db.inactivity_floor_loc()).await.unwrap();
+                if db.pruned_bits() >= 512 {
+                    break;
+                }
+                assert!(
+                    round < 500,
+                    "failed to reach 2 pruned chunks after {round} commits"
+                );
+            }
+            db.sync().await.unwrap();
+
+            let target_root = db.root();
+            drop(db);
+
+            let reopen_ctx = context.with_label("db_reopen");
+            let reopened: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                reopen_ctx.clone(),
+                variable_config::<OneCap>("test_prune_two", &reopen_ctx),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(reopened.root(), target_root);
+            assert_eq!(reopened.get(&k).await.unwrap(), expected);
+            reopened.destroy().await.unwrap();
+        });
+    }
+
+    /// Three rounds of grow + prune + reopen. Verifies repeated prune cycles don't diverge.
+    #[test_traced]
+    fn test_current_mmb_repeated_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut db_ctx = context.with_label("db_init");
+            let mut db: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                db_ctx.clone(),
+                variable_config::<OneCap>("test_repeated_prune", &db_ctx),
+            )
+            .await
+            .unwrap();
+
+            for round in 0..3u64 {
+                let k = key(round * 1000);
+                let mut expected = None;
+                for i in 0..90 {
+                    expected = Some(val(round * 1000 + i));
+                    mmb_commit(&mut db, [(k, expected)]).await;
+                }
+
+                db.prune(db.inactivity_floor_loc()).await.unwrap();
+                db.sync().await.unwrap();
+
+                let root_before = db.root();
+                db_ctx = context.with_label(&format!("db_{round}"));
+
+                let prev_db = db;
+                db = UnorderedVariableMmbDb::init(
+                    db_ctx.clone(),
+                    variable_config::<OneCap>("test_repeated_prune", &db_ctx),
+                )
+                .await
+                .unwrap();
+
+                assert_eq!(db.root(), root_before);
+                assert_eq!(db.get(&k).await.unwrap(), expected);
+                drop(prev_db);
+            }
+        });
+    }
+
+    /// Step-by-step growth after prune, comparing roots against an unpruned reference.
+    #[test_traced]
+    fn test_current_mmb_stepwise_growth_matches_unpruned_reference() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let db_ctx = context.with_label("db_stepwise");
+            let mut db: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                db_ctx.clone(),
+                variable_config::<OneCap>("test_stepwise", &db_ctx),
+            )
+            .await
+            .unwrap();
+
+            let ref_ctx = context.with_label("ref_stepwise");
+            let mut ref_db: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                ref_ctx.clone(),
+                variable_config::<OneCap>("test_stepwise_ref", &ref_ctx),
+            )
+            .await
+            .unwrap();
+
+            let k = key(0);
+            let mut commit_idx = 0u64;
+
+            // Grow until the inactivity floor reaches 4 chunks.
+            while *db.inactivity_floor_loc() < 1024 {
+                let value = Some(val(80_000 + commit_idx));
+                mmb_commit(&mut db, [(k, value)]).await;
+                mmb_commit(&mut ref_db, [(k, value)]).await;
+                commit_idx += 1;
+            }
+
+            db.prune(db.inactivity_floor_loc()).await.unwrap();
+            db.sync().await.unwrap();
+            assert_eq!(
+                db.root(),
+                ref_db.root(),
+                "root mismatch immediately after prune"
+            );
+
+            // Step-by-step growth through the delayed-merge window.
+            loop {
+                let db_leaves =
+                    *Location::<mmb::Family>::try_from(db.any.log.merkle.size()).unwrap();
+                if db_leaves >= 1560 {
+                    break;
+                }
+
+                let value = Some(val(80_000 + commit_idx));
+                mmb_commit(&mut db, [(k, value)]).await;
+                mmb_commit(&mut ref_db, [(k, value)]).await;
+                commit_idx += 1;
+
+                let db_leaves =
+                    *Location::<mmb::Family>::try_from(db.any.log.merkle.size()).unwrap();
+                assert_eq!(
+                    db.root(),
+                    ref_db.root(),
+                    "stepwise root mismatch: leaves={db_leaves}, commit_idx={commit_idx}"
+                );
+            }
+
+            db.destroy().await.unwrap();
+            ref_db.destroy().await.unwrap();
+        });
+    }
+
+    /// Multi-round prune + reopen + proof against an unpruned reference.
+    #[test_traced]
+    fn test_current_mmb_large_repeated_prune_matches_unpruned_reference() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const ROUNDS: u64 = 8;
+            const COMMITS_PER_ROUND: u64 = 120;
+
+            let mut db_ctx = context.with_label("db_init");
+            let mut db: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                db_ctx.clone(),
+                variable_config::<OneCap>("test_large_prune", &db_ctx),
+            )
+            .await
+            .unwrap();
+
+            let ref_ctx = context.with_label("ref");
+            let mut ref_db: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                ref_ctx.clone(),
+                variable_config::<OneCap>("test_large_prune_ref", &ref_ctx),
+            )
+            .await
+            .unwrap();
+
+            let k = key(0);
+            let mut expected = None;
+
+            for round in 0..ROUNDS {
+                for i in 0..COMMITS_PER_ROUND {
+                    let value = Some(val(round * 10_000 + i));
+                    expected = value;
+                    mmb_commit(&mut db, [(k, value)]).await;
+                    mmb_commit(&mut ref_db, [(k, value)]).await;
+                }
+
+                assert_eq!(
+                    db.root(),
+                    ref_db.root(),
+                    "root mismatch before prune at round {round}"
+                );
+
+                db.prune(db.inactivity_floor_loc()).await.unwrap();
+                db.sync().await.unwrap();
+
+                assert_eq!(
+                    db.root(),
+                    ref_db.root(),
+                    "root mismatch after prune at round {round}"
+                );
+
+                let mut hasher = commonware_cryptography::Sha256::new();
+                let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+                assert!(
+                    UnorderedVariableMmbDb::verify_key_value_proof(
+                        &mut hasher,
+                        k,
+                        expected.expect("value should exist"),
+                        &proof,
+                        &db.root()
+                    ),
+                    "proof verification failed at round {round}"
+                );
+
+                db_ctx = context.with_label(&format!("db_reopen_{round}"));
+                let prev_db = db;
+                db = UnorderedVariableMmbDb::init(
+                    db_ctx.clone(),
+                    variable_config::<OneCap>("test_large_prune", &db_ctx),
+                )
+                .await
+                .unwrap();
+
+                assert_eq!(
+                    db.root(),
+                    ref_db.root(),
+                    "root mismatch after reopen at round {round}"
+                );
+                assert_eq!(
+                    db.get(&k).await.unwrap(),
+                    expected,
+                    "value mismatch after reopen at round {round}"
+                );
+
+                let mut hasher = commonware_cryptography::Sha256::new();
+                let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+                assert!(
+                    UnorderedVariableMmbDb::verify_key_value_proof(
+                        &mut hasher,
+                        k,
+                        expected.expect("value should exist"),
+                        &proof,
+                        &db.root()
+                    ),
+                    "proof verification failed after reopen at round {round}"
+                );
+
+                drop(prev_db);
+            }
+
+            db.destroy().await.unwrap();
+            ref_db.destroy().await.unwrap();
+        });
+    }
+
+    /// Verify that prune beyond the inactivity floor is rejected without mutating state.
+    #[test_traced]
+    fn test_current_prune_rejects_beyond_inactivity_floor_without_mutation() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const COMMITS: u64 = 160;
+
+            let partition = "current-prune-beyond-floor";
+            let ctx = context.with_label("db");
+            let mut db: UnorderedVariableDb =
+                UnorderedVariableDb::init(ctx.clone(), variable_config::<OneCap>(partition, &ctx))
+                    .await
+                    .unwrap();
+
+            let key0 = key(0);
+            for round in 0..COMMITS {
+                commit_writes_with_metadata(&mut db, [(key0, Some(val(40_000 + round)))], None)
+                    .await;
+            }
+
+            let expected_root = db.root();
+            let expected_ops_root = db.ops_root();
+            let expected_floor = db.inactivity_floor_loc();
+            let expected_pruned_bits = db.pruned_bits();
+            let expected_value = db.get(&key0).await.unwrap();
+
+            // 32 * 8 = 256 bits per chunk for N=32.
+            let invalid_prune_loc = Location::new(*expected_floor + 256);
+            let result = db.prune(invalid_prune_loc).await;
+            assert!(
+                matches!(result, Err(Error::PruneBeyondMinRequired(loc, floor))
+                    if loc == invalid_prune_loc && floor == expected_floor),
+                "expected prune rejection above inactivity floor, got {result:?}"
+            );
+
+            assert_eq!(db.root(), expected_root);
+            assert_eq!(db.ops_root(), expected_ops_root);
+            assert_eq!(db.pruned_bits(), expected_pruned_bits);
+            assert_eq!(db.get(&key0).await.unwrap(), expected_value);
+
+            drop(db);
+
+            let reopened: UnorderedVariableDb = UnorderedVariableDb::init(
+                context.with_label("reopen"),
+                variable_config::<OneCap>(partition, &context),
+            )
+            .await
+            .unwrap();
+            assert_eq!(reopened.root(), expected_root);
+            assert_eq!(reopened.ops_root(), expected_ops_root);
+            assert_eq!(reopened.pruned_bits(), expected_pruned_bits);
+            assert_eq!(reopened.get(&key0).await.unwrap(), expected_value);
+
             reopened.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -162,11 +162,10 @@
 //!
 //! To avoid this, [`Db::prune`](db::Db::prune) defers bitmap pruning for chunks whose
 //! chunk-pair parent has not yet been born in the ops tree (see
-//! [`settled_bitmap_prune_loc`](db::Db::settled_bitmap_prune_loc) in db.rs). Once the
-//! parent is born, every ops peak within the pruned region is at height `gh+1` or above,
-//! and maps to a pinned peak or an ancestor of pinned peaks that can be reconstructed by
-//! hashing children (see [`reconstruct_grafted_node`](grafting::Storage::reconstruct_grafted_node)
-//! in grafting.rs).
+//! `settled_bitmap_prune_loc` in db.rs). Once the parent is born, every ops peak within
+//! the pruned region is at height `gh+1` or above, and maps to a pinned peak or an
+//! ancestor of pinned peaks that can be reconstructed by hashing children (see
+//! `reconstruct_grafted_node` in grafting.rs).
 //!
 //! The same birth threshold also defines a _rewind floor_: rewinding the database to a size
 //! where the chunk-pair parent has not been born would re-expose the individual ops peaks and

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -667,8 +667,8 @@ mod tests {
             };
             grafted.apply_batch(&merkleized).unwrap();
 
-            let storage = grafting::Storage::new(&grafted, grafting_height, &ops);
-            let root = db::compute_db_root::<F, Sha256, _, _, _, N>(
+            let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+            let root = db::compute_db_root::<F, Sha256, _, _, N>(
                 &hasher, &status, &storage, None, &ops_root,
             )
             .await
@@ -770,12 +770,12 @@ mod tests {
             };
             grafted.apply_batch(&merkleized).unwrap();
 
-            let storage = grafting::Storage::new(&grafted, grafting_height, &ops);
+            let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
             let partial = {
                 let (chunk, next_bit) = status.last_chunk();
                 Some((*chunk, next_bit))
             };
-            let root = db::compute_db_root::<F, Sha256, _, _, _, N>(
+            let root = db::compute_db_root::<F, Sha256, _, _, N>(
                 &hasher, &status, &storage, partial, &ops_root,
             )
             .await
@@ -877,12 +877,12 @@ mod tests {
             };
             grafted.apply_batch(&merkleized).unwrap();
 
-            let storage = grafting::Storage::new(&grafted, grafting_height, &ops);
+            let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
             let partial = {
                 let (chunk, next_bit) = status.last_chunk();
                 Some((*chunk, next_bit))
             };
-            let root = db::compute_db_root::<F, Sha256, _, _, _, N>(
+            let root = db::compute_db_root::<F, Sha256, _, _, N>(
                 &hasher, &status, &storage, partial, &ops_root,
             )
             .await
@@ -959,8 +959,8 @@ mod tests {
             };
             grafted.apply_batch(&merkleized).unwrap();
 
-            let storage = grafting::Storage::new(&grafted, grafting_height, &ops);
-            let root = db::compute_db_root::<F, Sha256, _, _, _, N>(
+            let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+            let root = db::compute_db_root::<F, Sha256, _, _, N>(
                 &hasher, &status, &storage, None, &ops_root,
             )
             .await
@@ -1059,8 +1059,8 @@ mod tests {
             };
             grafted.apply_batch(&merkleized).unwrap();
 
-            let storage = grafting::Storage::new(&grafted, grafting_height, &ops);
-            let root = db::compute_db_root::<F, Sha256, _, _, _, N>(
+            let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+            let root = db::compute_db_root::<F, Sha256, _, _, N>(
                 &hasher, &status, &storage, None, &ops_root,
             )
             .await

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -195,7 +195,12 @@ where
     // Compute the canonical root. The grafted root is deterministic from the ops
     // (which are authenticated by the engine) and the bitmap (which is deterministic
     // from the ops).
-    let storage = grafting::Storage::new(&grafted_tree, grafting::height::<N>(), &any.log.merkle);
+    let storage = grafting::Storage::new(
+        &grafted_tree,
+        grafting::height::<N>(),
+        &any.log.merkle,
+        hasher.clone(),
+    );
     let partial = db::partial_chunk(&status);
     let grafted_root = db::compute_grafted_root(&hasher, &status, &storage).await?;
     let ops_root = any.log.root();


### PR DESCRIPTION
Alternate approach to #3577 that retains required digests for root computation by delaying their pruning rather than persisting them in metadata. This approach is simpler and doesn't introduce any significant inefficiencies, since there is a tight (2 chunk) bound on pruning lag.

## The bug

After pruning `current` QMDB state backed by an MMB ops tree, the canonical root can diverge or fail with `MissingNode` during reopen, proof generation, or post-prune growth.

The root cause is that `compute_grafted_root` iterates the ops tree’s peaks and looks up the corresponding nodes in the grafted tree. After pruning, only the grafted tree’s pinned peaks are retained; interior nodes, including individual grafted leaves, are discarded. In an MMR, the ops tree’s peaks always coincide with pinned peaks, so this works. In an MMB, delayed merges cause the ops tree to retain individual height-`gh` peaks for recently completed chunks until the chunk-pair parent at height `gh+1` is born. Those height-`gh` peaks map to grafted leaves that are no longer available after pruning.

## The fix

Two guards plus ancestor reconstruction, with no new persisted data:

**1. Settlement guard** (`settled_bitmap_prune_loc`): Defers bitmap pruning for chunks whose chunk-pair parent at height `gh+1` has not yet been born in the ops tree. Once that parent is born, every ops peak within the pruned region is at height `gh+1` or above and maps to either a pinned peak or an ancestor of pinned peaks that can be reconstructed. Checking only the youngest pair is sufficient because older pairs have strictly earlier birth times. For MMR, this returns the inactivity floor unchanged.

**2. Ancestor reconstruction** (`reconstruct_grafted_node`): After pruning, later ops-tree merges can expose grafted ancestors that were not previously materialized. When `grafting::Storage` encounters a missing grafted node at height `> 0`, it recursively hashes children until it reaches pinned peaks or retained nodes. The settlement guard ensures this recursion never bottoms out at a missing grafted leaf.

**3. Rewind guard** (`delayed_merge_rewind_floor`): Rejects rewinds to a size where the chunk-pair parent has not yet been born, which would re-expose height-`gh` ops peaks for pruned chunks. This floor is a pure function of `pruned_chunks` and the family geometry, so it does not need to be persisted. For MMR, it returns `None`.

The pruning lag is small: at most `2^(gh+1) - 1` ops beyond the chunk boundary, i.e. no more than 2 chunks worth of data.

## Other changes

- Added `peak_birth_size` to `Graftable` (default implementation plus MMB override) to express when a node is first fully formed under the family’s merge schedule.
- Updated batch grafting logic to keep refreshing the last complete chunk while its grafting-height digest is still unsettled under delayed merges.
- Expanded module docs around pruning and delayed-merge settlement.
- Added focused regression coverage for prune/grow/reopen behavior under MMB.
