### PR TITLE
[runtime] Remove `async move` wrapping from `spawn_cell!`

### DIFF
--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -147,7 +147,7 @@ where
         mut self,
         network: (impl Sender<PublicKey = P>, impl Receiver<PublicKey = P>),
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(network).await)
+        spawn_cell!(self.context, self.run(network))
     }
 
     /// Inner run loop called by `start`.

--- a/collector/src/p2p/engine.rs
+++ b/collector/src/p2p/engine.rs
@@ -113,7 +113,7 @@ where
         requests: (impl Sender<PublicKey = P>, impl Receiver<PublicKey = P>),
         responses: (impl Sender<PublicKey = P>, impl Receiver<PublicKey = P>),
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(requests, responses).await)
+        spawn_cell!(self.context, self.run(requests, responses))
     }
 
     async fn run(

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -223,7 +223,7 @@ impl<
             impl Receiver<PublicKey = <P::Scheme as Scheme>::PublicKey>,
         ),
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(network).await)
+        spawn_cell!(self.context, self.run(network))
     }
 
     /// Inner run loop called by `start`.

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -403,7 +403,7 @@ where
         mut self,
         network: (impl Sender<PublicKey = P>, impl Receiver<PublicKey = P>),
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(network).await)
+        spawn_cell!(self.context, self.run(network))
     }
 
     /// Run the shard engine's event loop.

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -374,7 +374,7 @@ where
         >,
         Buf: Buffer<V, PublicKey = <P::Scheme as CertificateScheme>::PublicKey>,
     {
-        spawn_cell!(self.context, self.run(application, buffer, resolver).await)
+        spawn_cell!(self.context, self.run(application, buffer, resolver))
     }
 
     /// Run the application actor.

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -272,7 +272,7 @@ impl<
             impl Receiver<PublicKey = C::PublicKey>,
         ),
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(chunk_network, ack_network).await)
+        spawn_cell!(self.context, self.run(chunk_network, ack_network))
     }
 
     /// Inner run loop called by `start`.

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -276,7 +276,7 @@ where
     ) -> Handle<()> {
         spawn_cell!(
             self.context,
-            self.run(voter, vote_receiver, certificate_receiver).await
+            self.run(voter, vote_receiver, certificate_receiver)
         )
     }
 

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -85,7 +85,7 @@ impl<
         sender: impl Sender<PublicKey = S::PublicKey>,
         receiver: impl Receiver<PublicKey = S::PublicKey>,
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(voter, sender, receiver).await)
+        spawn_cell!(self.context, self.run(voter, sender, receiver))
     }
 
     async fn run(

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -691,7 +691,6 @@ impl<
         spawn_cell!(
             self.context,
             self.run(batcher, resolver, vote_sender, certificate_sender)
-                .await
         )
     }
 

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -183,7 +183,6 @@ impl<
         spawn_cell!(
             self.context,
             self.run(vote_network, certificate_network, resolver_network)
-                .await
         )
     }
 

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -388,7 +388,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
     }
 
     pub fn start(mut self) -> Handle<()> {
-        spawn_cell!(self.context, self.run().await)
+        spawn_cell!(self.context, self.run())
     }
 
     async fn run(mut self) {

--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -38,7 +38,7 @@ where
     }
 
     pub fn start(mut self, vote_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        spawn_cell!(self.context, self.run(vote_network).await)
+        spawn_cell!(self.context, self.run(vote_network))
     }
 
     async fn run(mut self, vote_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/equivocator.rs
+++ b/consensus/src/simplex/mocks/equivocator.rs
@@ -64,10 +64,7 @@ impl<E: Clock + Rng + Spawner, S: Scheme<H::Digest>, L: ElectorConfig<S>, H: Has
         vote_network: (impl Sender<PublicKey = S::PublicKey>, impl Receiver),
         certificate_network: (impl Sender, impl Receiver),
     ) -> Handle<()> {
-        spawn_cell!(
-            self.context,
-            self.run(vote_network, certificate_network).await
-        )
+        spawn_cell!(self.context, self.run(vote_network, certificate_network))
     }
 
     async fn run(

--- a/consensus/src/simplex/mocks/impersonator.rs
+++ b/consensus/src/simplex/mocks/impersonator.rs
@@ -39,7 +39,7 @@ impl<E: Clock + CryptoRngCore + Spawner, S: scheme::Scheme<H::Digest>, H: Hasher
     }
 
     pub fn start(mut self, vote_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        spawn_cell!(self.context, self.run(vote_network).await)
+        spawn_cell!(self.context, self.run(vote_network))
     }
 
     async fn run(self, vote_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/nuller.rs
+++ b/consensus/src/simplex/mocks/nuller.rs
@@ -36,7 +36,7 @@ where
     }
 
     pub fn start(mut self, vote_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        spawn_cell!(self.context, self.run(vote_network).await)
+        spawn_cell!(self.context, self.run(vote_network))
     }
 
     async fn run(self, vote_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/nullify_only.rs
+++ b/consensus/src/simplex/mocks/nullify_only.rs
@@ -35,7 +35,7 @@ impl<E: Spawner, S: Scheme<H::Digest>, H: Hasher> NullifyOnly<E, S, H> {
     }
 
     pub fn start(mut self, vote_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        spawn_cell!(self.context, self.run(vote_network).await)
+        spawn_cell!(self.context, self.run(vote_network))
     }
 
     async fn run(self, vote_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/outdated.rs
+++ b/consensus/src/simplex/mocks/outdated.rs
@@ -46,7 +46,7 @@ where
     }
 
     pub fn start(mut self, vote_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        spawn_cell!(self.context, self.run(vote_network).await)
+        spawn_cell!(self.context, self.run(vote_network))
     }
 
     async fn run(mut self, vote_network: (impl Sender, impl Receiver)) {

--- a/consensus/src/simplex/mocks/reconfigurer.rs
+++ b/consensus/src/simplex/mocks/reconfigurer.rs
@@ -38,7 +38,7 @@ where
     }
 
     pub fn start(mut self, vote_network: (impl Sender, impl Receiver)) -> Handle<()> {
-        spawn_cell!(self.context, self.run(vote_network).await)
+        spawn_cell!(self.context, self.run(vote_network))
     }
 
     async fn run(self, vote_network: (impl Sender, impl Receiver)) {

--- a/examples/log/src/application/actor.rs
+++ b/examples/log/src/application/actor.rs
@@ -42,7 +42,7 @@ impl<R: Rng + Spawner, H: Hasher> Application<R, H> {
 
     /// Run the application actor.
     pub fn start(mut self) -> Handle<()> {
-        spawn_cell!(self.context, self.run().await)
+        spawn_cell!(self.context, self.run())
     }
 
     async fn run(mut self) {

--- a/examples/reshare/src/dkg/actor.rs
+++ b/examples/reshare/src/dkg/actor.rs
@@ -217,7 +217,7 @@ where
         // cryptographic operations.
         spawn_cell!(
             self.context,
-            self.run(output, share, orchestrator, dkg, callback).await
+            self.run(output, share, orchestrator, dkg, callback)
         )
     }
 

--- a/examples/reshare/src/engine.rs
+++ b/examples/reshare/src/engine.rs
@@ -362,7 +362,6 @@ where
                 marshal,
                 callback
             )
-            .await
         )
     }
 

--- a/examples/reshare/src/orchestrator/actor.rs
+++ b/examples/reshare/src/orchestrator/actor.rs
@@ -149,7 +149,7 @@ where
             impl Receiver<PublicKey = C::PublicKey>,
         ),
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(votes, certificates, resolver,).await)
+        spawn_cell!(self.context, self.run(votes, certificates, resolver,))
     }
 
     async fn run(

--- a/p2p/src/authenticated/discovery/actors/dialer.rs
+++ b/p2p/src/authenticated/discovery/actors/dialer.rs
@@ -153,7 +153,7 @@ impl<
         tracker: UnboundedMailbox<tracker::Message<C::PublicKey>>,
         supervisor: SupervisorMailbox<E, C>,
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(tracker, supervisor).await)
+        spawn_cell!(self.context, self.run(tracker, supervisor))
     }
 
     async fn run(

--- a/p2p/src/authenticated/discovery/actors/listener.rs
+++ b/p2p/src/authenticated/discovery/actors/listener.rs
@@ -137,7 +137,7 @@ impl<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + Metrics, C: S
         tracker: UnboundedMailbox<tracker::Message<C::PublicKey>>,
         supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(tracker, supervisor).await)
+        spawn_cell!(self.context, self.run(tracker, supervisor))
     }
 
     #[allow(clippy::type_complexity)]

--- a/p2p/src/authenticated/discovery/actors/router/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/router/actor.rs
@@ -86,7 +86,7 @@ impl<E: Spawner + BufferPooler + Metrics, P: PublicKey> Actor<E, P> {
     /// Returns a [Handle] that can be used to await the completion of the task,
     /// which will run until its `control` receiver is closed.
     pub fn start(mut self, routing: Channels<P>) -> Handle<()> {
-        spawn_cell!(self.context, self.run(routing).await)
+        spawn_cell!(self.context, self.run(routing))
     }
 
     /// Runs the [Actor] event loop, processing incoming messages control messages

--- a/p2p/src/authenticated/discovery/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/spawner/actor.rs
@@ -100,7 +100,7 @@ impl<
         tracker: UnboundedMailbox<tracker::Message<C>>,
         router: Mailbox<router::Message<C>>,
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(tracker, router).await)
+        spawn_cell!(self.context, self.run(tracker, router))
     }
 
     async fn run(

--- a/p2p/src/authenticated/discovery/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/actor.rs
@@ -126,7 +126,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
 
     /// Start the actor and run it in the background.
     pub fn start(mut self) -> Handle<()> {
-        spawn_cell!(self.context, self.run().await)
+        spawn_cell!(self.context, self.run())
     }
 
     async fn run(mut self) {

--- a/p2p/src/authenticated/discovery/network.rs
+++ b/p2p/src/authenticated/discovery/network.rs
@@ -136,7 +136,7 @@ impl<
     ///
     /// After the network is started, it is not possible to add more channels.
     pub fn start(mut self) -> Handle<()> {
-        spawn_cell!(self.context, self.run().await)
+        spawn_cell!(self.context, self.run())
     }
 
     async fn run(self) {

--- a/p2p/src/authenticated/lookup/actors/dialer.rs
+++ b/p2p/src/authenticated/lookup/actors/dialer.rs
@@ -157,7 +157,7 @@ impl<
         tracker: UnboundedMailbox<tracker::Message<C::PublicKey>>,
         supervisor: SupervisorMailbox<E, C>,
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(tracker, supervisor).await)
+        spawn_cell!(self.context, self.run(tracker, supervisor))
     }
 
     async fn run(

--- a/p2p/src/authenticated/lookup/actors/listener.rs
+++ b/p2p/src/authenticated/lookup/actors/listener.rs
@@ -150,7 +150,7 @@ impl<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + Metrics, C: S
         tracker: UnboundedMailbox<tracker::Message<C::PublicKey>>,
         supervisor: Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(tracker, supervisor).await)
+        spawn_cell!(self.context, self.run(tracker, supervisor))
     }
 
     #[allow(clippy::type_complexity)]

--- a/p2p/src/authenticated/lookup/actors/router/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/router/actor.rs
@@ -86,7 +86,7 @@ impl<E: Spawner + BufferPooler + Metrics, P: PublicKey> Actor<E, P> {
     /// Returns a [Handle] that can be used to await the completion of the task,
     /// which will run until its `control` receiver is closed.
     pub fn start(mut self, routing: Channels<P>) -> Handle<()> {
-        spawn_cell!(self.context, self.run(routing).await)
+        spawn_cell!(self.context, self.run(routing))
     }
 
     /// Runs the [Actor] event loop, processing incoming messages control messages

--- a/p2p/src/authenticated/lookup/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/actor.rs
@@ -89,7 +89,7 @@ impl<
         tracker: UnboundedMailbox<tracker::Message<C>>,
         router: Mailbox<router::Message<C>>,
     ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(tracker, router).await)
+        spawn_cell!(self.context, self.run(tracker, router))
     }
 
     async fn run(

--- a/p2p/src/authenticated/lookup/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/actor.rs
@@ -104,7 +104,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
 
     /// Start the actor and run it in the background.
     pub fn start(mut self) -> Handle<()> {
-        spawn_cell!(self.context, self.run().await)
+        spawn_cell!(self.context, self.run())
     }
 
     async fn run(mut self) {

--- a/p2p/src/authenticated/lookup/network.rs
+++ b/p2p/src/authenticated/lookup/network.rs
@@ -130,7 +130,7 @@ impl<
     ///
     /// After the network is started, it is not possible to add more channels.
     pub fn start(mut self) -> Handle<()> {
-        spawn_cell!(self.context, self.run().await)
+        spawn_cell!(self.context, self.run())
     }
 
     async fn run(self) {

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -781,7 +781,7 @@ impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> Network<E, P> 
     /// It is not necessary to invoke this method before modifying the network topology, however,
     /// no messages will be sent until this method is called.
     pub fn start(mut self) -> Handle<()> {
-        spawn_cell!(self.context, self.run().await)
+        spawn_cell!(self.context, self.run())
     }
 
     async fn run(mut self) {

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -187,7 +187,7 @@ where
     /// Returns a [`Handle`] that must be kept alive for the background receiver to continue
     /// running. Dropping the handle will abort the background receiver.
     pub fn start(mut self) -> Handle<()> {
-        spawn_cell!(self.context, self.run().await)
+        spawn_cell!(self.context, self.run())
     }
 
     /// Run the background receiver's event loop.

--- a/p2p/src/utils/mux.rs
+++ b/p2p/src/utils/mux.rs
@@ -102,7 +102,7 @@ impl<E: Spawner, S: Sender, R: Receiver> Muxer<E, S, R> {
 
     /// Start the demuxer using the given spawner.
     pub fn start(mut self) -> Handle<Result<(), R::Error>> {
-        spawn_cell!(self.context, self.run().await)
+        spawn_cell!(self.context, self.run())
     }
 
     /// Drive demultiplexing of messages into per-subchannel receivers.

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -149,7 +149,7 @@ impl<
     /// - Fetching data from other peers and notifying the `Consumer`
     /// - Serving data to other peers by requesting it from the `Producer`
     pub fn start(mut self, network: (NetS, NetR)) -> Handle<()> {
-        spawn_cell!(self.context, self.run(network).await)
+        spawn_cell!(self.context, self.run(network))
     }
 
     /// Inner run loop called by `start`.

--- a/runtime/src/utils/cell.rs
+++ b/runtime/src/utils/cell.rs
@@ -13,8 +13,8 @@ use std::{
 const MISSING_CONTEXT: &str = "runtime context missing";
 const DUPLICATE_CONTEXT: &str = "runtime context already present";
 
-/// Spawn a task using a [`Cell`] by taking its context, executing the provided
-/// async block, and restoring the context before the block completes.
+/// Spawn a task using a [`Cell`] by taking its context, restoring the context synchronously
+/// in the spawned closure, and returning the provided future directly to the runtime.
 ///
 /// The macro uses the context's default spawn configuration (supervised, shared executor with
 /// `blocking == false`). If you need to mark the task as blocking or request a dedicated thread,
@@ -23,7 +23,7 @@ const DUPLICATE_CONTEXT: &str = "runtime context already present";
 macro_rules! spawn_cell {
     ($cell:expr, $body:expr $(,)?) => {{
         let __commonware_context = $cell.take();
-        __commonware_context.spawn(move |context| async move {
+        __commonware_context.spawn(move |context| {
             $cell.restore(context);
             $body
         })


### PR DESCRIPTION
`spawn_cell!` used to wrap `$body` in an inner async move { ... $body.await }, which doubled the spawn-time state machine in debug builds and was overflowing the stack when captured futures got large.

We changed the macro to pass `$body` through as a Future directly (callers drop the redundant `.await`), so the runtime polls one state machine instead of two.

In release builds, this should get largely optimized away but still was odd (the new code is now a transparent passthrough to `spawn` ... which is what it was originally intended to be).