### PR TITLE
[storage/merkle] fix verify_proof_and_pinned_nodes

### DIFF
--- a/storage/src/merkle/mmb/proof.rs
+++ b/storage/src/merkle/mmb/proof.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        merkle::{hasher::Standard, mmb::mem::Mmb, proof::Blueprint},
+        merkle::{hasher::Standard, mmb::mem::Mmb, proof::Blueprint, Family},
         mmb::Location,
     };
     use commonware_cryptography::Sha256;
@@ -26,6 +26,32 @@ mod tests {
         };
         mmb.apply_batch(&batch).unwrap();
         (hasher, mmb)
+    }
+
+    /// Regression for the earliest MMB case where a larger tree merges the entire
+    /// `[0, start)` prefix into a new fold-prefix peak that must be reconstructed
+    /// from finer-grained pinned peaks.
+    #[test]
+    fn test_verify_proof_and_pinned_nodes_recursive_fold_prefix_regression() {
+        let (hasher, mmb) = make_mmb(5);
+        let root = *mmb.root();
+        let start = 4;
+
+        let pinned: Vec<D> = crate::merkle::mmb::Family::nodes_to_pin(Location::new(start))
+            .map(|pos| mmb.get_node(pos).unwrap())
+            .collect();
+
+        let proof = mmb
+            .range_proof(&hasher, Location::new(start)..Location::new(start + 1))
+            .unwrap();
+
+        assert!(proof.verify_proof_and_pinned_nodes(
+            &hasher,
+            &[start.to_be_bytes()],
+            Location::new(start),
+            &pinned,
+            &root,
+        ));
     }
 
     #[test]

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -172,7 +172,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
             let Ok(bp) = Blueprint::new(self.leaves, *loc..*loc + 1) else {
                 return false;
             };
-            node_positions.extend(&bp.fold_prefix);
+            node_positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
             node_positions.extend(&bp.fetch_nodes);
             blueprints.insert(*loc, bp);
         }
@@ -196,12 +196,14 @@ impl<F: Family, D: Digest> Proof<F, D> {
             let mut digests = Vec::with_capacity(
                 if bp.fold_prefix.is_empty() { 0 } else { 1 } + bp.fetch_nodes.len(),
             );
-            if let Some((&first_pos, rest)) = bp.fold_prefix.split_first() {
+            if let Some((first_sub, rest)) = bp.fold_prefix.split_first() {
                 let first = *node_digests
-                    .get(&first_pos)
+                    .get(&first_sub.pos)
                     .expect("must exist by construction");
-                let acc = rest.iter().fold(first, |acc, &pos| {
-                    let d = node_digests.get(&pos).expect("must exist by construction");
+                let acc = rest.iter().fold(first, |acc, sub| {
+                    let d = node_digests
+                        .get(&sub.pos)
+                        .expect("must exist by construction");
                     hasher.fold(&acc, d)
                 });
                 digests.push(acc);
@@ -274,17 +276,32 @@ impl<F: Family, D: Digest> Proof<F, D> {
     /// Verify that both the proof and the pinned nodes are valid with respect to `root`.
     ///
     /// The `pinned_nodes` are the peak digests of the sub-structure at `start_loc`, in the order
-    /// returned by `Family::nodes_to_pin`.
-    ///
-    /// These pins may be finer-grained than the prefix structure authenticated by the proof itself.
-    /// In particular, when the larger `self.leaves`-sized tree has merged smaller peaks into larger
-    /// subtrees, the proof authenticates:
+    /// returned by `Family::nodes_to_pin`. The proof authenticates the prefix `[0, start_loc)` via:
     ///
     /// - fold-prefix peaks of the larger tree, and
-    /// - any sibling subtrees inside the first range peak that lie wholly before `start_loc`
+    /// - sibling subtrees inside the first range peak that lie wholly before `start_loc`.
     ///
-    /// This verifier reconstructs those authenticated prefix subtrees from the finer-grained pins
-    /// and compares the resulting digests against the proof.
+    /// When the larger tree has merged smaller subtrees into a bigger parent, the pins sit below
+    /// these authenticated subtrees. The verifier hashes pairs of pins up to each authenticated
+    /// subtree's root and compares against the proof.
+    ///
+    /// For example, in MMB at `leaves=5, start_loc=4`, the proof describes `[0, 4)` as one
+    /// height-2 subtree `p7`, while the pins cover the same leaves as two height-1 subtrees
+    /// `p2`, `p5`:
+    ///
+    /// ```text
+    ///     proof authenticates:         pins contain:
+    ///
+    ///             p7
+    ///           /    \
+    ///          p2    p5                p2         p5
+    ///         / \    / \              / \        / \
+    ///        L0 L1  L2 L3            L0 L1      L2 L3
+    /// ```
+    ///
+    /// The verifier walks down from `p7` via `F::children`, pulls the pins for `p2` and `p5`, and
+    /// hashes them back up (`node_digest(p7, pin[p2], pin[p5])`) to compare against the `p7`
+    /// digest the proof authenticates.
     ///
     /// Returns `true` only if the proof reconstructs to `root` and every pinned node digest is
     /// accounted for. When `start_loc` is 0, `pinned_nodes` must be empty.
@@ -300,118 +317,81 @@ impl<F: Family, D: Digest> Proof<F, D> {
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        let collected = match self
+        self.try_verify_proof_and_pinned_nodes(hasher, elements, start_loc, pinned_nodes, root)
+            .is_some()
+    }
+
+    /// Fallible implementation of [`verify_proof_and_pinned_nodes`](Self::verify_proof_and_pinned_nodes).
+    ///
+    /// Returns `Some(())` if the proof and pins are consistent with `root`, `None` otherwise. The
+    /// `Option` return lets the body use `?` on each fallible step; the public wrapper converts to
+    /// `bool` via `.is_some()`.
+    fn try_verify_proof_and_pinned_nodes<H, E>(
+        &self,
+        hasher: &H,
+        elements: &[E],
+        start_loc: Location<F>,
+        pinned_nodes: &[D],
+        root: &D,
+    ) -> Option<()>
+    where
+        H: Hasher<F, Digest = D>,
+        E: AsRef<[u8]>,
+    {
+        let collected = self
             .verify_range_inclusion_and_extract_digests(hasher, elements, start_loc, root)
-        {
-            Ok(c) => c,
-            Err(_) => return false,
-        };
+            .ok()?;
 
         if elements.is_empty() {
-            return pinned_nodes.is_empty();
+            return pinned_nodes.is_empty().then_some(());
         }
 
         if !start_loc.is_valid() || start_loc > self.leaves {
-            return false;
+            return None;
         }
 
-        let pinned_positions: alloc::vec::Vec<_> = F::nodes_to_pin(start_loc).collect();
+        let pinned_positions: Vec<_> = F::nodes_to_pin(start_loc).collect();
         if pinned_positions.len() != pinned_nodes.len() {
-            return false;
+            return None;
         }
 
-        let Some(end_loc) = start_loc.checked_add(elements.len() as u64) else {
-            return false;
-        };
-        let Ok(bp) = Blueprint::new(self.leaves, start_loc..end_loc) else {
-            return false;
-        };
-        let fold_prefix = bp.fold_prefix;
+        let end_loc = start_loc.checked_add(elements.len() as u64)?;
+        let bp = Blueprint::new(self.leaves, start_loc..end_loc).ok()?;
 
-        let mut pinned_map: alloc::collections::BTreeMap<Position<F>, D> = pinned_positions
+        let mut pinned_map: BTreeMap<Position<F>, D> = pinned_positions
             .into_iter()
             .zip(pinned_nodes.iter().copied())
             .collect();
 
-        /// Reconstruct the digest at `pos` from the pinned node map.
-        ///
-        /// If `pos` is directly in the map, returns its digest. Otherwise, recurses into `F::children(pos,
-        /// height)` and hashes the results. This bridges the gap between `F::nodes_to_pin(start_loc)`
-        /// positions (peaks of the smaller tree) and the coarser prefix subtrees authenticated by the
-        /// proof, which can differ when the larger tree has merged smaller peaks.
-        fn reconstruct_from_pins<F: Family, D: Digest, H: Hasher<F, Digest = D>>(
-            hasher: &H,
-            pos: Position<F>,
-            pinned_map: &mut alloc::collections::BTreeMap<Position<F>, D>,
-        ) -> Option<D> {
-            if let Some(d) = pinned_map.remove(&pos) {
-                return Some(d);
+        // Fold-prefix peaks of the larger tree may have merged several pins together. Reconstruct
+        // each peak's digest by hashing the pins beneath it up to the peak, then compare the
+        // folded accumulator against the one the proof carries.
+        if let Some((first_sub, rest)) = bp.fold_prefix.split_first() {
+            let &expected = self.digests.first()?;
+            let mut acc = first_sub.reconstruct_from_pins(hasher, &mut pinned_map)?;
+            for sub in rest {
+                let d = sub.reconstruct_from_pins(hasher, &mut pinned_map)?;
+                acc = hasher.fold(&acc, &d);
             }
-            let height = F::pos_to_height(pos);
-            if height == 0 {
+            if acc != expected {
                 return None;
             }
-            let (left, right) = F::children(pos, height);
-            let left_d = reconstruct_from_pins(hasher, left, pinned_map)?;
-            let right_d = reconstruct_from_pins(hasher, right, pinned_map)?;
-            Some(hasher.node_digest(pos, &left_d, &right_d))
         }
 
-        // Verify fold-prefix pinned nodes by recomputing the accumulator.
-        //
-        // The fold_prefix positions are peaks of the `self.leaves`-sized tree that lie entirely
-        // before `start_loc`. The pinned_map positions are peaks of the `start_loc`-sized tree.
-        // These can differ when the larger tree has merged smaller peaks into bigger ones. To
-        // handle this, we reconstruct each fold_prefix peak's digest from the finer-grained pinned
-        // peaks by walking the tree via `F::children`, while tracking exactly which pinned
-        // positions were consumed by that reconstruction.
-        if let Some((&first_pos, rest)) = fold_prefix.split_first() {
-            if self.digests.is_empty() {
-                return false;
-            }
-            let Some(first) = reconstruct_from_pins(hasher, first_pos, &mut pinned_map) else {
-                return false;
-            };
-            let mut acc = first;
-            for &pos in rest {
-                let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
-                    return false;
-                };
-                acc = hasher.fold(&acc, &digest);
-            }
-            if acc != self.digests[0] {
-                return false;
+        // Sibling subtrees inside the first range peak that lie wholly before `start_loc` are
+        // authenticated directly by the proof (their digests appear in `extracted`). Rebuild each
+        // from the pins and compare.
+        let extracted: BTreeMap<Position<F>, D> = collected.into_iter().collect();
+        for sibling in bp.prefix_siblings() {
+            let &expected = extracted.get(&sibling.pos)?;
+            let d = sibling.reconstruct_from_pins(hasher, &mut pinned_map)?;
+            if d != expected {
+                return None;
             }
         }
 
-        // Verify any sibling subtrees that lie wholly before `start_loc`. These are the coarser
-        // prefix targets authenticated directly by the proof inside the first range peak. The
-        // provided pinned nodes may be a finer partition of the same prefix, so we reconstruct
-        // each authenticated prefix subtree from pins and compare digests.
-        let extracted: alloc::collections::BTreeMap<Position<F>, D> =
-            collected.into_iter().collect();
-
-        // Only the first range peak can contain siblings wholly before `start_loc`; later peaks are
-        // entirely at or after `start_loc` by `Blueprint::new`'s classification.
-        let mut prefix_siblings = Vec::new();
-        if let Some(peak) = bp.range_peaks.first() {
-            peak.collect_prefix_siblings(&bp.range, &mut prefix_siblings);
-        }
-        for pos in prefix_siblings {
-            let Some(&expected_digest) = extracted.get(&pos) else {
-                return false;
-            };
-            let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
-                return false;
-            };
-            if digest != expected_digest {
-                return false;
-            }
-        }
-
-        // Every pin must have been consumed by either a fold-prefix peak reconstruction or a prefix
-        // sibling reconstruction.
-        pinned_map.is_empty()
+        // Every pin must have been consumed by one of the two reconstructions above.
+        pinned_map.is_empty().then_some(())
     }
 
     /// Like [`reconstruct_root`](Self::reconstruct_root), but if `collected` is `Some`, every
@@ -525,6 +505,16 @@ impl<F: Family> Subtree<F> {
         self.leaf_start + (1u64 << self.height)
     }
 
+    /// True if this subtree's leaves lie wholly before `range.start`.
+    fn is_before(&self, range: &Range<Location<F>>) -> bool {
+        self.leaf_end() <= range.start
+    }
+
+    /// True if this subtree's leaves lie wholly outside `range` (either before it or after it).
+    fn is_outside(&self, range: &Range<Location<F>>) -> bool {
+        self.is_before(range) || self.leaf_start >= range.end
+    }
+
     fn children(&self) -> (Self, Self) {
         let (left_pos, right_pos) = F::children(self.pos, self.height);
         let child_height = self.height - 1;
@@ -549,7 +539,7 @@ impl<F: Family> Subtree<F> {
     /// At each node: if the subtree is entirely outside the range, its root position is emitted. If
     /// it's a leaf in the range, nothing is emitted. Otherwise, recurse into children.
     fn collect_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
-        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+        if self.is_outside(range) {
             out.push(self.pos);
             return;
         }
@@ -561,16 +551,16 @@ impl<F: Family> Subtree<F> {
         }
     }
 
-    /// Collect sibling positions that lie wholly before the proven range, in the same
+    /// Collect sibling subtrees that lie wholly before the proven range, in the same
     /// left-first DFS order as [`collect_siblings`](Self::collect_siblings).
     ///
     /// Only `range.start` is consulted: the `range.end` side doesn't matter for prefix
     /// siblings. Pruning on `range.start` also keeps the traversal O(height) per peak —
     /// pruning only by `range.end` would recurse into both children whenever a subtree
     /// sits entirely inside the proven range, costing O(2^height) per such peak.
-    fn collect_prefix_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
-        if self.leaf_end() <= range.start {
-            out.push(self.pos);
+    fn collect_prefix_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Self>) {
+        if self.is_before(range) {
+            out.push(*self);
             return;
         }
 
@@ -583,6 +573,36 @@ impl<F: Family> Subtree<F> {
             left.collect_prefix_siblings(range, out);
             right.collect_prefix_siblings(range, out);
         }
+    }
+
+    /// Reconstruct this subtree's digest from a set of finer-grained pinned positions, consuming
+    /// each pin as it is used.
+    ///
+    /// Walks down via [`Self::children`] until each recursion hits a pin, then hashes back up with
+    /// [`Hasher::node_digest`] for position-keyed domain separation. Returns `None` if any required
+    /// pin is missing.
+    ///
+    /// On failure, `pinned_map` may have been partially consumed. Callers are expected to return
+    /// immediately without inspecting it further.
+    fn reconstruct_from_pins<D, H>(
+        &self,
+        hasher: &H,
+        pinned_map: &mut BTreeMap<Position<F>, D>,
+    ) -> Option<D>
+    where
+        D: Digest,
+        H: Hasher<F, Digest = D>,
+    {
+        if let Some(d) = pinned_map.remove(&self.pos) {
+            return Some(d);
+        }
+        if self.height == 0 {
+            return None;
+        }
+        let (left, right) = self.children();
+        let left_d = left.reconstruct_from_pins(hasher, pinned_map)?;
+        let right_d = right.reconstruct_from_pins(hasher, pinned_map)?;
+        Some(hasher.node_digest(self.pos, &left_d, &right_d))
     }
 
     /// Reconstruct the digest of this subtree from a range of elements and sibling digests,
@@ -610,7 +630,7 @@ impl<F: Family> Subtree<F> {
         E: Iterator<Item: AsRef<[u8]>>,
     {
         // Entirely outside the range: consume a sibling digest.
-        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+        if self.is_outside(range) {
             let Some(digest) = siblings.get(*cursor).copied() else {
                 return Err(ReconstructionError::MissingDigests);
             };
@@ -628,9 +648,6 @@ impl<F: Family> Subtree<F> {
 
         // Recurse into children.
         let (left, right) = self.children();
-        let left_pos = left.pos;
-        let right_pos = right.pos;
-
         let left_d = left.reconstruct_digest(
             hasher,
             range,
@@ -649,8 +666,8 @@ impl<F: Family> Subtree<F> {
         )?;
 
         if let Some(ref mut cd) = collected {
-            cd.push((left_pos, left_d));
-            cd.push((right_pos, right_d));
+            cd.push((left.pos, left_d));
+            cd.push((right.pos, right_d));
         }
 
         Ok(hasher.node_digest(self.pos, &left_d, &right_d))
@@ -663,8 +680,8 @@ pub(crate) struct Blueprint<F: Family> {
     leaves: Location<F>,
     /// The location range this blueprint was built for.
     pub range: Range<Location<F>>,
-    /// Peak positions that precede the proven range (to be folded into a single accumulator).
-    pub fold_prefix: Vec<Position<F>>,
+    /// Peaks that precede the proven range (to be folded into a single accumulator).
+    pub fold_prefix: Vec<Subtree<F>>,
     /// Peak positions entirely after the proven range.
     pub after_peaks: Vec<Position<F>>,
     /// The peaks that overlap the proven range.
@@ -726,7 +743,11 @@ impl<F: Family> Blueprint<F> {
             let leaf_end = leaf_start + (1u64 << height);
 
             if leaf_end <= range.start {
-                fold_prefix.push(peak_pos);
+                fold_prefix.push(Subtree {
+                    pos: peak_pos,
+                    height,
+                    leaf_start,
+                });
             } else if leaf_start >= range.end {
                 after_peaks.push(peak_pos);
             } else {
@@ -759,6 +780,18 @@ impl<F: Family> Blueprint<F> {
         })
     }
 
+    /// Sibling subtrees of the first range peak that lie wholly before `self.range.start`.
+    ///
+    /// Only the first range peak can contain such siblings; later range peaks are entirely at or
+    /// after `range.start` by this blueprint's classification.
+    pub(crate) fn prefix_siblings(&self) -> Vec<Subtree<F>> {
+        let mut out = Vec::new();
+        if let Some(peak) = self.range_peaks.first() {
+            peak.collect_prefix_siblings(&self.range, &mut out);
+        }
+        out
+    }
+
     /// Build a range proof from this blueprint and a node-fetching closure.
     ///
     /// The prover folds prefix peak digests into a single accumulator. The resulting proof
@@ -780,10 +813,10 @@ impl<F: Family> Blueprint<F> {
             if self.fold_prefix.is_empty() { 0 } else { 1 } + self.fetch_nodes.len(),
         );
 
-        if let Some((&first_pos, rest)) = self.fold_prefix.split_first() {
-            let first = get_node(first_pos).ok_or_else(|| element_pruned(first_pos))?;
-            let acc = rest.iter().try_fold(first, |acc, &pos| {
-                let d = get_node(pos).ok_or_else(|| element_pruned(pos))?;
+        if let Some((first_sub, rest)) = self.fold_prefix.split_first() {
+            let first = get_node(first_sub.pos).ok_or_else(|| element_pruned(first_sub.pos))?;
+            let acc = rest.iter().try_fold(first, |acc, sub| {
+                let d = get_node(sub.pos).ok_or_else(|| element_pruned(sub.pos))?;
                 Ok(hasher.fold(&acc, &d))
             })?;
             digests.push(acc);
@@ -842,7 +875,7 @@ pub(crate) fn nodes_required_for_multi_proof<F: Family>(
             return Err(super::Error::LocationOverflow(*loc));
         }
         let bp = Blueprint::new(leaves, *loc..*loc + 1)?;
-        acc.extend(bp.fold_prefix);
+        acc.extend(bp.fold_prefix.into_iter().map(|s| s.pos));
         acc.extend(bp.fetch_nodes);
         Ok(acc)
     })
@@ -1819,7 +1852,7 @@ mod tests {
                 let loc = Location::new(loc);
                 let bp = Blueprint::<F>::new(leaves, loc..loc + 1).unwrap();
                 let mut positions: Vec<Position<F>> = Vec::new();
-                positions.extend(&bp.fold_prefix);
+                positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
                 positions.extend(&bp.fetch_nodes);
                 let set: BTreeSet<_> = positions.iter().copied().collect();
                 assert_eq!(

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -274,12 +274,17 @@ impl<F: Family, D: Digest> Proof<F, D> {
     /// Verify that both the proof and the pinned nodes are valid with respect to `root`.
     ///
     /// The `pinned_nodes` are the peak digests of the sub-structure at `start_loc`, in the order
-    /// returned by `Family::nodes_to_pin`. Each pinned node is either:
+    /// returned by `Family::nodes_to_pin`.
     ///
-    /// - A peak that precedes the proven range (fold-prefix peak). These are verified by
-    ///   refolding them and comparing against the proof's fold-prefix accumulator.
-    /// - A sibling node within a range peak's reconstruction. These are verified against the
-    ///   digests extracted during proof verification.
+    /// These pins may be finer-grained than the prefix structure authenticated by the proof itself.
+    /// In particular, when the larger `self.leaves`-sized tree has merged smaller peaks into larger
+    /// subtrees, the proof authenticates:
+    ///
+    /// - fold-prefix peaks of the larger tree, and
+    /// - any sibling subtrees inside the first range peak that lie wholly before `start_loc`
+    ///
+    /// This verifier reconstructs those authenticated prefix subtrees from the finer-grained pins
+    /// and compares the resulting digests against the proof.
     ///
     /// Returns `true` only if the proof reconstructs to `root` and every pinned node digest is
     /// accounted for. When `start_loc` is 0, `pinned_nodes` must be empty.
@@ -315,27 +320,61 @@ impl<F: Family, D: Digest> Proof<F, D> {
             return false;
         }
 
-        let Ok(fold_prefix) = Blueprint::fold_prefix(self.leaves, start_loc) else {
+        let Some(end_loc) = start_loc.checked_add(elements.len() as u64) else {
             return false;
         };
+        let Ok(bp) = Blueprint::new(self.leaves, start_loc..end_loc) else {
+            return false;
+        };
+        let fold_prefix = bp.fold_prefix;
 
         let mut pinned_map: alloc::collections::BTreeMap<Position<F>, D> = pinned_positions
             .into_iter()
             .zip(pinned_nodes.iter().copied())
             .collect();
 
-        // Verify fold-prefix pinned nodes by recomputing the accumulator (without the leaf
-        // count, which is hashed into the final root independently).
-        if !fold_prefix.is_empty() {
+        /// Reconstruct the digest at `pos` from the pinned node map.
+        ///
+        /// If `pos` is directly in the map, returns its digest. Otherwise, recurses into `F::children(pos,
+        /// height)` and hashes the results. This bridges the gap between `F::nodes_to_pin(start_loc)`
+        /// positions (peaks of the smaller tree) and the coarser prefix subtrees authenticated by the
+        /// proof, which can differ when the larger tree has merged smaller peaks.
+        fn reconstruct_from_pins<F: Family, D: Digest, H: Hasher<F, Digest = D>>(
+            hasher: &H,
+            pos: Position<F>,
+            pinned_map: &mut alloc::collections::BTreeMap<Position<F>, D>,
+        ) -> Option<D> {
+            if let Some(d) = pinned_map.remove(&pos) {
+                return Some(d);
+            }
+            let height = F::pos_to_height(pos);
+            if height == 0 {
+                return None;
+            }
+            let (left, right) = F::children(pos, height);
+            let left_d = reconstruct_from_pins(hasher, left, pinned_map)?;
+            let right_d = reconstruct_from_pins(hasher, right, pinned_map)?;
+            Some(hasher.node_digest(pos, &left_d, &right_d))
+        }
+
+        // Verify fold-prefix pinned nodes by recomputing the accumulator.
+        //
+        // The fold_prefix positions are peaks of the `self.leaves`-sized tree that lie entirely
+        // before `start_loc`. The pinned_map positions are peaks of the `start_loc`-sized tree.
+        // These can differ when the larger tree has merged smaller peaks into bigger ones. To
+        // handle this, we reconstruct each fold_prefix peak's digest from the finer-grained pinned
+        // peaks by walking the tree via `F::children`, while tracking exactly which pinned
+        // positions were consumed by that reconstruction.
+        if let Some((&first_pos, rest)) = fold_prefix.split_first() {
             if self.digests.is_empty() {
                 return false;
             }
-            let Some(first) = pinned_map.remove(&fold_prefix[0]) else {
+            let Some(first) = reconstruct_from_pins(hasher, first_pos, &mut pinned_map) else {
                 return false;
             };
             let mut acc = first;
-            for pos in &fold_prefix[1..] {
-                let Some(digest) = pinned_map.remove(pos) else {
+            for &pos in rest {
+                let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
                     return false;
                 };
                 acc = hasher.fold(&acc, &digest);
@@ -345,16 +384,34 @@ impl<F: Family, D: Digest> Proof<F, D> {
             }
         }
 
-        // Verify remaining pinned nodes (siblings) against the extracted digests.
+        // Verify any sibling subtrees that lie wholly before `start_loc`. These are the coarser
+        // prefix targets authenticated directly by the proof inside the first range peak. The
+        // provided pinned nodes may be a finer partition of the same prefix, so we reconstruct
+        // each authenticated prefix subtree from pins and compare digests.
         let extracted: alloc::collections::BTreeMap<Position<F>, D> =
             collected.into_iter().collect();
-        for (pos, digest) in pinned_map {
-            if extracted.get(&pos) != Some(&digest) {
+
+        // Only the first range peak can contain siblings wholly before `start_loc`; later peaks are
+        // entirely at or after `start_loc` by `Blueprint::new`'s classification.
+        let mut prefix_siblings = Vec::new();
+        if let Some(peak) = bp.range_peaks.first() {
+            peak.collect_prefix_siblings(&bp.range, &mut prefix_siblings);
+        }
+        for pos in prefix_siblings {
+            let Some(&expected_digest) = extracted.get(&pos) else {
+                return false;
+            };
+            let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
+                return false;
+            };
+            if digest != expected_digest {
                 return false;
             }
         }
 
-        true
+        // Every pin must have been consumed by either a fold-prefix peak reconstruction or a prefix
+        // sibling reconstruction.
+        pinned_map.is_empty()
     }
 
     /// Like [`reconstruct_root`](Self::reconstruct_root), but if `collected` is `Some`, every
@@ -416,10 +473,9 @@ impl<F: Family, D: Digest> Proof<F, D> {
 
         let mut sibling_cursor = 0usize;
         let mut elements_iter = elements.iter();
-        for &peak in &bp.range_peaks {
-            let peak_digest = reconstruct_peak_from_range(
+        for peak in &bp.range_peaks {
+            let peak_digest = peak.reconstruct_digest(
                 hasher,
-                peak,
                 &bp.range,
                 &mut elements_iter,
                 siblings,
@@ -486,6 +542,119 @@ impl<F: Family> Subtree<F> {
             },
         )
     }
+
+    /// Collect sibling positions needed to reconstruct this subtree digest from a range of
+    /// elements, in left-first DFS order.
+    ///
+    /// At each node: if the subtree is entirely outside the range, its root position is emitted. If
+    /// it's a leaf in the range, nothing is emitted. Otherwise, recurse into children.
+    fn collect_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
+        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+            out.push(self.pos);
+            return;
+        }
+
+        if self.height > 0 {
+            let (left, right) = self.children();
+            left.collect_siblings(range, out);
+            right.collect_siblings(range, out);
+        }
+    }
+
+    /// Collect sibling positions that lie wholly before the proven range, in the same
+    /// left-first DFS order as [`collect_siblings`](Self::collect_siblings).
+    ///
+    /// Only `range.start` is consulted: the `range.end` side doesn't matter for prefix
+    /// siblings. Pruning on `range.start` also keeps the traversal O(height) per peak —
+    /// pruning only by `range.end` would recurse into both children whenever a subtree
+    /// sits entirely inside the proven range, costing O(2^height) per such peak.
+    fn collect_prefix_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
+        if self.leaf_end() <= range.start {
+            out.push(self.pos);
+            return;
+        }
+
+        if self.leaf_start >= range.start {
+            return;
+        }
+
+        if self.height > 0 {
+            let (left, right) = self.children();
+            left.collect_prefix_siblings(range, out);
+            right.collect_prefix_siblings(range, out);
+        }
+    }
+
+    /// Reconstruct the digest of this subtree from a range of elements and sibling digests,
+    /// consuming both in left-first DFS order.
+    ///
+    /// At each node:
+    /// - If the subtree is entirely outside the range: consume a sibling digest.
+    /// - If it's a leaf in the range: hash the next element.
+    /// - Otherwise: recurse into children via [`Family::children`] and compute the node digest.
+    ///
+    /// If `collected` is `Some`, every child `(position, digest)` pair encountered during
+    /// reconstruction is appended to the vector.
+    fn reconstruct_digest<D, H, E>(
+        &self,
+        hasher: &H,
+        range: &Range<Location<F>>,
+        elements: &mut E,
+        siblings: &[D],
+        cursor: &mut usize,
+        mut collected: Option<&mut Vec<(Position<F>, D)>>,
+    ) -> Result<D, ReconstructionError>
+    where
+        D: Digest,
+        H: Hasher<F, Digest = D>,
+        E: Iterator<Item: AsRef<[u8]>>,
+    {
+        // Entirely outside the range: consume a sibling digest.
+        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+            let Some(digest) = siblings.get(*cursor).copied() else {
+                return Err(ReconstructionError::MissingDigests);
+            };
+            *cursor += 1;
+            return Ok(digest);
+        }
+
+        // Leaf in range: hash the next element.
+        if self.height == 0 {
+            let elem = elements
+                .next()
+                .ok_or(ReconstructionError::MissingElements)?;
+            return Ok(hasher.leaf_digest(self.pos, elem.as_ref()));
+        }
+
+        // Recurse into children.
+        let (left, right) = self.children();
+        let left_pos = left.pos;
+        let right_pos = right.pos;
+
+        let left_d = left.reconstruct_digest(
+            hasher,
+            range,
+            elements,
+            siblings,
+            cursor,
+            collected.as_deref_mut(),
+        )?;
+        let right_d = right.reconstruct_digest(
+            hasher,
+            range,
+            elements,
+            siblings,
+            cursor,
+            collected.as_deref_mut(),
+        )?;
+
+        if let Some(ref mut cd) = collected {
+            cd.push((left_pos, left_d));
+            cd.push((right_pos, right_d));
+        }
+
+        Ok(hasher.node_digest(self.pos, &left_d, &right_d))
+    }
 }
 
 /// Blueprint for a range proof, separating fold-prefix peaks from nodes that must be fetched.
@@ -506,6 +675,7 @@ pub(crate) struct Blueprint<F: Family> {
 
 impl<F: Family> Blueprint<F> {
     /// Efficiently compute just the fold prefix for a given starting location.
+    #[cfg(any(feature = "std", test))]
     pub(crate) fn fold_prefix(
         leaves: Location<F>,
         start_loc: Location<F>,
@@ -575,8 +745,8 @@ impl<F: Family> Blueprint<F> {
         );
 
         let mut fetch_nodes = after_peaks.clone();
-        for &peak in &range_peaks {
-            collect_siblings_dfs(peak, &range, &mut fetch_nodes);
+        for peak in &range_peaks {
+            peak.collect_siblings(&range, &mut fetch_nodes);
         }
 
         Ok(Self {
@@ -676,103 +846,6 @@ pub(crate) fn nodes_required_for_multi_proof<F: Family>(
         acc.extend(bp.fetch_nodes);
         Ok(acc)
     })
-}
-
-/// Collect sibling positions needed to reconstruct a peak digest from a range of elements, in
-/// left-first DFS order. This mirrors the traversal order of [`reconstruct_peak_from_range`].
-///
-/// At each node: if the subtree is entirely outside the range, its root position is emitted. If
-/// it's a leaf in the range, nothing is emitted. Otherwise, recurse into children via
-/// [`Family::children`].
-pub(crate) fn collect_siblings_dfs<F: Family>(
-    node: Subtree<F>,
-    range: &Range<Location<F>>,
-    out: &mut Vec<Position<F>>,
-) {
-    if node.leaf_end() <= range.start || node.leaf_start >= range.end {
-        out.push(node.pos);
-        return;
-    }
-
-    if node.height > 0 {
-        let (left, right) = node.children();
-        collect_siblings_dfs::<F>(left, range, out);
-        collect_siblings_dfs::<F>(right, range, out);
-    }
-}
-
-/// Reconstruct the digest of a peak subtree from a range of elements and sibling digests, consuming
-/// both in left-first DFS order matching [`collect_siblings_dfs`].
-///
-/// At each node:
-/// - If the subtree is entirely outside the range: consume a sibling digest.
-/// - If it's a leaf in the range: hash the next element.
-/// - Otherwise: recurse into children via [`Family::children`] and compute the node digest.
-///
-/// If `collected` is `Some`, every child `(position, digest)` pair encountered during
-/// reconstruction is appended to the vector.
-pub(crate) fn reconstruct_peak_from_range<F, D, H, E>(
-    hasher: &H,
-    node: Subtree<F>,
-    range: &Range<Location<F>>,
-    elements: &mut E,
-    siblings: &[D],
-    cursor: &mut usize,
-    mut collected: Option<&mut Vec<(Position<F>, D)>>,
-) -> Result<D, ReconstructionError>
-where
-    F: Family,
-    D: Digest,
-    H: Hasher<F, Digest = D>,
-    E: Iterator<Item: AsRef<[u8]>>,
-{
-    // Entirely outside the range: consume a sibling digest.
-    if node.leaf_end() <= range.start || node.leaf_start >= range.end {
-        let Some(digest) = siblings.get(*cursor).copied() else {
-            return Err(ReconstructionError::MissingDigests);
-        };
-        *cursor += 1;
-        return Ok(digest);
-    }
-
-    // Leaf in range: hash the next element.
-    if node.height == 0 {
-        let elem = elements
-            .next()
-            .ok_or(ReconstructionError::MissingElements)?;
-        return Ok(hasher.leaf_digest(node.pos, elem.as_ref()));
-    }
-
-    // Recurse into children.
-    let (left, right) = node.children();
-    let left_pos = left.pos;
-    let right_pos = right.pos;
-
-    let left_d = reconstruct_peak_from_range::<F, D, H, E>(
-        hasher,
-        left,
-        range,
-        elements,
-        siblings,
-        cursor,
-        collected.as_deref_mut(),
-    )?;
-    let right_d = reconstruct_peak_from_range::<F, D, H, E>(
-        hasher,
-        right,
-        range,
-        elements,
-        siblings,
-        cursor,
-        collected.as_deref_mut(),
-    )?;
-
-    if let Some(ref mut cd) = collected {
-        cd.push((left_pos, left_d));
-        cd.push((right_pos, right_d));
-    }
-
-    Ok(hasher.node_digest(node.pos, &left_d, &right_d))
 }
 
 #[cfg(feature = "arbitrary")]
@@ -1758,6 +1831,63 @@ mod tests {
         }
     }
 
+    /// `verify_proof_and_pinned_nodes` must accept pinned nodes at
+    /// `F::nodes_to_pin(start_loc)` positions for any `(leaves, start_loc)` pair.
+    ///
+    /// `nodes_to_pin(L)` returns the peaks of the tree at size L (the peaks you'd
+    /// pin if you pruned to L). `fold_prefix(N, L)` returns the peaks of the size-N
+    /// tree that lie entirely before leaf L. These can disagree when the larger tree
+    /// has merged smaller peaks into larger subtrees. The verifier must handle this
+    /// for both families.
+    fn verify_proof_and_pinned_nodes_across_sizes<F: Family>() {
+        // Sweep (leaves, start) pairs. Larger trees with start far from a peak
+        // boundary are more likely to produce pinned positions that don't appear
+        // as siblings in the proof walk.
+        let cases: &[(u64, u64)] = &[
+            // First delayed-merge birth-boundary case: the larger tree exposes a
+            // fold-prefix peak that did not exist yet at `start`.
+            (5, 4),
+            (10, 3),
+            (20, 5),
+            (50, 10),
+            (100, 10),
+            (100, 30),
+            (200, 50),
+            (500, 100),
+            (1000, 100),
+            (1000, 300),
+            (2000, 500),
+        ];
+
+        let hasher = H::new();
+        for &(n, start) in cases {
+            let mem = build_raw::<F>(&hasher, n);
+            let root = *mem.root();
+
+            let pinned: Vec<D> = F::nodes_to_pin(Location::<F>::new(start))
+                .map(|pos| mem.get_node(pos).unwrap())
+                .collect();
+
+            let proof = mem
+                .range_proof(
+                    &hasher,
+                    Location::<F>::new(start)..Location::<F>::new(start + 1),
+                )
+                .unwrap();
+
+            assert!(
+                proof.verify_proof_and_pinned_nodes(
+                    &hasher,
+                    &[start.to_be_bytes()],
+                    Location::<F>::new(start),
+                    &pinned,
+                    &root,
+                ),
+                "verify_proof_and_pinned_nodes failed: leaves={n}, start={start}"
+            );
+        }
+    }
+
     // ---------------------------------------------------------------------------
     // MMR tests
     // ---------------------------------------------------------------------------
@@ -1837,6 +1967,10 @@ mod tests {
     #[test]
     fn mmr_no_duplicate_positions() {
         no_duplicate_positions::<mmr::Family>();
+    }
+    #[test]
+    fn mmr_verify_proof_and_pinned_nodes_across_sizes() {
+        verify_proof_and_pinned_nodes_across_sizes::<mmr::Family>();
     }
 
     // ---------------------------------------------------------------------------
@@ -1918,5 +2052,9 @@ mod tests {
     #[test]
     fn mmb_no_duplicate_positions() {
         no_duplicate_positions::<mmb::Family>();
+    }
+    #[test]
+    fn mmb_verify_proof_and_pinned_nodes_across_sizes() {
+        verify_proof_and_pinned_nodes_across_sizes::<mmb::Family>();
     }
 }

--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -95,12 +95,12 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
             // Start from the stored fold accumulator (which does not include the leaf count).
             let mut acc = self.fold_acc;
             // Fold in peaks beyond those already covered by the stored accumulator.
-            for &pos in bp.fold_prefix.iter().skip(self.num_fold_peaks) {
-                match self.digests.get(&pos) {
+            for sub in bp.fold_prefix.iter().skip(self.num_fold_peaks) {
+                match self.digests.get(&sub.pos) {
                     Some(d) => {
                         acc = Some(acc.map_or(*d, |a| hasher.fold(&a, d)));
                     }
-                    None => return Err(Error::ElementPruned(pos)),
+                    None => return Err(Error::ElementPruned(sub.pos)),
                 }
             }
             digests.push(acc.expect("fold_prefix is non-empty so acc must be set"));
@@ -198,11 +198,11 @@ pub async fn historical_range_proof<
 
     let mut digests: Vec<D> = Vec::new();
     if !bp.fold_prefix.is_empty() {
-        let node_futures = bp.fold_prefix.iter().map(|&pos| merkle.get_node(pos));
+        let node_futures = bp.fold_prefix.iter().map(|sub| merkle.get_node(sub.pos));
         let results = try_join_all(node_futures).await?;
-        let mut acc = results[0].ok_or(Error::ElementPruned(bp.fold_prefix[0]))?;
+        let mut acc = results[0].ok_or(Error::ElementPruned(bp.fold_prefix[0].pos))?;
         for (i, &result) in results.iter().enumerate().skip(1) {
-            let d = result.ok_or(Error::ElementPruned(bp.fold_prefix[i]))?;
+            let d = result.ok_or(Error::ElementPruned(bp.fold_prefix[i].pos))?;
             acc = hasher.fold(&acc, &d);
         }
         digests.push(acc);

--- a/storage/src/qmdb/verify.rs
+++ b/storage/src/qmdb/verify.rs
@@ -25,9 +25,10 @@ where
 /// Verify that both a [Proof] and a set of pinned nodes are valid with respect to a target root.
 ///
 /// The `pinned_nodes` are the pruning-boundary peaks at `start_loc` (as returned by
-/// `nodes_to_pin`). These may be finer-grained than the prefix subtrees authenticated directly by
-/// the proof; the verifier reconstructs those prefix subtrees from the pins as needed. When
-/// `start_loc` is 0, `pinned_nodes` must be empty.
+/// `nodes_to_pin`). When the larger tree has merged smaller subtrees into a bigger parent, the
+/// pins sit below the prefix subtrees authenticated by the proof; the verifier hashes pairs of
+/// pins up to each authenticated subtree's root and compares. When `start_loc` is 0,
+/// `pinned_nodes` must be empty.
 pub fn verify_proof_and_pinned_nodes<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,

--- a/storage/src/qmdb/verify.rs
+++ b/storage/src/qmdb/verify.rs
@@ -24,8 +24,10 @@ where
 
 /// Verify that both a [Proof] and a set of pinned nodes are valid with respect to a target root.
 ///
-/// The `pinned_nodes` are the individual peak digests before the proven range (as returned by
-/// `nodes_to_pin`). When `start_loc` is 0, `pinned_nodes` must be empty.
+/// The `pinned_nodes` are the pruning-boundary peaks at `start_loc` (as returned by
+/// `nodes_to_pin`). These may be finer-grained than the prefix subtrees authenticated directly by
+/// the proof; the verifier reconstructs those prefix subtrees from the pins as needed. When
+/// `start_loc` is 0, `pinned_nodes` must be empty.
 pub fn verify_proof_and_pinned_nodes<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,


### PR DESCRIPTION
## Summary                                                                                                                              
                                                                                                                                          
  Fixes `Proof::verify_proof_and_pinned_nodes` to work with MMB merkle family, which may require reconstructing a peak from pinned nodes at a lower height.   

  ## Fix

  The verifier walks *down* from each authenticated prefix subtree, pulling pins at whichever height they sit, and hashes back up to      
  reconstruct the subtree's digest for comparison against the proof:
                                                                                                                                          
  - **Pin reconstruction** — `Subtree::reconstruct_from_pins` descends through `F::children` and recombines with `Hasher::node_digest`    
  (position-based domain separation). Pins are consumed out of a `BTreeMap` as they're used.
  - **Two verification sites inside `verify_proof_and_pinned_nodes`**:                                                                    
    - **Fold-prefix peaks** (peaks of the larger tree entirely before `start_loc`): reconstruct each peak's digest from pins, fold them,
  compare against the proof's fold accumulator.                                                                                           
    - **Prefix siblings inside the first range peak** (authenticated directly by the proof): rebuild each from pins and compare.
  - **Pin-exhaustion check** — after both reconstructions, the pin map must be empty. Extra or misplaced pins (including malicious/garbage
   positions) are rejected because their digests would never be consumed.                                                                 
                                                                                                                                          
  Supporting restructuring: `Blueprint::fold_prefix` now carries `Subtree<F>` (with position, height, and leaf_start) rather than bare    
  `Position<F>`, so the full geometry flows through the pipeline; `Blueprint::prefix_siblings()` encapsulates the "only the first range
  peak can contribute" invariant; the verifier body uses `?` on an `Option<()>` inner helper to compress the many fallible steps; and     
  `Subtree` gains `is_before`/`is_outside` predicates plus an ASCII diagram in the public rustdoc showing the `p7` vs `p2`/`p5` case
  concretely.

  ## Test plan

  - [x] `test_verify_proof_and_pinned_nodes_across_sizes` in `storage/src/merkle/proof.rs` (instantiated for both MMR and MMB) sweeps     
  `(leaves, start_loc)` pairs, including the MMB delayed-merge boundary `(5, 4)` and coarser-sibling cases such as `(50, 10)`.
  - [x] `test_verify_proof_and_pinned_nodes_recursive_fold_prefix_regression` guards the smallest MMB regression case.                    
  - [x] Family-specific siblings/fold-prefix regression tests live alongside each family's proof module. 