### PR TITLE
[runtime/iouring] idle spinner

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -1815,7 +1815,8 @@ mod tests {
     fn test_advance_timeouts_ignores_stale_entry_after_slot_reuse() {
         // Verify timeout-wheel advancement ignores stale entries from a reused waiter slot.
         let cfg = Config {
-            max_request_timeout: Duration::from_millis(100),
+            max_request_timeout: Duration::from_secs(1),
+            timeout_wheel_tick: Duration::from_millis(100),
             ..Default::default()
         };
         let mut registry = Registry::default();
@@ -1868,12 +1869,12 @@ mod tests {
 
         // At tick 1, only the stale old entry should expire. The new waiter must
         // stay active and no cancel should be queued.
-        std::thread::sleep(iouring.cfg.timeout_wheel_tick + Duration::from_millis(2));
+        std::thread::sleep(iouring.cfg.timeout_wheel_tick + Duration::from_millis(10));
         iouring.advance_timeouts();
         assert!(iouring.pending_cancels.is_empty());
 
         // At tick 3, the real timeout should queue cancellation.
-        std::thread::sleep((iouring.cfg.timeout_wheel_tick * 2) + Duration::from_millis(2));
+        std::thread::sleep((iouring.cfg.timeout_wheel_tick * 2) + Duration::from_millis(10));
         iouring.advance_timeouts();
         assert_eq!(iouring.pending_cancels.len(), 1);
     }

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -177,6 +177,9 @@ mod waiter;
 use waiter::{CompletionOutcome, StageOutcome, WaiterId, Waiters};
 mod waker;
 use waker::{Waker, HALF_SUBMISSION_SEQUENCE_DOMAIN, SUBMISSION_SEQ_MASK, WAKE_USER_DATA};
+mod spinner;
+pub use spinner::Config as SpinnerConfig;
+use spinner::Spinner;
 
 /// Maximum rounded ring size accepted by [`Config::size`].
 ///
@@ -249,6 +252,8 @@ pub struct Config {
     /// Smaller values increase timing precision but increase wakeup and wheel
     /// processing frequency.
     pub timeout_wheel_tick: Duration,
+    /// Adaptive idle spinner configuration.
+    pub idle_spinner: SpinnerConfig,
 }
 
 impl Default for Config {
@@ -260,6 +265,7 @@ impl Default for Config {
             max_request_timeout: Duration::from_secs(60),
             shutdown_timeout: None,
             timeout_wheel_tick: Duration::from_millis(5),
+            idle_spinner: SpinnerConfig::default(),
         }
     }
 }
@@ -447,6 +453,7 @@ pub(crate) struct IoUringLoop {
     ready_queue: VecDeque<WaiterId>,
     pending_cancels: VecDeque<WaiterId>,
     timeout_wheel: TimeoutWheel,
+    idle_spinner: Spinner,
     waker: Waker,
     wake_rearm_needed: bool,
     processed_seq: u32,
@@ -536,8 +543,8 @@ impl IoUringLoop {
             cfg.timeout_wheel_tick,
             Instant::now(),
         );
+        let idle_spinner = Spinner::new(&cfg.idle_spinner, || waker.pending(0));
         let waiters = Waiters::new(size);
-
         let handle = Handle {
             inner: Arc::new(HandleInner {
                 sender: Some(sender),
@@ -555,6 +562,7 @@ impl IoUringLoop {
                 ready_queue: VecDeque::with_capacity(size),
                 pending_cancels: VecDeque::with_capacity(size),
                 timeout_wheel,
+                idle_spinner,
                 waker,
                 wake_rearm_needed: true,
                 processed_seq: 0,
@@ -625,9 +633,18 @@ impl IoUringLoop {
             // If the ring is truly idle, avoid `io_uring_enter` entirely and
             // wait on the shared wake state via futex until a producer changes
             // it. This bypasses the eventfd wake path when there are no active
-            // waiters.
+            // waiters. Before parking, spin briefly to avoid the futex
+            // round-trip when work is imminent.
             if self.waiters.is_empty() {
-                self.waker.park_idle(self.processed_seq);
+                if self
+                    .idle_spinner
+                    .spin(|| self.waker.pending(self.processed_seq))
+                {
+                    continue;
+                }
+                if let Some(park_duration) = self.waker.park_idle(self.processed_seq) {
+                    self.idle_spinner.on_wake(park_duration);
+                }
                 continue;
             }
 

--- a/runtime/src/iouring/spinner.rs
+++ b/runtime/src/iouring/spinner.rs
@@ -1,0 +1,320 @@
+//! Adaptive idle spinning for the io_uring event loop.
+//!
+//! When the ring is fully idle, the loop would normally park on a futex
+//! immediately. The futex park/wake round-trip has non-trivial cost due
+//! to scheduler involvement. [`Spinner`] adds a short spin phase before
+//! parking: if new work arrives during the spin, the park is avoided
+//! entirely.
+//!
+//! The spin budget (in iteration counts) adapts based on outcomes:
+//! - Hit (work arrived during spin): budget grows (+25%).
+//! - Miss (spin expired, had to park): budget shrinks (-12.5%).
+//! - Quick wake (parked but woke fast): budget grows aggressively (+50%).
+//!
+//! A quick wake indicates the loop committed to parking just before work
+//! arrived. The observed park duration is roughly how much longer it should
+//! have spun to avoid the scheduler round-trip. The spinner tracks a running
+//! estimate of these durations as a *near-miss floor* that acts as a learned
+//! lower bound on the budget. Without it, repeated misses would decay the
+//! budget down to the configured minimum even when the workload's actual
+//! near-miss cost is higher. The floor decays gently on misses (1/16 per miss)
+//! so it doesn't stay pinned after a workload shift.
+//!
+//! A one-time calibration at construction converts user-facing microsecond
+//! configuration into iteration counts. The caller provides a probe function
+//! with the same cost profile as the real spin condition so calibration
+//! accounts for per-iteration condition overhead.
+
+use std::time::{Duration, Instant};
+
+/// Number of iterations used by the calibration loop.
+const CALIBRATION_ITERATIONS: usize = 100_000;
+
+/// Spinner configuration. Values are in microseconds.
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// Initial and minimum spin budget in microseconds. The adaptive
+    /// controller grows the budget on hits and shrinks it on misses, but
+    /// never decays below this value. Set to 0 to disable spinning.
+    pub budget_us: usize,
+    /// Maximum spin budget in microseconds. The controller never exceeds
+    /// this regardless of adaptation.
+    pub max_budget_us: usize,
+    /// Quick-wake threshold in microseconds. If the loop parks and wakes
+    /// with real work in less than this duration, the controller grows the
+    /// budget aggressively (the loop should have spun longer).
+    pub quick_wake_us: usize,
+}
+
+impl Config {
+    /// Returns a config that disables spinning entirely.
+    pub const fn disabled() -> Self {
+        Self {
+            budget_us: 0,
+            max_budget_us: 0,
+            quick_wake_us: 0,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            budget_us: 50,
+            max_budget_us: 300,
+            quick_wake_us: 150,
+        }
+    }
+}
+
+/// Adaptive spin budget controller.
+///
+/// Call [`Spinner::spin`] with a condition to busy-wait up to the current
+/// budget. On a miss, call [`Spinner::on_wake`] after the fallback park
+/// returns, the spinner uses the park duration to adjust its budget.
+pub struct Spinner {
+    /// Current spin budget, in iterations.
+    budget: usize,
+    /// Minimum budget, in iterations. Budget never decays below this.
+    min_budget: usize,
+    /// Maximum budget, in iterations. Budget never grows above this.
+    max_budget: usize,
+    /// Learned near-miss floor, in iterations. Tracks a weighted average of
+    /// recent quick-wake park durations. Can push the effective minimum above
+    /// `min_budget`. Decays on misses at 1/16 per miss to avoid staying pinned
+    /// after workload shifts.
+    near_miss_floor: usize,
+    /// Calibrated iterations per microsecond. Used to convert microsecond
+    /// config values into iteration counts and to convert quick-wake park
+    /// durations back into iteration counts for the near-miss floor.
+    iters_per_us: usize,
+    /// Quick-wake threshold. Parks shorter than this grow the budget.
+    quick_wake: Duration,
+}
+
+impl Spinner {
+    /// Create a new spinner. Runs a one-time calibration loop using `probe`
+    /// to measure the per-iteration cost of the real spin condition. The probe
+    /// should have the same cost as the condition passed to [`Spinner::spin`].
+    ///
+    /// Panics if `budget_us > max_budget_us`.
+    pub fn new(cfg: &Config, probe: impl Fn() -> bool) -> Self {
+        assert!(
+            cfg.budget_us <= cfg.max_budget_us,
+            "spinner budget_us ({}) must not exceed max_budget_us ({})",
+            cfg.budget_us,
+            cfg.max_budget_us,
+        );
+        let iters_per_us = calibrate(probe);
+        let min_budget = cfg.budget_us.saturating_mul(iters_per_us);
+        Self {
+            budget: min_budget,
+            min_budget,
+            max_budget: cfg.max_budget_us.saturating_mul(iters_per_us),
+            near_miss_floor: min_budget,
+            iters_per_us,
+            quick_wake: Duration::from_micros(cfg.quick_wake_us as u64),
+        }
+    }
+
+    /// Spin for up to `budget` iterations, checking `condition` each time.
+    /// Returns `true` if the condition was met (hit), `false` if the budget
+    /// expired (miss). Adapts the budget internally based on the outcome.
+    /// Returns `false` immediately without calling `condition` or adapting
+    /// state when the budget is zero (spinning disabled).
+    #[inline]
+    pub fn spin(&mut self, mut condition: impl FnMut() -> bool) -> bool {
+        if self.budget == 0 {
+            return false;
+        }
+        for _ in 0..self.budget {
+            if condition() {
+                self.on_hit();
+                return true;
+            }
+            core::hint::spin_loop();
+        }
+        self.on_miss();
+        false
+    }
+
+    /// Work arrived during spin. Reward by growing the budget.
+    #[inline]
+    fn on_hit(&mut self) {
+        // Grow by 25%, capped at max_budget.
+        self.budget = (self.budget + self.budget / 4).min(self.max_budget);
+    }
+
+    /// Spin expired without work arriving. Gently reduce the budget
+    /// and decay the near-miss floor so stale history doesn't keep the
+    /// floor pinned.
+    #[inline]
+    fn on_miss(&mut self) {
+        // Decay the learned floor by 1/16.
+        self.near_miss_floor -= self.near_miss_floor / 16;
+        // Shrink by 12.5%, clamped to the effective floor.
+        let floor = self.near_miss_floor.max(self.min_budget);
+        self.budget = self.budget.saturating_sub(self.budget / 8).max(floor);
+    }
+
+    /// Called after a futex park that actually slept. If the park was
+    /// shorter than the quick-wake threshold, grows the budget by 50% (we
+    /// should have spun longer) and updates the near-miss floor.
+    #[inline]
+    pub fn on_wake(&mut self, park_duration: Duration) {
+        if park_duration <= self.quick_wake {
+            // Grow by 50%, capped at max_budget.
+            self.budget = (self.budget + self.budget / 2).min(self.max_budget);
+            // Update the learned floor with a 1/4-weighted sample of the
+            // observed park duration, clamped so it can't exceed max_budget.
+            let park_iters = (park_duration.as_nanos() * self.iters_per_us as u128 / 1000) as usize;
+            let floor = (self.near_miss_floor * 3 + park_iters) / 4;
+            self.near_miss_floor = floor.min(self.max_budget);
+        }
+    }
+}
+
+/// Measure iterations per microsecond by running `probe` + `spin_loop()`
+/// in a tight loop. The probe should match the real spin condition's cost.
+fn calibrate(probe: impl Fn() -> bool) -> usize {
+    let start = Instant::now();
+    for _ in 0..CALIBRATION_ITERATIONS {
+        std::hint::black_box(probe());
+        core::hint::spin_loop();
+    }
+    let elapsed_us = start.elapsed().as_micros() as usize;
+    CALIBRATION_ITERATIONS / elapsed_us.max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> Config {
+        Config {
+            budget_us: 10,
+            max_budget_us: 50,
+            quick_wake_us: 50,
+        }
+    }
+
+    #[test]
+    fn test_calibration_returns_nonzero() {
+        assert!(calibrate(|| false) > 0);
+    }
+
+    #[test]
+    fn test_spin_immediate_hit() {
+        let mut s = Spinner::new(&cfg(), || false);
+        assert!(s.spin(|| true));
+    }
+
+    #[test]
+    fn test_spin_miss() {
+        let mut s = Spinner::new(&cfg(), || false);
+        assert!(!s.spin(|| false));
+    }
+
+    #[test]
+    fn test_spin_delayed_hit() {
+        let mut s = Spinner::new(&cfg(), || false);
+        let mut count = 0usize;
+        let hit = s.spin(|| {
+            count += 1;
+            count >= 50
+        });
+        assert!(hit);
+        assert_eq!(count, 50);
+    }
+
+    #[test]
+    fn test_hit_grows_budget() {
+        let mut s = Spinner::new(&cfg(), || false);
+        let initial = s.budget;
+        s.spin(|| true);
+        assert!(s.budget > initial);
+    }
+
+    #[test]
+    fn test_miss_shrinks_budget() {
+        let mut s = Spinner::new(&cfg(), || false);
+        s.spin(|| true);
+        let after_hit = s.budget;
+        s.spin(|| false);
+        assert!(s.budget < after_hit);
+    }
+
+    #[test]
+    fn test_budget_does_not_go_below_min() {
+        let mut s = Spinner::new(&cfg(), || false);
+        for _ in 0..1000 {
+            s.spin(|| false);
+        }
+        assert!(s.budget >= s.min_budget);
+    }
+
+    #[test]
+    fn test_budget_does_not_exceed_max() {
+        let mut s = Spinner::new(&cfg(), || false);
+        for _ in 0..1000 {
+            s.spin(|| true);
+        }
+        assert!(s.budget <= s.max_budget);
+    }
+
+    #[test]
+    fn test_quick_wake_grows_budget_and_floor() {
+        let mut s = Spinner::new(&cfg(), || false);
+        assert_eq!(s.near_miss_floor, s.min_budget);
+        let before = s.near_miss_floor;
+        // Large quick-wake sample pushes the floor above min_budget.
+        s.on_wake(Duration::from_micros(30));
+        assert!(s.near_miss_floor > before);
+    }
+
+    #[test]
+    fn test_slow_block_does_not_grow() {
+        let mut s = Spinner::new(&cfg(), || false);
+        let before = s.budget;
+        s.on_wake(Duration::from_nanos(100_000));
+        assert_eq!(s.budget, before);
+    }
+
+    #[test]
+    fn test_near_miss_floor_decays_on_miss() {
+        let mut s = Spinner::new(&cfg(), || false);
+        s.on_wake(Duration::from_nanos(10_000));
+        let floor_after_wake = s.near_miss_floor;
+        assert!(floor_after_wake > 0);
+        for _ in 0..100 {
+            s.spin(|| false);
+        }
+        assert!(s.near_miss_floor < floor_after_wake);
+    }
+
+    #[test]
+    fn test_near_miss_floor_clamped_to_max() {
+        let mut s = Spinner::new(&cfg(), || false);
+        s.on_wake(Duration::from_nanos(40_000));
+        assert!(s.near_miss_floor <= s.max_budget);
+    }
+
+    #[test]
+    #[should_panic(expected = "must not exceed max_budget_us")]
+    fn test_new_panics_when_budget_exceeds_max() {
+        let _ = Spinner::new(
+            &Config {
+                budget_us: 100,
+                max_budget_us: 50,
+                quick_wake_us: 50,
+            },
+            || false,
+        );
+    }
+
+    #[test]
+    fn test_disabled_spinner() {
+        let mut s = Spinner::new(&Config::disabled(), || false);
+        assert!(!s.spin(|| true));
+    }
+}

--- a/runtime/src/iouring/spinner.rs
+++ b/runtime/src/iouring/spinner.rs
@@ -48,6 +48,8 @@ pub struct Config {
 
 impl Config {
     /// Returns a config that disables spinning entirely.
+    // TODO (#1045): remove `allow(dead_code)` once iouring config is exposed.
+    #[allow(dead_code)]
     pub const fn disabled() -> Self {
         Self {
             budget_us: 0,

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -250,9 +250,10 @@ impl Waker {
     /// This method hides the arm-and-recheck futex sequence used when the ring
     /// is fully idle. It always clears the current wait state before returning.
     ///
-    /// Returns `Some(duration)` with the time spent blocked in `futex_wait`,
-    /// or `None` if the snapshot showed work or a wake was already pending and
-    /// the call returned without sleeping.
+    /// Returns `Some(duration)` only if `futex_wait` actually blocked in the
+    /// kernel and later resumed. Returns `None` if the armed snapshot already
+    /// showed published work or a latched wake, or if a concurrent state
+    /// change rejected the snapshot before the thread could sleep.
     pub fn park_idle(&self, processed_seq: u32) -> Option<Duration> {
         // Arming only updates the packed wake state machine. It does not
         // publish queue memory or consume any out-of-band wake publication, so
@@ -276,9 +277,9 @@ impl Waker {
             && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq
         {
             let before = Instant::now();
-            self.futex_wait(snapshot);
+            let slept = self.futex_wait(snapshot);
             self.clear_wait();
-            Some(before.elapsed())
+            slept.then(|| before.elapsed())
         } else {
             self.clear_wait();
             None
@@ -492,13 +493,17 @@ impl Waker {
     ///
     /// Retries on `EINTR`. Treats `EAGAIN` as "state already changed before
     /// the kernel slept".
-    fn futex_wait(&self, snapshot: u32) {
+    ///
+    /// Returns `true` only if the kernel actually blocked the thread and later
+    /// resumed it. Returns `false` for stale-snapshot races, userspace
+    /// equality mismatches, and unexpected futex wait failures.
+    fn futex_wait(&self, snapshot: u32) -> bool {
         loop {
             // This is only a same-word equality check before entering the
             // syscall. It relies only on modification order of this atomic, so
             // `Relaxed` is sufficient.
             if self.inner.state.load(Ordering::Relaxed) != snapshot {
-                return;
+                return false;
             }
 
             // SAFETY: `state` is a valid aligned futex word for the duration of
@@ -513,19 +518,19 @@ impl Waker {
                 )
             };
             if ret == 0 {
-                return;
+                return true;
             }
             let err = std::io::Error::last_os_error();
             match err.raw_os_error() {
                 Some(libc::EINTR) => continue,
-                Some(libc::EAGAIN) => return,
+                Some(libc::EAGAIN) => return false,
                 _ => {
                     // With a null timeout, documented timeout-specific errors do not
                     // apply here. An unexpected futex wait error means the kernel
                     // refused to block, so the safe fallback is to return to
                     // userspace and re-check the packed state rather than panic.
                     warn!("futex wait failed: {err}");
-                    return;
+                    return false;
                 }
             }
         }
@@ -669,9 +674,8 @@ pub mod tests {
                     }
                 });
 
-                let duration = waker.park_idle(before);
+                let _ = waker.park_idle(before);
                 handle.join().expect("idle notifier thread panicked");
-                assert!(duration.is_some(), "{notifier:?}: should have slept");
 
                 let expected = match notifier {
                     Notifier::Wake => before,
@@ -741,8 +745,9 @@ pub mod tests {
 
         // If the stale snapshot were incorrectly accepted, this call could
         // block indefinitely. Returning here proves the userspace equality
-        // check / futex EAGAIN path rejected the outdated snapshot.
-        waker.futex_wait(snapshot);
+        // check / futex EAGAIN path rejected the outdated snapshot without
+        // ever committing to a real futex sleep.
+        assert!(!waker.futex_wait(snapshot));
         waker.clear_wait();
 
         // The publish should remain visible and the wait bits should be fully

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -29,6 +29,7 @@ use std::{
         atomic::{AtomicU32, Ordering},
         Arc,
     },
+    time::{Duration, Instant},
 };
 use tracing::warn;
 
@@ -248,7 +249,11 @@ impl Waker {
     ///
     /// This method hides the arm-and-recheck futex sequence used when the ring
     /// is fully idle. It always clears the current wait state before returning.
-    pub fn park_idle(&self, processed_seq: u32) {
+    ///
+    /// Returns `Some(duration)` with the time spent blocked in `futex_wait`,
+    /// or `None` if the snapshot showed work or a wake was already pending and
+    /// the call returned without sleeping.
+    pub fn park_idle(&self, processed_seq: u32) -> Option<Duration> {
         // Arming only updates the packed wake state machine. It does not
         // publish queue memory or consume any out-of-band wake publication, so
         // `Relaxed` is sufficient on this RMW.
@@ -270,9 +275,14 @@ impl Waker {
         if (snapshot & WAKE_SIGNALLED_BIT) == 0
             && ((snapshot >> STATE_BITS) & SUBMISSION_SEQ_MASK) == processed_seq
         {
+            let before = Instant::now();
             self.futex_wait(snapshot);
+            self.clear_wait();
+            Some(before.elapsed())
+        } else {
+            self.clear_wait();
+            None
         }
-        self.clear_wait();
     }
 
     /// Arm the blocking wake path used around `submit_and_wait`.
@@ -659,8 +669,9 @@ pub mod tests {
                     }
                 });
 
-                waker.park_idle(before);
+                let duration = waker.park_idle(before);
                 handle.join().expect("idle notifier thread panicked");
+                assert!(duration.is_some(), "{notifier:?}: should have slept");
 
                 let expected = match notifier {
                     Notifier::Wake => before,
@@ -691,8 +702,9 @@ pub mod tests {
         let before = submitted_seq(&waker);
 
         waker.wake();
-        waker.park_idle(before);
+        let duration = waker.park_idle(before);
 
+        assert!(duration.is_none(), "should not have slept");
         assert_eq!(submitted_seq(&waker), before);
         assert_eq!(state_bits(&waker), 0);
     }


### PR DESCRIPTION
This PR adds a short, adaptive spin phase before the io_uring event loop parks on the futex when the ring is fully idle. The futex park/wake round-trip has non-trivial cost from the scheduler round-trip, and when work arrives shortly after the loop commits to parking, that cost is wasted. Spinning briefly on the waker's shared state before parking avoids the round-trip when work is imminent, at the cost of some CPU during the spin window.

The new `Spinner` is a budget controller with no knowledge of wakers, rings, or blocking. The loop calls `spin(condition)` to busy-wait up to the current budget and `on_wake(duration)` after the fallback park returns. The budget (in iteration counts) adapts based on outcomes: it grows on hits (+25%), shrinks gently on misses (-12.5%), and grows aggressively on quick wakes (+50%). A learned near-miss floor tracks a weighted average of recent quick-wake durations and acts as a lower bound on the budget, without it repeated misses would decay the budget to the configured minimum even when the workload's actual near-miss cost is higher. The floor decays slowly on misses (1/16 per miss) so it doesn't stay pinned after a workload shift.

A CQE spinner (before `io_uring_enter`) was considered and deliberately not included. Fast completions (page cache reads, kernel buffer accepts, cached writes) typically complete inline during submission, so `submit_and_wait` returns immediately with no blocking cost to avoid. Slow completions (disk I/O, network receive) take milliseconds, well beyond any reasonable spin window. The "medium" regime a CQE spinner could help is narrow and largely moot under `DEFER_TASKRUN` (enabled with `single_issuer` throughout the runtime), where the kernel defers posting CQEs until the next `io_uring_enter`, so userspace peeks at the CQ ring cannot see async completions during a spin. The idle spinner is where the clear latency win lives, CQE spinning can be revisited later if profiling shows `io_uring_enter` blocking is a measurable bottleneck.
