### PR TITLE
regression test for bug

### DIFF
--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -1668,6 +1668,65 @@ where
     });
 }
 
+/// Test that `has_local_target_state` rejects a partition that has the right root and end
+/// location but has already been pruned past the requested sync start.
+pub(crate) fn test_has_local_target_state_rejects_pruned_past_target_start<H: SyncTestHarness>() {
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let db_config = H::config(&context.next_u64().to_string(), &context);
+        let mut db = H::init_db_with_config(context.with_label("local"), db_config.clone()).await;
+
+        let local_prune_boundary = {
+            let mut seed = 0;
+            loop {
+                db = H::apply_ops(db, H::create_ops_seeded(32, seed)).await;
+                let floor = db.inactivity_floor_loc().await;
+                if floor > Location::new(1) {
+                    break floor;
+                }
+                seed += 1;
+                assert!(seed < 8, "expected inactivity floor to advance beyond 1");
+            }
+        };
+        db.prune(local_prune_boundary).await.unwrap();
+        db.sync().await.unwrap();
+
+        let bounds = db.bounds().await;
+        let exact_target = Target {
+            root: H::sync_target_root(&db),
+            range: non_empty_range!(local_prune_boundary, bounds.end),
+        };
+        assert!(
+            <DbOf<H> as qmdb::sync::Database>::has_local_target_state(
+                context.with_label("probe_exact"),
+                &db_config,
+                &exact_target,
+            )
+            .await,
+            "sanity check: exact local boundary should be accepted",
+        );
+
+        let earlier_target_start = Location::new((*local_prune_boundary) / 2);
+        assert!(earlier_target_start > Location::new(0));
+        assert!(earlier_target_start < local_prune_boundary);
+        let earlier_target = Target {
+            root: H::sync_target_root(&db),
+            range: non_empty_range!(earlier_target_start, bounds.end),
+        };
+        assert!(
+            !<DbOf<H> as qmdb::sync::Database>::has_local_target_state(
+                context.with_label("probe_earlier"),
+                &db_config,
+                &earlier_target,
+            )
+            .await,
+            "local target probe must reject partitions pruned past target.range.start()",
+        );
+
+        db.destroy().await.unwrap();
+    });
+}
+
 /// A resolver wrapper that replays the first fresh boundary request against the retained
 /// historical root, then blocks the retry until the test releases it.
 #[derive(Clone)]
@@ -2265,6 +2324,11 @@ macro_rules! sync_tests_for_harness {
             #[test_traced]
             fn test_sync_retries_bad_pinned_nodes() {
                 super::test_sync_retries_bad_pinned_nodes::<$harness>();
+            }
+
+            #[test_traced]
+            fn test_has_local_target_state_rejects_pruned_past_target_start() {
+                super::test_has_local_target_state_rejects_pruned_past_target_start::<$harness>();
             }
 
             #[test_traced]

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -487,6 +487,11 @@ macro_rules! current_sync_tests_for_harness {
             fn test_sync_post_sync_usability() {
                 crate::qmdb::any::sync::tests::test_sync_post_sync_usability::<$harness>();
             }
+
+            #[test_traced]
+            fn test_has_local_target_state_rejects_pruned_past_target_start() {
+                crate::qmdb::any::sync::tests::test_has_local_target_state_rejects_pruned_past_target_start::<$harness>();
+            }
         }
     };
 }


### PR DESCRIPTION
Bug found by codex, verified by Opus 4.7:

The bug                                                                                                                                                                             
                                                                                                                                                                                      
  has_local_target_state in both any/sync/mod.rs:160 and current/sync/mod.rs:303 does:                                                                                                
                                                                                                                                                                                      
  matches!(                                                                                                                                                                           
      peek,                                                                                                                                                                           
      Ok(Some((_, journal_leaves, root)))                                                                                                                                             
          if journal_leaves == target.range.end() && root == target.root                                                                                                              
  )                                                                                                                                                                                   
                                                                                                                                                                                      
  The first tuple element is prune_loc — discarded with _. It only checks the tree size and root match, never the pruning boundary.
                                                                                                                                                                                      
  Why it matters                                          
                                                                                                                                                                                      
  When local_prune_boundary > target.range.start(), the DB has deleted operations in [target.range.start(), local_prune_boundary) but the MMR peaks for the full tree (which peek_root
   uses to compute the root) are still reachable via metadata and unpruned journal nodes. So the root/size check passes even though the operations needed for the requested sync range
   are gone.                                              
                                                  
  Downstream consequences when the engine trusts the true return:                                                                                                                     
                                                                                                                                                                                      
  1. local_target_state_available = true → has_boundary_state() returns true immediately.                                                                                             
  2. is_ready_to_complete() returns true before any fetching.                                                                                                                         
  3. from_sync_result is called with pinned_nodes = None. 
  4. init_sync tries to compute pins at nodes_to_pin(target.range.start()). Some of those positions lie below the current prune boundary and aren't in metadata (metadata only        
  accumulates historical prune points' pins, and this earlier range.start may never have been a prune boundary). Result: Error::MissingNode and the sync errors out.
                                                                                                                                                                                      
  So the user-visible failure mode is: sync fails with MissingNode when it should have either fetched from the resolver (ideal) or cleanly reported that local state doesn't cover the
   target's range.                                                                                                                                                                    
                                                          
  Fix                                                                                                                                                                                 
                                              
  Add a prune-boundary check to has_local_target_state in both any/sync/mod.rs and current/sync/mod.rs:                                                                               
                                              
  matches!(                                                                                                                                                                           
      peek,                                                                                                                                                                           
      Ok(Some((prune_loc, journal_leaves, root)))                                                                                                                                     
          if prune_loc <= target.range.start()                                                                                                                                        
              && journal_leaves == target.range.end()                                                                                                                                 
              && root == target.root     
  )                                                                                                                                                                                   
                                                
  Two choices to consider:               
                                                                                                                                                                                      
  - Conservative (prune_loc == target.range.start()) — only accept exact boundary match. Simple, always safe.
  - Permissive (prune_loc <= target.range.start()) — accept local being behind. Requires init_sync to re-prune forward and find pins for the new boundary. This may or may not succeed
   depending on whether nodes_to_pin(target.range.start()) happens to be available in metadata, so still risky.
                                                  
  I'd go with the conservative version unless you have a concrete use case for prune_loc < target.range.start(). Your test only pins down the reject-when-pruned-past direction, so
  the conservative fix makes the test pass and keeps the semantics tight.                                                                                                             
                                                          
  One additional consideration: the test assertion message says "pruned past target.range.start()" which matches the prune_loc > target.range.start() case. Keep that message even    
  with the == fix — the test is correct.      
