### PR TITLE
[runtime/append] Append::read_many_into test all items and concurrent reads

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -200,6 +200,10 @@ jobs:
       run: |
         cd runtime
         just miri iobuf:: --partition hash:${{matrix.partition}}/8
+    - name: Run miri tests for runtime::paged::append
+      run: |
+        cd runtime
+        just miri utils::buffer::paged::append::tests:: --partition hash:${{matrix.partition}}/8
 
   Unsafe-Tests-Gate:
     name: "Unsafe-Tests"

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -200,7 +200,7 @@ jobs:
       run: |
         cd runtime
         just miri iobuf:: --partition hash:${{matrix.partition}}/8
-    - name: Run miri tests for runtime::paged::append
+    - name: Run miri tests for runtime::buffer::paged::append
       run: |
         cd runtime
         just miri utils::buffer::paged::append::tests:: --partition hash:${{matrix.partition}}/8

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -1162,6 +1162,70 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
+    fn test_read_many_into_scattered_cache_misses() {
+        // Exercises all three source paths in a single read_many_into call:
+        // tip buffer, page cache hit, and page cache miss (blob I/O).
+        // The tip holds a partial page so one item straddles the tip boundary.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context.open("test_partition", b"rmany").await.unwrap();
+            // Small cache: only 2 pages, so we can force eviction.
+            let cache_ref =
+                CacheRef::from_pooler(&context.with_label("cache"), PAGE_SIZE, NZUsize!(2));
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            // Write 3 pages of data and sync to disk.
+            let synced: Vec<u8> = (0u8..=255)
+                .cycle()
+                .take(PAGE_SIZE.get() as usize * 3)
+                .collect();
+            append.append(&synced).await.unwrap();
+            append.sync().await.unwrap();
+
+            // Write a partial page that stays in the tip buffer. The item_size
+            // is chosen so the last item straddles the synced/tip boundary.
+            let item_size = 10;
+            let tip_len = PAGE_SIZE.get() as usize / 2;
+            let tip: Vec<u8> = (100u8..=255).cycle().take(tip_len).collect();
+            append.append(&tip).await.unwrap();
+
+            // Prime pages 0 and 2 into cache, leaving page 1 uncached.
+            let _ = append.read_at(0, item_size).await.unwrap();
+            let _ = append
+                .read_at(PAGE_SIZE.get() as u64 * 2, item_size)
+                .await
+                .unwrap();
+
+            // Offset that straddles the synced/tip boundary: starts in the last
+            // synced page, ends in the tip buffer.
+            let straddle_off = synced.len() as u64 - (item_size as u64 / 2);
+            let tip_off = synced.len() as u64 + item_size as u64;
+            let offsets = [
+                0u64,                       // page 0 (cached)
+                PAGE_SIZE.get() as u64,     // page 1 (not cached - blob I/O)
+                PAGE_SIZE.get() as u64 * 2, // page 2 (cached)
+                straddle_off,               // straddles synced/tip boundary
+                tip_off,                    // entirely in tip buffer
+            ];
+            let mut buf = vec![0u8; offsets.len() * item_size];
+            append
+                .read_many_into(&mut buf, &offsets, item_size)
+                .await
+                .unwrap();
+
+            let read: Vec<u8> = synced.iter().chain(tip.iter()).copied().collect();
+            for (i, &off) in offsets.iter().enumerate() {
+                assert_eq!(
+                    &buf[i * item_size..(i + 1) * item_size],
+                    &read[off as usize..off as usize + item_size],
+                );
+            }
+        });
+    }
+
+    #[test_traced("DEBUG")]
     fn test_append_crc_empty() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -463,7 +463,14 @@ impl<B: Blob> Append<B> {
         offsets: &[u64],
         item_size: usize,
     ) -> Result<(), Error> {
-        debug_assert_eq!(buf.len(), offsets.len() * item_size);
+        assert_eq!(
+            buf.len(),
+            offsets
+                .len()
+                .checked_mul(item_size)
+                .expect("read_many_into buffer length overflow"),
+            "read_many_into requires buf.len() == offsets.len() * item_size"
+        );
         if offsets.is_empty() {
             return Ok(());
         }
@@ -1103,6 +1110,30 @@ mod tests {
             let mut buf = vec![0u8; 8];
             append.read_many_into(&mut buf, &[0], 8).await.unwrap();
             assert_eq!(&buf, &data);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "read_many_into requires buf.len() == offsets.len() * item_size")]
+    fn test_read_many_into_short_buffer_panics() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context.open("test_partition", b"rmany").await.unwrap();
+            let cache_ref = CacheRef::from_pooler(
+                &context.with_label("cache"),
+                PAGE_SIZE,
+                NZUsize!(BUFFER_SIZE),
+            );
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            let data: Vec<u8> = (0..16).collect();
+            append.append(&data).await.unwrap();
+
+            let offsets = [0u64, 4];
+            let mut buf = vec![0u8; 7];
+            append.read_many_into(&mut buf, &offsets, 4).await.unwrap();
         });
     }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -478,40 +478,30 @@ impl<B: Blob> Append<B> {
             return Err(Error::BlobInsufficientLength);
         }
 
-        // Iterate over requested offsets and copy items that overlap with the tip
-        // buffer directly into the output. Items fully or partially below the tip
-        // need cache/blob reads and are recorded as (slice, offset) pairs. Slices
-        // are built via raw pointer arithmetic since each item occupies a disjoint,
-        // item_size-aligned region of the output.
+        // Iterate over fixed-size output slots and copy items that overlap with the
+        // tip buffer directly into place. Items fully or partially below the tip
+        // need cache/blob reads and are recorded as (slice, offset) pairs.
+        // `chunks_exact_mut` yields disjoint per-item slots, so we never have to
+        // reborrow the parent buffer while cache/blob destinations remain live.
+        if item_size == 0 {
+            return Ok(());
+        }
         let mut cache_ranges: Vec<(&mut [u8], u64)> = Vec::new();
-        for (i, &offset) in offsets.iter().enumerate() {
+        for (item_buf, &offset) in buf.chunks_exact_mut(item_size).zip(offsets.iter()) {
             let end = offset + item_size as u64;
 
             if end <= buffer.offset {
                 // Entirely below tip -- needs cache read.
-                // SAFETY: i * item_size < buf.len() because i < offsets.len() and
-                // buf.len() == offsets.len() * item_size.
-                let ptr = unsafe { buf.as_mut_ptr().add(i * item_size) };
-                // SAFETY: Each i is unique so the resulting slices are
-                // non-overlapping, and item_size keeps each within its slot.
-                let slice = unsafe { core::slice::from_raw_parts_mut(ptr, item_size) };
-                cache_ranges.push((slice, offset));
+                cache_ranges.push((item_buf, offset));
             } else if offset >= buffer.offset {
                 // Entirely in tip buffer.
                 let src = (offset - buffer.offset) as usize;
-                let item_buf = &mut buf[i * item_size..(i + 1) * item_size];
                 item_buf.copy_from_slice(&buffer.as_ref()[src..src + item_size]);
             } else {
                 // Straddles tip boundary: copy suffix from tip, record prefix for cache.
                 let prefix_len = (buffer.offset - offset) as usize;
-                let item_suffix_buf = &mut buf[i * item_size + prefix_len..(i + 1) * item_size];
-                item_suffix_buf.copy_from_slice(&buffer.as_ref()[..item_size - prefix_len]);
-                // SAFETY: i * item_size < buf.len() (same as above).
-                let ptr = unsafe { buf.as_mut_ptr().add(i * item_size) };
-                // SAFETY: Each i is unique so slices are non-overlapping,
-                // and prefix_len <= item_size keeps within the slot.
-                let slice = unsafe { core::slice::from_raw_parts_mut(ptr, prefix_len) };
-                cache_ranges.push((slice, offset));
+                item_buf[prefix_len..].copy_from_slice(&buffer.as_ref()[..item_size - prefix_len]);
+                cache_ranges.push((&mut item_buf[..prefix_len], offset));
             }
         }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -24,6 +24,7 @@ use crate::{
 use bytes::BufMut;
 use commonware_cryptography::Crc32;
 use commonware_utils::sync::{AsyncRwLock, AsyncRwLockWriteGuard};
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::{
     num::{NonZeroU16, NonZeroUsize},
     sync::Arc,
@@ -477,66 +478,70 @@ impl<B: Blob> Append<B> {
             return Err(Error::BlobInsufficientLength);
         }
 
-        // Resolve tip-buffer overlap for all items, tracking which indices need cache reads.
-        // cache_indices stores (item_index, byte_len, offset) for items needing cache reads.
-        let mut cache_indices: Vec<(usize, usize, u64)> = Vec::new();
+        // Iterate over requested offsets and copy items that overlap with the tip
+        // buffer directly into the output. Items fully or partially below the tip
+        // need cache/blob reads and are recorded as (slice, offset) pairs. Slices
+        // are built via raw pointer arithmetic since each item occupies a disjoint,
+        // item_size-aligned region of the output.
+        let mut cache_ranges: Vec<(&mut [u8], u64)> = Vec::new();
         for (i, &offset) in offsets.iter().enumerate() {
-            let item_buf = &mut buf[i * item_size..(i + 1) * item_size];
             let end = offset + item_size as u64;
 
             if end <= buffer.offset {
                 // Entirely below tip -- needs cache read.
-                cache_indices.push((i, item_size, offset));
+                // SAFETY: i * item_size < buf.len() because i < offsets.len() and
+                // buf.len() == offsets.len() * item_size.
+                let ptr = unsafe { buf.as_mut_ptr().add(i * item_size) };
+                // SAFETY: Each i is unique so the resulting slices are
+                // non-overlapping, and item_size keeps each within its slot.
+                let slice = unsafe { core::slice::from_raw_parts_mut(ptr, item_size) };
+                cache_ranges.push((slice, offset));
             } else if offset >= buffer.offset {
                 // Entirely in tip buffer.
                 let src = (offset - buffer.offset) as usize;
+                let item_buf = &mut buf[i * item_size..(i + 1) * item_size];
                 item_buf.copy_from_slice(&buffer.as_ref()[src..src + item_size]);
             } else {
-                // Straddles tip boundary.
+                // Straddles tip boundary: copy suffix from tip, record prefix for cache.
                 let prefix_len = (buffer.offset - offset) as usize;
-                item_buf[prefix_len..].copy_from_slice(&buffer.as_ref()[..item_size - prefix_len]);
-                cache_indices.push((i, prefix_len, offset));
+                let item_suffix_buf = &mut buf[i * item_size + prefix_len..(i + 1) * item_size];
+                item_suffix_buf.copy_from_slice(&buffer.as_ref()[..item_size - prefix_len]);
+                // SAFETY: i * item_size < buf.len() (same as above).
+                let ptr = unsafe { buf.as_mut_ptr().add(i * item_size) };
+                // SAFETY: Each i is unique so slices are non-overlapping,
+                // and prefix_len <= item_size keeps within the slot.
+                let slice = unsafe { core::slice::from_raw_parts_mut(ptr, prefix_len) };
+                cache_ranges.push((slice, offset));
             }
         }
 
         drop(buffer);
 
-        if cache_indices.is_empty() {
+        if cache_ranges.is_empty() {
             return Ok(());
         }
-
-        // Build mutable slices for the cache read. We split buf into non-overlapping
-        // sub-slices using raw pointer arithmetic (items are at fixed strides).
-        // SAFETY: Each (index, len) pair refers to a disjoint region of buf since
-        // indices are unique and item_size-aligned.
-        let mut cache_ranges: Vec<(&mut [u8], u64)> = cache_indices
-            .iter()
-            .map(|&(idx, len, offset)| {
-                let start = idx * item_size;
-                // SAFETY: start < buf.len() because idx < offsets.len() and
-                // buf.len() == offsets.len() * item_size.
-                let ptr = unsafe { buf.as_mut_ptr().add(start) };
-                // SAFETY: Each idx is unique so the resulting slices are
-                // non-overlapping, and len <= item_size keeps each within its slot.
-                let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
-                (slice, offset)
-            })
-            .collect();
 
         // Fast path: try page cache for all ranges in a single lock acquisition.
-        let fully_cached = self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
-
-        if fully_cached == cache_ranges.len() {
+        // Fully-cached ranges have their offset set to CacheRef::CACHED.
+        let all_cached = self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
+        if all_cached {
             return Ok(());
         }
 
-        // Slow path: cache miss on some ranges. Fall back to per-range reads.
+        // Slow path: read only the ranges that had cache misses, concurrently.
         let blob_guard = self.blob_state.read().await;
-        for (item_buf, offset) in &mut cache_ranges[fully_cached..] {
-            self.cache_ref
-                .read(&blob_guard.blob, self.id, item_buf, *offset)
-                .await?;
+        let mut reads = cache_ranges
+            .iter_mut()
+            .filter(|(_, offset)| *offset != CacheRef::CACHED)
+            .map(|(item_buf, offset)| {
+                self.cache_ref
+                    .read(&blob_guard.blob, self.id, item_buf, *offset)
+            })
+            .collect::<FuturesUnordered<_>>();
+        while let Some(result) = reads.next().await {
+            result?;
         }
+
         Ok(())
     }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -522,9 +522,9 @@ impl<B: Blob> Append<B> {
         }
 
         // Fast path: try page cache for all ranges in a single lock acquisition.
-        // Fully-cached ranges have their offset set to CacheRef::CACHED.
-        let all_cached = self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
-        if all_cached {
+        // Fully-cached ranges are removed from cache_ranges; only misses remain.
+        self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
+        if cache_ranges.is_empty() {
             return Ok(());
         }
 
@@ -532,7 +532,6 @@ impl<B: Blob> Append<B> {
         let blob_guard = self.blob_state.read().await;
         let mut reads = cache_ranges
             .iter_mut()
-            .filter(|(_, offset)| *offset != CacheRef::CACHED)
             .map(|(item_buf, offset)| {
                 self.cache_ref
                     .read(&blob_guard.blob, self.id, item_buf, *offset)

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -167,6 +167,9 @@ pub struct CacheRef {
 }
 
 impl CacheRef {
+    /// Sentinel offset written into fully-cached ranges by [`read_cached_many`](Self::read_cached_many).
+    pub(super) const CACHED: u64 = u64::MAX;
+
     /// Create a shared page-cache handle backed by `pool`.
     ///
     /// The cache stores at most `capacity` pages, each exactly `page_size` bytes.
@@ -239,12 +242,13 @@ impl CacheRef {
 
     /// Read multiple disjoint byte ranges from the page cache in a single lock acquisition.
     ///
-    /// Each element of `ranges` is `(dest_slice, logical_offset)`. Returns the number of
-    /// ranges that were *fully* read from cache before encountering a miss. Ranges must be
-    /// sorted by offset and non-overlapping.
-    pub(super) fn read_cached_many(&self, blob_id: u64, ranges: &mut [(&mut [u8], u64)]) -> usize {
+    /// Each element of `ranges` is `(dest_slice, logical_offset)`. All ranges are checked
+    /// against the cache. Fully-cached ranges have their data written to the destination
+    /// slice and their offset set to [`CACHED`](Self::CACHED). Returns `true` if every
+    /// range was fully served from cache.
+    pub(super) fn read_cached_many(&self, blob_id: u64, ranges: &mut [(&mut [u8], u64)]) -> bool {
         let page_cache = self.cache.read();
-        let mut fully_read = 0;
+        let mut all_cached = true;
         for (buf, logical_offset) in ranges.iter_mut() {
             let mut remaining = buf.len();
             let mut offset = *logical_offset;
@@ -252,15 +256,19 @@ impl CacheRef {
             while remaining > 0 {
                 let count = page_cache.read_at(blob_id, &mut buf[dst..], offset);
                 if count == 0 {
-                    return fully_read;
+                    break;
                 }
                 offset += count as u64;
                 dst += count;
                 remaining -= count;
             }
-            fully_read += 1;
+            if remaining == 0 {
+                *logical_offset = Self::CACHED;
+            } else {
+                all_cached = false;
+            }
         }
-        fully_read
+        all_cached
     }
 
     /// Read the specified bytes, preferentially from the page cache. Bytes not found in the cache

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -1139,4 +1139,106 @@ mod tests {
             assert_eq!(reads.load(Ordering::Relaxed), 2);
         });
     }
+
+    #[test_traced]
+    fn test_read_cached_many_all_cached() {
+        let mut registry = Registry::default();
+        let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut registry);
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
+        let blob_id = cache_ref.next_id();
+        let page0 = vec![0xAA; PAGE_SIZE.get() as usize];
+        let page1 = vec![0xBB; PAGE_SIZE.get() as usize];
+
+        // Populate two pages with distinct data.
+        {
+            let mut cache = cache_ref.cache.write();
+            cache.cache(blob_id, &page0, 0);
+            cache.cache(blob_id, &page1, 1);
+        }
+
+        let mut buf0 = vec![0u8; PAGE_SIZE_U64 as usize];
+        let mut buf1 = vec![0u8; PAGE_SIZE_U64 as usize];
+        let mut ranges: Vec<(&mut [u8], u64)> = vec![(&mut buf0, 0), (&mut buf1, PAGE_SIZE_U64)];
+
+        let all_cached = cache_ref.read_cached_many(blob_id, &mut ranges);
+
+        // All ranges served from cache.
+        assert!(all_cached);
+
+        // Both offsets should be marked as CACHED.
+        assert_eq!(ranges[0].1, CacheRef::CACHED);
+        assert_eq!(ranges[1].1, CacheRef::CACHED);
+        drop(ranges);
+
+        // Buffers should contain the cached page data.
+        assert!(buf0 == page0);
+        assert!(buf1 == page1);
+    }
+
+    #[test_traced]
+    fn test_read_cached_many_none_cached() {
+        let mut registry = Registry::default();
+        let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut registry);
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
+        let blob_id = cache_ref.next_id();
+
+        let mut buf0 = vec![0u8; PAGE_SIZE_U64 as usize];
+        let mut buf1 = vec![0u8; PAGE_SIZE_U64 as usize];
+        let mut ranges: Vec<(&mut [u8], u64)> = vec![(&mut buf0, 0), (&mut buf1, PAGE_SIZE_U64)];
+
+        // Empty cache: both ranges should miss.
+        let all_cached = cache_ref.read_cached_many(blob_id, &mut ranges);
+        assert!(!all_cached);
+
+        // Offsets should be left unchanged (not marked as CACHED).
+        assert_eq!(ranges[0].1, 0);
+        assert_eq!(ranges[1].1, PAGE_SIZE_U64);
+    }
+
+    #[test_traced]
+    fn test_read_cached_many_scattered_misses() {
+        // Verify that read_cached_many checks ALL ranges, not just up to the
+        // first miss. Pages 0 and 2 are cached, page 1 is not.
+        let mut registry = Registry::default();
+        let pool = BufferPool::new(BufferPoolConfig::for_storage(), &mut registry);
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
+        let blob_id = cache_ref.next_id();
+
+        let page0 = vec![0x11; PAGE_SIZE.get() as usize];
+        let page2 = vec![0x33; PAGE_SIZE.get() as usize];
+        {
+            let mut cache = cache_ref.cache.write();
+            cache.cache(blob_id, &page0, 0);
+            // page 1 deliberately not cached
+            cache.cache(blob_id, &page2, 2);
+        }
+
+        let mut buf0 = vec![0u8; PAGE_SIZE_U64 as usize];
+        let mut buf1 = vec![0u8; PAGE_SIZE_U64 as usize];
+        let mut buf2 = vec![0u8; PAGE_SIZE_U64 as usize];
+        let mut ranges: Vec<(&mut [u8], u64)> = vec![
+            (&mut buf0, 0),
+            (&mut buf1, PAGE_SIZE_U64),
+            (&mut buf2, PAGE_SIZE_U64 * 2),
+        ];
+
+        let all_cached = cache_ref.read_cached_many(blob_id, &mut ranges);
+
+        // Not all cached because page 1 is missing.
+        assert!(!all_cached);
+
+        // Page 0: cached, offset marked as CACHED.
+        assert_eq!(ranges[0].1, CacheRef::CACHED);
+        // Page 1: miss, offset left unchanged.
+        assert_eq!(ranges[1].1, PAGE_SIZE_U64);
+        // Page 2: cached despite the earlier miss on page 1, offset marked.
+        assert_eq!(ranges[2].1, CacheRef::CACHED);
+        drop(ranges);
+
+        // Cached pages should have their data written to the buffers.
+        assert!(buf0 == page0);
+        assert!(buf2 == page2);
+        // Missed page's buffer should be untouched (still zeroed).
+        assert!(buf1.iter().all(|b| *b == 0));
+    }
 }

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -167,9 +167,6 @@ pub struct CacheRef {
 }
 
 impl CacheRef {
-    /// Sentinel offset written into fully-cached ranges by [`read_cached_many`](Self::read_cached_many).
-    pub(super) const CACHED: u64 = u64::MAX;
-
     /// Create a shared page-cache handle backed by `pool`.
     ///
     /// The cache stores at most `capacity` pages, each exactly `page_size` bytes.
@@ -242,14 +239,13 @@ impl CacheRef {
 
     /// Read multiple disjoint byte ranges from the page cache in a single lock acquisition.
     ///
-    /// Each element of `ranges` is `(dest_slice, logical_offset)`. All ranges are checked
-    /// against the cache. Fully-cached ranges have their data written to the destination
-    /// slice and their offset set to [`CACHED`](Self::CACHED). Returns `true` if every
-    /// range was fully served from cache.
-    pub(super) fn read_cached_many(&self, blob_id: u64, ranges: &mut [(&mut [u8], u64)]) -> bool {
+    /// Each element of `ranges` is `(dest_slice, logical_offset)`. Fully-cached ranges have
+    /// their data written to the destination slice and are removed from `ranges`. Entries left
+    /// in `ranges` correspond to cache misses that the caller must read from the underlying
+    /// blob.
+    pub(super) fn read_cached_many(&self, blob_id: u64, ranges: &mut Vec<(&mut [u8], u64)>) {
         let page_cache = self.cache.read();
-        let mut all_cached = true;
-        for (buf, logical_offset) in ranges.iter_mut() {
+        ranges.retain_mut(|(buf, logical_offset)| {
             let mut remaining = buf.len();
             let mut offset = *logical_offset;
             let mut dst = 0;
@@ -262,13 +258,10 @@ impl CacheRef {
                 dst += count;
                 remaining -= count;
             }
-            if remaining == 0 {
-                *logical_offset = Self::CACHED;
-            } else {
-                all_cached = false;
-            }
-        }
-        all_cached
+
+            // Keep cache misses in `ranges`; drop fully-cached entries.
+            remaining > 0
+        });
     }
 
     /// Read the specified bytes, preferentially from the page cache. Bytes not found in the cache
@@ -1160,14 +1153,10 @@ mod tests {
         let mut buf1 = vec![0u8; PAGE_SIZE_U64 as usize];
         let mut ranges: Vec<(&mut [u8], u64)> = vec![(&mut buf0, 0), (&mut buf1, PAGE_SIZE_U64)];
 
-        let all_cached = cache_ref.read_cached_many(blob_id, &mut ranges);
+        cache_ref.read_cached_many(blob_id, &mut ranges);
 
-        // All ranges served from cache.
-        assert!(all_cached);
-
-        // Both offsets should be marked as CACHED.
-        assert_eq!(ranges[0].1, CacheRef::CACHED);
-        assert_eq!(ranges[1].1, CacheRef::CACHED);
+        // All ranges served from cache, so the vec is now empty.
+        assert!(ranges.is_empty());
         drop(ranges);
 
         // Buffers should contain the cached page data.
@@ -1186,11 +1175,9 @@ mod tests {
         let mut buf1 = vec![0u8; PAGE_SIZE_U64 as usize];
         let mut ranges: Vec<(&mut [u8], u64)> = vec![(&mut buf0, 0), (&mut buf1, PAGE_SIZE_U64)];
 
-        // Empty cache: both ranges should miss.
-        let all_cached = cache_ref.read_cached_many(blob_id, &mut ranges);
-        assert!(!all_cached);
-
-        // Offsets should be left unchanged (not marked as CACHED).
+        // Empty cache: both ranges should miss and remain in the vec unchanged.
+        cache_ref.read_cached_many(blob_id, &mut ranges);
+        assert_eq!(ranges.len(), 2);
         assert_eq!(ranges[0].1, 0);
         assert_eq!(ranges[1].1, PAGE_SIZE_U64);
     }
@@ -1222,17 +1209,12 @@ mod tests {
             (&mut buf2, PAGE_SIZE_U64 * 2),
         ];
 
-        let all_cached = cache_ref.read_cached_many(blob_id, &mut ranges);
+        cache_ref.read_cached_many(blob_id, &mut ranges);
 
-        // Not all cached because page 1 is missing.
-        assert!(!all_cached);
-
-        // Page 0: cached, offset marked as CACHED.
-        assert_eq!(ranges[0].1, CacheRef::CACHED);
-        // Page 1: miss, offset left unchanged.
-        assert_eq!(ranges[1].1, PAGE_SIZE_U64);
-        // Page 2: cached despite the earlier miss on page 1, offset marked.
-        assert_eq!(ranges[2].1, CacheRef::CACHED);
+        // Only the page 1 miss should remain (page 2 is still processed despite
+        // the earlier miss).
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].1, PAGE_SIZE_U64);
         drop(ranges);
 
         // Cached pages should have their data written to the buffers.


### PR DESCRIPTION
`Append::read_many_into` previously read cache-missed ranges sequentially, and `CacheRef::read_cached_many` short-circuited on the first cache miss, skipping ranges that might already be cached. This PR makes `CacheRef::read_cached_many` check all ranges under a single lock acquisition, marking cached ranges with a sentinel offset. Only true cache misses are then read concurrently via `FuturesUnordered`, since every item in the set is guaranteed to need I/O.

Follow-up to #3574.