### PR TITLE
[runtime/iouring] wakeup through futex or eventfd

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -1035,7 +1035,7 @@ mod tests {
         // after ring-size round-up.
         let mut registry = Registry::default();
         let cfg = Config {
-            size: (1 << 28) + 1,
+            size: (MAX_SUBMISSION_SEQUENCE_DOMAIN / 2) + 1,
             ..Default::default()
         };
         let _ = IoUringLoop::new(cfg, &mut registry);

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -174,7 +174,7 @@ use timeout::{Tick, TimeoutWheel};
 mod waiter;
 use waiter::{CompletionOutcome, StageOutcome, WaiterId, Waiters};
 mod waker;
-use waker::{Waker, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
+use waker::{Waker, MAX_SUBMISSION_SEQUENCE_DOMAIN, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
 
 /// Packed `io_uring` `user_data` value.
 type UserData = u64;
@@ -461,8 +461,8 @@ impl IoUringLoop {
             .checked_next_power_of_two()
             .expect("ring size exceeds u32::MAX");
         assert!(
-            cfg.size < (1 << 29),
-            "rounded ring size must stay below 1<<29 to preserve the 29-bit wake sequence bound"
+            cfg.size < MAX_SUBMISSION_SEQUENCE_DOMAIN,
+            "rounded ring size must stay below the packed wake sequence domain"
         );
         let size = cfg.size as usize;
         let metrics = Arc::new(Metrics::new(registry));
@@ -666,6 +666,13 @@ impl IoUringLoop {
 
         // Reinstall wake poll only when a prior wake CQE indicated multishot
         // termination. Otherwise keep the existing poll registration.
+        //
+        // This check runs before every possible transition into the eventfd-backed
+        // blocking path. The fully idle futex path does not need the poll to be
+        // live, so an iteration that parks in futex may skip kernel entry
+        // entirely. If multishot termination was observed earlier, the next
+        // iteration that might block in `submit_and_wait` stages the rearm SQE
+        // here before entering the kernel again.
         if std::mem::take(&mut self.wake_rearm_needed) {
             self.waker.reinstall(&mut submission_queue);
         }
@@ -1017,7 +1024,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "rounded ring size must stay below 1<<29")]
+    #[should_panic(expected = "rounded ring size must stay below the packed wake sequence domain")]
     fn test_iouring_loop_rejects_sizes_that_exceed_wake_sequence_domain() {
         // The wake state reserves only 29 bits for the submission sequence, so
         // the bounded request channel must stay strictly below that domain even

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -769,12 +769,17 @@ impl IoUringLoop {
                     }
 
                     // `pending()`'s acquire load observed a published-ahead
-                    // sequence delta after the empty observation. The rounded
-                    // ring size stays below half the packed sequence domain, so
-                    // that delta is directional: producers are genuinely ahead.
-                    // Tokio's bounded MPSC also guarantees `try_recv()` returns
-                    // `Disconnected` only when the channel is closed AND empty
-                    // (we keep a canary test to lock in those semantics).
+                    // sequence delta after the empty observation. Producers
+                    // execute `send().await` before `publish()`, and that
+                    // release/acquire edge makes the corresponding enqueue
+                    // visible here before the second `try_recv()`.
+                    //
+                    // The rounded ring size stays below half the packed
+                    // sequence domain, so the observed delta is directional:
+                    // producers are genuinely ahead. Tokio's bounded MPSC also
+                    // guarantees `try_recv()` returns `Disconnected` only when
+                    // the channel is closed AND empty (we keep canaries for
+                    // both assumptions below).
                     self.receiver.try_recv().expect(
                         "published-ahead sequence observed after acquire, but channel had no request",
                     )
@@ -1103,6 +1108,49 @@ mod tests {
         assert_eq!(receiver.try_recv(), Ok(41));
         assert_eq!(receiver.try_recv(), Ok(42));
         assert_eq!(receiver.try_recv(), Err(TryRecvError::Disconnected));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pending_recheck_after_empty_observes_published_request() {
+        // Lock in the stronger post-`pending()` recheck assumption used by the
+        // `expect(...)` in `fill_submission_queue()`: once the consumer sees
+        // a published-ahead sequence after an `Empty` observation, the second
+        // `try_recv()` must observe the corresponding request rather than
+        // returning `Empty` again.
+        //
+        // This is the minimal shape of that race:
+        // 1. consumer sees the channel as empty
+        // 2. producer enqueues one item and then publishes it
+        // 3. consumer notices the published-ahead sequence
+        // 4. consumer's second `try_recv()` must now observe the item
+        let (sender, mut receiver) = mpsc::channel(1);
+        let waker = Waker::new().expect("eventfd creation should succeed");
+
+        // Start from the same state as the real loop's slow path: the first
+        // receive attempt found no immediately visible work.
+        assert_eq!(receiver.try_recv(), Err(TryRecvError::Empty));
+
+        let publish_waker = waker.clone();
+        let submit = tokio::spawn(async move {
+            // Match the real producer protocol exactly: enqueue first, then
+            // publish the sequence increment that `pending()` observes.
+            sender
+                .send(7u8)
+                .await
+                .expect("send should succeed before publish");
+            publish_waker.publish();
+        });
+
+        // Poll until the acquire/release pair says producers are ahead. The
+        // real loop would take the `expect(...)` path at this point.
+        while !waker.pending(0) {
+            tokio::task::yield_now().await;
+        }
+
+        // Once `pending()` is true for `processed_seq = 0`, the second receive
+        // must see the request rather than report `Empty` again.
+        assert_eq!(receiver.try_recv(), Ok(7));
+        submit.await.expect("sender task should finish");
     }
 
     #[test]
@@ -2015,6 +2063,94 @@ mod tests {
             .expect("blocking recv should succeed");
         assert_eq!(read1, 1);
 
+        drop(pipe_right1);
+        drop(pipe_right2);
+        drop(submitter);
+        handle.join().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_deferred_wake_reinstall_survives_idle_futex_path() {
+        // Simulate a prior wake CQE that terminated multishot delivery by
+        // seeding `wake_rearm_needed = true`, then verify an idle futex pass
+        // can defer the reinstall until the next non-idle submission without
+        // losing later eventfd-based wakeups.
+        let cfg = Config {
+            size: 2,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (submitter, mut iouring) = IoUringLoop::new(cfg, &mut registry);
+        let idle_waker = iouring.waker.clone();
+        let eventfd_waker = iouring.waker.clone();
+        iouring.wake_rearm_needed = true;
+        let handle = std::thread::spawn(move || iouring.run());
+
+        // With no work yet, the loop stages the reinstall SQE but then parks
+        // on the fully idle futex path instead of entering the kernel.
+        waker::tests::wait_until_futex_armed(&idle_waker);
+
+        let (pipe_left1, pipe_right1) = UnixStream::pair().unwrap();
+        let (tx1, rx1) = oneshot::channel();
+        submitter
+            .enqueue(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left1.into()),
+                buf: IoBufMut::with_capacity(1),
+                offset: 0,
+                len: 1,
+                exact: true,
+                deadline: None,
+                result: None,
+                sender: tx1,
+            }))
+            .await
+            .unwrap();
+
+        // This first request wakes the futex-idle loop. The subsequent
+        // non-idle iteration must submit both the deferred reinstall SQE and
+        // the recv SQE before blocking on the eventfd-backed path again.
+        waker::tests::wait_until_eventfd_armed(&eventfd_waker);
+
+        let (pipe_left2, pipe_right2) = UnixStream::pair().unwrap();
+        (&pipe_right2).write_all(&[5]).unwrap();
+        let (tx2, rx2) = oneshot::channel();
+        submitter
+            .enqueue(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left2.into()),
+                buf: IoBufMut::with_capacity(1),
+                offset: 0,
+                len: 1,
+                exact: true,
+                deadline: None,
+                result: None,
+                sender: tx2,
+            }))
+            .await
+            .unwrap();
+
+        // The second recv can only complete promptly if the deferred reinstall
+        // became live before the loop re-entered `submit_and_wait`.
+        let (_, read2) = tokio::time::timeout(Duration::from_secs(2), rx2)
+            .await
+            .expect("deferred-reinstall recv timed out")
+            .expect("missing deferred-reinstall recv completion")
+            .expect("deferred-reinstall recv should succeed");
+        assert_eq!(read2, 1);
+
+        // Finish the original blocking recv as well. This keeps the test
+        // focused on the deferred-reinstall wake path rather than on shutdown
+        // abandonment behavior for the first waiter.
+        (&pipe_right1).write_all(&[3]).unwrap();
+        let (_, read1) = tokio::time::timeout(Duration::from_secs(2), rx1)
+            .await
+            .expect("blocking recv timed out")
+            .expect("missing blocking recv completion")
+            .expect("blocking recv should succeed");
+        assert_eq!(read1, 1);
+
+        // With both logical requests completed, shutdown should now be a
+        // trivial clean exit rather than a second source of liveness in this
+        // test.
         drop(pipe_right1);
         drop(pipe_right2);
         drop(submitter);

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -1255,6 +1255,103 @@ mod tests {
     }
 
     #[test]
+    fn test_fill_submission_queue_returns_disconnected_when_early_return_skips_receiver() {
+        #[derive(Debug)]
+        enum EarlyReturnPath {
+            Cancel,
+            Ready,
+        }
+
+        // Both early-return paths share the same underlying issue: waiter
+        // pressure is already saturated, the fill pass exits before any
+        // `try_recv()` call, and a closed+empty request channel still needs to
+        // be normalized into `Disconnected`.
+        //
+        // Run both shapes:
+        // - cancel staging fills the local SQ with AsyncCancel SQEs
+        // - ready-queue staging fills the local SQ with restaged requests
+        for path in [EarlyReturnPath::Cancel, EarlyReturnPath::Ready] {
+            let cfg = Config {
+                size: 8,
+                ..Default::default()
+            };
+            let mut registry = Registry::default();
+            let (submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+            let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+            match path {
+                EarlyReturnPath::Cancel => {
+                    // Queue enough in-flight cancellations to overflow one
+                    // staging pass once wake poll rearm also consumes an SQE.
+                    for _ in 0..cfg.size as usize {
+                        let (sock_left, _sock_right) =
+                            UnixStream::pair().expect("failed to create unix socket pair");
+                        // SAFETY: sock_left is a valid fd that we own.
+                        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+                        let (tx, _rx) = oneshot::channel();
+                        let request = Request::Sync(SyncRequest {
+                            file: Arc::new(file),
+                            result: None,
+                            sender: tx,
+                        });
+                        let waiter_id = iouring.waiters.insert(request, None);
+                        assert!(matches!(
+                            iouring.waiters.stage(waiter_id),
+                            StageOutcome::Submit(_)
+                        ));
+                        assert!(
+                            iouring.waiters.cancel(waiter_id),
+                            "cancel should transition waiter to cancel-requested"
+                        );
+                        iouring.pending_cancels.push_back(waiter_id);
+                    }
+                }
+                EarlyReturnPath::Ready => {
+                    // Leave wake rearm enabled so the wake poll consumes one
+                    // SQE and the ready queue cannot fully drain in a single
+                    // staging pass.
+                    for _ in 0..cfg.size as usize {
+                        let (sock_left, _sock_right) =
+                            UnixStream::pair().expect("failed to create unix socket pair");
+                        // SAFETY: sock_left is a valid fd that we own.
+                        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+                        let (tx, _rx) = oneshot::channel();
+                        let request = Request::Sync(SyncRequest {
+                            file: Arc::new(file),
+                            result: None,
+                            sender: tx,
+                        });
+                        let waiter_id = iouring.waiters.insert(request, None);
+                        iouring.ready_queue.push_back(waiter_id);
+                    }
+                }
+            }
+
+            drop(submitter);
+
+            // `fill_submission_queue()` should classify this waiter-full,
+            // channel-closed, channel-empty state as `Disconnected` even
+            // though the early return happens before any channel drain attempt.
+            let fill_result = iouring.fill_submission_queue(&mut ring);
+
+            assert_eq!(fill_result, FillResult::Disconnected, "{path:?}");
+            match path {
+                EarlyReturnPath::Cancel => {
+                    // The cancel queue must still be non-empty, proving the
+                    // result came from the cancel early-return path rather than
+                    // from draining all queued cancels first.
+                    assert!(!iouring.pending_cancels.is_empty(), "{path:?}");
+                }
+                EarlyReturnPath::Ready => {
+                    // The ready queue should remain partially staged, proving
+                    // the result came from the ready-queue early-return path.
+                    assert!(!iouring.ready_queue.is_empty(), "{path:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_fill_submission_queue_returns_submission_queue_capacity_when_fresh_staging_fills_sq() {
         // Verify newly submitted work can fill the SQ before waiter capacity is exhausted.
         let cfg = Config {
@@ -1838,51 +1935,90 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_wake_path_progress_scenarios() {
-        // Run both wake-path variants: one with strict success assertions and
-        // one that only checks for forward progress without inspecting results.
-        for should_succeed in [true, false] {
-            let cfg = Config::default();
-            let mut registry = Registry::default();
-            let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
-            let handle = std::thread::spawn(move || iouring.run());
+    async fn test_publish_wakes_eventfd_blocked_loop() {
+        // Verify a publish wakes the eventfd-backed blocking path while an
+        // earlier waiter keeps the loop out of the fully idle futex path.
+        //
+        // The first recv occupies one waiter slot and stays blocked forever
+        // until the test explicitly writes to its peer. That guarantees the
+        // loop is sleeping in `submit_and_wait`, not in the futex-backed idle
+        // path. The second recv already has data available, so once its
+        // publish wakes the loop it should be admitted and complete promptly.
+        // If the publish wake were lost, the second recv would stall until the
+        // first recv was manually released.
+        let cfg = Config {
+            size: 2,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
+        let eventfd_waker = iouring.waker.clone();
+        let handle = std::thread::spawn(move || iouring.run());
 
-            let (left_pipe, right_pipe) = UnixStream::pair().unwrap();
+        let (pipe_left1, pipe_right1) = UnixStream::pair().unwrap();
+        let (tx1, rx1) = oneshot::channel();
+        submitter
+            .enqueue(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left1.into()),
+                buf: IoBufMut::with_capacity(1),
+                offset: 0,
+                len: 1,
+                exact: true,
+                deadline: None,
+                result: None,
+                sender: tx1,
+            }))
+            .await
+            .unwrap();
 
-            // Submit a recv.
-            let recv = submitter.recv(
-                Arc::new(left_pipe.into()),
-                IoBufMut::with_capacity(5),
-                0,
-                5,
-                false,
-                Instant::now() + Duration::from_secs(5),
-            );
-            let send = submitter.send(
-                Arc::new(right_pipe.into()),
-                IoBufs::from(IoBuf::from(b"hello")),
-                Instant::now() + Duration::from_secs(5),
-            );
+        // Wait until the loop is armed on the eventfd-backed blocking path.
+        // This first recv stays blocked, so no CQE can make progress for the
+        // loop once the second request is published.
+        waker::tests::wait_until_eventfd_armed(&eventfd_waker);
 
-            let timeout = tokio::time::timeout(Duration::from_secs(2), async {
-                let (recv_result, send_result) = join(recv, send).await;
-                if should_succeed {
-                    let (_, read) = recv_result.expect("recv should succeed");
-                    assert!(read > 0);
-                    send_result.expect("send should succeed");
-                } else {
-                    let _ = recv_result;
-                    let _ = send_result;
-                }
-            });
-            assert!(
-                timeout.await.is_ok(),
-                "wake path test timed out (should_succeed={should_succeed})"
-            );
+        let (pipe_left2, pipe_right2) = UnixStream::pair().unwrap();
+        // Preload the second pipe so that once the loop wakes and stages this
+        // recv, the CQE can complete immediately without any further help.
+        (&pipe_right2).write_all(&[9]).unwrap();
+        let (tx2, rx2) = oneshot::channel();
+        submitter
+            .enqueue(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left2.into()),
+                buf: IoBufMut::with_capacity(1),
+                offset: 0,
+                len: 1,
+                exact: true,
+                deadline: None,
+                result: None,
+                sender: tx2,
+            }))
+            .await
+            .unwrap();
 
-            drop(submitter);
-            handle.join().unwrap();
-        }
+        // This completion is the actual regression check: the second recv can
+        // only finish promptly if its publish woke the eventfd-blocked loop and
+        // caused the request to be staged while the first recv is still stuck.
+        let (_, read2) = tokio::time::timeout(Duration::from_secs(2), rx2)
+            .await
+            .expect("published recv timed out")
+            .expect("missing published recv completion")
+            .expect("published recv should succeed");
+        assert_eq!(read2, 1);
+
+        // Cleanly finish the original blocking recv so shutdown does not depend
+        // on abandoning it.
+        (&pipe_right1).write_all(&[3]).unwrap();
+        let (_, read1) = tokio::time::timeout(Duration::from_secs(2), rx1)
+            .await
+            .expect("blocking recv timed out")
+            .expect("missing blocking recv completion")
+            .expect("blocking recv should succeed");
+        assert_eq!(read1, 1);
+
+        drop(pipe_right1);
+        drop(pipe_right2);
+        drop(submitter);
+        handle.join().unwrap();
     }
 
     #[test]
@@ -2055,6 +2191,11 @@ mod tests {
     async fn test_shutdown_timeout_when_waiters_full_and_channel_empty() {
         // Verify shutdown is still observed when waiter pressure prevents the
         // fill pass from touching the receiver at all.
+        //
+        // With `size = 1`, the single in-flight recv saturates waiter capacity.
+        // After that point each fill pass can return from the waiter-pressure
+        // path without ever calling `try_recv()`. This is the exact shape that
+        // previously hid producer disconnect forever.
         let cfg = Config {
             size: 1,
             shutdown_timeout: Some(Duration::from_millis(50)),
@@ -2084,6 +2225,9 @@ mod tests {
         // Wait until the full waiter table forces the loop onto the
         // eventfd-backed blocking path before closing the final handle.
         waker::tests::wait_until_eventfd_armed(&eventfd_waker);
+        // Closing the final submitter leaves the channel closed and empty, but
+        // still with one blocked waiter in flight. The loop must convert that
+        // waiter-full state into shutdown rather than sleeping forever.
         drop(submitter);
 
         let err = tokio::time::timeout(Duration::from_secs(2), rx)
@@ -2100,6 +2244,11 @@ mod tests {
     async fn test_shutdown_drains_buffered_request_behind_full_waiter_capacity() {
         // Verify shutdown starts only after the closed producer side is also
         // drained, so buffered requests behind waiter pressure still complete.
+        //
+        // This guards the opposite mistake from the hang above: once waiter
+        // pressure is saturated, dropping the last submitter must not jump
+        // straight to shutdown if there is still buffered channel work that
+        // has not yet been admitted into the waiter table.
         let cfg = Config {
             size: 1,
             shutdown_timeout: None,
@@ -2130,6 +2279,9 @@ mod tests {
         waker::tests::wait_until_eventfd_armed(&eventfd_waker);
 
         let (pipe_left2, pipe_right2) = UnixStream::pair().unwrap();
+        // Preload the buffered request so that as soon as the first waiter
+        // completes and frees capacity, the second recv can complete without
+        // any extra synchronization from the test.
         (&pipe_right2).write_all(&[7]).unwrap();
         let (tx2, rx2) = oneshot::channel();
         submitter
@@ -2151,6 +2303,8 @@ mod tests {
         drop(submitter);
 
         // Release the in-flight waiter so the buffered request can be admitted.
+        // If shutdown incorrectly started as soon as the channel closed, `rx2`
+        // would never receive a successful completion here.
         (&pipe_right1).write_all(&[3]).unwrap();
 
         let result1 = tokio::time::timeout(Duration::from_secs(2), rx1)

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -694,8 +694,12 @@ impl IoUringLoop {
         // entirely. If multishot termination was observed earlier, the next
         // iteration that might block in `submit_and_wait` stages the rearm SQE
         // here before entering the kernel again.
-        if std::mem::take(&mut self.wake_rearm_needed) {
-            self.waker.reinstall(&mut submission_queue);
+        if self.wake_rearm_needed {
+            // If the SQ is already full from a previous iteration, submit them first.
+            if !self.waker.reinstall(&mut submission_queue) {
+                return FillResult::AtSubmissionQueueCapacity;
+            }
+            self.wake_rearm_needed = false;
         }
 
         // Stage pending cancel SQEs first so timed-out requests are canceled promptly.
@@ -1260,6 +1264,38 @@ mod tests {
         assert_eq!(fill_result, FillResult::AtSubmissionQueueCapacity);
         assert!(ring.submission().is_full());
         assert!(iouring.waiters.len() < cfg.size as usize);
+    }
+
+    #[test]
+    fn test_fill_submission_queue_preserves_wake_rearm_when_submission_queue_starts_full() {
+        // Verify a full local SQ defers wake rearm without clearing the retry flag.
+        let cfg = Config {
+            size: 8,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        iouring.wake_rearm_needed = true;
+
+        {
+            let mut submission_queue = ring.submission();
+            while !submission_queue.is_full() {
+                let nop = io_uring::opcode::Nop::new().build().user_data(0);
+                // SAFETY: Nop SQE owns no user pointers or external resources.
+                unsafe {
+                    submission_queue
+                        .push(&nop)
+                        .expect("unable to fill submission queue");
+                }
+            }
+        }
+
+        let fill_result = iouring.fill_submission_queue(&mut ring);
+
+        assert_eq!(fill_result, FillResult::AtSubmissionQueueCapacity);
+        assert!(iouring.wake_rearm_needed);
     }
 
     #[test]

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -99,6 +99,8 @@
 //! - Wake CQEs drain `eventfd` readiness and re-install poll when `IORING_CQE_F_MORE`
 //!   is not set
 //! - The loop uses an arm-and-recheck sleep handshake (`submitted_seq` vs `processed_seq`)
+//! - The rounded ring/channel size stays below half the packed submission-sequence
+//!   domain so modular sequence deltas remain directional
 //! - A dedicated signalled bit coalesces repeated wake attempts while a wait is armed
 //!
 //! ## Shutdown Process
@@ -174,7 +176,12 @@ use timeout::{Tick, TimeoutWheel};
 mod waiter;
 use waiter::{CompletionOutcome, StageOutcome, WaiterId, Waiters};
 mod waker;
-use waker::{Waker, MAX_SUBMISSION_SEQUENCE_DOMAIN, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
+use waker::{Waker, HALF_SUBMISSION_SEQUENCE_DOMAIN, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
+
+/// Maximum rounded ring size accepted by [`Config::size`].
+///
+/// Requested sizes are rounded up to the next power of two before validation.
+pub const MAX_RING_SIZE: u32 = HALF_SUBMISSION_SEQUENCE_DOMAIN / 2;
 
 /// Packed `io_uring` `user_data` value.
 type UserData = u64;
@@ -212,7 +219,8 @@ pub struct Config {
     ///
     /// This value is rounded up to the next power of two when constructing
     /// [IoUringLoop], so the configured in-flight waiter capacity matches the
-    /// effective ring sizing behavior.
+    /// effective ring sizing behavior. After rounding, the maximum allowed size
+    /// is [`MAX_RING_SIZE`], larger rounded sizes panic during construction.
     pub size: u32,
     /// If true, use IOPOLL mode.
     pub io_poll: bool,
@@ -461,9 +469,13 @@ impl IoUringLoop {
             .size
             .checked_next_power_of_two()
             .expect("ring size exceeds u32::MAX");
+        // `pending()` interprets packed submission-sequence deltas with
+        // half-range modular ordering. After rounding to a power of two, that
+        // means the maximum admissible ring size is `MAX_RING_SIZE`.
         assert!(
-            cfg.size < MAX_SUBMISSION_SEQUENCE_DOMAIN,
-            "rounded ring size must stay below the packed wake sequence domain"
+            cfg.size <= MAX_RING_SIZE,
+            "rounded ring size must be at most {}",
+            MAX_RING_SIZE
         );
         let size = cfg.size as usize;
         let metrics = Arc::new(Metrics::new(registry));
@@ -525,15 +537,14 @@ impl IoUringLoop {
             // Update pending operations metric.
             self.metrics.pending_operations.set(self.waiters.len() as _);
 
-            // If submissions are still pending, do not arm idle sleep.
+            // If producers are still ahead of the drained sequence, do not arm
+            // idle sleep.
             //
-            // `pending(processed_seq)` means producers have published work we
-            // have not yet drained. Sleep here could park with pending work and
-            // no guaranteed wake, because publish only signals once a wait target
-            // is armed.
+            // Sleep here could park with published work and no guaranteed wake,
+            // because `publish()` only signals once a wait target is armed.
             if self.waker.pending(self.processed_seq) {
                 if at_capacity {
-                    // Pending submissions exist and staging stopped at capacity.
+                    // Producers are still ahead and staging stopped at capacity.
                     //
                     // Enter the kernel to submit pending SQEs and wait for at
                     // least one completion so capacity can open up.
@@ -550,7 +561,7 @@ impl IoUringLoop {
                 continue;
             }
 
-            // No pending submissions are currently visible.
+            // No published-ahead sequence is currently visible.
             //
             // If the ring is truly idle, avoid `io_uring_enter` entirely and
             // wait on the shared wake state via futex until a producer changes
@@ -665,7 +676,6 @@ impl IoUringLoop {
     /// Returns whether staging ended at waiter or SQ capacity, or `None` if the
     /// producer channel disconnected.
     fn fill_submission_queue(&mut self, ring: &mut IoUring) -> Option<bool> {
-        let mut drained = 0u32;
         let mut submission_queue = ring.submission();
         let mut wheel_aligned = self.timeout_wheel.next_deadline().is_some();
 
@@ -697,17 +707,37 @@ impl IoUringLoop {
         // Stage operations until the channel is empty, waiter capacity is hit,
         // or the SQ is full. Waiter capacity is bounded by `cfg.size`.
         while self.waiters.len() < self.cfg.size as usize && !submission_queue.is_full() {
-            // Try to drain one operation from the channel. If the channel is empty, we're
-            // done for now.
+            // Try to drain one operation from the channel. If the first
+            // `try_recv()` reports `Empty`, do one acquire-guided recheck
+            // before concluding there is nothing more to drain in this pass.
             let request = match self.receiver.try_recv() {
                 Ok(request) => request,
                 Err(TryRecvError::Disconnected) => return None,
-                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Empty) => {
+                    // Catch the race where a producer submitted after the
+                    // empty observation but before the loop decided to stop
+                    // draining in this pass.
+                    if !self.waker.pending(self.processed_seq) {
+                        break;
+                    }
+
+                    // `pending()`'s acquire load observed a published-ahead
+                    // sequence delta after the empty observation. The rounded
+                    // ring size stays below half the packed sequence domain, so
+                    // that delta is directional: producers are genuinely ahead.
+                    // Tokio's bounded MPSC also guarantees `try_recv()` returns
+                    // `Disconnected` only when the channel is closed AND empty.
+                    // We keep a canary test to lock in those semantics.
+                    self.receiver.try_recv().expect(
+                        "published-ahead sequence observed after acquire, but channel had no request",
+                    )
+                }
             };
 
-            // Count exactly how many published submissions we consumed so
-            // `processed_seq` stays in sync with the published sequence domain.
-            drained += 1;
+            // `processed_seq` counts items drained from the channel. Once a
+            // request is removed from the queue by either receive path above,
+            // it is considered processed for the wake protocol.
+            self.processed_seq = self.processed_seq.wrapping_add(1) & SUBMISSION_SEQ_MASK;
 
             // Avoid per-loop clock reads when no deadlines are active. When the
             // first deadline arrives after an idle period, align wheel time once
@@ -721,9 +751,6 @@ impl IoUringLoop {
                 self.stage_request(waiter_id, &mut submission_queue);
             }
         }
-
-        // Track which submitted sequence has been consumed.
-        self.processed_seq = self.processed_seq.wrapping_add(drained) & SUBMISSION_SEQ_MASK;
 
         let at_sq_capacity = submission_queue.is_full();
         let at_waiter_capacity = self.waiters.len() == self.cfg.size as usize;
@@ -1009,6 +1036,25 @@ mod tests {
     };
 
     #[test]
+    fn test_bounded_mpsc_drains_all_buffered_messages_before_disconnected() {
+        // Lock in the Tokio MPSC semantics relied on by `fill_submission_queue()`:
+        // once the last sender is dropped, all buffered messages are still
+        // drained before `try_recv()` reports `Disconnected`.
+        let (sender, mut receiver) = mpsc::channel(2);
+        sender
+            .try_send(41)
+            .expect("first buffered send should succeed");
+        sender
+            .try_send(42)
+            .expect("second buffered send should succeed");
+        drop(sender);
+
+        assert_eq!(receiver.try_recv(), Ok(41));
+        assert_eq!(receiver.try_recv(), Ok(42));
+        assert_eq!(receiver.try_recv(), Err(TryRecvError::Disconnected));
+    }
+
+    #[test]
     fn test_iouring_loop_rounds_ring_size_up_to_power_of_two() {
         // Ring size is rounded to the next power of two.
         let mut registry = Registry::default();
@@ -1029,14 +1075,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "rounded ring size must stay below the packed wake sequence domain")]
-    fn test_iouring_loop_rejects_sizes_that_exceed_wake_sequence_domain() {
-        // The wake state reserves only 29 bits for the submission sequence, so
-        // the bounded request channel must stay strictly below that domain even
-        // after ring-size round-up.
+    #[should_panic(expected = "rounded ring size must be at most")]
+    fn test_iouring_loop_rejects_sizes_that_exceed_max_ring_size() {
+        // The wake state reserves 29 bits for the submission sequence, and
+        // `pending()` relies on half-range modular ordering. The rounded
+        // request channel size must therefore stay at or below
+        // `MAX_RING_SIZE`.
         let mut registry = Registry::default();
         let cfg = Config {
-            size: (MAX_SUBMISSION_SEQUENCE_DOMAIN / 2) + 1,
+            size: MAX_RING_SIZE + 1,
             ..Default::default()
         };
         let _ = IoUringLoop::new(cfg, &mut registry);

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -469,6 +469,23 @@ enum FillResult {
     AtWaiterCapacity,
 }
 
+impl FillResult {
+    /// Derive the staging result from waiter-table and submission-queue fullness.
+    #[inline]
+    const fn from_capacities(waiters_full: bool, submission_queue_full: bool) -> Self {
+        // Waiter pressure dominates SQ pressure: when the waiter table is full
+        // the loop must wait for completions before it can admit more work,
+        // while SQ pressure alone only forces a submit.
+        if waiters_full {
+            Self::AtWaiterCapacity
+        } else if submission_queue_full {
+            Self::AtSubmissionQueueCapacity
+        } else {
+            Self::Drained
+        }
+    }
+}
+
 impl IoUringLoop {
     /// Create a new io_uring loop and submit handle.
     ///
@@ -697,6 +714,11 @@ impl IoUringLoop {
         if self.wake_rearm_needed {
             // If the SQ is already full from a previous iteration, submit them first.
             if !self.waker.reinstall(&mut submission_queue) {
+                // Even if waiter capacity is also exhausted, we must not take
+                // the blocking path yet: the wake poll is not rearmed, so
+                // `submit_and_wait` would sleep without the eventfd wake path
+                // being live. Flush staged SQEs first, then retry rearm in the
+                // next pass.
                 return FillResult::AtSubmissionQueueCapacity;
             }
             self.wake_rearm_needed = false;
@@ -704,20 +726,18 @@ impl IoUringLoop {
 
         // Stage pending cancel SQEs first so timed-out requests are canceled promptly.
         if self.stage_cancellations(&mut submission_queue) {
-            // If cancels alone filled the SQ, submit them first.
-            return FillResult::AtSubmissionQueueCapacity;
+            return FillResult::from_capacities(self.waiters.is_full(), true);
         }
 
         // Requeued work already owns waiter capacity, so restage it before
         // admitting fresh channel requests.
         if self.stage_ready_requests(&mut submission_queue) {
-            // If ready request alone filled the SQ, submit them first.
-            return FillResult::AtSubmissionQueueCapacity;
+            return FillResult::from_capacities(self.waiters.is_full(), true);
         }
 
         // Stage operations until the channel is empty, waiter capacity is hit,
         // or the SQ is full. Waiter capacity is bounded by `cfg.size`.
-        while self.waiters.len() < self.cfg.size as usize && !submission_queue.is_full() {
+        while !self.waiters.is_full() && !submission_queue.is_full() {
             // Try to drain one operation from the channel. If the first
             // `try_recv()` reports `Empty`, do one acquire-guided recheck
             // before concluding there is nothing more to drain in this pass.
@@ -763,16 +783,7 @@ impl IoUringLoop {
             }
         }
 
-        // Waiter pressure dominates SQ pressure: when the waiter table is full
-        // the loop must wait for completions before it can admit more work,
-        // while SQ pressure alone only forces a submit.
-        if self.waiters.len() == self.cfg.size as usize {
-            FillResult::AtWaiterCapacity
-        } else if submission_queue.is_full() {
-            FillResult::AtSubmissionQueueCapacity
-        } else {
-            FillResult::Drained
-        }
+        FillResult::from_capacities(self.waiters.is_full(), submission_queue.is_full())
     }
 
     /// Stage queued cancellation SQEs from `pending_cancels` in FIFO order.

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -470,15 +470,31 @@ enum FillResult {
 }
 
 impl FillResult {
-    /// Derive the staging result from waiter-table and submission-queue fullness.
+    /// Derive the staging outcome from the current fill state.
+    ///
+    /// Waiter saturation dominates submission-queue saturation: once the
+    /// waiter table is full, the loop cannot admit more work until completions
+    /// arrive, regardless of remaining SQ capacity. That same waiter-full path
+    /// is also where shutdown needs extra normalization, because a closed and
+    /// drained request channel should transition directly to `Disconnected`
+    /// instead of blocking forever on waiter pressure alone.
     #[inline]
-    const fn from_capacities(waiters_full: bool, submission_queue_full: bool) -> Self {
-        // Waiter pressure dominates SQ pressure: when the waiter table is full
-        // the loop must wait for completions before it can admit more work,
-        // while SQ pressure alone only forces a submit.
-        if waiters_full {
+    fn from_fill_state(
+        waiters: &Waiters,
+        submission_queue: &SubmissionQueue<'_>,
+        receiver: &mpsc::Receiver<Request>,
+    ) -> Self {
+        // Check waiter pressure first because it dominates SQ pressure and is
+        // the only case that needs shutdown normalization.
+        if waiters.is_full() {
+            // A waiter-full loop that also has no remaining producers and no
+            // buffered requests must enter shutdown drain rather than sleeping
+            // for completions forever.
+            if receiver.is_closed() && receiver.is_empty() {
+                return Self::Disconnected;
+            }
             Self::AtWaiterCapacity
-        } else if submission_queue_full {
+        } else if submission_queue.is_full() {
             Self::AtSubmissionQueueCapacity
         } else {
             Self::Drained
@@ -726,13 +742,13 @@ impl IoUringLoop {
 
         // Stage pending cancel SQEs first so timed-out requests are canceled promptly.
         if self.stage_cancellations(&mut submission_queue) {
-            return FillResult::from_capacities(self.waiters.is_full(), true);
+            return FillResult::from_fill_state(&self.waiters, &submission_queue, &self.receiver);
         }
 
         // Requeued work already owns waiter capacity, so restage it before
         // admitting fresh channel requests.
         if self.stage_ready_requests(&mut submission_queue) {
-            return FillResult::from_capacities(self.waiters.is_full(), true);
+            return FillResult::from_fill_state(&self.waiters, &submission_queue, &self.receiver);
         }
 
         // Stage operations until the channel is empty, waiter capacity is hit,
@@ -783,7 +799,7 @@ impl IoUringLoop {
             }
         }
 
-        FillResult::from_capacities(self.waiters.is_full(), submission_queue.is_full())
+        FillResult::from_fill_state(&self.waiters, &submission_queue, &self.receiver)
     }
 
     /// Stage queued cancellation SQEs from `pending_cancels` in FIFO order.
@@ -2032,6 +2048,127 @@ mod tests {
         // dropping `tx` and causing `rx` to return RecvError.
         let err = rx.await.unwrap_err();
         assert!(matches!(err, RecvError { .. }));
+        handle.join().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_shutdown_timeout_when_waiters_full_and_channel_empty() {
+        // Verify shutdown is still observed when waiter pressure prevents the
+        // fill pass from touching the receiver at all.
+        let cfg = Config {
+            size: 1,
+            shutdown_timeout: Some(Duration::from_millis(50)),
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
+        let eventfd_waker = iouring.waker.clone();
+        let handle = std::thread::spawn(move || iouring.run());
+
+        let (pipe_left, pipe_right) = UnixStream::pair().unwrap();
+        let (tx, rx) = oneshot::channel();
+        submitter
+            .enqueue(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left.into()),
+                buf: IoBufMut::with_capacity(8),
+                offset: 0,
+                len: 8,
+                exact: false,
+                deadline: None,
+                result: None,
+                sender: tx,
+            }))
+            .await
+            .unwrap();
+
+        // Wait until the full waiter table forces the loop onto the
+        // eventfd-backed blocking path before closing the final handle.
+        waker::tests::wait_until_eventfd_armed(&eventfd_waker);
+        drop(submitter);
+
+        let err = tokio::time::timeout(Duration::from_secs(2), rx)
+            .await
+            .expect("shutdown abandonment timed out")
+            .unwrap_err();
+        assert!(matches!(err, RecvError { .. }));
+
+        drop(pipe_right);
+        handle.join().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_shutdown_drains_buffered_request_behind_full_waiter_capacity() {
+        // Verify shutdown starts only after the closed producer side is also
+        // drained, so buffered requests behind waiter pressure still complete.
+        let cfg = Config {
+            size: 1,
+            shutdown_timeout: None,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
+        let eventfd_waker = iouring.waker.clone();
+        let handle = std::thread::spawn(move || iouring.run());
+
+        let (pipe_left1, pipe_right1) = UnixStream::pair().unwrap();
+        let (tx1, rx1) = oneshot::channel();
+        submitter
+            .enqueue(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left1.into()),
+                buf: IoBufMut::with_capacity(1),
+                offset: 0,
+                len: 1,
+                exact: true,
+                deadline: None,
+                result: None,
+                sender: tx1,
+            }))
+            .await
+            .unwrap();
+
+        // Wait until the loop is blocked with the sole waiter slot occupied.
+        waker::tests::wait_until_eventfd_armed(&eventfd_waker);
+
+        let (pipe_left2, pipe_right2) = UnixStream::pair().unwrap();
+        (&pipe_right2).write_all(&[7]).unwrap();
+        let (tx2, rx2) = oneshot::channel();
+        submitter
+            .enqueue(Request::Recv(RecvRequest {
+                fd: Arc::new(pipe_left2.into()),
+                buf: IoBufMut::with_capacity(1),
+                offset: 0,
+                len: 1,
+                exact: true,
+                deadline: None,
+                result: None,
+                sender: tx2,
+            }))
+            .await
+            .unwrap();
+
+        // Close the channel while the second request is still buffered behind
+        // the full waiter table.
+        drop(submitter);
+
+        // Release the in-flight waiter so the buffered request can be admitted.
+        (&pipe_right1).write_all(&[3]).unwrap();
+
+        let result1 = tokio::time::timeout(Duration::from_secs(2), rx1)
+            .await
+            .expect("first recv timed out")
+            .expect("missing first recv completion");
+        let result2 = tokio::time::timeout(Duration::from_secs(2), rx2)
+            .await
+            .expect("buffered recv timed out")
+            .expect("missing buffered recv completion");
+
+        let (_, read1) = result1.expect("first recv should succeed");
+        let (_, read2) = result2.expect("buffered recv should succeed");
+        assert_eq!(read1, 1);
+        assert_eq!(read2, 1);
+
+        drop(pipe_right1);
+        drop(pipe_right2);
         handle.join().unwrap();
     }
 

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -452,6 +452,23 @@ pub(crate) struct IoUringLoop {
     processed_seq: u32,
 }
 
+/// Outcome of one `fill_submission_queue()` staging pass.
+///
+/// This tells the outer loop whether staging drained all currently visible
+/// work, hit submission-queue pressure, hit waiter-capacity pressure, or
+/// discovered producer disconnect.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FillResult {
+    /// The producer side disconnected while draining the request channel.
+    Disconnected,
+    /// Staging drained all currently visible work without hitting a hard limit.
+    Drained,
+    /// The submission queue filled before waiter capacity was exhausted.
+    AtSubmissionQueueCapacity,
+    /// The waiter table filled, regardless of whether the submission queue also filled.
+    AtWaiterCapacity,
+}
+
 impl IoUringLoop {
     /// Create a new io_uring loop and submit handle.
     ///
@@ -528,41 +545,40 @@ impl IoUringLoop {
             self.advance_timeouts();
 
             // Stage as much inbound work as capacity allows.
-            let Some(at_capacity) = self.fill_submission_queue(&mut ring) else {
-                // Producer side disconnected. Drain in-flight requests and exit.
-                self.drain(&mut ring);
-                return;
-            };
+            let fill_result = self.fill_submission_queue(&mut ring);
 
             // Update pending operations metric.
             self.metrics.pending_operations.set(self.waiters.len() as _);
 
-            // If producers are still ahead of the drained sequence, do not arm
-            // idle sleep.
-            //
-            // Sleep here could park with published work and no guaranteed wake,
-            // because `publish()` only signals once a wait target is armed.
-            if self.waker.pending(self.processed_seq) {
-                if at_capacity {
-                    // Producers are still ahead and staging stopped at capacity.
-                    //
-                    // Enter the kernel to submit pending SQEs and wait for at
-                    // least one completion so capacity can open up.
-                    //
-                    // Keep the eventfd-backed wake path armed across this
-                    // blocking section so a later producer disconnect can
-                    // interrupt `submit_and_wait` instead of waiting for an
-                    // unrelated CQE or timeout.
+            match fill_result {
+                FillResult::Disconnected => {
+                    // Producer side disconnected. Drain in-flight requests and exit.
+                    self.drain(&mut ring);
+                    return;
+                }
+                FillResult::AtWaiterCapacity => {
+                    // Waiter pressure means completions are required before the
+                    // loop can admit more work, so submit pending SQEs and block
+                    // for progress with the eventfd-backed wake path armed.
                     let _arm = self.waker.arm(self.processed_seq);
                     self.submit_and_wait(&mut ring, 1, self.timeout_wheel.next_deadline())
                         .expect("unable to submit to ring");
+                    continue;
                 }
-
-                continue;
+                FillResult::AtSubmissionQueueCapacity => {
+                    // SQ pressure alone only means the staged batch must be
+                    // flushed into the kernel. Do that without waiting and then
+                    // re-enter the loop to drain completions or stage more work.
+                    self.submit(&mut ring).expect("unable to submit to ring");
+                    continue;
+                }
+                FillResult::Drained => {
+                    // The staging pass drained all currently visible work from
+                    // the request channel. Fall through to the normal
+                    // idle-vs-blocking decision below.
+                }
             }
 
-            // No published-ahead sequence is currently visible.
-            //
             // If the ring is truly idle, avoid `io_uring_enter` entirely and
             // wait on the shared wake state via futex until a producer changes
             // it. This bypasses the eventfd wake path when there are no active
@@ -572,20 +588,11 @@ impl IoUringLoop {
                 continue;
             }
 
-            // Otherwise, active waiters remain in the ring, so sleep by
-            // blocking in `submit_and_wait`.
-            //
-            // If staging hit capacity, force a submit-and-wait cycle to open
-            // space, even though the sequence snapshot looks idle here.
-            // Otherwise, arm the eventfd-backed blocking path. If
-            // `arm.should_block()` is true, we may enter `submit_and_wait`.
-            //
-            // While the returned guard is live, any later submission or
-            // producer disconnect observes the armed eventfd target and wakes
-            // this blocking section instead of waiting for an unrelated CQE or
-            // timeout.
+            // Otherwise, active waiters remain in the ring and no forced
+            // submit is needed. Arm the eventfd-backed blocking path and block
+            // only if the post-arm snapshot still looks idle.
             let arm = self.waker.arm(self.processed_seq);
-            if at_capacity || arm.should_block() {
+            if arm.should_block() {
                 self.submit_and_wait(&mut ring, 1, self.timeout_wheel.next_deadline())
                     .expect("unable to submit to ring");
             }
@@ -673,9 +680,8 @@ impl IoUringLoop {
     ///
     /// Advances `processed_seq` by exactly the number of drained submissions.
     ///
-    /// Returns whether staging ended at waiter or SQ capacity, or `None` if the
-    /// producer channel disconnected.
-    fn fill_submission_queue(&mut self, ring: &mut IoUring) -> Option<bool> {
+    /// Returns why staging stopped.
+    fn fill_submission_queue(&mut self, ring: &mut IoUring) -> FillResult {
         let mut submission_queue = ring.submission();
         let mut wheel_aligned = self.timeout_wheel.next_deadline().is_some();
 
@@ -695,13 +701,14 @@ impl IoUringLoop {
         // Stage pending cancel SQEs first so timed-out requests are canceled promptly.
         if self.stage_cancellations(&mut submission_queue) {
             // If cancels alone filled the SQ, submit them first.
-            return Some(true);
+            return FillResult::AtSubmissionQueueCapacity;
         }
 
         // Requeued work already owns waiter capacity, so restage it before
         // admitting fresh channel requests.
         if self.stage_ready_requests(&mut submission_queue) {
-            return Some(true);
+            // If ready request alone filled the SQ, submit them first.
+            return FillResult::AtSubmissionQueueCapacity;
         }
 
         // Stage operations until the channel is empty, waiter capacity is hit,
@@ -712,7 +719,7 @@ impl IoUringLoop {
             // before concluding there is nothing more to drain in this pass.
             let request = match self.receiver.try_recv() {
                 Ok(request) => request,
-                Err(TryRecvError::Disconnected) => return None,
+                Err(TryRecvError::Disconnected) => return FillResult::Disconnected,
                 Err(TryRecvError::Empty) => {
                     // Catch the race where a producer submitted after the
                     // empty observation but before the loop decided to stop
@@ -752,9 +759,16 @@ impl IoUringLoop {
             }
         }
 
-        let at_sq_capacity = submission_queue.is_full();
-        let at_waiter_capacity = self.waiters.len() == self.cfg.size as usize;
-        Some(at_sq_capacity || at_waiter_capacity)
+        // Waiter pressure dominates SQ pressure: when the waiter table is full
+        // the loop must wait for completions before it can admit more work,
+        // while SQ pressure alone only forces a submit.
+        if self.waiters.len() == self.cfg.size as usize {
+            FillResult::AtWaiterCapacity
+        } else if submission_queue.is_full() {
+            FillResult::AtSubmissionQueueCapacity
+        } else {
+            FillResult::Drained
+        }
     }
 
     /// Stage queued cancellation SQEs from `pending_cancels` in FIFO order.
@@ -989,6 +1003,12 @@ impl IoUringLoop {
             },
         }
     }
+
+    /// Submit pending SQEs without waiting for a completion.
+    #[inline]
+    fn submit(&self, ring: &mut IoUring) -> Result<(), std::io::Error> {
+        self.submit_and_wait(ring, 0, None).map(|_| ())
+    }
 }
 
 /// Build and configure an `io_uring` instance.
@@ -1126,9 +1146,9 @@ mod tests {
     }
 
     #[test]
-    fn test_fill_submission_queue_returns_true_when_cancel_staging_fills_sq() {
-        // Verify cancel staging reports SQ saturation so the loop drains completions
-        // before trying to enqueue more work.
+    fn test_fill_submission_queue_returns_waiter_capacity_when_cancel_staging_fills_sq() {
+        // Verify cancel staging reports waiter pressure when the waiter table
+        // is already full, even if the SQ is also saturated.
         let cfg = Config {
             size: 8,
             ..Default::default()
@@ -1163,17 +1183,15 @@ mod tests {
         }
 
         // Staging should stop at SQ capacity and leave some cancels queued.
-        let at_capacity = iouring
-            .fill_submission_queue(&mut ring)
-            .expect("channel should remain connected");
-        assert!(at_capacity);
+        let fill_result = iouring.fill_submission_queue(&mut ring);
+        assert_eq!(fill_result, FillResult::AtWaiterCapacity);
         assert!(!iouring.pending_cancels.is_empty());
     }
 
     #[test]
-    fn test_fill_submission_queue_returns_true_when_ready_staging_fills_sq() {
-        // Verify requeued work can also saturate the SQ and force the loop to
-        // return early with ready-queue work still pending.
+    fn test_fill_submission_queue_returns_waiter_capacity_when_ready_staging_fills_sq() {
+        // Verify requeued work reports waiter pressure when the waiter table is
+        // already full, even if the SQ is also saturated.
         let cfg = Config {
             size: 8,
             ..Default::default()
@@ -1199,16 +1217,14 @@ mod tests {
             iouring.ready_queue.push_back(waiter_id);
         }
 
-        let at_capacity = iouring
-            .fill_submission_queue(&mut ring)
-            .expect("channel should remain connected");
+        let fill_result = iouring.fill_submission_queue(&mut ring);
 
-        assert!(at_capacity);
+        assert_eq!(fill_result, FillResult::AtWaiterCapacity);
         assert!(!iouring.ready_queue.is_empty());
     }
 
     #[test]
-    fn test_fill_submission_queue_returns_true_when_fresh_staging_fills_sq() {
+    fn test_fill_submission_queue_returns_submission_queue_capacity_when_fresh_staging_fills_sq() {
         // Verify newly submitted work can fill the SQ before waiter capacity is exhausted.
         let cfg = Config {
             size: 8,
@@ -1239,13 +1255,84 @@ mod tests {
             }
         });
 
-        let at_capacity = iouring
-            .fill_submission_queue(&mut ring)
-            .expect("channel should remain connected");
+        let fill_result = iouring.fill_submission_queue(&mut ring);
 
-        assert!(at_capacity);
+        assert_eq!(fill_result, FillResult::AtSubmissionQueueCapacity);
         assert!(ring.submission().is_full());
         assert!(iouring.waiters.len() < cfg.size as usize);
+    }
+
+    #[test]
+    fn test_fill_submission_queue_returns_waiter_capacity_when_waiters_are_full() {
+        // Verify staging reports waiter pressure even when the SQ itself still
+        // has room.
+        let cfg = Config {
+            size: 8,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        iouring.wake_rearm_needed = false;
+
+        for _ in 0..cfg.size as usize {
+            let (sock_left, _sock_right) =
+                UnixStream::pair().expect("failed to create unix socket pair");
+            // SAFETY: sock_left is a valid fd that we own.
+            let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+            let (tx, _rx) = oneshot::channel();
+            let request = Request::Sync(SyncRequest {
+                file: Arc::new(file),
+                result: None,
+                sender: tx,
+            });
+            iouring.waiters.insert(request, None);
+        }
+
+        let fill_result = iouring.fill_submission_queue(&mut ring);
+
+        assert_eq!(fill_result, FillResult::AtWaiterCapacity);
+        assert_eq!(ring.submission().len(), 0);
+    }
+
+    #[test]
+    fn test_fill_submission_queue_returns_waiter_capacity_when_fresh_staging_fills_everything() {
+        // Verify a full fresh staging pass reports waiter pressure when both
+        // the SQ and waiter table saturate in the same iteration.
+        let cfg = Config {
+            size: 8,
+            ..Default::default()
+        };
+        let mut registry = Registry::default();
+        let (submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+        iouring.wake_rearm_needed = false;
+
+        futures::executor::block_on(async {
+            for _ in 0..cfg.size as usize {
+                let (sock_left, _sock_right) =
+                    UnixStream::pair().expect("failed to create unix socket pair");
+                // SAFETY: sock_left is a valid fd that we own.
+                let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+                let (tx, _rx) = oneshot::channel();
+                submitter
+                    .enqueue(Request::Sync(SyncRequest {
+                        file: Arc::new(file),
+                        result: None,
+                        sender: tx,
+                    }))
+                    .await
+                    .expect("failed to enqueue request");
+            }
+        });
+
+        let fill_result = iouring.fill_submission_queue(&mut ring);
+
+        assert_eq!(fill_result, FillResult::AtWaiterCapacity);
+        assert!(ring.submission().is_full());
+        assert_eq!(iouring.waiters.len(), cfg.size as usize);
     }
 
     #[test]
@@ -1276,12 +1363,10 @@ mod tests {
         assert!(iouring.waiters.cancel(waiter_id));
         iouring.pending_cancels.push_back(waiter_id);
 
-        let at_capacity = iouring
-            .fill_submission_queue(&mut ring)
-            .expect("channel should remain connected");
+        let fill_result = iouring.fill_submission_queue(&mut ring);
 
         // No cancel SQE should be staged because there is no in-flight op left to cancel.
-        assert!(!at_capacity);
+        assert_eq!(fill_result, FillResult::Drained);
         assert!(iouring.pending_cancels.is_empty());
         assert_eq!(ring.submission().len(), 0);
         assert!(matches!(
@@ -1318,11 +1403,9 @@ mod tests {
             .await
             .expect("failed to enqueue request");
 
-        let at_capacity = iouring
-            .fill_submission_queue(&mut ring)
-            .expect("channel should remain connected");
+        let fill_result = iouring.fill_submission_queue(&mut ring);
 
-        assert!(!at_capacity);
+        assert_eq!(fill_result, FillResult::Drained);
         assert!(iouring.pending_cancels.is_empty());
         assert!(iouring.waiters.is_empty());
         assert_eq!(ring.submission().len(), 0);
@@ -2308,12 +2391,10 @@ mod tests {
         assert!(iouring.waiters.cancel(waiter_id));
         iouring.ready_queue.push_back(waiter_id);
 
-        let at_capacity = iouring
-            .fill_submission_queue(&mut ring)
-            .expect("channel should remain connected");
+        let fill_result = iouring.fill_submission_queue(&mut ring);
 
         // Ready-queue staging should retire the waiter locally and leave the SQ untouched.
-        assert!(!at_capacity);
+        assert_eq!(fill_result, FillResult::Drained);
         assert!(iouring.waiters.is_empty());
         assert_eq!(ring.submission().len(), 0);
         let result = rx.await.expect("missing timeout completion");
@@ -2346,13 +2427,11 @@ mod tests {
             .await
             .expect("request should enqueue");
 
-        let at_capacity = iouring
-            .fill_submission_queue(&mut ring)
-            .expect("channel should remain connected");
+        let fill_result = iouring.fill_submission_queue(&mut ring);
 
         // The request should retire locally without consuming waiter or SQ
         // capacity, and its scheduled deadline should disappear as well.
-        assert!(!at_capacity);
+        assert_eq!(fill_result, FillResult::Drained);
         assert!(iouring.waiters.is_empty());
         assert_eq!(ring.submission().len(), 0);
         assert_eq!(iouring.timeout_wheel.next_deadline(), None);
@@ -2376,12 +2455,10 @@ mod tests {
             .await
             .expect("request should enqueue");
 
-        let at_capacity = iouring
-            .fill_submission_queue(&mut ring)
-            .expect("channel should remain connected");
+        let fill_result = iouring.fill_submission_queue(&mut ring);
 
         // The read request should take the same orphan path as send.
-        assert!(!at_capacity);
+        assert_eq!(fill_result, FillResult::Drained);
         assert!(iouring.waiters.is_empty());
         assert_eq!(ring.submission().len(), 0);
         assert_eq!(iouring.timeout_wheel.next_deadline(), None);
@@ -2417,13 +2494,11 @@ mod tests {
         iouring.timeout_wheel.schedule(waiter_id, 1);
         iouring.ready_queue.push_back(waiter_id);
 
-        let at_capacity = iouring
-            .fill_submission_queue(&mut ring)
-            .expect("channel should remain connected");
+        let fill_result = iouring.fill_submission_queue(&mut ring);
 
         // Restaging should notice the closed caller, drop the request locally,
         // and clean up its deadline tracking without touching the SQ.
-        assert!(!at_capacity);
+        assert_eq!(fill_result, FillResult::Drained);
         assert!(iouring.waiters.is_empty());
         assert_eq!(ring.submission().len(), 0);
         assert_eq!(iouring.timeout_wheel.next_deadline(), None);

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -263,8 +263,9 @@ struct HandleInner {
 
 impl Drop for HandleInner {
     fn drop(&mut self) {
-        // Disconnect first, then wake. This avoids a race where the loop
-        // handles a wake CQE before channel closure becomes observable.
+        // Disconnect first, then wake. `Waker::wake` is the publishing edge
+        // for this out-of-band shutdown signal, so channel closure must happen
+        // before the wake is issued.
         drop(self.sender.take());
 
         // Wake the loop so shutdown observes disconnect promptly. This is an

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -266,7 +266,7 @@ impl Drop for HandleInner {
         // Wake the loop so shutdown observes disconnect promptly. This is an
         // out-of-band wake for channel closure, so do not publish a synthetic
         // submission sequence increment.
-        self.waker.notify();
+        self.waker.wake();
     }
 }
 

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -50,7 +50,10 @@
 //!   2) Advance timeouts.
 //!   3) Rarely rearm wake polling, then stage cancels, ready-queue requests,
 //!      and new inbound requests into SQ.
-//!   4) Submit and block in io_uring_enter until a CQE (data or wake) arrives.
+//!   4) If work is pending or active waiters remain, submit and possibly block in
+//!      io_uring_enter until a CQE (data or wake) arrives.
+//!   5) If the ring is fully idle, arm the shared wake word and sleep in futex
+//!      wait until a producer publishes work or latches an out-of-band wake.
 //! ```
 //!
 //! ## Work Tracking
@@ -104,8 +107,9 @@
 //! 1. Stops accepting new requests
 //! 2. Waits for all in-flight requests to complete or be cancelled
 //! 3. If `shutdown_timeout` is configured, abandons remaining requests after the timeout
-//! 4. Cleans up and exits. Dropping the last submitter signals the currently armed
-//!    wake target so shutdown is observed promptly even if the loop is blocked.
+//! 4. Cleans up and exits. Dropping the last submitter latches one wake and, if a
+//!    target is currently armed, signals it immediately so shutdown is observed
+//!    promptly whether the loop is already blocked or about to sleep.
 //!
 //! ## Liveness Model
 //!

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -535,9 +535,12 @@ impl IoUringLoop {
                     // Pending submissions exist and staging stopped at capacity.
                     //
                     // Enter the kernel to submit pending SQEs and wait for at
-                    // least one completion so capacity can open up. Arm the
-                    // eventfd wait so producer disconnect is still observed
-                    // promptly while blocked in `submit_and_wait`.
+                    // least one completion so capacity can open up.
+                    //
+                    // Keep the eventfd-backed wake path armed across this
+                    // blocking section so a later producer disconnect can
+                    // interrupt `submit_and_wait` instead of waiting for an
+                    // unrelated CQE or timeout.
                     let _arm = self.waker.arm(self.processed_seq);
                     self.submit_and_wait(&mut ring, 1, self.timeout_wheel.next_deadline())
                         .expect("unable to submit to ring");
@@ -562,12 +565,13 @@ impl IoUringLoop {
             //
             // If staging hit capacity, force a submit-and-wait cycle to open
             // space, even though the sequence snapshot looks idle here.
+            // Otherwise, arm the eventfd-backed blocking path. If
+            // `arm.should_block()` is true, we may enter `submit_and_wait`.
             //
-            // Otherwise, arm the blocking wake path. If the post-arm snapshot
-            // still looks idle, we may enter `submit_and_wait`. Any submission
-            // that arrives after `arm()` observes the wait target and rings
-            // eventfd, so the loop is woken instead of sleeping through newly
-            // published work.
+            // While the returned guard is live, any later submission or
+            // producer disconnect observes the armed eventfd target and wakes
+            // this blocking section instead of waiting for an unrelated CQE or
+            // timeout.
             let arm = self.waker.arm(self.processed_seq);
             if at_capacity || arm.should_block() {
                 self.submit_and_wait(&mut ring, 1, self.timeout_wheel.next_deadline())

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -591,11 +591,21 @@ impl IoUringLoop {
                 }
                 FillResult::AtWaiterCapacity => {
                     // Waiter pressure means completions are required before the
-                    // loop can admit more work, so submit pending SQEs and block
-                    // for progress with the eventfd-backed wake path armed.
-                    let _arm = self.waker.arm(self.processed_seq);
-                    self.submit_and_wait(&mut ring, 1, self.timeout_wheel.next_deadline())
-                        .expect("unable to submit to ring");
+                    // loop can admit more work, so the default behavior is to
+                    // submit pending SQEs and block for progress with the
+                    // eventfd-backed wake path armed.
+                    //
+                    // The only exception is an already-latched out-of-band
+                    // wake, such as final-handle disconnect. In that case the
+                    // loop must recheck shutdown instead of sleeping, but a
+                    // published-ahead submission sequence alone is not a reason
+                    // to skip blocking here because waiter pressure still
+                    // prevents admitting more work.
+                    let arm = self.waker.arm(self.processed_seq);
+                    if !arm.wake_latched() {
+                        self.submit_and_wait(&mut ring, 1, self.timeout_wheel.next_deadline())
+                            .expect("unable to submit to ring");
+                    }
                     continue;
                 }
                 FillResult::AtSubmissionQueueCapacity => {
@@ -625,7 +635,7 @@ impl IoUringLoop {
             // submit is needed. Arm the eventfd-backed blocking path and block
             // only if the post-arm snapshot still looks idle.
             let arm = self.waker.arm(self.processed_seq);
-            if arm.should_block() {
+            if arm.still_idle() {
                 self.submit_and_wait(&mut ring, 1, self.timeout_wheel.next_deadline())
                     .expect("unable to submit to ring");
             }
@@ -1111,46 +1121,87 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_pending_recheck_after_empty_observes_published_request() {
+    async fn test_pending_recheck_after_empty_preserves_fifo_order_across_producers() {
         // Lock in the stronger post-`pending()` recheck assumption used by the
         // `expect(...)` in `fill_submission_queue()`: once the consumer sees
         // a published-ahead sequence after an `Empty` observation, the second
-        // `try_recv()` must observe the corresponding request rather than
-        // returning `Empty` again.
+        // `try_recv()` must observe some queued request rather than reporting
+        // `Empty` again.
         //
-        // This is the minimal shape of that race:
-        // 1. consumer sees the channel as empty
-        // 2. producer enqueues one item and then publishes it
-        // 3. consumer notices the published-ahead sequence
-        // 4. consumer's second `try_recv()` must now observe the item
-        let (sender, mut receiver) = mpsc::channel(1);
+        // Use two producers to pin the FIFO shape that matters here:
+        // 1. producer A enqueues first but intentionally delays its publish
+        // 2. producer B enqueues second and performs the publish that flips
+        //    `pending(processed_seq = 0)` to true
+        // 3. the consumer's second `try_recv()` must still return A's request,
+        //    proving the recheck only needs "a producer is published ahead"
+        //    and does not assume that the publisher owns the next FIFO slot
+        let (sender_a, mut receiver) = mpsc::channel(2);
+        let sender_b = sender_a.clone();
         let waker = Waker::new().expect("eventfd creation should succeed");
 
         // Start from the same state as the real loop's slow path: the first
         // receive attempt found no immediately visible work.
         assert_eq!(receiver.try_recv(), Err(TryRecvError::Empty));
 
-        let publish_waker = waker.clone();
-        let submit = tokio::spawn(async move {
-            // Match the real producer protocol exactly: enqueue first, then
-            // publish the sequence increment that `pending()` observes.
-            sender
-                .send(7u8)
+        let (a_enqueued_tx, a_enqueued_rx) = tokio::sync::oneshot::channel();
+        let (allow_a_publish_tx, allow_a_publish_rx) = tokio::sync::oneshot::channel();
+
+        let waker_a = waker.clone();
+        let producer_a = tokio::spawn(async move {
+            sender_a
+                .send(1u8)
                 .await
-                .expect("send should succeed before publish");
-            publish_waker.publish();
+                .expect("producer A should enqueue before publishing");
+            a_enqueued_tx
+                .send(())
+                .expect("producer A enqueue signal should be received");
+            allow_a_publish_rx
+                .await
+                .expect("producer A publish should be released");
+            waker_a.publish();
         });
 
-        // Poll until the acquire/release pair says producers are ahead. The
-        // real loop would take the `expect(...)` path at this point.
+        let waker_b = waker.clone();
+        let producer_b = tokio::spawn(async move {
+            a_enqueued_rx
+                .await
+                .expect("producer B should wait for producer A enqueue");
+            sender_b
+                .send(2u8)
+                .await
+                .expect("producer B should enqueue after producer A");
+            waker_b.publish();
+        });
+
+        // Poll until producer B's publish makes the packed sequence look
+        // ahead. The real loop would take the `expect(...)` recheck path now.
         while !waker.pending(0) {
             tokio::task::yield_now().await;
         }
 
-        // Once `pending()` is true for `processed_seq = 0`, the second receive
-        // must see the request rather than report `Empty` again.
-        assert_eq!(receiver.try_recv(), Ok(7));
-        submit.await.expect("sender task should finish");
+        // Even though producer B is the publisher that flipped `pending()`,
+        // FIFO still requires the next dequeue to be producer A's older entry.
+        assert_eq!(receiver.try_recv(), Ok(1));
+
+        // At this point exactly one publish is visible and exactly one request
+        // has been drained, so the loop should no longer see producers ahead
+        // until producer A finally publishes its already-queued request.
+        assert!(!waker.pending(1));
+
+        allow_a_publish_tx
+            .send(())
+            .expect("producer A publish should be unblocked");
+
+        while !waker.pending(1) {
+            tokio::task::yield_now().await;
+        }
+
+        // Once producer A publishes, the second queued request becomes
+        // directionally visible to the same recheck logic as usual.
+        assert_eq!(receiver.try_recv(), Ok(2));
+
+        producer_a.await.expect("producer A task should finish");
+        producer_b.await.expect("producer B task should finish");
     }
 
     #[test]
@@ -1436,38 +1487,6 @@ mod tests {
         assert_eq!(fill_result, FillResult::AtSubmissionQueueCapacity);
         assert!(ring.submission().is_full());
         assert!(iouring.waiters.len() < cfg.size as usize);
-    }
-
-    #[test]
-    fn test_fill_submission_queue_preserves_wake_rearm_when_submission_queue_starts_full() {
-        // Verify a full local SQ defers wake rearm without clearing the retry flag.
-        let cfg = Config {
-            size: 8,
-            ..Default::default()
-        };
-        let mut registry = Registry::default();
-        let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
-        let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
-
-        iouring.wake_rearm_needed = true;
-
-        {
-            let mut submission_queue = ring.submission();
-            while !submission_queue.is_full() {
-                let nop = io_uring::opcode::Nop::new().build().user_data(0);
-                // SAFETY: Nop SQE owns no user pointers or external resources.
-                unsafe {
-                    submission_queue
-                        .push(&nop)
-                        .expect("unable to fill submission queue");
-                }
-            }
-        }
-
-        let fill_result = iouring.fill_submission_queue(&mut ring);
-
-        assert_eq!(fill_result, FillResult::AtSubmissionQueueCapacity);
-        assert!(iouring.wake_rearm_needed);
     }
 
     #[test]
@@ -2070,11 +2089,55 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_deferred_wake_reinstall_survives_idle_futex_path() {
-        // Simulate a prior wake CQE that terminated multishot delivery by
-        // seeding `wake_rearm_needed = true`, then verify an idle futex pass
-        // can defer the reinstall until the next non-idle submission without
-        // losing later eventfd-based wakeups.
+    async fn test_wake_reinstall_survives_submission_queue_full_and_idle_futex_deferral() {
+        // Lock in the two deferral cases that protect wake-poll reinstall:
+        //
+        // 1. if the local SQ starts full, the fill pass must report
+        //    `AtSubmissionQueueCapacity` and leave `wake_rearm_needed = true`
+        //    so the reinstall can be retried after a submit-only handoff
+        // 2. once the reinstall does stage successfully, an idle futex park
+        //    may still defer the actual kernel submission until a later
+        //    non-idle iteration, and that later iteration must reactivate
+        //    eventfd-based wakeups before blocking again
+
+        // Phase 1: direct unit-level coverage of the SQ-full handoff. The
+        // local SQ is pre-filled before `fill_submission_queue()` runs, so the
+        // reinstall attempt must fail without consuming the retry flag.
+        {
+            let cfg = Config {
+                size: 8,
+                ..Default::default()
+            };
+            let mut registry = Registry::default();
+            let (_submitter, mut iouring) = IoUringLoop::new(cfg.clone(), &mut registry);
+            let mut ring = new_ring(&cfg).expect("unable to create io_uring instance");
+
+            iouring.wake_rearm_needed = true;
+
+            {
+                let mut submission_queue = ring.submission();
+                while !submission_queue.is_full() {
+                    let nop = io_uring::opcode::Nop::new().build().user_data(0);
+                    // SAFETY: Nop SQE owns no user pointers or external resources.
+                    unsafe {
+                        submission_queue
+                            .push(&nop)
+                            .expect("unable to fill submission queue");
+                    }
+                }
+            }
+
+            let fill_result = iouring.fill_submission_queue(&mut ring);
+
+            assert_eq!(fill_result, FillResult::AtSubmissionQueueCapacity);
+            assert!(iouring.wake_rearm_needed);
+        }
+
+        // Phase 2: end-to-end coverage of the idle futex deferral. Start from
+        // the same `wake_rearm_needed = true` state, but this time allow the
+        // reinstall SQE to stage. Because the loop is otherwise idle, it parks
+        // on the futex path before entering the kernel, so the reinstall only
+        // becomes live on a later non-idle iteration.
         let cfg = Config {
             size: 2,
             ..Default::default()

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -757,8 +757,8 @@ impl IoUringLoop {
                     // ring size stays below half the packed sequence domain, so
                     // that delta is directional: producers are genuinely ahead.
                     // Tokio's bounded MPSC also guarantees `try_recv()` returns
-                    // `Disconnected` only when the channel is closed AND empty.
-                    // We keep a canary test to lock in those semantics.
+                    // `Disconnected` only when the channel is closed AND empty
+                    // (we keep a canary test to lock in those semantics).
                     self.receiver.try_recv().expect(
                         "published-ahead sequence observed after acquire, but channel had no request",
                     )

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -2221,21 +2221,72 @@ mod tests {
     }
 
     #[test]
-    fn test_idle_shutdown_wakes_futex_wait() {
-        // Verify dropping the last submitter wakes an otherwise idle loop that
-        // is sleeping on the futex-backed idle path.
-        let cfg = Config::default();
-        let mut registry = Registry::default();
-        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
-        let idle_waker = iouring.waker.clone();
-        let handle = std::thread::spawn(move || iouring.run());
+    fn test_idle_shutdown_wakes_futex_wait_across_publish_then_drop_interleavings() {
+        #[derive(Clone, Copy, Debug)]
+        enum Scenario {
+            DropOnly,
+            PublishThenDrop,
+        }
 
-        // Wait until the loop has armed its futex-backed idle path before
-        // dropping the final submitter.
-        waker::tests::wait_until_futex_armed(&idle_waker);
-        drop(submitter);
+        // Cover the two idle-path shutdown shapes that matter for
+        // `HandleInner::drop -> Waker::wake`:
+        //
+        // - plain final-handle drop while the loop is futex-armed and idle
+        // - a request publish wakes the idle loop, then the final handle drops
+        //   immediately afterward on the producer thread
+        //
+        // The waiter-full `submit_and_wait` shutdown path is covered separately
+        // by `test_shutdown_timeout_when_waiters_full_and_channel_empty`.
+        for scenario in [Scenario::DropOnly, Scenario::PublishThenDrop] {
+            let cfg = Config::default();
+            let mut registry = Registry::default();
+            let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
+            let idle_waker = iouring.waker.clone();
+            let handle = std::thread::spawn(move || iouring.run());
 
-        handle.join().expect("io_uring loop thread panicked");
+            // Wait until the loop has armed its futex-backed idle path before
+            // driving the chosen shutdown interleaving.
+            waker::tests::wait_until_futex_armed(&idle_waker);
+
+            match scenario {
+                Scenario::DropOnly => {
+                    // Baseline: final-handle drop alone must wake the idle
+                    // futex path and let the loop exit.
+                    drop(submitter);
+                }
+                Scenario::PublishThenDrop => {
+                    // Enqueue one request while the loop is idle so
+                    // `Handle::enqueue` performs a real `publish()` wake before
+                    // the final handle is dropped.
+                    let (sock_left, _sock_right) = UnixStream::pair().unwrap();
+                    // SAFETY: sock_left is a valid fd that we own.
+                    let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+                    let (tx, rx) = oneshot::channel();
+
+                    futures::executor::block_on(submitter.enqueue(Request::Sync(SyncRequest {
+                        file: Arc::new(file),
+                        result: None,
+                        sender: tx,
+                    })))
+                    .expect("idle publish enqueue should succeed");
+
+                    // Drop immediately after the publish. This exercises the
+                    // "published wake then final-drop wake" ordering on the
+                    // producer side while the loop was previously parked idle.
+                    drop(submitter);
+
+                    let result = futures::executor::block_on(rx)
+                        .expect("missing published request completion");
+                    // Socket fsync may succeed or fail, either is fine here;
+                    // the regression is about wake/liveness, not op result.
+                    let _ = result;
+                }
+            }
+
+            handle
+                .join()
+                .unwrap_or_else(|_| panic!("io_uring loop thread panicked: {scenario:?}"));
+        }
     }
 
     #[tokio::test]

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -5,9 +5,13 @@
 //! manages the submission queue (SQ) and completion queue (CQ) of an io_uring instance.
 //!
 //! Work is submitted via [Handle], which pushes [Request]s into an MPSC queue and signals
-//! an internal `eventfd` wake source. The event loop blocks in `io_uring_enter` and is woken by:
+//! an internal wake source. The event loop blocks either in userspace futex wait
+//! (when the ring is truly idle) or in `io_uring_enter` (when the ring has active
+//! waiters), and is woken by:
 //! - normal CQE progress in the ring
-//! - `eventfd` readiness when new work is queued or all submitters are dropped
+//! - futex wake when new work is queued while fully idle
+//! - `eventfd` readiness when new work is queued or all submitters are dropped while
+//!   blocked in `submit_and_wait`
 //!
 //! # Kernel Requirements
 //!
@@ -37,7 +41,8 @@
 //!   Client task -> Handle -> bounded MPSC -> IoUringLoop -> SQE -> io_uring
 //!   Client task <- typed oneshot <- IoUringLoop <- CQE <- io_uring
 //!
-//! Wake path:
+//! Wake paths:
+//!   Handle --futex wake--> packed wake state --> IoUringLoop
 //!   Handle --write(eventfd)--> wake_fd --POLLIN CQE (WAKE_USER_DATA)--> IoUringLoop
 //!
 //! Loop behavior:
@@ -83,12 +88,15 @@
 //!
 //! ## Wake Handling
 //!
-//! To avoid submission latency while the loop is blocked in `submit_and_wait`, the loop maintains
-//! a multishot `PollAdd` on an internal `eventfd`.
+//! The wake path uses one shared atomic state word plus an internal `eventfd`.
 //! - [Handle::enqueue] increments an atomic submission sequence
-//! - Wake CQEs drain `eventfd` readiness and re-install poll when `IORING_CQE_F_MORE` is not set
+//! - When the loop has no waiters, it sleeps in futex wait on that shared word
+//! - When the loop blocks in `submit_and_wait`, it keeps a multishot `PollAdd`
+//!   on the internal `eventfd`
+//! - Wake CQEs drain `eventfd` readiness and re-install poll when `IORING_CQE_F_MORE`
+//!   is not set
 //! - The loop uses an arm-and-recheck sleep handshake (`submitted_seq` vs `processed_seq`)
-//! - Submitters ring `eventfd` only while sleep intent is armed
+//! - A dedicated signalled bit coalesces repeated wake attempts while a wait is armed
 //!
 //! ## Shutdown Process
 //!
@@ -96,8 +104,8 @@
 //! 1. Stops accepting new requests
 //! 2. Waits for all in-flight requests to complete or be cancelled
 //! 3. If `shutdown_timeout` is configured, abandons remaining requests after the timeout
-//! 4. Cleans up and exits. Dropping the last submitter signals `eventfd` so shutdown is observed
-//!    promptly even if the loop is blocked.
+//! 4. Cleans up and exits. Dropping the last submitter signals the currently armed
+//!    wake target so shutdown is observed promptly even if the loop is blocked.
 //!
 //! ## Liveness Model
 //!
@@ -256,9 +264,9 @@ impl Drop for HandleInner {
         drop(self.sender.take());
 
         // Wake the loop so shutdown observes disconnect promptly. This is an
-        // out-of-band wake for channel closure, so we ring directly rather
-        // than publish a synthetic submission.
-        self.waker.ring();
+        // out-of-band wake for channel closure, so do not publish a synthetic
+        // submission sequence increment.
+        self.waker.notify();
     }
 }
 
@@ -271,8 +279,8 @@ pub struct Handle {
 impl Handle {
     /// Enqueue a request for the io_uring loop.
     ///
-    /// On success, this publishes one submission and conditionally rings the loop's
-    /// `eventfd` wake source if sleep intent is armed.
+    /// On success, this publishes one submission and conditionally wakes the
+    /// loop if a futex or eventfd wait target is currently armed.
     async fn enqueue(&self, request: Request) -> Result<(), mpsc::error::SendError<Request>> {
         self.inner
             .sender
@@ -281,7 +289,7 @@ impl Handle {
             .send(request)
             .await?;
 
-        // Publish submission and ring eventfd only if loop sleep intent is armed.
+        // Publish submission and wake the armed wait target, if any.
         self.inner.waker.publish();
 
         Ok(())
@@ -428,7 +436,7 @@ pub(crate) struct IoUringLoop {
     timeout_wheel: TimeoutWheel,
     waker: Waker,
     wake_rearm_needed: bool,
-    processed_seq: u64,
+    processed_seq: u32,
 }
 
 impl IoUringLoop {
@@ -448,6 +456,10 @@ impl IoUringLoop {
             .size
             .checked_next_power_of_two()
             .expect("ring size exceeds u32::MAX");
+        assert!(
+            cfg.size < (1 << 29),
+            "rounded ring size must stay below 1<<29 to preserve the 29-bit wake sequence bound"
+        );
         let size = cfg.size as usize;
         let metrics = Arc::new(Metrics::new(registry));
         let (sender, receiver) = mpsc::channel(size);
@@ -508,18 +520,21 @@ impl IoUringLoop {
             // Update pending operations metric.
             self.metrics.pending_operations.set(self.waiters.len() as _);
 
-            // If submissions are still pending, do not arm sleep.
+            // If submissions are still pending, do not arm idle sleep.
             //
-            // `submitted != processed_seq` means producers have published work we
+            // `pending(processed_seq)` means producers have published work we
             // have not yet drained. Sleep here could park with pending work and
-            // no guaranteed eventfd wake, because publish only rings after sleep
-            // intent is armed.
-            if self.waker.submitted() != self.processed_seq {
+            // no guaranteed wake, because publish only signals once a wait target
+            // is armed.
+            if self.waker.pending(self.processed_seq) {
                 if at_capacity {
                     // Pending submissions exist and staging stopped at capacity.
                     //
                     // Enter the kernel to submit pending SQEs and wait for at
-                    // least one completion so capacity can open up.
+                    // least one completion so capacity can open up. Arm the
+                    // eventfd wait so producer disconnect is still observed
+                    // promptly while blocked in `submit_and_wait`.
+                    let _arm = self.waker.arm(self.processed_seq);
                     self.submit_and_wait(&mut ring, 1, self.timeout_wheel.next_deadline())
                         .expect("unable to submit to ring");
                 }
@@ -529,21 +544,31 @@ impl IoUringLoop {
 
             // No pending submissions are currently visible.
             //
-            // If staging hit capacity, force a submit and wait cycle to open
+            // If the ring is truly idle, avoid `io_uring_enter` entirely and
+            // wait on the shared wake state via futex until a producer changes
+            // it. This bypasses the eventfd wake path when there are no active
+            // waiters.
+            if self.waiters.is_empty() {
+                self.waker.park_idle(self.processed_seq);
+                continue;
+            }
+
+            // Otherwise, active waiters remain in the ring, so sleep by
+            // blocking in `submit_and_wait`.
+            //
+            // If staging hit capacity, force a submit-and-wait cycle to open
             // space, even though the sequence snapshot looks idle here.
             //
-            // Otherwise, arm sleep intent and capture a post-arm sequence
-            // snapshot from the same atomic operation. Block only if still idle.
-            // Any submission that arrives after `arm()` observes sleep intent
-            // and rings eventfd, so the loop is woken instead of sleeping
-            // through newly published work.
-            if at_capacity || self.waker.arm() == self.processed_seq {
+            // Otherwise, arm the blocking wake path. If the post-arm snapshot
+            // still looks idle, we may enter `submit_and_wait`. Any submission
+            // that arrives after `arm()` observes the wait target and rings
+            // eventfd, so the loop is woken instead of sleeping through newly
+            // published work.
+            let arm = self.waker.arm(self.processed_seq);
+            if at_capacity || arm.should_block() {
                 self.submit_and_wait(&mut ring, 1, self.timeout_wheel.next_deadline())
                     .expect("unable to submit to ring");
             }
-            // Disarm sleep intent as soon as we resume running. While disarmed,
-            // producers do not ring eventfd for each publish.
-            self.waker.disarm();
         }
     }
 
@@ -631,7 +656,7 @@ impl IoUringLoop {
     /// Returns whether staging ended at waiter or SQ capacity, or `None` if the
     /// producer channel disconnected.
     fn fill_submission_queue(&mut self, ring: &mut IoUring) -> Option<bool> {
-        let mut drained = 0u64;
+        let mut drained = 0u32;
         let mut submission_queue = ring.submission();
         let mut wheel_aligned = self.timeout_wheel.next_deadline().is_some();
 
@@ -985,6 +1010,20 @@ mod tests {
         };
         let (_, iouring) = IoUringLoop::new(cfg, &mut registry);
         assert_eq!(iouring.cfg.size, 1_024);
+    }
+
+    #[test]
+    #[should_panic(expected = "rounded ring size must stay below 1<<29")]
+    fn test_iouring_loop_rejects_sizes_that_exceed_wake_sequence_domain() {
+        // The wake state reserves only 29 bits for the submission sequence, so
+        // the bounded request channel must stay strictly below that domain even
+        // after ring-size round-up.
+        let mut registry = Registry::default();
+        let cfg = Config {
+            size: (1 << 28) + 1,
+            ..Default::default()
+        };
+        let _ = IoUringLoop::new(cfg, &mut registry);
     }
 
     #[test]
@@ -1635,6 +1674,24 @@ mod tests {
             drop(submitter);
             handle.join().unwrap();
         }
+    }
+
+    #[test]
+    fn test_idle_shutdown_wakes_futex_wait() {
+        // Verify dropping the last submitter wakes an otherwise idle loop that
+        // is sleeping on the futex-backed idle path.
+        let cfg = Config::default();
+        let mut registry = Registry::default();
+        let (submitter, iouring) = IoUringLoop::new(cfg, &mut registry);
+        let idle_waker = iouring.waker.clone();
+        let handle = std::thread::spawn(move || iouring.run());
+
+        // Wait until the loop has armed its futex-backed idle path before
+        // dropping the final submitter.
+        waker::tests::wait_until_futex_armed(&idle_waker);
+        drop(submitter);
+
+        handle.join().expect("io_uring loop thread panicked");
     }
 
     #[tokio::test]

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -198,6 +198,11 @@ impl Waiters {
         self.len == 0
     }
 
+    /// Return whether all waiter slots are currently occupied.
+    pub const fn is_full(&self) -> bool {
+        self.len == self.entries.len()
+    }
+
     /// Insert a request and return its assigned id.
     ///
     /// Panics if no free slot is available.
@@ -466,6 +471,7 @@ mod tests {
         let id1 = waiters.insert(req1, Some(9));
         assert_eq!((id0.index(), id1.index()), (0, 1));
         assert_eq!(waiters.len(), 2);
+        assert!(!waiters.is_full());
 
         // A stale operation CQE should panic because only cancel CQEs are
         // expected to arrive after slot reuse.
@@ -556,6 +562,7 @@ mod tests {
         let (req, _rx) = make_sync_request();
         let waiter_id = waiters.insert(req, Some(4));
 
+        assert!(waiters.is_full());
         assert!(!waiters.is_in_flight(waiter_id));
         assert!(matches!(waiters.stage(waiter_id), StageOutcome::Submit(_)));
         assert!(waiters.is_in_flight(waiter_id));
@@ -940,6 +947,7 @@ mod tests {
         let (req1, _rx1) = make_sync_request();
         let _ = waiters.insert(req0, None);
         let _ = waiters.insert(req1, None);
+        assert!(waiters.is_full());
         let insert_overflow = catch_unwind(AssertUnwindSafe(|| {
             let (req2, _rx2) = make_sync_request();
             let _ = waiters.insert(req2, None);

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -186,6 +186,7 @@ impl Waker {
     /// armed and no wake has yet been claimed for that epoch, this caller
     /// claims `WAKE_SIGNALLED_BIT` with a follow-up atomic update and then
     /// signals the armed wait target.
+    #[inline]
     pub fn publish(&self) {
         let prev = self
             .inner
@@ -205,6 +206,7 @@ impl Waker {
 
     /// Return whether producers have published work the loop has not yet
     /// drained from the channel.
+    #[inline]
     pub fn pending(&self, processed_seq: u32) -> bool {
         ((self.inner.state.load(Ordering::Relaxed) >> STATE_BITS) & SUBMISSION_SEQ_MASK)
             != processed_seq

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -452,11 +452,22 @@ impl Waker {
             if ret >= 0 {
                 return;
             }
-            match std::io::Error::last_os_error().raw_os_error() {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
                 Some(libc::EINTR) => continue,
                 _ => {
-                    warn!("futex wake failed");
-                    return;
+                    // The operation-specific `FUTEX_WAKE` error here is `EINVAL` for
+                    // a PI waiter mismatch, and the generic futex syscall errors are
+                    // invalid or inaccessible user memory, invalid arguments, or an
+                    // unsupported op. For this private, aligned in-process futex,
+                    // all of those indicate a broken invariant or environment.
+                    // Unlike `futex_wait()`, there is no safe "just continue in
+                    // userspace" fallback here: because `WAKE_SIGNALLED_BIT` is
+                    // already latched for this epoch, logging and continuing would
+                    // risk a permanent lost wake.
+                    //
+                    // [https://www.man7.org/linux/man-pages/man2/FUTEX_WAKE.2const.html#ERRORS]
+                    panic!("futex wake failed: {err}");
                 }
             }
         }
@@ -494,11 +505,16 @@ impl Waker {
             if ret == 0 {
                 return;
             }
-            match std::io::Error::last_os_error().raw_os_error() {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
                 Some(libc::EINTR) => continue,
                 Some(libc::EAGAIN) => return,
                 _ => {
-                    warn!("futex wait failed");
+                    // With a null timeout, documented timeout-specific errors do not
+                    // apply here. An unexpected futex wait error means the kernel
+                    // refused to block, so the safe fallback is to return to
+                    // userspace and re-check the packed state rather than panic.
+                    warn!("futex wait failed: {err}");
                     return;
                 }
             }
@@ -513,6 +529,7 @@ pub mod tests {
     use std::{
         mem::size_of,
         os::fd::{AsRawFd, FromRawFd},
+        sync::Arc,
     };
 
     pub fn wait_until_futex_armed(waker: &Waker) {
@@ -614,23 +631,46 @@ pub mod tests {
     }
 
     #[test]
-    fn test_park_idle_wake_keeps_sequence_stable() {
-        // Verify `park_idle` sleeps on the idle path and out-of-band wakes do
-        // not perturb the logical submission sequence.
-        let waker = Waker::new().expect("eventfd creation should succeed");
-        let before = submitted_seq(&waker);
-        let notifier = waker.clone();
+    fn test_park_idle_handles_concurrent_publish_and_wake_races() {
+        #[derive(Clone, Copy, Debug)]
+        enum Notifier {
+            Wake,
+            Publish,
+        }
 
-        let handle = std::thread::spawn(move || {
-            while state_bits(&notifier) & WAITING_ON_FUTEX_BIT == 0 {
-                std::hint::spin_loop();
+        // Stress the real concurrent idle-path races rather than only the
+        // single-threaded stale-snapshot path. The notifier thread waits until
+        // `WAITING_ON_FUTEX_BIT` is visible and then races a `wake()` or
+        // `publish()` against the parked thread's equality check, futex
+        // syscall, and eventual `clear_wait()`.
+        for notifier in [Notifier::Wake, Notifier::Publish] {
+            for _ in 0..64 {
+                let waker = Waker::new().expect("eventfd creation should succeed");
+                let before = submitted_seq(&waker);
+                let notifier_waker = waker.clone();
+
+                let handle = std::thread::spawn(move || {
+                    while state_bits(&notifier_waker) & WAITING_ON_FUTEX_BIT == 0 {
+                        std::hint::spin_loop();
+                    }
+                    match notifier {
+                        Notifier::Wake => notifier_waker.wake(),
+                        Notifier::Publish => notifier_waker.publish(),
+                    }
+                });
+
+                waker.park_idle(before);
+                handle.join().expect("idle notifier thread panicked");
+
+                let expected = match notifier {
+                    Notifier::Wake => before,
+                    Notifier::Publish => before.wrapping_add(1) & SUBMISSION_SEQ_MASK,
+                };
+
+                assert_eq!(submitted_seq(&waker), expected, "{notifier:?}");
+                assert_eq!(state_bits(&waker), 0, "{notifier:?}");
             }
-            notifier.wake();
-        });
-
-        waker.park_idle(before);
-        handle.join().expect("idle notifier thread panicked");
-        assert_eq!(submitted_seq(&waker), before);
+        }
     }
 
     #[test]
@@ -704,17 +744,30 @@ pub mod tests {
 
     #[test]
     fn test_publish_deduplicates_eventfd_wakes() {
-        // Verify repeated publishes while the same eventfd wait is armed only
-        // queue one wake write, while still advancing the sequence each time.
+        // Verify contended publishes while the same eventfd wait is armed only
+        // queue one wake write, while still advancing the sequence for every
+        // publisher that raced in this epoch.
         let waker = Waker::new().expect("eventfd creation should succeed");
+        let barrier = Arc::new(std::sync::Barrier::new(5));
+        let mut handles = Vec::new();
 
         let arm = waker.arm(0);
         assert!(arm.still_idle());
         assert!(!arm.wake_latched());
-        waker.publish();
-        waker.publish();
+        for _ in 0..4 {
+            let publisher = waker.clone();
+            let barrier = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                publisher.publish();
+            }));
+        }
+        barrier.wait();
+        for handle in handles {
+            handle.join().expect("publish thread panicked");
+        }
 
-        assert_eq!(submitted_seq(&waker), 2);
+        assert_eq!(submitted_seq(&waker), 4);
         assert_eq!(read_eventfd_count(&waker), 1);
         drop(arm);
     }
@@ -754,15 +807,27 @@ pub mod tests {
 
     #[test]
     fn test_wake_deduplicates_eventfd_wakes() {
-        // Verify repeated out-of-band notifications while the same eventfd
+        // Verify contended out-of-band notifications while the same eventfd
         // wait is armed only queue one wake write and do not perturb sequence.
         let waker = Waker::new().expect("eventfd creation should succeed");
+        let barrier = Arc::new(std::sync::Barrier::new(5));
+        let mut handles = Vec::new();
 
         let arm = waker.arm(0);
         assert!(arm.still_idle());
         assert!(!arm.wake_latched());
-        waker.wake();
-        waker.wake();
+        for _ in 0..4 {
+            let notifier = waker.clone();
+            let barrier = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                notifier.wake();
+            }));
+        }
+        barrier.wait();
+        for handle in handles {
+            handle.join().expect("wake thread panicked");
+        }
 
         assert_eq!(submitted_seq(&waker), 0);
         assert_eq!(read_eventfd_count(&waker), 1);

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -645,6 +645,51 @@ pub mod tests {
     }
 
     #[test]
+    fn test_publish_after_futex_arm_rejects_stale_snapshot() {
+        // Verify the futex idle path tolerates a publish that lands after
+        // WAITING_ON_FUTEX_BIT is armed but before the armed thread commits to
+        // a stable futex wait on that snapshot.
+        //
+        // This models the race that `park_idle()` closes:
+        // 1. idle path arms WAITING_ON_FUTEX_BIT and computes a snapshot
+        // 2. producer publishes, changing the packed state word
+        // 3. a futex wait on the stale snapshot must return immediately
+        let waker = Waker::new().expect("eventfd creation should succeed");
+        let before = submitted_seq(&waker);
+
+        // Manually split `park_idle()` into "arm" and "wait" so the publish
+        // can be injected exactly between those two steps.
+        let prev = waker
+            .inner
+            .state
+            .fetch_or(WAITING_ON_FUTEX_BIT, Ordering::Relaxed);
+        assert_eq!(prev & WAITING_MASK, 0);
+        let snapshot = prev | WAITING_ON_FUTEX_BIT;
+
+        // This publish changes the packed word after arming, so a futex wait
+        // on the stale snapshot must now return immediately.
+        waker.publish();
+        assert_eq!(
+            submitted_seq(&waker),
+            before.wrapping_add(1) & SUBMISSION_SEQ_MASK
+        );
+
+        // If the stale snapshot were incorrectly accepted, this call could
+        // block indefinitely. Returning here proves the userspace equality
+        // check / futex EAGAIN path rejected the outdated snapshot.
+        waker.futex_wait(snapshot);
+        waker.clear_wait();
+
+        // The publish should remain visible and the wait bits should be fully
+        // cleared on exit, matching `park_idle()`'s contract.
+        assert_eq!(
+            submitted_seq(&waker),
+            before.wrapping_add(1) & SUBMISSION_SEQ_MASK
+        );
+        assert_eq!(state_bits(&waker), 0);
+    }
+
+    #[test]
     fn test_publish_deduplicates_eventfd_wakes() {
         // Verify repeated publishes while the same eventfd wait is armed only
         // queue one wake write, while still advancing the sequence each time.

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -151,11 +151,19 @@ impl Waker {
     /// The first caller to set `WAKE_SIGNALLED_BIT` in an epoch performs the
     /// wake. Subsequent callers do nothing until the loop disarms and clears
     /// the bit.
+    ///
+    /// All claimed wakes flow through this path, whether they come from
+    /// `publish()` on an armed epoch or from an out-of-band caller such as the
+    /// final sender disconnecting.
     pub fn wake(&self) {
+        // `HandleInner::drop` uses this path without bumping the submission
+        // sequence. Publish that disconnect here so that after the loop resumes
+        // and `clear_wait()` acquires, the next channel check cannot observe
+        // the wake without also observing the disconnect that caused it.
         let prev = self
             .inner
             .state
-            .fetch_or(WAKE_SIGNALLED_BIT, Ordering::Relaxed);
+            .fetch_or(WAKE_SIGNALLED_BIT, Ordering::Release);
 
         if (prev & WAKE_SIGNALLED_BIT) != 0 {
             return;
@@ -179,8 +187,7 @@ impl Waker {
     /// wait target.
     ///
     /// Callers must invoke this only after successfully enqueueing work into
-    /// the MPSC channel. That ordering guarantees that when the loop observes
-    /// an updated sequence, there is corresponding work to drain.
+    /// the MPSC channel.
     ///
     /// The common unarmed path performs only one `fetch_add`. When a wait is
     /// armed and no wake has yet been claimed for that epoch, this caller
@@ -188,6 +195,12 @@ impl Waker {
     /// signals the armed wait target.
     #[inline]
     pub fn publish(&self) {
+        // The sequence is only a sticky "do not sleep yet" hint. The loop may
+        // observe this increment before Tokio makes the corresponding enqueue
+        // visible to `try_recv`. That can cause a transient extra iteration,
+        // but the mismatched sequence still prevents sleep until the channel
+        // drain catches up. Since this counter does not publish request memory,
+        // `Relaxed` is sufficient here.
         let prev = self
             .inner
             .state
@@ -208,6 +221,9 @@ impl Waker {
     /// drained from the channel.
     #[inline]
     pub fn pending(&self, processed_seq: u32) -> bool {
+        // A visible mismatch only means "do not sleep yet", it does not mean a
+        // following `try_recv` must succeed immediately. This comparison is
+        // only against the packed sequence domain, so `Relaxed` is sufficient.
         ((self.inner.state.load(Ordering::Relaxed) >> STATE_BITS) & SUBMISSION_SEQ_MASK)
             != processed_seq
     }
@@ -217,6 +233,9 @@ impl Waker {
     /// This method hides the arm-and-recheck futex sequence used when the ring
     /// is fully idle. It always clears the current wait state before returning.
     pub fn park_idle(&self, processed_seq: u32) {
+        // Arming only updates the packed wake state machine. It does not
+        // publish queue memory or consume any out-of-band wake publication, so
+        // `Relaxed` is sufficient on this RMW.
         let prev = self
             .inner
             .state
@@ -246,6 +265,9 @@ impl Waker {
     /// [`ArmGuard::should_block`] to decide whether the loop was still idle
     /// after arming.
     pub fn arm(&self, processed_seq: u32) -> ArmGuard<'_> {
+        // Arming only updates the packed wake state machine. It does not
+        // publish queue memory or consume any out-of-band wake publication, so
+        // `Relaxed` is sufficient on this RMW.
         let prev = self
             .inner
             .state
@@ -328,14 +350,19 @@ impl Waker {
         }
     }
 
-    /// Disarm the current wait target after we resume running.
+    /// Clear the current wait epoch after we resume running.
     ///
     /// Keeping wait bits clear while actively running avoids redundant futex
-    /// wakes and eventfd writes during bursts. This is done both after a real
-    /// wake and after a post-arm recheck decides not to block.
+    /// wakes and eventfd writes during bursts. This is done both after
+    /// `park_idle()` / `submit_and_wait` return and after a post-arm recheck
+    /// decides not to block.
     #[inline]
     fn clear_wait(&self) {
-        self.inner.state.fetch_and(!STATE_MASK, Ordering::Relaxed);
+        // Pair with `wake()`'s `Release`. This is the first common point after
+        // resuming from a wake and before the next channel check, so acquiring
+        // here ensures the loop cannot observe the wake without also observing
+        // the sender-side state change that caused it.
+        self.inner.state.fetch_and(!STATE_MASK, Ordering::Acquire);
     }
 
     /// Wake the loop while it is blocked in `submit_and_wait`.
@@ -418,7 +445,8 @@ impl Waker {
     fn futex_wait(&self, snapshot: u32) {
         loop {
             // This is only a same-word equality check before entering the
-            // syscall.
+            // syscall. It relies only on modification order of this atomic, so
+            // `Relaxed` is sufficient.
             if self.inner.state.load(Ordering::Relaxed) != snapshot {
                 return;
             }
@@ -464,6 +492,10 @@ pub mod tests {
         }
     }
 
+    fn state_bits(waker: &Waker) -> u32 {
+        waker.inner.state.load(Ordering::Relaxed) & STATE_MASK
+    }
+
     fn submitted_seq(waker: &Waker) -> u32 {
         (waker.inner.state.load(Ordering::Relaxed) >> STATE_BITS) & SUBMISSION_SEQ_MASK
     }
@@ -507,10 +539,7 @@ pub mod tests {
         assert_eq!(submitted_seq(&waker), 2);
         drop(arm);
         assert_eq!(submitted_seq(&waker), 2);
-        assert_eq!(
-            waker.inner.state.load(std::sync::atomic::Ordering::Relaxed) & STATE_MASK,
-            0
-        );
+        assert_eq!(state_bits(&waker), 0);
 
         // Re-arming should observe the same submitted snapshot while idle.
         let arm = waker.arm(2);
@@ -527,13 +556,7 @@ pub mod tests {
         let notifier = waker.clone();
 
         let handle = std::thread::spawn(move || {
-            while notifier
-                .inner
-                .state
-                .load(std::sync::atomic::Ordering::Relaxed)
-                & WAITING_ON_FUTEX_BIT
-                == 0
-            {
+            while state_bits(&notifier) & WAITING_ON_FUTEX_BIT == 0 {
                 std::hint::spin_loop();
             }
             notifier.wake();
@@ -565,7 +588,7 @@ pub mod tests {
         waker.park_idle(before);
 
         assert_eq!(submitted_seq(&waker), before);
-        assert_eq!(waker.inner.state.load(Ordering::Relaxed) & STATE_MASK, 0);
+        assert_eq!(state_bits(&waker), 0);
     }
 
     #[test]
@@ -596,7 +619,7 @@ pub mod tests {
         drop(arm);
 
         assert_eq!(submitted_seq(&waker), 0);
-        assert_eq!(waker.inner.state.load(Ordering::Relaxed) & STATE_MASK, 0);
+        assert_eq!(state_bits(&waker), 0);
     }
 
     #[test]
@@ -611,7 +634,7 @@ pub mod tests {
         drop(arm);
 
         assert_eq!(submitted_seq(&waker), 1);
-        assert_eq!(waker.inner.state.load(Ordering::Relaxed) & STATE_MASK, 0);
+        assert_eq!(state_bits(&waker), 0);
     }
 
     #[test]

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -51,6 +51,8 @@ const WAITING_MASK: u32 = WAITING_ON_FUTEX_BIT | WAITING_ON_EVENTFD_BIT;
 const SUBMISSION_INCREMENT: u32 = 1 << STATE_BITS;
 /// Sequence domain used by the packed submission counter (state >> 3).
 pub(super) const SUBMISSION_SEQ_MASK: u32 = u32::MAX >> STATE_BITS;
+/// Maximum bounded queue size that preserves alias-free sequence comparisons.
+pub(super) const MAX_SUBMISSION_SEQUENCE_DOMAIN: u32 = SUBMISSION_SEQ_MASK + 1;
 
 /// RAII guard covering a `submit_and_wait` blocking section.
 ///
@@ -487,7 +489,7 @@ pub(super) mod tests {
         drop(arm);
         assert_eq!(submitted_seq(&waker), 2);
         assert_eq!(
-            waker.inner.state.load(std::sync::atomic::Ordering::Acquire) & STATE_MASK,
+            waker.inner.state.load(std::sync::atomic::Ordering::Relaxed) & STATE_MASK,
             0
         );
 
@@ -509,7 +511,7 @@ pub(super) mod tests {
             while notifier
                 .inner
                 .state
-                .load(std::sync::atomic::Ordering::Acquire)
+                .load(std::sync::atomic::Ordering::Relaxed)
                 & WAITING_ON_FUTEX_BIT
                 == 0
             {

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -7,6 +7,7 @@
 //!   blocking in `submit_and_wait`.
 //! - Producers wake only the currently armed wait target.
 //! - A dedicated "wake signalled" bit coalesces repeated wake attempts.
+//! - Out-of-band wake requests use [`Waker::wake`].
 //! - Wake CQEs are acknowledged with [`Waker::acknowledge`].
 //!
 //! The packed atomic state combines:
@@ -88,8 +89,8 @@ impl Drop for BlockGuard<'_> {
 ///
 /// Blocking follows an arm-and-recheck protocol:
 /// - The loop first verifies `submitted_seq == processed_seq`, then arms a wait target.
-/// - `blocking_snapshot()` returns the post-arm snapshot only when blocking still
-///   looks safe after that same atomic state transition.
+/// - The loop blocks only if the post-arm snapshot still looks idle after that
+///   same atomic state transition.
 /// - Submitters signal the currently armed wait target exactly once.
 /// - Out-of-band notifications latch one wake even while unarmed, so the next
 ///   arm-and-recheck cycle skips blocking once.
@@ -104,7 +105,7 @@ struct WakerInner {
 /// Internal hybrid futex/eventfd wake source for the io_uring loop.
 ///
 /// - Publish submissions from producers via [`Waker::publish`]
-/// - Wake without publishing via [`Waker::notify`]
+/// - Wake without publishing via [`Waker::wake`]
 /// - Test whether published work is still pending via [`Waker::pending`]
 /// - Park in the fully-idle path via [`Waker::park_idle`]
 /// - Arm a `submit_and_wait` blocking section via [`Waker::arm`]
@@ -203,22 +204,24 @@ impl Waker {
         }
     }
 
-    /// Atomically latch one pending wake and return the previous state.
+    /// Latch one pending wake and, if a target is currently armed, wake it.
     ///
-    /// The first caller to set `WAKE_SIGNALLED_BIT` in an epoch receives the
-    /// full pre-update state. Subsequent callers observe `None` until the loop
-    /// disarms and clears the bit.
-    fn latch_signal(&self) -> Option<u32> {
-        self.inner
-            .state
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-                ((current & WAKE_SIGNALLED_BIT) == 0).then_some(current | WAKE_SIGNALLED_BIT)
-            })
-            .ok()
-    }
+    /// The first caller to set `WAKE_SIGNALLED_BIT` in an epoch performs the
+    /// wake. Subsequent callers do nothing until the loop disarms and clears
+    /// the bit.
+    pub(super) fn wake(&self) {
+        let Some(prev) =
+            self.inner
+                .state
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                    ((current & WAKE_SIGNALLED_BIT) == 0).then_some(current | WAKE_SIGNALLED_BIT)
+                })
+                .ok()
+        else {
+            return;
+        };
 
-    /// Signal the currently armed wait target described by `waiting`.
-    fn signal_waiter(&self, waiting: u32) {
+        let waiting = prev & WAITING_MASK;
         assert_ne!(
             waiting, WAITING_MASK,
             "iouring wake state cannot wait on futex and eventfd simultaneously"
@@ -255,21 +258,7 @@ impl Waker {
             return;
         }
 
-        if let Some(prev) = self.latch_signal() {
-            self.signal_waiter(prev & WAITING_MASK);
-        }
-    }
-
-    /// Wake the loop without publishing a new submission.
-    ///
-    /// This is used for out-of-band notifications like producer disconnect.
-    ///
-    /// Unlike `publish()`, this also latches a pending wake while no wait
-    /// target is armed so the next arm-and-recheck cycle skips blocking once.
-    pub(super) fn notify(&self) {
-        if let Some(prev) = self.latch_signal() {
-            self.signal_waiter(prev & WAITING_MASK);
-        }
+        self.wake();
     }
 
     /// Return the current submitted sequence.
@@ -291,7 +280,24 @@ impl Waker {
     /// This method hides the arm-and-recheck futex sequence used when the ring
     /// is fully idle. It always disarms the wait bits before returning.
     pub(super) fn park_idle(&self, processed_seq: u32) {
-        if let Some(snapshot) = self.blocking_snapshot(WAITING_ON_FUTEX_BIT, processed_seq) {
+        // This transition only mutates the packed wake state. Tokio's channel
+        // synchronizes message and close visibility independently.
+        let prev = self
+            .inner
+            .state
+            .fetch_or(WAITING_ON_FUTEX_BIT, Ordering::Relaxed);
+        assert_eq!(
+            prev & WAITING_MASK,
+            0,
+            "iouring wait target should be disarmed before re-arming"
+        );
+        let snapshot = prev | WAITING_ON_FUTEX_BIT;
+
+        // Only block if the post-arm snapshot still looks idle. When that is
+        // true, futex-wait on the same packed state word that was just armed.
+        if (snapshot & WAKE_SIGNALLED_BIT) == 0
+            && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq
+        {
             self.wait_futex(snapshot);
         }
         self.disarm();
@@ -303,34 +309,24 @@ impl Waker {
     /// [`BlockGuard::should_block`] to decide whether the loop was still idle
     /// after arming.
     pub(super) fn arm(&self, processed_seq: u32) -> BlockGuard<'_> {
-        let should_block = self
-            .blocking_snapshot(WAITING_ON_EVENTFD_BIT, processed_seq)
-            .is_some();
-        BlockGuard {
-            waker: self,
-            should_block,
-        }
-    }
-
-    /// Set one wait target and return the post-update snapshot when it still
-    /// permits blocking.
-    fn blocking_snapshot(&self, wait_bit: u32, processed_seq: u32) -> Option<u32> {
         // This transition only mutates the packed wake state. Tokio's channel
         // synchronizes message and close visibility independently.
-        let prev = self.inner.state.fetch_or(wait_bit, Ordering::Relaxed);
+        let prev = self
+            .inner
+            .state
+            .fetch_or(WAITING_ON_EVENTFD_BIT, Ordering::Relaxed);
         assert_eq!(
             prev & WAITING_MASK,
             0,
             "iouring wait target should be disarmed before re-arming"
         );
-        let snapshot = prev | wait_bit;
-
-        // Only block if the post-arm snapshot still looks idle. When that is
-        // true, return the exact packed word so the idle path can futex-wait
-        // on the same state it just armed.
-        ((snapshot & WAKE_SIGNALLED_BIT) == 0
-            && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq)
-            .then_some(snapshot)
+        let snapshot = prev | WAITING_ON_EVENTFD_BIT;
+        let should_block = (snapshot & WAKE_SIGNALLED_BIT) == 0
+            && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq;
+        BlockGuard {
+            waker: self,
+            should_block,
+        }
     }
 
     /// Sleep on the packed state word with futex until it changes.
@@ -508,7 +504,7 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn test_park_idle_notify_keeps_sequence_stable() {
+    fn test_park_idle_wake_keeps_sequence_stable() {
         // Verify `park_idle` sleeps on the idle path and out-of-band wakes do
         // not perturb the logical submission sequence.
         let waker = Waker::new().expect("eventfd creation should succeed");
@@ -525,7 +521,7 @@ pub(super) mod tests {
             {
                 std::hint::spin_loop();
             }
-            notifier.notify();
+            notifier.wake();
         });
 
         waker.park_idle(before);
@@ -534,23 +530,23 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn test_notify_without_idle_wait_keeps_sequence_stable() {
+    fn test_wake_without_idle_wait_keeps_sequence_stable() {
         // Verify out-of-band notifications without an idle wait do not perturb
         // submission sequence.
         let waker = Waker::new().expect("eventfd creation should succeed");
         let before = waker.submitted();
-        waker.notify();
+        waker.wake();
         assert_eq!(waker.submitted(), before);
     }
 
     #[test]
-    fn test_notify_before_park_idle_skips_sleep() {
+    fn test_wake_before_park_idle_skips_sleep() {
         // Verify an out-of-band wake latched before idle arming makes the next
         // idle park return immediately instead of sleeping.
         let waker = Waker::new().expect("eventfd creation should succeed");
         let before = waker.submitted();
 
-        waker.notify();
+        waker.wake();
         waker.park_idle(before);
 
         assert_eq!(waker.submitted(), before);
@@ -574,15 +570,15 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn test_notify_deduplicates_eventfd_wakes() {
+    fn test_wake_deduplicates_eventfd_wakes() {
         // Verify repeated out-of-band notifications while the same eventfd
         // wait is armed only queue one wake write and do not perturb sequence.
         let waker = Waker::new().expect("eventfd creation should succeed");
 
         let arm = waker.arm(0);
         assert!(arm.should_block());
-        waker.notify();
-        waker.notify();
+        waker.wake();
+        waker.wake();
 
         assert_eq!(waker.submitted(), 0);
         assert_eq!(read_eventfd_count(&waker), 1);

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -585,6 +585,36 @@ pub mod tests {
     }
 
     #[test]
+    fn test_arm_after_sticky_wake_skips_blocking() {
+        // Verify a wake latched before arming makes the next blocking section
+        // skip `submit_and_wait`.
+        let waker = Waker::new().expect("eventfd creation should succeed");
+
+        waker.wake();
+        let arm = waker.arm(0);
+        assert!(!arm.should_block());
+        drop(arm);
+
+        assert_eq!(submitted_seq(&waker), 0);
+        assert_eq!(waker.inner.state.load(Ordering::Relaxed) & STATE_MASK, 0);
+    }
+
+    #[test]
+    fn test_arm_after_publish_skips_blocking() {
+        // Verify arming with a stale processed sequence notices the newly
+        // published submission and skips blocking.
+        let waker = Waker::new().expect("eventfd creation should succeed");
+
+        waker.publish();
+        let arm = waker.arm(0);
+        assert!(!arm.should_block());
+        drop(arm);
+
+        assert_eq!(submitted_seq(&waker), 1);
+        assert_eq!(waker.inner.state.load(Ordering::Relaxed) & STATE_MASK, 0);
+    }
+
+    #[test]
     fn test_wake_deduplicates_eventfd_wakes() {
         // Verify repeated out-of-band notifications while the same eventfd
         // wait is armed only queue one wake write and do not perturb sequence.

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -60,14 +60,21 @@ pub const HALF_SUBMISSION_SEQUENCE_DOMAIN: u32 = SUBMISSION_SEQ_MASK.div_ceil(2)
 /// wake if producers publish new work or the final handle disconnects.
 pub struct ArmGuard<'a> {
     waker: &'a Waker,
-    should_block: bool,
+    still_idle: bool,
+    wake_latched: bool,
 }
 
 impl ArmGuard<'_> {
-    /// Return whether the loop was still idle after arming the blocking wake
-    /// path and therefore may safely enter `submit_and_wait`.
-    pub const fn should_block(&self) -> bool {
-        self.should_block
+    /// Return whether the post-arm snapshot still looked idle, meaning no
+    /// wake was latched and the published sequence still matched the loop's
+    /// `processed_seq`.
+    pub const fn still_idle(&self) -> bool {
+        self.still_idle
+    }
+
+    /// Return whether a wake was already latched before or during arming.
+    pub const fn wake_latched(&self) -> bool {
+        self.wake_latched
     }
 }
 
@@ -270,9 +277,11 @@ impl Waker {
 
     /// Arm the blocking wake path used around `submit_and_wait`.
     ///
-    /// The returned guard automatically clears the current wait state on drop. Call
-    /// [`ArmGuard::should_block`] to decide whether the loop was still idle
-    /// after arming.
+    /// The returned guard automatically clears the current wait state on drop.
+    /// Call [`ArmGuard::still_idle`] to decide whether the loop may block on
+    /// the normal "still idle" path, or [`ArmGuard::wake_latched`] to detect
+    /// an already-latched wake without conflating it with published-ahead
+    /// sequence progress.
     pub fn arm(&self, processed_seq: u32) -> ArmGuard<'_> {
         // Arming only updates the packed wake state machine. It does not
         // publish queue memory or consume any out-of-band wake publication, so
@@ -289,12 +298,14 @@ impl Waker {
         );
 
         let snapshot = prev | WAITING_ON_EVENTFD_BIT;
-        let should_block = (snapshot & WAKE_SIGNALLED_BIT) == 0
+        let wake_latched = (snapshot & WAKE_SIGNALLED_BIT) != 0;
+        let still_idle = !wake_latched
             && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq;
 
         ArmGuard {
             waker: self,
-            should_block,
+            still_idle,
+            wake_latched,
         }
     }
 
@@ -553,7 +564,8 @@ pub mod tests {
 
         // Arm and publish should trigger an eventfd wake; acknowledge drains it.
         let arm = waker.arm(1);
-        assert!(arm.should_block());
+        assert!(arm.still_idle());
+        assert!(!arm.wake_latched());
         waker.publish();
         assert_eq!(submitted_seq(&waker), 2);
 
@@ -567,7 +579,8 @@ pub mod tests {
 
         // Re-arming should observe the same submitted snapshot while idle.
         let arm = waker.arm(2);
-        assert!(arm.should_block());
+        assert!(arm.still_idle());
+        assert!(!arm.wake_latched());
         drop(arm);
     }
 
@@ -696,7 +709,8 @@ pub mod tests {
         let waker = Waker::new().expect("eventfd creation should succeed");
 
         let arm = waker.arm(0);
-        assert!(arm.should_block());
+        assert!(arm.still_idle());
+        assert!(!arm.wake_latched());
         waker.publish();
         waker.publish();
 
@@ -708,12 +722,14 @@ pub mod tests {
     #[test]
     fn test_arm_after_sticky_wake_skips_blocking() {
         // Verify a wake latched before arming makes the next blocking section
-        // skip `submit_and_wait`.
+        // skip the normal idle-based blocking decision, and surface that the
+        // reason was an out-of-band wake rather than published-ahead work.
         let waker = Waker::new().expect("eventfd creation should succeed");
 
         waker.wake();
         let arm = waker.arm(0);
-        assert!(!arm.should_block());
+        assert!(!arm.still_idle());
+        assert!(arm.wake_latched());
         drop(arm);
 
         assert_eq!(submitted_seq(&waker), 0);
@@ -728,7 +744,8 @@ pub mod tests {
 
         waker.publish();
         let arm = waker.arm(0);
-        assert!(!arm.should_block());
+        assert!(!arm.still_idle());
+        assert!(!arm.wake_latched());
         drop(arm);
 
         assert_eq!(submitted_seq(&waker), 1);
@@ -742,7 +759,8 @@ pub mod tests {
         let waker = Waker::new().expect("eventfd creation should succeed");
 
         let arm = waker.arm(0);
-        assert!(arm.should_block());
+        assert!(arm.still_idle());
+        assert!(!arm.wake_latched());
         waker.wake();
         waker.wake();
 

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -3,7 +3,7 @@
 //! This module implements the producer-to-loop wake protocol used by [`super::IoUringLoop`]:
 //! - Producers call [`Waker::publish`] after enqueueing work.
 //! - The loop calls [`Waker::park_idle`] when it is fully idle.
-//! - The loop acquires a [`BlockGuard`] from [`Waker::arm`] before
+//! - The loop acquires an [`ArmGuard`] from [`Waker::arm`] before
 //!   blocking in `submit_and_wait`.
 //! - Producers wake only the currently armed wait target.
 //! - A dedicated "wake signalled" bit coalesces repeated wake attempts.
@@ -56,12 +56,12 @@ pub(super) const SUBMISSION_SEQ_MASK: u32 = u32::MAX >> STATE_BITS;
 ///
 /// While this guard is live, the loop is armed to receive an eventfd-based
 /// wake if producers publish new work or the final handle disconnects.
-pub(super) struct BlockGuard<'a> {
+pub(super) struct ArmGuard<'a> {
     waker: &'a Waker,
     should_block: bool,
 }
 
-impl BlockGuard<'_> {
+impl ArmGuard<'_> {
     /// Return whether the loop was still idle after arming the blocking wake
     /// path and therefore may safely enter `submit_and_wait`.
     pub(super) const fn should_block(&self) -> bool {
@@ -69,9 +69,9 @@ impl BlockGuard<'_> {
     }
 }
 
-impl Drop for BlockGuard<'_> {
+impl Drop for ArmGuard<'_> {
     fn drop(&mut self) {
-        self.waker.disarm();
+        self.waker.clear_wait();
     }
 }
 
@@ -143,8 +143,8 @@ impl Waker {
         })
     }
 
-    /// Ring the eventfd doorbell.
-    fn ring(&self) {
+    /// Wake the blocking path via eventfd.
+    fn eventfd_wake(&self) {
         let value: u64 = 1;
         loop {
             // SAFETY: `wake_fd` is a valid eventfd descriptor and `value` points
@@ -210,16 +210,13 @@ impl Waker {
     /// wake. Subsequent callers do nothing until the loop disarms and clears
     /// the bit.
     pub(super) fn wake(&self) {
-        let Some(prev) =
-            self.inner
-                .state
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-                    ((current & WAKE_SIGNALLED_BIT) == 0).then_some(current | WAKE_SIGNALLED_BIT)
-                })
-                .ok()
-        else {
+        let prev = self
+            .inner
+            .state
+            .fetch_or(WAKE_SIGNALLED_BIT, Ordering::Relaxed);
+        if (prev & WAKE_SIGNALLED_BIT) != 0 {
             return;
-        };
+        }
 
         let waiting = prev & WAITING_MASK;
         assert_ne!(
@@ -230,12 +227,12 @@ impl Waker {
         match waiting {
             0 => {}
             WAITING_ON_FUTEX_BIT => self.futex_wake(),
-            WAITING_ON_EVENTFD_BIT => self.ring(),
+            WAITING_ON_EVENTFD_BIT => self.eventfd_wake(),
             _ => unreachable!("unexpected iouring wake target"),
         }
     }
 
-    /// Publish one submitted operation and optionally ring `eventfd`.
+    /// Publish one submitted operation and optionally wake via `eventfd`.
     ///
     /// Callers must invoke this only after successfully enqueueing work into
     /// the MPSC channel. That ordering guarantees that when the loop observes
@@ -261,24 +258,17 @@ impl Waker {
         self.wake();
     }
 
-    /// Return the current submitted sequence.
-    ///
-    /// The sequence domain is masked to 29 bits and compared against the
-    /// loop-local `processed_seq` in the same domain.
-    fn submitted(&self) -> u32 {
-        (self.inner.state.load(Ordering::Relaxed) >> STATE_BITS) & SUBMISSION_SEQ_MASK
-    }
-
     /// Return whether producers have published work the loop has not yet
     /// drained from the channel.
     pub(super) fn pending(&self, processed_seq: u32) -> bool {
-        self.submitted() != processed_seq
+        ((self.inner.state.load(Ordering::Relaxed) >> STATE_BITS) & SUBMISSION_SEQ_MASK)
+            != processed_seq
     }
 
     /// Park on the idle path until the packed wake state changes.
     ///
     /// This method hides the arm-and-recheck futex sequence used when the ring
-    /// is fully idle. It always disarms the wait bits before returning.
+    /// is fully idle. It always clears the current wait state before returning.
     pub(super) fn park_idle(&self, processed_seq: u32) {
         // This transition only mutates the packed wake state. Tokio's channel
         // synchronizes message and close visibility independently.
@@ -298,17 +288,17 @@ impl Waker {
         if (snapshot & WAKE_SIGNALLED_BIT) == 0
             && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq
         {
-            self.wait_futex(snapshot);
+            self.futex_wait(snapshot);
         }
-        self.disarm();
+        self.clear_wait();
     }
 
     /// Arm the blocking wake path used around `submit_and_wait`.
     ///
-    /// The returned guard automatically disarms the wait bits on drop. Call
-    /// [`BlockGuard::should_block`] to decide whether the loop was still idle
+    /// The returned guard automatically clears the current wait state on drop. Call
+    /// [`ArmGuard::should_block`] to decide whether the loop was still idle
     /// after arming.
-    pub(super) fn arm(&self, processed_seq: u32) -> BlockGuard<'_> {
+    pub(super) fn arm(&self, processed_seq: u32) -> ArmGuard<'_> {
         // This transition only mutates the packed wake state. Tokio's channel
         // synchronizes message and close visibility independently.
         let prev = self
@@ -323,7 +313,7 @@ impl Waker {
         let snapshot = prev | WAITING_ON_EVENTFD_BIT;
         let should_block = (snapshot & WAKE_SIGNALLED_BIT) == 0
             && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq;
-        BlockGuard {
+        ArmGuard {
             waker: self,
             should_block,
         }
@@ -333,7 +323,7 @@ impl Waker {
     ///
     /// Retries on `EINTR`. Treats `EAGAIN` as "state already changed". The
     /// caller must pass the exact armed snapshot.
-    fn wait_futex(&self, snapshot: u32) {
+    fn futex_wait(&self, snapshot: u32) {
         loop {
             // This is only a same-word equality check before entering the
             // syscall.
@@ -372,7 +362,7 @@ impl Waker {
     /// wakes and eventfd writes during bursts. This is done both after a real
     /// wake and after a post-arm recheck decides not to block.
     #[inline]
-    fn disarm(&self) {
+    fn clear_wait(&self) {
         self.inner.state.fetch_and(!STATE_MASK, Ordering::Relaxed);
     }
 
@@ -453,6 +443,10 @@ pub(super) mod tests {
         }
     }
 
+    fn submitted_seq(waker: &Waker) -> u32 {
+        (waker.inner.state.load(Ordering::Relaxed) >> STATE_BITS) & SUBMISSION_SEQ_MASK
+    }
+
     fn read_eventfd_count(waker: &Waker) -> u64 {
         let mut value = 0u64;
         // SAFETY: `wake_fd` is a valid eventfd descriptor and `value` points
@@ -474,24 +468,24 @@ pub(super) mod tests {
         // from the blocking wake state across the normal publish and
         // acknowledge flow.
         let waker = Waker::new().expect("eventfd creation should succeed");
-        assert_eq!(waker.submitted(), 0);
+        assert_eq!(submitted_seq(&waker), 0);
 
         // Publish without an armed wait target only advances sequence.
         waker.publish();
-        assert_eq!(waker.submitted(), 1);
+        assert_eq!(submitted_seq(&waker), 1);
 
-        // Arm and publish should trigger a ring; acknowledge drains it.
+        // Arm and publish should trigger an eventfd wake; acknowledge drains it.
         let arm = waker.arm(1);
         assert!(arm.should_block());
         waker.publish();
-        assert_eq!(waker.submitted(), 2);
+        assert_eq!(submitted_seq(&waker), 2);
 
         // Acknowledge and guard drop are wake-gating operations and must not change
         // the submitted sequence domain.
         waker.acknowledge();
-        assert_eq!(waker.submitted(), 2);
+        assert_eq!(submitted_seq(&waker), 2);
         drop(arm);
-        assert_eq!(waker.submitted(), 2);
+        assert_eq!(submitted_seq(&waker), 2);
         assert_eq!(
             waker.inner.state.load(std::sync::atomic::Ordering::Acquire) & STATE_MASK,
             0
@@ -503,12 +497,12 @@ pub(super) mod tests {
         drop(arm);
     }
 
-    #[test]
-    fn test_park_idle_wake_keeps_sequence_stable() {
-        // Verify `park_idle` sleeps on the idle path and out-of-band wakes do
-        // not perturb the logical submission sequence.
-        let waker = Waker::new().expect("eventfd creation should succeed");
-        let before = waker.submitted();
+        #[test]
+        fn test_park_idle_wake_keeps_sequence_stable() {
+            // Verify `park_idle` sleeps on the idle path and out-of-band wakes do
+            // not perturb the logical submission sequence.
+            let waker = Waker::new().expect("eventfd creation should succeed");
+        let before = submitted_seq(&waker);
         let notifier = waker.clone();
 
         let handle = std::thread::spawn(move || {
@@ -526,7 +520,7 @@ pub(super) mod tests {
 
         waker.park_idle(before);
         handle.join().expect("idle notifier thread panicked");
-        assert_eq!(waker.submitted(), before);
+        assert_eq!(submitted_seq(&waker), before);
     }
 
     #[test]
@@ -534,9 +528,9 @@ pub(super) mod tests {
         // Verify out-of-band notifications without an idle wait do not perturb
         // submission sequence.
         let waker = Waker::new().expect("eventfd creation should succeed");
-        let before = waker.submitted();
+        let before = submitted_seq(&waker);
         waker.wake();
-        assert_eq!(waker.submitted(), before);
+        assert_eq!(submitted_seq(&waker), before);
     }
 
     #[test]
@@ -544,12 +538,12 @@ pub(super) mod tests {
         // Verify an out-of-band wake latched before idle arming makes the next
         // idle park return immediately instead of sleeping.
         let waker = Waker::new().expect("eventfd creation should succeed");
-        let before = waker.submitted();
+        let before = submitted_seq(&waker);
 
         waker.wake();
         waker.park_idle(before);
 
-        assert_eq!(waker.submitted(), before);
+        assert_eq!(submitted_seq(&waker), before);
         assert_eq!(waker.inner.state.load(Ordering::Relaxed) & STATE_MASK, 0);
     }
 
@@ -564,7 +558,7 @@ pub(super) mod tests {
         waker.publish();
         waker.publish();
 
-        assert_eq!(waker.submitted(), 2);
+        assert_eq!(submitted_seq(&waker), 2);
         assert_eq!(read_eventfd_count(&waker), 1);
         drop(arm);
     }
@@ -580,26 +574,26 @@ pub(super) mod tests {
         waker.wake();
         waker.wake();
 
-        assert_eq!(waker.submitted(), 0);
+        assert_eq!(submitted_seq(&waker), 0);
         assert_eq!(read_eventfd_count(&waker), 1);
         drop(arm);
     }
 
     #[test]
-    fn test_ring_and_acknowledge_empty_paths_keep_sequence_stable() {
-        // Verify ringing and draining the eventfd does not perturb the
+    fn test_eventfd_wake_and_acknowledge_empty_paths_keep_sequence_stable() {
+        // Verify eventfd wake and drain do not perturb the
         // logical submission sequence, even when the counter is already empty.
         let waker = Waker::new().expect("eventfd creation should succeed");
-        let before = waker.submitted();
+        let before = submitted_seq(&waker);
 
         // Drive one normal wake cycle, then immediately drain again to hit the
         // non-blocking empty-read path.
-        waker.ring();
+        waker.eventfd_wake();
         waker.acknowledge();
         // Second acknowledge should take the non-blocking empty path.
         waker.acknowledge();
 
-        assert_eq!(waker.submitted(), before);
+        assert_eq!(submitted_seq(&waker), before);
     }
 
     #[test]
@@ -616,13 +610,13 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn test_ring_and_acknowledge_error_branches() {
+    fn test_eventfd_wake_and_acknowledge_error_branches() {
         // Verify the explicit EAGAIN and generic error branches leave the
         // logical submission sequence unchanged.
         let mut waker = Waker::new().expect("eventfd creation should succeed");
-        let before = waker.submitted();
+        let before = submitted_seq(&waker);
 
-        // Saturate the eventfd counter near its maximum so `ring` takes the
+        // Saturate the eventfd counter near its maximum so `eventfd_wake` takes the
         // non-blocking EAGAIN path and `acknowledge` drains the queued wake.
         let fd = waker.inner.wake_fd.as_raw_fd();
         let value = u64::MAX - 1;
@@ -635,7 +629,7 @@ pub(super) mod tests {
             )
         };
         assert_eq!(wrote, size_of::<u64>() as isize);
-        waker.ring();
+        waker.eventfd_wake();
         waker.acknowledge();
 
         // Then close the descriptor so both helpers exercise their generic
@@ -643,7 +637,7 @@ pub(super) mod tests {
         // SAFETY: closing a valid fd is safe.
         let closed = unsafe { libc::close(fd) };
         assert_eq!(closed, 0);
-        waker.ring();
+        waker.eventfd_wake();
         waker.acknowledge();
 
         // Replace with a known-good fd so drop doesn't accidentally close a reused
@@ -661,6 +655,6 @@ pub(super) mod tests {
         std::mem::forget(old);
 
         // Direct eventfd read/write error paths should not perturb sequence tracking.
-        assert_eq!(waker.submitted(), before);
+        assert_eq!(submitted_seq(&waker), before);
     }
 }

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -127,7 +127,8 @@ pub struct Waker {
 }
 
 impl Waker {
-    /// Create a non-blocking eventfd wake source.
+    /// Create a hybrid futex/eventfd wake source backed by a non-blocking
+    /// `eventfd`.
     pub fn new() -> Result<Self, std::io::Error> {
         // SAFETY: `eventfd` is called with valid flags and no aliasing pointers.
         let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK) };
@@ -155,6 +156,7 @@ impl Waker {
             .inner
             .state
             .fetch_or(WAKE_SIGNALLED_BIT, Ordering::Relaxed);
+
         if (prev & WAKE_SIGNALLED_BIT) != 0 {
             return;
         }
@@ -173,7 +175,8 @@ impl Waker {
         }
     }
 
-    /// Publish one submitted operation and optionally wake via `eventfd`.
+    /// Publish one submitted operation and optionally wake the currently armed
+    /// wait target.
     ///
     /// Callers must invoke this only after successfully enqueueing work into
     /// the MPSC channel. That ordering guarantees that when the loop observes
@@ -188,6 +191,7 @@ impl Waker {
             .inner
             .state
             .fetch_add(SUBMISSION_INCREMENT, Ordering::Relaxed);
+
         let waiting = prev & WAITING_MASK;
 
         // Fast path: the loop is not waiting, or another publisher already
@@ -211,17 +215,17 @@ impl Waker {
     /// This method hides the arm-and-recheck futex sequence used when the ring
     /// is fully idle. It always clears the current wait state before returning.
     pub fn park_idle(&self, processed_seq: u32) {
-        // This transition only mutates the packed wake state. Tokio's channel
-        // synchronizes message and close visibility independently.
         let prev = self
             .inner
             .state
             .fetch_or(WAITING_ON_FUTEX_BIT, Ordering::Relaxed);
+
         assert_eq!(
             prev & WAITING_MASK,
             0,
             "iouring wait target should be disarmed before re-arming"
         );
+
         let snapshot = prev | WAITING_ON_FUTEX_BIT;
 
         // Only block if the post-arm snapshot still looks idle. When that is
@@ -240,30 +244,31 @@ impl Waker {
     /// [`ArmGuard::should_block`] to decide whether the loop was still idle
     /// after arming.
     pub fn arm(&self, processed_seq: u32) -> ArmGuard<'_> {
-        // This transition only mutates the packed wake state. Tokio's channel
-        // synchronizes message and close visibility independently.
         let prev = self
             .inner
             .state
             .fetch_or(WAITING_ON_EVENTFD_BIT, Ordering::Relaxed);
+
         assert_eq!(
             prev & WAITING_MASK,
             0,
             "iouring wait target should be disarmed before re-arming"
         );
+
         let snapshot = prev | WAITING_ON_EVENTFD_BIT;
         let should_block = (snapshot & WAKE_SIGNALLED_BIT) == 0
             && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq;
+
         ArmGuard {
             waker: self,
             should_block,
         }
     }
 
-    /// Drain eventfd readiness acknowledged by a wake CQE.
+    /// Drain readiness from the internal `eventfd` after a wake CQE.
     ///
-    /// This acknowledges kernel-visible wake readiness. Wait gating is tracked
-    /// separately in the packed `state` atomic and is managed by
+    /// This acknowledges kernel-visible `eventfd` readiness. Wait gating is
+    /// tracked separately in the packed `state` atomic and is managed by
     /// [`Waker::park_idle`] and [`Waker::arm`].
     ///
     /// Retries on `EINTR`. Treats `EAGAIN` as "nothing to drain". Without
@@ -303,7 +308,7 @@ impl Waker {
         }
     }
 
-    /// Install the wake poll request into the SQ.
+    /// Install the internal `eventfd` multishot poll request into the SQ.
     ///
     /// This uses multishot poll and is called on startup and whenever a wake
     /// CQE indicates the previous multishot request is no longer active.
@@ -331,7 +336,11 @@ impl Waker {
         self.inner.state.fetch_and(!STATE_MASK, Ordering::Relaxed);
     }
 
-    /// Wake the blocking path via eventfd.
+    /// Wake the loop while it is blocked in `submit_and_wait`.
+    ///
+    /// This writes to the internal `eventfd` monitored by the ring's multishot
+    /// poll request. The resulting wake CQE causes the loop to leave its
+    /// eventfd-backed blocking section and resume in userspace.
     fn eventfd_wake(&self) {
         let value: u64 = 1;
         loop {
@@ -366,7 +375,10 @@ impl Waker {
         }
     }
 
-    /// Wake one thread waiting on the idle path.
+    /// Wake one thread sleeping on the fully-idle futex path.
+    ///
+    /// This is used only when the loop has no active ring waiters and is
+    /// blocked in [`Waker::futex_wait`] on the packed wake-state word.
     fn futex_wake(&self) {
         loop {
             // SAFETY: `state` is a valid aligned futex word for the duration of
@@ -393,10 +405,15 @@ impl Waker {
     }
 
 
-    /// Sleep on the packed state word with futex until it changes.
+    /// Sleep on the packed wake-state word for the fully-idle path.
     ///
-    /// Retries on `EINTR`. Treats `EAGAIN` as "state already changed". The
-    /// caller must pass the exact armed snapshot.
+    /// The caller must pass the exact post-arm snapshot from the same atomic
+    /// transition that set `WAITING_ON_FUTEX_BIT`. `FUTEX_WAIT` only blocks
+    /// while the word still equals that value, which closes the race between
+    /// arming idle sleep and a concurrent publish or out-of-band wake.
+    ///
+    /// Retries on `EINTR`. Treats `EAGAIN` as "state already changed before
+    /// the kernel slept".
     fn futex_wait(&self, snapshot: u32) {
         loop {
             // This is only a same-word equality check before entering the

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -145,67 +145,6 @@ impl Waker {
         })
     }
 
-    /// Wake the blocking path via eventfd.
-    fn eventfd_wake(&self) {
-        let value: u64 = 1;
-        loop {
-            // SAFETY: `wake_fd` is a valid eventfd descriptor and `value` points
-            // to an initialized 8-byte integer for the duration of the call.
-            let ret = unsafe {
-                libc::write(
-                    self.inner.wake_fd.as_raw_fd(),
-                    &value as *const u64 as *const libc::c_void,
-                    size_of::<u64>(),
-                )
-            };
-            if ret == size_of::<u64>() as isize {
-                return;
-            }
-            assert_eq!(
-                ret, -1,
-                "eventfd write returned unexpected byte count: {ret}"
-            );
-            match std::io::Error::last_os_error().raw_os_error() {
-                // Retry if interrupted by a signal before completion.
-                Some(libc::EINTR) => continue,
-                // Non-blocking write would block because the eventfd
-                // counter is saturated. A wake is already queued, so no
-                // retry is needed.
-                Some(libc::EAGAIN) => return,
-                _ => {
-                    warn!("eventfd write failed");
-                    return;
-                }
-            }
-        }
-    }
-
-    /// Wake one thread waiting on the idle path.
-    fn futex_wake(&self) {
-        loop {
-            // SAFETY: `state` is a valid aligned futex word for the duration of
-            // the syscall.
-            let ret = unsafe {
-                libc::syscall(
-                    libc::SYS_futex,
-                    self.inner.state.as_ptr(),
-                    libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG,
-                    1u32,
-                )
-            };
-            if ret >= 0 {
-                return;
-            }
-            match std::io::Error::last_os_error().raw_os_error() {
-                Some(libc::EINTR) => continue,
-                _ => {
-                    warn!("futex wake failed");
-                    return;
-                }
-            }
-        }
-    }
-
     /// Latch one pending wake and, if a target is currently armed, wake it.
     ///
     /// The first caller to set `WAKE_SIGNALLED_BIT` in an epoch performs the
@@ -321,53 +260,6 @@ impl Waker {
         }
     }
 
-    /// Sleep on the packed state word with futex until it changes.
-    ///
-    /// Retries on `EINTR`. Treats `EAGAIN` as "state already changed". The
-    /// caller must pass the exact armed snapshot.
-    fn futex_wait(&self, snapshot: u32) {
-        loop {
-            // This is only a same-word equality check before entering the
-            // syscall.
-            if self.inner.state.load(Ordering::Relaxed) != snapshot {
-                return;
-            }
-
-            // SAFETY: `state` is a valid aligned futex word for the duration of
-            // the syscall.
-            let ret = unsafe {
-                libc::syscall(
-                    libc::SYS_futex,
-                    self.inner.state.as_ptr(),
-                    libc::FUTEX_WAIT | libc::FUTEX_PRIVATE_FLAG,
-                    snapshot,
-                    std::ptr::null::<libc::timespec>(),
-                )
-            };
-            if ret == 0 {
-                return;
-            }
-            match std::io::Error::last_os_error().raw_os_error() {
-                Some(libc::EINTR) => continue,
-                Some(libc::EAGAIN) => return,
-                _ => {
-                    warn!("futex wait failed");
-                    return;
-                }
-            }
-        }
-    }
-
-    /// Disarm the current wait target after we resume running.
-    ///
-    /// Keeping wait bits clear while actively running avoids redundant futex
-    /// wakes and eventfd writes during bursts. This is done both after a real
-    /// wake and after a post-arm recheck decides not to block.
-    #[inline]
-    fn clear_wait(&self) {
-        self.inner.state.fetch_and(!STATE_MASK, Ordering::Relaxed);
-    }
-
     /// Drain eventfd readiness acknowledged by a wake CQE.
     ///
     /// This acknowledges kernel-visible wake readiness. Wait gating is tracked
@@ -426,6 +318,115 @@ impl Waker {
             submission_queue
                 .push(&wake_poll)
                 .expect("wake poll SQE should always fit in the ring");
+        }
+    }
+
+    /// Disarm the current wait target after we resume running.
+    ///
+    /// Keeping wait bits clear while actively running avoids redundant futex
+    /// wakes and eventfd writes during bursts. This is done both after a real
+    /// wake and after a post-arm recheck decides not to block.
+    #[inline]
+    fn clear_wait(&self) {
+        self.inner.state.fetch_and(!STATE_MASK, Ordering::Relaxed);
+    }
+
+    /// Wake the blocking path via eventfd.
+    fn eventfd_wake(&self) {
+        let value: u64 = 1;
+        loop {
+            // SAFETY: `wake_fd` is a valid eventfd descriptor and `value` points
+            // to an initialized 8-byte integer for the duration of the call.
+            let ret = unsafe {
+                libc::write(
+                    self.inner.wake_fd.as_raw_fd(),
+                    &value as *const u64 as *const libc::c_void,
+                    size_of::<u64>(),
+                )
+            };
+            if ret == size_of::<u64>() as isize {
+                return;
+            }
+            assert_eq!(
+                ret, -1,
+                "eventfd write returned unexpected byte count: {ret}"
+            );
+            match std::io::Error::last_os_error().raw_os_error() {
+                // Retry if interrupted by a signal before completion.
+                Some(libc::EINTR) => continue,
+                // Non-blocking write would block because the eventfd
+                // counter is saturated. A wake is already queued, so no
+                // retry is needed.
+                Some(libc::EAGAIN) => return,
+                _ => {
+                    warn!("eventfd write failed");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Wake one thread waiting on the idle path.
+    fn futex_wake(&self) {
+        loop {
+            // SAFETY: `state` is a valid aligned futex word for the duration of
+            // the syscall.
+            let ret = unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    self.inner.state.as_ptr(),
+                    libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG,
+                    1u32,
+                )
+            };
+            if ret >= 0 {
+                return;
+            }
+            match std::io::Error::last_os_error().raw_os_error() {
+                Some(libc::EINTR) => continue,
+                _ => {
+                    warn!("futex wake failed");
+                    return;
+                }
+            }
+        }
+    }
+
+
+    /// Sleep on the packed state word with futex until it changes.
+    ///
+    /// Retries on `EINTR`. Treats `EAGAIN` as "state already changed". The
+    /// caller must pass the exact armed snapshot.
+    fn futex_wait(&self, snapshot: u32) {
+        loop {
+            // This is only a same-word equality check before entering the
+            // syscall.
+            if self.inner.state.load(Ordering::Relaxed) != snapshot {
+                return;
+            }
+
+            // SAFETY: `state` is a valid aligned futex word for the duration of
+            // the syscall.
+            let ret = unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    self.inner.state.as_ptr(),
+                    libc::FUTEX_WAIT | libc::FUTEX_PRIVATE_FLAG,
+                    snapshot,
+                    std::ptr::null::<libc::timespec>(),
+                )
+            };
+            if ret == 0 {
+                return;
+            }
+            match std::io::Error::last_os_error().raw_os_error() {
+                Some(libc::EINTR) => continue,
+                Some(libc::EAGAIN) => return,
+                _ => {
+                    warn!("futex wait failed");
+                    return;
+                }
+            }
         }
     }
 }

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -497,11 +497,11 @@ pub(super) mod tests {
         drop(arm);
     }
 
-        #[test]
-        fn test_park_idle_wake_keeps_sequence_stable() {
-            // Verify `park_idle` sleeps on the idle path and out-of-band wakes do
-            // not perturb the logical submission sequence.
-            let waker = Waker::new().expect("eventfd creation should succeed");
+    #[test]
+    fn test_park_idle_wake_keeps_sequence_stable() {
+        // Verify `park_idle` sleeps on the idle path and out-of-band wakes do
+        // not perturb the logical submission sequence.
+        let waker = Waker::new().expect("eventfd creation should succeed");
         let before = submitted_seq(&waker);
         let notifier = waker.clone();
 

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -406,7 +406,6 @@ impl Waker {
         }
     }
 
-
     /// Sleep on the packed wake-state word for the fully-idle path.
     ///
     /// The caller must pass the exact post-arm snapshot from the same atomic

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -345,7 +345,14 @@ impl Waker {
     ///
     /// This uses multishot poll and is called on startup and whenever a wake
     /// CQE indicates the previous multishot request is no longer active.
-    pub fn reinstall(&self, submission_queue: &mut SubmissionQueue<'_>) {
+    ///
+    /// Returns `false` if the local SQ is already full and the rearm must be
+    /// retried in a later staging pass.
+    pub fn reinstall(&self, submission_queue: &mut SubmissionQueue<'_>) -> bool {
+        if submission_queue.is_full() {
+            return false;
+        }
+
         let wake_poll = PollAdd::new(Fd(self.inner.wake_fd.as_raw_fd()), libc::POLLIN as u32)
             .multi(true)
             .build()
@@ -355,8 +362,10 @@ impl Waker {
         unsafe {
             submission_queue
                 .push(&wake_poll)
-                .expect("wake poll SQE should always fit in the ring");
+                .expect("checked wake poll SQE capacity");
         }
+
+        true
     }
 
     /// Clear the current wait epoch after we resume running.
@@ -702,15 +711,28 @@ pub mod tests {
 
     #[test]
     fn test_reinstall_pushes_wake_poll() {
-        // Verify reinstall contributes exactly one multishot wake poll SQE.
+        // Verify reinstall enqueues one multishot wake poll SQE when space is
+        // available and reports failure without mutating the SQ when it is full.
         let waker = Waker::new().expect("eventfd creation should succeed");
         let mut ring = IoUring::new(8).expect("io_uring creation should succeed");
 
         // Reinstall should enqueue exactly one wake poll request.
         let mut sq = ring.submission();
         let before = sq.len();
-        waker.reinstall(&mut sq);
+        assert!(waker.reinstall(&mut sq));
         assert_eq!(sq.len(), before + 1);
+
+        while !sq.is_full() {
+            let nop = io_uring::opcode::Nop::new().build().user_data(0);
+            // SAFETY: Nop SQE owns no user pointers or external resources.
+            unsafe {
+                sq.push(&nop).expect("unable to fill submission queue");
+            }
+        }
+
+        let before = sq.len();
+        assert!(!waker.reinstall(&mut sq));
+        assert_eq!(sq.len(), before);
     }
 
     #[test]

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -299,8 +299,8 @@ impl Waker {
 
         let snapshot = prev | WAITING_ON_EVENTFD_BIT;
         let wake_latched = (snapshot & WAKE_SIGNALLED_BIT) != 0;
-        let still_idle = !wake_latched
-            && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq;
+        let still_idle =
+            !wake_latched && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq;
 
         ArmGuard {
             waker: self,

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -510,6 +510,12 @@ pub mod tests {
         }
     }
 
+    pub fn wait_until_eventfd_armed(waker: &Waker) {
+        while waker.inner.state.load(Ordering::Relaxed) & WAITING_ON_EVENTFD_BIT == 0 {
+            std::hint::spin_loop();
+        }
+    }
+
     fn state_bits(waker: &Waker) -> u32 {
         waker.inner.state.load(Ordering::Relaxed) & STATE_MASK
     }

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -33,7 +33,7 @@ use std::{
 use tracing::warn;
 
 /// Reserved `user_data` value for internal wake poll completions.
-pub(super) const WAKE_USER_DATA: UserData = UserData::MAX;
+pub const WAKE_USER_DATA: UserData = UserData::MAX;
 
 /// Number of low bits reserved for wake-state flags.
 const STATE_BITS: u32 = 3;
@@ -50,15 +50,15 @@ const WAITING_MASK: u32 = WAITING_ON_FUTEX_BIT | WAITING_ON_EVENTFD_BIT;
 /// Packed-state increment for one submitted operation (low bits are reserved).
 const SUBMISSION_INCREMENT: u32 = 1 << STATE_BITS;
 /// Sequence domain used by the packed submission counter (state >> 3).
-pub(super) const SUBMISSION_SEQ_MASK: u32 = u32::MAX >> STATE_BITS;
+pub const SUBMISSION_SEQ_MASK: u32 = u32::MAX >> STATE_BITS;
 /// Maximum bounded queue size that preserves alias-free sequence comparisons.
-pub(super) const MAX_SUBMISSION_SEQUENCE_DOMAIN: u32 = SUBMISSION_SEQ_MASK + 1;
+pub const MAX_SUBMISSION_SEQUENCE_DOMAIN: u32 = SUBMISSION_SEQ_MASK + 1;
 
-/// RAII guard covering a `submit_and_wait` blocking section.
+/// RAII guard returned by [`Waker::arm`] for a `submit_and_wait` blocking section.
 ///
 /// While this guard is live, the loop is armed to receive an eventfd-based
 /// wake if producers publish new work or the final handle disconnects.
-pub(super) struct ArmGuard<'a> {
+pub struct ArmGuard<'a> {
     waker: &'a Waker,
     should_block: bool,
 }
@@ -66,7 +66,7 @@ pub(super) struct ArmGuard<'a> {
 impl ArmGuard<'_> {
     /// Return whether the loop was still idle after arming the blocking wake
     /// path and therefore may safely enter `submit_and_wait`.
-    pub(super) const fn should_block(&self) -> bool {
+    pub const fn should_block(&self) -> bool {
         self.should_block
     }
 }
@@ -122,13 +122,13 @@ struct WakerInner {
 /// Keeping these concerns separate makes the wake protocol explicit and avoids
 /// coupling correctness to exact eventfd coalescing behavior.
 #[derive(Clone)]
-pub(super) struct Waker {
+pub struct Waker {
     inner: Arc<WakerInner>,
 }
 
 impl Waker {
     /// Create a non-blocking eventfd wake source.
-    pub(super) fn new() -> Result<Self, std::io::Error> {
+    pub fn new() -> Result<Self, std::io::Error> {
         // SAFETY: `eventfd` is called with valid flags and no aliasing pointers.
         let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK) };
         if fd < 0 {
@@ -211,7 +211,7 @@ impl Waker {
     /// The first caller to set `WAKE_SIGNALLED_BIT` in an epoch performs the
     /// wake. Subsequent callers do nothing until the loop disarms and clears
     /// the bit.
-    pub(super) fn wake(&self) {
+    pub fn wake(&self) {
         let prev = self
             .inner
             .state
@@ -244,7 +244,7 @@ impl Waker {
     /// armed and no wake has yet been claimed for that epoch, this caller
     /// claims `WAKE_SIGNALLED_BIT` with a follow-up atomic update and then
     /// signals the armed wait target.
-    pub(super) fn publish(&self) {
+    pub fn publish(&self) {
         let prev = self
             .inner
             .state
@@ -262,7 +262,7 @@ impl Waker {
 
     /// Return whether producers have published work the loop has not yet
     /// drained from the channel.
-    pub(super) fn pending(&self, processed_seq: u32) -> bool {
+    pub fn pending(&self, processed_seq: u32) -> bool {
         ((self.inner.state.load(Ordering::Relaxed) >> STATE_BITS) & SUBMISSION_SEQ_MASK)
             != processed_seq
     }
@@ -271,7 +271,7 @@ impl Waker {
     ///
     /// This method hides the arm-and-recheck futex sequence used when the ring
     /// is fully idle. It always clears the current wait state before returning.
-    pub(super) fn park_idle(&self, processed_seq: u32) {
+    pub fn park_idle(&self, processed_seq: u32) {
         // This transition only mutates the packed wake state. Tokio's channel
         // synchronizes message and close visibility independently.
         let prev = self
@@ -300,7 +300,7 @@ impl Waker {
     /// The returned guard automatically clears the current wait state on drop. Call
     /// [`ArmGuard::should_block`] to decide whether the loop was still idle
     /// after arming.
-    pub(super) fn arm(&self, processed_seq: u32) -> ArmGuard<'_> {
+    pub fn arm(&self, processed_seq: u32) -> ArmGuard<'_> {
         // This transition only mutates the packed wake state. Tokio's channel
         // synchronizes message and close visibility independently.
         let prev = self
@@ -376,7 +376,7 @@ impl Waker {
     ///
     /// Retries on `EINTR`. Treats `EAGAIN` as "nothing to drain". Without
     /// `EFD_SEMAPHORE`, one successful read drains the full counter to zero.
-    pub(super) fn acknowledge(&self) {
+    pub fn acknowledge(&self) {
         let mut value: u64 = 0;
         loop {
             // SAFETY: `wake_fd` is a valid eventfd descriptor and `value` points
@@ -415,7 +415,7 @@ impl Waker {
     ///
     /// This uses multishot poll and is called on startup and whenever a wake
     /// CQE indicates the previous multishot request is no longer active.
-    pub(super) fn reinstall(&self, submission_queue: &mut SubmissionQueue<'_>) {
+    pub fn reinstall(&self, submission_queue: &mut SubmissionQueue<'_>) {
         let wake_poll = PollAdd::new(Fd(self.inner.wake_fd.as_raw_fd()), libc::POLLIN as u32)
             .multi(true)
             .build()
@@ -431,7 +431,7 @@ impl Waker {
 }
 
 #[cfg(test)]
-pub(super) mod tests {
+pub mod tests {
     use super::*;
     use io_uring::IoUring;
     use std::{
@@ -439,7 +439,7 @@ pub(super) mod tests {
         os::fd::{AsRawFd, FromRawFd},
     };
 
-    pub(crate) fn wait_until_futex_armed(waker: &Waker) {
+    pub fn wait_until_futex_armed(waker: &Waker) {
         while waker.inner.state.load(Ordering::Relaxed) & WAITING_ON_FUTEX_BIT == 0 {
             std::hint::spin_loop();
         }

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -49,10 +49,10 @@ const STATE_MASK: u32 = WAITING_ON_FUTEX_BIT | WAITING_ON_EVENTFD_BIT | WAKE_SIG
 const WAITING_MASK: u32 = WAITING_ON_FUTEX_BIT | WAITING_ON_EVENTFD_BIT;
 /// Packed-state increment for one submitted operation (low bits are reserved).
 const SUBMISSION_INCREMENT: u32 = 1 << STATE_BITS;
-/// Sequence domain used by the packed submission counter (state >> 3).
+/// Full sequence domain used by the packed submission counter (state >> 3).
 pub const SUBMISSION_SEQ_MASK: u32 = u32::MAX >> STATE_BITS;
-/// Maximum bounded queue size that preserves alias-free sequence comparisons.
-pub const MAX_SUBMISSION_SEQUENCE_DOMAIN: u32 = SUBMISSION_SEQ_MASK + 1;
+/// Maximum live published-minus-processed gap that keeps modular order directional.
+pub const HALF_SUBMISSION_SEQUENCE_DOMAIN: u32 = SUBMISSION_SEQ_MASK.div_ceil(2);
 
 /// RAII guard returned by [`Waker::arm`] for a `submit_and_wait` blocking section.
 ///
@@ -85,12 +85,18 @@ impl Drop for ArmGuard<'_> {
 ///
 /// Submitters always increment `submitted_seq` after enqueueing onto the MPSC. The
 /// loop tracks how many submissions it has drained from the MPSC (`processed_seq`,
-/// stored in loop-local state). The loop may block only when:
-/// - a wait target is armed, and
-/// - `submitted_seq == processed_seq`.
+/// stored in loop-local state). After arming a wait target, the loop blocks only
+/// if the same post-arm snapshot still shows no latched wake and still carries
+/// the exact `submitted_seq == processed_seq` snapshot the loop armed against.
+///
+/// The loop bounds the rounded channel/ring size strictly below half the packed
+/// sequence domain. That makes the modular delta `submitted_seq - processed_seq`
+/// directional: any non-zero delta smaller than half the domain means
+/// `submitted_seq` is ahead, while larger deltas mean the visible submission
+/// sequence is lagging behind requests the loop has already drained.
 ///
 /// Blocking follows an arm-and-recheck protocol:
-/// - The loop first verifies `submitted_seq == processed_seq`, then arms a wait target.
+/// - The loop first checks for a published-ahead delta, then arms a wait target.
 /// - The loop blocks only if the post-arm snapshot still looks idle after that
 ///   same atomic state transition.
 /// - Submitters signal the currently armed wait target exactly once.
@@ -195,16 +201,14 @@ impl Waker {
     /// signals the armed wait target.
     #[inline]
     pub fn publish(&self) {
-        // The sequence is only a sticky "do not sleep yet" hint. The loop may
-        // observe this increment before Tokio makes the corresponding enqueue
-        // visible to `try_recv`. That can cause a transient extra iteration,
-        // but the mismatched sequence still prevents sleep until the channel
-        // drain catches up. Since this counter does not publish request memory,
-        // `Relaxed` is sufficient here.
+        // Use `Release` so that when `pending()` later observes a published-ahead
+        // sequence delta with its `Acquire` load, a following
+        // `self.receiver.try_recv()` in `fill_submission_queue()` must observe
+        // the corresponding request.
         let prev = self
             .inner
             .state
-            .fetch_add(SUBMISSION_INCREMENT, Ordering::Relaxed);
+            .fetch_add(SUBMISSION_INCREMENT, Ordering::Release);
 
         let waiting = prev & WAITING_MASK;
 
@@ -217,15 +221,20 @@ impl Waker {
         self.wake();
     }
 
-    /// Return whether producers have published work the loop has not yet
-    /// drained from the channel.
+    /// Return whether any published submissions are still pending relative to
+    /// `processed_seq`, i.e. whether the published sequence is currently ahead
+    /// of that drained sequence.
     #[inline]
     pub fn pending(&self, processed_seq: u32) -> bool {
-        // A visible mismatch only means "do not sleep yet", it does not mean a
-        // following `try_recv` must succeed immediately. This comparison is
-        // only against the packed sequence domain, so `Relaxed` is sufficient.
-        ((self.inner.state.load(Ordering::Relaxed) >> STATE_BITS) & SUBMISSION_SEQ_MASK)
-            != processed_seq
+        // Pair this `Acquire` with `publish()`'s `Release`. The rounded ring
+        // size is kept strictly below half the packed sequence domain, so a
+        // non-zero modular delta smaller than that half-range unambiguously
+        // means `published_seq` is ahead of `processed_seq`.
+        let published_seq =
+            (self.inner.state.load(Ordering::Acquire) >> STATE_BITS) & SUBMISSION_SEQ_MASK;
+
+        let delta = published_seq.wrapping_sub(processed_seq) & SUBMISSION_SEQ_MASK;
+        delta != 0 && delta < HALF_SUBMISSION_SEQUENCE_DOMAIN
     }
 
     /// Park on the idle path until the packed wake state changes.
@@ -545,6 +554,27 @@ pub mod tests {
         let arm = waker.arm(2);
         assert!(arm.should_block());
         drop(arm);
+    }
+
+    #[test]
+    fn test_pending_uses_directional_half_range_compare() {
+        let waker = Waker::new().expect("eventfd creation should succeed");
+
+        waker.inner.state.store(1 << STATE_BITS, Ordering::Relaxed);
+        assert!(waker.pending(0));
+        assert!(!waker.pending(1));
+
+        waker.inner.state.store(0, Ordering::Relaxed);
+        assert!(!waker.pending(1));
+
+        waker.inner.state.store(
+            HALF_SUBMISSION_SEQUENCE_DOMAIN << STATE_BITS,
+            Ordering::Relaxed,
+        );
+        assert!(!waker.pending(0));
+
+        waker.inner.state.store(0, Ordering::Relaxed);
+        assert!(waker.pending(SUBMISSION_SEQ_MASK));
     }
 
     #[test]

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -1,17 +1,23 @@
-//! Eventfd-backed wake coordination for the io_uring loop.
+//! Hybrid futex/eventfd wake coordination for the io_uring loop.
 //!
 //! This module implements the producer-to-loop wake protocol used by [`super::IoUringLoop`]:
 //! - Producers call [`Waker::publish`] after enqueueing work.
-//! - The loop arms sleep intent with [`Waker::arm`] before blocking.
-//! - Producers ring `eventfd` only when sleep intent is armed.
+//! - The loop calls [`Waker::park_idle`] when it is fully idle.
+//! - The loop acquires a [`BlockGuard`] from [`Waker::arm`] before
+//!   blocking in `submit_and_wait`.
+//! - Producers wake only the currently armed wait target.
+//! - A dedicated "wake signalled" bit coalesces repeated wake attempts.
 //! - Wake CQEs are acknowledged with [`Waker::acknowledge`].
 //!
 //! The packed atomic state combines:
-//! - bit 0: sleep intent flag
-//! - bits 1..: submitted sequence
+//! - bit 0: waiting on futex
+//! - bit 1: waiting on eventfd
+//! - bit 2: wake already signalled
+//! - bits 3..: submitted sequence
 //!
-//! This keeps the arm-and-recheck handshake lock-free while avoiding redundant `eventfd`
-//! writes during normal running.
+//! This keeps the arm-and-recheck handshake lock-free, enables futex sleep when
+//! the loop is truly idle, and avoids repeated wake writes while a wake is
+//! already pending.
 
 use super::UserData;
 use io_uring::{opcode::PollAdd, squeue::SubmissionQueue, types::Fd};
@@ -19,70 +25,107 @@ use std::{
     mem::size_of,
     os::fd::{AsRawFd, FromRawFd, OwnedFd},
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU32, Ordering},
         Arc,
     },
 };
 use tracing::warn;
 
 /// Reserved `user_data` value for internal wake poll completions.
-pub const WAKE_USER_DATA: UserData = UserData::MAX;
+pub(super) const WAKE_USER_DATA: UserData = UserData::MAX;
 
-/// Bit used to mark that the loop is armed for sleep.
-const SLEEP_INTENT_BIT: u64 = 1;
-/// Packed-state increment for one submitted operation (bit 0 is reserved).
-const SUBMISSION_INCREMENT: u64 = 2;
-/// Sequence domain used by the packed submission counter (state >> 1).
-pub const SUBMISSION_SEQ_MASK: u64 = u64::MAX >> 1;
+/// Number of low bits reserved for wake-state flags.
+const STATE_BITS: u32 = 3;
+/// Bit used when the loop is sleeping on a futex.
+const WAITING_ON_FUTEX_BIT: u32 = 1;
+/// Bit used when the loop is blocked in `submit_and_wait` and wakeable via eventfd.
+const WAITING_ON_EVENTFD_BIT: u32 = 1 << 1;
+/// Bit used once a wake has already been signalled for the current wait.
+const WAKE_SIGNALLED_BIT: u32 = 1 << 2;
+/// Mask covering all non-sequence wake-state flags.
+const STATE_MASK: u32 = WAITING_ON_FUTEX_BIT | WAITING_ON_EVENTFD_BIT | WAKE_SIGNALLED_BIT;
+/// Mask covering just the current wait target bits.
+const WAITING_MASK: u32 = WAITING_ON_FUTEX_BIT | WAITING_ON_EVENTFD_BIT;
+/// Packed-state increment for one submitted operation (low bits are reserved).
+const SUBMISSION_INCREMENT: u32 = 1 << STATE_BITS;
+/// Sequence domain used by the packed submission counter (state >> 3).
+pub(super) const SUBMISSION_SEQ_MASK: u32 = u32::MAX >> STATE_BITS;
+
+/// RAII guard covering a `submit_and_wait` blocking section.
+///
+/// While this guard is live, the loop is armed to receive an eventfd-based
+/// wake if producers publish new work or the final handle disconnects.
+pub(super) struct BlockGuard<'a> {
+    waker: &'a Waker,
+    should_block: bool,
+}
+
+impl BlockGuard<'_> {
+    /// Return whether the loop was still idle after arming the blocking wake
+    /// path and therefore may safely enter `submit_and_wait`.
+    pub(super) const fn should_block(&self) -> bool {
+        self.should_block
+    }
+}
+
+impl Drop for BlockGuard<'_> {
+    fn drop(&mut self) {
+        self.waker.disarm();
+    }
+}
 
 /// Shared wake state used by submitters and the io_uring loop.
 ///
 /// `state` packs two values:
-/// - bit 0: sleep intent flag (`1` means the loop may block in `submit_and_wait`)
-/// - bits 1..: submitted sequence (`submitted_seq`)
+/// - bits 0..2: wait target and wake state
+/// - bits 3..: submitted sequence (`submitted_seq`)
 ///
 /// Submitters always increment `submitted_seq` after enqueueing onto the MPSC. The
 /// loop tracks how many submissions it has drained from the MPSC (`processed_seq`,
 /// stored in loop-local state). The loop may block only when:
-/// - sleep intent is armed, and
+/// - a wait target is armed, and
 /// - `submitted_seq == processed_seq`.
 ///
 /// Blocking follows an arm-and-recheck protocol:
-/// - The loop first verifies `submitted_seq == processed_seq`, then arms sleep intent.
-/// - `arm()` returns a submission-sequence snapshot from the same atomic state transition.
-/// - The loop blocks only if that post-arm snapshot still equals `processed_seq`.
-/// - Submitters ring `eventfd` only when they observe sleep intent armed.
+/// - The loop first verifies `submitted_seq == processed_seq`, then arms a wait target.
+/// - `blocking_snapshot()` returns the post-arm snapshot only when blocking still
+///   looks safe after that same atomic state transition.
+/// - Submitters signal the currently armed wait target exactly once.
+/// - Out-of-band notifications latch one wake even while unarmed, so the next
+///   arm-and-recheck cycle skips blocking once.
 ///
 /// This makes submissions racing with the sleep transition observable either by
-/// sequence mismatch in the loop or by an eventfd wakeup.
+/// sequence mismatch in the loop or by a futex/eventfd wakeup.
 struct WakerInner {
     wake_fd: OwnedFd,
-    state: AtomicU64,
+    state: AtomicU32,
 }
 
-/// Internal eventfd-backed wake source for the io_uring loop.
+/// Internal hybrid futex/eventfd wake source for the io_uring loop.
 ///
 /// - Publish submissions from producers via [`Waker::publish`]
-/// - Expose submitted sequence snapshots via [`Waker::submitted`]
-/// - Coordinate sleep intent transitions via [`Waker::arm`] and [`Waker::disarm`]
+/// - Wake without publishing via [`Waker::notify`]
+/// - Test whether published work is still pending via [`Waker::pending`]
+/// - Park in the fully-idle path via [`Waker::park_idle`]
+/// - Arm a `submit_and_wait` blocking section via [`Waker::arm`]
 /// - Drain `eventfd` readiness on wake CQEs via [`Waker::acknowledge`]
 /// - Re-arm the multishot poll request when needed via [`Waker::reinstall`]
 ///
 /// This type intentionally separates:
 /// - sequence publication (`state` high bits)
-/// - sleep gating (`state` bit 0)
+/// - wait gating (`state` low bits)
 /// - kernel readiness consumption (`eventfd` read path)
 ///
 /// Keeping these concerns separate makes the wake protocol explicit and avoids
 /// coupling correctness to exact eventfd coalescing behavior.
 #[derive(Clone)]
-pub struct Waker {
+pub(super) struct Waker {
     inner: Arc<WakerInner>,
 }
 
 impl Waker {
     /// Create a non-blocking eventfd wake source.
-    pub fn new() -> Result<Self, std::io::Error> {
+    pub(super) fn new() -> Result<Self, std::io::Error> {
         // SAFETY: `eventfd` is called with valid flags and no aliasing pointers.
         let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK) };
         if fd < 0 {
@@ -94,13 +137,13 @@ impl Waker {
         Ok(Self {
             inner: Arc::new(WakerInner {
                 wake_fd,
-                state: AtomicU64::new(0),
+                state: AtomicU32::new(0),
             }),
         })
     }
 
     /// Ring the eventfd doorbell.
-    pub fn ring(&self) {
+    fn ring(&self) {
         let value: u64 = 1;
         loop {
             // SAFETY: `wake_fd` is a valid eventfd descriptor and `value` points
@@ -134,71 +177,218 @@ impl Waker {
         }
     }
 
+    /// Wake one thread waiting on the idle path.
+    fn futex_wake(&self) {
+        loop {
+            // SAFETY: `state` is a valid aligned futex word for the duration of
+            // the syscall.
+            let ret = unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    self.inner.state.as_ptr(),
+                    libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG,
+                    1u32,
+                )
+            };
+            if ret >= 0 {
+                return;
+            }
+            match std::io::Error::last_os_error().raw_os_error() {
+                Some(libc::EINTR) => continue,
+                _ => {
+                    warn!("futex wake failed");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Atomically latch one pending wake and return the previous state.
+    ///
+    /// The first caller to set `WAKE_SIGNALLED_BIT` in an epoch receives the
+    /// full pre-update state. Subsequent callers observe `None` until the loop
+    /// disarms and clears the bit.
+    fn latch_signal(&self) -> Option<u32> {
+        self.inner
+            .state
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                ((current & WAKE_SIGNALLED_BIT) == 0).then_some(current | WAKE_SIGNALLED_BIT)
+            })
+            .ok()
+    }
+
+    /// Signal the currently armed wait target described by `waiting`.
+    fn signal_waiter(&self, waiting: u32) {
+        assert_ne!(
+            waiting, WAITING_MASK,
+            "iouring wake state cannot wait on futex and eventfd simultaneously"
+        );
+
+        match waiting {
+            0 => {}
+            WAITING_ON_FUTEX_BIT => self.futex_wake(),
+            WAITING_ON_EVENTFD_BIT => self.ring(),
+            _ => unreachable!("unexpected iouring wake target"),
+        }
+    }
+
     /// Publish one submitted operation and optionally ring `eventfd`.
     ///
     /// Callers must invoke this only after successfully enqueueing work into
     /// the MPSC channel. That ordering guarantees that when the loop observes
     /// an updated sequence, there is corresponding work to drain.
     ///
-    /// We ring `eventfd` only when sleep intent was armed in the previous
-    /// state. This ensures submissions that race with the sleep transition
-    /// are visible to the loop without requiring submitters to ring on every
-    /// enqueue.
-    pub fn publish(&self) {
+    /// The common unarmed path performs only one `fetch_add`. When a wait is
+    /// armed and no wake has yet been claimed for that epoch, this caller
+    /// claims `WAKE_SIGNALLED_BIT` with a follow-up atomic update and then
+    /// signals the armed wait target.
+    pub(super) fn publish(&self) {
         let prev = self
             .inner
             .state
-            .fetch_add(SUBMISSION_INCREMENT, Ordering::Release);
+            .fetch_add(SUBMISSION_INCREMENT, Ordering::Relaxed);
+        let waiting = prev & WAITING_MASK;
 
-        if (prev & SLEEP_INTENT_BIT) != 0 {
-            self.ring();
+        // Fast path: the loop is not waiting, or another publisher already
+        // claimed the wake for the current armed epoch.
+        if waiting == 0 || (prev & WAKE_SIGNALLED_BIT) != 0 {
+            return;
+        }
+
+        if let Some(prev) = self.latch_signal() {
+            self.signal_waiter(prev & WAITING_MASK);
+        }
+    }
+
+    /// Wake the loop without publishing a new submission.
+    ///
+    /// This is used for out-of-band notifications like producer disconnect.
+    ///
+    /// Unlike `publish()`, this also latches a pending wake while no wait
+    /// target is armed so the next arm-and-recheck cycle skips blocking once.
+    pub(super) fn notify(&self) {
+        if let Some(prev) = self.latch_signal() {
+            self.signal_waiter(prev & WAITING_MASK);
         }
     }
 
     /// Return the current submitted sequence.
     ///
-    /// The sequence domain is masked to 63 bits and compared against the
+    /// The sequence domain is masked to 29 bits and compared against the
     /// loop-local `processed_seq` in the same domain.
-    pub fn submitted(&self) -> u64 {
-        (self.inner.state.load(Ordering::Acquire) >> 1) & SUBMISSION_SEQ_MASK
+    fn submitted(&self) -> u32 {
+        (self.inner.state.load(Ordering::Relaxed) >> STATE_BITS) & SUBMISSION_SEQ_MASK
     }
 
-    /// Arm sleep intent before attempting to block.
-    ///
-    /// After this point, any successful submission that races with sleep will
-    /// observe sleep intent and ring eventfd.
-    ///
-    /// Returns the current submitted sequence snapshot from the same atomic
-    /// operation that arms sleep intent. If this differs from loop-local
-    /// `processed_seq`, the loop skips blocking and disarms immediately.
-    pub fn arm(&self) -> u64 {
-        let prev = self
-            .inner
-            .state
-            .fetch_or(SLEEP_INTENT_BIT, Ordering::Acquire);
-        (prev >> 1) & SUBMISSION_SEQ_MASK
+    /// Return whether producers have published work the loop has not yet
+    /// drained from the channel.
+    pub(super) fn pending(&self, processed_seq: u32) -> bool {
+        self.submitted() != processed_seq
     }
 
-    /// Disarm sleep intent after we resume running.
+    /// Park on the idle path until the packed wake state changes.
     ///
-    /// Keeping sleep intent clear while actively running avoids redundant
-    /// eventfd writes during bursts. This is done both after a real wake and
-    /// after a post-arm recheck decides not to block.
-    pub fn disarm(&self) {
-        self.inner
-            .state
-            .fetch_and(!SLEEP_INTENT_BIT, Ordering::Release);
+    /// This method hides the arm-and-recheck futex sequence used when the ring
+    /// is fully idle. It always disarms the wait bits before returning.
+    pub(super) fn park_idle(&self, processed_seq: u32) {
+        if let Some(snapshot) = self.blocking_snapshot(WAITING_ON_FUTEX_BIT, processed_seq) {
+            self.wait_futex(snapshot);
+        }
+        self.disarm();
+    }
+
+    /// Arm the blocking wake path used around `submit_and_wait`.
+    ///
+    /// The returned guard automatically disarms the wait bits on drop. Call
+    /// [`BlockGuard::should_block`] to decide whether the loop was still idle
+    /// after arming.
+    pub(super) fn arm(&self, processed_seq: u32) -> BlockGuard<'_> {
+        let should_block = self
+            .blocking_snapshot(WAITING_ON_EVENTFD_BIT, processed_seq)
+            .is_some();
+        BlockGuard {
+            waker: self,
+            should_block,
+        }
+    }
+
+    /// Set one wait target and return the post-update snapshot when it still
+    /// permits blocking.
+    fn blocking_snapshot(&self, wait_bit: u32, processed_seq: u32) -> Option<u32> {
+        // This transition only mutates the packed wake state. Tokio's channel
+        // synchronizes message and close visibility independently.
+        let prev = self.inner.state.fetch_or(wait_bit, Ordering::Relaxed);
+        assert_eq!(
+            prev & WAITING_MASK,
+            0,
+            "iouring wait target should be disarmed before re-arming"
+        );
+        let snapshot = prev | wait_bit;
+
+        // Only block if the post-arm snapshot still looks idle. When that is
+        // true, return the exact packed word so the idle path can futex-wait
+        // on the same state it just armed.
+        ((snapshot & WAKE_SIGNALLED_BIT) == 0
+            && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq)
+            .then_some(snapshot)
+    }
+
+    /// Sleep on the packed state word with futex until it changes.
+    ///
+    /// Retries on `EINTR`. Treats `EAGAIN` as "state already changed". The
+    /// caller must pass the exact armed snapshot.
+    fn wait_futex(&self, snapshot: u32) {
+        loop {
+            // This is only a same-word equality check before entering the
+            // syscall.
+            if self.inner.state.load(Ordering::Relaxed) != snapshot {
+                return;
+            }
+
+            // SAFETY: `state` is a valid aligned futex word for the duration of
+            // the syscall.
+            let ret = unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    self.inner.state.as_ptr(),
+                    libc::FUTEX_WAIT | libc::FUTEX_PRIVATE_FLAG,
+                    snapshot,
+                    std::ptr::null::<libc::timespec>(),
+                )
+            };
+            if ret == 0 {
+                return;
+            }
+            match std::io::Error::last_os_error().raw_os_error() {
+                Some(libc::EINTR) => continue,
+                Some(libc::EAGAIN) => return,
+                _ => {
+                    warn!("futex wait failed");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Disarm the current wait target after we resume running.
+    ///
+    /// Keeping wait bits clear while actively running avoids redundant futex
+    /// wakes and eventfd writes during bursts. This is done both after a real
+    /// wake and after a post-arm recheck decides not to block.
+    #[inline]
+    fn disarm(&self) {
+        self.inner.state.fetch_and(!STATE_MASK, Ordering::Relaxed);
     }
 
     /// Drain eventfd readiness acknowledged by a wake CQE.
     ///
-    /// This acknowledges kernel-visible wake readiness. Sleep gating is tracked
+    /// This acknowledges kernel-visible wake readiness. Wait gating is tracked
     /// separately in the packed `state` atomic and is managed by
-    /// [`Waker::arm`] / [`Waker::disarm`].
+    /// [`Waker::park_idle`] and [`Waker::arm`].
     ///
     /// Retries on `EINTR`. Treats `EAGAIN` as "nothing to drain". Without
     /// `EFD_SEMAPHORE`, one successful read drains the full counter to zero.
-    pub fn acknowledge(&self) {
+    pub(super) fn acknowledge(&self) {
         let mut value: u64 = 0;
         loop {
             // SAFETY: `wake_fd` is a valid eventfd descriptor and `value` points
@@ -237,7 +427,7 @@ impl Waker {
     ///
     /// This uses multishot poll and is called on startup and whenever a wake
     /// CQE indicates the previous multishot request is no longer active.
-    pub fn reinstall(&self, submission_queue: &mut SubmissionQueue<'_>) {
+    pub(super) fn reinstall(&self, submission_queue: &mut SubmissionQueue<'_>) {
         let wake_poll = PollAdd::new(Fd(self.inner.wake_fd.as_raw_fd()), libc::POLLIN as u32)
             .multi(true)
             .build()
@@ -253,38 +443,150 @@ impl Waker {
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     use super::*;
     use io_uring::IoUring;
-    use std::os::fd::FromRawFd;
+    use std::{
+        mem::size_of,
+        os::fd::{AsRawFd, FromRawFd},
+    };
+
+    pub(crate) fn wait_until_futex_armed(waker: &Waker) {
+        while waker.inner.state.load(Ordering::Relaxed) & WAITING_ON_FUTEX_BIT == 0 {
+            std::hint::spin_loop();
+        }
+    }
+
+    fn read_eventfd_count(waker: &Waker) -> u64 {
+        let mut value = 0u64;
+        // SAFETY: `wake_fd` is a valid eventfd descriptor and `value` points
+        // to writable 8-byte storage for the duration of the call.
+        let ret = unsafe {
+            libc::read(
+                waker.inner.wake_fd.as_raw_fd(),
+                &mut value as *mut u64 as *mut libc::c_void,
+                size_of::<u64>(),
+            )
+        };
+        assert_eq!(ret, size_of::<u64>() as isize);
+        value
+    }
 
     #[test]
-    fn test_publish_arm_disarm_and_submitted() {
+    fn test_publish_arm_guard_and_submitted() {
         // Verify the packed wake state tracks submission sequence separately
-        // from sleep intent across the normal publish and acknowledge flow.
+        // from the blocking wake state across the normal publish and
+        // acknowledge flow.
         let waker = Waker::new().expect("eventfd creation should succeed");
         assert_eq!(waker.submitted(), 0);
 
-        // Publish without sleep intent only advances sequence.
+        // Publish without an armed wait target only advances sequence.
         waker.publish();
         assert_eq!(waker.submitted(), 1);
 
         // Arm and publish should trigger a ring; acknowledge drains it.
-        let snapshot = waker.arm();
-        assert_eq!(snapshot, 1);
+        let arm = waker.arm(1);
+        assert!(arm.should_block());
         waker.publish();
         assert_eq!(waker.submitted(), 2);
 
-        // Acknowledge/disarm are wake-gating operations and must not change
+        // Acknowledge and guard drop are wake-gating operations and must not change
         // the submitted sequence domain.
         waker.acknowledge();
         assert_eq!(waker.submitted(), 2);
-        waker.disarm();
+        drop(arm);
         assert_eq!(waker.submitted(), 2);
+        assert_eq!(
+            waker.inner.state.load(std::sync::atomic::Ordering::Acquire) & STATE_MASK,
+            0
+        );
 
         // Re-arming should observe the same submitted snapshot while idle.
-        assert_eq!(waker.arm(), 2);
-        waker.disarm();
+        let arm = waker.arm(2);
+        assert!(arm.should_block());
+        drop(arm);
+    }
+
+    #[test]
+    fn test_park_idle_notify_keeps_sequence_stable() {
+        // Verify `park_idle` sleeps on the idle path and out-of-band wakes do
+        // not perturb the logical submission sequence.
+        let waker = Waker::new().expect("eventfd creation should succeed");
+        let before = waker.submitted();
+        let notifier = waker.clone();
+
+        let handle = std::thread::spawn(move || {
+            while notifier
+                .inner
+                .state
+                .load(std::sync::atomic::Ordering::Acquire)
+                & WAITING_ON_FUTEX_BIT
+                == 0
+            {
+                std::hint::spin_loop();
+            }
+            notifier.notify();
+        });
+
+        waker.park_idle(before);
+        handle.join().expect("idle notifier thread panicked");
+        assert_eq!(waker.submitted(), before);
+    }
+
+    #[test]
+    fn test_notify_without_idle_wait_keeps_sequence_stable() {
+        // Verify out-of-band notifications without an idle wait do not perturb
+        // submission sequence.
+        let waker = Waker::new().expect("eventfd creation should succeed");
+        let before = waker.submitted();
+        waker.notify();
+        assert_eq!(waker.submitted(), before);
+    }
+
+    #[test]
+    fn test_notify_before_park_idle_skips_sleep() {
+        // Verify an out-of-band wake latched before idle arming makes the next
+        // idle park return immediately instead of sleeping.
+        let waker = Waker::new().expect("eventfd creation should succeed");
+        let before = waker.submitted();
+
+        waker.notify();
+        waker.park_idle(before);
+
+        assert_eq!(waker.submitted(), before);
+        assert_eq!(waker.inner.state.load(Ordering::Relaxed) & STATE_MASK, 0);
+    }
+
+    #[test]
+    fn test_publish_deduplicates_eventfd_wakes() {
+        // Verify repeated publishes while the same eventfd wait is armed only
+        // queue one wake write, while still advancing the sequence each time.
+        let waker = Waker::new().expect("eventfd creation should succeed");
+
+        let arm = waker.arm(0);
+        assert!(arm.should_block());
+        waker.publish();
+        waker.publish();
+
+        assert_eq!(waker.submitted(), 2);
+        assert_eq!(read_eventfd_count(&waker), 1);
+        drop(arm);
+    }
+
+    #[test]
+    fn test_notify_deduplicates_eventfd_wakes() {
+        // Verify repeated out-of-band notifications while the same eventfd
+        // wait is armed only queue one wake write and do not perturb sequence.
+        let waker = Waker::new().expect("eventfd creation should succeed");
+
+        let arm = waker.arm(0);
+        assert!(arm.should_block());
+        waker.notify();
+        waker.notify();
+
+        assert_eq!(waker.submitted(), 0);
+        assert_eq!(read_eventfd_count(&waker), 1);
+        drop(arm);
     }
 
     #[test]
@@ -300,9 +602,8 @@ mod tests {
         waker.acknowledge();
         // Second acknowledge should take the non-blocking empty path.
         waker.acknowledge();
-        let after = waker.submitted();
 
-        assert_eq!(after, before);
+        assert_eq!(waker.submitted(), before);
     }
 
     #[test]

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -567,21 +567,29 @@ pub mod tests {
 
     #[test]
     fn test_pending_uses_directional_half_range_compare() {
+        // Verify `pending()` only reports work when the published sequence is
+        // directionally ahead within the half-range window.
         let waker = Waker::new().expect("eventfd creation should succeed");
 
+        // A one-step published-ahead delta is pending for `processed_seq = 0`,
+        // but not once the loop has caught up.
         waker.inner.state.store(1 << STATE_BITS, Ordering::Relaxed);
         assert!(waker.pending(0));
         assert!(!waker.pending(1));
 
+        // A visible published sequence that lags behind `processed_seq` must
+        // not be treated as pending work.
         waker.inner.state.store(0, Ordering::Relaxed);
         assert!(!waker.pending(1));
 
+        // Exactly half the domain is ambiguous and therefore not directional.
         waker.inner.state.store(
             HALF_SUBMISSION_SEQUENCE_DOMAIN << STATE_BITS,
             Ordering::Relaxed,
         );
         assert!(!waker.pending(0));
 
+        // Wrapping by one still counts as a published-ahead delta.
         waker.inner.state.store(0, Ordering::Relaxed);
         assert!(waker.pending(SUBMISSION_SEQ_MASK));
     }
@@ -711,17 +719,21 @@ pub mod tests {
 
     #[test]
     fn test_reinstall_pushes_wake_poll() {
-        // Verify reinstall enqueues one multishot wake poll SQE when space is
-        // available and reports failure without mutating the SQ when it is full.
+        // Verify `reinstall()` queues one multishot wake poll SQE when space
+        // is available and reports failure without mutating the SQ when it is
+        // full.
         let waker = Waker::new().expect("eventfd creation should succeed");
         let mut ring = IoUring::new(8).expect("io_uring creation should succeed");
 
-        // Reinstall should enqueue exactly one wake poll request.
+        // With SQ space available, `reinstall()` should enqueue exactly one
+        // wake poll request.
         let mut sq = ring.submission();
         let before = sq.len();
         assert!(waker.reinstall(&mut sq));
         assert_eq!(sq.len(), before + 1);
 
+        // Once the SQ is full, `reinstall()` must leave it unchanged and ask
+        // the caller to retry later.
         while !sq.is_full() {
             let nop = io_uring::opcode::Nop::new().build().user_data(0);
             // SAFETY: Nop SQE owns no user pointers or external resources.


### PR DESCRIPTION
This PR reduces io_uring wake overhead by splitting the loop's sleep behavior into two paths. When the ring is fully idle, the loop now parks in userspace on a futex-backed state word instead of going through `io_uring_enter`, when there are active waiters and the loop may block in `submit_and_wait`, it continues to use the existing eventfd wake path. The wake state is packed into a single atomic word that carries the current wait target, a latched wake bit, and the published submission sequence.

The packed state keeps the arm-and-recheck protocol coherent while also coalescing repeated wake attempts. Producers increment the submission sequence on successful enqueue and only the first wake in a given armed epoch performs the actual futex wake or eventfd write, later wake attempts observe the latched bit and return. Out-of-band wakeups, including final-handle drop during shutdown, now latch a sticky wake even if no wait target is currently armed, so the next idle/blocking arm will skip sleeping instead of missing shutdown.

The Waker API is also simplified around loop semantics rather than wake mechanisms. The loop now uses `pending(processed_seq)`, `park_idle(processed_seq)`, and `arm(processed_seq) -> ArmGuard`, which hides the old futex/eventfd-specific arming details and makes the wait lifetime explicit through RAII.

All atomic operations on the packed wake state are now `Relaxed`. That is sufficient because the waker word is only a control-state machine for wait intent, wake deduplication, and the submission sequence, it does not publish request payload memory or channel-close visibility. Those memory-ordering guarantees remain the responsibility of tokio's MPSC and the surrounding request/channel machinery. Correctness here depends only on atomicity and per-location modification order of the single packed state word, plus the existing arm-and-recheck protocol that uses snapshots from that same atomic.