### PR TITLE
[storage/qmdb/sync] bind fetches to target size and wait for boundary state 

### DIFF
--- a/storage/src/merkle/journaled.rs
+++ b/storage/src/merkle/journaled.rs
@@ -245,19 +245,11 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Journaled<F, E, D> {
 
     /// Read-only peek at the persisted structure's root and boundaries.
     ///
-    /// Opens the journal and metadata partitions, reconstructs the in-memory MMR
-    /// from persisted pinned nodes, and returns the root without performing any
-    /// of the mutations that [`Self::init_sync`] or [`Self::init`] would apply
-    /// (no `metadata.sync`, no `journal.prune`, no `journal.clear_to_size`).
-    ///
     /// Returns `Ok(None)` when:
     /// - The journal is empty.
     /// - Journal size is structurally invalid and would require a rewind (i.e.
     ///   a crash left the structure in an unrecoverable state for a read-only
     ///   probe).
-    ///
-    /// Intended for callers that need to verify "does persisted state match a
-    /// target" without paying the cost of a full database rebuild.
     pub async fn peek_root(
         context: E,
         cfg: Config,

--- a/storage/src/merkle/journaled.rs
+++ b/storage/src/merkle/journaled.rs
@@ -243,6 +243,94 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Journaled<F, E, D> {
         Ok(())
     }
 
+    /// Read-only peek at the persisted structure's root and boundaries.
+    ///
+    /// Opens the journal and metadata partitions, reconstructs the in-memory MMR
+    /// from persisted pinned nodes, and returns the root without performing any
+    /// of the mutations that [`Self::init_sync`] or [`Self::init`] would apply
+    /// (no `metadata.sync`, no `journal.prune`, no `journal.clear_to_size`).
+    ///
+    /// Returns `Ok(None)` when:
+    /// - The journal is empty.
+    /// - Journal size is structurally invalid and would require a rewind (i.e.
+    ///   a crash left the structure in an unrecoverable state for a read-only
+    ///   probe).
+    ///
+    /// Intended for callers that need to verify "does persisted state match a
+    /// target" without paying the cost of a full database rebuild.
+    pub async fn peek_root(
+        context: E,
+        cfg: Config,
+        hasher: &impl Hasher<F, Digest = D>,
+    ) -> Result<Option<(Location<F>, Location<F>, D)>, Error<F>> {
+        let journal_cfg = JConfig {
+            partition: cfg.journal_partition,
+            items_per_blob: cfg.items_per_blob,
+            write_buffer: cfg.write_buffer,
+            page_cache: cfg.page_cache,
+        };
+        let journal: Journal<E, D> =
+            Journal::init(context.with_label("merkle_journal_peek"), journal_cfg).await?;
+        let journal_size = Position::<F>::new(journal.size().await);
+
+        if journal_size == 0 {
+            return Ok(None);
+        }
+
+        // Bail if the journal would require a rewind to reach a valid size.
+        // Probe is read-only; the caller will handle recovery via `init`.
+        let last_valid_size = F::to_nearest_size(journal_size);
+        if last_valid_size != journal_size {
+            return Ok(None);
+        }
+
+        let metadata_cfg = MConfig {
+            partition: cfg.metadata_partition,
+            codec_config: ((0..).into(), ()),
+        };
+        let metadata = Metadata::<_, U64, Vec<u8>>::init(
+            context.with_label("merkle_metadata_peek"),
+            metadata_cfg,
+        )
+        .await?;
+
+        let prune_loc = metadata
+            .get(&U64::new(PRUNED_TO_PREFIX, 0))
+            .map(|bytes| -> Result<Location<F>, Error<F>> {
+                let raw: [u8; 8] = bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| Error::DataCorrupted("metadata pruned_to is not 8 bytes"))?;
+                Ok(Location::<F>::new(u64::from_be_bytes(raw)))
+            })
+            .transpose()?
+            .unwrap_or_else(|| Location::<F>::new(0));
+        let prune_pos = Position::try_from(prune_loc)?;
+
+        let journal_leaves = Location::try_from(journal_size)?;
+        let nodes_to_pin_mem = F::nodes_to_pin(journal_leaves);
+        let mut mem_pinned_nodes = Vec::new();
+        for pos in nodes_to_pin_mem {
+            let digest = Self::get_from_metadata_or_journal(&metadata, &journal, pos).await?;
+            mem_pinned_nodes.push(digest);
+        }
+        let mut mem = Mem::init(
+            MemConfig {
+                nodes: vec![],
+                pruning_boundary: journal_leaves,
+                pinned_nodes: mem_pinned_nodes,
+            },
+            hasher,
+        )?;
+
+        if prune_pos < journal_size {
+            Self::add_extra_pinned_nodes(&mut mem, &metadata, &journal, prune_pos).await?;
+        }
+
+        let root = *mem.root();
+        Ok(Some((prune_loc, journal_leaves, root)))
+    }
+
     /// Initialize a new `Journaled` instance.
     pub async fn init(
         context: E,

--- a/storage/src/merkle/journaled.rs
+++ b/storage/src/merkle/journaled.rs
@@ -246,7 +246,6 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Journaled<F, E, D> {
     /// Read-only peek at the persisted structure's root and boundaries.
     ///
     /// Returns `Ok(None)` when:
-    /// - The journal is empty.
     /// - Journal size is structurally invalid and would require a rewind (i.e.
     ///   a crash left the structure in an unrecoverable state for a read-only
     ///   probe).
@@ -266,7 +265,8 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Journaled<F, E, D> {
         let journal_size = Position::<F>::new(journal.size().await);
 
         if journal_size == 0 {
-            return Ok(None);
+            let empty_root = *Mem::new(hasher).root();
+            return Ok(Some((Location::new(0), Location::new(0), empty_root)));
         }
 
         // Bail if the journal would require a rewind to reach a valid size.

--- a/storage/src/merkle/mmr/journaled.rs
+++ b/storage/src/merkle/mmr/journaled.rs
@@ -86,6 +86,20 @@ mod tests {
         });
     }
 
+    #[test]
+    fn test_journaled_mmr_peek_root_empty_journal() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let hasher: Standard<Sha256> = Standard::new();
+            let peek = Mmr::<_, Digest>::peek_root(context.clone(), test_config(&context), &hasher)
+                .await
+                .unwrap();
+
+            let empty_root = *mem::Mmr::new(&hasher).root();
+            assert_eq!(peek, Some((Location::new(0), Location::new(0), empty_root)));
+        });
+    }
+
     #[test_traced]
     fn test_journaled_mmr_pop() {
         let executor = deterministic::Runner::default();

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -47,6 +47,48 @@ use std::ops::Range;
 #[cfg(test)]
 pub(crate) mod tests;
 
+/// Returns whether persisted local state already matches the requested sync target.
+///
+/// Shared across [crate::qmdb::any] and [crate::qmdb::current] sync because both
+/// build on the same operations-MMR layout and share the same merkle partition.
+/// Uses a read-only MMR peek: the journal and metadata partitions are opened,
+/// the in-memory MMR is reconstructed from persisted pinned nodes, the root is
+/// computed, and handles are dropped. No disk mutations, no snapshot replay.
+///
+/// # Caller contract
+///
+/// `target.range.start()` **must** equal the committed inactivity floor of the
+/// target state (i.e. the floor carried by the last `CommitFloor` op). Only the
+/// persisted tree size and root are checked; the merkle pruning boundary is not.
+/// Callers that set `target.range.start()` below the committed floor (or that
+/// prune their own database past the committed floor) can cause a later
+/// [`qmdb::sync::Database::from_sync_result`] rebuild to fail with `MissingNode`
+/// even though this function returned `true`.
+pub async fn has_local_target_state<E, H>(
+    context: E,
+    merkle_config: journaled::Config,
+    target: &qmdb::sync::Target<H::Digest>,
+) -> bool
+where
+    E: Context,
+    H: Hasher,
+{
+    let hasher = StandardHasher::<H>::new();
+    let peek = journaled::Mmr::<_, H::Digest>::peek_root(
+        context.with_label("local_target_probe"),
+        merkle_config,
+        &hasher,
+    )
+    .await;
+    // Size + root match implies the last CommitFloor op (and therefore the
+    // committed inactivity floor) matches, per the caller contract above.
+    matches!(
+        peek,
+        Ok(Some((_, journal_leaves, root)))
+            if journal_leaves == target.range.end() && root == target.root
+    )
+}
+
 /// Shared helper to build a [Db] from sync components.
 async fn build_db<E, O, I, H, U, C, T>(
     context: E,
@@ -141,28 +183,12 @@ macro_rules! impl_sync_database {
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Digest>,
             ) -> bool {
-                // Read-only peek: compute the persisted ops MMR root without
-                // opening the full database or replaying the operations log.
-                // Avoids the O(N) snapshot rebuild and all disk mutations that
-                // `Self::init` would perform.
-                let hasher = StandardHasher::<H>::new();
-                let peek = journaled::Mmr::<_, H::Digest>::peek_root(
-                    context.with_label("local_target_probe"),
+                qmdb::any::sync::has_local_target_state::<_, H>(
+                    context,
                     config.merkle_config.clone(),
-                    &hasher,
+                    target,
                 )
-                .await;
-                // Size + root match implies the last CommitFloor op (and
-                // therefore the committed inactivity floor) matches. The
-                // persisted merkle pruning boundary is not checked directly;
-                // see the trait contract on [`Database::has_local_target_state`]
-                // for the `target.range.start()` == committed-inactivity-floor
-                // invariant that makes this safe.
-                matches!(
-                    peek,
-                    Ok(Some((_, journal_leaves, root)))
-                        if journal_leaves == target.range.end() && root == target.root
-                )
+                .await
             }
 
             fn root(&self) -> Self::Digest {

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -136,24 +136,21 @@ macro_rules! impl_sync_database {
                 .await
             }
 
-            fn has_local_target_state(
+            async fn has_local_target_state(
                 context: Self::Context,
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Digest>,
-            ) -> impl std::future::Future<Output = bool> + Send {
+            ) -> bool {
                 let config = config.clone();
                 let target = target.clone();
-
-                async move {
-                    let Ok(db) = Self::init(context, config).await else {
-                        return false;
-                    };
-                    let bounds = db.bounds().await;
-                    let lower_bound = db.inactivity_floor_loc();
-                    lower_bound == target.range.start()
-                        && bounds.end == target.range.end()
-                        && <Self as qmdb::sync::Database>::root(&db) == target.root
-                }
+                let Ok(db) = Self::init(context, config).await else {
+                    return false;
+                };
+                let bounds = db.bounds().await;
+                let lower_bound = db.inactivity_floor_loc();
+                lower_bound == target.range.start()
+                    && bounds.end == target.range.end()
+                    && <Self as qmdb::sync::Database>::root(&db) == target.root
             }
 
             fn root(&self) -> Self::Digest {

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -152,11 +152,12 @@ macro_rules! impl_sync_database {
                     &hasher,
                 )
                 .await;
-                // Only (journal_leaves, root) are checked. The merkle pruning
-                // boundary is blob-aligned and can lag behind the db's
-                // inactivity floor, but the MMR root is a cryptographic commitment
-                // to every leaf, so matching size + root implies matching last-op
-                // (and therefore matching inactivity floor).
+                // Size + root match implies the last CommitFloor op (and
+                // therefore the committed inactivity floor) matches. The
+                // persisted merkle pruning boundary is not checked directly;
+                // see the trait contract on [`Database::has_local_target_state`]
+                // for the `target.range.start()` == committed-inactivity-floor
+                // invariant that makes this safe.
                 matches!(
                     peek,
                     Ok(Some((_, journal_leaves, root)))

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -141,16 +141,27 @@ macro_rules! impl_sync_database {
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Digest>,
             ) -> bool {
-                let config = config.clone();
-                let target = target.clone();
-                let Ok(db) = Self::init(context, config).await else {
-                    return false;
-                };
-                let bounds = db.bounds().await;
-                let lower_bound = db.inactivity_floor_loc();
-                lower_bound == target.range.start()
-                    && bounds.end == target.range.end()
-                    && <Self as qmdb::sync::Database>::root(&db) == target.root
+                // Read-only peek: compute the persisted ops MMR root without
+                // opening the full database or replaying the operations log.
+                // Avoids the O(N) snapshot rebuild and all disk mutations that
+                // `Self::init` would perform.
+                let hasher = StandardHasher::<H>::new();
+                let peek = journaled::Mmr::<_, H::Digest>::peek_root(
+                    context.with_label("local_target_probe"),
+                    config.merkle_config.clone(),
+                    &hasher,
+                )
+                .await;
+                // Only (journal_leaves, root) are checked. The merkle pruning
+                // boundary is blob-aligned and can lag behind the db's
+                // inactivity floor, but the MMR root is a cryptographic commitment
+                // to every leaf, so matching size + root implies matching last-op
+                // (and therefore matching inactivity floor).
+                matches!(
+                    peek,
+                    Ok(Some((_, journal_leaves, root)))
+                        if journal_leaves == target.range.end() && root == target.root
+                )
             }
 
             fn root(&self) -> Self::Digest {

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -136,6 +136,26 @@ macro_rules! impl_sync_database {
                 .await
             }
 
+            fn has_local_target_state(
+                context: Self::Context,
+                config: &Self::Config,
+                target: &qmdb::sync::Target<Self::Digest>,
+            ) -> impl std::future::Future<Output = bool> + Send {
+                let config = config.clone();
+                let target = target.clone();
+
+                async move {
+                    let Ok(db) = Self::init(context, config).await else {
+                        return false;
+                    };
+                    let bounds = db.bounds().await;
+                    let lower_bound = db.inactivity_floor_loc();
+                    lower_bound == target.range.start()
+                        && bounds.end == target.range.end()
+                        && <Self as qmdb::sync::Database>::root(&db) == target.root
+                }
+            }
+
             fn root(&self) -> Self::Digest {
                 self.log.root()
             }

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -51,9 +51,6 @@ pub(crate) mod tests;
 ///
 /// Shared across [crate::qmdb::any] and [crate::qmdb::current] sync because both
 /// build on the same operations-MMR layout and share the same merkle partition.
-/// Uses a read-only MMR peek: the journal and metadata partitions are opened,
-/// the in-memory MMR is reconstructed from persisted pinned nodes, the root is
-/// computed, and handles are dropped. No disk mutations, no snapshot replay.
 ///
 /// # Caller contract
 ///

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -27,7 +27,7 @@ use commonware_runtime::{deterministic, BufferPooler, Clock, Metrics, Runner as 
 use commonware_utils::{
     channel::{mpsc, oneshot},
     non_empty_range,
-    sync::AsyncRwLock,
+    sync::{AsyncRwLock, Mutex},
     NZU64,
 };
 use futures::{pin_mut, FutureExt};
@@ -36,7 +36,7 @@ use std::{
     num::NonZeroU64,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc, Mutex,
+        Arc,
     },
     time::Duration,
 };
@@ -1708,7 +1708,7 @@ impl<R: Resolver<Digest = Digest>> Resolver for ReplayFreshBoundaryResolver<R> {
                     .await;
             }
 
-            let release = self.release_historical_gap.lock().unwrap().take();
+            let release = self.release_historical_gap.lock().take();
             if let Some(release) = release {
                 let _ = release.await;
             }
@@ -1731,7 +1731,7 @@ impl<R: Resolver<Digest = Digest>> Resolver for ReplayFreshBoundaryResolver<R> {
                 return Ok(result);
             }
 
-            let release = self.release_boundary_retry.lock().unwrap().take();
+            let release = self.release_boundary_retry.lock().take();
             if let Some(release) = release {
                 let _ = release.await;
             }

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -23,7 +23,7 @@ use crate::{
 use commonware_codec::Encode;
 use commonware_cryptography::sha256::Digest;
 use commonware_macros::select;
-use commonware_runtime::{deterministic, BufferPooler, Metrics, Runner as _};
+use commonware_runtime::{deterministic, BufferPooler, Clock, Metrics, Runner as _};
 use commonware_utils::{
     channel::{mpsc, oneshot},
     non_empty_range,
@@ -32,7 +32,14 @@ use commonware_utils::{
 };
 use futures::{pin_mut, FutureExt};
 use rand::RngCore as _;
-use std::{num::NonZeroU64, sync::Arc};
+use std::{
+    num::NonZeroU64,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
 
 /// Type alias for the database type of a harness.
 pub(crate) type DbOf<H> = <H as SyncTestHarness>::Db;
@@ -1661,6 +1668,224 @@ where
     });
 }
 
+/// A resolver wrapper that replays the first fresh boundary request against the retained
+/// historical root, then blocks the retry until the test releases it.
+#[derive(Clone)]
+struct ReplayFreshBoundaryResolver<R> {
+    inner: R,
+    historical_target_size: Location,
+    boundary_start: Location,
+    release_historical_gap: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
+    release_boundary_retry: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
+    boundary_attempts: Arc<AtomicUsize>,
+}
+
+impl<R: Resolver<Digest = Digest>> Resolver for ReplayFreshBoundaryResolver<R> {
+    type Digest = Digest;
+    type Op = R::Op;
+    type Error = R::Error;
+
+    async fn get_operations(
+        &self,
+        op_count: Location,
+        start_loc: Location,
+        max_ops: NonZeroU64,
+        include_pinned_nodes: bool,
+        cancel_rx: oneshot::Receiver<()>,
+    ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+        if op_count == self.historical_target_size {
+            if include_pinned_nodes {
+                let _ = cancel_rx.await;
+                return self
+                    .inner
+                    .get_operations(
+                        op_count,
+                        start_loc,
+                        max_ops,
+                        include_pinned_nodes,
+                        oneshot::channel().1,
+                    )
+                    .await;
+            }
+
+            let release = self.release_historical_gap.lock().unwrap().take();
+            if let Some(release) = release {
+                let _ = release.await;
+            }
+        }
+
+        if include_pinned_nodes && start_loc == self.boundary_start {
+            let attempt = self.boundary_attempts.fetch_add(1, Ordering::Relaxed);
+            if attempt == 0 {
+                let mut result = self
+                    .inner
+                    .get_operations(
+                        self.historical_target_size,
+                        start_loc,
+                        max_ops,
+                        false,
+                        oneshot::channel().1,
+                    )
+                    .await?;
+                result.pinned_nodes = None;
+                return Ok(result);
+            }
+
+            let release = self.release_boundary_retry.lock().unwrap().take();
+            if let Some(release) = release {
+                let _ = release.await;
+            }
+        }
+
+        self.inner
+            .get_operations(
+                op_count,
+                start_loc,
+                max_ops,
+                include_pinned_nodes,
+                cancel_rx,
+            )
+            .await
+    }
+}
+
+/// Test that reaching the journal target does not report completion while the pruned
+/// boundary retry is still outstanding.
+pub(crate) fn test_sync_waits_for_boundary_retry_after_target_update<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.with_label("target")).await;
+
+        let mut seed = 0;
+        loop {
+            target_db = H::apply_ops(target_db, H::create_ops_seeded(32, seed)).await;
+            target_db
+                .prune(target_db.inactivity_floor_loc().await)
+                .await
+                .unwrap();
+
+            if target_db.inactivity_floor_loc().await > Location::new(0) {
+                break;
+            }
+
+            seed += 1;
+            assert!(seed < 8, "expected prune floor to advance");
+        }
+
+        let old_target = Target {
+            root: H::sync_target_root(&target_db),
+            range: non_empty_range!(
+                target_db.inactivity_floor_loc().await,
+                target_db.bounds().await.end
+            ),
+        };
+
+        target_db = H::apply_ops(target_db, H::create_ops_seeded(3, seed + 1)).await;
+        let new_target = Target {
+            root: H::sync_target_root(&target_db),
+            range: non_empty_range!(
+                target_db.inactivity_floor_loc().await,
+                target_db.bounds().await.end
+            ),
+        };
+        let verification_root = target_db.root();
+
+        assert!(old_target.range.start() > Location::new(0));
+        assert!(new_target.range.end() > old_target.range.end());
+
+        let (release_historical_gap_tx, release_historical_gap_rx) = oneshot::channel();
+        let (release_boundary_retry_tx, release_boundary_retry_rx) = oneshot::channel();
+        let target_db = Arc::new(target_db);
+        let resolver = ReplayFreshBoundaryResolver {
+            inner: target_db.clone(),
+            historical_target_size: old_target.range.end(),
+            boundary_start: new_target.range.start(),
+            release_historical_gap: Arc::new(Mutex::new(Some(release_historical_gap_rx))),
+            release_boundary_retry: Arc::new(Mutex::new(Some(release_boundary_retry_rx))),
+            boundary_attempts: Arc::new(AtomicUsize::new(0)),
+        };
+
+        let (update_sender, update_receiver) = mpsc::channel(1);
+        let (finish_sender, finish_receiver) = mpsc::channel(1);
+        let (reached_sender, mut reached_receiver) = mpsc::channel(1);
+
+        let config = Config {
+            context: context.with_label("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(1),
+            target: old_target.clone(),
+            resolver,
+            apply_batch_size: 1024,
+            max_outstanding_requests: 2,
+            update_rx: Some(update_receiver),
+            finish_rx: Some(finish_receiver),
+            reached_target_tx: Some(reached_sender),
+            max_retained_roots: 1,
+        };
+
+        let mut engine: Engine<H::Db, _> = Engine::new(config).await.unwrap();
+
+        update_sender.send(new_target.clone()).await.unwrap();
+        finish_sender.send(()).await.unwrap();
+
+        engine = match engine.step().await.unwrap() {
+            NextStep::Continue(engine) => engine,
+            NextStep::Complete(_) => panic!("target update should not complete sync"),
+        };
+
+        let _ = release_historical_gap_tx.send(());
+
+        let journal_start = engine.journal().size().await;
+        for step_idx in 0..4 {
+            let next_step = engine.step();
+            pin_mut!(next_step);
+
+            select! {
+                result = next_step.as_mut() => {
+                    engine = match result.unwrap() {
+                        NextStep::Continue(engine) => engine,
+                        NextStep::Complete(_) => panic!("boundary retry should still be required"),
+                    };
+                    assert_eq!(
+                        engine.journal().size().await,
+                        journal_start,
+                        "replayed fresh boundary responses must not advance the journal"
+                    );
+                },
+                _ = context.sleep(Duration::from_millis(100)) => {
+                    panic!(
+                        "engine should keep processing fetch results while the boundary retry is blocked: step={step_idx}"
+                    );
+                },
+            }
+        }
+        assert!(
+            reached_receiver.recv().now_or_never().is_none(),
+            "engine should not report reached-target while boundary state is missing"
+        );
+
+        let _ = release_boundary_retry_tx.send(());
+
+        let synced_db = engine.sync().await.unwrap();
+
+        let reached = reached_receiver.recv().await.unwrap();
+        assert_eq!(reached, new_target);
+        assert_eq!(synced_db.root(), verification_root);
+
+        synced_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
 mod harnesses {
     use super::SyncTestHarness;
     use crate::{qmdb::any::value::VariableEncoding, translator::TwoCap};
@@ -2040,6 +2265,11 @@ macro_rules! sync_tests_for_harness {
             #[test_traced]
             fn test_sync_retries_bad_pinned_nodes() {
                 super::test_sync_retries_bad_pinned_nodes::<$harness>();
+            }
+
+            #[test_traced]
+            fn test_sync_waits_for_boundary_retry_after_target_update() {
+                super::test_sync_waits_for_boundary_retry_after_target_update::<$harness>();
             }
 
             #[test_traced("WARN")]

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -291,30 +291,12 @@ macro_rules! impl_current_sync_database {
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Digest>,
             ) -> bool {
-                // Read-only peek: compute the persisted ops MMR root without
-                // opening the full database or replaying the operations log.
-                // Avoids the O(N) snapshot rebuild and all disk mutations that
-                // `Self::init` would perform. The sync engine verifies against
-                // the ops root (not the canonical root), which is what
-                // `peek_root` returns.
-                let hasher = StandardHasher::<H>::new();
-                let peek = mmr::journaled::Mmr::<_, DigestOf<H>>::peek_root(
-                    context.with_label("local_target_probe"),
+                qmdb::any::sync::has_local_target_state::<_, H>(
+                    context,
                     config.merkle_config.clone(),
-                    &hasher,
+                    target,
                 )
-                .await;
-                // Size + root match implies the last CommitFloor op (and
-                // therefore the committed inactivity floor) matches. The
-                // persisted merkle pruning boundary is not checked directly;
-                // see the trait contract on [`Database::has_local_target_state`]
-                // for the `target.range.start()` == committed-inactivity-floor
-                // invariant that makes this safe.
-                matches!(
-                    peek,
-                    Ok(Some((_, journal_leaves, root)))
-                        if journal_leaves == target.range.end() && root == target.root
-                )
+                .await
             }
 
             /// Returns the ops root (not the canonical root), since the sync engine verifies

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -286,24 +286,21 @@ macro_rules! impl_current_sync_database {
                 .await
             }
 
-            fn has_local_target_state(
+            async fn has_local_target_state(
                 context: Self::Context,
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Digest>,
-            ) -> impl std::future::Future<Output = bool> + Send {
+            ) -> bool {
                 let config = config.clone();
                 let target = target.clone();
-
-                async move {
-                    let Ok(db) = Self::init(context, config).await else {
-                        return false;
-                    };
-                    let bounds = db.bounds().await;
-                    let lower_bound = db.inactivity_floor_loc();
-                    lower_bound == target.range.start()
-                        && bounds.end == target.range.end()
-                        && <Self as qmdb::sync::Database>::root(&db) == target.root
-                }
+                let Ok(db) = Self::init(context, config).await else {
+                    return false;
+                };
+                let bounds = db.bounds().await;
+                let lower_bound = db.inactivity_floor_loc();
+                lower_bound == target.range.start()
+                    && bounds.end == target.range.end()
+                    && <Self as qmdb::sync::Database>::root(&db) == target.root
             }
 
             /// Returns the ops root (not the canonical root), since the sync engine verifies

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -247,7 +247,7 @@ macro_rules! impl_current_sync_database {
         impl<E, K, V, H, T, const N: usize> Database for $db<Family, E, K, V, H, T, N>
         where
             E: Context,
-            K: $key_bound,
+            K: Array + $key_bound,
             V: $value_bound + 'static,
             H: Hasher,
             T: Translator,
@@ -284,6 +284,26 @@ macro_rules! impl_current_sync_database {
                     thread_pool,
                 )
                 .await
+            }
+
+            fn has_local_target_state(
+                context: Self::Context,
+                config: &Self::Config,
+                target: &qmdb::sync::Target<Self::Digest>,
+            ) -> impl std::future::Future<Output = bool> + Send {
+                let config = config.clone();
+                let target = target.clone();
+
+                async move {
+                    let Ok(db) = Self::init(context, config).await else {
+                        return false;
+                    };
+                    let bounds = db.bounds().await;
+                    let lower_bound = db.inactivity_floor_loc();
+                    lower_bound == target.range.start()
+                        && bounds.end == target.range.end()
+                        && <Self as qmdb::sync::Database>::root(&db) == target.root
+                }
             }
 
             /// Returns the ops root (not the canonical root), since the sync engine verifies

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -247,7 +247,7 @@ macro_rules! impl_current_sync_database {
         impl<E, K, V, H, T, const N: usize> Database for $db<Family, E, K, V, H, T, N>
         where
             E: Context,
-            K: Array + $key_bound,
+            K: $key_bound,
             V: $value_bound + 'static,
             H: Hasher,
             T: Translator,
@@ -291,16 +291,29 @@ macro_rules! impl_current_sync_database {
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Digest>,
             ) -> bool {
-                let config = config.clone();
-                let target = target.clone();
-                let Ok(db) = Self::init(context, config).await else {
-                    return false;
-                };
-                let bounds = db.bounds().await;
-                let lower_bound = db.inactivity_floor_loc();
-                lower_bound == target.range.start()
-                    && bounds.end == target.range.end()
-                    && <Self as qmdb::sync::Database>::root(&db) == target.root
+                // Read-only peek: compute the persisted ops MMR root without
+                // opening the full database or replaying the operations log.
+                // Avoids the O(N) snapshot rebuild and all disk mutations that
+                // `Self::init` would perform. The sync engine verifies against
+                // the ops root (not the canonical root), which is what
+                // `peek_root` returns.
+                let hasher = StandardHasher::<H>::new();
+                let peek = mmr::journaled::Mmr::<_, DigestOf<H>>::peek_root(
+                    context.with_label("local_target_probe"),
+                    config.merkle_config.clone(),
+                    &hasher,
+                )
+                .await;
+                // Only (journal_leaves, root) are checked. The merkle pruning
+                // boundary is blob-aligned and can lag behind the db's
+                // inactivity floor, but the MMR root is a cryptographic commitment
+                // to every leaf, so matching size + root implies matching last-op
+                // (and therefore matching inactivity floor).
+                matches!(
+                    peek,
+                    Ok(Some((_, journal_leaves, root)))
+                        if journal_leaves == target.range.end() && root == target.root
+                )
             }
 
             /// Returns the ops root (not the canonical root), since the sync engine verifies

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -304,11 +304,12 @@ macro_rules! impl_current_sync_database {
                     &hasher,
                 )
                 .await;
-                // Only (journal_leaves, root) are checked. The merkle pruning
-                // boundary is blob-aligned and can lag behind the db's
-                // inactivity floor, but the MMR root is a cryptographic commitment
-                // to every leaf, so matching size + root implies matching last-op
-                // (and therefore matching inactivity floor).
+                // Size + root match implies the last CommitFloor op (and
+                // therefore the committed inactivity floor) matches. The
+                // persisted merkle pruning boundary is not checked directly;
+                // see the trait contract on [`Database::has_local_target_state`]
+                // for the `target.range.start()` == committed-inactivity-floor
+                // invariant that makes this safe.
                 matches!(
                     peek,
                     Ok(Some((_, journal_leaves, root)))

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -55,6 +55,17 @@ pub trait Database: Sized + Send {
     /// Databases can override this to allow the sync engine to complete immediately
     /// when an on-disk database already matches the target and can be rebuilt without
     /// fetching fresh boundary pins.
+    ///
+    /// # Caller contract
+    ///
+    /// `target.range.start()` **must** equal the committed inactivity floor of
+    /// the target state (i.e. the floor carried by the last `CommitFloor` op).
+    /// Implementations are free to verify only that the persisted tree size and
+    /// root match and to skip checking the persisted merkle pruning boundary
+    /// directly. Callers that set `target.range.start()` below the committed
+    /// floor (or that prune their own database past the committed floor) can cause
+    /// a later [`Self::from_sync_result`] rebuild to fail with `MissingNode` even
+    /// though this function returned `true`.
     fn has_local_target_state(
         _context: Self::Context,
         _config: &Self::Config,

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -50,6 +50,19 @@ pub trait Database: Sized + Send {
         apply_batch_size: usize,
     ) -> impl Future<Output = Result<Self, crate::qmdb::Error<crate::merkle::mmr::Family>>> + Send;
 
+    /// Returns whether persisted local state already matches the requested sync target.
+    ///
+    /// Databases can override this to allow the sync engine to complete immediately
+    /// when an on-disk database already matches the target and can be rebuilt without
+    /// fetching fresh boundary pins.
+    fn has_local_target_state(
+        _context: Self::Context,
+        _config: &Self::Config,
+        _target: &crate::qmdb::sync::Target<Self::Digest>,
+    ) -> impl Future<Output = bool> + Send {
+        async { false }
+    }
+
     /// Get the root digest of the database for verification
     fn root(&self) -> Self::Digest;
 }

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -168,6 +168,10 @@ where
     /// Pinned MMR nodes extracted from proofs, used for database construction
     pinned_nodes: Option<Vec<DB::Digest>>,
 
+    /// Whether persisted local state already matches the current target and can be
+    /// rebuilt without fetching fresh boundary pins.
+    local_target_state_available: bool,
+
     /// Historical roots from previous sync targets, keyed by tree size
     /// (target.range.end()). Each tree size maps to a unique root because
     /// the MMR is append-only and validate_update rejects unchanged roots.
@@ -267,10 +271,22 @@ where
         )
         .await?;
 
+        let local_target_state_available = if config.target.range.start() > Location::new(0) {
+            DB::has_local_target_state(
+                config.context.with_label("local_target_probe"),
+                &config.db_config,
+                &config.target,
+            )
+            .await
+        } else {
+            false
+        };
+
         let mut engine = Self {
             outstanding_requests: Requests::new(),
             fetched_operations: BTreeMap::new(),
             pinned_nodes: None,
+            local_target_state_available,
             retained_roots: HashMap::new(),
             retained_roots_order: VecDeque::new(),
             max_retained_roots: config.max_retained_roots,
@@ -390,6 +406,7 @@ where
             .remove_before(new_target.range.start().checked_add(1).unwrap());
         self.fetched_operations.clear();
         self.pinned_nodes = None;
+        self.local_target_state_available = false;
 
         // Save the current root keyed by its tree size for verifying
         // retained requests that were issued against this target.
@@ -560,7 +577,9 @@ where
 
     /// Returns whether the current target has the boundary state needed for completion.
     fn has_boundary_state(&self) -> bool {
-        !self.needs_pinned_boundary() || self.pinned_nodes.is_some()
+        !self.needs_pinned_boundary()
+            || self.pinned_nodes.is_some()
+            || self.local_target_state_available
     }
 
     /// Returns whether the journal and boundary state are both ready for completion.

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -263,14 +263,11 @@ where
             }));
         }
 
-        // Create journal and verifier using the database's factory methods
-        let journal = <DB::Journal as Journal>::new(
-            config.context.with_label("journal"),
-            config.db_config.journal_config(),
-            config.target.range.clone().into(),
-        )
-        .await?;
-
+        // Probe for persisted local state matching the target before opening
+        // any engine-owned handles. `has_local_target_state` opens the full
+        // database to inspect bounds and root; running it before journal
+        // creation ensures its handles are dropped before the engine takes
+        // its own, avoiding concurrent access to the same on-disk partition.
         let local_target_state_available = if config.target.range.start() > Location::new(0) {
             DB::has_local_target_state(
                 config.context.with_label("local_target_probe"),
@@ -281,6 +278,14 @@ where
         } else {
             false
         };
+
+        // Create journal and verifier using the database's factory methods
+        let journal = <DB::Journal as Journal>::new(
+            config.context.with_label("journal"),
+            config.db_config.journal_config(),
+            config.target.range.clone().into(),
+        )
+        .await?;
 
         let mut engine = Self {
             outstanding_requests: Requests::new(),

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -319,8 +319,8 @@ where
         let target_size = self.target.range.end();
 
         // Schedule a pinned-nodes request at the lower sync bound if we don't
-        // have pinned nodes yet and one isn't already in flight.
-        if self.pinned_nodes.is_none()
+        // have boundary state yet and one isn't already in flight.
+        if !self.has_boundary_state()
             && !self
                 .outstanding_requests
                 .contains(&self.target.range.start())
@@ -634,8 +634,8 @@ where
         // Look up the root to verify against using the tree size the request
         // asked for. Fresh requests match the current target; retained
         // requests match a historical root that was explicitly retained.
-        let is_current = request.target_size == self.target.range.end();
-        let target_root = if is_current {
+        let is_current_target = request.target_size == self.target.range.end();
+        let target_root = if is_current_target {
             &self.target.root
         } else {
             let Some(root) = self.retained_roots.get(&request.target_size) else {
@@ -650,8 +650,9 @@ where
         // Verify the proof. Pinned nodes are only extracted from proofs
         // for the current root because the database needs them for the
         // latest tree size.
-        let need_pinned =
-            is_current && self.pinned_nodes.is_none() && start_loc == self.target.range.start();
+        let need_pinned = is_current_target
+            && self.pinned_nodes.is_none()
+            && start_loc == self.target.range.start();
         let valid = if need_pinned {
             let nodes = pinned_nodes.as_deref().unwrap_or(&[]);
             qmdb::verify_proof_and_pinned_nodes(

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -649,9 +649,15 @@ where
 
         // Verify the proof. Pinned nodes are only extracted from proofs
         // for the current root because the database needs them for the
-        // latest tree size.
+        // latest tree size. When local state already satisfies the boundary
+        // (pins are available in on-disk metadata), we must not demand
+        // pinned nodes from the proof: an empty pinned set would fail
+        // `verify_proof_and_pinned_nodes` against the expected
+        // `nodes_to_pin(range.start)` count, causing an infinite retry loop
+        // whenever a gap request happens to land at `range.start`.
         let need_pinned = is_current_target
             && self.pinned_nodes.is_none()
+            && !self.local_target_state_available
             && start_loc == self.target.range.start();
         let valid = if need_pinned {
             let nodes = pinned_nodes.as_deref().unwrap_or(&[]);

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -264,10 +264,7 @@ where
         }
 
         // Probe for persisted local state matching the target before opening
-        // any engine-owned handles. `has_local_target_state` opens the full
-        // database to inspect bounds and root; running it before journal
-        // creation ensures its handles are dropped before the engine takes
-        // its own, avoiding concurrent access to the same on-disk partition.
+        // any engine-owned handles.
         let local_target_state_available = if config.target.range.start() > Location::new(0) {
             DB::has_local_target_state(
                 config.context.with_label("local_target_probe"),

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -67,8 +67,6 @@ enum Event<Op, D: Digest, E> {
 pub(super) struct IndexedFetchResult<Op, D: Digest, E> {
     /// Unique ID assigned when the request was scheduled.
     pub id: RequestId,
-    /// The location of the first operation in the batch.
-    pub start_loc: Location,
     /// The result of the fetch operation.
     pub result: Result<FetchResult<Op, D>, E>,
 }
@@ -313,16 +311,13 @@ where
             self.outstanding_requests.insert(
                 id,
                 start_loc,
+                target_size,
                 cancel_tx,
                 Box::pin(async move {
                     let result = resolver
                         .get_operations(target_size, start_loc, NZU64!(1), true, cancel_rx)
                         .await;
-                    IndexedFetchResult {
-                        id,
-                        start_loc,
-                        result,
-                    }
+                    IndexedFetchResult { id, result }
                 }),
             );
         }
@@ -364,16 +359,13 @@ where
             self.outstanding_requests.insert(
                 id,
                 gap_range.start,
+                target_size,
                 cancel_tx,
                 Box::pin(async move {
                     let result = resolver
                         .get_operations(target_size, gap_range.start, batch_size, false, cancel_rx)
                         .await;
-                    IndexedFetchResult {
-                        id,
-                        start_loc: gap_range.start,
-                        result,
-                    }
+                    IndexedFetchResult { id, result }
                 }),
             );
         }
@@ -561,6 +553,21 @@ where
         Ok(false)
     }
 
+    /// Returns whether this target needs pinned boundary nodes to reconstruct pruned state.
+    fn needs_pinned_boundary(&self) -> bool {
+        self.target.range.start() > Location::new(0)
+    }
+
+    /// Returns whether the current target has the boundary state needed for completion.
+    fn has_boundary_state(&self) -> bool {
+        !self.needs_pinned_boundary() || self.pinned_nodes.is_some()
+    }
+
+    /// Returns whether the journal and boundary state are both ready for completion.
+    async fn is_ready_to_complete(&self) -> Result<bool, Error<DB, R>> {
+        Ok(self.is_at_target().await? && self.has_boundary_state())
+    }
+
     /// Handle the result of a fetch operation.
     ///
     /// Discards results for requests no longer tracked (removed by
@@ -574,11 +581,11 @@ where
         // Discard results for stale requests (removed by a target update).
         // Using the request ID prevents a stale future from consuming the
         // tracking entry of a fresh request at the same location.
-        if !self.outstanding_requests.remove(fetch_result.id) {
+        let Some(request) = self.outstanding_requests.remove(fetch_result.id) else {
             return Ok(());
-        }
+        };
 
-        let start_loc = fetch_result.start_loc;
+        let start_loc = request.start_loc;
         let FetchResult {
             proof,
             operations,
@@ -595,14 +602,19 @@ where
             return Ok(());
         }
 
-        // Look up the root to verify against using proof.leaves (the tree
-        // size the request was issued for). Fresh requests match the current
-        // target; retained requests match a historical root.
-        let is_current = proof.leaves == self.target.range.end();
+        if proof.leaves != request.target_size {
+            success_tx.send_lossy(false);
+            return Ok(());
+        }
+
+        // Look up the root to verify against using the tree size the request
+        // asked for. Fresh requests match the current target; retained
+        // requests match a historical root that was explicitly retained.
+        let is_current = request.target_size == self.target.range.end();
         let target_root = if is_current {
             &self.target.root
         } else {
-            let Some(root) = self.retained_roots.get(&proof.leaves) else {
+            let Some(root) = self.retained_roots.get(&request.target_size) else {
                 // No historical root to verify against (evicted or
                 // max_retained_roots is 0). Drop the result without
                 // penalizing the resolver — the data may be valid.
@@ -698,7 +710,7 @@ where
         self.drain_finish_requests()?;
 
         // Check if sync is complete
-        if self.is_at_target().await? {
+        if self.is_ready_to_complete().await? {
             self.report_reached_target().await;
 
             if self.finish_rx.is_some() && !self.finish_requested {
@@ -775,12 +787,11 @@ mod tests {
     /// Create a no-op fetch result future for testing request tracking.
     fn dummy_future(
         id: RequestId,
-        loc: u64,
-    ) -> Pin<Box<dyn Future<Output = IndexedFetchResult<i32, sha256::Digest, ()>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = IndexedFetchResult<i32, sha256::Digest, ()>> + Send + Sync>>
+    {
         Box::pin(async move {
             IndexedFetchResult {
                 id,
-                start_loc: Location::new(loc),
                 result: Ok(FetchResult {
                     proof: Proof {
                         leaves: Location::new(0),
@@ -800,8 +811,9 @@ mod tests {
         requests.insert(
             id,
             Location::new(loc),
+            Location::new(loc),
             oneshot::channel().0,
-            dummy_future(id, loc),
+            dummy_future(id),
         );
         id
     }
@@ -815,9 +827,9 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert!(requests.contains(&Location::new(10)));
 
-        assert!(requests.remove(id));
+        assert!(requests.remove(id).is_some());
         assert!(!requests.contains(&Location::new(10)));
-        assert!(!requests.remove(id));
+        assert!(requests.remove(id).is_none());
     }
 
     #[test]
@@ -884,11 +896,11 @@ mod tests {
         assert_eq!(requests.len(), 1);
 
         // Old ID is no longer tracked (superseded by insert)
-        assert!(!requests.remove(old_id));
+        assert!(requests.remove(old_id).is_none());
 
         // New ID is still tracked and by_location is intact
         assert!(requests.contains(&Location::new(10)));
-        assert!(requests.remove(new_id));
+        assert!(requests.remove(new_id).is_some());
         assert!(!requests.contains(&Location::new(10)));
     }
 
@@ -901,11 +913,11 @@ mod tests {
         requests.remove_before(Location::new(10));
 
         // Old ID at location 5 was discarded by remove_before
-        assert!(!requests.remove(old_id));
+        assert!(requests.remove(old_id).is_none());
 
         // New request at the same location gets a different ID
         let new_id = add(&mut requests, 5);
         assert_ne!(old_id, new_id);
-        assert!(requests.remove(new_id));
+        assert!(requests.remove(new_id).is_some());
     }
 }

--- a/storage/src/qmdb/sync/requests.rs
+++ b/storage/src/qmdb/sync/requests.rs
@@ -24,7 +24,7 @@ pub(super) struct Id(u64);
 pub(super) struct RequestInfo {
     /// The location of the first requested operation.
     pub start_loc: Location,
-    /// The tree size the request asked the resolver to prove against.
+    /// The database size the request asked the resolver to prove against.
     pub target_size: Location,
 }
 

--- a/storage/src/qmdb/sync/requests.rs
+++ b/storage/src/qmdb/sync/requests.rs
@@ -1,7 +1,9 @@
 //! Manages outstanding fetch requests with monotonically increasing request IDs.
 //!
-//! Each request is assigned a unique ID when added. This prevents stale futures
-//! from colliding with fresh requests at the same location after a target update.
+//! Each request is assigned a unique ID and remembers the tree size it was issued
+//! against. This prevents stale futures from colliding with fresh requests at the
+//! same location after a target update, and lets the engine reject replies that
+//! do not match the requested historical view.
 
 use crate::{mmr::Location, qmdb::sync::engine::IndexedFetchResult};
 use commonware_cryptography::Digest;
@@ -17,6 +19,21 @@ use std::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct Id(u64);
 
+/// Immutable details about a tracked request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RequestInfo {
+    /// The location of the first requested operation.
+    pub start_loc: Location,
+    /// The tree size the request asked the resolver to prove against.
+    pub target_size: Location,
+}
+
+/// Mutable request state kept while the request is still tracked.
+struct TrackedRequest {
+    info: RequestInfo,
+    _cancel_tx: oneshot::Sender<()>,
+}
+
 /// Manages outstanding fetch requests.
 pub(super) struct Requests<Op, D: Digest, E> {
     /// Futures that will resolve to fetch results.
@@ -28,7 +45,7 @@ pub(super) struct Requests<Op, D: Digest, E> {
 
     /// Active requests keyed by ID. Removing an entry drops the cancel sender,
     /// causing the resolver's `cancel_rx.await` to return `Err`.
-    tracked: HashMap<Id, (Location, oneshot::Sender<()>)>,
+    tracked: HashMap<Id, TrackedRequest>,
 
     /// Reverse index from location to request ID, for gap detection.
     by_location: BTreeMap<Location, Id>,
@@ -59,27 +76,41 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
         &mut self,
         id: Id,
         start_loc: Location,
+        target_size: Location,
         cancel_tx: oneshot::Sender<()>,
         future: Pin<Box<dyn Future<Output = IndexedFetchResult<Op, D, E>> + Send>>,
     ) {
         if let Some(old_id) = self.by_location.insert(start_loc, id) {
             self.tracked.remove(&old_id);
         }
-        self.tracked.insert(id, (start_loc, cancel_tx));
+        self.tracked.insert(
+            id,
+            TrackedRequest {
+                info: RequestInfo {
+                    start_loc,
+                    target_size,
+                },
+                _cancel_tx: cancel_tx,
+            },
+        );
         self.futures.push(future);
     }
 
-    /// Complete a request by ID. Returns `true` if it was tracked.
-    pub fn remove(&mut self, id: Id) -> bool {
-        if let Some((loc, _cancel_tx)) = self.tracked.remove(&id) {
+    /// Complete a request by ID. Returns its metadata if it was tracked.
+    pub fn remove(&mut self, id: Id) -> Option<RequestInfo> {
+        if let Some(TrackedRequest {
+            info,
+            _cancel_tx: _,
+        }) = self.tracked.remove(&id)
+        {
             // Only remove from by_location if it still points to this ID.
             // A newer request may have superseded this location.
-            if self.by_location.get(&loc) == Some(&id) {
-                self.by_location.remove(&loc);
+            if self.by_location.get(&info.start_loc) == Some(&id) {
+                self.by_location.remove(&info.start_loc);
             }
-            true
+            Some(info)
         } else {
-            false
+            None
         }
     }
 


### PR DESCRIPTION
## Overview

After a target update, a resolver could answer a fresh lower-bound request with a valid proof for a retained historical root. The engine would accept that response, retry the boundary fetch, but still report `reached_target` based only on journal length. That let startup finalize without current pinned boundary nodes and fail with `MissingNode`.

The fix binds each tracked fetch request to the target size it was issued against and rejects responses whose `proof.leaves` do not match the request's target size.