### PR TITLE
[storage/qmdb] Extend sync protocol to support MMB family

### DIFF
--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -8,7 +8,7 @@ use commonware_codec::{EncodeShared, Read};
 use commonware_runtime::{
     tokio as tokio_runtime, BufferPooler, Clock, Metrics, Network, Runner, Spawner, Storage,
 };
-use commonware_storage::qmdb::sync;
+use commonware_storage::{mmr, qmdb::sync};
 use commonware_sync::{
     any, crate_version, current, databases::DatabaseType, immutable, keyless, net::Resolver,
     Digest, Error, Key,
@@ -60,9 +60,9 @@ struct Config {
 async fn target_update_task<E, Op, D>(
     context: E,
     resolver: Resolver<Op, D>,
-    update_tx: mpsc::Sender<sync::Target<D>>,
+    update_tx: mpsc::Sender<sync::Target<mmr::Family, D>>,
     interval_duration: Duration,
-    initial_target: sync::Target<D>,
+    initial_target: sync::Target<mmr::Family, D>,
 ) -> Result<(), Error>
 where
     E: Clock,

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -173,6 +173,7 @@ where
         target: Target {
             root,
             range: non_empty_range!(inactivity_floor, size),
+            canonical_root: None,
         },
     };
 

--- a/examples/sync/src/net/resolver.rs
+++ b/examples/sync/src/net/resolver.rs
@@ -3,7 +3,10 @@ use crate::net::request_id;
 use commonware_codec::{EncodeShared, IsUnit, Read};
 use commonware_cryptography::Digest;
 use commonware_runtime::{Network, Spawner};
-use commonware_storage::{mmr::Location, qmdb::sync};
+use commonware_storage::{
+    mmr::{self, Location},
+    qmdb::sync,
+};
 use commonware_utils::channel::{mpsc, oneshot};
 use std::num::NonZeroU64;
 
@@ -42,7 +45,7 @@ where
     }
 
     /// Returns the current sync target from the server.
-    pub async fn get_sync_target(&self) -> Result<sync::Target<D>, crate::Error> {
+    pub async fn get_sync_target(&self) -> Result<sync::Target<mmr::Family, D>, crate::Error> {
         let request_id = self.request_id_generator.next();
         let request =
             wire::Message::GetSyncTargetRequest(wire::GetSyncTargetRequest { request_id });
@@ -75,6 +78,7 @@ where
     Op::Cfg: IsUnit,
     D: Digest,
 {
+    type Family = mmr::Family;
     type Digest = D;
     type Op = Op;
     type Error = crate::Error;
@@ -86,7 +90,8 @@ where
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
         _cancel_rx: oneshot::Receiver<()>,
-    ) -> Result<sync::resolver::FetchResult<Self::Op, Self::Digest>, Self::Error> {
+    ) -> Result<sync::resolver::FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error>
+    {
         let request_id = self.request_id_generator.next();
         let request = wire::Message::GetOperationsRequest(wire::GetOperationsRequest {
             request_id,
@@ -123,6 +128,7 @@ where
             operations,
             success_tx: tx,
             pinned_nodes,
+            overlay_state: None,
         })
     }
 }

--- a/examples/sync/src/net/wire.rs
+++ b/examples/sync/src/net/wire.rs
@@ -5,7 +5,7 @@ use commonware_codec::{
 use commonware_cryptography::Digest;
 use commonware_runtime::{Buf, BufMut};
 use commonware_storage::{
-    mmr::{Location, Proof},
+    mmr::{self, Location, Proof},
     qmdb::sync::Target,
 };
 use std::num::NonZeroU64;
@@ -51,7 +51,7 @@ where
     D: Digest,
 {
     pub request_id: RequestId,
-    pub target: Target<D>,
+    pub target: Target<mmr::Family, D>,
 }
 
 /// Messages that can be sent over the wire.
@@ -334,7 +334,7 @@ where
     type Cfg = ();
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let request_id = RequestId::read_cfg(buf, &())?;
-        let target = Target::<D>::read_cfg(buf, &())?;
+        let target = Target::<mmr::Family, D>::read_cfg(buf, &())?;
         Ok(Self { request_id, target })
     }
 }

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -158,6 +158,10 @@ hash = "c692a20fa40180844888e7a26401f99a45ce3127faeca5f1228a41b454424623"
 n_cases = 65536
 hash = "b41d6c6ec560bde9caf2e206526864c618a0721af367585a1719617ca7ce9291"
 
+["commonware_storage::qmdb::sync::target::tests::conformance::CodecConformance<Target<MmrFamily,sha256::Digest>>"]
+n_cases = 65536
+hash = "baab7048605f293d9358f980b87a2abc0b33a9b91099c7de29fc6033ed6206f7"
+
 ["commonware_storage::qmdb::sync::target::tests::conformance::CodecConformance<Target<sha256::Digest>>"]
 n_cases = 65536
 hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -114,13 +114,14 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap> {
 
 async fn test_sync<
     R: sync::resolver::Resolver<
+        Family = Family,
         Digest = commonware_cryptography::sha256::Digest,
         Op = FixedOperation<Family, Key, Value>,
     >,
 >(
     context: deterministic::Context,
     resolver: R,
-    target: sync::Target<commonware_cryptography::sha256::Digest>,
+    target: sync::Target<Family, commonware_cryptography::sha256::Digest>,
     fetch_batch_size: u64,
     test_name: &str,
     sync_id: usize,
@@ -236,6 +237,7 @@ fn fuzz(mut input: FuzzInput) {
                     let target = sync::Target {
                         root: db.root(),
                         range: non_empty_range!(db.inactivity_floor_loc(), db.bounds().await.end),
+                        canonical_root: None,
                     };
 
                     let wrapped_src = Arc::new(db);

--- a/storage/src/merkle/mmb/proof.rs
+++ b/storage/src/merkle/mmb/proof.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        merkle::{hasher::Standard, mmb::mem::Mmb, proof::Blueprint},
+        merkle::{hasher::Standard, mmb::mem::Mmb, proof::Blueprint, Family},
         mmb::Location,
     };
     use commonware_cryptography::Sha256;
@@ -26,6 +26,32 @@ mod tests {
         };
         mmb.apply_batch(&batch).unwrap();
         (hasher, mmb)
+    }
+
+    /// Regression for the earliest MMB case where a larger tree merges the entire
+    /// `[0, start)` prefix into a new fold-prefix peak that must be reconstructed
+    /// from finer-grained pinned peaks.
+    #[test]
+    fn test_verify_proof_and_pinned_nodes_recursive_fold_prefix_regression() {
+        let (hasher, mmb) = make_mmb(5);
+        let root = *mmb.root();
+        let start = 4;
+
+        let pinned: Vec<D> = crate::merkle::mmb::Family::nodes_to_pin(Location::new(start))
+            .map(|pos| mmb.get_node(pos).unwrap())
+            .collect();
+
+        let proof = mmb
+            .range_proof(&hasher, Location::new(start)..Location::new(start + 1))
+            .unwrap();
+
+        assert!(proof.verify_proof_and_pinned_nodes(
+            &hasher,
+            &[start.to_be_bytes()],
+            Location::new(start),
+            &pinned,
+            &root,
+        ));
     }
 
     #[test]

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -67,7 +67,7 @@ pub trait Family: Copy + Clone + Debug + Default + Send + Sync + 'static {
     /// Return the peaks of a structure with the given `size` as `(position, height)` pairs
     /// in canonical oldest-to-newest order (suitable for
     /// [`Hasher::root`](crate::merkle::hasher::Hasher::root)).
-    fn peaks(size: Position<Self>) -> impl Iterator<Item = (Position<Self>, u32)>;
+    fn peaks(size: Position<Self>) -> impl Iterator<Item = (Position<Self>, u32)> + Send;
 
     /// Compute positions of nodes that must be pinned when pruning to `prune_loc`.
     ///

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -172,7 +172,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
             let Ok(bp) = Blueprint::new(self.leaves, *loc..*loc + 1) else {
                 return false;
             };
-            node_positions.extend(&bp.fold_prefix);
+            node_positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
             node_positions.extend(&bp.fetch_nodes);
             blueprints.insert(*loc, bp);
         }
@@ -196,12 +196,14 @@ impl<F: Family, D: Digest> Proof<F, D> {
             let mut digests = Vec::with_capacity(
                 if bp.fold_prefix.is_empty() { 0 } else { 1 } + bp.fetch_nodes.len(),
             );
-            if let Some((&first_pos, rest)) = bp.fold_prefix.split_first() {
+            if let Some((first_sub, rest)) = bp.fold_prefix.split_first() {
                 let first = *node_digests
-                    .get(&first_pos)
+                    .get(&first_sub.pos)
                     .expect("must exist by construction");
-                let acc = rest.iter().fold(first, |acc, &pos| {
-                    let d = node_digests.get(&pos).expect("must exist by construction");
+                let acc = rest.iter().fold(first, |acc, sub| {
+                    let d = node_digests
+                        .get(&sub.pos)
+                        .expect("must exist by construction");
                     hasher.fold(&acc, d)
                 });
                 digests.push(acc);
@@ -274,17 +276,32 @@ impl<F: Family, D: Digest> Proof<F, D> {
     /// Verify that both the proof and the pinned nodes are valid with respect to `root`.
     ///
     /// The `pinned_nodes` are the peak digests of the sub-structure at `start_loc`, in the order
-    /// returned by `Family::nodes_to_pin`.
-    ///
-    /// These pins may be finer-grained than the prefix structure authenticated by the proof itself.
-    /// In particular, when the larger `self.leaves`-sized tree has merged smaller peaks into larger
-    /// subtrees, the proof authenticates:
+    /// returned by `Family::nodes_to_pin`. The proof authenticates the prefix `[0, start_loc)` via:
     ///
     /// - fold-prefix peaks of the larger tree, and
-    /// - any sibling subtrees inside the first range peak that lie wholly before `start_loc`
+    /// - sibling subtrees inside the first range peak that lie wholly before `start_loc`.
     ///
-    /// This verifier reconstructs those authenticated prefix subtrees from the finer-grained pins
-    /// and compares the resulting digests against the proof.
+    /// When the larger tree has merged smaller subtrees into a bigger parent, the pins sit below
+    /// these authenticated subtrees. The verifier hashes pairs of pins up to each authenticated
+    /// subtree's root and compares against the proof.
+    ///
+    /// For example, in MMB at `leaves=5, start_loc=4`, the proof describes `[0, 4)` as one
+    /// height-2 subtree `p7`, while the pins cover the same leaves as two height-1 subtrees
+    /// `p2`, `p5`:
+    ///
+    /// ```text
+    ///     proof authenticates:         pins contain:
+    ///
+    ///             p7
+    ///           /    \
+    ///          p2    p5                p2         p5
+    ///         / \    / \              / \        / \
+    ///        L0 L1  L2 L3            L0 L1      L2 L3
+    /// ```
+    ///
+    /// The verifier walks down from `p7` via `F::children`, pulls the pins for `p2` and `p5`, and
+    /// hashes them back up (`node_digest(p7, pin[p2], pin[p5])`) to compare against the `p7`
+    /// digest the proof authenticates.
     ///
     /// Returns `true` only if the proof reconstructs to `root` and every pinned node digest is
     /// accounted for. When `start_loc` is 0, `pinned_nodes` must be empty.
@@ -300,118 +317,81 @@ impl<F: Family, D: Digest> Proof<F, D> {
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        let collected = match self
+        self.try_verify_proof_and_pinned_nodes(hasher, elements, start_loc, pinned_nodes, root)
+            .is_some()
+    }
+
+    /// Fallible implementation of [`verify_proof_and_pinned_nodes`](Self::verify_proof_and_pinned_nodes).
+    ///
+    /// Returns `Some(())` if the proof and pins are consistent with `root`, `None` otherwise. The
+    /// `Option` return lets the body use `?` on each fallible step; the public wrapper converts to
+    /// `bool` via `.is_some()`.
+    fn try_verify_proof_and_pinned_nodes<H, E>(
+        &self,
+        hasher: &H,
+        elements: &[E],
+        start_loc: Location<F>,
+        pinned_nodes: &[D],
+        root: &D,
+    ) -> Option<()>
+    where
+        H: Hasher<F, Digest = D>,
+        E: AsRef<[u8]>,
+    {
+        let collected = self
             .verify_range_inclusion_and_extract_digests(hasher, elements, start_loc, root)
-        {
-            Ok(c) => c,
-            Err(_) => return false,
-        };
+            .ok()?;
 
         if elements.is_empty() {
-            return pinned_nodes.is_empty();
+            return pinned_nodes.is_empty().then_some(());
         }
 
         if !start_loc.is_valid() || start_loc > self.leaves {
-            return false;
+            return None;
         }
 
-        let pinned_positions: alloc::vec::Vec<_> = F::nodes_to_pin(start_loc).collect();
+        let pinned_positions: Vec<_> = F::nodes_to_pin(start_loc).collect();
         if pinned_positions.len() != pinned_nodes.len() {
-            return false;
+            return None;
         }
 
-        let Some(end_loc) = start_loc.checked_add(elements.len() as u64) else {
-            return false;
-        };
-        let Ok(bp) = Blueprint::new(self.leaves, start_loc..end_loc) else {
-            return false;
-        };
-        let fold_prefix = bp.fold_prefix;
+        let end_loc = start_loc.checked_add(elements.len() as u64)?;
+        let bp = Blueprint::new(self.leaves, start_loc..end_loc).ok()?;
 
-        let mut pinned_map: alloc::collections::BTreeMap<Position<F>, D> = pinned_positions
+        let mut pinned_map: BTreeMap<Position<F>, D> = pinned_positions
             .into_iter()
             .zip(pinned_nodes.iter().copied())
             .collect();
 
-        /// Reconstruct the digest at `pos` from the pinned node map.
-        ///
-        /// If `pos` is directly in the map, returns its digest. Otherwise, recurses into `F::children(pos,
-        /// height)` and hashes the results. This bridges the gap between `F::nodes_to_pin(start_loc)`
-        /// positions (peaks of the smaller tree) and the coarser prefix subtrees authenticated by the
-        /// proof, which can differ when the larger tree has merged smaller peaks.
-        fn reconstruct_from_pins<F: Family, D: Digest, H: Hasher<F, Digest = D>>(
-            hasher: &H,
-            pos: Position<F>,
-            pinned_map: &mut alloc::collections::BTreeMap<Position<F>, D>,
-        ) -> Option<D> {
-            if let Some(d) = pinned_map.remove(&pos) {
-                return Some(d);
+        // Fold-prefix peaks of the larger tree may have merged several pins together. Reconstruct
+        // each peak's digest by hashing the pins beneath it up to the peak, then compare the
+        // folded accumulator against the one the proof carries.
+        if let Some((first_sub, rest)) = bp.fold_prefix.split_first() {
+            let &expected = self.digests.first()?;
+            let mut acc = first_sub.reconstruct_from_pins(hasher, &mut pinned_map)?;
+            for sub in rest {
+                let d = sub.reconstruct_from_pins(hasher, &mut pinned_map)?;
+                acc = hasher.fold(&acc, &d);
             }
-            let height = F::pos_to_height(pos);
-            if height == 0 {
+            if acc != expected {
                 return None;
             }
-            let (left, right) = F::children(pos, height);
-            let left_d = reconstruct_from_pins(hasher, left, pinned_map)?;
-            let right_d = reconstruct_from_pins(hasher, right, pinned_map)?;
-            Some(hasher.node_digest(pos, &left_d, &right_d))
         }
 
-        // Verify fold-prefix pinned nodes by recomputing the accumulator.
-        //
-        // The fold_prefix positions are peaks of the `self.leaves`-sized tree that lie entirely
-        // before `start_loc`. The pinned_map positions are peaks of the `start_loc`-sized tree.
-        // These can differ when the larger tree has merged smaller peaks into bigger ones. To
-        // handle this, we reconstruct each fold_prefix peak's digest from the finer-grained pinned
-        // peaks by walking the tree via `F::children`, while tracking exactly which pinned
-        // positions were consumed by that reconstruction.
-        if let Some((&first_pos, rest)) = fold_prefix.split_first() {
-            if self.digests.is_empty() {
-                return false;
-            }
-            let Some(first) = reconstruct_from_pins(hasher, first_pos, &mut pinned_map) else {
-                return false;
-            };
-            let mut acc = first;
-            for &pos in rest {
-                let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
-                    return false;
-                };
-                acc = hasher.fold(&acc, &digest);
-            }
-            if acc != self.digests[0] {
-                return false;
+        // Sibling subtrees inside the first range peak that lie wholly before `start_loc` are
+        // authenticated directly by the proof (their digests appear in `extracted`). Rebuild each
+        // from the pins and compare.
+        let extracted: BTreeMap<Position<F>, D> = collected.into_iter().collect();
+        for sibling in bp.prefix_siblings() {
+            let &expected = extracted.get(&sibling.pos)?;
+            let d = sibling.reconstruct_from_pins(hasher, &mut pinned_map)?;
+            if d != expected {
+                return None;
             }
         }
 
-        // Verify any sibling subtrees that lie wholly before `start_loc`. These are the coarser
-        // prefix targets authenticated directly by the proof inside the first range peak. The
-        // provided pinned nodes may be a finer partition of the same prefix, so we reconstruct
-        // each authenticated prefix subtree from pins and compare digests.
-        let extracted: alloc::collections::BTreeMap<Position<F>, D> =
-            collected.into_iter().collect();
-
-        // Only the first range peak can contain siblings wholly before `start_loc`; later peaks are
-        // entirely at or after `start_loc` by `Blueprint::new`'s classification.
-        let mut prefix_siblings = Vec::new();
-        if let Some(peak) = bp.range_peaks.first() {
-            peak.collect_prefix_siblings(&bp.range, &mut prefix_siblings);
-        }
-        for pos in prefix_siblings {
-            let Some(&expected_digest) = extracted.get(&pos) else {
-                return false;
-            };
-            let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
-                return false;
-            };
-            if digest != expected_digest {
-                return false;
-            }
-        }
-
-        // Every pin must have been consumed by either a fold-prefix peak reconstruction or a prefix
-        // sibling reconstruction.
-        pinned_map.is_empty()
+        // Every pin must have been consumed by one of the two reconstructions above.
+        pinned_map.is_empty().then_some(())
     }
 
     /// Like [`reconstruct_root`](Self::reconstruct_root), but if `collected` is `Some`, every
@@ -525,6 +505,16 @@ impl<F: Family> Subtree<F> {
         self.leaf_start + (1u64 << self.height)
     }
 
+    /// True if this subtree's leaves lie wholly before `range.start`.
+    fn is_before(&self, range: &Range<Location<F>>) -> bool {
+        self.leaf_end() <= range.start
+    }
+
+    /// True if this subtree's leaves lie wholly outside `range` (either before it or after it).
+    fn is_outside(&self, range: &Range<Location<F>>) -> bool {
+        self.is_before(range) || self.leaf_start >= range.end
+    }
+
     fn children(&self) -> (Self, Self) {
         let (left_pos, right_pos) = F::children(self.pos, self.height);
         let child_height = self.height - 1;
@@ -549,7 +539,7 @@ impl<F: Family> Subtree<F> {
     /// At each node: if the subtree is entirely outside the range, its root position is emitted. If
     /// it's a leaf in the range, nothing is emitted. Otherwise, recurse into children.
     fn collect_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
-        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+        if self.is_outside(range) {
             out.push(self.pos);
             return;
         }
@@ -561,16 +551,16 @@ impl<F: Family> Subtree<F> {
         }
     }
 
-    /// Collect sibling positions that lie wholly before the proven range, in the same
+    /// Collect sibling subtrees that lie wholly before the proven range, in the same
     /// left-first DFS order as [`collect_siblings`](Self::collect_siblings).
     ///
     /// Only `range.start` is consulted: the `range.end` side doesn't matter for prefix
     /// siblings. Pruning on `range.start` also keeps the traversal O(height) per peak —
     /// pruning only by `range.end` would recurse into both children whenever a subtree
     /// sits entirely inside the proven range, costing O(2^height) per such peak.
-    fn collect_prefix_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
-        if self.leaf_end() <= range.start {
-            out.push(self.pos);
+    fn collect_prefix_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Self>) {
+        if self.is_before(range) {
+            out.push(*self);
             return;
         }
 
@@ -583,6 +573,36 @@ impl<F: Family> Subtree<F> {
             left.collect_prefix_siblings(range, out);
             right.collect_prefix_siblings(range, out);
         }
+    }
+
+    /// Reconstruct this subtree's digest from a set of finer-grained pinned positions, consuming
+    /// each pin as it is used.
+    ///
+    /// Walks down via [`Self::children`] until each recursion hits a pin, then hashes back up with
+    /// [`Hasher::node_digest`] for position-keyed domain separation. Returns `None` if any required
+    /// pin is missing.
+    ///
+    /// On failure, `pinned_map` may have been partially consumed. Callers are expected to return
+    /// immediately without inspecting it further.
+    fn reconstruct_from_pins<D, H>(
+        &self,
+        hasher: &H,
+        pinned_map: &mut BTreeMap<Position<F>, D>,
+    ) -> Option<D>
+    where
+        D: Digest,
+        H: Hasher<F, Digest = D>,
+    {
+        if let Some(d) = pinned_map.remove(&self.pos) {
+            return Some(d);
+        }
+        if self.height == 0 {
+            return None;
+        }
+        let (left, right) = self.children();
+        let left_d = left.reconstruct_from_pins(hasher, pinned_map)?;
+        let right_d = right.reconstruct_from_pins(hasher, pinned_map)?;
+        Some(hasher.node_digest(self.pos, &left_d, &right_d))
     }
 
     /// Reconstruct the digest of this subtree from a range of elements and sibling digests,
@@ -610,7 +630,7 @@ impl<F: Family> Subtree<F> {
         E: Iterator<Item: AsRef<[u8]>>,
     {
         // Entirely outside the range: consume a sibling digest.
-        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+        if self.is_outside(range) {
             let Some(digest) = siblings.get(*cursor).copied() else {
                 return Err(ReconstructionError::MissingDigests);
             };
@@ -628,9 +648,6 @@ impl<F: Family> Subtree<F> {
 
         // Recurse into children.
         let (left, right) = self.children();
-        let left_pos = left.pos;
-        let right_pos = right.pos;
-
         let left_d = left.reconstruct_digest(
             hasher,
             range,
@@ -649,8 +666,8 @@ impl<F: Family> Subtree<F> {
         )?;
 
         if let Some(ref mut cd) = collected {
-            cd.push((left_pos, left_d));
-            cd.push((right_pos, right_d));
+            cd.push((left.pos, left_d));
+            cd.push((right.pos, right_d));
         }
 
         Ok(hasher.node_digest(self.pos, &left_d, &right_d))
@@ -663,8 +680,8 @@ pub(crate) struct Blueprint<F: Family> {
     leaves: Location<F>,
     /// The location range this blueprint was built for.
     pub range: Range<Location<F>>,
-    /// Peak positions that precede the proven range (to be folded into a single accumulator).
-    pub fold_prefix: Vec<Position<F>>,
+    /// Peaks that precede the proven range (to be folded into a single accumulator).
+    pub fold_prefix: Vec<Subtree<F>>,
     /// Peak positions entirely after the proven range.
     pub after_peaks: Vec<Position<F>>,
     /// The peaks that overlap the proven range.
@@ -726,7 +743,11 @@ impl<F: Family> Blueprint<F> {
             let leaf_end = leaf_start + (1u64 << height);
 
             if leaf_end <= range.start {
-                fold_prefix.push(peak_pos);
+                fold_prefix.push(Subtree {
+                    pos: peak_pos,
+                    height,
+                    leaf_start,
+                });
             } else if leaf_start >= range.end {
                 after_peaks.push(peak_pos);
             } else {
@@ -759,6 +780,18 @@ impl<F: Family> Blueprint<F> {
         })
     }
 
+    /// Sibling subtrees of the first range peak that lie wholly before `self.range.start`.
+    ///
+    /// Only the first range peak can contain such siblings; later range peaks are entirely at or
+    /// after `range.start` by this blueprint's classification.
+    pub(crate) fn prefix_siblings(&self) -> Vec<Subtree<F>> {
+        let mut out = Vec::new();
+        if let Some(peak) = self.range_peaks.first() {
+            peak.collect_prefix_siblings(&self.range, &mut out);
+        }
+        out
+    }
+
     /// Build a range proof from this blueprint and a node-fetching closure.
     ///
     /// The prover folds prefix peak digests into a single accumulator. The resulting proof
@@ -780,10 +813,10 @@ impl<F: Family> Blueprint<F> {
             if self.fold_prefix.is_empty() { 0 } else { 1 } + self.fetch_nodes.len(),
         );
 
-        if let Some((&first_pos, rest)) = self.fold_prefix.split_first() {
-            let first = get_node(first_pos).ok_or_else(|| element_pruned(first_pos))?;
-            let acc = rest.iter().try_fold(first, |acc, &pos| {
-                let d = get_node(pos).ok_or_else(|| element_pruned(pos))?;
+        if let Some((first_sub, rest)) = self.fold_prefix.split_first() {
+            let first = get_node(first_sub.pos).ok_or_else(|| element_pruned(first_sub.pos))?;
+            let acc = rest.iter().try_fold(first, |acc, sub| {
+                let d = get_node(sub.pos).ok_or_else(|| element_pruned(sub.pos))?;
                 Ok(hasher.fold(&acc, &d))
             })?;
             digests.push(acc);
@@ -842,7 +875,7 @@ pub(crate) fn nodes_required_for_multi_proof<F: Family>(
             return Err(super::Error::LocationOverflow(*loc));
         }
         let bp = Blueprint::new(leaves, *loc..*loc + 1)?;
-        acc.extend(bp.fold_prefix);
+        acc.extend(bp.fold_prefix.into_iter().map(|s| s.pos));
         acc.extend(bp.fetch_nodes);
         Ok(acc)
     })
@@ -1819,7 +1852,7 @@ mod tests {
                 let loc = Location::new(loc);
                 let bp = Blueprint::<F>::new(leaves, loc..loc + 1).unwrap();
                 let mut positions: Vec<Position<F>> = Vec::new();
-                positions.extend(&bp.fold_prefix);
+                positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
                 positions.extend(&bp.fetch_nodes);
                 let set: BTreeSet<_> = positions.iter().copied().collect();
                 assert_eq!(

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -274,12 +274,17 @@ impl<F: Family, D: Digest> Proof<F, D> {
     /// Verify that both the proof and the pinned nodes are valid with respect to `root`.
     ///
     /// The `pinned_nodes` are the peak digests of the sub-structure at `start_loc`, in the order
-    /// returned by `Family::nodes_to_pin`. Each pinned node is either:
+    /// returned by `Family::nodes_to_pin`.
     ///
-    /// - A peak that precedes the proven range (fold-prefix peak). These are verified by
-    ///   refolding them and comparing against the proof's fold-prefix accumulator.
-    /// - A sibling node within a range peak's reconstruction. These are verified against the
-    ///   digests extracted during proof verification.
+    /// These pins may be finer-grained than the prefix structure authenticated by the proof itself.
+    /// In particular, when the larger `self.leaves`-sized tree has merged smaller peaks into larger
+    /// subtrees, the proof authenticates:
+    ///
+    /// - fold-prefix peaks of the larger tree, and
+    /// - any sibling subtrees inside the first range peak that lie wholly before `start_loc`
+    ///
+    /// This verifier reconstructs those authenticated prefix subtrees from the finer-grained pins
+    /// and compares the resulting digests against the proof.
     ///
     /// Returns `true` only if the proof reconstructs to `root` and every pinned node digest is
     /// accounted for. When `start_loc` is 0, `pinned_nodes` must be empty.
@@ -315,27 +320,61 @@ impl<F: Family, D: Digest> Proof<F, D> {
             return false;
         }
 
-        let Ok(fold_prefix) = Blueprint::fold_prefix(self.leaves, start_loc) else {
+        let Some(end_loc) = start_loc.checked_add(elements.len() as u64) else {
             return false;
         };
+        let Ok(bp) = Blueprint::new(self.leaves, start_loc..end_loc) else {
+            return false;
+        };
+        let fold_prefix = bp.fold_prefix;
 
         let mut pinned_map: alloc::collections::BTreeMap<Position<F>, D> = pinned_positions
             .into_iter()
             .zip(pinned_nodes.iter().copied())
             .collect();
 
-        // Verify fold-prefix pinned nodes by recomputing the accumulator (without the leaf
-        // count, which is hashed into the final root independently).
-        if !fold_prefix.is_empty() {
+        /// Reconstruct the digest at `pos` from the pinned node map.
+        ///
+        /// If `pos` is directly in the map, returns its digest. Otherwise, recurses into `F::children(pos,
+        /// height)` and hashes the results. This bridges the gap between `F::nodes_to_pin(start_loc)`
+        /// positions (peaks of the smaller tree) and the coarser prefix subtrees authenticated by the
+        /// proof, which can differ when the larger tree has merged smaller peaks.
+        fn reconstruct_from_pins<F: Family, D: Digest, H: Hasher<F, Digest = D>>(
+            hasher: &H,
+            pos: Position<F>,
+            pinned_map: &mut alloc::collections::BTreeMap<Position<F>, D>,
+        ) -> Option<D> {
+            if let Some(d) = pinned_map.remove(&pos) {
+                return Some(d);
+            }
+            let height = F::pos_to_height(pos);
+            if height == 0 {
+                return None;
+            }
+            let (left, right) = F::children(pos, height);
+            let left_d = reconstruct_from_pins(hasher, left, pinned_map)?;
+            let right_d = reconstruct_from_pins(hasher, right, pinned_map)?;
+            Some(hasher.node_digest(pos, &left_d, &right_d))
+        }
+
+        // Verify fold-prefix pinned nodes by recomputing the accumulator.
+        //
+        // The fold_prefix positions are peaks of the `self.leaves`-sized tree that lie entirely
+        // before `start_loc`. The pinned_map positions are peaks of the `start_loc`-sized tree.
+        // These can differ when the larger tree has merged smaller peaks into bigger ones. To
+        // handle this, we reconstruct each fold_prefix peak's digest from the finer-grained pinned
+        // peaks by walking the tree via `F::children`, while tracking exactly which pinned
+        // positions were consumed by that reconstruction.
+        if let Some((&first_pos, rest)) = fold_prefix.split_first() {
             if self.digests.is_empty() {
                 return false;
             }
-            let Some(first) = pinned_map.remove(&fold_prefix[0]) else {
+            let Some(first) = reconstruct_from_pins(hasher, first_pos, &mut pinned_map) else {
                 return false;
             };
             let mut acc = first;
-            for pos in &fold_prefix[1..] {
-                let Some(digest) = pinned_map.remove(pos) else {
+            for &pos in rest {
+                let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
                     return false;
                 };
                 acc = hasher.fold(&acc, &digest);
@@ -345,16 +384,34 @@ impl<F: Family, D: Digest> Proof<F, D> {
             }
         }
 
-        // Verify remaining pinned nodes (siblings) against the extracted digests.
+        // Verify any sibling subtrees that lie wholly before `start_loc`. These are the coarser
+        // prefix targets authenticated directly by the proof inside the first range peak. The
+        // provided pinned nodes may be a finer partition of the same prefix, so we reconstruct
+        // each authenticated prefix subtree from pins and compare digests.
         let extracted: alloc::collections::BTreeMap<Position<F>, D> =
             collected.into_iter().collect();
-        for (pos, digest) in pinned_map {
-            if extracted.get(&pos) != Some(&digest) {
+
+        // Only the first range peak can contain siblings wholly before `start_loc`; later peaks are
+        // entirely at or after `start_loc` by `Blueprint::new`'s classification.
+        let mut prefix_siblings = Vec::new();
+        if let Some(peak) = bp.range_peaks.first() {
+            peak.collect_prefix_siblings(&bp.range, &mut prefix_siblings);
+        }
+        for pos in prefix_siblings {
+            let Some(&expected_digest) = extracted.get(&pos) else {
+                return false;
+            };
+            let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
+                return false;
+            };
+            if digest != expected_digest {
                 return false;
             }
         }
 
-        true
+        // Every pin must have been consumed by either a fold-prefix peak reconstruction or a prefix
+        // sibling reconstruction.
+        pinned_map.is_empty()
     }
 
     /// Like [`reconstruct_root`](Self::reconstruct_root), but if `collected` is `Some`, every
@@ -416,10 +473,9 @@ impl<F: Family, D: Digest> Proof<F, D> {
 
         let mut sibling_cursor = 0usize;
         let mut elements_iter = elements.iter();
-        for &peak in &bp.range_peaks {
-            let peak_digest = reconstruct_peak_from_range(
+        for peak in &bp.range_peaks {
+            let peak_digest = peak.reconstruct_digest(
                 hasher,
-                peak,
                 &bp.range,
                 &mut elements_iter,
                 siblings,
@@ -486,6 +542,119 @@ impl<F: Family> Subtree<F> {
             },
         )
     }
+
+    /// Collect sibling positions needed to reconstruct this subtree digest from a range of
+    /// elements, in left-first DFS order.
+    ///
+    /// At each node: if the subtree is entirely outside the range, its root position is emitted. If
+    /// it's a leaf in the range, nothing is emitted. Otherwise, recurse into children.
+    fn collect_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
+        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+            out.push(self.pos);
+            return;
+        }
+
+        if self.height > 0 {
+            let (left, right) = self.children();
+            left.collect_siblings(range, out);
+            right.collect_siblings(range, out);
+        }
+    }
+
+    /// Collect sibling positions that lie wholly before the proven range, in the same
+    /// left-first DFS order as [`collect_siblings`](Self::collect_siblings).
+    ///
+    /// Only `range.start` is consulted: the `range.end` side doesn't matter for prefix
+    /// siblings. Pruning on `range.start` also keeps the traversal O(height) per peak —
+    /// pruning only by `range.end` would recurse into both children whenever a subtree
+    /// sits entirely inside the proven range, costing O(2^height) per such peak.
+    fn collect_prefix_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
+        if self.leaf_end() <= range.start {
+            out.push(self.pos);
+            return;
+        }
+
+        if self.leaf_start >= range.start {
+            return;
+        }
+
+        if self.height > 0 {
+            let (left, right) = self.children();
+            left.collect_prefix_siblings(range, out);
+            right.collect_prefix_siblings(range, out);
+        }
+    }
+
+    /// Reconstruct the digest of this subtree from a range of elements and sibling digests,
+    /// consuming both in left-first DFS order.
+    ///
+    /// At each node:
+    /// - If the subtree is entirely outside the range: consume a sibling digest.
+    /// - If it's a leaf in the range: hash the next element.
+    /// - Otherwise: recurse into children via [`Family::children`] and compute the node digest.
+    ///
+    /// If `collected` is `Some`, every child `(position, digest)` pair encountered during
+    /// reconstruction is appended to the vector.
+    fn reconstruct_digest<D, H, E>(
+        &self,
+        hasher: &H,
+        range: &Range<Location<F>>,
+        elements: &mut E,
+        siblings: &[D],
+        cursor: &mut usize,
+        mut collected: Option<&mut Vec<(Position<F>, D)>>,
+    ) -> Result<D, ReconstructionError>
+    where
+        D: Digest,
+        H: Hasher<F, Digest = D>,
+        E: Iterator<Item: AsRef<[u8]>>,
+    {
+        // Entirely outside the range: consume a sibling digest.
+        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+            let Some(digest) = siblings.get(*cursor).copied() else {
+                return Err(ReconstructionError::MissingDigests);
+            };
+            *cursor += 1;
+            return Ok(digest);
+        }
+
+        // Leaf in range: hash the next element.
+        if self.height == 0 {
+            let elem = elements
+                .next()
+                .ok_or(ReconstructionError::MissingElements)?;
+            return Ok(hasher.leaf_digest(self.pos, elem.as_ref()));
+        }
+
+        // Recurse into children.
+        let (left, right) = self.children();
+        let left_pos = left.pos;
+        let right_pos = right.pos;
+
+        let left_d = left.reconstruct_digest(
+            hasher,
+            range,
+            elements,
+            siblings,
+            cursor,
+            collected.as_deref_mut(),
+        )?;
+        let right_d = right.reconstruct_digest(
+            hasher,
+            range,
+            elements,
+            siblings,
+            cursor,
+            collected.as_deref_mut(),
+        )?;
+
+        if let Some(ref mut cd) = collected {
+            cd.push((left_pos, left_d));
+            cd.push((right_pos, right_d));
+        }
+
+        Ok(hasher.node_digest(self.pos, &left_d, &right_d))
+    }
 }
 
 /// Blueprint for a range proof, separating fold-prefix peaks from nodes that must be fetched.
@@ -506,6 +675,7 @@ pub(crate) struct Blueprint<F: Family> {
 
 impl<F: Family> Blueprint<F> {
     /// Efficiently compute just the fold prefix for a given starting location.
+    #[cfg(any(feature = "std", test))]
     pub(crate) fn fold_prefix(
         leaves: Location<F>,
         start_loc: Location<F>,
@@ -575,8 +745,8 @@ impl<F: Family> Blueprint<F> {
         );
 
         let mut fetch_nodes = after_peaks.clone();
-        for &peak in &range_peaks {
-            collect_siblings_dfs(peak, &range, &mut fetch_nodes);
+        for peak in &range_peaks {
+            peak.collect_siblings(&range, &mut fetch_nodes);
         }
 
         Ok(Self {
@@ -676,103 +846,6 @@ pub(crate) fn nodes_required_for_multi_proof<F: Family>(
         acc.extend(bp.fetch_nodes);
         Ok(acc)
     })
-}
-
-/// Collect sibling positions needed to reconstruct a peak digest from a range of elements, in
-/// left-first DFS order. This mirrors the traversal order of [`reconstruct_peak_from_range`].
-///
-/// At each node: if the subtree is entirely outside the range, its root position is emitted. If
-/// it's a leaf in the range, nothing is emitted. Otherwise, recurse into children via
-/// [`Family::children`].
-pub(crate) fn collect_siblings_dfs<F: Family>(
-    node: Subtree<F>,
-    range: &Range<Location<F>>,
-    out: &mut Vec<Position<F>>,
-) {
-    if node.leaf_end() <= range.start || node.leaf_start >= range.end {
-        out.push(node.pos);
-        return;
-    }
-
-    if node.height > 0 {
-        let (left, right) = node.children();
-        collect_siblings_dfs::<F>(left, range, out);
-        collect_siblings_dfs::<F>(right, range, out);
-    }
-}
-
-/// Reconstruct the digest of a peak subtree from a range of elements and sibling digests, consuming
-/// both in left-first DFS order matching [`collect_siblings_dfs`].
-///
-/// At each node:
-/// - If the subtree is entirely outside the range: consume a sibling digest.
-/// - If it's a leaf in the range: hash the next element.
-/// - Otherwise: recurse into children via [`Family::children`] and compute the node digest.
-///
-/// If `collected` is `Some`, every child `(position, digest)` pair encountered during
-/// reconstruction is appended to the vector.
-pub(crate) fn reconstruct_peak_from_range<F, D, H, E>(
-    hasher: &H,
-    node: Subtree<F>,
-    range: &Range<Location<F>>,
-    elements: &mut E,
-    siblings: &[D],
-    cursor: &mut usize,
-    mut collected: Option<&mut Vec<(Position<F>, D)>>,
-) -> Result<D, ReconstructionError>
-where
-    F: Family,
-    D: Digest,
-    H: Hasher<F, Digest = D>,
-    E: Iterator<Item: AsRef<[u8]>>,
-{
-    // Entirely outside the range: consume a sibling digest.
-    if node.leaf_end() <= range.start || node.leaf_start >= range.end {
-        let Some(digest) = siblings.get(*cursor).copied() else {
-            return Err(ReconstructionError::MissingDigests);
-        };
-        *cursor += 1;
-        return Ok(digest);
-    }
-
-    // Leaf in range: hash the next element.
-    if node.height == 0 {
-        let elem = elements
-            .next()
-            .ok_or(ReconstructionError::MissingElements)?;
-        return Ok(hasher.leaf_digest(node.pos, elem.as_ref()));
-    }
-
-    // Recurse into children.
-    let (left, right) = node.children();
-    let left_pos = left.pos;
-    let right_pos = right.pos;
-
-    let left_d = reconstruct_peak_from_range::<F, D, H, E>(
-        hasher,
-        left,
-        range,
-        elements,
-        siblings,
-        cursor,
-        collected.as_deref_mut(),
-    )?;
-    let right_d = reconstruct_peak_from_range::<F, D, H, E>(
-        hasher,
-        right,
-        range,
-        elements,
-        siblings,
-        cursor,
-        collected.as_deref_mut(),
-    )?;
-
-    if let Some(ref mut cd) = collected {
-        cd.push((left_pos, left_d));
-        cd.push((right_pos, right_d));
-    }
-
-    Ok(hasher.node_digest(node.pos, &left_d, &right_d))
 }
 
 #[cfg(feature = "arbitrary")]
@@ -1758,6 +1831,63 @@ mod tests {
         }
     }
 
+    /// `verify_proof_and_pinned_nodes` must accept pinned nodes at
+    /// `F::nodes_to_pin(start_loc)` positions for any `(leaves, start_loc)` pair.
+    ///
+    /// `nodes_to_pin(L)` returns the peaks of the tree at size L (the peaks you'd
+    /// pin if you pruned to L). `fold_prefix(N, L)` returns the peaks of the size-N
+    /// tree that lie entirely before leaf L. These can disagree when the larger tree
+    /// has merged smaller peaks into larger subtrees. The verifier must handle this
+    /// for both families.
+    fn verify_proof_and_pinned_nodes_across_sizes<F: Family>() {
+        // Sweep (leaves, start) pairs. Larger trees with start far from a peak
+        // boundary are more likely to produce pinned positions that don't appear
+        // as siblings in the proof walk.
+        let cases: &[(u64, u64)] = &[
+            // First delayed-merge birth-boundary case: the larger tree exposes a
+            // fold-prefix peak that did not exist yet at `start`.
+            (5, 4),
+            (10, 3),
+            (20, 5),
+            (50, 10),
+            (100, 10),
+            (100, 30),
+            (200, 50),
+            (500, 100),
+            (1000, 100),
+            (1000, 300),
+            (2000, 500),
+        ];
+
+        let hasher = H::new();
+        for &(n, start) in cases {
+            let mem = build_raw::<F>(&hasher, n);
+            let root = *mem.root();
+
+            let pinned: Vec<D> = F::nodes_to_pin(Location::<F>::new(start))
+                .map(|pos| mem.get_node(pos).unwrap())
+                .collect();
+
+            let proof = mem
+                .range_proof(
+                    &hasher,
+                    Location::<F>::new(start)..Location::<F>::new(start + 1),
+                )
+                .unwrap();
+
+            assert!(
+                proof.verify_proof_and_pinned_nodes(
+                    &hasher,
+                    &[start.to_be_bytes()],
+                    Location::<F>::new(start),
+                    &pinned,
+                    &root,
+                ),
+                "verify_proof_and_pinned_nodes failed: leaves={n}, start={start}"
+            );
+        }
+    }
+
     // ---------------------------------------------------------------------------
     // MMR tests
     // ---------------------------------------------------------------------------
@@ -1837,6 +1967,10 @@ mod tests {
     #[test]
     fn mmr_no_duplicate_positions() {
         no_duplicate_positions::<mmr::Family>();
+    }
+    #[test]
+    fn mmr_verify_proof_and_pinned_nodes_across_sizes() {
+        verify_proof_and_pinned_nodes_across_sizes::<mmr::Family>();
     }
 
     // ---------------------------------------------------------------------------
@@ -1918,5 +2052,9 @@ mod tests {
     #[test]
     fn mmb_no_duplicate_positions() {
         no_duplicate_positions::<mmb::Family>();
+    }
+    #[test]
+    fn mmb_verify_proof_and_pinned_nodes_across_sizes() {
+        verify_proof_and_pinned_nodes_across_sizes::<mmb::Family>();
     }
 }

--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -95,12 +95,12 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
             // Start from the stored fold accumulator (which does not include the leaf count).
             let mut acc = self.fold_acc;
             // Fold in peaks beyond those already covered by the stored accumulator.
-            for &pos in bp.fold_prefix.iter().skip(self.num_fold_peaks) {
-                match self.digests.get(&pos) {
+            for sub in bp.fold_prefix.iter().skip(self.num_fold_peaks) {
+                match self.digests.get(&sub.pos) {
                     Some(d) => {
                         acc = Some(acc.map_or(*d, |a| hasher.fold(&a, d)));
                     }
-                    None => return Err(Error::ElementPruned(pos)),
+                    None => return Err(Error::ElementPruned(sub.pos)),
                 }
             }
             digests.push(acc.expect("fold_prefix is non-empty so acc must be set"));
@@ -198,11 +198,11 @@ pub async fn historical_range_proof<
 
     let mut digests: Vec<D> = Vec::new();
     if !bp.fold_prefix.is_empty() {
-        let node_futures = bp.fold_prefix.iter().map(|&pos| merkle.get_node(pos));
+        let node_futures = bp.fold_prefix.iter().map(|sub| merkle.get_node(sub.pos));
         let results = try_join_all(node_futures).await?;
-        let mut acc = results[0].ok_or(Error::ElementPruned(bp.fold_prefix[0]))?;
+        let mut acc = results[0].ok_or(Error::ElementPruned(bp.fold_prefix[0].pos))?;
         for (i, &result) in results.iter().enumerate().skip(1) {
-            let d = result.ok_or(Error::ElementPruned(bp.fold_prefix[i]))?;
+            let d = result.ok_or(Error::ElementPruned(bp.fold_prefix[i].pos))?;
             acc = hasher.fold(&acc, &d);
         }
         digests.push(acc);

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -1666,9 +1666,9 @@ pub(crate) mod test {
         type TestMmr = Mmr<deterministic::Context, Digest>;
 
         impl FromSyncTestable for AnyTest {
-            type Mmr = TestMmr;
+            type Merkle = TestMmr;
 
-            fn into_log_components(self) -> (Self::Mmr, Self::Journal) {
+            fn into_log_components(self) -> (Self::Merkle, Self::Journal) {
                 (self.log.merkle, self.log.journal)
             }
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -605,9 +605,9 @@ pub(crate) mod test {
         type TestMmr = Mmr<deterministic::Context, Digest>;
 
         impl FromSyncTestable for AnyTest {
-            type Mmr = TestMmr;
+            type Merkle = TestMmr;
 
-            fn into_log_components(self) -> (Self::Mmr, Self::Journal) {
+            fn into_log_components(self) -> (Self::Merkle, Self::Journal) {
                 (self.log.merkle, self.log.journal)
             }
 

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -107,6 +107,7 @@ macro_rules! impl_sync_database {
             T: Translator,
             $($($where_extra)+)?
         {
+            type Family = mmr::Family;
             type Context = E;
             type Op = $op<mmr::Family, K, V>;
             type Journal = $journal;
@@ -119,6 +120,12 @@ macro_rules! impl_sync_database {
                 config: Self::Config,
                 log: Self::Journal,
                 pinned_nodes: Option<Vec<Self::Digest>>,
+                // `any` does not distinguish between ops and canonical roots and does not
+                // use overlay state; ignore both fields entirely.
+                _overlay_state: Option<
+                    crate::qmdb::current::sync::CurrentOverlayState<Self::Digest>,
+                >,
+                _canonical_root: Option<Self::Digest>,
                 range: Range<Location>,
                 apply_batch_size: usize,
             ) -> Result<Self, qmdb::Error<mmr::Family>> {

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         authenticated,
         contiguous::{fixed, variable, Mutable},
     },
-    merkle::mmr::{self, journaled, Location, StandardHasher},
+    merkle::{self, hasher::Standard as StandardHasher, journaled, Location},
     qmdb::{
         self,
         any::{
@@ -48,19 +48,20 @@ use std::ops::Range;
 pub(crate) mod tests;
 
 /// Shared helper to build a [Db] from sync components.
-async fn build_db<E, O, I, H, U, C, T>(
+async fn build_db<F, E, O, I, H, U, C, T>(
     context: E,
-    mmr_config: journaled::Config,
+    merkle_config: journaled::Config,
     log: C,
     translator: T,
     pinned_nodes: Option<Vec<H::Digest>>,
-    range: Range<Location>,
+    range: Range<Location<F>>,
     apply_batch_size: usize,
-) -> Result<Db<mmr::Family, E, C, I, H, U>, qmdb::Error<mmr::Family>>
+) -> Result<Db<F, E, C, I, H, U>, qmdb::Error<F>>
 where
+    F: merkle::Family,
     E: Context,
-    O: Operation<mmr::Family> + Committable + CodecShared + Send + Sync + 'static,
-    I: IndexFactory<T, Value = Location>,
+    O: Operation<F> + Committable + CodecShared + Send + Sync + 'static,
+    I: IndexFactory<T, Value = Location<F>>,
     H: Hasher,
     U: Send + Sync + 'static,
     T: Translator,
@@ -68,10 +69,10 @@ where
 {
     let hasher = StandardHasher::<H>::new();
 
-    let mmr = crate::mmr::journaled::Mmr::init_sync(
-        context.with_label("mmr"),
-        crate::mmr::journaled::SyncConfig {
-            config: mmr_config,
+    let merkle = journaled::Journaled::<F, _, _>::init_sync(
+        context.with_label("merkle"),
+        journaled::SyncConfig {
+            config: merkle_config,
             range: range.clone(),
             pinned_nodes,
         },
@@ -81,8 +82,8 @@ where
 
     let index = I::new(context.with_label("index"), translator);
 
-    let log = authenticated::Journal::<mmr::Family, _, _, _>::from_components(
-        mmr,
+    let log = authenticated::Journal::<F, _, _, _>::from_components(
+        merkle,
         log,
         hasher,
         apply_batch_size as u64,
@@ -98,8 +99,9 @@ macro_rules! impl_sync_database {
      $journal:ty, $config:ty,
      $key_bound:path, $value_bound:ident
      $(; $($where_extra:tt)+)?) => {
-        impl<E, K, V, H, T> qmdb::sync::Database for $db<mmr::Family, E, K, V, H, T>
+        impl<F, E, K, V, H, T> qmdb::sync::Database for $db<F, E, K, V, H, T>
         where
+            F: merkle::Family,
             E: Context,
             K: $key_bound,
             V: $value_bound + 'static,
@@ -107,9 +109,9 @@ macro_rules! impl_sync_database {
             T: Translator,
             $($($where_extra)+)?
         {
-            type Family = mmr::Family;
+            type Family = F;
             type Context = E;
-            type Op = $op<mmr::Family, K, V>;
+            type Op = $op<F, K, V>;
             type Journal = $journal;
             type Hasher = H;
             type Config = $config;
@@ -126,14 +128,14 @@ macro_rules! impl_sync_database {
                     crate::qmdb::current::sync::CurrentOverlayState<Self::Digest>,
                 >,
                 _canonical_root: Option<Self::Digest>,
-                range: Range<Location>,
+                range: Range<Location<F>>,
                 apply_batch_size: usize,
-            ) -> Result<Self, qmdb::Error<mmr::Family>> {
-                let mmr_config = config.merkle_config.clone();
+            ) -> Result<Self, qmdb::Error<F>> {
+                let merkle_config = config.merkle_config.clone();
                 let translator = config.translator.clone();
-                build_db::<_, Self::Op, _, H, $update<K, V>, _, T>(
+                build_db::<F, _, Self::Op, _, H, $update<K, V>, _, T>(
                     context,
-                    mmr_config,
+                    merkle_config,
                     log,
                     translator,
                     pinned_nodes,
@@ -159,9 +161,9 @@ impl_sync_database!(
 impl_sync_database!(
     UnorderedVariableDb, UnorderedVariableOp, UnorderedVariableUpdate,
     variable::Journal<E, Self::Op>,
-    VariableConfig<T, <UnorderedVariableOp<mmr::Family, K, V> as CodecRead>::Cfg>,
+    VariableConfig<T, <UnorderedVariableOp<F, K, V> as CodecRead>::Cfg>,
     Key, VariableValue;
-    UnorderedVariableOp<mmr::Family, K, V>: CodecShared
+    UnorderedVariableOp<F, K, V>: CodecShared
 );
 
 impl_sync_database!(
@@ -173,7 +175,7 @@ impl_sync_database!(
 impl_sync_database!(
     OrderedVariableDb, OrderedVariableOp, OrderedVariableUpdate,
     variable::Journal<E, Self::Op>,
-    VariableConfig<T, <OrderedVariableOp<mmr::Family, K, V> as CodecRead>::Cfg>,
+    VariableConfig<T, <OrderedVariableOp<F, K, V> as CodecRead>::Cfg>,
     Key, VariableValue;
-    OrderedVariableOp<mmr::Family, K, V>: CodecShared
+    OrderedVariableOp<F, K, V>: CodecShared
 );

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -1718,9 +1718,119 @@ where
 
 mod harnesses {
     use super::SyncTestHarness;
-    use crate::{qmdb::any::value::VariableEncoding, translator::TwoCap};
+    use crate::{
+        merkle::{self, mmb},
+        qmdb::any::value::VariableEncoding,
+        translator::TwoCap,
+    };
     use commonware_cryptography::sha256::Digest;
+    use commonware_math::algebra::Random;
     use commonware_runtime::{deterministic::Context, BufferPooler};
+    use commonware_utils::test_rng_seeded;
+    use rand::RngCore;
+
+    // ===== Family-generic op creation helpers =====
+    //
+    // `Operation<F, K, V>` is phantom in F for Update/Delete variants, so ops
+    // are structurally identical across families.
+
+    fn create_ordered_fixed_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let next_key = Digest::random(&mut rng);
+                let value = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update {
+                    key,
+                    value,
+                    next_key,
+                }));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_unordered_fixed_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let value = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update(key, value)));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_ordered_variable_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::ordered::variable::Operation<F, Digest, Vec<u8>>> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let next_key = Digest::random(&mut rng);
+                let len = ((rng.next_u64() % 13) + 7) as usize;
+                let value = vec![(rng.next_u64() % 255) as u8; len];
+                ops.push(Operation::Update(Update {
+                    key,
+                    value,
+                    next_key,
+                }));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_unordered_variable_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::unordered::variable::Operation<F, Digest, Vec<u8>>> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let len = ((rng.next_u64() % 13) + 7) as usize;
+                let value = vec![(rng.next_u64() % 255) as u8; len];
+                ops.push(Operation::Update(Update(key, value)));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    // ===== MMR harnesses (existing, unchanged) =====
 
     // ----- Ordered/Fixed -----
 
@@ -1972,6 +2082,323 @@ mod harnesses {
             db
         }
     }
+
+    // ===== MMB harnesses =====
+
+    // ----- Ordered/Fixed MMB -----
+
+    pub struct OrderedFixedMmbHarness;
+
+    impl SyncTestHarness for OrderedFixedMmbHarness {
+        type Family = mmb::Family;
+        type Db = crate::qmdb::any::ordered::fixed::Db<
+            mmb::Family,
+            Context,
+            Digest,
+            Digest,
+            commonware_cryptography::Sha256,
+            TwoCap,
+        >;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            db.root()
+        }
+
+        fn config(
+            suffix: &str,
+            pooler: &impl BufferPooler,
+        ) -> crate::qmdb::any::FixedConfig<TwoCap> {
+            crate::qmdb::any::test::fixed_db_config(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>> {
+            create_ordered_fixed_ops(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>> {
+            create_ordered_fixed_ops(n, seed)
+        }
+
+        async fn init_db(mut ctx: Context) -> Self::Db {
+            let seed = ctx.next_u64();
+            let cfg = crate::qmdb::any::test::fixed_db_config::<TwoCap>(&seed.to_string(), &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(
+            ctx: Context,
+            config: crate::qmdb::any::FixedConfig<TwoCap>,
+        ) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            mut db: Self::Db,
+            ops: Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            use crate::qmdb::any::operation::Operation;
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(data) => {
+                        batch = batch.write(data.key, Some(data.value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db
+        }
+    }
+
+    // ----- Ordered/Variable MMB -----
+
+    pub struct OrderedVariableMmbHarness;
+
+    impl SyncTestHarness for OrderedVariableMmbHarness {
+        type Family = mmb::Family;
+        type Db = crate::qmdb::any::ordered::variable::Db<
+            mmb::Family,
+            Context,
+            Digest,
+            Vec<u8>,
+            commonware_cryptography::Sha256,
+            TwoCap,
+        >;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            db.root()
+        }
+
+        fn config(
+            suffix: &str,
+            pooler: &impl BufferPooler,
+        ) -> crate::qmdb::any::ordered::variable::test::VarConfig {
+            crate::qmdb::any::ordered::variable::test::create_test_config(
+                suffix.parse().unwrap_or(0),
+                pooler,
+            )
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>
+        {
+            create_ordered_variable_ops(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>
+        {
+            create_ordered_variable_ops(n, seed)
+        }
+
+        async fn init_db(mut ctx: Context) -> Self::Db {
+            let seed = ctx.next_u64();
+            let config = crate::qmdb::any::ordered::variable::test::create_test_config(seed, &ctx);
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn init_db_with_config(
+            ctx: Context,
+            config: crate::qmdb::any::ordered::variable::test::VarConfig,
+        ) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            mut db: Self::Db,
+            ops: Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>,
+        ) -> Self::Db {
+            use crate::qmdb::any::operation::Operation;
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(data) => {
+                        batch = batch.write(data.key, Some(data.value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            let merkleized = batch.merkleize(&db, None::<Vec<u8>>).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db
+        }
+    }
+
+    // ----- Unordered/Fixed MMB -----
+
+    pub struct UnorderedFixedMmbHarness;
+
+    impl SyncTestHarness for UnorderedFixedMmbHarness {
+        type Family = mmb::Family;
+        type Db = crate::qmdb::any::unordered::fixed::Db<
+            mmb::Family,
+            Context,
+            Digest,
+            Digest,
+            commonware_cryptography::Sha256,
+            TwoCap,
+        >;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            db.root()
+        }
+
+        fn config(
+            suffix: &str,
+            pooler: &impl BufferPooler,
+        ) -> crate::qmdb::any::FixedConfig<TwoCap> {
+            crate::qmdb::any::test::fixed_db_config(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_fixed_ops(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_fixed_ops(n, seed)
+        }
+
+        async fn init_db(mut ctx: Context) -> Self::Db {
+            let seed = ctx.next_u64();
+            let cfg = crate::qmdb::any::test::fixed_db_config::<TwoCap>(&seed.to_string(), &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(
+            ctx: Context,
+            config: crate::qmdb::any::FixedConfig<TwoCap>,
+        ) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            mut db: Self::Db,
+            ops: Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            use crate::qmdb::any::operation::Operation;
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(data) => {
+                        batch = batch.write(data.0, Some(data.1));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db
+        }
+    }
+
+    // ----- Unordered/Variable MMB -----
+
+    pub struct UnorderedVariableMmbHarness;
+
+    impl SyncTestHarness for UnorderedVariableMmbHarness {
+        type Family = mmb::Family;
+        type Db = crate::qmdb::any::unordered::variable::Db<
+            mmb::Family,
+            Context,
+            Digest,
+            Vec<u8>,
+            commonware_cryptography::Sha256,
+            TwoCap,
+        >;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            db.root()
+        }
+
+        fn config(
+            suffix: &str,
+            pooler: &impl BufferPooler,
+        ) -> crate::qmdb::any::unordered::variable::test::VarConfig {
+            crate::qmdb::any::unordered::variable::test::create_test_config(
+                suffix.parse().unwrap_or(0),
+                pooler,
+            )
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>
+        {
+            create_unordered_variable_ops(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>
+        {
+            create_unordered_variable_ops(n, seed)
+        }
+
+        async fn init_db(mut ctx: Context) -> Self::Db {
+            let seed = ctx.next_u64();
+            let config =
+                crate::qmdb::any::unordered::variable::test::create_test_config(seed, &ctx);
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn init_db_with_config(
+            ctx: Context,
+            config: crate::qmdb::any::unordered::variable::test::VarConfig,
+        ) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            mut db: Self::Db,
+            ops: Vec<
+                crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Vec<u8>>,
+            >,
+        ) -> Self::Db {
+            use crate::qmdb::any::operation::Operation;
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(data) => {
+                        batch = batch.write(data.0, Some(data.1));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            let merkleized = batch.merkleize(&db, None::<Vec<u8>>).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db
+        }
+    }
 }
 
 // ===== Test Generation Macro =====
@@ -2100,6 +2527,17 @@ macro_rules! sync_tests_for_harness {
             fn test_sync_retries_bad_pinned_nodes() {
                 super::test_sync_retries_bad_pinned_nodes::<$harness>();
             }
+        }
+    };
+}
+
+/// Additional from_sync_result tests that require `FromSyncTestable`.
+/// Only the MMR harnesses have `FromSyncTestable` impls.
+macro_rules! from_sync_result_tests_for_harness {
+    ($harness:ty, $mod_name:ident) => {
+        mod $mod_name {
+            use super::harnesses;
+            use commonware_macros::test_traced;
 
             #[test_traced("WARN")]
             fn test_from_sync_result_empty_to_empty() {
@@ -2124,7 +2562,28 @@ macro_rules! sync_tests_for_harness {
     };
 }
 
+// MMR harnesses (all tests including from_sync_result)
 sync_tests_for_harness!(harnesses::OrderedFixedHarness, ordered_fixed);
 sync_tests_for_harness!(harnesses::OrderedVariableHarness, ordered_variable);
 sync_tests_for_harness!(harnesses::UnorderedFixedHarness, unordered_fixed);
 sync_tests_for_harness!(harnesses::UnorderedVariableHarness, unordered_variable);
+
+from_sync_result_tests_for_harness!(harnesses::OrderedFixedHarness, ordered_fixed_from_sync);
+from_sync_result_tests_for_harness!(
+    harnesses::OrderedVariableHarness,
+    ordered_variable_from_sync
+);
+from_sync_result_tests_for_harness!(harnesses::UnorderedFixedHarness, unordered_fixed_from_sync);
+from_sync_result_tests_for_harness!(
+    harnesses::UnorderedVariableHarness,
+    unordered_variable_from_sync
+);
+
+// MMB harnesses (sync tests only, no from_sync_result)
+sync_tests_for_harness!(harnesses::OrderedFixedMmbHarness, ordered_fixed_mmb);
+sync_tests_for_harness!(harnesses::OrderedVariableMmbHarness, ordered_variable_mmb);
+sync_tests_for_harness!(harnesses::UnorderedFixedMmbHarness, unordered_fixed_mmb);
+sync_tests_for_harness!(
+    harnesses::UnorderedVariableMmbHarness,
+    unordered_variable_mmb
+);

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     journal::contiguous::Contiguous,
-    merkle::{mmr, mmr::Location},
+    merkle::{self, Location},
     qmdb::{
         self,
         any::traits::DbAny,
@@ -46,40 +46,56 @@ pub(crate) type ConfigOf<H> = <DbOf<H> as qmdb::sync::Database>::Config;
 /// Type alias for the journal type of a harness.
 pub(crate) type JournalOf<H> = <DbOf<H> as qmdb::sync::Database>::Journal;
 
+/// Type alias for the merkle family used by a harness.
+pub(crate) type FamilyOf<H> = <DbOf<H> as qmdb::sync::Database>::Family;
+
 /// Trait for cleanup operations in tests.
 pub(crate) trait Destructible {
+    type Family: merkle::Family;
+
     fn destroy(
         self,
-    ) -> impl std::future::Future<Output = Result<(), qmdb::Error<crate::mmr::Family>>> + Send;
+    ) -> impl std::future::Future<Output = Result<(), qmdb::Error<Self::Family>>> + Send;
 }
 
-// Implement Destructible for the concrete MMR type used in tests.
+// Implement Destructible once for the generic journaled Merkle type used in tests.
 // This is here (rather than in fixed/variable modules) to avoid duplicate implementations.
-impl Destructible for crate::mmr::journaled::Mmr<deterministic::Context, Digest> {
-    async fn destroy(self) -> Result<(), qmdb::Error<crate::mmr::Family>> {
+impl<F: merkle::Family> Destructible
+    for crate::merkle::journaled::Journaled<F, deterministic::Context, Digest>
+{
+    type Family = F;
+
+    async fn destroy(self) -> Result<(), qmdb::Error<F>> {
         self.destroy().await.map_err(qmdb::Error::Merkle)
     }
 }
 
 /// Trait providing internal access for from_sync_result tests.
 pub(crate) trait FromSyncTestable: qmdb::sync::Database {
-    type Mmr: Destructible + Send;
+    type Merkle: Destructible<Family = Self::Family> + Send;
 
-    /// Get the MMR and journal from the database
-    fn into_log_components(self) -> (Self::Mmr, Self::Journal);
+    /// Get the Merkle structure and journal from the database.
+    fn into_log_components(self) -> (Self::Merkle, Self::Journal);
 
     /// Get the pinned nodes at a given location
     fn pinned_nodes_at(
         &self,
-        loc: Location,
+        loc: Location<Self::Family>,
     ) -> impl std::future::Future<Output = Vec<Self::Digest>> + Send;
 }
 
 /// Harness for sync tests.
 pub(crate) trait SyncTestHarness: Sized + 'static {
+    /// The merkle family the database under test uses.
+    type Family: merkle::Family;
+
     /// The database type being tested.
-    type Db: qmdb::sync::Database<Context = deterministic::Context, Digest = Digest, Config: Clone>
-        + DbAny<mmr::Family, Key = Digest, Digest = Digest>;
+    type Db: qmdb::sync::Database<
+            Family = Self::Family,
+            Context = deterministic::Context,
+            Digest = Digest,
+            Config: Clone,
+        > + DbAny<Self::Family, Key = Digest, Digest = Digest>;
 
     /// Return the root the sync engine targets.
     fn sync_target_root(db: &Self::Db) -> Digest;
@@ -113,7 +129,7 @@ pub(crate) trait SyncTestHarness: Sized + 'static {
 /// Test that empty operations arrays fetched do not cause panics when stored and applied
 pub(crate) fn test_sync_empty_operations_no_panic<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -130,6 +146,7 @@ where
             target: Target {
                 root: Digest::from([1u8; 32]),
                 range: non_empty_range!(Location::new(0), Location::new(10)),
+                canonical_root: None,
             },
             context: context.with_label("client"),
             resolver: Arc::new(target_db),
@@ -158,13 +175,14 @@ where
 /// Test that resolver failure is handled correctly
 pub(crate) fn test_sync_resolver_fails<H: SyncTestHarness>()
 where
-    resolver::tests::FailResolver<OpOf<H>, Digest>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    resolver::tests::FailResolver<FamilyOf<H>, OpOf<H>, Digest>:
+        Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
     let executor = deterministic::Runner::default();
     executor.start(|mut context| async move {
-        let resolver = resolver::tests::FailResolver::<OpOf<H>, Digest>::new();
+        let resolver = resolver::tests::FailResolver::<FamilyOf<H>, OpOf<H>, Digest>::new();
         let target_root = Digest::from([0; 32]);
 
         let db_config = H::config(&context.next_u64().to_string(), &context);
@@ -173,6 +191,7 @@ where
             target: Target {
                 root: target_root,
                 range: non_empty_range!(Location::new(0), Location::new(5)),
+                canonical_root: None,
             },
             resolver,
             apply_batch_size: 2,
@@ -193,7 +212,7 @@ where
 /// Test basic sync functionality with various batch sizes
 pub(crate) fn test_sync<H: SyncTestHarness>(target_db_ops: usize, fetch_batch_size: NonZeroU64)
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -225,6 +244,7 @@ where
             target: Target {
                 root: sync_root,
                 range: non_empty_range!(lower_bound, target_op_count),
+                canonical_root: None,
             },
             context: client_context.clone(),
             resolver: target_db.clone(),
@@ -276,8 +296,8 @@ where
 /// Test syncing to a subset of the target database (target has additional ops beyond sync range)
 pub(crate) fn test_sync_subset_of_target_database<H: SyncTestHarness>(target_db_ops: usize)
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone + OperationTrait<mmr::Family, Key = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone + OperationTrait<FamilyOf<H>, Key = Digest>,
     JournalOf<H>: Contiguous,
 {
     let executor = deterministic::Runner::default();
@@ -308,6 +328,7 @@ where
             target: Target {
                 root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
+                canonical_root: None,
             },
             context: context.with_label("client"),
             resolver: Arc::new(target_db),
@@ -342,8 +363,8 @@ where
 /// Tests the scenario where sync_db already has partial data and needs to sync additional ops.
 pub(crate) fn test_sync_use_existing_db_partial_match<H: SyncTestHarness>(original_ops: usize)
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone + OperationTrait<mmr::Family, Key = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone + OperationTrait<FamilyOf<H>, Key = Digest>,
     JournalOf<H>: Contiguous,
 {
     let executor = deterministic::Runner::default();
@@ -384,6 +405,7 @@ where
             target: Target {
                 root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
+                canonical_root: None,
             },
             context: client_context.with_label("sync"),
             resolver: target_db.clone(),
@@ -437,8 +459,9 @@ where
 /// Uses FailResolver to verify that no network requests are made since data already exists.
 pub(crate) fn test_sync_use_existing_db_exact_match<H: SyncTestHarness>(num_ops: usize)
 where
-    resolver::tests::FailResolver<OpOf<H>, Digest>: Resolver<Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone + OperationTrait<mmr::Family, Key = Digest>,
+    resolver::tests::FailResolver<FamilyOf<H>, OpOf<H>, Digest>:
+        Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone + OperationTrait<FamilyOf<H>, Key = Digest>,
     JournalOf<H>: Contiguous,
 {
     let executor = deterministic::Runner::default();
@@ -480,13 +503,14 @@ where
         // sync_db should never ask the resolver for operations
         // because it is already complete. Use a resolver that always fails
         // to ensure that it's not being used.
-        let resolver = resolver::tests::FailResolver::<OpOf<H>, Digest>::new();
+        let resolver = resolver::tests::FailResolver::<FamilyOf<H>, OpOf<H>, Digest>::new();
         let config = Config {
             db_config: sync_config, // Use same config to access same partitions
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
+                canonical_root: None,
             },
             context: client_context.with_label("sync"),
             resolver,
@@ -525,7 +549,7 @@ where
 /// Test that the client fails to sync if the lower bound is decreased via target update.
 pub(crate) fn test_target_update_lower_bound_decrease<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -552,6 +576,7 @@ where
             target: Target {
                 root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                canonical_root: None,
             },
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -571,6 +596,7 @@ where
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound.checked_add(1).unwrap()
                 ),
+                canonical_root: None,
             })
             .await
             .unwrap();
@@ -594,7 +620,7 @@ where
 /// Test that the client fails to sync if the upper bound is decreased via target update.
 pub(crate) fn test_target_update_upper_bound_decrease<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -621,6 +647,7 @@ where
             target: Target {
                 root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                canonical_root: None,
             },
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -640,6 +667,7 @@ where
                     initial_lower_bound,
                     initial_upper_bound.checked_sub(1).unwrap()
                 ),
+                canonical_root: None,
             })
             .await
             .unwrap();
@@ -663,7 +691,7 @@ where
 /// Test that the client succeeds when bounds are updated (increased).
 pub(crate) fn test_target_update_bounds_increase<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode + Clone,
     JournalOf<H>: Contiguous,
 {
@@ -704,6 +732,7 @@ where
                 target: Target {
                     root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,
@@ -719,6 +748,7 @@ where
                 .send(Target {
                     root: new_sync_root,
                     range: non_empty_range!(new_lower_bound, new_upper_bound),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -748,7 +778,7 @@ where
 /// Test that target updates can be sent even after the client is done (no panic).
 pub(crate) fn test_target_update_on_done_client<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -776,6 +806,7 @@ where
             target: Target {
                 root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
+                canonical_root: None,
             },
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -796,6 +827,7 @@ where
                 // Dummy target update
                 root: Digest::from([2u8; 32]),
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
+                canonical_root: None,
             })
             .await;
 
@@ -817,7 +849,7 @@ where
 /// Test that explicit finish control waits for a finish signal even after reaching target.
 pub(crate) fn test_sync_waits_for_explicit_finish<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -831,6 +863,7 @@ where
                 target_db.inactivity_floor_loc().await,
                 target_db.bounds().await.end
             ),
+            canonical_root: None,
         };
 
         target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
@@ -839,6 +872,7 @@ where
         let updated_target = Target {
             root: H::sync_target_root(&target_db),
             range: non_empty_range!(updated_lower_bound, updated_upper_bound),
+            canonical_root: None,
         };
         let updated_verification_root = target_db.root();
 
@@ -920,7 +954,7 @@ where
 /// Test that a finish signal received before target completion still allows full sync.
 pub(crate) fn test_sync_handles_early_finish_signal<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -933,6 +967,7 @@ where
         let target = Target {
             root: H::sync_target_root(&target_db),
             range: non_empty_range!(lower_bound, upper_bound),
+            canonical_root: None,
         };
         let verification_root = target_db.root();
 
@@ -983,7 +1018,7 @@ where
 /// Test that dropping finish sender without sending is treated as an error.
 pub(crate) fn test_sync_fails_when_finish_sender_dropped<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -1005,6 +1040,7 @@ where
             target: Target {
                 root: H::sync_target_root(&target_db),
                 range: non_empty_range!(lower_bound, upper_bound),
+                canonical_root: None,
             },
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -1032,7 +1068,7 @@ where
 /// Test that dropping reached-target receiver does not fail sync.
 pub(crate) fn test_sync_allows_dropped_reached_target_receiver<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -1055,6 +1091,7 @@ where
             target: Target {
                 root: H::sync_target_root(&target_db),
                 range: non_empty_range!(lower_bound, upper_bound),
+                canonical_root: None,
             },
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -1086,7 +1123,8 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
     initial_ops: usize,
     additional_ops: usize,
 ) where
-    Arc<AsyncRwLock<Option<DbOf<H>>>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<AsyncRwLock<Option<DbOf<H>>>>:
+        Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode + Clone,
     JournalOf<H>: Contiguous,
 {
@@ -1116,6 +1154,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
                 target: Target {
                     root: initial_sync_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 fetch_batch_size: NZU64!(1), // Small batch size so we don't finish after one batch
@@ -1160,6 +1199,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
                 .send(Target {
                     root: new_sync_root,
                     range: non_empty_range!(new_lower_bound, new_upper_bound),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -1197,7 +1237,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
 /// Test demonstrating that a synced database can be reopened and retain its state.
 pub(crate) fn test_sync_database_persistence<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode + Clone,
     JournalOf<H>: Contiguous,
 {
@@ -1225,6 +1265,7 @@ where
             target: Target {
                 root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
+                canonical_root: None,
             },
             context: client_context.clone(),
             resolver: target_db.clone(),
@@ -1271,7 +1312,7 @@ where
 /// Test post-sync usability: after syncing, the database supports normal operations.
 pub(crate) fn test_sync_post_sync_usability<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -1293,6 +1334,7 @@ where
             target: Target {
                 root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
+                canonical_root: None,
             },
             context: context.with_label("client"),
             resolver: target_db.clone(),
@@ -1353,6 +1395,8 @@ where
             db_config,
             journal,
             Some(pinned_nodes),
+            None,
+            None,
             sync_lower_bound..sync_upper_bound,
             1024,
         )
@@ -1429,6 +1473,8 @@ where
             sync_db_config,
             journal,
             Some(pinned_nodes),
+            None,
+            None,
             sync_lower_bound..sync_upper_bound,
             1024,
         )
@@ -1491,6 +1537,8 @@ where
             new_db_config,
             journal,
             Some(pinned_nodes),
+            None,
+            None,
             lower_bound..upper_bound,
             1024,
         )
@@ -1536,6 +1584,8 @@ where
             new_db_config,
             journal,
             None,
+            None,
+            None,
             Location::new(0)..Location::new(1),
             1024,
         )
@@ -1567,19 +1617,23 @@ struct CorruptFirstPinnedNodesResolver<R> {
     corrupted: Arc<std::sync::atomic::AtomicBool>,
 }
 
-impl<R: Resolver<Digest = Digest>> Resolver for CorruptFirstPinnedNodesResolver<R> {
+impl<R> Resolver for CorruptFirstPinnedNodesResolver<R>
+where
+    R: Resolver<Digest = Digest>,
+{
+    type Family = R::Family;
     type Digest = Digest;
     type Op = R::Op;
     type Error = R::Error;
 
     async fn get_operations(
         &self,
-        op_count: Location,
-        start_loc: Location,
+        op_count: Location<Self::Family>,
+        start_loc: Location<Self::Family>,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
         cancel_rx: oneshot::Receiver<()>,
-    ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+    ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
         let mut result = self
             .inner
             .get_operations(
@@ -1610,7 +1664,7 @@ impl<R: Resolver<Digest = Digest>> Resolver for CorruptFirstPinnedNodesResolver<
 /// succeeds on retry when the resolver returns correct data.
 pub(crate) fn test_sync_retries_bad_pinned_nodes<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -1642,6 +1696,7 @@ where
             target: Target {
                 root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
+                canonical_root: None,
             },
             context: context.with_label("client"),
             resolver,
@@ -1672,6 +1727,7 @@ mod harnesses {
     pub struct OrderedFixedHarness;
 
     impl SyncTestHarness for OrderedFixedHarness {
+        type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::ordered::fixed::test::AnyTest;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
@@ -1729,6 +1785,7 @@ mod harnesses {
     pub struct OrderedVariableHarness;
 
     impl SyncTestHarness for OrderedVariableHarness {
+        type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::ordered::variable::test::AnyTest;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
@@ -1793,6 +1850,7 @@ mod harnesses {
     pub struct UnorderedFixedHarness;
 
     impl SyncTestHarness for UnorderedFixedHarness {
+        type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::unordered::fixed::test::AnyTest;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
@@ -1850,6 +1908,7 @@ mod harnesses {
     pub struct UnorderedVariableHarness;
 
     impl SyncTestHarness for UnorderedVariableHarness {
+        type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::unordered::variable::test::AnyTest;
 
         fn sync_target_root(db: &Self::Db) -> Digest {

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -798,9 +798,9 @@ pub(crate) mod test {
         type TestMmr = Mmr<deterministic::Context, Digest>;
 
         impl FromSyncTestable for AnyTest {
-            type Mmr = TestMmr;
+            type Merkle = TestMmr;
 
-            fn into_log_components(self) -> (Self::Mmr, Self::Journal) {
+            fn into_log_components(self) -> (Self::Merkle, Self::Journal) {
                 (self.log.merkle, self.log.journal)
             }
 

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -720,9 +720,9 @@ pub(crate) mod test {
         type TestMmr = Mmr<deterministic::Context, Digest>;
 
         impl FromSyncTestable for AnyTest {
-            type Mmr = TestMmr;
+            type Merkle = TestMmr;
 
-            fn into_log_components(self) -> (Self::Mmr, Self::Journal) {
+            fn into_log_components(self) -> (Self::Merkle, Self::Journal) {
                 (self.log.merkle, self.log.journal)
             }
 

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -12,7 +12,7 @@
 //! range proofs (identical to `any` sync). Validating that the ops root is part of the
 //! canonical root is the caller's responsibility; the sync engine does not perform this check.
 //!
-//! The [Database](crate::qmdb::sync::Database)`::`[root()](crate::qmdb::sync::Database::root)
+//! The [Database]`::`[root()](crate::qmdb::sync::Database::root)
 //! implementation returns the **ops root** (not the canonical root) because that is what the
 //! sync engine verifies against.
 //!

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -1,28 +1,44 @@
 //! Shared synchronization logic for [crate::qmdb::current] databases.
 //!
-//! Contains implementation of [crate::qmdb::sync::Database] for all [Db](crate::qmdb::current::db::Db)
-//! variants (ordered/unordered, fixed/variable).
+//! Contains implementation of [crate::qmdb::sync::Database] for all
+//! [Db](crate::qmdb::current::db::Db) variants (ordered/unordered, fixed/variable).
 //!
-//! The canonical root of a `current` database combines the ops root, grafted MMR root, and
+//! # Trust model
+//!
+//! The canonical root of a `current` database combines the ops root, grafted tree root, and
 //! optional partial chunk into a single hash (see the [Root structure](super) section in the
 //! module documentation). The sync engine operates on the **ops root**, not the canonical root:
-//! it downloads operations and verifies each batch against the ops root using standard MMR
+//! it downloads operations and verifies each batch against the ops root using standard Merkle
 //! range proofs (identical to `any` sync). Validating that the ops root is part of the
 //! canonical root is the caller's responsibility; the sync engine does not perform this check.
 //!
-//! After all operations are synced, the bitmap and grafted MMR are reconstructed
-//! deterministically from the operations. The canonical root is then computed from the
-//! ops root, the reconstructed grafted MMR root, and any partial chunk.
-//!
-//! The [Database]`::`[root()](crate::qmdb::sync::Database::root)
+//! The [Database](crate::qmdb::sync::Database)`::`[root()](crate::qmdb::sync::Database::root)
 //! implementation returns the **ops root** (not the canonical root) because that is what the
 //! sync engine verifies against.
 //!
-//! For pruned databases (`range.start > 0`), grafted MMR pinned nodes for the pruned region
-//! are read directly from the ops MMR after it is built. This works because of the zero-chunk
-//! identity: for all-zero bitmap chunks (which all pruned chunks are), the grafted leaf equals
-//! the ops subtree root, making the grafted MMR structurally identical to the ops MMR at and
-//! above the grafting height.
+//! # Grafted pruning state and overlay state
+//!
+//! For pruned databases (`range.start > 0`), the receiver needs the grafted tree's pinned
+//! nodes at the sender's pruning boundary in order to reconstruct the canonical root.
+//! Deriving those pins from the synced ops tree alone (e.g., taking the first
+//! `popcount(pruned_chunks)` entries of `F::nodes_to_pin(range.start)`) relies on the
+//! zero-chunk identity (pruned chunks are all-zero so each grafted leaf equals its ops
+//! subtree root) **and** on the ops pin ordering coinciding with the grafted pin ordering.
+//!
+//! That coincidence holds for MMR. It does **not** hold in general for MMB: delayed merges
+//! can put ops pins at heights below the grafting height, and for some sender states the
+//! receiver's derivation produces a different `pruned_chunks` value than the sender's actual
+//! overlay pruning. When that happens the reconstructed grafted tree diverges from the
+//! sender's, and the canonical root drifts.
+//!
+//! To avoid that divergence, the sender ships its overlay state explicitly via
+//! [`CurrentOverlayState`] on the first (boundary) batch of the sync, carried on
+//! [`FetchResult`](crate::qmdb::sync::FetchResult). The receiver seeds the grafted tree from
+//! those pins rather than re-deriving them from `range.start`, and authenticates the payload
+//! indirectly by comparing the rebuilt database's canonical root against
+//! [`Target::canonical_root`](crate::qmdb::sync::Target::canonical_root) (when the caller
+//! supplied one). A lying sender therefore cannot coerce the receiver into persisting a
+//! diverged overlay: the canonical-root check fails before anything is written to disk.
 
 use crate::{
     index::Factory as IndexFactory,
@@ -30,10 +46,7 @@ use crate::{
         authenticated,
         contiguous::{fixed, variable, Mutable},
     },
-    merkle::{
-        mmr::{self, Family, Location, StandardHasher},
-        Family as _,
-    },
+    merkle::{self, hasher::Standard as StandardHasher, journaled, Location},
     qmdb::{
         self,
         any::{
@@ -66,12 +79,57 @@ use crate::{
     Context, Persistable,
 };
 use commonware_codec::{Codec, CodecShared, Read as CodecRead};
-use commonware_cryptography::{DigestOf, Hasher};
-use commonware_utils::{bitmap::Prunable as BitMap, channel::oneshot, sync::AsyncMutex, Array};
+use commonware_cryptography::{Digest, DigestOf, Hasher};
+use commonware_utils::{
+    bitmap::{Prunable as BitMap, Readable as BitmapReadable},
+    channel::oneshot,
+    sync::AsyncMutex,
+    Array,
+};
 use std::{ops::Range, sync::Arc};
 
 #[cfg(test)]
 pub(crate) mod tests;
+
+/// Sender-supplied overlay state for [crate::qmdb::current] sync.
+///
+/// The sync engine authenticates operations and ops-MMR pinned nodes against the **ops root**.
+/// That does not authenticate the grafted tree's pruning state. For `current` sync to reproduce
+/// the sender's actual overlay (bitmap pruning + grafted pinned digests) — not a reconstruction
+/// inferred from the synced ops range — the sender must ship its overlay state explicitly, and
+/// the receiver must validate it indirectly by checking that the rebuilt database's **canonical
+/// root** matches the canonical root supplied in the sync target.
+///
+/// See the [module-level trust model](self) for the full authentication story.
+///
+/// # Invariants (enforced at the sync boundary, not by this struct)
+///
+/// - `grafted_pinned_nodes.len() == F::nodes_to_pin(Location::new(pruned_chunks)).count()`
+/// - `pruned_chunks * CHUNK_SIZE_BITS <= range.start` (sender hasn't pruned past the synced
+///   ops-range floor)
+/// - `pruned_chunks * CHUNK_SIZE_BITS <= range.end` (sender hasn't pruned past the top of the
+///   synced ops range)
+/// - If `pruned_chunks == 0`, `grafted_pinned_nodes` is empty
+///
+/// These invariants are intentionally validated at `build_db` time rather than in a constructor
+/// here, because the check needs access to the merkle family `F` and the sync range; this struct
+/// is a pure data carrier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentOverlayState<D: Digest> {
+    /// Number of fully-pruned bitmap chunks at the sender.
+    ///
+    /// Note that under the MMB settlement guard this may lag
+    /// `inactivity_floor_loc / CHUNK_SIZE_BITS` — the receiver must trust this field rather
+    /// than re-deriving it from `range.start`.
+    pub pruned_chunks: u64,
+
+    /// Grafted tree's pinned node digests at the `pruned_chunks` boundary, in the order
+    /// returned by `F::nodes_to_pin(Location::new(pruned_chunks))`.
+    ///
+    /// Length equals `F::nodes_to_pin(Location::new(pruned_chunks)).count()` (the popcount
+    /// of `pruned_chunks` under the default `nodes_to_pin` behavior).
+    pub grafted_pinned_nodes: Vec<D>,
+}
 
 impl<T: Translator, J: Clone> Config for super::Config<T, J> {
     type JournalConfig = J;
@@ -83,38 +141,140 @@ impl<T: Translator, J: Clone> Config for super::Config<T, J> {
 
 /// Shared helper to build a `current::db::Db` from sync components.
 ///
-/// This follows the same pattern as `any/sync/mod.rs::build_db` but additionally:
-/// * Builds the activity bitmap by replaying the operations log.
-/// * Extracts grafted pinned nodes from the ops MMR (zero-chunk identity).
-/// * Builds the grafted MMR from the bitmap and ops MMR.
-/// * Computes and caches the canonical root.
+/// Runs one of two reconstruction paths depending on whether the sender supplied overlay
+/// state:
+///
+/// * **Sender-supplied overlay (normal sync).** `overlay_state` carries the sender's
+///   `pruned_chunks` and the corresponding grafted pinned nodes. The receiver validates the
+///   payload's invariants, uses those pins to seed the grafted tree, and replays the synced
+///   operations to populate the bitmap tail. The grafted pruning boundary intentionally does
+///   **not** derive from `range.start`: under the MMB settlement guard the sender's
+///   `pruned_chunks` lags its inactivity floor, and deriving from the ops range would
+///   produce a divergent grafted tree.
+///
+/// * **No overlay, existing on-disk state (exact-match reopen).** `overlay_state` is `None`
+///   only when the engine completed without canonical-root authentication (e.g. `any`,
+///   `immutable`, `keyless` databases, or `current` without a trusted canonical root). When
+///   `canonical_root` is set, the engine defers completion until the normal boundary-request
+///   pipeline has delivered fresh overlay state (see `Engine::needs_fresh_boundary_state`),
+///   so `overlay_state` is always `Some` for authenticated `current` sync. The fallback to
+///   persisted metadata therefore only applies to the unauthenticated path, which trusts the
+///   overlay persisted by a prior run. If no persisted overlay exists, we treat the database
+///   as unpruned (`pruned_chunks = 0`), matching the normal init path.
+///
+/// If `canonical_root` is `Some`, the rebuilt database's canonical root is compared against
+/// it after construction; a mismatch returns [`qmdb::Error::DataCorrupted`] without
+/// persisting any metadata. This is the authentication anchor for the overlay payload: the
+/// sync engine verifies operations against the ops root but has no way to verify overlay
+/// state on its own, so the caller must supply a trusted canonical root to detect a lying
+/// sender.
 #[allow(clippy::too_many_arguments)]
-async fn build_db<E, U, I, H, J, T, const N: usize>(
+async fn build_db<F, E, U, I, H, J, T, const N: usize>(
     context: E,
-    mmr_config: mmr::journaled::Config,
+    merkle_config: journaled::Config,
     log: J,
     translator: T,
     pinned_nodes: Option<Vec<H::Digest>>,
-    range: Range<Location>,
+    overlay_state: Option<CurrentOverlayState<H::Digest>>,
+    canonical_root: Option<H::Digest>,
+    range: Range<Location<F>>,
     apply_batch_size: usize,
     metadata_partition: String,
     thread_pool: Option<commonware_parallel::ThreadPool>,
-) -> Result<db::Db<Family, E, J, I, H, U, N>, qmdb::Error<Family>>
+) -> Result<db::Db<F, E, J, I, H, U, N>, qmdb::Error<F>>
 where
+    F: merkle::Graftable,
     E: Context,
     U: Update + Send + Sync + 'static,
-    I: IndexFactory<T, Value = Location>,
+    I: IndexFactory<T, Value = Location<F>>,
     H: Hasher,
     T: Translator,
-    J: Mutable<Item = Operation<Family, U>> + Persistable<Error = crate::journal::Error>,
-    Operation<Family, U>: Codec + Committable + CodecShared,
+    J: Mutable<Item = Operation<F, U>> + Persistable<Error = crate::journal::Error>,
+    Operation<F, U>: Codec + Committable + CodecShared,
 {
+    // Load persisted metadata up front. On a fresh partition this returns
+    // `(metadata, 0, vec![])`; on a reopen of an already-synced partition it returns the
+    // previously-persisted `pruned_chunks` and grafted pins, which we use as the fallback
+    // when the sync engine did not obtain overlay state from the sender.
+    let (metadata, persisted_pruned_chunks, persisted_pins) =
+        db::init_metadata::<F, E, DigestOf<H>>(context.with_label("metadata"), &metadata_partition)
+            .await?;
+
+    // Resolve the effective overlay state. `overlay_state` from the sender takes precedence.
+    // When absent, fall back to persisted metadata — but only for the unauthenticated path
+    // (canonical_root is None). For authenticated pruned sync the engine guarantees a fresh
+    // boundary fetch, so overlay_state should always be Some.
+    let (pruned_chunks, grafted_pinned_nodes) = match overlay_state {
+        Some(state) => {
+            // Validate sender-supplied overlay-state invariants before touching any tree
+            // state. Digest validity is already enforced by codec.
+            let CurrentOverlayState {
+                pruned_chunks,
+                grafted_pinned_nodes,
+            } = state;
+            let pruned_chunks = usize::try_from(pruned_chunks).map_err(|_| {
+                qmdb::Error::<F>::DataCorrupted("overlay pruned_chunks overflows usize")
+            })?;
+            // `F::nodes_to_pin` panics on invalid `prune_loc` (exceeds `F::MAX_LEAVES`),
+            // so validate the location before invoking it. A malicious sender could otherwise
+            // supply an oversized `pruned_chunks` and convert a protocol-level failure into a
+            // panic in the receiver.
+            let pruned_loc = Location::<F>::new(pruned_chunks as u64);
+            if !pruned_loc.is_valid() {
+                return Err(qmdb::Error::<F>::DataCorrupted(
+                    "overlay pruned_chunks exceeds F::MAX_LEAVES",
+                ));
+            }
+            let expected_pins = F::nodes_to_pin(pruned_loc).count();
+            if grafted_pinned_nodes.len() != expected_pins {
+                return Err(qmdb::Error::<F>::DataCorrupted(
+                    "overlay grafted_pinned_nodes length does not match F::nodes_to_pin(pruned_chunks)",
+                ));
+            }
+            if pruned_chunks == 0 && !grafted_pinned_nodes.is_empty() {
+                return Err(qmdb::Error::<F>::DataCorrupted(
+                    "overlay grafted_pinned_nodes must be empty when pruned_chunks == 0",
+                ));
+            }
+            // The sender cannot have pruned past the synced ops range; otherwise the receiver
+            // would claim chunks pruned that it lacks the ops to reconstruct.
+            let pruned_bits = (pruned_chunks as u64)
+                .checked_mul(BitMap::<N>::CHUNK_SIZE_BITS)
+                .ok_or(qmdb::Error::<F>::DataCorrupted(
+                    "overlay pruned_chunks * chunk bits overflows u64",
+                ))?;
+            if pruned_bits > *range.start {
+                return Err(qmdb::Error::<F>::DataCorrupted(
+                    "overlay pruned_chunks extends past sync range.start",
+                ));
+            }
+            if pruned_bits > *range.end {
+                return Err(qmdb::Error::<F>::DataCorrupted(
+                    "overlay pruned_chunks extends past sync range.end",
+                ));
+            }
+            (pruned_chunks, grafted_pinned_nodes)
+        }
+        None => {
+            // Authenticated pruned sync requires fresh overlay state — the engine
+            // guarantees a boundary fetch when canonical_root is set, so reaching here
+            // with canonical_root + pruned persisted state means something went wrong
+            // (e.g. stale metadata from a prior failed sync).
+            if canonical_root.is_some() && persisted_pruned_chunks > 0 {
+                return Err(qmdb::Error::<F>::DataCorrupted(
+                    "overlay state required for authenticated pruned sync but not provided",
+                ));
+            }
+            (persisted_pruned_chunks, persisted_pins)
+        }
+    };
+
     // Build authenticated log.
     let hasher = StandardHasher::<H>::new();
-    let mmr = mmr::journaled::Mmr::init_sync(
-        context.with_label("mmr"),
-        mmr::journaled::SyncConfig {
-            config: mmr_config,
+    let merkle = journaled::Journaled::<F, _, _>::init_sync(
+        context.with_label("merkle"),
+        journaled::SyncConfig {
+            config: merkle_config,
             range: range.clone(),
             pinned_nodes,
         },
@@ -122,34 +282,31 @@ where
     )
     .await?;
     let index = I::new(context.with_label("index"), translator);
-    let log = authenticated::Journal::<Family, _, _, _>::from_components(
-        mmr,
+    let log = authenticated::Journal::<F, _, _, _>::from_components(
+        merkle,
         log,
         hasher,
         apply_batch_size as u64,
     )
     .await?;
 
-    // Initialize bitmap with pruned chunks.
-    //
-    // Floor division is intentional: chunks entirely below range.start are pruned.
-    // If range.start is not chunk-aligned, the partial leading chunk is reconstructed by
-    // init_from_log, which pads the gap between `pruned_chunks * CHUNK_SIZE_BITS` and the
-    // journal's inactivity floor with inactive (false) bits.
-    let pruned_chunks = (*range.start / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
+    // Initialize bitmap with the sender's overlay pruning boundary. If `pruned_bits` is less
+    // than the ops log's inactivity floor (e.g. MMB settlement guard defers bitmap pruning),
+    // init_from_log below replays ops from `pruned_bits` up to the floor and populates those
+    // bits as inactive (they correspond to ops that have been superseded or committed).
     let mut status = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
-        .map_err(|_| qmdb::Error::<Family>::DataCorrupted("pruned chunks overflow"))?;
+        .map_err(|_| qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
 
     // Build any::Db with bitmap callback.
     //
     // init_from_log replays the operations, building the snapshot (index) and invoking
     // our callback for each operation to populate the bitmap.
     let known_inactivity_floor = Location::new(status.len());
-    let any: AnyDb<Family, E, J, I, H, U> = AnyDb::init_from_log(
+    let any: AnyDb<F, E, J, I, H, U> = AnyDb::init_from_log(
         index,
         log,
         Some(known_inactivity_floor),
-        |is_active: bool, old_loc: Option<Location>| {
+        |is_active: bool, old_loc: Option<Location<F>>| {
             status.push(is_active);
             if let Some(loc) = old_loc {
                 status.set_bit(*loc, false);
@@ -158,32 +315,9 @@ where
     )
     .await?;
 
-    // Extract grafted pinned nodes from the ops MMR.
-    //
-    // With the zero-chunk identity, all-zero bitmap chunks (which all pruned chunks are)
-    // produce grafted leaves equal to the corresponding ops subtree root. The grafted
-    // MMR's pinned nodes for the pruned region are therefore the first
-    // `popcount(pruned_chunks)` ops pinned nodes (in decreasing height order).
-    //
-    // `nodes_to_pin(range.start)` returns all ops peaks, but only the first
-    // `popcount(pruned_chunks)` are at or above the grafting height. The remaining
-    // smaller peaks cover the partial trailing chunk and are not grafted pinned nodes.
-    let grafted_pinned_nodes = {
-        let ops_pin_positions = mmr::Family::nodes_to_pin(range.start);
-        let num_grafted_pins = (pruned_chunks as u64).count_ones() as usize;
-        let mut pins = Vec::with_capacity(num_grafted_pins);
-        for pos in ops_pin_positions.take(num_grafted_pins) {
-            let digest = any.log.merkle.get_node(pos).await?.ok_or(
-                qmdb::Error::<mmr::Family>::DataCorrupted("missing ops pinned node"),
-            )?;
-            pins.push(digest);
-        }
-        pins
-    };
-
-    // Build grafted MMR.
+    // Build grafted tree.
     let hasher = StandardHasher::<H>::new();
-    let grafted_tree = db::build_grafted_tree::<Family, H, N>(
+    let grafted_tree = db::build_grafted_tree::<F, H, N>(
         &hasher,
         &status,
         &grafted_pinned_nodes,
@@ -215,13 +349,8 @@ where
         partial_digest.as_ref().map(|(nb, d)| (*nb, d)),
     );
 
-    // Initialize metadata store and construct the Db.
-    let (metadata, _, _) = db::init_metadata::<Family, E, DigestOf<H>>(
-        context.with_label("metadata"),
-        &metadata_partition,
-    )
-    .await?;
-
+    // The metadata store was loaded earlier (to resolve overlay-state fallback). Construct
+    // the Db and persist the final overlay state below.
     let current_db = db::Db {
         any,
         status: crate::qmdb::current::batch::BitmapBatch::Base(Arc::new(status)),
@@ -231,10 +360,59 @@ where
         root,
     };
 
+    // Authenticate the overlay payload indirectly: the sync engine only verifies operations
+    // against the ops root, so a lying sender could have shipped overlay state that produces
+    // a different canonical root than the one the caller trusts. Check the rebuilt canonical
+    // root against the caller-supplied anchor before persisting any metadata.
+    if let Some(expected) = canonical_root {
+        if current_db.root != expected {
+            return Err(qmdb::Error::<F>::DataCorrupted(
+                "rebuilt canonical root does not match target canonical_root",
+            ));
+        }
+    }
+
     // Persist metadata so the db can be reopened with init_fixed/init_variable.
     current_db.sync_metadata().await?;
 
     Ok(current_db)
+}
+
+/// Extract the sender's overlay state from a live `current::db::Db`.
+///
+/// Called by the current-sync resolver on boundary batches (when `include_pinned_nodes`
+/// is set) to ship the exact grafted-tree pruning state to the receiver. This reads the
+/// live in-memory `grafted_tree` directly rather than going through persisted metadata,
+/// which can lag the in-memory state between commits.
+fn extract_overlay_state<F, E, C, I, H, U, const N: usize>(
+    db: &db::Db<F, E, C, I, H, U, N>,
+) -> Result<CurrentOverlayState<H::Digest>, qmdb::Error<F>>
+where
+    F: merkle::Graftable,
+    E: Context,
+    C: crate::journal::contiguous::Contiguous<Item: CodecShared>,
+    I: crate::index::Unordered<Value = Location<F>>,
+    H: Hasher,
+    U: Send + Sync,
+{
+    let pruned_chunks = db.status.pruned_chunks() as u64;
+    let mut grafted_pinned_nodes = Vec::new();
+    if pruned_chunks > 0 {
+        let grafted_boundary = Location::<F>::new(pruned_chunks);
+        for pos in F::nodes_to_pin(grafted_boundary) {
+            let digest = db
+                .grafted_tree
+                .get_node(pos)
+                .ok_or(qmdb::Error::<F>::DataCorrupted(
+                    "grafted tree missing pinned node for pruned boundary",
+                ))?;
+            grafted_pinned_nodes.push(digest);
+        }
+    }
+    Ok(CurrentOverlayState {
+        pruned_chunks,
+        grafted_pinned_nodes,
+    })
 }
 
 // --- Database trait implementations ---
@@ -244,8 +422,9 @@ macro_rules! impl_current_sync_database {
      $journal:ty, $config:ty,
      $key_bound:path, $value_bound:ident
      $(; $($where_extra:tt)+)?) => {
-        impl<E, K, V, H, T, const N: usize> Database for $db<Family, E, K, V, H, T, N>
+        impl<F, E, K, V, H, T, const N: usize> Database for $db<F, E, K, V, H, T, N>
         where
+            F: merkle::Graftable,
             E: Context,
             K: $key_bound,
             V: $value_bound + 'static,
@@ -253,8 +432,9 @@ macro_rules! impl_current_sync_database {
             T: Translator,
             $($($where_extra)+)?
         {
+            type Family = F;
             type Context = E;
-            type Op = $op<Family, K, V>;
+            type Op = $op<F, K, V>;
             type Journal = $journal;
             type Hasher = H;
             type Config = $config;
@@ -265,19 +445,23 @@ macro_rules! impl_current_sync_database {
                 config: Self::Config,
                 log: Self::Journal,
                 pinned_nodes: Option<Vec<Self::Digest>>,
-                range: Range<Location>,
+                overlay_state: Option<CurrentOverlayState<Self::Digest>>,
+                canonical_root: Option<Self::Digest>,
+                range: Range<Location<F>>,
                 apply_batch_size: usize,
-            ) -> Result<Self, qmdb::Error<Family>> {
-                let mmr_config = config.merkle_config.clone();
+            ) -> Result<Self, qmdb::Error<F>> {
+                let merkle_config = config.merkle_config.clone();
                 let metadata_partition = config.grafted_metadata_partition.clone();
                 let thread_pool = config.merkle_config.thread_pool.clone();
                 let translator = config.translator.clone();
-                build_db::<_, $update<K, V>, _, H, _, T, N>(
+                build_db::<F, _, $update<K, V>, _, H, _, T, N>(
                     context,
-                    mmr_config,
+                    merkle_config,
                     log,
                     translator,
                     pinned_nodes,
+                    overlay_state,
+                    canonical_root,
                     range,
                     apply_batch_size,
                     metadata_partition,
@@ -287,7 +471,7 @@ macro_rules! impl_current_sync_database {
             }
 
             /// Returns the ops root (not the canonical root), since the sync engine verifies
-            /// batches against the ops MMR.
+            /// batches against the ops tree.
             fn root(&self) -> Self::Digest {
                 self.any.log.root()
             }
@@ -304,9 +488,9 @@ impl_current_sync_database!(
 impl_current_sync_database!(
     CurrentUnorderedVariableDb, UnorderedVariableOp, UnorderedVariableUpdate,
     variable::Journal<E, Self::Op>,
-    VariableConfig<T, <UnorderedVariableOp<Family, K, V> as CodecRead>::Cfg>,
+    VariableConfig<T, <UnorderedVariableOp<F, K, V> as CodecRead>::Cfg>,
     Key, VariableValue;
-    UnorderedVariableOp<Family, K, V>: CodecShared
+    UnorderedVariableOp<F, K, V>: CodecShared
 );
 
 impl_current_sync_database!(
@@ -318,9 +502,9 @@ impl_current_sync_database!(
 impl_current_sync_database!(
     CurrentOrderedVariableDb, OrderedVariableOp, OrderedVariableUpdate,
     variable::Journal<E, Self::Op>,
-    VariableConfig<T, <OrderedVariableOp<Family, K, V> as CodecRead>::Cfg>,
+    VariableConfig<T, <OrderedVariableOp<F, K, V> as CodecRead>::Cfg>,
     Key, VariableValue;
-    OrderedVariableOp<Family, K, V>: CodecShared
+    OrderedVariableOp<F, K, V>: CodecShared
 );
 
 // --- Resolver implementations ---
@@ -330,9 +514,10 @@ impl_current_sync_database!(
 
 macro_rules! impl_current_resolver {
     ($db:ident, $op:ident, $val_bound:ident, $key_bound:path $(; $($where_extra:tt)+)?) => {
-        impl<E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
-            for std::sync::Arc<$db<Family, E, K, V, H, T, N>>
+        impl<F, E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
+            for std::sync::Arc<$db<F, E, K, V, H, T, N>>
         where
+            F: merkle::Graftable,
             E: Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -341,42 +526,51 @@ macro_rules! impl_current_resolver {
             T::Key: Send + Sync,
             $($($where_extra)+)?
         {
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<Family, K, V>;
-            type Error = qmdb::Error<Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<F>,
+                start_loc: Location<F>,
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<crate::qmdb::sync::FetchResult<Self::Op, Self::Digest>, Self::Error> {
+            ) -> Result<
+                crate::qmdb::sync::FetchResult<Self::Family, Self::Op, Self::Digest>,
+                Self::Error,
+            > {
                 let (proof, operations) = self.any
                     .historical_proof(op_count, start_loc, max_ops)
                     .await?;
-                let pinned_nodes = if include_pinned_nodes {
-                    Some(self.any.pinned_nodes_at(start_loc).await?)
+                let (pinned_nodes, overlay_state) = if include_pinned_nodes {
+                    (
+                        Some(self.any.pinned_nodes_at(start_loc).await?),
+                        Some(extract_overlay_state(&**self)?),
+                    )
                 } else {
-                    None
+                    (None, None)
                 };
                 Ok(crate::qmdb::sync::FetchResult {
                     proof,
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state,
                 })
             }
         }
 
-        impl<E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
+        impl<F, E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
             for std::sync::Arc<
                 commonware_utils::sync::AsyncRwLock<
-                    $db<Family, E, K, V, H, T, N>,
+                    $db<F, E, K, V, H, T, N>,
                 >,
             >
         where
+            F: merkle::Graftable,
             E: Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -385,43 +579,52 @@ macro_rules! impl_current_resolver {
             T::Key: Send + Sync,
             $($($where_extra)+)?
         {
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<Family, K, V>;
-            type Error = qmdb::Error<Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<F>,
+                start_loc: Location<F>,
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<crate::qmdb::sync::FetchResult<Self::Op, Self::Digest>, qmdb::Error<Family>> {
+            ) -> Result<
+                crate::qmdb::sync::FetchResult<Self::Family, Self::Op, Self::Digest>,
+                qmdb::Error<F>,
+            > {
                 let db = self.read().await;
                 let (proof, operations) = db.any
                     .historical_proof(op_count, start_loc, max_ops)
                     .await?;
-                let pinned_nodes = if include_pinned_nodes {
-                    Some(db.any.pinned_nodes_at(start_loc).await?)
+                let (pinned_nodes, overlay_state) = if include_pinned_nodes {
+                    (
+                        Some(db.any.pinned_nodes_at(start_loc).await?),
+                        Some(extract_overlay_state(&*db)?),
+                    )
                 } else {
-                    None
+                    (None, None)
                 };
                 Ok(crate::qmdb::sync::FetchResult {
                     proof,
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state,
                 })
             }
         }
 
-        impl<E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
+        impl<F, E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
             for std::sync::Arc<
                 commonware_utils::sync::AsyncRwLock<
-                    Option<$db<Family, E, K, V, H, T, N>>,
+                    Option<$db<F, E, K, V, H, T, N>>,
                 >,
             >
         where
+            F: merkle::Graftable,
             E: Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -430,33 +633,41 @@ macro_rules! impl_current_resolver {
             T::Key: Send + Sync,
             $($($where_extra)+)?
         {
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<Family, K, V>;
-            type Error = qmdb::Error<Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<F>,
+                start_loc: Location<F>,
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<crate::qmdb::sync::FetchResult<Self::Op, Self::Digest>, qmdb::Error<Family>> {
+            ) -> Result<
+                crate::qmdb::sync::FetchResult<Self::Family, Self::Op, Self::Digest>,
+                qmdb::Error<F>,
+            > {
                 let guard = self.read().await;
-                let db = guard.as_ref().ok_or(qmdb::Error::<Family>::KeyNotFound)?;
+                let db = guard.as_ref().ok_or(qmdb::Error::<F>::KeyNotFound)?;
                 let (proof, operations) = db.any
                     .historical_proof(op_count, start_loc, max_ops)
                     .await?;
-                let pinned_nodes = if include_pinned_nodes {
-                    Some(db.any.pinned_nodes_at(start_loc).await?)
+                let (pinned_nodes, overlay_state) = if include_pinned_nodes {
+                    (
+                        Some(db.any.pinned_nodes_at(start_loc).await?),
+                        Some(extract_overlay_state(db)?),
+                    )
                 } else {
-                    None
+                    (None, None)
                 };
                 Ok(crate::qmdb::sync::FetchResult {
                     proof,
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state,
                 })
             }
         }
@@ -469,7 +680,7 @@ impl_current_resolver!(CurrentUnorderedFixedDb, UnorderedFixedOp, FixedValue, Ar
 // Unordered Variable
 impl_current_resolver!(
     CurrentUnorderedVariableDb, UnorderedVariableOp, VariableValue, Key;
-    UnorderedVariableOp<Family, K, V>: CodecShared,
+    UnorderedVariableOp<F, K, V>: CodecShared,
 );
 
 // Ordered Fixed
@@ -478,5 +689,5 @@ impl_current_resolver!(CurrentOrderedFixedDb, OrderedFixedOp, FixedValue, Array)
 // Ordered Variable
 impl_current_resolver!(
     CurrentOrderedVariableDb, OrderedVariableOp, VariableValue, Key;
-    OrderedVariableOp<Family, K, V>: CodecShared,
+    OrderedVariableOp<F, K, V>: CodecShared,
 );

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -5,37 +5,272 @@
 //! `any` harnesses is that `sync_target_root` returns the **ops root** (via
 //! [qmdb::sync::Database::root](crate::qmdb::sync::Database::root)), not the canonical root
 //! returned by `Db::root()`.
+//!
+//! Harnesses are instantiated for **both** MMR and MMB merkle families across each (ordered,
+//! unordered) x (fixed, variable) database variant, so the shared suite runs twice per
+//! variant.
+//!
+//! In addition to the shared harness-based suite, this module contains focused tests for
+//! `current`-specific sync behavior: overlay-state authentication (canonical-root check),
+//! pruned MMB round-trip, and target-update regression coverage.
 
-use crate::{
-    merkle::mmr,
-    qmdb::{
-        any::sync::tests::{ConfigOf, SyncTestHarness},
-        current::tests::{fixed_config, variable_config},
-        sync::Database as SyncDatabase,
-    },
+use crate::qmdb::{
+    any::sync::tests::{ConfigOf, SyncTestHarness},
+    current::tests::{fixed_config, variable_config},
+    sync::Database as SyncDatabase,
 };
-use commonware_cryptography::sha256::Digest;
-use commonware_runtime::{deterministic::Context, BufferPooler};
+use commonware_cryptography::{sha256::Digest, Sha256};
+use commonware_macros::test_traced;
+use commonware_runtime::{
+    deterministic, deterministic::Context, BufferPooler, Metrics as _, Runner as _,
+};
+use rand::RngCore as _;
 
 // ===== Harness Implementations =====
 
 mod harnesses {
     use super::*;
+    use crate::merkle::{self, mmb, mmr};
+    use commonware_math::algebra::Random;
+    use commonware_utils::test_rng_seeded;
 
-    // ----- Unordered/Fixed -----
+    type OrderedFixedDb<F> = crate::qmdb::current::ordered::fixed::Db<
+        F,
+        Context,
+        Digest,
+        Digest,
+        Sha256,
+        crate::translator::OneCap,
+        32,
+    >;
+    type OrderedVariableDb<F> = crate::qmdb::current::ordered::variable::Db<
+        F,
+        Context,
+        Digest,
+        Digest,
+        Sha256,
+        crate::translator::OneCap,
+        32,
+    >;
+    type UnorderedFixedDb<F> = crate::qmdb::current::unordered::fixed::Db<
+        F,
+        Context,
+        Digest,
+        Digest,
+        Sha256,
+        crate::translator::TwoCap,
+        32,
+    >;
+    type UnorderedVariableDb<F> = crate::qmdb::current::unordered::variable::Db<
+        F,
+        Context,
+        Digest,
+        Digest,
+        Sha256,
+        crate::translator::TwoCap,
+        32,
+    >;
 
-    pub struct UnorderedFixedHarness;
+    fn create_unordered_fixed_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
 
-    impl SyncTestHarness for UnorderedFixedHarness {
-        type Db = crate::qmdb::current::unordered::fixed::Db<
-            mmr::Family,
-            Context,
-            Digest,
-            Digest,
-            commonware_cryptography::Sha256,
-            crate::translator::TwoCap,
-            32,
-        >;
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            let key = Digest::random(&mut rng);
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let value = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update(key, value)));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_unordered_variable_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::unordered::variable::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            let key = Digest::random(&mut rng);
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let value = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update(key, value)));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_ordered_fixed_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+
+        let mut rng = test_rng_seeded(seed);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                let key = Digest::random(&mut rng);
+                ops.push(Operation::Delete(key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let value = Digest::random(&mut rng);
+                let next_key = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update {
+                    key,
+                    value,
+                    next_key,
+                }));
+            }
+        }
+        ops
+    }
+
+    fn create_ordered_variable_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::ordered::variable::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+
+        let mut rng = test_rng_seeded(seed);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            let key = Digest::random(&mut rng);
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(key));
+            } else {
+                let value = Digest::random(&mut rng);
+                let next_key = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update {
+                    key,
+                    value,
+                    next_key,
+                }));
+            }
+        }
+        ops
+    }
+
+    async fn apply_unordered_fixed_ops<F: merkle::Graftable>(
+        mut db: UnorderedFixedDb<F>,
+        ops: Vec<crate::qmdb::any::unordered::fixed::Operation<F, Digest, Digest>>,
+    ) -> UnorderedFixedDb<F> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+
+        let merkleized = {
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(Update(key, value)) => {
+                        batch = batch.write(key, Some(value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            batch.merkleize(&db, None::<Digest>).await.unwrap()
+        };
+        db.apply_batch(merkleized).await.unwrap();
+        db
+    }
+
+    async fn apply_unordered_variable_ops<F: merkle::Graftable>(
+        mut db: UnorderedVariableDb<F>,
+        ops: Vec<crate::qmdb::any::unordered::variable::Operation<F, Digest, Digest>>,
+    ) -> UnorderedVariableDb<F> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+
+        let merkleized = {
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(Update(key, value)) => {
+                        batch = batch.write(key, Some(value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            batch.merkleize(&db, None::<Digest>).await.unwrap()
+        };
+        db.apply_batch(merkleized).await.unwrap();
+        db
+    }
+
+    async fn apply_ordered_fixed_ops<F: merkle::Graftable>(
+        mut db: OrderedFixedDb<F>,
+        ops: Vec<crate::qmdb::any::ordered::fixed::Operation<F, Digest, Digest>>,
+    ) -> OrderedFixedDb<F> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+
+        let merkleized = {
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(Update { key, value, .. }) => {
+                        batch = batch.write(key, Some(value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            batch.merkleize(&db, None::<Digest>).await.unwrap()
+        };
+        db.apply_batch(merkleized).await.unwrap();
+        db
+    }
+
+    async fn apply_ordered_variable_ops<F: merkle::Graftable>(
+        mut db: OrderedVariableDb<F>,
+        ops: Vec<crate::qmdb::any::ordered::variable::Operation<F, Digest, Digest>>,
+    ) -> OrderedVariableDb<F> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+
+        let merkleized = {
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(Update { key, value, .. }) => {
+                        batch = batch.write(key, Some(value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            batch.merkleize(&db, None::<Digest>).await.unwrap()
+        };
+        db.apply_batch(merkleized).await.unwrap();
+        db
+    }
+
+    pub struct UnorderedFixedMmrHarness;
+
+    impl SyncTestHarness for UnorderedFixedMmrHarness {
+        type Family = mmr::Family;
+        type Db = UnorderedFixedDb<mmr::Family>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
             SyncDatabase::root(db)
@@ -49,7 +284,7 @@ mod harnesses {
             n: usize,
         ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmr::Family, Digest, Digest>>
         {
-            crate::qmdb::any::unordered::fixed::test::create_test_ops(n)
+            create_unordered_fixed_ops::<mmr::Family>(n, 0)
         }
 
         fn create_ops_seeded(
@@ -57,7 +292,7 @@ mod harnesses {
             seed: u64,
         ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmr::Family, Digest, Digest>>
         {
-            crate::qmdb::any::unordered::fixed::test::create_test_ops_seeded(n, seed)
+            create_unordered_fixed_ops::<mmr::Family>(n, seed)
         }
 
         async fn init_db(ctx: Context) -> Self::Db {
@@ -70,42 +305,64 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::unordered::fixed::Operation<mmr::Family, Digest, Digest>>,
         ) -> Self::Db {
-            use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
-            let mut batch = db.new_batch();
-            for op in ops {
-                match op {
-                    Operation::Update(Update(key, value)) => {
-                        batch = batch.write(key, Some(value));
-                    }
-                    Operation::Delete(key) => {
-                        batch = batch.write(key, None);
-                    }
-                    Operation::CommitFloor(_, _) => {}
-                }
-            }
-            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db
+            apply_unordered_fixed_ops(db, ops).await
         }
     }
 
-    // ----- Unordered/Variable -----
+    pub struct UnorderedFixedMmbHarness;
 
-    pub struct UnorderedVariableHarness;
+    impl SyncTestHarness for UnorderedFixedMmbHarness {
+        type Family = mmb::Family;
+        type Db = UnorderedFixedDb<mmb::Family>;
 
-    impl SyncTestHarness for UnorderedVariableHarness {
-        type Db = crate::qmdb::current::unordered::variable::Db<
-            mmr::Family,
-            Context,
-            Digest,
-            Digest,
-            commonware_cryptography::Sha256,
-            crate::translator::TwoCap,
-            32,
-        >;
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            SyncDatabase::root(db)
+        }
+
+        fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
+            fixed_config::<crate::translator::TwoCap>(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_fixed_ops::<mmb::Family>(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_fixed_ops::<mmb::Family>(n, seed)
+        }
+
+        async fn init_db(ctx: Context) -> Self::Db {
+            let cfg = fixed_config::<crate::translator::TwoCap>("default", &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(ctx: Context, config: ConfigOf<Self>) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            db: Self::Db,
+            ops: Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            apply_unordered_fixed_ops(db, ops).await
+        }
+    }
+
+    pub struct UnorderedVariableMmrHarness;
+
+    impl SyncTestHarness for UnorderedVariableMmrHarness {
+        type Family = mmr::Family;
+        type Db = UnorderedVariableDb<mmr::Family>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
             SyncDatabase::root(db)
@@ -119,7 +376,7 @@ mod harnesses {
             n: usize,
         ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmr::Family, Digest, Digest>>
         {
-            create_unordered_variable_ops(n, 0)
+            create_unordered_variable_ops::<mmr::Family>(n, 0)
         }
 
         fn create_ops_seeded(
@@ -127,7 +384,7 @@ mod harnesses {
             seed: u64,
         ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmr::Family, Digest, Digest>>
         {
-            create_unordered_variable_ops(n, seed)
+            create_unordered_variable_ops::<mmr::Family>(n, seed)
         }
 
         async fn init_db(ctx: Context) -> Self::Db {
@@ -140,42 +397,64 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::unordered::variable::Operation<mmr::Family, Digest, Digest>>,
         ) -> Self::Db {
-            use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
-            let mut batch = db.new_batch();
-            for op in ops {
-                match op {
-                    Operation::Update(Update(key, value)) => {
-                        batch = batch.write(key, Some(value));
-                    }
-                    Operation::Delete(key) => {
-                        batch = batch.write(key, None);
-                    }
-                    Operation::CommitFloor(_, _) => {}
-                }
-            }
-            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db
+            apply_unordered_variable_ops(db, ops).await
         }
     }
 
-    // ----- Ordered/Fixed -----
+    pub struct UnorderedVariableMmbHarness;
 
-    pub struct OrderedFixedHarness;
+    impl SyncTestHarness for UnorderedVariableMmbHarness {
+        type Family = mmb::Family;
+        type Db = UnorderedVariableDb<mmb::Family>;
 
-    impl SyncTestHarness for OrderedFixedHarness {
-        type Db = crate::qmdb::current::ordered::fixed::Db<
-            mmr::Family,
-            Context,
-            Digest,
-            Digest,
-            commonware_cryptography::Sha256,
-            crate::translator::OneCap,
-            32,
-        >;
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            SyncDatabase::root(db)
+        }
+
+        fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
+            variable_config::<crate::translator::TwoCap>(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_variable_ops::<mmb::Family>(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_variable_ops::<mmb::Family>(n, seed)
+        }
+
+        async fn init_db(ctx: Context) -> Self::Db {
+            let cfg = variable_config::<crate::translator::TwoCap>("default", &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(ctx: Context, config: ConfigOf<Self>) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            db: Self::Db,
+            ops: Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            apply_unordered_variable_ops(db, ops).await
+        }
+    }
+
+    pub struct OrderedFixedMmrHarness;
+
+    impl SyncTestHarness for OrderedFixedMmrHarness {
+        type Family = mmr::Family;
+        type Db = OrderedFixedDb<mmr::Family>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
             SyncDatabase::root(db)
@@ -188,14 +467,14 @@ mod harnesses {
         fn create_ops(
             n: usize,
         ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmr::Family, Digest, Digest>> {
-            crate::qmdb::any::ordered::fixed::test::create_test_ops(n)
+            create_ordered_fixed_ops::<mmr::Family>(n, 0)
         }
 
         fn create_ops_seeded(
             n: usize,
             seed: u64,
         ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmr::Family, Digest, Digest>> {
-            crate::qmdb::any::ordered::fixed::test::create_test_ops_seeded(n, seed)
+            create_ordered_fixed_ops::<mmr::Family>(n, seed)
         }
 
         async fn init_db(ctx: Context) -> Self::Db {
@@ -208,42 +487,62 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::ordered::fixed::Operation<mmr::Family, Digest, Digest>>,
         ) -> Self::Db {
-            use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
-            let mut batch = db.new_batch();
-            for op in ops {
-                match op {
-                    Operation::Update(Update { key, value, .. }) => {
-                        batch = batch.write(key, Some(value));
-                    }
-                    Operation::Delete(key) => {
-                        batch = batch.write(key, None);
-                    }
-                    Operation::CommitFloor(_, _) => {}
-                }
-            }
-            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db
+            apply_ordered_fixed_ops(db, ops).await
         }
     }
 
-    // ----- Ordered/Variable -----
+    pub struct OrderedFixedMmbHarness;
 
-    pub struct OrderedVariableHarness;
+    impl SyncTestHarness for OrderedFixedMmbHarness {
+        type Family = mmb::Family;
+        type Db = OrderedFixedDb<mmb::Family>;
 
-    impl SyncTestHarness for OrderedVariableHarness {
-        type Db = crate::qmdb::current::ordered::variable::Db<
-            mmr::Family,
-            Context,
-            Digest,
-            Digest,
-            commonware_cryptography::Sha256,
-            crate::translator::OneCap,
-            32,
-        >;
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            SyncDatabase::root(db)
+        }
+
+        fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
+            fixed_config::<crate::translator::OneCap>(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>> {
+            create_ordered_fixed_ops::<mmb::Family>(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>> {
+            create_ordered_fixed_ops::<mmb::Family>(n, seed)
+        }
+
+        async fn init_db(ctx: Context) -> Self::Db {
+            let cfg = fixed_config::<crate::translator::OneCap>("default", &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(ctx: Context, config: ConfigOf<Self>) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            db: Self::Db,
+            ops: Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            apply_ordered_fixed_ops(db, ops).await
+        }
+    }
+
+    pub struct OrderedVariableMmrHarness;
+
+    impl SyncTestHarness for OrderedVariableMmrHarness {
+        type Family = mmr::Family;
+        type Db = OrderedVariableDb<mmr::Family>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
             SyncDatabase::root(db)
@@ -257,7 +556,7 @@ mod harnesses {
             n: usize,
         ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmr::Family, Digest, Digest>>
         {
-            create_ordered_variable_ops(n, 0)
+            create_ordered_variable_ops::<mmr::Family>(n, 0)
         }
 
         fn create_ops_seeded(
@@ -265,7 +564,7 @@ mod harnesses {
             seed: u64,
         ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmr::Family, Digest, Digest>>
         {
-            create_ordered_variable_ops(n, seed)
+            create_ordered_variable_ops::<mmr::Family>(n, seed)
         }
 
         async fn init_db(ctx: Context) -> Self::Db {
@@ -278,82 +577,630 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::ordered::variable::Operation<mmr::Family, Digest, Digest>>,
         ) -> Self::Db {
-            use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
-            let mut batch = db.new_batch();
-            for op in ops {
-                match op {
-                    Operation::Update(Update { key, value, .. }) => {
-                        batch = batch.write(key, Some(value));
-                    }
-                    Operation::Delete(key) => {
-                        batch = batch.write(key, None);
-                    }
-                    Operation::CommitFloor(_, _) => {}
-                }
-            }
-            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
+            apply_ordered_variable_ops(db, ops).await
+        }
+    }
+
+    pub struct OrderedVariableMmbHarness;
+
+    impl SyncTestHarness for OrderedVariableMmbHarness {
+        type Family = mmb::Family;
+        type Db = OrderedVariableDb<mmb::Family>;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            SyncDatabase::root(db)
+        }
+
+        fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
+            variable_config::<crate::translator::OneCap>(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_ordered_variable_ops::<mmb::Family>(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_ordered_variable_ops::<mmb::Family>(n, seed)
+        }
+
+        async fn init_db(ctx: Context) -> Self::Db {
+            let cfg = variable_config::<crate::translator::OneCap>("default", &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(ctx: Context, config: ConfigOf<Self>) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            db: Self::Db,
+            ops: Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            apply_ordered_variable_ops(db, ops).await
+        }
+    }
+}
+
+/// Regression test: sync a pruned MMB-backed current DB and verify the synced DB has the
+/// same canonical root, reopens cleanly, and returns the expected value.
+///
+/// The target DB commits the same key 100 times, forcing the inactivity floor past a full
+/// 256-bit chunk boundary. Without overlay-state in the sync protocol, the receiver
+/// re-derives `pruned_chunks` from `range.start / chunk_bits` and builds a grafted tree
+/// whose pinned nodes don't match the sender's. The canonical roots diverge.
+#[test_traced("INFO")]
+fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context: Context| async move {
+        type Db = crate::qmdb::current::unordered::variable::Db<
+            crate::merkle::mmb::Family,
+            Context,
+            Digest,
+            Digest,
+            Sha256,
+            crate::translator::TwoCap,
+            32,
+        >;
+
+        const COMMITS: u64 = 100;
+
+        let target_suffix = context.next_u64().to_string();
+        let target_context = context.with_label("target");
+        let mut target_db: Db = Db::init(
+            target_context.clone(),
+            variable_config::<crate::translator::TwoCap>(&target_suffix, &target_context),
+        )
+        .await
+        .unwrap();
+
+        let key = Digest::from([7u8; 32]);
+        let mut expected = None;
+        for round in 0..COMMITS {
+            expected = Some(Digest::from([round as u8; 32]));
+            let merkleized = target_db
+                .new_batch()
+                .write(key, expected)
+                .merkleize(&target_db, None)
+                .await
+                .unwrap();
+            target_db.apply_batch(merkleized).await.unwrap();
+            target_db.commit().await.unwrap();
+        }
+
+        assert!(
+            *target_db.inactivity_floor_loc() >= 256,
+            "expected inactivity floor past chunk 0"
+        );
+
+        target_db
+            .prune(target_db.inactivity_floor_loc())
+            .await
+            .unwrap();
+
+        let sync_root = SyncDatabase::root(&target_db);
+        let verification_root = target_db.root();
+        let lower_bound = target_db.inactivity_floor_loc();
+        let upper_bound = target_db.bounds().await.end;
+
+        let client_suffix = context.next_u64().to_string();
+        let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+        let target_db = std::sync::Arc::new(target_db);
+        // Supply the trusted canonical root so `build_db`'s authentication check actually
+        // runs: this is the success-path coverage for the overlay-state authentication
+        // anchor. A bad-root rejection path test belongs with the focused sync tests.
+        let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
+            context: context.with_label("client"),
+            db_config: client_config.clone(),
+            fetch_batch_size: commonware_utils::NZU64!(64),
+            target: crate::qmdb::sync::Target {
+                root: sync_root,
+                range: commonware_utils::non_empty_range!(lower_bound, upper_bound),
+                canonical_root: Some(verification_root),
+            },
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 4,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(SyncDatabase::root(&synced_db), sync_root);
+        assert_eq!(synced_db.root(), verification_root);
+        assert_eq!(synced_db.inactivity_floor_loc(), lower_bound);
+        assert_eq!(synced_db.get(&key).await.unwrap(), expected);
+
+        drop(synced_db);
+
+        let reopened: Db = Db::init(context.with_label("reopened"), client_config)
+            .await
+            .unwrap();
+        assert_eq!(SyncDatabase::root(&reopened), sync_root);
+        assert_eq!(reopened.root(), verification_root);
+        assert_eq!(reopened.inactivity_floor_loc(), lower_bound);
+        assert_eq!(reopened.get(&key).await.unwrap(), expected);
+
+        reopened.destroy().await.unwrap();
+        std::sync::Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Verify that a wrong `canonical_root` in the sync target is rejected.
+///
+/// Uses the same pruned-MMB setup as `test_current_mmb_sync_with_pruned_full_chunk_reopens`
+/// but supplies a fabricated canonical root. The sync engine successfully downloads and
+/// applies all operations (the ops root is correct), but `build_db` rejects the result
+/// because the rebuilt canonical root does not match the bogus target.
+#[test_traced("INFO")]
+fn test_canonical_root_mismatch_rejects_sync() {
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context: Context| async move {
+        type Db = crate::qmdb::current::unordered::variable::Db<
+            crate::merkle::mmb::Family,
+            Context,
+            Digest,
+            Digest,
+            Sha256,
+            crate::translator::TwoCap,
+            32,
+        >;
+
+        const COMMITS: u64 = 100;
+
+        let target_suffix = context.next_u64().to_string();
+        let target_context = context.with_label("target");
+        let mut target_db: Db = Db::init(
+            target_context.clone(),
+            variable_config::<crate::translator::TwoCap>(&target_suffix, &target_context),
+        )
+        .await
+        .unwrap();
+
+        let key = Digest::from([7u8; 32]);
+        for round in 0..COMMITS {
+            let value = Some(Digest::from([round as u8; 32]));
+            let merkleized = target_db
+                .new_batch()
+                .write(key, value)
+                .merkleize(&target_db, None)
+                .await
+                .unwrap();
+            target_db.apply_batch(merkleized).await.unwrap();
+            target_db.commit().await.unwrap();
+        }
+
+        target_db
+            .prune(target_db.inactivity_floor_loc())
+            .await
+            .unwrap();
+
+        let sync_root = SyncDatabase::root(&target_db);
+        let lower_bound = target_db.inactivity_floor_loc();
+        let upper_bound = target_db.bounds().await.end;
+
+        // Fabricate a wrong canonical root.
+        let wrong_canonical_root = Digest::from([0xFFu8; 32]);
+
+        let client_suffix = context.next_u64().to_string();
+        let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+        let target_db = std::sync::Arc::new(target_db);
+        let result = crate::qmdb::sync::sync::<Db, _>(crate::qmdb::sync::engine::Config {
+            context: context.with_label("client"),
+            db_config: client_config,
+            fetch_batch_size: commonware_utils::NZU64!(64),
+            target: crate::qmdb::sync::Target {
+                root: sync_root,
+                range: commonware_utils::non_empty_range!(lower_bound, upper_bound),
+                canonical_root: Some(wrong_canonical_root),
+            },
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 4,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        })
+        .await;
+
+        // The sync should fail because the canonical root doesn't match.
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("sync should fail with wrong canonical_root"),
+        };
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("rebuilt canonical root does not match"),
+            "unexpected error: {err_msg}",
+        );
+
+        std::sync::Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Verify that canonical-root authentication works for an unpruned database.
+///
+/// An unpruned `current` DB still has a canonical root (it just equals `combine_roots(ops,
+/// empty_grafted, None)`). Passing the correct canonical root must succeed, confirming the
+/// check works even when there is no overlay state to validate.
+#[test_traced("INFO")]
+fn test_canonical_root_correct_unpruned_sync() {
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context: Context| async move {
+        type Db = crate::qmdb::current::unordered::variable::Db<
+            crate::merkle::mmr::Family,
+            Context,
+            Digest,
+            Digest,
+            Sha256,
+            crate::translator::TwoCap,
+            32,
+        >;
+
+        let target_suffix = context.next_u64().to_string();
+        let target_context = context.with_label("target");
+        let mut target_db: Db = Db::init(
+            target_context.clone(),
+            variable_config::<crate::translator::TwoCap>(&target_suffix, &target_context),
+        )
+        .await
+        .unwrap();
+
+        // Populate with distinct keys (no pruning).
+        for i in 0u8..20 {
+            let key = Digest::from([i; 32]);
+            let value = Digest::from([i.wrapping_add(100); 32]);
+            let merkleized = target_db
+                .new_batch()
+                .write(key, Some(value))
+                .merkleize(&target_db, None)
+                .await
+                .unwrap();
+            target_db.apply_batch(merkleized).await.unwrap();
+            target_db.commit().await.unwrap();
+        }
+
+        let sync_root = SyncDatabase::root(&target_db);
+        let canonical_root = target_db.root();
+        let upper_bound = target_db.bounds().await.end;
+
+        let client_suffix = context.next_u64().to_string();
+        let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+        let target_db = std::sync::Arc::new(target_db);
+        let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
+            context: context.with_label("client"),
+            db_config: client_config,
+            fetch_batch_size: commonware_utils::NZU64!(64),
+            target: crate::qmdb::sync::Target {
+                root: sync_root,
+                range: commonware_utils::non_empty_range!(
+                    crate::merkle::Location::new(0),
+                    upper_bound
+                ),
+                canonical_root: Some(canonical_root),
+            },
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 4,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(SyncDatabase::root(&synced_db), sync_root);
+        assert_eq!(synced_db.root(), canonical_root);
+
+        drop(synced_db);
+        std::sync::Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Verify that an authenticated retry forces fresh boundary state instead of reusing
+/// stale persisted metadata.
+///
+/// Scenario:
+/// 1. First sync attempt with a wrong `canonical_root` downloads all operations and
+///    syncs the journal to disk, but fails the canonical-root check in `build_db`
+///    before `sync_metadata` runs. The journal is at target; metadata is stale (empty).
+/// 2. Second sync attempt with the correct `canonical_root` reuses the same journal
+///    partition. Without the `needs_fresh_boundary_state` guard the engine would see
+///    `is_at_target() == true`, complete immediately with `overlay_state == None`, fall
+///    back to stale metadata, and fail the canonical-root check again — a permanent
+///    stuck state.
+/// 3. With the guard, the engine defers completion, fetches a fresh boundary batch
+///    through the normal pipeline, obtains correct overlay state, and completes
+///    successfully.
+#[test_traced("INFO")]
+fn test_authenticated_retry_forces_fresh_boundary_state() {
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context: Context| async move {
+        type Db = crate::qmdb::current::unordered::variable::Db<
+            crate::merkle::mmb::Family,
+            Context,
+            Digest,
+            Digest,
+            Sha256,
+            crate::translator::TwoCap,
+            32,
+        >;
+
+        const COMMITS: u64 = 100;
+
+        let target_suffix = context.next_u64().to_string();
+        let target_context = context.with_label("target");
+        let mut target_db: Db = Db::init(
+            target_context.clone(),
+            variable_config::<crate::translator::TwoCap>(&target_suffix, &target_context),
+        )
+        .await
+        .unwrap();
+
+        let key = Digest::from([7u8; 32]);
+        for round in 0..COMMITS {
+            let value = Some(Digest::from([round as u8; 32]));
+            let merkleized = target_db
+                .new_batch()
+                .write(key, value)
+                .merkleize(&target_db, None)
+                .await
+                .unwrap();
+            target_db.apply_batch(merkleized).await.unwrap();
+            target_db.commit().await.unwrap();
+        }
+
+        target_db
+            .prune(target_db.inactivity_floor_loc())
+            .await
+            .unwrap();
+
+        let sync_root = SyncDatabase::root(&target_db);
+        let correct_canonical_root = target_db.root();
+        let lower_bound = target_db.inactivity_floor_loc();
+        let upper_bound = target_db.bounds().await.end;
+
+        let client_suffix = context.next_u64().to_string();
+        let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+        let target_db = std::sync::Arc::new(target_db);
+
+        // Attempt 1: wrong canonical root. The engine downloads all ops and syncs the
+        // journal, but from_sync_result fails the canonical-root check. The on-disk
+        // journal now contains all operations; metadata is still empty.
+        let wrong_canonical_root = Digest::from([0xFFu8; 32]);
+        let result = crate::qmdb::sync::sync::<Db, _>(crate::qmdb::sync::engine::Config {
+            context: context.with_label("client1"),
+            db_config: client_config.clone(),
+            fetch_batch_size: commonware_utils::NZU64!(64),
+            target: crate::qmdb::sync::Target {
+                root: sync_root,
+                range: commonware_utils::non_empty_range!(lower_bound, upper_bound),
+                canonical_root: Some(wrong_canonical_root),
+            },
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 4,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        })
+        .await;
+        assert!(
+            result.is_err(),
+            "first sync should fail with wrong canonical root",
+        );
+
+        // Attempt 2: correct canonical root, same journal partition. The engine finds
+        // the journal already at target but defers completion until a fresh boundary
+        // batch provides overlay state.
+        let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
+            context: context.with_label("client2"),
+            db_config: client_config,
+            fetch_batch_size: commonware_utils::NZU64!(64),
+            target: crate::qmdb::sync::Target {
+                root: sync_root,
+                range: commonware_utils::non_empty_range!(lower_bound, upper_bound),
+                canonical_root: Some(correct_canonical_root),
+            },
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 4,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(SyncDatabase::root(&synced_db), sync_root);
+        assert_eq!(synced_db.root(), correct_canonical_root);
+
+        drop(synced_db);
+        std::sync::Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Regression test: unordered MMB sync with explicit pruning across multiple chunks.
+///
+/// Commits a hot key 1000 times, prunes to the inactivity floor (which spans multiple
+/// pruned chunks), then mid-sync adds 1000 more commits and prunes again. Historically this
+/// tripped the grafted-tree reconstruction bug in the buggy
+/// `nodes_to_pin(range.start).take(popcount(pruned_chunks))` extraction: for MMB with many
+/// pruned chunks the first N ops pins did not correspond to the grafted pin positions, so
+/// some pruned chunks needed internal ops nodes that were not boundary-stable pins and
+/// `compute_grafted_root` failed looking them up.
+///
+/// After the overlay-state rollout (receiver rebuilds from explicit sender-supplied overlay
+/// state instead of inferring from `range.start`), this passes. Kept as a regression guard
+/// so the same shape cannot silently re-introduce the bug.
+#[test_traced("INFO")]
+fn test_current_mmb_unordered_sync_target_update_hot_key_exposes_bug() {
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context: Context| async move {
+        type Db = crate::qmdb::current::unordered::variable::Db<
+            crate::merkle::mmb::Family,
+            Context,
+            Digest,
+            Digest,
+            Sha256,
+            crate::translator::TwoCap,
+            32,
+        >;
+
+        // Push the sender's inactivity floor past several chunk boundaries so the pruned
+        // prefix spans multiple chunks. The target update then adds more hot-key commits
+        // on top, advancing the floor to a position that may or may not align with the
+        // grafted pin structure under MMB's delayed merges.
+        const INITIAL_COMMITS: u64 = 1000;
+        const ADDITIONAL_COMMITS: u64 = 1000;
+
+        let target_suffix = context.next_u64().to_string();
+        let target_context = context.with_label("target");
+        let mut target_db: Db = Db::init(
+            target_context.clone(),
+            variable_config::<crate::translator::TwoCap>(&target_suffix, &target_context),
+        )
+        .await
+        .unwrap();
+
+        let key = Digest::from([0x42u8; 32]);
+        async fn commit_once(db: &mut Db, key: Digest, value: Digest) {
+            let merkleized = db
+                .new_batch()
+                .write(key, Some(value))
+                .merkleize(db, None)
+                .await
+                .unwrap();
             db.apply_batch(merkleized).await.unwrap();
-            db
+            db.commit().await.unwrap();
         }
-    }
-}
 
-// ===== Helper functions for creating test operations =====
-
-/// Create test operations for unordered variable databases with Digest values.
-fn create_unordered_variable_ops(
-    n: usize,
-    seed: u64,
-) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmr::Family, Digest, Digest>> {
-    use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
-    use commonware_math::algebra::Random;
-    use commonware_utils::test_rng_seeded;
-
-    let mut rng = test_rng_seeded(seed);
-    let mut prev_key = Digest::random(&mut rng);
-    let mut ops = Vec::new();
-    for i in 0..n {
-        let key = Digest::random(&mut rng);
-        if i % 10 == 0 && i > 0 {
-            ops.push(Operation::Delete(prev_key));
-        } else {
-            let value = Digest::random(&mut rng);
-            ops.push(Operation::Update(Update(key, value)));
-            prev_key = key;
+        for round in 0..INITIAL_COMMITS {
+            commit_once(&mut target_db, key, Digest::from([round as u8; 32])).await;
         }
-    }
-    ops
-}
 
-/// Create test operations for ordered variable databases with Digest values.
-fn create_ordered_variable_ops(
-    n: usize,
-    seed: u64,
-) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmr::Family, Digest, Digest>> {
-    use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
-    use commonware_math::algebra::Random;
-    use commonware_utils::test_rng_seeded;
+        // Prune so the sender has an explicitly pruned bitmap prefix. This forces the
+        // receiver's sync-side `build_db` to reconstruct grafted pins from the synced
+        // ops tree — the exact code path the overlay-state PR will fix.
+        target_db
+            .prune(target_db.inactivity_floor_loc())
+            .await
+            .unwrap();
 
-    let mut rng = test_rng_seeded(seed);
-    let mut ops = Vec::new();
-    for i in 0..n {
-        let key = Digest::random(&mut rng);
-        if i % 10 == 0 && i > 0 {
-            ops.push(Operation::Delete(key));
-        } else {
-            let value = Digest::random(&mut rng);
-            let next_key = Digest::random(&mut rng);
-            ops.push(Operation::Update(Update {
-                key,
-                value,
-                next_key,
-            }));
+        // Capture initial target state and start syncing.
+        let initial_sync_root = SyncDatabase::root(&target_db);
+        let initial_lower_bound = target_db.inactivity_floor_loc();
+        let initial_upper_bound = target_db.bounds().await.end;
+
+        let target_db =
+            std::sync::Arc::new(commonware_utils::sync::AsyncRwLock::new(Some(target_db)));
+        let (update_tx, update_rx) = commonware_utils::channel::mpsc::channel(1);
+
+        let client_suffix = context.next_u64().to_string();
+        let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+        let config = crate::qmdb::sync::engine::Config {
+            context: context.with_label("client"),
+            db_config: client_config,
+            fetch_batch_size: commonware_utils::NZU64!(1),
+            target: crate::qmdb::sync::Target {
+                root: initial_sync_root,
+                range: commonware_utils::non_empty_range!(initial_lower_bound, initial_upper_bound),
+                canonical_root: None,
+            },
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 4,
+            update_rx: Some(update_rx),
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 1,
+        };
+
+        // Step until the client has made some progress.
+        let mut client = crate::qmdb::sync::engine::Engine::<Db, _>::new(config)
+            .await
+            .unwrap();
+        loop {
+            client = match client.step().await.unwrap() {
+                crate::qmdb::sync::engine::NextStep::Continue(c) => c,
+                crate::qmdb::sync::engine::NextStep::Complete(_) => {
+                    panic!("client should not complete before target update")
+                }
+            };
+            if client.journal().size().await > *initial_lower_bound {
+                break;
+            }
         }
-    }
-    ops
+
+        // Drive the target forward with more hot-key commits so that the new inactivity
+        // floor lands in the delayed-merge-unstable region for MMB pin extraction.
+        {
+            let mut guard = target_db.write().await;
+            let mut db = guard.take().unwrap();
+            for round in 0..ADDITIONAL_COMMITS {
+                commit_once(
+                    &mut db,
+                    key,
+                    Digest::from([(round as u8).wrapping_add(128); 32]),
+                )
+                .await;
+            }
+            // Prune again so the new target boundary is also at a pruned prefix.
+            db.prune(db.inactivity_floor_loc()).await.unwrap();
+            let new_sync_root = SyncDatabase::root(&db);
+            let new_lower = db.inactivity_floor_loc();
+            let new_upper = db.bounds().await.end;
+            *guard = Some(db);
+            update_tx
+                .send(crate::qmdb::sync::Target {
+                    root: new_sync_root,
+                    range: commonware_utils::non_empty_range!(new_lower, new_upper),
+                    canonical_root: None,
+                })
+                .await
+                .unwrap();
+        }
+
+        // Drive the sync to completion. Historically this aborted via the
+        // verification-failure guard because the buggy ops-pin-derived grafted reconstruction
+        // diverged from the sender's true overlay after the target update. After the
+        // overlay-state rollout the receiver rebuilds from the sender's explicit overlay
+        // payload, so the sync must complete successfully; the `.unwrap()` is the regression
+        // guard.
+        client.sync().await.unwrap();
+    });
 }
 
 // ===== Test Generation Macro =====
@@ -491,7 +1338,17 @@ macro_rules! current_sync_tests_for_harness {
     };
 }
 
-current_sync_tests_for_harness!(harnesses::UnorderedFixedHarness, unordered_fixed);
-current_sync_tests_for_harness!(harnesses::UnorderedVariableHarness, unordered_variable);
-current_sync_tests_for_harness!(harnesses::OrderedFixedHarness, ordered_fixed);
-current_sync_tests_for_harness!(harnesses::OrderedVariableHarness, ordered_variable);
+current_sync_tests_for_harness!(harnesses::UnorderedFixedMmrHarness, unordered_fixed_mmr);
+current_sync_tests_for_harness!(harnesses::UnorderedFixedMmbHarness, unordered_fixed_mmb);
+current_sync_tests_for_harness!(
+    harnesses::UnorderedVariableMmrHarness,
+    unordered_variable_mmr
+);
+current_sync_tests_for_harness!(
+    harnesses::UnorderedVariableMmbHarness,
+    unordered_variable_mmb
+);
+current_sync_tests_for_harness!(harnesses::OrderedFixedMmrHarness, ordered_fixed_mmr);
+current_sync_tests_for_harness!(harnesses::OrderedFixedMmbHarness, ordered_fixed_mmb);
+current_sync_tests_for_harness!(harnesses::OrderedVariableMmrHarness, ordered_variable_mmr);
+current_sync_tests_for_harness!(harnesses::OrderedVariableMmbHarness, ordered_variable_mmb);

--- a/storage/src/qmdb/immutable/sync.rs
+++ b/storage/src/qmdb/immutable/sync.rs
@@ -33,12 +33,13 @@ where
     V: ValueEncoding,
     C: Mutable<Item = Operation<K, V>>
         + Persistable<Error = JournalError>
-        + sync::Journal<Context = E, Op = Operation<K, V>>,
+        + sync::Journal<mmr::Family, Context = E, Op = Operation<K, V>>,
     C::Item: EncodeShared,
     C::Config: Clone + Send,
     H: Hasher,
     T: Translator,
 {
+    type Family = mmr::Family;
     type Op = Operation<K, V>;
     type Journal = C;
     type Hasher = H;
@@ -67,6 +68,10 @@ where
         db_config: Self::Config,
         log: Self::Journal,
         pinned_nodes: Option<Vec<Self::Digest>>,
+        // `immutable` does not distinguish between ops and canonical roots and does not use
+        // overlay state; ignore both fields entirely.
+        _overlay_state: Option<crate::qmdb::current::sync::CurrentOverlayState<Self::Digest>>,
+        _canonical_root: Option<Self::Digest>,
         range: Range<mmr::Location>,
         apply_batch_size: usize,
     ) -> Result<Self, Error<mmr::Family>> {
@@ -289,6 +294,7 @@ mod tests {
                 target: Target {
                     root: target_root,
                     range: non_empty_range!(target_oldest_retained_loc, target_op_count),
+                    canonical_root: None,
                 },
                 context: context.with_label("client"),
                 resolver: target_db.clone(),
@@ -370,6 +376,7 @@ mod tests {
                 target: Target {
                     root: target_root,
                     range: non_empty_range!(target_oldest_retained_loc, target_op_count),
+                    canonical_root: None,
                 },
                 context: context.with_label("client"),
                 resolver: target_db.clone(),
@@ -422,6 +429,7 @@ mod tests {
                 target: Target {
                     root: target_root,
                     range: non_empty_range!(lower_bound, op_count),
+                    canonical_root: None,
                 },
                 context: client_context.clone(),
                 resolver: target_db.clone(),
@@ -509,6 +517,7 @@ mod tests {
                     target: Target {
                         root: initial_root,
                         range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                        canonical_root: None,
                     },
                     resolver: target_db.clone(),
                     fetch_batch_size: NZU64!(2), // Very small batch size to ensure multiple batches needed
@@ -539,6 +548,7 @@ mod tests {
                 .send(Target {
                     root: final_root,
                     range: non_empty_range!(initial_lower_bound, final_upper_bound),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -600,6 +610,7 @@ mod tests {
                 target: Target {
                     root: target_root,
                     range: non_empty_range!(lower_bound, op_count),
+                    canonical_root: None,
                 },
                 context: context.with_label("client"),
                 resolver: target_db.clone(),
@@ -664,6 +675,7 @@ mod tests {
                 target: Target {
                     root,
                     range: non_empty_range!(lower_bound, upper_bound),
+                    canonical_root: None,
                 },
                 context: context.with_label("sync"),
                 resolver: target_db.clone(),
@@ -724,6 +736,7 @@ mod tests {
                 target: Target {
                     root,
                     range: non_empty_range!(lower_bound, upper_bound),
+                    canonical_root: None,
                 },
                 context: context.with_label("sync"),
                 resolver: resolver.clone(),
@@ -774,6 +787,7 @@ mod tests {
                 target: Target {
                     root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,
@@ -793,6 +807,7 @@ mod tests {
                         initial_lower_bound.checked_sub(1).unwrap(),
                         initial_upper_bound
                     ),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -837,6 +852,7 @@ mod tests {
                 target: Target {
                     root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,
@@ -853,6 +869,7 @@ mod tests {
                 .send(Target {
                     root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -918,6 +935,7 @@ mod tests {
                 target: Target {
                     root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,
@@ -933,6 +951,7 @@ mod tests {
                 .send(Target {
                     root: final_root,
                     range: non_empty_range!(final_lower_bound, final_upper_bound),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -979,6 +998,7 @@ mod tests {
                 target: Target {
                     root,
                     range: non_empty_range!(lower_bound, upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,
@@ -997,6 +1017,7 @@ mod tests {
                 .send(Target {
                     root: sha256::Digest::from([2u8; 32]),
                     range: non_empty_range!(lower_bound + 1, upper_bound + 1),
+                    canonical_root: None,
                 })
                 .await;
 

--- a/storage/src/qmdb/keyless/sync.rs
+++ b/storage/src/qmdb/keyless/sync.rs
@@ -27,11 +27,12 @@ where
     V: ValueEncoding + Codec,
     C: Mutable<Item = Operation<V>>
         + Persistable<Error = JournalError>
-        + sync::Journal<Context = E, Op = Operation<V>>,
+        + sync::Journal<mmr::Family, Context = E, Op = Operation<V>>,
     C::Config: Clone + Send,
     H: Hasher,
     Operation<V>: EncodeShared,
 {
+    type Family = mmr::Family;
     type Op = Operation<V>;
     type Journal = C;
     type Hasher = H;
@@ -59,6 +60,10 @@ where
         config: Self::Config,
         log: Self::Journal,
         pinned_nodes: Option<Vec<Self::Digest>>,
+        // `keyless` does not distinguish between ops and canonical roots and does not use
+        // overlay state; ignore both fields entirely.
+        _overlay_state: Option<crate::qmdb::current::sync::CurrentOverlayState<Self::Digest>>,
+        _canonical_root: Option<Self::Digest>,
         range: Range<Location>,
         apply_batch_size: usize,
     ) -> Result<Self, qmdb::Error<mmr::Family>> {
@@ -226,13 +231,14 @@ mod tests {
     fn test_sync_resolver_fails() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
-            let resolver = FailResolver::<VariableOp, sha256::Digest>::new();
+            let resolver = FailResolver::<mmr::Family, VariableOp, sha256::Digest>::new();
             let db_config = create_sync_config(&context.next_u64().to_string(), &context);
             let config = Config {
                 context: context.with_label("client"),
                 target: Target {
                     root: sha256::Digest::from([0; 32]),
                     range: non_empty_range!(Location::new(0), Location::new(5)),
+                    canonical_root: None,
                 },
                 resolver,
                 apply_batch_size: 2,
@@ -280,6 +286,7 @@ mod tests {
                 target: Target {
                     root: target_root,
                     range: non_empty_range!(target_oldest_retained_loc, target_op_count),
+                    canonical_root: None,
                 },
                 context: context.with_label("client"),
                 resolver: target_db.clone(),
@@ -343,6 +350,7 @@ mod tests {
                 target: Target {
                     root: target_root,
                     range: non_empty_range!(target_oldest_retained_loc, target_op_count),
+                    canonical_root: None,
                 },
                 context: context.with_label("client"),
                 resolver: target_db.clone(),
@@ -390,6 +398,7 @@ mod tests {
                 target: Target {
                     root: target_root,
                     range: non_empty_range!(lower_bound, op_count),
+                    canonical_root: None,
                 },
                 context: client_context.clone(),
                 resolver: target_db.clone(),
@@ -466,6 +475,7 @@ mod tests {
                     target: Target {
                         root: initial_root,
                         range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                        canonical_root: None,
                     },
                     resolver: target_db.clone(),
                     fetch_batch_size: NZU64!(2),
@@ -493,6 +503,7 @@ mod tests {
                 .send(Target {
                     root: final_root,
                     range: non_empty_range!(initial_lower_bound, final_upper_bound),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -539,6 +550,7 @@ mod tests {
                 target: Target {
                     root: target_root,
                     range: non_empty_range!(lower_bound, op_count),
+                    canonical_root: None,
                 },
                 context: context.with_label("client"),
                 resolver: target_db.clone(),
@@ -597,6 +609,7 @@ mod tests {
                 target: Target {
                     root,
                     range: non_empty_range!(lower_bound, upper_bound),
+                    canonical_root: None,
                 },
                 context: context.with_label("sync"),
                 resolver: target_db.clone(),
@@ -651,6 +664,7 @@ mod tests {
                 target: Target {
                     root,
                     range: non_empty_range!(lower_bound, upper_bound),
+                    canonical_root: None,
                 },
                 context: context.with_label("sync"),
                 resolver: resolver.clone(),
@@ -697,6 +711,7 @@ mod tests {
                 target: Target {
                     root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,
@@ -715,6 +730,7 @@ mod tests {
                         initial_lower_bound.checked_sub(1).unwrap(),
                         initial_upper_bound
                     ),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -755,6 +771,7 @@ mod tests {
                 target: Target {
                     root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,
@@ -770,6 +787,7 @@ mod tests {
                 .send(Target {
                     root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -827,6 +845,7 @@ mod tests {
                 target: Target {
                     root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,
@@ -841,6 +860,7 @@ mod tests {
                 .send(Target {
                     root: final_root,
                     range: non_empty_range!(final_lower_bound, final_upper_bound),
+                    canonical_root: None,
                 })
                 .await
                 .unwrap();
@@ -881,6 +901,7 @@ mod tests {
                 target: Target {
                     root,
                     range: non_empty_range!(lower_bound, upper_bound),
+                    canonical_root: None,
                 },
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,
@@ -897,6 +918,7 @@ mod tests {
                 .send(Target {
                     root: sha256::Digest::from([2u8; 32]),
                     range: non_empty_range!(lower_bound + 1, upper_bound + 1),
+                    canonical_root: None,
                 })
                 .await;
 
@@ -994,6 +1016,7 @@ mod tests {
                 target: Target {
                     root: target_root,
                     range: non_empty_range!(lower_bound, upper_bound),
+                    canonical_root: None,
                 },
                 context: context.with_label("client"),
                 resolver: target_db.clone(),

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -1,4 +1,8 @@
-use crate::{mmr::Location, qmdb::sync::Journal, translator::Translator};
+use crate::{
+    merkle::{Family, Location},
+    qmdb::{current::sync::CurrentOverlayState, sync::Journal},
+    translator::Translator,
+};
 use commonware_cryptography::Digest;
 use std::{future::Future, ops::Range};
 
@@ -31,24 +35,43 @@ impl<J: Clone> Config for crate::qmdb::keyless::Config<J> {
     }
 }
 pub trait Database: Sized + Send {
+    /// The merkle family backing this database (e.g. MMR or MMB).
+    type Family: Family;
     type Op: Send;
-    type Journal: Journal<Context = Self::Context, Op = Self::Op>;
-    type Config: Config<JournalConfig = <Self::Journal as Journal>::Config>;
+    type Journal: Journal<Self::Family, Context = Self::Context, Op = Self::Op>;
+    type Config: Config<JournalConfig = <Self::Journal as Journal<Self::Family>>::Config>;
     type Digest: Digest;
     type Context: commonware_runtime::Storage
         + commonware_runtime::Clock
         + commonware_runtime::Metrics;
     type Hasher: commonware_cryptography::Hasher<Digest = Self::Digest>;
 
-    /// Build a database from the journal and pinned nodes populated by the sync engine.
+    /// Build a database from the journal and boundary state populated by the sync engine.
+    ///
+    /// `overlay_state` carries the sender's grafted pruning state for `current` sync; it is
+    /// `None` for databases that do not use overlay state (`any`, `immutable`, `keyless`).
+    ///
+    /// `canonical_root` is the trusted canonical root from [`Target::canonical_root`] —
+    /// used by `current` to authenticate the reconstructed overlay state by comparing the
+    /// rebuilt database's canonical root against this value. `None` means the caller did
+    /// not supply one (either the database doesn't need it, or current sync was started
+    /// without canonical-root authentication).
+    ///
+    /// Implementations that do not distinguish between ops and canonical roots should
+    /// ignore `overlay_state` and `canonical_root`.
+    ///
+    /// [`Target::canonical_root`]: crate::qmdb::sync::Target::canonical_root
+    #[allow(clippy::too_many_arguments)]
     fn from_sync_result(
         context: Self::Context,
         config: Self::Config,
         journal: Self::Journal,
         pinned_nodes: Option<Vec<Self::Digest>>,
-        range: Range<Location>,
+        overlay_state: Option<CurrentOverlayState<Self::Digest>>,
+        canonical_root: Option<Self::Digest>,
+        range: Range<Location<Self::Family>>,
         apply_batch_size: usize,
-    ) -> impl Future<Output = Result<Self, crate::qmdb::Error<crate::merkle::mmr::Family>>> + Send;
+    ) -> impl Future<Output = Result<Self, crate::qmdb::Error<Self::Family>>> + Send;
 
     /// Get the root digest of the database for verification
     fn root(&self) -> Self::Digest;

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -1,8 +1,9 @@
 //! Core sync engine components that are shared across sync clients.
 use crate::{
-    merkle::mmr::{Location, StandardHasher},
+    merkle::{hasher::Standard as StandardHasher, Family, Location},
     qmdb::{
         self,
+        current::sync::CurrentOverlayState,
         sync::{
             database::Config as _,
             error::EngineError,
@@ -36,7 +37,8 @@ use std::{
 };
 
 /// Type alias for sync engine errors
-type Error<DB, R> = qmdb::sync::Error<<R as Resolver>::Error, <DB as Database>::Digest>;
+type Error<DB, R> =
+    qmdb::sync::Error<<DB as Database>::Family, <R as Resolver>::Error, <DB as Database>::Digest>;
 
 /// Whether sync should continue or complete
 #[derive(Debug)]
@@ -49,11 +51,11 @@ pub(crate) enum NextStep<C, D> {
 
 /// Events that can occur during synchronization
 #[derive(Debug)]
-enum Event<Op, D: Digest, E> {
+enum Event<F: Family, Op, D: Digest, E> {
     /// A target update was received
-    TargetUpdate(Target<D>),
+    TargetUpdate(Target<F, D>),
     /// A batch of operations was received
-    BatchReceived(IndexedFetchResult<Op, D, E>),
+    BatchReceived(IndexedFetchResult<F, Op, D, E>),
     /// The target update channel was closed
     UpdateChannelClosed,
     /// A finish signal was received
@@ -64,22 +66,22 @@ enum Event<Op, D: Digest, E> {
 
 /// Result from a fetch operation with its request ID and starting location.
 #[derive(Debug)]
-pub(super) struct IndexedFetchResult<Op, D: Digest, E> {
+pub(super) struct IndexedFetchResult<F: Family, Op, D: Digest, E> {
     /// Unique ID assigned when the request was scheduled.
     pub id: RequestId,
     /// The location of the first operation in the batch.
-    pub start_loc: Location,
+    pub start_loc: Location<F>,
     /// The result of the fetch operation.
-    pub result: Result<FetchResult<Op, D>, E>,
+    pub result: Result<FetchResult<F, Op, D>, E>,
 }
 
 /// Wait for the next synchronization event.
 /// Returns `None` when there are no outstanding requests and no channels to wait on.
-async fn wait_for_event<Op, D: Digest, E>(
-    update_rx: &mut Option<mpsc::Receiver<Target<D>>>,
+async fn wait_for_event<F: Family, Op, D: Digest, E>(
+    update_rx: &mut Option<mpsc::Receiver<Target<F, D>>>,
     finish_rx: &mut Option<mpsc::Receiver<()>>,
-    outstanding_requests: &mut Requests<Op, D, E>,
-) -> Option<Event<Op, D, E>> {
+    outstanding_requests: &mut Requests<F, Op, D, E>,
+) -> Option<Event<F, Op, D, E>> {
     if outstanding_requests.len() == 0 && update_rx.is_none() && finish_rx.is_none() {
         return None;
     }
@@ -115,7 +117,7 @@ async fn wait_for_event<Op, D: Digest, E>(
 pub struct Config<DB, R>
 where
     DB: Database,
-    R: Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     /// Runtime context for creating database components
@@ -123,7 +125,7 @@ where
     /// Network resolver for fetching operations and proofs
     pub resolver: R,
     /// Sync target (root digest and operation bounds)
-    pub target: Target<DB::Digest>,
+    pub target: Target<DB::Family, DB::Digest>,
     /// Maximum number of outstanding requests for operation batches
     pub max_outstanding_requests: usize,
     /// Maximum operations to fetch per batch
@@ -133,7 +135,7 @@ where
     /// Database-specific configuration
     pub db_config: DB::Config,
     /// Channel for receiving sync target updates
-    pub update_rx: Option<mpsc::Receiver<Target<DB::Digest>>>,
+    pub update_rx: Option<mpsc::Receiver<Target<DB::Family, DB::Digest>>>,
     /// Channel that requests sync completion once the current target is reached.
     ///
     /// When `None`, sync completes as soon as the target is reached.
@@ -144,7 +146,7 @@ where
     /// When `reached_target_tx` is `Some(...)`, this receiver must be actively
     /// drained by the observer. The engine awaits send capacity on this channel before
     /// proceeding, so backpressure can pause progress at target.
-    pub reached_target_tx: Option<mpsc::Sender<Target<DB::Digest>>>,
+    pub reached_target_tx: Option<mpsc::Sender<Target<DB::Family, DB::Digest>>>,
     /// Maximum number of previous roots to retain for verifying in-flight
     /// requests after target updates. Set to 0 to disable (all retained
     /// requests will be re-fetched).
@@ -154,38 +156,42 @@ where
 pub(crate) struct Engine<DB, R>
 where
     DB: Database,
-    R: Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     /// Tracks outstanding fetch requests and their futures
-    outstanding_requests: Requests<DB::Op, DB::Digest, R::Error>,
+    outstanding_requests: Requests<DB::Family, DB::Op, DB::Digest, R::Error>,
 
     /// Operations that have been fetched but not yet applied to the log.
     ///
     /// # Invariant
     ///
     /// The vectors in the map are non-empty.
-    fetched_operations: BTreeMap<Location, Vec<DB::Op>>,
+    fetched_operations: BTreeMap<Location<DB::Family>, Vec<DB::Op>>,
 
     /// Pinned MMR nodes extracted from proofs, used for database construction
     pinned_nodes: Option<Vec<DB::Digest>>,
+
+    /// Overlay state extracted from the boundary batch. Populated only for `current`
+    /// resolvers; `None` for other databases. Reset on target update (mirrors `pinned_nodes`).
+    overlay_state: Option<CurrentOverlayState<DB::Digest>>,
 
     /// Historical roots from previous sync targets, keyed by tree size
     /// (target.range.end()). Each tree size maps to a unique root because
     /// the MMR is append-only and validate_update rejects unchanged roots.
     /// When a retained request completes, proof.leaves identifies which
     /// historical root to verify against.
-    retained_roots: HashMap<Location, DB::Digest>,
+    retained_roots: HashMap<Location<DB::Family>, DB::Digest>,
 
     /// Tree sizes of retained roots in insertion order (oldest first),
     /// used for FIFO eviction when retained_roots exceeds capacity.
-    retained_roots_order: VecDeque<Location>,
+    retained_roots_order: VecDeque<Location<DB::Family>>,
 
     /// Maximum number of historical roots to retain
     max_retained_roots: usize,
 
     /// The current sync target (root digest and operation bounds)
-    target: Target<DB::Digest>,
+    target: Target<DB::Family, DB::Digest>,
 
     /// Maximum number of parallel outstanding requests
     max_outstanding_requests: usize,
@@ -212,7 +218,7 @@ where
     config: DB::Config,
 
     /// Optional receiver for target updates during sync
-    update_rx: Option<mpsc::Receiver<Target<DB::Digest>>>,
+    update_rx: Option<mpsc::Receiver<Target<DB::Family, DB::Digest>>>,
 
     /// Channel that requests sync completion once the current target is reached.
     ///
@@ -225,20 +231,37 @@ where
     /// When `reached_target_tx` is `Some(...)`, this receiver must be actively
     /// drained by the observer. The engine awaits send capacity on this channel before
     /// proceeding, so backpressure can pause progress at target.
-    reached_target_tx: Option<mpsc::Sender<Target<DB::Digest>>>,
+    reached_target_tx: Option<mpsc::Sender<Target<DB::Family, DB::Digest>>>,
 
     /// Whether explicit finish has been requested.
     finish_requested: bool,
 
     /// Tracks whether the current target has already been reported as reached.
     reached_current_target_reported: bool,
+
+    /// Count of consecutive proof/pinned-nodes verification failures.
+    ///
+    /// Incremented on every verification failure in `handle_fetch_result`, reset to 0
+    /// on any verified batch. When it reaches [`MAX_VERIFICATION_FAILURES`] the engine
+    /// aborts via [`EngineError::TooManyVerificationFailures`] instead of retrying
+    /// the same (bad) request indefinitely.
+    consecutive_verification_failures: u32,
 }
+
+/// Maximum consecutive proof/pinned-nodes verification failures before aborting sync.
+///
+/// We tolerate transient failures (e.g. a partial or reordered batch from a misbehaving
+/// resolver), but persistent failures almost always mean a permanent fault: a wrong
+/// target root, a bad resolver, or a bug in proof construction/verification. Without
+/// this bound, the engine would reschedule the same failing request forever, which
+/// presents to callers as a hang.
+const MAX_VERIFICATION_FAILURES: u32 = 10;
 
 #[cfg(test)]
 impl<DB, R> Engine<DB, R>
 where
     DB: Database,
-    R: Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     pub(crate) fn journal(&self) -> &DB::Journal {
@@ -249,7 +272,7 @@ where
 impl<DB, R> Engine<DB, R>
 where
     DB: Database,
-    R: Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     /// Create a new sync engine with the given configuration
@@ -262,7 +285,7 @@ where
         }
 
         // Create journal and verifier using the database's factory methods
-        let journal = <DB::Journal as Journal>::new(
+        let journal = <DB::Journal as Journal<DB::Family>>::new(
             config.context.with_label("journal"),
             config.db_config.journal_config(),
             config.target.range.clone().into(),
@@ -273,6 +296,7 @@ where
             outstanding_requests: Requests::new(),
             fetched_operations: BTreeMap::new(),
             pinned_nodes: None,
+            overlay_state: None,
             retained_roots: HashMap::new(),
             retained_roots_order: VecDeque::new(),
             max_retained_roots: config.max_retained_roots,
@@ -290,6 +314,7 @@ where
             reached_target_tx: config.reached_target_tx,
             finish_requested: false,
             reached_current_target_reported: false,
+            consecutive_verification_failures: 0,
         };
         engine.schedule_requests().await?;
         Ok(engine)
@@ -336,7 +361,7 @@ where
 
         for _ in 0..num_requests {
             // Convert fetched operations to operation counts for shared gap detection
-            let operation_counts: BTreeMap<Location, u64> = self
+            let operation_counts: BTreeMap<Location<DB::Family>, u64> = self
                 .fetched_operations
                 .iter()
                 .map(|(&start_loc, operations)| (start_loc, operations.len() as u64))
@@ -389,7 +414,7 @@ where
     /// `retained_roots`) so the fetched operations can still be used.
     pub async fn reset_for_target_update(
         mut self,
-        new_target: Target<DB::Digest>,
+        new_target: Target<DB::Family, DB::Digest>,
     ) -> Result<Self, Error<DB, R>> {
         self.journal.resize(new_target.range.start()).await?;
         // Remove requests at or before the new start. The request at start
@@ -398,6 +423,10 @@ where
             .remove_before(new_target.range.start().checked_add(1).unwrap());
         self.fetched_operations.clear();
         self.pinned_nodes = None;
+        // Overlay state is boundary state for the prior target; the new target's boundary
+        // may be at a different pruning position, so drop it and let the next boundary
+        // batch refresh it.
+        self.overlay_state = None;
 
         // Save the current root keyed by its tree size for verifying
         // retained requests that were issued against this target.
@@ -419,6 +448,10 @@ where
 
         self.target = new_target;
         self.reached_current_target_reported = false;
+        // A new target means a fresh root; prior verification failures were against
+        // the old root and aren't relevant. Reset so the new target gets a full budget
+        // of retries before the engine gives up.
+        self.consecutive_verification_failures = 0;
         Ok(self)
     }
 
@@ -472,7 +505,11 @@ where
     }
 
     /// Store a batch of fetched operations. If the input list is empty, this is a no-op.
-    pub(crate) fn store_operations(&mut self, start_loc: Location, operations: Vec<DB::Op>) {
+    pub(crate) fn store_operations(
+        &mut self,
+        start_loc: Location<DB::Family>,
+        operations: Vec<DB::Op>,
+    ) {
         if operations.is_empty() {
             return;
         }
@@ -561,6 +598,20 @@ where
         Ok(false)
     }
 
+    /// Whether the engine requires a fresh boundary batch before completing.
+    ///
+    /// For databases with canonical-root authentication (`canonical_root` is set), the
+    /// engine must have fetched and verified a boundary batch — falling back to stale
+    /// persisted metadata can create a stuck retry loop when a prior sync wrote the
+    /// journal but failed the canonical-root check before persisting metadata.
+    ///
+    /// When this returns `true`, `step()` defers completion and falls through to
+    /// `schedule_requests()` + the normal event loop so that the boundary batch is
+    /// fetched and verified through the standard pipeline.
+    const fn needs_fresh_boundary_state(&self) -> bool {
+        self.target.canonical_root.is_some() && self.overlay_state.is_none()
+    }
+
     /// Handle the result of a fetch operation.
     ///
     /// Discards results for requests no longer tracked (removed by
@@ -569,7 +620,7 @@ where
     /// to a matching historical root from `retained_roots` if available.
     fn handle_fetch_result(
         &mut self,
-        fetch_result: IndexedFetchResult<DB::Op, DB::Digest, R::Error>,
+        fetch_result: IndexedFetchResult<DB::Family, DB::Op, DB::Digest, R::Error>,
     ) -> Result<(), Error<DB, R>> {
         // Discard results for stale requests (removed by a target update).
         // Using the request ID prevents a stale future from consuming the
@@ -584,6 +635,7 @@ where
             operations,
             success_tx,
             pinned_nodes,
+            overlay_state,
         } = fetch_result.result.map_err(SyncError::Resolver)?;
 
         // Validate batch size
@@ -634,16 +686,45 @@ where
         success_tx.send_lossy(valid);
 
         if !valid {
+            // Silent retries tolerate transient resolver issues but, left unbounded, turn
+            // a permanent fault (wrong target root, buggy proof construction, adversarial
+            // resolver) into an indefinite hang. Track consecutive failures and abort
+            // once we've clearly stopped making progress.
+            self.consecutive_verification_failures =
+                self.consecutive_verification_failures.saturating_add(1);
             if need_pinned {
-                tracing::warn!("boundary proof or pinned nodes failed verification, will retry");
+                tracing::warn!(
+                    failures = self.consecutive_verification_failures,
+                    "boundary proof or pinned nodes failed verification, will retry"
+                );
+            } else {
+                tracing::warn!(
+                    failures = self.consecutive_verification_failures,
+                    "proof failed verification, will retry"
+                );
+            }
+            if self.consecutive_verification_failures >= MAX_VERIFICATION_FAILURES {
+                return Err(SyncError::Engine(EngineError::TooManyVerificationFailures(
+                    self.consecutive_verification_failures,
+                )));
             }
             return Ok(());
         }
 
-        // Cache pinned nodes only from current-root-verified proofs.
+        // Successful verification — reset the failure counter.
+        self.consecutive_verification_failures = 0;
+
+        // Cache pinned nodes and overlay state only from current-root-verified boundary
+        // proofs. Overlay state is authenticated indirectly at sync completion by comparing
+        // the rebuilt database's canonical root against a trusted canonical root supplied in
+        // the sync target (for databases that use overlay state); the ops-root proof chain
+        // does not cover it.
         if need_pinned {
             if let Some(nodes) = pinned_nodes {
                 self.pinned_nodes = Some(nodes);
+            }
+            if let Some(state) = overlay_state {
+                self.overlay_state = Some(state);
             }
         }
 
@@ -656,7 +737,7 @@ where
     /// Handle a sync event and return the next engine state.
     async fn handle_event(
         mut self,
-        event: Event<DB::Op, DB::Digest, R::Error>,
+        event: Event<DB::Family, DB::Op, DB::Digest, R::Error>,
     ) -> Result<NextStep<Self, DB>, Error<DB, R>> {
         match event {
             Event::TargetUpdate(new_target) => {
@@ -697,8 +778,10 @@ where
     pub(crate) async fn step(mut self) -> Result<NextStep<Self, DB>, Error<DB, R>> {
         self.drain_finish_requests()?;
 
-        // Check if sync is complete
-        if self.is_at_target().await? {
+        // Check if sync is complete. For databases with canonical-root authentication,
+        // defer completion until a fresh boundary batch has been fetched and verified —
+        // fall through to `schedule_requests` + the normal event loop instead.
+        if self.is_at_target().await? && !self.needs_fresh_boundary_state() {
             self.report_reached_target().await;
 
             if self.finish_rx.is_some() && !self.finish_requested {
@@ -714,12 +797,16 @@ where
 
             self.journal.sync().await?;
 
-            // Build the database from the completed sync
+            // Build the database from the completed sync. The engine forwards the target's
+            // `canonical_root` so that databases with canonical-root authentication (currently
+            // only `current`) can check the rebuilt state against it.
             let database = DB::from_sync_result(
                 self.context,
                 self.config,
                 self.journal,
                 self.pinned_nodes,
+                self.overlay_state,
+                self.target.canonical_root,
                 self.target.range.clone().into(),
                 self.apply_batch_size,
             )
@@ -773,10 +860,22 @@ mod tests {
     use std::{future::Future, pin::Pin};
 
     /// Create a no-op fetch result future for testing request tracking.
+    #[allow(clippy::type_complexity)]
     fn dummy_future(
         id: RequestId,
         loc: u64,
-    ) -> Pin<Box<dyn Future<Output = IndexedFetchResult<i32, sha256::Digest, ()>> + Send>> {
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = IndexedFetchResult<
+                        crate::merkle::mmr::Family,
+                        i32,
+                        sha256::Digest,
+                        (),
+                    >,
+                > + Send,
+        >,
+    > {
         Box::pin(async move {
             IndexedFetchResult {
                 id,
@@ -789,13 +888,17 @@ mod tests {
                     operations: vec![],
                     success_tx: oneshot::channel().0,
                     pinned_nodes: None,
+                    overlay_state: None,
                 }),
             }
         })
     }
 
     /// Helper to add a request at a given location.
-    fn add(requests: &mut Requests<i32, sha256::Digest, ()>, loc: u64) -> RequestId {
+    fn add(
+        requests: &mut Requests<crate::merkle::mmr::Family, i32, sha256::Digest, ()>,
+        loc: u64,
+    ) -> RequestId {
         let id = requests.next_id();
         requests.insert(
             id,
@@ -808,7 +911,8 @@ mod tests {
 
     #[test]
     fn test_add_and_remove() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<crate::merkle::mmr::Family, i32, sha256::Digest, ()> =
+            Requests::new();
         assert_eq!(requests.len(), 0);
 
         let id = add(&mut requests, 10);
@@ -822,7 +926,8 @@ mod tests {
 
     #[test]
     fn test_remove_before() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<crate::merkle::mmr::Family, i32, sha256::Digest, ()> =
+            Requests::new();
 
         add(&mut requests, 5);
         add(&mut requests, 10);
@@ -840,7 +945,8 @@ mod tests {
 
     #[test]
     fn test_remove_before_all() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<crate::merkle::mmr::Family, i32, sha256::Digest, ()> =
+            Requests::new();
 
         add(&mut requests, 5);
         add(&mut requests, 10);
@@ -852,14 +958,16 @@ mod tests {
 
     #[test]
     fn test_remove_before_empty() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<crate::merkle::mmr::Family, i32, sha256::Digest, ()> =
+            Requests::new();
         requests.remove_before(Location::new(10));
         assert_eq!(requests.len(), 0);
     }
 
     #[test]
     fn test_remove_before_none() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<crate::merkle::mmr::Family, i32, sha256::Digest, ()> =
+            Requests::new();
 
         add(&mut requests, 10);
         add(&mut requests, 20);
@@ -873,7 +981,8 @@ mod tests {
 
     #[test]
     fn test_superseded_request() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<crate::merkle::mmr::Family, i32, sha256::Digest, ()> =
+            Requests::new();
 
         // Old request at location 10
         let old_id = add(&mut requests, 10);
@@ -894,7 +1003,8 @@ mod tests {
 
     #[test]
     fn test_stale_id_after_remove_before() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<crate::merkle::mmr::Family, i32, sha256::Digest, ()> =
+            Requests::new();
 
         let old_id = add(&mut requests, 5);
         add(&mut requests, 15);

--- a/storage/src/qmdb/sync/error.rs
+++ b/storage/src/qmdb/sync/error.rs
@@ -1,18 +1,21 @@
 //! Shared sync error types that can be used across different database implementations.
 
-use crate::{mmr::Location, qmdb::sync::Target};
+use crate::{
+    merkle::{Family, Location},
+    qmdb::sync::Target,
+};
 use commonware_cryptography::Digest;
 
 #[derive(Debug, thiserror::Error)]
-pub enum EngineError<D: Digest> {
+pub enum EngineError<F: Family, D: Digest> {
     /// Hash mismatch after sync
     #[error("root digest mismatch - expected {expected:?}, got {actual:?}")]
     RootMismatch { expected: D, actual: D },
     /// Invalid target parameters
     #[error("invalid bounds: lower bound {lower_bound_pos} > upper bound {upper_bound_pos}")]
     InvalidTarget {
-        lower_bound_pos: Location,
-        upper_bound_pos: Location,
+        lower_bound_pos: Location<F>,
+        upper_bound_pos: Location<F>,
     },
     /// Invalid client state
     #[error("invalid client state")]
@@ -22,7 +25,10 @@ pub enum EngineError<D: Digest> {
     SyncTargetRootUnchanged,
     /// Sync target moved backward
     #[error("sync target moved backward: {old:?} -> {new:?}")]
-    SyncTargetMovedBackward { old: Target<D>, new: Target<D> },
+    SyncTargetMovedBackward {
+        old: Target<F, D>,
+        new: Target<F, D>,
+    },
     /// Sync already completed
     #[error("sync already completed")]
     AlreadyComplete,
@@ -35,18 +41,27 @@ pub enum EngineError<D: Digest> {
     /// Error extracting pinned nodes
     #[error("error extracting pinned nodes: {0}")]
     PinnedNodes(String),
+    /// Too many consecutive proof/pinned-nodes verification failures.
+    ///
+    /// The engine silently retries after a verification failure to tolerate transient
+    /// resolver issues. If verification keeps failing for the same request, that is a
+    /// permanent fault (bad resolver, wrong target root, bug) and the engine aborts
+    /// rather than looping forever.
+    #[error("sync aborted after {0} consecutive verification failures")]
+    TooManyVerificationFailures(u32),
 }
 
 /// Errors that can occur during database synchronization.
 #[derive(Debug, thiserror::Error)]
-pub enum Error<U, D>
+pub enum Error<F, U, D>
 where
+    F: Family,
     U: std::error::Error + Send + 'static,
     D: Digest,
 {
     /// Database error
     #[error("database error: {0}")]
-    Database(crate::qmdb::Error<crate::merkle::mmr::Family>),
+    Database(crate::qmdb::Error<F>),
 
     /// Resolver error
     #[error("resolver error: {0:?}")]
@@ -54,14 +69,15 @@ where
 
     /// Engine error
     #[error("engine error: {0}")]
-    Engine(EngineError<D>),
+    Engine(EngineError<F, D>),
 }
 
-impl<T, U, D> From<T> for Error<U, D>
+impl<F, T, U, D> From<T> for Error<F, U, D>
 where
+    F: Family,
     U: std::error::Error + Send + 'static,
     D: Digest,
-    T: Into<crate::qmdb::Error<crate::merkle::mmr::Family>>,
+    T: Into<crate::qmdb::Error<F>>,
 {
     fn from(err: T) -> Self {
         Self::Database(err.into())

--- a/storage/src/qmdb/sync/gaps.rs
+++ b/storage/src/qmdb/sync/gaps.rs
@@ -1,6 +1,6 @@
 //! Gap detection algorithm for sync operations.
 
-use crate::merkle::mmr::Location;
+use crate::merkle::{Family, Location};
 use core::{num::NonZeroU64, ops::Range};
 use std::collections::BTreeMap;
 
@@ -23,18 +23,18 @@ use std::collections::BTreeMap;
 /// - All start locations in `fetched_operations` are in `range`
 /// - All start locations in `outstanding_requests` are in `range`
 /// - All operation counts in `fetched_operations` are > 0
-pub fn find_next<'a>(
-    range: Range<Location>,
-    fetched_operations: &BTreeMap<Location, u64>, // start_loc -> operation_count
-    outstanding_requests: impl IntoIterator<Item = &'a Location>,
+pub fn find_next<'a, F: Family>(
+    range: Range<Location<F>>,
+    fetched_operations: &BTreeMap<Location<F>, u64>, // start_loc -> operation_count
+    outstanding_requests: impl IntoIterator<Item = &'a Location<F>>,
     fetch_batch_size: NonZeroU64,
-) -> Option<Range<Location>> {
+) -> Option<Range<Location<F>>> {
     if range.is_empty() {
         return None;
     }
 
     // Track the next uncovered location (exclusive end of covered range)
-    let mut next_uncovered: Location = range.start;
+    let mut next_uncovered: Location<F> = range.start;
 
     // Create iterators for both data structures (already sorted)
     let mut fetched_ops_iter = fetched_operations
@@ -95,6 +95,7 @@ pub fn find_next<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::merkle::mmr::Location;
     use rstest::rstest;
 
     /// Test case structure for find_next tests

--- a/storage/src/qmdb/sync/journal.rs
+++ b/storage/src/qmdb/sync/journal.rs
@@ -1,8 +1,14 @@
-use crate::{journal::contiguous::Contiguous, mmr::Location};
+use crate::{
+    journal::contiguous::Contiguous,
+    merkle::{Family, Location},
+};
 use std::{future::Future, ops::Range};
 
-/// Journal of operations used by a [super::Database]
-pub trait Journal: Sized + Send {
+/// Journal of operations used by a [super::Database].
+///
+/// Parameterized over the merkle family `F` so that `Location<F>` typing matches
+/// the rest of the sync stack.
+pub trait Journal<F: Family>: Sized + Send {
     /// The context of the journal
     type Context;
 
@@ -13,10 +19,7 @@ pub trait Journal: Sized + Send {
     type Op: Send;
 
     /// The error type returned by the journal
-    type Error: std::error::Error
-        + Send
-        + 'static
-        + Into<crate::qmdb::Error<crate::merkle::mmr::Family>>;
+    type Error: std::error::Error + Send + 'static + Into<crate::qmdb::Error<F>>;
 
     /// Create/open a journal for syncing the given range.
     ///
@@ -27,14 +30,17 @@ pub trait Journal: Sized + Send {
     fn new(
         context: Self::Context,
         config: Self::Config,
-        range: Range<Location>,
+        range: Range<Location<F>>,
     ) -> impl Future<Output = Result<Self, Self::Error>>;
 
     /// Discard all operations before the given location.
     ///
     /// If current `size() <= start`, initialize as empty at the given location.
     /// Otherwise prune data before the given location.
-    fn resize(&mut self, start: Location) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    fn resize(
+        &mut self,
+        start: Location<F>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Persist the journal.
     fn sync(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send;
@@ -46,8 +52,9 @@ pub trait Journal: Sized + Send {
     fn append(&mut self, op: Self::Op) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
-impl<E, V> Journal for crate::journal::contiguous::variable::Journal<E, V>
+impl<F, E, V> Journal<F> for crate::journal::contiguous::variable::Journal<E, V>
 where
+    F: Family,
     E: crate::Context,
     V: commonware_codec::CodecShared,
 {
@@ -59,12 +66,12 @@ where
     async fn new(
         context: Self::Context,
         config: Self::Config,
-        range: Range<Location>,
+        range: Range<Location<F>>,
     ) -> Result<Self, Self::Error> {
         Self::init_sync(context, config.clone(), *range.start..*range.end).await
     }
 
-    async fn resize(&mut self, start: Location) -> Result<(), Self::Error> {
+    async fn resize(&mut self, start: Location<F>) -> Result<(), Self::Error> {
         if Contiguous::size(self).await <= start {
             self.clear_to_size(*start).await
         } else {
@@ -85,8 +92,9 @@ where
     }
 }
 
-impl<E, A> Journal for crate::journal::contiguous::fixed::Journal<E, A>
+impl<F, E, A> Journal<F> for crate::journal::contiguous::fixed::Journal<E, A>
 where
+    F: Family,
     E: crate::Context,
     A: commonware_codec::CodecFixedShared,
 {
@@ -98,7 +106,7 @@ where
     async fn new(
         context: Self::Context,
         config: Self::Config,
-        range: Range<Location>,
+        range: Range<Location<F>>,
     ) -> Result<Self, Self::Error> {
         assert!(!range.is_empty(), "range must not be empty");
 
@@ -119,7 +127,7 @@ where
         Ok(journal)
     }
 
-    async fn resize(&mut self, start: Location) -> Result<(), Self::Error> {
+    async fn resize(&mut self, start: Location<F>) -> Result<(), Self::Error> {
         if Contiguous::size(self).await <= start {
             self.clear_to_size(*start).await
         } else {

--- a/storage/src/qmdb/sync/mod.rs
+++ b/storage/src/qmdb/sync/mod.rs
@@ -26,11 +26,13 @@ pub use target::Target;
 mod requests;
 
 /// Create/open a database and sync it to a target state
-pub async fn sync<DB, R>(config: Config<DB, R>) -> Result<DB, Error<R::Error, DB::Digest>>
+pub async fn sync<DB, R>(
+    config: Config<DB, R>,
+) -> Result<DB, Error<DB::Family, R::Error, DB::Digest>>
 where
     DB: Database,
     DB::Op: Encode,
-    R: resolver::Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: resolver::Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
 {
     Engine::new(config).await?.sync().await
 }

--- a/storage/src/qmdb/sync/requests.rs
+++ b/storage/src/qmdb/sync/requests.rs
@@ -3,7 +3,10 @@
 //! Each request is assigned a unique ID when added. This prevents stale futures
 //! from colliding with fresh requests at the same location after a target update.
 
-use crate::{mmr::Location, qmdb::sync::engine::IndexedFetchResult};
+use crate::{
+    merkle::{Family, Location},
+    qmdb::sync::engine::IndexedFetchResult,
+};
 use commonware_cryptography::Digest;
 use commonware_utils::channel::oneshot;
 use futures::stream::FuturesUnordered;
@@ -18,23 +21,24 @@ use std::{
 pub(super) struct Id(u64);
 
 /// Manages outstanding fetch requests.
-pub(super) struct Requests<Op, D: Digest, E> {
+pub(super) struct Requests<F: Family, Op, D: Digest, E> {
     /// Futures that will resolve to fetch results.
     #[allow(clippy::type_complexity)]
-    futures: FuturesUnordered<Pin<Box<dyn Future<Output = IndexedFetchResult<Op, D, E>> + Send>>>,
+    futures:
+        FuturesUnordered<Pin<Box<dyn Future<Output = IndexedFetchResult<F, Op, D, E>> + Send>>>,
 
     /// Counter for assigning unique request IDs.
     next_id: u64,
 
     /// Active requests keyed by ID. Removing an entry drops the cancel sender,
     /// causing the resolver's `cancel_rx.await` to return `Err`.
-    tracked: HashMap<Id, (Location, oneshot::Sender<()>)>,
+    tracked: HashMap<Id, (Location<F>, oneshot::Sender<()>)>,
 
     /// Reverse index from location to request ID, for gap detection.
-    by_location: BTreeMap<Location, Id>,
+    by_location: BTreeMap<Location<F>, Id>,
 }
 
-impl<Op, D: Digest, E> Requests<Op, D, E> {
+impl<F: Family, Op, D: Digest, E> Requests<F, Op, D, E> {
     pub fn new() -> Self {
         Self {
             futures: FuturesUnordered::new(),
@@ -55,12 +59,13 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
     /// Register a request with a previously allocated ID. If a request already
     /// exists at `start_loc`, the old one is superseded (its cancel sender is
     /// dropped and its future will be discarded when it completes).
+    #[allow(clippy::type_complexity)]
     pub fn insert(
         &mut self,
         id: Id,
-        start_loc: Location,
+        start_loc: Location<F>,
         cancel_tx: oneshot::Sender<()>,
-        future: Pin<Box<dyn Future<Output = IndexedFetchResult<Op, D, E>> + Send>>,
+        future: Pin<Box<dyn Future<Output = IndexedFetchResult<F, Op, D, E>> + Send>>,
     ) {
         if let Some(old_id) = self.by_location.insert(start_loc, id) {
             self.tracked.remove(&old_id);
@@ -85,7 +90,7 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
 
     /// Remove all requests at locations before `loc`. Dropped cancel senders
     /// signal resolvers to abort.
-    pub fn remove_before(&mut self, loc: Location) {
+    pub fn remove_before(&mut self, loc: Location<F>) {
         let keep = self.by_location.split_off(&loc);
         for id in self.by_location.values() {
             self.tracked.remove(id);
@@ -94,12 +99,12 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
     }
 
     /// Iterate over outstanding request locations in ascending order.
-    pub fn locations(&self) -> impl Iterator<Item = &Location> {
+    pub fn locations(&self) -> impl Iterator<Item = &Location<F>> {
         self.by_location.keys()
     }
 
     /// Check if a location has an outstanding request.
-    pub fn contains(&self, loc: &Location) -> bool {
+    pub fn contains(&self, loc: &Location<F>) -> bool {
         self.by_location.contains_key(loc)
     }
 
@@ -107,7 +112,7 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
     #[allow(clippy::type_complexity)]
     pub fn futures_mut(
         &mut self,
-    ) -> &mut FuturesUnordered<Pin<Box<dyn Future<Output = IndexedFetchResult<Op, D, E>> + Send>>>
+    ) -> &mut FuturesUnordered<Pin<Box<dyn Future<Output = IndexedFetchResult<F, Op, D, E>> + Send>>>
     {
         &mut self.futures
     }
@@ -118,7 +123,7 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
     }
 }
 
-impl<Op, D: Digest, E> Default for Requests<Op, D, E> {
+impl<F: Family, Op, D: Digest, E> Default for Requests<F, Op, D, E> {
     fn default() -> Self {
         Self::new()
     }

--- a/storage/src/qmdb/sync/resolver.rs
+++ b/storage/src/qmdb/sync/resolver.rs
@@ -1,5 +1,5 @@
 use crate::{
-    merkle::mmr::{self, Location, Proof},
+    merkle::{mmr, Family, Location, Proof},
     qmdb::{
         self,
         any::{
@@ -13,6 +13,7 @@ use crate::{
             },
             FixedValue, VariableValue,
         },
+        current::sync::CurrentOverlayState,
         immutable::{
             fixed::{Db as ImmutableFixedDb, Operation as ImmutableFixedOp},
             variable::{Db as ImmutableVariableDb, Operation as ImmutableVariableOp},
@@ -30,31 +31,50 @@ use commonware_cryptography::{Digest, Hasher};
 use commonware_utils::{channel::oneshot, sync::AsyncRwLock, Array};
 use std::{future::Future, num::NonZeroU64, sync::Arc};
 
-/// Result from a fetch operation
-pub struct FetchResult<Op, D: Digest> {
+/// Result from a fetch operation.
+///
+/// Parameterized over the merkle family `F` so the embedded `Proof<F, D>` matches
+/// the [Database](super::Database) being synced.
+pub struct FetchResult<F: Family, Op, D: Digest> {
     /// The proof for the operations
-    pub proof: Proof<D>,
+    pub proof: Proof<F, D>,
     /// The operations that were fetched
     pub operations: Vec<Op>,
     /// Channel to report success/failure back to resolver
     pub success_tx: oneshot::Sender<bool>,
     /// Pinned MMR nodes at the start location, if requested
     pub pinned_nodes: Option<Vec<D>>,
+    /// Sender's current overlay state, populated only on the first (boundary) batch by
+    /// [crate::qmdb::current::sync] resolvers; `None` otherwise. The engine extracts overlay
+    /// state only when the same conditions that gate `pinned_nodes` hold (first batch at the
+    /// sync range's lower bound).
+    ///
+    /// Overlay state is not authenticated by the ops-root proof chain and must be validated
+    /// indirectly by the receiver by comparing the rebuilt database's canonical root against
+    /// a trusted canonical root supplied in the sync target.
+    pub overlay_state: Option<CurrentOverlayState<D>>,
 }
 
-impl<Op: std::fmt::Debug, D: Digest> std::fmt::Debug for FetchResult<Op, D> {
+impl<F: Family, Op: std::fmt::Debug, D: Digest> std::fmt::Debug for FetchResult<F, Op, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FetchResult")
             .field("proof", &self.proof)
             .field("operations", &self.operations)
             .field("success_tx", &"<callback>")
             .field("pinned_nodes", &self.pinned_nodes)
+            .field("overlay_state", &self.overlay_state)
             .finish()
     }
 }
 
-/// Trait for network communication with the sync server
+/// Trait for network communication with the sync server.
+///
+/// The associated `Family` is the merkle family whose proofs this resolver serves.
+/// It must match the [Database](super::Database) being synced.
 pub trait Resolver: Send + Sync + Clone + 'static {
+    /// The merkle family backing the resolver's proofs.
+    type Family: Family;
+
     /// The digest type used in proofs returned by the resolver
     type Digest: Digest;
 
@@ -67,7 +87,8 @@ pub trait Resolver: Send + Sync + Clone + 'static {
     /// Get the operations starting at `start_loc` in the database, up to `max_ops` operations.
     /// Returns the operations and a proof that they were present in the database when it had
     /// `op_count` operations. If `include_pinned_nodes` is true, the result will include the
-    /// pinned MMR nodes at `start_loc`.
+    /// pinned MMR nodes at `start_loc` and, for `current` resolvers, the sender's current
+    /// [`CurrentOverlayState`] in `FetchResult::overlay_state`.
     ///
     /// The corresponding `cancel_tx` is dropped when the engine no longer needs this
     /// request (e.g. due to a target update), causing `cancel_rx.await` to return
@@ -75,18 +96,19 @@ pub trait Resolver: Send + Sync + Clone + 'static {
     #[allow(clippy::type_complexity)]
     fn get_operations<'a>(
         &'a self,
-        op_count: Location,
-        start_loc: Location,
+        op_count: Location<Self::Family>,
+        start_loc: Location<Self::Family>,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
         cancel_rx: oneshot::Receiver<()>,
-    ) -> impl Future<Output = Result<FetchResult<Self::Op, Self::Digest>, Self::Error>> + Send + 'a;
+    ) -> impl Future<Output = Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error>>
+           + Send
+           + 'a;
 }
 
 macro_rules! impl_resolver {
     ($db:ident, $op:ident, $val_bound:ident) => {
-        impl<E, K, V, H, T> Resolver
-            for Arc<$db<crate::merkle::mmr::Family, E, K, V, H, T>>
+        impl<E, K, V, H, T> Resolver for Arc<$db<mmr::Family, E, K, V, H, T>>
         where
             E: Context,
             K: Array,
@@ -95,18 +117,19 @@ macro_rules! impl_resolver {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
-            type Op = $op<crate::merkle::mmr::Family, K, V>;
-            type Error = qmdb::Error<crate::merkle::mmr::Family>;
+            type Op = $op<mmr::Family, K, V>;
+            type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let (proof, operations) =
                     self.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -119,12 +142,12 @@ macro_rules! impl_resolver {
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state: None,
                 })
             }
         }
 
-        impl<E, K, V, H, T> Resolver
-            for Arc<AsyncRwLock<$db<crate::merkle::mmr::Family, E, K, V, H, T>>>
+        impl<E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<mmr::Family, E, K, V, H, T>>>
         where
             E: Context,
             K: Array,
@@ -133,18 +156,19 @@ macro_rules! impl_resolver {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
-            type Op = $op<crate::merkle::mmr::Family, K, V>;
-            type Error = qmdb::Error<crate::merkle::mmr::Family>;
+            type Op = $op<mmr::Family, K, V>;
+            type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<crate::merkle::mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let db = self.read().await;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -157,12 +181,12 @@ macro_rules! impl_resolver {
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state: None,
                 })
             }
         }
 
-        impl<E, K, V, H, T> Resolver
-            for Arc<AsyncRwLock<Option<$db<crate::merkle::mmr::Family, E, K, V, H, T>>>>
+        impl<E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<mmr::Family, E, K, V, H, T>>>>
         where
             E: Context,
             K: Array,
@@ -171,18 +195,19 @@ macro_rules! impl_resolver {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
-            type Op = $op<crate::merkle::mmr::Family, K, V>;
-            type Error = qmdb::Error<crate::merkle::mmr::Family>;
+            type Op = $op<mmr::Family, K, V>;
+            type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<crate::merkle::mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
@@ -196,6 +221,7 @@ macro_rules! impl_resolver {
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state: None,
                 })
             }
         }
@@ -227,18 +253,19 @@ macro_rules! impl_resolver_immutable {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<K, V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let (proof, operations) =
                     self.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -251,6 +278,7 @@ macro_rules! impl_resolver_immutable {
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state: None,
                 })
             }
         }
@@ -264,18 +292,19 @@ macro_rules! impl_resolver_immutable {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<K, V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let db = self.read().await;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -288,6 +317,7 @@ macro_rules! impl_resolver_immutable {
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state: None,
                 })
             }
         }
@@ -301,18 +331,19 @@ macro_rules! impl_resolver_immutable {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<K, V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
@@ -326,6 +357,7 @@ macro_rules! impl_resolver_immutable {
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state: None,
                 })
             }
         }
@@ -347,18 +379,19 @@ macro_rules! impl_resolver_keyless {
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let (proof, operations) =
                     self.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -371,6 +404,7 @@ macro_rules! impl_resolver_keyless {
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state: None,
                 })
             }
         }
@@ -381,18 +415,19 @@ macro_rules! impl_resolver_keyless {
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let db = self.read().await;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -405,6 +440,7 @@ macro_rules! impl_resolver_keyless {
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state: None,
                 })
             }
         }
@@ -415,18 +451,19 @@ macro_rules! impl_resolver_keyless {
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
@@ -440,6 +477,7 @@ macro_rules! impl_resolver_keyless {
                     operations,
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
+                    overlay_state: None,
                 })
             }
         }
@@ -459,33 +497,34 @@ pub(crate) mod tests {
 
     /// A resolver that always fails.
     #[derive(Clone)]
-    pub struct FailResolver<Op, D> {
-        _phantom: PhantomData<(Op, D)>,
+    pub struct FailResolver<F: Family, Op, D> {
+        _phantom: PhantomData<(F, Op, D)>,
     }
 
-    impl<Op, D> Resolver for FailResolver<Op, D>
+    impl<F, Op, D> Resolver for FailResolver<F, Op, D>
     where
+        F: Family,
         D: Digest,
         Op: Send + Sync + Clone + 'static,
     {
+        type Family = F;
         type Digest = D;
         type Op = Op;
-        type Error = qmdb::Error<crate::merkle::mmr::Family>;
+        type Error = qmdb::Error<F>;
 
         async fn get_operations(
             &self,
-            _op_count: Location,
-            _start_loc: Location,
+            _op_count: Location<F>,
+            _start_loc: Location<F>,
             _max_ops: NonZeroU64,
             _include_pinned_nodes: bool,
             _cancel: oneshot::Receiver<()>,
-        ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<crate::merkle::mmr::Family>>
-        {
+        ) -> Result<FetchResult<F, Op, D>, qmdb::Error<F>> {
             Err(qmdb::Error::KeyNotFound) // Arbitrary dummy error
         }
     }
 
-    impl<Op, D> FailResolver<Op, D> {
+    impl<F: Family, Op, D> FailResolver<F, Op, D> {
         pub fn new() -> Self {
             Self {
                 _phantom: PhantomData,

--- a/storage/src/qmdb/sync/resolver.rs
+++ b/storage/src/qmdb/sync/resolver.rs
@@ -34,7 +34,7 @@ use std::{future::Future, num::NonZeroU64, sync::Arc};
 /// Result from a fetch operation.
 ///
 /// Parameterized over the merkle family `F` so the embedded `Proof<F, D>` matches
-/// the [Database](super::Database) being synced.
+/// the database being synced.
 pub struct FetchResult<F: Family, Op, D: Digest> {
     /// The proof for the operations
     pub proof: Proof<F, D>,
@@ -45,9 +45,9 @@ pub struct FetchResult<F: Family, Op, D: Digest> {
     /// Pinned MMR nodes at the start location, if requested
     pub pinned_nodes: Option<Vec<D>>,
     /// Sender's current overlay state, populated only on the first (boundary) batch by
-    /// [crate::qmdb::current::sync] resolvers; `None` otherwise. The engine extracts overlay
-    /// state only when the same conditions that gate `pinned_nodes` hold (first batch at the
-    /// sync range's lower bound).
+    /// `current` resolvers; `None` otherwise. The engine extracts overlay state only when
+    /// the same conditions that gate `pinned_nodes` hold (first batch at the sync range's
+    /// lower bound).
     ///
     /// Overlay state is not authenticated by the ops-root proof chain and must be validated
     /// indirectly by the receiver by comparing the rebuilt database's canonical root against
@@ -70,7 +70,7 @@ impl<F: Family, Op: std::fmt::Debug, D: Digest> std::fmt::Debug for FetchResult<
 /// Trait for network communication with the sync server.
 ///
 /// The associated `Family` is the merkle family whose proofs this resolver serves.
-/// It must match the [Database](super::Database) being synced.
+/// It must match the database being synced.
 pub trait Resolver: Send + Sync + Clone + 'static {
     /// The merkle family backing the resolver's proofs.
     type Family: Family;
@@ -88,7 +88,7 @@ pub trait Resolver: Send + Sync + Clone + 'static {
     /// Returns the operations and a proof that they were present in the database when it had
     /// `op_count` operations. If `include_pinned_nodes` is true, the result will include the
     /// pinned MMR nodes at `start_loc` and, for `current` resolvers, the sender's current
-    /// [`CurrentOverlayState`] in `FetchResult::overlay_state`.
+    /// `CurrentOverlayState` in `FetchResult::overlay_state`.
     ///
     /// The corresponding `cancel_tx` is dropped when the engine no longer needs this
     /// request (e.g. due to a target update), causing `cancel_rx.await` to return
@@ -108,8 +108,9 @@ pub trait Resolver: Send + Sync + Clone + 'static {
 
 macro_rules! impl_resolver {
     ($db:ident, $op:ident, $val_bound:ident) => {
-        impl<E, K, V, H, T> Resolver for Arc<$db<mmr::Family, E, K, V, H, T>>
+        impl<F, E, K, V, H, T> Resolver for Arc<$db<F, E, K, V, H, T>>
         where
+            F: Family,
             E: Context,
             K: Array,
             V: $val_bound + Send + Sync + 'static,
@@ -117,10 +118,10 @@ macro_rules! impl_resolver {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
-            type Family = mmr::Family;
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<mmr::Family, K, V>;
-            type Error = qmdb::Error<mmr::Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
@@ -147,8 +148,9 @@ macro_rules! impl_resolver {
             }
         }
 
-        impl<E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<mmr::Family, E, K, V, H, T>>>
+        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T>>>
         where
+            F: Family,
             E: Context,
             K: Array,
             V: $val_bound + Send + Sync + 'static,
@@ -156,10 +158,10 @@ macro_rules! impl_resolver {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
-            type Family = mmr::Family;
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<mmr::Family, K, V>;
-            type Error = qmdb::Error<mmr::Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
@@ -186,8 +188,9 @@ macro_rules! impl_resolver {
             }
         }
 
-        impl<E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<mmr::Family, E, K, V, H, T>>>>
+        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T>>>>
         where
+            F: Family,
             E: Context,
             K: Array,
             V: $val_bound + Send + Sync + 'static,
@@ -195,10 +198,10 @@ macro_rules! impl_resolver {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
-            type Family = mmr::Family;
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<mmr::Family, K, V>;
-            type Error = qmdb::Error<mmr::Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,

--- a/storage/src/qmdb/sync/target.rs
+++ b/storage/src/qmdb/sync/target.rs
@@ -1,9 +1,5 @@
-#[cfg(feature = "arbitrary")]
-use crate::merkle::mmr::Family;
-#[cfg(feature = "arbitrary")]
-use crate::merkle::Family as _;
 use crate::{
-    merkle::mmr::Location,
+    merkle::{Family, Location},
     qmdb::sync::{self, error::EngineError},
 };
 use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
@@ -11,67 +7,112 @@ use commonware_cryptography::Digest;
 use commonware_runtime::{Buf, BufMut};
 use commonware_utils::range::NonEmptyRange;
 
-/// Target state to sync to
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Target<D: Digest> {
-    /// The root digest we're syncing to
+/// Target state to sync to.
+///
+/// `root` is the **ops root** that the sync engine verifies streaming batches against.
+///
+/// `canonical_root` is a separate, optional trust anchor used by databases whose canonical
+/// commitment is not the ops root alone (currently [crate::qmdb::current]). When set, the
+/// receiver must verify that the rebuilt database's canonical root matches this value;
+/// the ops-root proof chain does **not** authenticate grafted overlay state on its own, so
+/// a trusted `canonical_root` is load-bearing for pruned `current` sync. Databases that do
+/// not distinguish between ops and canonical roots (`any`, `immutable`, `keyless`) set this
+/// to `None` and the engine ignores it for them.
+///
+/// `PartialEq`, `Eq`, and `Clone` are implemented manually so they do not require
+/// `F: PartialEq + Clone`; the family `F` is a zero-sized marker.
+#[derive(Debug)]
+pub struct Target<F: Family, D: Digest> {
+    /// The ops root the sync engine verifies streaming batches against.
     pub root: D,
     /// Range of operations to sync
-    pub range: NonEmptyRange<Location>,
+    pub range: NonEmptyRange<Location<F>>,
+    /// Optional canonical root that authenticates database-level state (e.g. grafted
+    /// overlay) that is not covered by the ops-root proof chain. See the type-level docs.
+    pub canonical_root: Option<D>,
 }
 
-impl<D: Digest> Write for Target<D> {
+impl<F: Family, D: Digest> Clone for Target<F, D> {
+    fn clone(&self) -> Self {
+        Self {
+            root: self.root,
+            range: self.range.clone(),
+            canonical_root: self.canonical_root,
+        }
+    }
+}
+
+impl<F: Family, D: Digest> PartialEq for Target<F, D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root
+            && self.range == other.range
+            && self.canonical_root == other.canonical_root
+    }
+}
+
+impl<F: Family, D: Digest> Eq for Target<F, D> {}
+
+impl<F: Family, D: Digest> Write for Target<F, D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.root.write(buf);
         self.range.write(buf);
+        self.canonical_root.write(buf);
     }
 }
 
-impl<D: Digest> EncodeSize for Target<D> {
+impl<F: Family, D: Digest> EncodeSize for Target<F, D> {
     fn encode_size(&self) -> usize {
-        self.root.encode_size() + self.range.encode_size()
+        self.root.encode_size() + self.range.encode_size() + self.canonical_root.encode_size()
     }
 }
 
-impl<D: Digest> Read for Target<D> {
+impl<F: Family, D: Digest> Read for Target<F, D> {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let root = D::read(buf)?;
-        let range = NonEmptyRange::<Location>::read(buf)?;
+        let range = NonEmptyRange::<Location<F>>::read(buf)?;
         if !range.start().is_valid() || !range.end().is_valid() {
             return Err(CodecError::Invalid(
                 "storage::qmdb::sync::Target",
                 "range bounds out of valid range",
             ));
         }
-        Ok(Self { root, range })
+        let canonical_root = Option::<D>::read(buf)?;
+        Ok(Self {
+            root,
+            range,
+            canonical_root,
+        })
     }
 }
 
 #[cfg(feature = "arbitrary")]
-impl<D: Digest> arbitrary::Arbitrary<'_> for Target<D>
+impl<F: Family, D: Digest> arbitrary::Arbitrary<'_> for Target<F, D>
 where
     D: for<'a> arbitrary::Arbitrary<'a>,
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         let root = u.arbitrary()?;
-        let max_loc = Family::MAX_LEAVES;
+        let canonical_root = u.arbitrary()?;
+        let max_loc = F::MAX_LEAVES;
         let lower = u.int_in_range(0..=*max_loc - 1)?;
         let upper = u.int_in_range(lower + 1..=*max_loc)?;
         Ok(Self {
             root,
             range: commonware_utils::non_empty_range!(Location::new(lower), Location::new(upper)),
+            canonical_root,
         })
     }
 }
 
 /// Validate a target update against the current target
-pub fn validate_update<U, D>(
-    old_target: &Target<D>,
-    new_target: &Target<D>,
-) -> Result<(), sync::Error<U, D>>
+pub fn validate_update<F, U, D>(
+    old_target: &Target<F, D>,
+    new_target: &Target<F, D>,
+) -> Result<(), sync::Error<F, U, D>>
 where
+    F: Family,
     U: std::error::Error + Send + 'static,
     D: Digest,
 {
@@ -105,15 +146,17 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::merkle::mmr::Family as MmrFamily;
     use commonware_cryptography::sha256;
     use commonware_utils::non_empty_range;
     use rstest::rstest;
     use std::io::Cursor;
 
-    fn target(root: sha256::Digest, start: u64, end: u64) -> Target<sha256::Digest> {
+    fn target(root: sha256::Digest, start: u64, end: u64) -> Target<MmrFamily, sha256::Digest> {
         Target {
             root,
             range: non_empty_range!(Location::new(start), Location::new(end)),
+            canonical_root: None,
         }
     }
 
@@ -143,12 +186,12 @@ mod tests {
         // Manually encode root + two Locations to bypass the Range write panic
         let mut buffer = Vec::new();
         sha256::Digest::from([42; 32]).write(&mut buffer);
-        Location::new(100).write(&mut buffer); // start
-        Location::new(50).write(&mut buffer); // end (< start = invalid)
+        Location::<MmrFamily>::new(100).write(&mut buffer); // start
+        Location::<MmrFamily>::new(50).write(&mut buffer); // end (< start = invalid)
 
         let mut cursor = Cursor::new(buffer);
         assert!(matches!(
-            Target::<sha256::Digest>::read(&mut cursor),
+            Target::<MmrFamily, sha256::Digest>::read(&mut cursor),
             Err(CodecError::Invalid("Range", "start must be <= end"))
         ));
 
@@ -156,16 +199,16 @@ mod tests {
         let root = sha256::Digest::from([42; 32]);
         let mut buffer = Vec::new();
         root.write(&mut buffer);
-        (Location::new(100)..Location::new(100)).write(&mut buffer);
+        (Location::<MmrFamily>::new(100)..Location::<MmrFamily>::new(100)).write(&mut buffer);
 
         let mut cursor = Cursor::new(buffer);
         assert!(matches!(
-            Target::<sha256::Digest>::read(&mut cursor),
+            Target::<MmrFamily, sha256::Digest>::read(&mut cursor),
             Err(CodecError::Invalid("NonEmptyRange", "start must be < end"))
         ));
     }
 
-    type TestError = sync::Error<std::io::Error, sha256::Digest>;
+    type TestError = sync::Error<MmrFamily, std::io::Error, sha256::Digest>;
 
     #[rstest]
     #[case::valid_update(
@@ -200,8 +243,8 @@ mod tests {
         Err(TestError::Engine(EngineError::SyncTargetRootUnchanged))
     )]
     fn test_validate_update(
-        #[case] old_target: Target<sha256::Digest>,
-        #[case] new_target: Target<sha256::Digest>,
+        #[case] old_target: Target<MmrFamily, sha256::Digest>,
+        #[case] new_target: Target<MmrFamily, sha256::Digest>,
         #[case] expected: Result<(), TestError>,
     ) {
         let result = validate_update(&old_target, &new_target);
@@ -246,7 +289,7 @@ mod tests {
         use commonware_codec::conformance::CodecConformance;
 
         commonware_conformance::conformance_tests! {
-            CodecConformance<Target<sha256::Digest>>,
+            CodecConformance<Target<MmrFamily, sha256::Digest>>,
         }
     }
 }

--- a/storage/src/qmdb/verify.rs
+++ b/storage/src/qmdb/verify.rs
@@ -25,9 +25,10 @@ where
 /// Verify that both a [Proof] and a set of pinned nodes are valid with respect to a target root.
 ///
 /// The `pinned_nodes` are the pruning-boundary peaks at `start_loc` (as returned by
-/// `nodes_to_pin`). These may be finer-grained than the prefix subtrees authenticated directly by
-/// the proof; the verifier reconstructs those prefix subtrees from the pins as needed. When
-/// `start_loc` is 0, `pinned_nodes` must be empty.
+/// `nodes_to_pin`). When the larger tree has merged smaller subtrees into a bigger parent, the
+/// pins sit below the prefix subtrees authenticated by the proof; the verifier hashes pairs of
+/// pins up to each authenticated subtree's root and compares. When `start_loc` is 0,
+/// `pinned_nodes` must be empty.
 pub fn verify_proof_and_pinned_nodes<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,

--- a/storage/src/qmdb/verify.rs
+++ b/storage/src/qmdb/verify.rs
@@ -24,8 +24,10 @@ where
 
 /// Verify that both a [Proof] and a set of pinned nodes are valid with respect to a target root.
 ///
-/// The `pinned_nodes` are the individual peak digests before the proven range (as returned by
-/// `nodes_to_pin`). When `start_loc` is 0, `pinned_nodes` must be empty.
+/// The `pinned_nodes` are the pruning-boundary peaks at `start_loc` (as returned by
+/// `nodes_to_pin`). These may be finer-grained than the prefix subtrees authenticated directly by
+/// the proof; the verifier reconstructs those prefix subtrees from the pins as needed. When
+/// `start_loc` is 0, `pinned_nodes` must be empty.
 pub fn verify_proof_and_pinned_nodes<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,


### PR DESCRIPTION
## Summary

Generalize QMDB sync to work across both Merkle families (MMR and MMB), and fix pruned `current` sync for MMB by syncing the sender's grafted overlay state explicitly and authenticating it with the canonical root.

Before this change, the shared sync path was effectively MMR-only across all variants. In particular, `current` sync reconstructed its grafted pruning boundary by deriving grafted pinned nodes from the synced ops tree at `range.start`. That works for MMR, but not for MMB: delayed merges can cause the ops tree's boundary pins to diverge from the grafted tree's true pruning boundary, which can produce a different grafted tree and therefore a different canonical root on the receiver.

This change does two things:

- generalizes the shared sync infrastructure so databases can sync over either MMR or MMB
- makes pruned `current` sync reproduce the sender's actual overlay state instead of trying to infer it from the ops range

## Main changes

### 1. Generalized shared sync over the database's Merkle family

The sync layer is now parameterized over `Database::Family` rather than implicitly assuming MMR everywhere.

That affects the shared types and plumbing used by all database variants, including:

- `FetchResult`
- `Resolver`
- the sync engine request/result flow
- `Database::from_sync_result`
- `Target`

This means:

- `any` sync now works generically for both MMR and MMB
- `current` sync can share the same family-generic engine/plumbing instead of relying on MMR-specific assumptions
- `immutable` and `keyless` continue to use the same shared sync infrastructure, but now through the same family-generic path

### 2. Added explicit overlay sync state for `current`

Introduced `CurrentOverlayState` in `storage/src/qmdb/current/sync/mod.rs`:

- `pruned_chunks`
- `grafted_pinned_nodes`

This is carried on the first boundary batch via `FetchResult::overlay_state`.

### 3. Rebuild `current` from sender overlay state

`current::sync::build_db` no longer derives grafted pinned nodes from `range.start`.

Instead, for normal pruned sync it:

- validates the sender-supplied overlay payload
- seeds the grafted tree from `grafted_pinned_nodes`
- initializes the bitmap from the sender's `pruned_chunks`
- replays the synced ops log to populate the bitmap tail
- computes the canonical root from the rebuilt state

This is the key MMB fix: the receiver now rebuilds from the sender's actual grafted pruning state rather than from a lossy ops-boundary approximation.

### 4. Added canonical-root authentication for `current`

The sync engine already authenticates streamed batches against the **ops root**. That proves the journal contents, but it does not authenticate grafted overlay state.

To close that gap, `Target` now carries an optional `canonical_root`. When supplied for `current` sync, `build_db` verifies:

- rebuilt canonical root == trusted canonical root

before calling `sync_metadata()`.

This prevents a malicious or buggy sender from causing the receiver to persist a diverged grafted overlay.

### 5. Require fresh boundary state before authenticated completion

For authenticated `current` sync, the engine now defers completion until a fresh boundary batch has been fetched and verified through the normal request path.

This avoids the stale-metadata retry trap where:

- a prior sync finished downloading the journal
- canonical-root verification failed before metadata persistence
- a later retry could otherwise have reused stale persisted overlay metadata

## Why this is needed

The old shared sync flow assumed that ops-boundary information was enough to reconstruct database state.

That is true for MMR-backed variants, and it is fine for `any`, where the authenticated state is just the ops structure itself.

It is not true for pruned `current` on MMB, because the canonical root depends on:

- the ops root
- the grafted tree root
- any partial chunk state

and delayed merges mean the grafted pruning boundary cannot always be recovered from `range.start` alone.

The fix is therefore:

- make the shared sync plumbing family-generic
- ship `current` overlay state explicitly
- rebuild from that overlay state
- authenticate the rebuilt canonical root when the caller provides a trusted canonical root

## Tests

Added/updated focused coverage for:

- family-generic sync plumbing
- successful pruned MMB `current` sync with canonical-root authentication
- canonical-root mismatch rejection
- authenticated unpruned `current` sync
- the previous MMB target-update regression shape, which now passes as a regression guard

## Result

This change makes sync:

- family-generic across MMR and MMB
- correct for pruned `current` on MMB delayed-merge families
- faithful to the sender's actual pruning state
- robust against stale-overlay reuse on retries
- authenticated at the canonical-root level for `current`, rather than only at the ops-root level
