### PR TITLE
[storage/qmdb/current] add ability to authenticate ops root from qmdb canonical root

### DIFF
--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -21,7 +21,7 @@ use crate::{
         current::{
             batch::BitmapBatch,
             grafting,
-            proof::{OperationProof, RangeProof},
+            proof::{OperationProof, OpsRootWitness, RangeProof},
         },
         operation::Operation as _,
         Error,
@@ -174,6 +174,24 @@ where
     /// See the [Root structure](super) section in the module documentation.
     pub fn ops_root(&self) -> H::Digest {
         self.any.log.root()
+    }
+
+    /// Returns a witness that this database's canonical root commits to its ops root.
+    ///
+    /// This can be used to authenticate an ops root against a trusted canonical `current` root.
+    pub async fn ops_root_witness(
+        &self,
+        hasher: &mut StandardHasher<H>,
+    ) -> Result<OpsRootWitness<H::Digest>, Error<F>> {
+        let storage = self.grafted_storage();
+        let grafted_root =
+            compute_grafted_root::<F, H, _, _, N>(hasher, &self.status, &storage).await?;
+        let partial_chunk = partial_chunk::<_, N>(&self.status)
+            .map(|(chunk, next_bit)| (next_bit, hasher.digest(&chunk)));
+        Ok(OpsRootWitness {
+            grafted_root,
+            partial_chunk,
+        })
     }
 
     /// Snapshot of the grafted tree for use in batch chains.
@@ -1032,8 +1050,18 @@ pub(super) async fn init_metadata<F: merkle::Graftable, E: Context, D: Digest>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        merkle::{mmb, mmr},
+        qmdb::{
+            any::traits::{DbAny, UnmerkleizedBatch as _},
+            current::{tests::fixed_config, unordered::fixed},
+        },
+        translator::OneCap,
+    };
     use commonware_codec::FixedSize;
     use commonware_cryptography::{sha256, Sha256};
+    use commonware_macros::test_traced;
+    use commonware_runtime::{deterministic, Runner as _};
     use commonware_utils::bitmap::Prunable as PrunableBitMap;
 
     const N: usize = sha256::Digest::SIZE;
@@ -1106,5 +1134,175 @@ mod tests {
         let r1 = combine_roots(&h1, &ops_a, &grafted, None);
         let r2 = combine_roots(&h2, &ops_b, &grafted, None);
         assert_ne!(r1, r2);
+    }
+
+    type MmrDb = fixed::Db<
+        mmr::Family,
+        deterministic::Context,
+        sha256::Digest,
+        sha256::Digest,
+        Sha256,
+        OneCap,
+        32,
+    >;
+    type MmbDb = fixed::Db<
+        mmb::Family,
+        deterministic::Context,
+        sha256::Digest,
+        sha256::Digest,
+        Sha256,
+        OneCap,
+        32,
+    >;
+
+    async fn populate_fixed_db<F, DB>(db: &mut DB, start: u64, count: u64)
+    where
+        F: merkle::Graftable,
+        DB: DbAny<F, Key = sha256::Digest, Value = sha256::Digest>,
+    {
+        let mut batch = db.new_batch();
+        for idx in start..start + count {
+            let key = Sha256::hash(&idx.to_be_bytes());
+            let value = Sha256::hash(&(idx + count).to_be_bytes());
+            batch = batch.write(key, Some(value));
+        }
+        let merkleized = batch.merkleize(db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+    }
+
+    #[test_traced]
+    fn test_ops_root_witness_verifies_without_partial_chunk() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            let mut db = MmrDb::init(
+                ctx.clone(),
+                fixed_config::<OneCap>("ops-root-witness-full", &ctx),
+            )
+            .await
+            .unwrap();
+            let mut next_idx = 0;
+            populate_fixed_db::<mmr::Family, _>(&mut db, next_idx, 256).await;
+            next_idx += 256;
+            while partial_chunk::<_, 32>(&db.status).is_some() {
+                populate_fixed_db::<mmr::Family, _>(&mut db, next_idx, 1).await;
+                next_idx += 1;
+            }
+
+            let mut hasher = StandardHasher::<Sha256>::new();
+            let witness = db.ops_root_witness(&mut hasher).await.unwrap();
+            let ops_root = db.ops_root();
+            let canonical_root = db.root();
+
+            assert!(witness.partial_chunk.is_none());
+            assert!(witness.verify(&mut hasher, &ops_root, &canonical_root));
+
+            let wrong_ops_root = Sha256::hash(b"wrong ops root");
+            assert!(!witness.verify(&mut hasher, &wrong_ops_root, &canonical_root));
+
+            let wrong_canonical_root = Sha256::hash(b"wrong canonical root");
+            assert!(!witness.verify(&mut hasher, &ops_root, &wrong_canonical_root));
+
+            let mut tampered = witness;
+            tampered.grafted_root = Sha256::hash(b"wrong grafted root");
+            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+        });
+    }
+
+    #[test_traced]
+    fn test_ops_root_witness_verifies_with_partial_chunk() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            let mut db = MmbDb::init(
+                ctx.clone(),
+                fixed_config::<OneCap>("ops-root-witness-partial", &ctx),
+            )
+            .await
+            .unwrap();
+            populate_fixed_db::<mmb::Family, _>(&mut db, 0, 260).await;
+
+            let mut hasher = StandardHasher::<Sha256>::new();
+            let witness = db.ops_root_witness(&mut hasher).await.unwrap();
+            let ops_root = db.ops_root();
+            let canonical_root = db.root();
+
+            assert!(witness.partial_chunk.is_some());
+            assert!(witness.verify(&mut hasher, &ops_root, &canonical_root));
+
+            let wrong_ops_root = Sha256::hash(b"wrong ops root");
+            assert!(!witness.verify(&mut hasher, &wrong_ops_root, &canonical_root));
+
+            let wrong_canonical_root = Sha256::hash(b"wrong canonical root");
+            assert!(!witness.verify(&mut hasher, &ops_root, &wrong_canonical_root));
+
+            let mut tampered = witness.clone();
+            tampered.grafted_root = Sha256::hash(b"wrong grafted root");
+            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+
+            let mut tampered = witness.clone();
+            tampered.partial_chunk.as_mut().unwrap().0 += 1;
+            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+
+            let mut tampered = witness;
+            tampered.partial_chunk.as_mut().unwrap().1 = Sha256::hash(b"wrong partial chunk");
+            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+        });
+    }
+
+    #[test_traced]
+    fn test_ops_root_witness_verifies_with_pruned_db() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            let mut db = MmrDb::init(
+                ctx.clone(),
+                fixed_config::<OneCap>("ops-root-witness-pruned", &ctx),
+            )
+            .await
+            .unwrap();
+
+            // Churn the same keys repeatedly to drive the inactivity floor past chunk boundaries.
+            for _ in 0..5 {
+                populate_fixed_db::<mmr::Family, _>(&mut db, 0, 512).await;
+            }
+            db.prune(db.inactivity_floor_loc()).await.unwrap();
+            assert!(
+                db.status.pruned_chunks() > 0,
+                "test requires at least one pruned chunk to exercise the zero-chunk path"
+            );
+
+            let mut hasher = StandardHasher::<Sha256>::new();
+            let witness = db.ops_root_witness(&mut hasher).await.unwrap();
+            let ops_root = db.ops_root();
+            let canonical_root = db.root();
+
+            assert!(witness.verify(&mut hasher, &ops_root, &canonical_root));
+
+            let wrong_canonical_root = Sha256::hash(b"wrong canonical root");
+            assert!(!witness.verify(&mut hasher, &ops_root, &wrong_canonical_root));
+
+            let mut tampered = witness;
+            tampered.grafted_root = Sha256::hash(b"wrong grafted root");
+            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+        });
+    }
+
+    #[test_traced]
+    fn test_ops_root_witness_verifies_on_fresh_db() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            let db = MmrDb::init(
+                ctx.clone(),
+                fixed_config::<OneCap>("ops-root-witness-fresh", &ctx),
+            )
+            .await
+            .unwrap();
+
+            let mut hasher = StandardHasher::<Sha256>::new();
+            let witness = db.ops_root_witness(&mut hasher).await.unwrap();
+            let ops_root = db.ops_root();
+            let canonical_root = db.root();
+
+            assert!(witness.verify(&mut hasher, &ops_root, &canonical_root));
+        });
     }
 }

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -209,8 +209,9 @@
 //!
 //! For state sync, the sync engine targets the ops root and verifies each batch against it.
 //! After sync, the bitmap and grafted tree are reconstructed deterministically from the
-//! operations, and the canonical root is computed. Validating that the ops root is part of the
-//! canonical root is the caller's responsibility; the sync engine does not perform this check.
+//! operations, and the canonical root is computed. [proof::OpsRootWitness] can be used to validate
+//! that a particular ops root is committed by a trusted canonical root; the sync engine does not
+//! perform this check itself.
 
 use crate::{
     index::Factory as IndexFactory,

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -1,23 +1,97 @@
 //! Proof types for [crate::qmdb::current] authenticated databases.
 //!
 //! This module provides:
+//! - [OpsRootWitness]: Authenticates an ops root against a canonical `current` root.
 //! - [RangeProof]: Proves a range of operations exist in the database.
 //! - [OperationProof]: Proves a specific operation is active in the database.
 
 use crate::{
     journal::contiguous::{Contiguous, Reader as _},
     merkle::{
-        self, hasher::Hasher, storage::Storage, Family, Graftable, Location, Position, Proof,
+        self,
+        hasher::{Hasher, Standard as StandardHasher},
+        storage::Storage,
+        Family, Graftable, Location, Position, Proof,
     },
-    qmdb::{current::grafting, Error},
+    qmdb::{
+        current::{db::combine_roots, grafting},
+        Error,
+    },
 };
-use commonware_codec::Codec;
+use bytes::{Buf, BufMut};
+use commonware_codec::{varint::UInt, Codec, EncodeSize, Read, ReadExt as _, Write};
 use commonware_cryptography::{Digest, Hasher as CHasher};
 use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
 use core::ops::Range;
 use futures::future::try_join_all;
 use std::{collections::BTreeMap, num::NonZeroU64};
 use tracing::debug;
+
+/// Witness that a particular `ops_root` is committed by a `current` canonical root.
+///
+/// `canonical_root = hash(ops_root || grafted_root [|| next_bit || partial_chunk_digest])`
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct OpsRootWitness<D: Digest> {
+    /// The grafted-tree root committed by the canonical root.
+    pub grafted_root: D,
+
+    /// The trailing partial chunk contribution, if the bitmap length is not chunk-aligned:
+    /// `(next_bit, partial_chunk_digest)`.
+    pub partial_chunk: Option<(u64, D)>,
+}
+
+impl<D: Digest> OpsRootWitness<D> {
+    /// Return true if this witness proves that `canonical_root` commits to `ops_root`.
+    pub fn verify<H: CHasher<Digest = D>>(
+        &self,
+        hasher: &mut StandardHasher<H>,
+        ops_root: &D,
+        canonical_root: &D,
+    ) -> bool {
+        let partial = self.partial_chunk.as_ref().map(|(nb, d)| (*nb, d));
+        combine_roots(hasher, ops_root, &self.grafted_root, partial) == *canonical_root
+    }
+}
+
+impl<D: Digest> Write for OpsRootWitness<D> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.grafted_root.write(buf);
+        self.partial_chunk.is_some().write(buf);
+        if let Some((next_bit, digest)) = &self.partial_chunk {
+            UInt(*next_bit).write(buf);
+            digest.write(buf);
+        }
+    }
+}
+
+impl<D: Digest> EncodeSize for OpsRootWitness<D> {
+    fn encode_size(&self) -> usize {
+        self.grafted_root.encode_size()
+            + self
+                .partial_chunk
+                .as_ref()
+                .map_or(1, |(nb, d)| 1 + UInt(*nb).encode_size() + d.encode_size())
+    }
+}
+
+impl<D: Digest> Read for OpsRootWitness<D> {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _: &Self::Cfg) -> Result<Self, commonware_codec::Error> {
+        let grafted_root = D::read(buf)?;
+        let partial_chunk = if bool::read(buf)? {
+            let next_bit = UInt::<u64>::read(buf)?.into();
+            let digest = D::read(buf)?;
+            Some((next_bit, digest))
+        } else {
+            None
+        };
+        Ok(Self {
+            grafted_root,
+            partial_chunk,
+        })
+    }
+}
 
 /// An inventory of all structural peaks for a Merkle-family tree, mapped linearly top-to-bottom
 /// relative to the bounds of a verified range proof.
@@ -611,10 +685,29 @@ mod tests {
         mmr::StandardHasher,
         qmdb::current::{db, grafting},
     };
+    use commonware_codec::{DecodeExt as _, Encode as _};
     use commonware_cryptography::{sha256, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Runner};
     use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
+
+    #[test]
+    fn test_ops_root_witness_codec_roundtrip() {
+        for partial_chunk in [
+            None,
+            Some((0u64, Sha256::hash(b"partial-zero"))),
+            Some((123u64, Sha256::hash(b"partial-nonzero"))),
+        ] {
+            let witness = OpsRootWitness {
+                grafted_root: Sha256::hash(b"grafted"),
+                partial_chunk,
+            };
+            let encoded = witness.encode();
+            assert_eq!(encoded.len(), witness.encode_size());
+            let decoded = OpsRootWitness::<sha256::Digest>::decode(encoded).unwrap();
+            assert_eq!(decoded, witness);
+        }
+    }
 
     #[test_traced]
     fn test_range_proof_verifies_for_mmb_multi_peak_chunk() {

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -7,8 +7,9 @@
 //! optional partial chunk into a single hash (see the [Root structure](super) section in the
 //! module documentation). The sync engine operates on the **ops root**, not the canonical root:
 //! it downloads operations and verifies each batch against the ops root using standard MMR
-//! range proofs (identical to `any` sync). Validating that the ops root is part of the
-//! canonical root is the caller's responsibility; the sync engine does not perform this check.
+//! range proofs (identical to `any` sync). [crate::qmdb::current::proof::OpsRootWitness] can be
+//! used by callers that need to authenticate the synced ops root against a trusted canonical root;
+//! the sync engine does not perform this check itself.
 //!
 //! After all operations are synced, the bitmap and grafted MMR are reconstructed
 //! deterministically from the operations. The canonical root is then computed from the


### PR DESCRIPTION
In order to avoid having to store both ops_root and canonical tree root in a block, we need to be able to authenticate the ops root.   This PR adds that capability.