### PR TITLE
[storage/qmdb/sync] Generalize sync on merkle family - approach #2

### DIFF
--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -8,7 +8,7 @@ use commonware_codec::{EncodeShared, Read};
 use commonware_runtime::{
     tokio as tokio_runtime, BufferPooler, Clock, Metrics, Network, Runner, Spawner, Storage,
 };
-use commonware_storage::qmdb::sync;
+use commonware_storage::{mmr, qmdb::sync};
 use commonware_sync::{
     any, crate_version, current, databases::DatabaseType, immutable, keyless, net::Resolver,
     Digest, Error, Key,
@@ -60,9 +60,9 @@ struct Config {
 async fn target_update_task<E, Op, D>(
     context: E,
     resolver: Resolver<Op, D>,
-    update_tx: mpsc::Sender<sync::Target<D>>,
+    update_tx: mpsc::Sender<sync::Target<mmr::Family, D>>,
     interval_duration: Duration,
-    initial_target: sync::Target<D>,
+    initial_target: sync::Target<mmr::Family, D>,
 ) -> Result<(), Error>
 where
     E: Clock,

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -160,11 +160,11 @@ where
     state.request_counter.inc();
 
     // Get the current database state
-    let (root, inactivity_floor, size) = {
+    let (root, sync_boundary, size) = {
         let database = state.database.read().await;
         (
             database.root(),
-            database.inactivity_floor().await,
+            database.sync_boundary().await,
             database.size().await,
         )
     };
@@ -172,7 +172,7 @@ where
         request_id: request.request_id,
         target: Target {
             root,
-            range: non_empty_range!(inactivity_floor, size),
+            range: non_empty_range!(sync_boundary, size),
         },
     };
 
@@ -430,7 +430,7 @@ where
         .collect::<String>();
     info!(
         size = ?database.size().await,
-        inactivity_floor = ?database.inactivity_floor().await,
+        sync_boundary = ?database.sync_boundary().await,
         root = %root_hex,
         "{} database ready",
         DB::name()

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -123,8 +123,8 @@ where
         self.bounds().await.end
     }
 
-    async fn inactivity_floor(&self) -> Location {
-        self.inactivity_floor_loc()
+    async fn sync_boundary(&self) -> Location {
+        self.sync_boundary()
     }
 
     fn historical_proof(

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -139,8 +139,9 @@ where
         self.bounds().await.end
     }
 
-    async fn inactivity_floor(&self) -> Location {
-        self.inactivity_floor_loc()
+    async fn sync_boundary(&self) -> Location {
+        self.sync_boundary()
+            .expect("sync_boundary should not overflow")
     }
 
     fn historical_proof(

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -129,10 +129,8 @@ where
         self.bounds().await.end
     }
 
-    async fn inactivity_floor(&self) -> Location {
-        // For Immutable databases, all retained operations are active,
-        // so the inactivity floor equals the pruning boundary.
-        self.bounds().await.start
+    async fn sync_boundary(&self) -> Location {
+        self.sync_boundary().await
     }
 
     fn historical_proof(

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -126,10 +126,8 @@ where
         self.bounds().await.end
     }
 
-    async fn inactivity_floor(&self) -> Location {
-        // Keyless databases have no inactivity floor concept.
-        // Use the pruning boundary, same as immutable.
-        self.bounds().await.start
+    async fn sync_boundary(&self) -> Location {
+        self.sync_boundary().await
     }
 
     async fn historical_proof(

--- a/examples/sync/src/databases/mod.rs
+++ b/examples/sync/src/databases/mod.rs
@@ -75,8 +75,11 @@ pub trait Syncable: Sized {
     /// Get the total number of operations in the database (including pruned operations).
     fn size(&self) -> impl Future<Output = Location<Self::Family>> + Send;
 
-    /// Get the inactivity floor, the location below which all operations are inactive.
-    fn inactivity_floor(&self) -> impl Future<Output = Location<Self::Family>> + Send;
+    /// Get the most recent location from which this database can safely be synced.
+    ///
+    /// Callers constructing a sync target should use this value (or any earlier retained
+    /// location) as the `range.start`.
+    fn sync_boundary(&self) -> impl Future<Output = Location<Self::Family>> + Send;
 
     /// Get historical proof and operations.
     fn historical_proof(

--- a/examples/sync/src/net/resolver.rs
+++ b/examples/sync/src/net/resolver.rs
@@ -3,7 +3,10 @@ use crate::net::request_id;
 use commonware_codec::{EncodeShared, IsUnit, Read};
 use commonware_cryptography::Digest;
 use commonware_runtime::{Network, Spawner};
-use commonware_storage::{mmr::Location, qmdb::sync};
+use commonware_storage::{
+    mmr::{self, Location},
+    qmdb::sync,
+};
 use commonware_utils::channel::{mpsc, oneshot};
 use std::num::NonZeroU64;
 
@@ -42,7 +45,7 @@ where
     }
 
     /// Returns the current sync target from the server.
-    pub async fn get_sync_target(&self) -> Result<sync::Target<D>, crate::Error> {
+    pub async fn get_sync_target(&self) -> Result<sync::Target<mmr::Family, D>, crate::Error> {
         let request_id = self.request_id_generator.next();
         let request =
             wire::Message::GetSyncTargetRequest(wire::GetSyncTargetRequest { request_id });
@@ -75,6 +78,7 @@ where
     Op::Cfg: IsUnit,
     D: Digest,
 {
+    type Family = mmr::Family;
     type Digest = D;
     type Op = Op;
     type Error = crate::Error;
@@ -86,7 +90,8 @@ where
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
         _cancel_rx: oneshot::Receiver<()>,
-    ) -> Result<sync::resolver::FetchResult<Self::Op, Self::Digest>, Self::Error> {
+    ) -> Result<sync::resolver::FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error>
+    {
         let request_id = self.request_id_generator.next();
         let request = wire::Message::GetOperationsRequest(wire::GetOperationsRequest {
             request_id,

--- a/examples/sync/src/net/wire.rs
+++ b/examples/sync/src/net/wire.rs
@@ -5,7 +5,7 @@ use commonware_codec::{
 use commonware_cryptography::Digest;
 use commonware_runtime::{Buf, BufMut};
 use commonware_storage::{
-    mmr::{Location, Proof},
+    mmr::{self, Location, Proof},
     qmdb::sync::Target,
 };
 use std::num::NonZeroU64;
@@ -51,7 +51,7 @@ where
     D: Digest,
 {
     pub request_id: RequestId,
-    pub target: Target<D>,
+    pub target: Target<mmr::Family, D>,
 }
 
 /// Messages that can be sent over the wire.
@@ -334,7 +334,7 @@ where
     type Cfg = ();
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let request_id = RequestId::read_cfg(buf, &())?;
-        let target = Target::<D>::read_cfg(buf, &())?;
+        let target = Target::<mmr::Family, D>::read_cfg(buf, &())?;
         Ok(Self { request_id, target })
     }
 }

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -265,8 +265,10 @@ fn fuzz(input: FuzzInput) {
                         {
                             break;
                         }
-                        let floor = db.inactivity_floor_loc();
-                        if db.prune(floor).await.is_err() {
+                        let Ok(boundary) = db.sync_boundary() else {
+                            break;
+                        };
+                        if db.prune(boundary).await.is_err() {
                             break;
                         }
                     }
@@ -325,7 +327,9 @@ fn fuzz(input: FuzzInput) {
             }
 
             // Verify range proofs over the recovered DB.
-            let floor = *db.inactivity_floor_loc();
+            let floor = *db
+                .sync_boundary()
+                .expect("sync_boundary should not overflow");
             let size = *db.bounds().await.end;
             for i in floor..size {
                 let loc = Location::new(i);

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -215,9 +215,10 @@ async fn commit_pending(
 }
 
 async fn prune_to_floor(db: &mut Db, reference_db: &Db, context: &str) {
-    db.prune(db.inactivity_floor_loc())
-        .await
-        .expect("prune should not fail");
+    let boundary = db
+        .sync_boundary()
+        .expect("sync_boundary should not overflow");
+    db.prune(boundary).await.expect("prune should not fail");
     assert_matches_reference(db, reference_db, context).await;
 }
 

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -215,7 +215,7 @@ fn fuzz(data: FuzzInput) {
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
                     committed_op_count = db.bounds().await.end;
-                    db.prune(db.inactivity_floor_loc()).await.expect("Prune should not fail");
+                    db.prune(db.sync_boundary().expect("sync_boundary should not overflow")).await.expect("Prune should not fail");
                 }
 
                 CurrentOperation::Root => {
@@ -243,7 +243,7 @@ fn fuzz(data: FuzzInput) {
                     let current_op_count = db.bounds().await.end;
                     let start_loc = Location::new(start_loc % *current_op_count);
 
-                    let oldest_loc = db.inactivity_floor_loc();
+                    let oldest_loc = db.sync_boundary().expect("sync_boundary should not overflow");
                     if start_loc >= oldest_loc {
                         let (proof, ops, chunks) = db
                             .range_proof(&mut hasher, start_loc, *max_ops)

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -197,7 +197,7 @@ fn fuzz(data: FuzzInput) {
                 CurrentOperation::Prune => {
                     commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                     committed_op_count = db.bounds().await.end;
-                    db.prune(db.inactivity_floor_loc()).await.expect("Prune should not fail");
+                    db.prune(db.sync_boundary().expect("sync_boundary should not overflow")).await.expect("Prune should not fail");
                 }
 
                 CurrentOperation::Root => {
@@ -218,7 +218,7 @@ fn fuzz(data: FuzzInput) {
 
                     let current_op_count = db.bounds().await.end;
                     let start_loc = Location::new(start_loc % *current_op_count);
-                    let oldest_loc = db.inactivity_floor_loc();
+                    let oldest_loc = db.sync_boundary().expect("sync_boundary should not overflow");
                     if start_loc >= oldest_loc {
                         let (proof, ops, chunks) = db
                             .range_proof(&mut hasher, start_loc, *max_ops)

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -114,13 +114,14 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap> {
 
 async fn test_sync<
     R: sync::resolver::Resolver<
+        Family = Family,
         Digest = commonware_cryptography::sha256::Digest,
         Op = FixedOperation<Family, Key, Value>,
     >,
 >(
     context: deterministic::Context,
     resolver: R,
-    target: sync::Target<commonware_cryptography::sha256::Digest>,
+    target: sync::Target<Family, commonware_cryptography::sha256::Digest>,
     fetch_batch_size: u64,
     test_name: &str,
     sync_id: usize,
@@ -209,7 +210,7 @@ fn fuzz(mut input: FuzzInput) {
                 }
 
                 Operation::Prune => {
-                    db.prune(db.inactivity_floor_loc())
+                    db.prune(db.sync_boundary())
                         .await
                         .expect("Prune should not fail");
                 }
@@ -235,7 +236,7 @@ fn fuzz(mut input: FuzzInput) {
                     db.commit().await.expect("Commit should not fail");
                     let target = sync::Target {
                         root: db.root(),
-                        range: non_empty_range!(db.inactivity_floor_loc(), db.bounds().await.end),
+                        range: non_empty_range!(db.sync_boundary(), db.bounds().await.end),
                     };
 
                     let wrapped_src = Arc::new(db);

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -204,7 +204,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 Operation::Prune => {
-                    db.prune(db.inactivity_floor_loc())
+                    db.prune(db.sync_boundary())
                         .await
                         .expect("Prune should not fail");
                 }
@@ -230,7 +230,7 @@ fn fuzz(input: FuzzInput) {
                     db.commit().await.expect("Commit should not fail");
                     historical_roots.insert(db.bounds().await.end, db.root());
                     let op_count = db.bounds().await.end;
-                    let oldest_retained_loc = db.inactivity_floor_loc();
+                    let oldest_retained_loc = db.sync_boundary();
                     if *start_loc >= oldest_retained_loc && *start_loc < *op_count {
                         if let Ok((proof, log)) = db.proof(*start_loc, *max_ops).await {
                             let root = db.root();
@@ -291,7 +291,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 Operation::InactivityFloorLoc => {
-                    let _ = db.inactivity_floor_loc();
+                    let _ = db.sync_boundary();
                 }
 
                 Operation::OpCount => {

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -67,7 +67,7 @@ pub trait Family: Copy + Clone + Debug + Default + Send + Sync + 'static {
     /// Return the peaks of a structure with the given `size` as `(position, height)` pairs
     /// in canonical oldest-to-newest order (suitable for
     /// [`Hasher::root`](crate::merkle::hasher::Hasher::root)).
-    fn peaks(size: Position<Self>) -> impl Iterator<Item = (Position<Self>, u32)>;
+    fn peaks(size: Position<Self>) -> impl Iterator<Item = (Position<Self>, u32)> + Send;
 
     /// Compute positions of nodes that must be pinned when pruning to `prune_loc`.
     ///

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -172,7 +172,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
             let Ok(bp) = Blueprint::new(self.leaves, *loc..*loc + 1) else {
                 return false;
             };
-            node_positions.extend(&bp.fold_prefix);
+            node_positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
             node_positions.extend(&bp.fetch_nodes);
             blueprints.insert(*loc, bp);
         }
@@ -196,12 +196,14 @@ impl<F: Family, D: Digest> Proof<F, D> {
             let mut digests = Vec::with_capacity(
                 if bp.fold_prefix.is_empty() { 0 } else { 1 } + bp.fetch_nodes.len(),
             );
-            if let Some((&first_pos, rest)) = bp.fold_prefix.split_first() {
+            if let Some((first_sub, rest)) = bp.fold_prefix.split_first() {
                 let first = *node_digests
-                    .get(&first_pos)
+                    .get(&first_sub.pos)
                     .expect("must exist by construction");
-                let acc = rest.iter().fold(first, |acc, &pos| {
-                    let d = node_digests.get(&pos).expect("must exist by construction");
+                let acc = rest.iter().fold(first, |acc, sub| {
+                    let d = node_digests
+                        .get(&sub.pos)
+                        .expect("must exist by construction");
                     hasher.fold(&acc, d)
                 });
                 digests.push(acc);
@@ -274,17 +276,32 @@ impl<F: Family, D: Digest> Proof<F, D> {
     /// Verify that both the proof and the pinned nodes are valid with respect to `root`.
     ///
     /// The `pinned_nodes` are the peak digests of the sub-structure at `start_loc`, in the order
-    /// returned by `Family::nodes_to_pin`.
-    ///
-    /// These pins may be finer-grained than the prefix structure authenticated by the proof itself.
-    /// In particular, when the larger `self.leaves`-sized tree has merged smaller peaks into larger
-    /// subtrees, the proof authenticates:
+    /// returned by `Family::nodes_to_pin`. The proof authenticates the prefix `[0, start_loc)` via:
     ///
     /// - fold-prefix peaks of the larger tree, and
-    /// - any sibling subtrees inside the first range peak that lie wholly before `start_loc`
+    /// - sibling subtrees inside the first range peak that lie wholly before `start_loc`.
     ///
-    /// This verifier reconstructs those authenticated prefix subtrees from the finer-grained pins
-    /// and compares the resulting digests against the proof.
+    /// When the larger tree has merged smaller subtrees into a bigger parent, the pins sit below
+    /// these authenticated subtrees. The verifier hashes pairs of pins up to each authenticated
+    /// subtree's root and compares against the proof.
+    ///
+    /// For example, in MMB at `leaves=5, start_loc=4`, the proof describes `[0, 4)` as one
+    /// height-2 subtree `p7`, while the pins cover the same leaves as two height-1 subtrees
+    /// `p2`, `p5`:
+    ///
+    /// ```text
+    ///     proof authenticates:         pins contain:
+    ///
+    ///             p7
+    ///           /    \
+    ///          p2    p5                p2         p5
+    ///         / \    / \              / \        / \
+    ///        L0 L1  L2 L3            L0 L1      L2 L3
+    /// ```
+    ///
+    /// The verifier walks down from `p7` via `F::children`, pulls the pins for `p2` and `p5`, and
+    /// hashes them back up (`node_digest(p7, pin[p2], pin[p5])`) to compare against the `p7`
+    /// digest the proof authenticates.
     ///
     /// Returns `true` only if the proof reconstructs to `root` and every pinned node digest is
     /// accounted for. When `start_loc` is 0, `pinned_nodes` must be empty.
@@ -300,118 +317,81 @@ impl<F: Family, D: Digest> Proof<F, D> {
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        let collected = match self
+        self.try_verify_proof_and_pinned_nodes(hasher, elements, start_loc, pinned_nodes, root)
+            .is_some()
+    }
+
+    /// Fallible implementation of [`verify_proof_and_pinned_nodes`](Self::verify_proof_and_pinned_nodes).
+    ///
+    /// Returns `Some(())` if the proof and pins are consistent with `root`, `None` otherwise. The
+    /// `Option` return lets the body use `?` on each fallible step; the public wrapper converts to
+    /// `bool` via `.is_some()`.
+    fn try_verify_proof_and_pinned_nodes<H, E>(
+        &self,
+        hasher: &H,
+        elements: &[E],
+        start_loc: Location<F>,
+        pinned_nodes: &[D],
+        root: &D,
+    ) -> Option<()>
+    where
+        H: Hasher<F, Digest = D>,
+        E: AsRef<[u8]>,
+    {
+        let collected = self
             .verify_range_inclusion_and_extract_digests(hasher, elements, start_loc, root)
-        {
-            Ok(c) => c,
-            Err(_) => return false,
-        };
+            .ok()?;
 
         if elements.is_empty() {
-            return pinned_nodes.is_empty();
+            return pinned_nodes.is_empty().then_some(());
         }
 
         if !start_loc.is_valid() || start_loc > self.leaves {
-            return false;
+            return None;
         }
 
-        let pinned_positions: alloc::vec::Vec<_> = F::nodes_to_pin(start_loc).collect();
+        let pinned_positions: Vec<_> = F::nodes_to_pin(start_loc).collect();
         if pinned_positions.len() != pinned_nodes.len() {
-            return false;
+            return None;
         }
 
-        let Some(end_loc) = start_loc.checked_add(elements.len() as u64) else {
-            return false;
-        };
-        let Ok(bp) = Blueprint::new(self.leaves, start_loc..end_loc) else {
-            return false;
-        };
-        let fold_prefix = bp.fold_prefix;
+        let end_loc = start_loc.checked_add(elements.len() as u64)?;
+        let bp = Blueprint::new(self.leaves, start_loc..end_loc).ok()?;
 
-        let mut pinned_map: alloc::collections::BTreeMap<Position<F>, D> = pinned_positions
+        let mut pinned_map: BTreeMap<Position<F>, D> = pinned_positions
             .into_iter()
             .zip(pinned_nodes.iter().copied())
             .collect();
 
-        /// Reconstruct the digest at `pos` from the pinned node map.
-        ///
-        /// If `pos` is directly in the map, returns its digest. Otherwise, recurses into `F::children(pos,
-        /// height)` and hashes the results. This bridges the gap between `F::nodes_to_pin(start_loc)`
-        /// positions (peaks of the smaller tree) and the coarser prefix subtrees authenticated by the
-        /// proof, which can differ when the larger tree has merged smaller peaks.
-        fn reconstruct_from_pins<F: Family, D: Digest, H: Hasher<F, Digest = D>>(
-            hasher: &H,
-            pos: Position<F>,
-            pinned_map: &mut alloc::collections::BTreeMap<Position<F>, D>,
-        ) -> Option<D> {
-            if let Some(d) = pinned_map.remove(&pos) {
-                return Some(d);
+        // Fold-prefix peaks of the larger tree may have merged several pins together. Reconstruct
+        // each peak's digest by hashing the pins beneath it up to the peak, then compare the
+        // folded accumulator against the one the proof carries.
+        if let Some((first_sub, rest)) = bp.fold_prefix.split_first() {
+            let &expected = self.digests.first()?;
+            let mut acc = first_sub.reconstruct_from_pins(hasher, &mut pinned_map)?;
+            for sub in rest {
+                let d = sub.reconstruct_from_pins(hasher, &mut pinned_map)?;
+                acc = hasher.fold(&acc, &d);
             }
-            let height = F::pos_to_height(pos);
-            if height == 0 {
+            if acc != expected {
                 return None;
             }
-            let (left, right) = F::children(pos, height);
-            let left_d = reconstruct_from_pins(hasher, left, pinned_map)?;
-            let right_d = reconstruct_from_pins(hasher, right, pinned_map)?;
-            Some(hasher.node_digest(pos, &left_d, &right_d))
         }
 
-        // Verify fold-prefix pinned nodes by recomputing the accumulator.
-        //
-        // The fold_prefix positions are peaks of the `self.leaves`-sized tree that lie entirely
-        // before `start_loc`. The pinned_map positions are peaks of the `start_loc`-sized tree.
-        // These can differ when the larger tree has merged smaller peaks into bigger ones. To
-        // handle this, we reconstruct each fold_prefix peak's digest from the finer-grained pinned
-        // peaks by walking the tree via `F::children`, while tracking exactly which pinned
-        // positions were consumed by that reconstruction.
-        if let Some((&first_pos, rest)) = fold_prefix.split_first() {
-            if self.digests.is_empty() {
-                return false;
-            }
-            let Some(first) = reconstruct_from_pins(hasher, first_pos, &mut pinned_map) else {
-                return false;
-            };
-            let mut acc = first;
-            for &pos in rest {
-                let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
-                    return false;
-                };
-                acc = hasher.fold(&acc, &digest);
-            }
-            if acc != self.digests[0] {
-                return false;
+        // Sibling subtrees inside the first range peak that lie wholly before `start_loc` are
+        // authenticated directly by the proof (their digests appear in `extracted`). Rebuild each
+        // from the pins and compare.
+        let extracted: BTreeMap<Position<F>, D> = collected.into_iter().collect();
+        for sibling in bp.prefix_siblings() {
+            let &expected = extracted.get(&sibling.pos)?;
+            let d = sibling.reconstruct_from_pins(hasher, &mut pinned_map)?;
+            if d != expected {
+                return None;
             }
         }
 
-        // Verify any sibling subtrees that lie wholly before `start_loc`. These are the coarser
-        // prefix targets authenticated directly by the proof inside the first range peak. The
-        // provided pinned nodes may be a finer partition of the same prefix, so we reconstruct
-        // each authenticated prefix subtree from pins and compare digests.
-        let extracted: alloc::collections::BTreeMap<Position<F>, D> =
-            collected.into_iter().collect();
-
-        // Only the first range peak can contain siblings wholly before `start_loc`; later peaks are
-        // entirely at or after `start_loc` by `Blueprint::new`'s classification.
-        let mut prefix_siblings = Vec::new();
-        if let Some(peak) = bp.range_peaks.first() {
-            peak.collect_prefix_siblings(&bp.range, &mut prefix_siblings);
-        }
-        for pos in prefix_siblings {
-            let Some(&expected_digest) = extracted.get(&pos) else {
-                return false;
-            };
-            let Some(digest) = reconstruct_from_pins(hasher, pos, &mut pinned_map) else {
-                return false;
-            };
-            if digest != expected_digest {
-                return false;
-            }
-        }
-
-        // Every pin must have been consumed by either a fold-prefix peak reconstruction or a prefix
-        // sibling reconstruction.
-        pinned_map.is_empty()
+        // Every pin must have been consumed by one of the two reconstructions above.
+        pinned_map.is_empty().then_some(())
     }
 
     /// Like [`reconstruct_root`](Self::reconstruct_root), but if `collected` is `Some`, every
@@ -525,6 +505,16 @@ impl<F: Family> Subtree<F> {
         self.leaf_start + (1u64 << self.height)
     }
 
+    /// True if this subtree's leaves lie wholly before `range.start`.
+    fn is_before(&self, range: &Range<Location<F>>) -> bool {
+        self.leaf_end() <= range.start
+    }
+
+    /// True if this subtree's leaves lie wholly outside `range` (either before it or after it).
+    fn is_outside(&self, range: &Range<Location<F>>) -> bool {
+        self.is_before(range) || self.leaf_start >= range.end
+    }
+
     fn children(&self) -> (Self, Self) {
         let (left_pos, right_pos) = F::children(self.pos, self.height);
         let child_height = self.height - 1;
@@ -549,7 +539,7 @@ impl<F: Family> Subtree<F> {
     /// At each node: if the subtree is entirely outside the range, its root position is emitted. If
     /// it's a leaf in the range, nothing is emitted. Otherwise, recurse into children.
     fn collect_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
-        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+        if self.is_outside(range) {
             out.push(self.pos);
             return;
         }
@@ -561,16 +551,16 @@ impl<F: Family> Subtree<F> {
         }
     }
 
-    /// Collect sibling positions that lie wholly before the proven range, in the same
+    /// Collect sibling subtrees that lie wholly before the proven range, in the same
     /// left-first DFS order as [`collect_siblings`](Self::collect_siblings).
     ///
     /// Only `range.start` is consulted: the `range.end` side doesn't matter for prefix
     /// siblings. Pruning on `range.start` also keeps the traversal O(height) per peak —
     /// pruning only by `range.end` would recurse into both children whenever a subtree
     /// sits entirely inside the proven range, costing O(2^height) per such peak.
-    fn collect_prefix_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Position<F>>) {
-        if self.leaf_end() <= range.start {
-            out.push(self.pos);
+    fn collect_prefix_siblings(&self, range: &Range<Location<F>>, out: &mut Vec<Self>) {
+        if self.is_before(range) {
+            out.push(*self);
             return;
         }
 
@@ -583,6 +573,36 @@ impl<F: Family> Subtree<F> {
             left.collect_prefix_siblings(range, out);
             right.collect_prefix_siblings(range, out);
         }
+    }
+
+    /// Reconstruct this subtree's digest from a set of finer-grained pinned positions, consuming
+    /// each pin as it is used.
+    ///
+    /// Walks down via [`Self::children`] until each recursion hits a pin, then hashes back up with
+    /// [`Hasher::node_digest`] for position-keyed domain separation. Returns `None` if any required
+    /// pin is missing.
+    ///
+    /// On failure, `pinned_map` may have been partially consumed. Callers are expected to return
+    /// immediately without inspecting it further.
+    fn reconstruct_from_pins<D, H>(
+        &self,
+        hasher: &H,
+        pinned_map: &mut BTreeMap<Position<F>, D>,
+    ) -> Option<D>
+    where
+        D: Digest,
+        H: Hasher<F, Digest = D>,
+    {
+        if let Some(d) = pinned_map.remove(&self.pos) {
+            return Some(d);
+        }
+        if self.height == 0 {
+            return None;
+        }
+        let (left, right) = self.children();
+        let left_d = left.reconstruct_from_pins(hasher, pinned_map)?;
+        let right_d = right.reconstruct_from_pins(hasher, pinned_map)?;
+        Some(hasher.node_digest(self.pos, &left_d, &right_d))
     }
 
     /// Reconstruct the digest of this subtree from a range of elements and sibling digests,
@@ -610,7 +630,7 @@ impl<F: Family> Subtree<F> {
         E: Iterator<Item: AsRef<[u8]>>,
     {
         // Entirely outside the range: consume a sibling digest.
-        if self.leaf_end() <= range.start || self.leaf_start >= range.end {
+        if self.is_outside(range) {
             let Some(digest) = siblings.get(*cursor).copied() else {
                 return Err(ReconstructionError::MissingDigests);
             };
@@ -628,9 +648,6 @@ impl<F: Family> Subtree<F> {
 
         // Recurse into children.
         let (left, right) = self.children();
-        let left_pos = left.pos;
-        let right_pos = right.pos;
-
         let left_d = left.reconstruct_digest(
             hasher,
             range,
@@ -649,8 +666,8 @@ impl<F: Family> Subtree<F> {
         )?;
 
         if let Some(ref mut cd) = collected {
-            cd.push((left_pos, left_d));
-            cd.push((right_pos, right_d));
+            cd.push((left.pos, left_d));
+            cd.push((right.pos, right_d));
         }
 
         Ok(hasher.node_digest(self.pos, &left_d, &right_d))
@@ -663,8 +680,8 @@ pub(crate) struct Blueprint<F: Family> {
     leaves: Location<F>,
     /// The location range this blueprint was built for.
     pub range: Range<Location<F>>,
-    /// Peak positions that precede the proven range (to be folded into a single accumulator).
-    pub fold_prefix: Vec<Position<F>>,
+    /// Peaks that precede the proven range (to be folded into a single accumulator).
+    pub fold_prefix: Vec<Subtree<F>>,
     /// Peak positions entirely after the proven range.
     pub after_peaks: Vec<Position<F>>,
     /// The peaks that overlap the proven range.
@@ -726,7 +743,11 @@ impl<F: Family> Blueprint<F> {
             let leaf_end = leaf_start + (1u64 << height);
 
             if leaf_end <= range.start {
-                fold_prefix.push(peak_pos);
+                fold_prefix.push(Subtree {
+                    pos: peak_pos,
+                    height,
+                    leaf_start,
+                });
             } else if leaf_start >= range.end {
                 after_peaks.push(peak_pos);
             } else {
@@ -759,6 +780,18 @@ impl<F: Family> Blueprint<F> {
         })
     }
 
+    /// Sibling subtrees of the first range peak that lie wholly before `self.range.start`.
+    ///
+    /// Only the first range peak can contain such siblings; later range peaks are entirely at or
+    /// after `range.start` by this blueprint's classification.
+    pub(crate) fn prefix_siblings(&self) -> Vec<Subtree<F>> {
+        let mut out = Vec::new();
+        if let Some(peak) = self.range_peaks.first() {
+            peak.collect_prefix_siblings(&self.range, &mut out);
+        }
+        out
+    }
+
     /// Build a range proof from this blueprint and a node-fetching closure.
     ///
     /// The prover folds prefix peak digests into a single accumulator. The resulting proof
@@ -780,10 +813,10 @@ impl<F: Family> Blueprint<F> {
             if self.fold_prefix.is_empty() { 0 } else { 1 } + self.fetch_nodes.len(),
         );
 
-        if let Some((&first_pos, rest)) = self.fold_prefix.split_first() {
-            let first = get_node(first_pos).ok_or_else(|| element_pruned(first_pos))?;
-            let acc = rest.iter().try_fold(first, |acc, &pos| {
-                let d = get_node(pos).ok_or_else(|| element_pruned(pos))?;
+        if let Some((first_sub, rest)) = self.fold_prefix.split_first() {
+            let first = get_node(first_sub.pos).ok_or_else(|| element_pruned(first_sub.pos))?;
+            let acc = rest.iter().try_fold(first, |acc, sub| {
+                let d = get_node(sub.pos).ok_or_else(|| element_pruned(sub.pos))?;
                 Ok(hasher.fold(&acc, &d))
             })?;
             digests.push(acc);
@@ -842,7 +875,7 @@ pub(crate) fn nodes_required_for_multi_proof<F: Family>(
             return Err(super::Error::LocationOverflow(*loc));
         }
         let bp = Blueprint::new(leaves, *loc..*loc + 1)?;
-        acc.extend(bp.fold_prefix);
+        acc.extend(bp.fold_prefix.into_iter().map(|s| s.pos));
         acc.extend(bp.fetch_nodes);
         Ok(acc)
     })
@@ -1819,7 +1852,7 @@ mod tests {
                 let loc = Location::new(loc);
                 let bp = Blueprint::<F>::new(leaves, loc..loc + 1).unwrap();
                 let mut positions: Vec<Position<F>> = Vec::new();
-                positions.extend(&bp.fold_prefix);
+                positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
                 positions.extend(&bp.fetch_nodes);
                 let set: BTreeSet<_> = positions.iter().copied().collect();
                 assert_eq!(

--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -95,12 +95,12 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
             // Start from the stored fold accumulator (which does not include the leaf count).
             let mut acc = self.fold_acc;
             // Fold in peaks beyond those already covered by the stored accumulator.
-            for &pos in bp.fold_prefix.iter().skip(self.num_fold_peaks) {
-                match self.digests.get(&pos) {
+            for sub in bp.fold_prefix.iter().skip(self.num_fold_peaks) {
+                match self.digests.get(&sub.pos) {
                     Some(d) => {
                         acc = Some(acc.map_or(*d, |a| hasher.fold(&a, d)));
                     }
-                    None => return Err(Error::ElementPruned(pos)),
+                    None => return Err(Error::ElementPruned(sub.pos)),
                 }
             }
             digests.push(acc.expect("fold_prefix is non-empty so acc must be set"));
@@ -198,11 +198,11 @@ pub async fn historical_range_proof<
 
     let mut digests: Vec<D> = Vec::new();
     if !bp.fold_prefix.is_empty() {
-        let node_futures = bp.fold_prefix.iter().map(|&pos| merkle.get_node(pos));
+        let node_futures = bp.fold_prefix.iter().map(|sub| merkle.get_node(sub.pos));
         let results = try_join_all(node_futures).await?;
-        let mut acc = results[0].ok_or(Error::ElementPruned(bp.fold_prefix[0]))?;
+        let mut acc = results[0].ok_or(Error::ElementPruned(bp.fold_prefix[0].pos))?;
         for (i, &result) in results.iter().enumerate().skip(1) {
-            let d = result.ok_or(Error::ElementPruned(bp.fold_prefix[i]))?;
+            let d = result.ok_or(Error::ElementPruned(bp.fold_prefix[i].pos))?;
             acc = hasher.fold(&acc, &d);
         }
         digests.push(acc);

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -100,7 +100,20 @@ where
 {
     /// Return the inactivity floor location. This is the location before which all operations are
     /// known to be inactive. Operations before this point can be safely pruned.
-    pub const fn inactivity_floor_loc(&self) -> Location<F> {
+    ///
+    /// This is an implementation detail of the activity tracking; external callers should
+    /// prefer [`Self::sync_boundary`] when constructing a sync target.
+    pub(crate) const fn inactivity_floor_loc(&self) -> Location<F> {
+        self.inactivity_floor_loc
+    }
+
+    /// Return the most recent location from which this database can safely be synced.
+    ///
+    /// Callers constructing a sync [`Target`](crate::qmdb::sync::Target) may use this value, or
+    /// any earlier retained location, as `range.start`. For `any` databases this equals the
+    /// inactivity floor; the receiver's reconstruction does not require chunk alignment, so any
+    /// retained earlier location is also valid.
+    pub const fn sync_boundary(&self) -> Location<F> {
         self.inactivity_floor_loc
     }
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -1666,9 +1666,9 @@ pub(crate) mod test {
         type TestMmr = Mmr<deterministic::Context, Digest>;
 
         impl FromSyncTestable for AnyTest {
-            type Mmr = TestMmr;
+            type Merkle = TestMmr;
 
-            fn into_log_components(self) -> (Self::Mmr, Self::Journal) {
+            fn into_log_components(self) -> (Self::Merkle, Self::Journal) {
                 (self.log.merkle, self.log.journal)
             }
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -605,9 +605,9 @@ pub(crate) mod test {
         type TestMmr = Mmr<deterministic::Context, Digest>;
 
         impl FromSyncTestable for AnyTest {
-            type Mmr = TestMmr;
+            type Merkle = TestMmr;
 
-            fn into_log_components(self) -> (Self::Mmr, Self::Journal) {
+            fn into_log_components(self) -> (Self::Merkle, Self::Journal) {
                 (self.log.merkle, self.log.journal)
             }
 

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         authenticated,
         contiguous::{fixed, variable, Mutable},
     },
-    merkle::mmr::{self, journaled, Location, StandardHasher},
+    merkle::{self, hasher::Standard as StandardHasher, journaled, Location},
     qmdb::{
         self,
         any::{
@@ -48,19 +48,20 @@ use std::ops::Range;
 pub(crate) mod tests;
 
 /// Shared helper to build a [Db] from sync components.
-async fn build_db<E, O, I, H, U, C, T>(
+async fn build_db<F, E, O, I, H, U, C, T>(
     context: E,
-    mmr_config: journaled::Config,
+    merkle_config: journaled::Config,
     log: C,
     translator: T,
     pinned_nodes: Option<Vec<H::Digest>>,
-    range: Range<Location>,
+    range: Range<Location<F>>,
     apply_batch_size: usize,
-) -> Result<Db<mmr::Family, E, C, I, H, U>, qmdb::Error<mmr::Family>>
+) -> Result<Db<F, E, C, I, H, U>, qmdb::Error<F>>
 where
+    F: merkle::Family,
     E: Context,
-    O: Operation<mmr::Family> + Committable + CodecShared + Send + Sync + 'static,
-    I: IndexFactory<T, Value = Location>,
+    O: Operation<F> + Committable + CodecShared + Send + Sync + 'static,
+    I: IndexFactory<T, Value = Location<F>>,
     H: Hasher,
     U: Send + Sync + 'static,
     T: Translator,
@@ -68,10 +69,10 @@ where
 {
     let hasher = StandardHasher::<H>::new();
 
-    let mmr = crate::mmr::journaled::Mmr::init_sync(
-        context.with_label("mmr"),
-        crate::mmr::journaled::SyncConfig {
-            config: mmr_config,
+    let merkle = journaled::Journaled::<F, _, _>::init_sync(
+        context.with_label("merkle"),
+        journaled::SyncConfig {
+            config: merkle_config,
             range: range.clone(),
             pinned_nodes,
         },
@@ -81,8 +82,8 @@ where
 
     let index = I::new(context.with_label("index"), translator);
 
-    let log = authenticated::Journal::<mmr::Family, _, _, _>::from_components(
-        mmr,
+    let log = authenticated::Journal::<F, _, _, _>::from_components(
+        merkle,
         log,
         hasher,
         apply_batch_size as u64,
@@ -98,8 +99,9 @@ macro_rules! impl_sync_database {
      $journal:ty, $config:ty,
      $key_bound:path, $value_bound:ident
      $(; $($where_extra:tt)+)?) => {
-        impl<E, K, V, H, T> qmdb::sync::Database for $db<mmr::Family, E, K, V, H, T>
+        impl<F, E, K, V, H, T> qmdb::sync::Database for $db<F, E, K, V, H, T>
         where
+            F: merkle::Family,
             E: Context,
             K: $key_bound,
             V: $value_bound + 'static,
@@ -107,8 +109,9 @@ macro_rules! impl_sync_database {
             T: Translator,
             $($($where_extra)+)?
         {
+            type Family = F;
             type Context = E;
-            type Op = $op<mmr::Family, K, V>;
+            type Op = $op<F, K, V>;
             type Journal = $journal;
             type Hasher = H;
             type Config = $config;
@@ -119,14 +122,14 @@ macro_rules! impl_sync_database {
                 config: Self::Config,
                 log: Self::Journal,
                 pinned_nodes: Option<Vec<Self::Digest>>,
-                range: Range<Location>,
+                range: Range<Location<F>>,
                 apply_batch_size: usize,
-            ) -> Result<Self, qmdb::Error<mmr::Family>> {
-                let mmr_config = config.merkle_config.clone();
+            ) -> Result<Self, qmdb::Error<F>> {
+                let merkle_config = config.merkle_config.clone();
                 let translator = config.translator.clone();
-                build_db::<_, Self::Op, _, H, $update<K, V>, _, T>(
+                build_db::<F, _, Self::Op, _, H, $update<K, V>, _, T>(
                     context,
-                    mmr_config,
+                    merkle_config,
                     log,
                     translator,
                     pinned_nodes,
@@ -152,9 +155,9 @@ impl_sync_database!(
 impl_sync_database!(
     UnorderedVariableDb, UnorderedVariableOp, UnorderedVariableUpdate,
     variable::Journal<E, Self::Op>,
-    VariableConfig<T, <UnorderedVariableOp<mmr::Family, K, V> as CodecRead>::Cfg>,
+    VariableConfig<T, <UnorderedVariableOp<F, K, V> as CodecRead>::Cfg>,
     Key, VariableValue;
-    UnorderedVariableOp<mmr::Family, K, V>: CodecShared
+    UnorderedVariableOp<F, K, V>: CodecShared
 );
 
 impl_sync_database!(
@@ -166,7 +169,7 @@ impl_sync_database!(
 impl_sync_database!(
     OrderedVariableDb, OrderedVariableOp, OrderedVariableUpdate,
     variable::Journal<E, Self::Op>,
-    VariableConfig<T, <OrderedVariableOp<mmr::Family, K, V> as CodecRead>::Cfg>,
+    VariableConfig<T, <OrderedVariableOp<F, K, V> as CodecRead>::Cfg>,
     Key, VariableValue;
-    OrderedVariableOp<mmr::Family, K, V>: CodecShared
+    OrderedVariableOp<F, K, V>: CodecShared
 );

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     journal::contiguous::Contiguous,
-    merkle::{mmr, mmr::Location},
+    merkle::{self, Location},
     qmdb::{
         self,
         any::traits::DbAny,
@@ -46,40 +46,56 @@ pub(crate) type ConfigOf<H> = <DbOf<H> as qmdb::sync::Database>::Config;
 /// Type alias for the journal type of a harness.
 pub(crate) type JournalOf<H> = <DbOf<H> as qmdb::sync::Database>::Journal;
 
+/// Type alias for the merkle family used by a harness.
+pub(crate) type FamilyOf<H> = <DbOf<H> as qmdb::sync::Database>::Family;
+
 /// Trait for cleanup operations in tests.
 pub(crate) trait Destructible {
+    type Family: merkle::Family;
+
     fn destroy(
         self,
-    ) -> impl std::future::Future<Output = Result<(), qmdb::Error<crate::mmr::Family>>> + Send;
+    ) -> impl std::future::Future<Output = Result<(), qmdb::Error<Self::Family>>> + Send;
 }
 
-// Implement Destructible for the concrete MMR type used in tests.
+// Implement Destructible once for the generic journaled Merkle type used in tests.
 // This is here (rather than in fixed/variable modules) to avoid duplicate implementations.
-impl Destructible for crate::mmr::journaled::Mmr<deterministic::Context, Digest> {
-    async fn destroy(self) -> Result<(), qmdb::Error<crate::mmr::Family>> {
+impl<F: merkle::Family> Destructible
+    for crate::merkle::journaled::Journaled<F, deterministic::Context, Digest>
+{
+    type Family = F;
+
+    async fn destroy(self) -> Result<(), qmdb::Error<F>> {
         self.destroy().await.map_err(qmdb::Error::Merkle)
     }
 }
 
 /// Trait providing internal access for from_sync_result tests.
 pub(crate) trait FromSyncTestable: qmdb::sync::Database {
-    type Mmr: Destructible + Send;
+    type Merkle: Destructible<Family = Self::Family> + Send;
 
-    /// Get the MMR and journal from the database
-    fn into_log_components(self) -> (Self::Mmr, Self::Journal);
+    /// Get the Merkle structure and journal from the database.
+    fn into_log_components(self) -> (Self::Merkle, Self::Journal);
 
     /// Get the pinned nodes at a given location
     fn pinned_nodes_at(
         &self,
-        loc: Location,
+        loc: Location<Self::Family>,
     ) -> impl std::future::Future<Output = Vec<Self::Digest>> + Send;
 }
 
 /// Harness for sync tests.
 pub(crate) trait SyncTestHarness: Sized + 'static {
+    /// The merkle family the database under test uses.
+    type Family: merkle::Family;
+
     /// The database type being tested.
-    type Db: qmdb::sync::Database<Context = deterministic::Context, Digest = Digest, Config: Clone>
-        + DbAny<mmr::Family, Key = Digest, Digest = Digest>;
+    type Db: qmdb::sync::Database<
+            Family = Self::Family,
+            Context = deterministic::Context,
+            Digest = Digest,
+            Config: Clone,
+        > + DbAny<Self::Family, Key = Digest, Digest = Digest>;
 
     /// Return the root the sync engine targets.
     fn sync_target_root(db: &Self::Db) -> Digest;
@@ -113,7 +129,7 @@ pub(crate) trait SyncTestHarness: Sized + 'static {
 /// Test that empty operations arrays fetched do not cause panics when stored and applied
 pub(crate) fn test_sync_empty_operations_no_panic<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -158,13 +174,14 @@ where
 /// Test that resolver failure is handled correctly
 pub(crate) fn test_sync_resolver_fails<H: SyncTestHarness>()
 where
-    resolver::tests::FailResolver<OpOf<H>, Digest>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    resolver::tests::FailResolver<FamilyOf<H>, OpOf<H>, Digest>:
+        Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
     let executor = deterministic::Runner::default();
     executor.start(|mut context| async move {
-        let resolver = resolver::tests::FailResolver::<OpOf<H>, Digest>::new();
+        let resolver = resolver::tests::FailResolver::<FamilyOf<H>, OpOf<H>, Digest>::new();
         let target_root = Digest::from([0; 32]);
 
         let db_config = H::config(&context.next_u64().to_string(), &context);
@@ -193,7 +210,7 @@ where
 /// Test basic sync functionality with various batch sizes
 pub(crate) fn test_sync<H: SyncTestHarness>(target_db_ops: usize, fetch_batch_size: NonZeroU64)
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -276,8 +293,8 @@ where
 /// Test syncing to a subset of the target database (target has additional ops beyond sync range)
 pub(crate) fn test_sync_subset_of_target_database<H: SyncTestHarness>(target_db_ops: usize)
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone + OperationTrait<mmr::Family, Key = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone + OperationTrait<FamilyOf<H>, Key = Digest>,
     JournalOf<H>: Contiguous,
 {
     let executor = deterministic::Runner::default();
@@ -342,8 +359,8 @@ where
 /// Tests the scenario where sync_db already has partial data and needs to sync additional ops.
 pub(crate) fn test_sync_use_existing_db_partial_match<H: SyncTestHarness>(original_ops: usize)
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone + OperationTrait<mmr::Family, Key = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone + OperationTrait<FamilyOf<H>, Key = Digest>,
     JournalOf<H>: Contiguous,
 {
     let executor = deterministic::Runner::default();
@@ -437,8 +454,9 @@ where
 /// Uses FailResolver to verify that no network requests are made since data already exists.
 pub(crate) fn test_sync_use_existing_db_exact_match<H: SyncTestHarness>(num_ops: usize)
 where
-    resolver::tests::FailResolver<OpOf<H>, Digest>: Resolver<Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone + OperationTrait<mmr::Family, Key = Digest>,
+    resolver::tests::FailResolver<FamilyOf<H>, OpOf<H>, Digest>:
+        Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone + OperationTrait<FamilyOf<H>, Key = Digest>,
     JournalOf<H>: Contiguous,
 {
     let executor = deterministic::Runner::default();
@@ -480,7 +498,7 @@ where
         // sync_db should never ask the resolver for operations
         // because it is already complete. Use a resolver that always fails
         // to ensure that it's not being used.
-        let resolver = resolver::tests::FailResolver::<OpOf<H>, Digest>::new();
+        let resolver = resolver::tests::FailResolver::<FamilyOf<H>, OpOf<H>, Digest>::new();
         let config = Config {
             db_config: sync_config, // Use same config to access same partitions
             fetch_batch_size: NZU64!(10),
@@ -525,7 +543,7 @@ where
 /// Test that the client fails to sync if the lower bound is decreased via target update.
 pub(crate) fn test_target_update_lower_bound_decrease<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -594,7 +612,7 @@ where
 /// Test that the client fails to sync if the upper bound is decreased via target update.
 pub(crate) fn test_target_update_upper_bound_decrease<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -663,7 +681,7 @@ where
 /// Test that the client succeeds when bounds are updated (increased).
 pub(crate) fn test_target_update_bounds_increase<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode + Clone,
     JournalOf<H>: Contiguous,
 {
@@ -748,7 +766,7 @@ where
 /// Test that target updates can be sent even after the client is done (no panic).
 pub(crate) fn test_target_update_on_done_client<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -817,7 +835,7 @@ where
 /// Test that explicit finish control waits for a finish signal even after reaching target.
 pub(crate) fn test_sync_waits_for_explicit_finish<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -920,7 +938,7 @@ where
 /// Test that a finish signal received before target completion still allows full sync.
 pub(crate) fn test_sync_handles_early_finish_signal<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -983,7 +1001,7 @@ where
 /// Test that dropping finish sender without sending is treated as an error.
 pub(crate) fn test_sync_fails_when_finish_sender_dropped<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -1032,7 +1050,7 @@ where
 /// Test that dropping reached-target receiver does not fail sync.
 pub(crate) fn test_sync_allows_dropped_reached_target_receiver<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -1086,7 +1104,8 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
     initial_ops: usize,
     additional_ops: usize,
 ) where
-    Arc<AsyncRwLock<Option<DbOf<H>>>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<AsyncRwLock<Option<DbOf<H>>>>:
+        Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode + Clone,
     JournalOf<H>: Contiguous,
 {
@@ -1197,7 +1216,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
 /// Test demonstrating that a synced database can be reopened and retain its state.
 pub(crate) fn test_sync_database_persistence<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode + Clone,
     JournalOf<H>: Contiguous,
 {
@@ -1271,7 +1290,7 @@ where
 /// Test post-sync usability: after syncing, the database supports normal operations.
 pub(crate) fn test_sync_post_sync_usability<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -1567,19 +1586,23 @@ struct CorruptFirstPinnedNodesResolver<R> {
     corrupted: Arc<std::sync::atomic::AtomicBool>,
 }
 
-impl<R: Resolver<Digest = Digest>> Resolver for CorruptFirstPinnedNodesResolver<R> {
+impl<R> Resolver for CorruptFirstPinnedNodesResolver<R>
+where
+    R: Resolver<Digest = Digest>,
+{
+    type Family = R::Family;
     type Digest = Digest;
     type Op = R::Op;
     type Error = R::Error;
 
     async fn get_operations(
         &self,
-        op_count: Location,
-        start_loc: Location,
+        op_count: Location<Self::Family>,
+        start_loc: Location<Self::Family>,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
         cancel_rx: oneshot::Receiver<()>,
-    ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+    ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
         let mut result = self
             .inner
             .get_operations(
@@ -1610,7 +1633,7 @@ impl<R: Resolver<Digest = Digest>> Resolver for CorruptFirstPinnedNodesResolver<
 /// succeeds on retry when the resolver returns correct data.
 pub(crate) fn test_sync_retries_bad_pinned_nodes<H: SyncTestHarness>()
 where
-    Arc<DbOf<H>>: Resolver<Op = OpOf<H>, Digest = Digest>,
+    Arc<DbOf<H>>: Resolver<Family = FamilyOf<H>, Op = OpOf<H>, Digest = Digest>,
     OpOf<H>: Encode,
     JournalOf<H>: Contiguous,
 {
@@ -1663,15 +1686,126 @@ where
 
 mod harnesses {
     use super::SyncTestHarness;
-    use crate::{qmdb::any::value::VariableEncoding, translator::TwoCap};
+    use crate::{
+        merkle::{self, mmb},
+        qmdb::any::value::VariableEncoding,
+        translator::TwoCap,
+    };
     use commonware_cryptography::sha256::Digest;
+    use commonware_math::algebra::Random;
     use commonware_runtime::{deterministic::Context, BufferPooler};
+    use commonware_utils::test_rng_seeded;
+    use rand::RngCore;
+
+    // ===== Family-generic op creation helpers =====
+    //
+    // `Operation<F, K, V>` is phantom in F for Update/Delete variants, so ops
+    // are structurally identical across families.
+
+    fn create_ordered_fixed_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let next_key = Digest::random(&mut rng);
+                let value = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update {
+                    key,
+                    value,
+                    next_key,
+                }));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_unordered_fixed_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let value = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update(key, value)));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_ordered_variable_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::ordered::variable::Operation<F, Digest, Vec<u8>>> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let next_key = Digest::random(&mut rng);
+                let len = ((rng.next_u64() % 13) + 7) as usize;
+                let value = vec![(rng.next_u64() % 255) as u8; len];
+                ops.push(Operation::Update(Update {
+                    key,
+                    value,
+                    next_key,
+                }));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_unordered_variable_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::unordered::variable::Operation<F, Digest, Vec<u8>>> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let len = ((rng.next_u64() % 13) + 7) as usize;
+                let value = vec![(rng.next_u64() % 255) as u8; len];
+                ops.push(Operation::Update(Update(key, value)));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    // ===== MMR harnesses (existing, unchanged) =====
 
     // ----- Ordered/Fixed -----
 
     pub struct OrderedFixedHarness;
 
     impl SyncTestHarness for OrderedFixedHarness {
+        type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::ordered::fixed::test::AnyTest;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
@@ -1729,6 +1863,7 @@ mod harnesses {
     pub struct OrderedVariableHarness;
 
     impl SyncTestHarness for OrderedVariableHarness {
+        type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::ordered::variable::test::AnyTest;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
@@ -1793,6 +1928,7 @@ mod harnesses {
     pub struct UnorderedFixedHarness;
 
     impl SyncTestHarness for UnorderedFixedHarness {
+        type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::unordered::fixed::test::AnyTest;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
@@ -1850,6 +1986,7 @@ mod harnesses {
     pub struct UnorderedVariableHarness;
 
     impl SyncTestHarness for UnorderedVariableHarness {
+        type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::unordered::variable::test::AnyTest;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
@@ -1909,6 +2046,323 @@ mod harnesses {
                 .merkleize(&db, None::<Vec<u8>>)
                 .await
                 .unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db
+        }
+    }
+
+    // ===== MMB harnesses =====
+
+    // ----- Ordered/Fixed MMB -----
+
+    pub struct OrderedFixedMmbHarness;
+
+    impl SyncTestHarness for OrderedFixedMmbHarness {
+        type Family = mmb::Family;
+        type Db = crate::qmdb::any::ordered::fixed::Db<
+            mmb::Family,
+            Context,
+            Digest,
+            Digest,
+            commonware_cryptography::Sha256,
+            TwoCap,
+        >;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            db.root()
+        }
+
+        fn config(
+            suffix: &str,
+            pooler: &impl BufferPooler,
+        ) -> crate::qmdb::any::FixedConfig<TwoCap> {
+            crate::qmdb::any::test::fixed_db_config(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>> {
+            create_ordered_fixed_ops(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>> {
+            create_ordered_fixed_ops(n, seed)
+        }
+
+        async fn init_db(mut ctx: Context) -> Self::Db {
+            let seed = ctx.next_u64();
+            let cfg = crate::qmdb::any::test::fixed_db_config::<TwoCap>(&seed.to_string(), &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(
+            ctx: Context,
+            config: crate::qmdb::any::FixedConfig<TwoCap>,
+        ) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            mut db: Self::Db,
+            ops: Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            use crate::qmdb::any::operation::Operation;
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(data) => {
+                        batch = batch.write(data.key, Some(data.value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db
+        }
+    }
+
+    // ----- Ordered/Variable MMB -----
+
+    pub struct OrderedVariableMmbHarness;
+
+    impl SyncTestHarness for OrderedVariableMmbHarness {
+        type Family = mmb::Family;
+        type Db = crate::qmdb::any::ordered::variable::Db<
+            mmb::Family,
+            Context,
+            Digest,
+            Vec<u8>,
+            commonware_cryptography::Sha256,
+            TwoCap,
+        >;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            db.root()
+        }
+
+        fn config(
+            suffix: &str,
+            pooler: &impl BufferPooler,
+        ) -> crate::qmdb::any::ordered::variable::test::VarConfig {
+            crate::qmdb::any::ordered::variable::test::create_test_config(
+                suffix.parse().unwrap_or(0),
+                pooler,
+            )
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>
+        {
+            create_ordered_variable_ops(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>
+        {
+            create_ordered_variable_ops(n, seed)
+        }
+
+        async fn init_db(mut ctx: Context) -> Self::Db {
+            let seed = ctx.next_u64();
+            let config = crate::qmdb::any::ordered::variable::test::create_test_config(seed, &ctx);
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn init_db_with_config(
+            ctx: Context,
+            config: crate::qmdb::any::ordered::variable::test::VarConfig,
+        ) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            mut db: Self::Db,
+            ops: Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>,
+        ) -> Self::Db {
+            use crate::qmdb::any::operation::Operation;
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(data) => {
+                        batch = batch.write(data.key, Some(data.value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            let merkleized = batch.merkleize(&db, None::<Vec<u8>>).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db
+        }
+    }
+
+    // ----- Unordered/Fixed MMB -----
+
+    pub struct UnorderedFixedMmbHarness;
+
+    impl SyncTestHarness for UnorderedFixedMmbHarness {
+        type Family = mmb::Family;
+        type Db = crate::qmdb::any::unordered::fixed::Db<
+            mmb::Family,
+            Context,
+            Digest,
+            Digest,
+            commonware_cryptography::Sha256,
+            TwoCap,
+        >;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            db.root()
+        }
+
+        fn config(
+            suffix: &str,
+            pooler: &impl BufferPooler,
+        ) -> crate::qmdb::any::FixedConfig<TwoCap> {
+            crate::qmdb::any::test::fixed_db_config(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_fixed_ops(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_fixed_ops(n, seed)
+        }
+
+        async fn init_db(mut ctx: Context) -> Self::Db {
+            let seed = ctx.next_u64();
+            let cfg = crate::qmdb::any::test::fixed_db_config::<TwoCap>(&seed.to_string(), &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(
+            ctx: Context,
+            config: crate::qmdb::any::FixedConfig<TwoCap>,
+        ) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            mut db: Self::Db,
+            ops: Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            use crate::qmdb::any::operation::Operation;
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(data) => {
+                        batch = batch.write(data.0, Some(data.1));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db
+        }
+    }
+
+    // ----- Unordered/Variable MMB -----
+
+    pub struct UnorderedVariableMmbHarness;
+
+    impl SyncTestHarness for UnorderedVariableMmbHarness {
+        type Family = mmb::Family;
+        type Db = crate::qmdb::any::unordered::variable::Db<
+            mmb::Family,
+            Context,
+            Digest,
+            Vec<u8>,
+            commonware_cryptography::Sha256,
+            TwoCap,
+        >;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            db.root()
+        }
+
+        fn config(
+            suffix: &str,
+            pooler: &impl BufferPooler,
+        ) -> crate::qmdb::any::unordered::variable::test::VarConfig {
+            crate::qmdb::any::unordered::variable::test::create_test_config(
+                suffix.parse().unwrap_or(0),
+                pooler,
+            )
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>
+        {
+            create_unordered_variable_ops(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>
+        {
+            create_unordered_variable_ops(n, seed)
+        }
+
+        async fn init_db(mut ctx: Context) -> Self::Db {
+            let seed = ctx.next_u64();
+            let config =
+                crate::qmdb::any::unordered::variable::test::create_test_config(seed, &ctx);
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn init_db_with_config(
+            ctx: Context,
+            config: crate::qmdb::any::unordered::variable::test::VarConfig,
+        ) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            mut db: Self::Db,
+            ops: Vec<
+                crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Vec<u8>>,
+            >,
+        ) -> Self::Db {
+            use crate::qmdb::any::operation::Operation;
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(data) => {
+                        batch = batch.write(data.0, Some(data.1));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            let merkleized = batch.merkleize(&db, None::<Vec<u8>>).await.unwrap();
             db.apply_batch(merkleized).await.unwrap();
             db
         }
@@ -2041,6 +2495,17 @@ macro_rules! sync_tests_for_harness {
             fn test_sync_retries_bad_pinned_nodes() {
                 super::test_sync_retries_bad_pinned_nodes::<$harness>();
             }
+        }
+    };
+}
+
+/// Additional from_sync_result tests that require `FromSyncTestable`.
+/// Only the MMR harnesses have `FromSyncTestable` impls.
+macro_rules! from_sync_result_tests_for_harness {
+    ($harness:ty, $mod_name:ident) => {
+        mod $mod_name {
+            use super::harnesses;
+            use commonware_macros::test_traced;
 
             #[test_traced("WARN")]
             fn test_from_sync_result_empty_to_empty() {
@@ -2065,7 +2530,28 @@ macro_rules! sync_tests_for_harness {
     };
 }
 
+// MMR harnesses (all tests including from_sync_result)
 sync_tests_for_harness!(harnesses::OrderedFixedHarness, ordered_fixed);
 sync_tests_for_harness!(harnesses::OrderedVariableHarness, ordered_variable);
 sync_tests_for_harness!(harnesses::UnorderedFixedHarness, unordered_fixed);
 sync_tests_for_harness!(harnesses::UnorderedVariableHarness, unordered_variable);
+
+from_sync_result_tests_for_harness!(harnesses::OrderedFixedHarness, ordered_fixed_from_sync);
+from_sync_result_tests_for_harness!(
+    harnesses::OrderedVariableHarness,
+    ordered_variable_from_sync
+);
+from_sync_result_tests_for_harness!(harnesses::UnorderedFixedHarness, unordered_fixed_from_sync);
+from_sync_result_tests_for_harness!(
+    harnesses::UnorderedVariableHarness,
+    unordered_variable_from_sync
+);
+
+// MMB harnesses (sync tests only, no from_sync_result)
+sync_tests_for_harness!(harnesses::OrderedFixedMmbHarness, ordered_fixed_mmb);
+sync_tests_for_harness!(harnesses::OrderedVariableMmbHarness, ordered_variable_mmb);
+sync_tests_for_harness!(harnesses::UnorderedFixedMmbHarness, unordered_fixed_mmb);
+sync_tests_for_harness!(
+    harnesses::UnorderedVariableMmbHarness,
+    unordered_variable_mmb
+);

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -798,9 +798,9 @@ pub(crate) mod test {
         type TestMmr = Mmr<deterministic::Context, Digest>;
 
         impl FromSyncTestable for AnyTest {
-            type Mmr = TestMmr;
+            type Merkle = TestMmr;
 
-            fn into_log_components(self) -> (Self::Mmr, Self::Journal) {
+            fn into_log_components(self) -> (Self::Merkle, Self::Journal) {
                 (self.log.merkle, self.log.journal)
             }
 

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -720,9 +720,9 @@ pub(crate) mod test {
         type TestMmr = Mmr<deterministic::Context, Digest>;
 
         impl FromSyncTestable for AnyTest {
-            type Mmr = TestMmr;
+            type Merkle = TestMmr;
 
-            fn into_log_components(self) -> (Self::Mmr, Self::Journal) {
+            fn into_log_components(self) -> (Self::Merkle, Self::Journal) {
                 (self.log.merkle, self.log.journal)
             }
 

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -102,7 +102,10 @@ where
 {
     /// Return the inactivity floor location. This is the location before which all operations are
     /// known to be inactive. Operations before this point can be safely pruned.
-    pub const fn inactivity_floor_loc(&self) -> Location<F> {
+    ///
+    /// This is an implementation detail of the activity tracking; external callers should
+    /// prefer [`Self::sync_boundary`] when constructing a sync target or calling [`Self::prune`].
+    pub(crate) const fn inactivity_floor_loc(&self) -> Location<F> {
         self.any.inactivity_floor_loc()
     }
 
@@ -264,6 +267,21 @@ where
         self.any.pinned_nodes_at(loc).await
     }
 
+    /// Returns the most recent location from which this database can safely be synced.
+    ///
+    /// Callers constructing a sync [`Target`](crate::qmdb::sync::Target) may use this value, or
+    /// any earlier retained location, as `range.start`. Values *above* this boundary are unsafe:
+    /// the receiver's grafted-pin derivation requires chunk-aligned, absorbed state at the start
+    /// of the range, and locations above this boundary place that derivation in the
+    /// delayed-merge-unstable region (relevant for MMB).
+    ///
+    /// For families without delayed merges this is the inactivity floor rounded down to the
+    /// nearest chunk boundary. For families with delayed merges (MMB) it is held back further,
+    /// until the youngest pruned chunk-pair's height-`gh+1` parent has been born in the ops tree.
+    pub fn sync_boundary(&self) -> Result<Location<F>, Error<F>> {
+        self.settled_bitmap_prune_loc()
+    }
+
     /// For the youngest of `pruned_chunks` chunks, return the `peak_birth_size` of its
     /// chunk-pair parent at height `gh+1`. Returns `None` for families without delayed merges
     /// (where `peak_birth_size` at height `gh` equals the chunk boundary).
@@ -379,8 +397,9 @@ where
     /// Prunes historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
     ///
-    /// `prune_loc` controls ops-log pruning only. Bitmap pruning advances to the settled
-    /// portion of the inactivity floor, independent of `prune_loc`.
+    /// Pruning is clipped to the settled bitmap boundary (see [`Db::sync_boundary`]): the ops
+    /// log's lower bound is never advanced past where the grafting overlay has been pruned. The
+    /// bitmap and grafted tree advance to that same settled boundary regardless of `prune_loc`.
     ///
     /// # Errors
     ///
@@ -442,7 +461,7 @@ where
         // a pruned log with stale metadata would lose peak digests permanently.
         self.sync_metadata().await?;
 
-        self.any.prune(prune_loc).await
+        self.any.prune(prune_loc.min(settled_bitmap_floor)).await
     }
 
     /// Rewind the database to `size` operations, where `size` is the location of the next append.

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1778,6 +1778,131 @@ pub mod tests {
         });
     }
 
+    /// Verify that `Db::prune` never advances the ops journal past the settled bitmap
+    /// pruning boundary on a delayed-merge (MMB) family. The journal's lower bound must be
+    /// less than or equal to `pruning_boundary()`, and the test setup must force the lag to
+    /// be strictly active so the assertion is not vacuous.
+    #[test_traced]
+    fn test_current_mmb_prune_clips_journal_to_settled_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const COMMITS: u64 = 320;
+
+            let ctx = context.with_label("db");
+            let mut db: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
+                ctx.clone(),
+                variable_config::<OneCap>("prune-clip-mmb", &ctx),
+            )
+            .await
+            .unwrap();
+
+            let k = key(0);
+            for round in 0..COMMITS {
+                mmb_commit(&mut db, [(k, Some(val(70_000 + round)))]).await;
+            }
+
+            db.prune(db.inactivity_floor_loc()).await.unwrap();
+
+            let boundary = db.sync_boundary().unwrap();
+            let floor = db.inactivity_floor_loc();
+            assert!(
+                boundary < floor,
+                "delayed-merge lag must be strictly active: boundary={boundary}, floor={floor}"
+            );
+            assert!(
+                db.bounds().await.start <= boundary,
+                "ops journal was pruned past the settled bitmap boundary: \
+                 bounds.start={}, boundary={boundary}",
+                db.bounds().await.start
+            );
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Verify that on a non-delayed-merge (MMR) family `pruning_boundary()` lags the
+    /// inactivity floor only by chunk alignment (less than one chunk) — never by a
+    /// delayed-merge absorption window. Guards against an accidental regression that
+    /// would introduce a larger lag on families that don't need it.
+    #[test_traced]
+    fn test_current_mmr_prune_boundary_lag_is_only_chunk_alignment() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const COMMITS: u64 = 320;
+            const N: usize = 32;
+
+            let ctx = context.with_label("db");
+            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+                ctx.clone(),
+                variable_config::<OneCap>("prune-clip-mmr", &ctx),
+            )
+            .await
+            .unwrap();
+
+            for round in 0..COMMITS {
+                commit_writes_with_metadata(
+                    &mut db,
+                    [(key(0), Some(val(80_000 + round)))],
+                    None,
+                )
+                .await;
+            }
+
+            db.prune(db.inactivity_floor_loc()).await.unwrap();
+
+            let boundary = db.sync_boundary().unwrap();
+            let floor = db.inactivity_floor_loc();
+            let chunk_bits = commonware_utils::bitmap::BitMap::<N>::CHUNK_SIZE_BITS;
+            assert!(
+                boundary <= floor && *floor - *boundary < chunk_bits,
+                "MMR lag should be only chunk alignment: boundary={boundary}, floor={floor}, chunk_bits={chunk_bits}"
+            );
+            assert!(
+                db.bounds().await.start <= boundary,
+                "ops journal bounds must be <= pruning_boundary: bounds.start={}, boundary={boundary}",
+                db.bounds().await.start
+            );
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Verify that `prune(loc)` with `loc < pruning_boundary()` prunes the ops journal only
+    /// as far as the caller requested. The clip must pick the smaller of the two — it must
+    /// not over-prune when the caller asked for less than the settled boundary.
+    #[test_traced]
+    fn test_current_prune_below_settled_boundary_is_honored() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const COMMITS: u64 = 100;
+
+            let ctx = context.with_label("db");
+            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+                ctx.clone(),
+                variable_config::<OneCap>("prune-below-boundary", &ctx),
+            )
+            .await
+            .unwrap();
+
+            for round in 0..COMMITS {
+                commit_writes_with_metadata(&mut db, [(key(0), Some(val(90_000 + round)))], None)
+                    .await;
+            }
+
+            assert!(*db.inactivity_floor_loc() > 1);
+            let small = Location::new(1);
+            db.prune(small).await.unwrap();
+
+            assert!(
+                db.bounds().await.start <= small,
+                "journal pruning exceeded the caller-supplied target: bounds.start={}, requested={small}",
+                db.bounds().await.start
+            );
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// Prune, then grow without pruning again so delayed MMB merges occur inside the
     /// already-pruned region. Verify proof + reopen correctness.
     #[test_traced]

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -31,8 +31,9 @@ use crate::{
         contiguous::{fixed, variable, Mutable},
     },
     merkle::{
-        mmr::{self, Family, Location, StandardHasher},
-        Family as _,
+        hasher::Standard as StandardHasher,
+        journaled::{self, Journaled},
+        Graftable, Location,
     },
     qmdb::{
         self,
@@ -89,32 +90,33 @@ impl<T: Translator, J: Clone> Config for super::Config<T, J> {
 /// * Builds the grafted MMR from the bitmap and ops MMR.
 /// * Computes and caches the canonical root.
 #[allow(clippy::too_many_arguments)]
-async fn build_db<E, U, I, H, J, T, const N: usize>(
+async fn build_db<F, E, U, I, H, J, T, const N: usize>(
     context: E,
-    mmr_config: mmr::journaled::Config,
+    merkle_config: journaled::Config,
     log: J,
     translator: T,
     pinned_nodes: Option<Vec<H::Digest>>,
-    range: Range<Location>,
+    range: Range<Location<F>>,
     apply_batch_size: usize,
     metadata_partition: String,
     thread_pool: Option<commonware_parallel::ThreadPool>,
-) -> Result<db::Db<Family, E, J, I, H, U, N>, qmdb::Error<Family>>
+) -> Result<db::Db<F, E, J, I, H, U, N>, qmdb::Error<F>>
 where
+    F: Graftable,
     E: Context,
     U: Update + Send + Sync + 'static,
-    I: IndexFactory<T, Value = Location>,
+    I: IndexFactory<T, Value = Location<F>>,
     H: Hasher,
     T: Translator,
-    J: Mutable<Item = Operation<Family, U>> + Persistable<Error = crate::journal::Error>,
-    Operation<Family, U>: Codec + Committable + CodecShared,
+    J: Mutable<Item = Operation<F, U>> + Persistable<Error = crate::journal::Error>,
+    Operation<F, U>: Codec + Committable + CodecShared,
 {
     // Build authenticated log.
     let hasher = StandardHasher::<H>::new();
-    let mmr = mmr::journaled::Mmr::init_sync(
+    let merkle = Journaled::<F, _, _>::init_sync(
         context.with_label("mmr"),
-        mmr::journaled::SyncConfig {
-            config: mmr_config,
+        journaled::SyncConfig {
+            config: merkle_config,
             range: range.clone(),
             pinned_nodes,
         },
@@ -122,8 +124,8 @@ where
     )
     .await?;
     let index = I::new(context.with_label("index"), translator);
-    let log = authenticated::Journal::<Family, _, _, _>::from_components(
-        mmr,
+    let log = authenticated::Journal::<F, _, _, _>::from_components(
+        merkle,
         log,
         hasher,
         apply_batch_size as u64,
@@ -138,18 +140,18 @@ where
     // journal's inactivity floor with inactive (false) bits.
     let pruned_chunks = (*range.start / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
     let mut status = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
-        .map_err(|_| qmdb::Error::<Family>::DataCorrupted("pruned chunks overflow"))?;
+        .map_err(|_| qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
 
     // Build any::Db with bitmap callback.
     //
     // init_from_log replays the operations, building the snapshot (index) and invoking
     // our callback for each operation to populate the bitmap.
-    let known_inactivity_floor = Location::new(status.len());
-    let any: AnyDb<Family, E, J, I, H, U> = AnyDb::init_from_log(
+    let known_inactivity_floor = Location::<F>::new(status.len());
+    let any: AnyDb<F, E, J, I, H, U> = AnyDb::init_from_log(
         index,
         log,
         Some(known_inactivity_floor),
-        |is_active: bool, old_loc: Option<Location>| {
+        |is_active: bool, old_loc: Option<Location<F>>| {
             status.push(is_active);
             if let Some(loc) = old_loc {
                 status.set_bit(*loc, false);
@@ -168,14 +170,21 @@ where
     // `nodes_to_pin(range.start)` returns all ops peaks, but only the first
     // `popcount(pruned_chunks)` are at or above the grafting height. The remaining
     // smaller peaks cover the partial trailing chunk and are not grafted pinned nodes.
+    //
+    // This relies on the pruning-boundary invariant: at `range.end`, every pruned chunk's
+    // height-`gh` subtree is absorbed, so `nodes_to_pin` at a chunk-aligned `range.start`
+    // returns the correct positions for both MMR and MMB.
     let grafted_pinned_nodes = {
-        let ops_pin_positions = mmr::Family::nodes_to_pin(range.start);
+        let ops_pin_positions: Vec<_> = F::nodes_to_pin(range.start).collect();
         let num_grafted_pins = (pruned_chunks as u64).count_ones() as usize;
         let mut pins = Vec::with_capacity(num_grafted_pins);
-        for pos in ops_pin_positions.take(num_grafted_pins) {
-            let digest = any.log.merkle.get_node(pos).await?.ok_or(
-                qmdb::Error::<mmr::Family>::DataCorrupted("missing ops pinned node"),
-            )?;
+        for pos in ops_pin_positions.into_iter().take(num_grafted_pins) {
+            let digest = any
+                .log
+                .merkle
+                .get_node(pos)
+                .await?
+                .ok_or(qmdb::Error::<F>::DataCorrupted("missing ops pinned node"))?;
             pins.push(digest);
         }
         pins
@@ -183,7 +192,7 @@ where
 
     // Build grafted MMR.
     let hasher = StandardHasher::<H>::new();
-    let grafted_tree = db::build_grafted_tree::<Family, H, N>(
+    let grafted_tree = db::build_grafted_tree::<F, H, N>(
         &hasher,
         &status,
         &grafted_pinned_nodes,
@@ -216,11 +225,9 @@ where
     );
 
     // Initialize metadata store and construct the Db.
-    let (metadata, _, _) = db::init_metadata::<Family, E, DigestOf<H>>(
-        context.with_label("metadata"),
-        &metadata_partition,
-    )
-    .await?;
+    let (metadata, _, _) =
+        db::init_metadata::<F, E, DigestOf<H>>(context.with_label("metadata"), &metadata_partition)
+            .await?;
 
     let current_db = db::Db {
         any,
@@ -244,8 +251,9 @@ macro_rules! impl_current_sync_database {
      $journal:ty, $config:ty,
      $key_bound:path, $value_bound:ident
      $(; $($where_extra:tt)+)?) => {
-        impl<E, K, V, H, T, const N: usize> Database for $db<Family, E, K, V, H, T, N>
+        impl<F, E, K, V, H, T, const N: usize> Database for $db<F, E, K, V, H, T, N>
         where
+            F: Graftable,
             E: Context,
             K: $key_bound,
             V: $value_bound + 'static,
@@ -253,8 +261,9 @@ macro_rules! impl_current_sync_database {
             T: Translator,
             $($($where_extra)+)?
         {
+            type Family = F;
             type Context = E;
-            type Op = $op<Family, K, V>;
+            type Op = $op<F, K, V>;
             type Journal = $journal;
             type Hasher = H;
             type Config = $config;
@@ -265,16 +274,16 @@ macro_rules! impl_current_sync_database {
                 config: Self::Config,
                 log: Self::Journal,
                 pinned_nodes: Option<Vec<Self::Digest>>,
-                range: Range<Location>,
+                range: Range<Location<F>>,
                 apply_batch_size: usize,
-            ) -> Result<Self, qmdb::Error<Family>> {
-                let mmr_config = config.merkle_config.clone();
+            ) -> Result<Self, qmdb::Error<F>> {
+                let merkle_config = config.merkle_config.clone();
                 let metadata_partition = config.grafted_metadata_partition.clone();
                 let thread_pool = config.merkle_config.thread_pool.clone();
                 let translator = config.translator.clone();
-                build_db::<_, $update<K, V>, _, H, _, T, N>(
+                build_db::<F, _, $update<K, V>, _, H, _, T, N>(
                     context,
-                    mmr_config,
+                    merkle_config,
                     log,
                     translator,
                     pinned_nodes,
@@ -304,9 +313,9 @@ impl_current_sync_database!(
 impl_current_sync_database!(
     CurrentUnorderedVariableDb, UnorderedVariableOp, UnorderedVariableUpdate,
     variable::Journal<E, Self::Op>,
-    VariableConfig<T, <UnorderedVariableOp<Family, K, V> as CodecRead>::Cfg>,
+    VariableConfig<T, <UnorderedVariableOp<F, K, V> as CodecRead>::Cfg>,
     Key, VariableValue;
-    UnorderedVariableOp<Family, K, V>: CodecShared
+    UnorderedVariableOp<F, K, V>: CodecShared
 );
 
 impl_current_sync_database!(
@@ -318,9 +327,9 @@ impl_current_sync_database!(
 impl_current_sync_database!(
     CurrentOrderedVariableDb, OrderedVariableOp, OrderedVariableUpdate,
     variable::Journal<E, Self::Op>,
-    VariableConfig<T, <OrderedVariableOp<Family, K, V> as CodecRead>::Cfg>,
+    VariableConfig<T, <OrderedVariableOp<F, K, V> as CodecRead>::Cfg>,
     Key, VariableValue;
-    OrderedVariableOp<Family, K, V>: CodecShared
+    OrderedVariableOp<F, K, V>: CodecShared
 );
 
 // --- Resolver implementations ---
@@ -330,9 +339,10 @@ impl_current_sync_database!(
 
 macro_rules! impl_current_resolver {
     ($db:ident, $op:ident, $val_bound:ident, $key_bound:path $(; $($where_extra:tt)+)?) => {
-        impl<E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
-            for std::sync::Arc<$db<Family, E, K, V, H, T, N>>
+        impl<F, E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
+            for std::sync::Arc<$db<F, E, K, V, H, T, N>>
         where
+            F: Graftable,
             E: Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -341,18 +351,19 @@ macro_rules! impl_current_resolver {
             T::Key: Send + Sync,
             $($($where_extra)+)?
         {
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<Family, K, V>;
-            type Error = qmdb::Error<Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<F>,
+                start_loc: Location<F>,
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<crate::qmdb::sync::FetchResult<Self::Op, Self::Digest>, Self::Error> {
+            ) -> Result<crate::qmdb::sync::FetchResult<F, Self::Op, Self::Digest>, Self::Error> {
                 let (proof, operations) = self.any
                     .historical_proof(op_count, start_loc, max_ops)
                     .await?;
@@ -370,13 +381,14 @@ macro_rules! impl_current_resolver {
             }
         }
 
-        impl<E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
+        impl<F, E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
             for std::sync::Arc<
                 commonware_utils::sync::AsyncRwLock<
-                    $db<Family, E, K, V, H, T, N>,
+                    $db<F, E, K, V, H, T, N>,
                 >,
             >
         where
+            F: Graftable,
             E: Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -385,18 +397,19 @@ macro_rules! impl_current_resolver {
             T::Key: Send + Sync,
             $($($where_extra)+)?
         {
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<Family, K, V>;
-            type Error = qmdb::Error<Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<F>,
+                start_loc: Location<F>,
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<crate::qmdb::sync::FetchResult<Self::Op, Self::Digest>, qmdb::Error<Family>> {
+            ) -> Result<crate::qmdb::sync::FetchResult<F, Self::Op, Self::Digest>, qmdb::Error<F>> {
                 let db = self.read().await;
                 let (proof, operations) = db.any
                     .historical_proof(op_count, start_loc, max_ops)
@@ -415,13 +428,14 @@ macro_rules! impl_current_resolver {
             }
         }
 
-        impl<E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
+        impl<F, E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
             for std::sync::Arc<
                 commonware_utils::sync::AsyncRwLock<
-                    Option<$db<Family, E, K, V, H, T, N>>,
+                    Option<$db<F, E, K, V, H, T, N>>,
                 >,
             >
         where
+            F: Graftable,
             E: Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -430,20 +444,21 @@ macro_rules! impl_current_resolver {
             T::Key: Send + Sync,
             $($($where_extra)+)?
         {
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<Family, K, V>;
-            type Error = qmdb::Error<Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<F>,
+                start_loc: Location<F>,
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<crate::qmdb::sync::FetchResult<Self::Op, Self::Digest>, qmdb::Error<Family>> {
+            ) -> Result<crate::qmdb::sync::FetchResult<F, Self::Op, Self::Digest>, qmdb::Error<F>> {
                 let guard = self.read().await;
-                let db = guard.as_ref().ok_or(qmdb::Error::<Family>::KeyNotFound)?;
+                let db = guard.as_ref().ok_or(qmdb::Error::<F>::KeyNotFound)?;
                 let (proof, operations) = db.any
                     .historical_proof(op_count, start_loc, max_ops)
                     .await?;
@@ -469,7 +484,7 @@ impl_current_resolver!(CurrentUnorderedFixedDb, UnorderedFixedOp, FixedValue, Ar
 // Unordered Variable
 impl_current_resolver!(
     CurrentUnorderedVariableDb, UnorderedVariableOp, VariableValue, Key;
-    UnorderedVariableOp<Family, K, V>: CodecShared,
+    UnorderedVariableOp<F, K, V>: CodecShared,
 );
 
 // Ordered Fixed
@@ -478,5 +493,5 @@ impl_current_resolver!(CurrentOrderedFixedDb, OrderedFixedOp, FixedValue, Array)
 // Ordered Variable
 impl_current_resolver!(
     CurrentOrderedVariableDb, OrderedVariableOp, VariableValue, Key;
-    OrderedVariableOp<Family, K, V>: CodecShared,
+    OrderedVariableOp<F, K, V>: CodecShared,
 );

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -5,37 +5,272 @@
 //! `any` harnesses is that `sync_target_root` returns the **ops root** (via
 //! [qmdb::sync::Database::root](crate::qmdb::sync::Database::root)), not the canonical root
 //! returned by `Db::root()`.
+//!
+//! Harnesses are instantiated for **both** MMR and MMB merkle families across each (ordered,
+//! unordered) x (fixed, variable) database variant, so the shared suite runs twice per
+//! variant.
+//!
+//! In addition to the shared harness-based suite, this module contains focused tests for
+//! `current`-specific sync behavior: overlay-state authentication (canonical-root check),
+//! pruned MMB round-trip, and target-update regression coverage.
 
-use crate::{
-    merkle::mmr,
-    qmdb::{
-        any::sync::tests::{ConfigOf, SyncTestHarness},
-        current::tests::{fixed_config, variable_config},
-        sync::Database as SyncDatabase,
-    },
+use crate::qmdb::{
+    any::sync::tests::{ConfigOf, SyncTestHarness},
+    current::tests::{fixed_config, variable_config},
+    sync::Database as SyncDatabase,
 };
-use commonware_cryptography::sha256::Digest;
-use commonware_runtime::{deterministic::Context, BufferPooler};
+use commonware_cryptography::{sha256::Digest, Sha256};
+use commonware_macros::test_traced;
+use commonware_runtime::{
+    deterministic, deterministic::Context, BufferPooler, Metrics as _, Runner as _,
+};
+use rand::RngCore as _;
 
 // ===== Harness Implementations =====
 
 mod harnesses {
     use super::*;
+    use crate::merkle::{self, mmb, mmr};
+    use commonware_math::algebra::Random;
+    use commonware_utils::test_rng_seeded;
 
-    // ----- Unordered/Fixed -----
+    type OrderedFixedDb<F> = crate::qmdb::current::ordered::fixed::Db<
+        F,
+        Context,
+        Digest,
+        Digest,
+        Sha256,
+        crate::translator::OneCap,
+        32,
+    >;
+    type OrderedVariableDb<F> = crate::qmdb::current::ordered::variable::Db<
+        F,
+        Context,
+        Digest,
+        Digest,
+        Sha256,
+        crate::translator::OneCap,
+        32,
+    >;
+    type UnorderedFixedDb<F> = crate::qmdb::current::unordered::fixed::Db<
+        F,
+        Context,
+        Digest,
+        Digest,
+        Sha256,
+        crate::translator::TwoCap,
+        32,
+    >;
+    type UnorderedVariableDb<F> = crate::qmdb::current::unordered::variable::Db<
+        F,
+        Context,
+        Digest,
+        Digest,
+        Sha256,
+        crate::translator::TwoCap,
+        32,
+    >;
 
-    pub struct UnorderedFixedHarness;
+    fn create_unordered_fixed_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
 
-    impl SyncTestHarness for UnorderedFixedHarness {
-        type Db = crate::qmdb::current::unordered::fixed::Db<
-            mmr::Family,
-            Context,
-            Digest,
-            Digest,
-            commonware_cryptography::Sha256,
-            crate::translator::TwoCap,
-            32,
-        >;
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            let key = Digest::random(&mut rng);
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let value = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update(key, value)));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_unordered_variable_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::unordered::variable::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+
+        let mut rng = test_rng_seeded(seed);
+        let mut prev_key = Digest::random(&mut rng);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            let key = Digest::random(&mut rng);
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(prev_key));
+            } else {
+                let value = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update(key, value)));
+                prev_key = key;
+            }
+        }
+        ops
+    }
+
+    fn create_ordered_fixed_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+
+        let mut rng = test_rng_seeded(seed);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            if i % 10 == 0 && i > 0 {
+                let key = Digest::random(&mut rng);
+                ops.push(Operation::Delete(key));
+            } else {
+                let key = Digest::random(&mut rng);
+                let value = Digest::random(&mut rng);
+                let next_key = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update {
+                    key,
+                    value,
+                    next_key,
+                }));
+            }
+        }
+        ops
+    }
+
+    fn create_ordered_variable_ops<F: merkle::Family>(
+        n: usize,
+        seed: u64,
+    ) -> Vec<crate::qmdb::any::ordered::variable::Operation<F, Digest, Digest>> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+
+        let mut rng = test_rng_seeded(seed);
+        let mut ops = Vec::new();
+        for i in 0..n {
+            let key = Digest::random(&mut rng);
+            if i % 10 == 0 && i > 0 {
+                ops.push(Operation::Delete(key));
+            } else {
+                let value = Digest::random(&mut rng);
+                let next_key = Digest::random(&mut rng);
+                ops.push(Operation::Update(Update {
+                    key,
+                    value,
+                    next_key,
+                }));
+            }
+        }
+        ops
+    }
+
+    async fn apply_unordered_fixed_ops<F: merkle::Graftable>(
+        mut db: UnorderedFixedDb<F>,
+        ops: Vec<crate::qmdb::any::unordered::fixed::Operation<F, Digest, Digest>>,
+    ) -> UnorderedFixedDb<F> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+
+        let merkleized = {
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(Update(key, value)) => {
+                        batch = batch.write(key, Some(value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            batch.merkleize(&db, None::<Digest>).await.unwrap()
+        };
+        db.apply_batch(merkleized).await.unwrap();
+        db
+    }
+
+    async fn apply_unordered_variable_ops<F: merkle::Graftable>(
+        mut db: UnorderedVariableDb<F>,
+        ops: Vec<crate::qmdb::any::unordered::variable::Operation<F, Digest, Digest>>,
+    ) -> UnorderedVariableDb<F> {
+        use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
+
+        let merkleized = {
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(Update(key, value)) => {
+                        batch = batch.write(key, Some(value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            batch.merkleize(&db, None::<Digest>).await.unwrap()
+        };
+        db.apply_batch(merkleized).await.unwrap();
+        db
+    }
+
+    async fn apply_ordered_fixed_ops<F: merkle::Graftable>(
+        mut db: OrderedFixedDb<F>,
+        ops: Vec<crate::qmdb::any::ordered::fixed::Operation<F, Digest, Digest>>,
+    ) -> OrderedFixedDb<F> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+
+        let merkleized = {
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(Update { key, value, .. }) => {
+                        batch = batch.write(key, Some(value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            batch.merkleize(&db, None::<Digest>).await.unwrap()
+        };
+        db.apply_batch(merkleized).await.unwrap();
+        db
+    }
+
+    async fn apply_ordered_variable_ops<F: merkle::Graftable>(
+        mut db: OrderedVariableDb<F>,
+        ops: Vec<crate::qmdb::any::ordered::variable::Operation<F, Digest, Digest>>,
+    ) -> OrderedVariableDb<F> {
+        use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
+
+        let merkleized = {
+            let mut batch = db.new_batch();
+            for op in ops {
+                match op {
+                    Operation::Update(Update { key, value, .. }) => {
+                        batch = batch.write(key, Some(value));
+                    }
+                    Operation::Delete(key) => {
+                        batch = batch.write(key, None);
+                    }
+                    Operation::CommitFloor(_, _) => {}
+                }
+            }
+            batch.merkleize(&db, None::<Digest>).await.unwrap()
+        };
+        db.apply_batch(merkleized).await.unwrap();
+        db
+    }
+
+    pub struct UnorderedFixedMmrHarness;
+
+    impl SyncTestHarness for UnorderedFixedMmrHarness {
+        type Family = mmr::Family;
+        type Db = UnorderedFixedDb<mmr::Family>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
             SyncDatabase::root(db)
@@ -49,7 +284,7 @@ mod harnesses {
             n: usize,
         ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmr::Family, Digest, Digest>>
         {
-            crate::qmdb::any::unordered::fixed::test::create_test_ops(n)
+            create_unordered_fixed_ops::<mmr::Family>(n, 0)
         }
 
         fn create_ops_seeded(
@@ -57,7 +292,7 @@ mod harnesses {
             seed: u64,
         ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmr::Family, Digest, Digest>>
         {
-            crate::qmdb::any::unordered::fixed::test::create_test_ops_seeded(n, seed)
+            create_unordered_fixed_ops::<mmr::Family>(n, seed)
         }
 
         async fn init_db(ctx: Context) -> Self::Db {
@@ -70,42 +305,64 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::unordered::fixed::Operation<mmr::Family, Digest, Digest>>,
         ) -> Self::Db {
-            use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
-            let mut batch = db.new_batch();
-            for op in ops {
-                match op {
-                    Operation::Update(Update(key, value)) => {
-                        batch = batch.write(key, Some(value));
-                    }
-                    Operation::Delete(key) => {
-                        batch = batch.write(key, None);
-                    }
-                    Operation::CommitFloor(_, _) => {}
-                }
-            }
-            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db
+            apply_unordered_fixed_ops(db, ops).await
         }
     }
 
-    // ----- Unordered/Variable -----
+    pub struct UnorderedFixedMmbHarness;
 
-    pub struct UnorderedVariableHarness;
+    impl SyncTestHarness for UnorderedFixedMmbHarness {
+        type Family = mmb::Family;
+        type Db = UnorderedFixedDb<mmb::Family>;
 
-    impl SyncTestHarness for UnorderedVariableHarness {
-        type Db = crate::qmdb::current::unordered::variable::Db<
-            mmr::Family,
-            Context,
-            Digest,
-            Digest,
-            commonware_cryptography::Sha256,
-            crate::translator::TwoCap,
-            32,
-        >;
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            SyncDatabase::root(db)
+        }
+
+        fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
+            fixed_config::<crate::translator::TwoCap>(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_fixed_ops::<mmb::Family>(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_fixed_ops::<mmb::Family>(n, seed)
+        }
+
+        async fn init_db(ctx: Context) -> Self::Db {
+            let cfg = fixed_config::<crate::translator::TwoCap>("default", &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(ctx: Context, config: ConfigOf<Self>) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            db: Self::Db,
+            ops: Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            apply_unordered_fixed_ops(db, ops).await
+        }
+    }
+
+    pub struct UnorderedVariableMmrHarness;
+
+    impl SyncTestHarness for UnorderedVariableMmrHarness {
+        type Family = mmr::Family;
+        type Db = UnorderedVariableDb<mmr::Family>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
             SyncDatabase::root(db)
@@ -119,7 +376,7 @@ mod harnesses {
             n: usize,
         ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmr::Family, Digest, Digest>>
         {
-            create_unordered_variable_ops(n, 0)
+            create_unordered_variable_ops::<mmr::Family>(n, 0)
         }
 
         fn create_ops_seeded(
@@ -127,7 +384,7 @@ mod harnesses {
             seed: u64,
         ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmr::Family, Digest, Digest>>
         {
-            create_unordered_variable_ops(n, seed)
+            create_unordered_variable_ops::<mmr::Family>(n, seed)
         }
 
         async fn init_db(ctx: Context) -> Self::Db {
@@ -140,42 +397,64 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::unordered::variable::Operation<mmr::Family, Digest, Digest>>,
         ) -> Self::Db {
-            use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
-            let mut batch = db.new_batch();
-            for op in ops {
-                match op {
-                    Operation::Update(Update(key, value)) => {
-                        batch = batch.write(key, Some(value));
-                    }
-                    Operation::Delete(key) => {
-                        batch = batch.write(key, None);
-                    }
-                    Operation::CommitFloor(_, _) => {}
-                }
-            }
-            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db
+            apply_unordered_variable_ops(db, ops).await
         }
     }
 
-    // ----- Ordered/Fixed -----
+    pub struct UnorderedVariableMmbHarness;
 
-    pub struct OrderedFixedHarness;
+    impl SyncTestHarness for UnorderedVariableMmbHarness {
+        type Family = mmb::Family;
+        type Db = UnorderedVariableDb<mmb::Family>;
 
-    impl SyncTestHarness for OrderedFixedHarness {
-        type Db = crate::qmdb::current::ordered::fixed::Db<
-            mmr::Family,
-            Context,
-            Digest,
-            Digest,
-            commonware_cryptography::Sha256,
-            crate::translator::OneCap,
-            32,
-        >;
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            SyncDatabase::root(db)
+        }
+
+        fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
+            variable_config::<crate::translator::TwoCap>(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_variable_ops::<mmb::Family>(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_unordered_variable_ops::<mmb::Family>(n, seed)
+        }
+
+        async fn init_db(ctx: Context) -> Self::Db {
+            let cfg = variable_config::<crate::translator::TwoCap>("default", &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(ctx: Context, config: ConfigOf<Self>) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            db: Self::Db,
+            ops: Vec<crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            apply_unordered_variable_ops(db, ops).await
+        }
+    }
+
+    pub struct OrderedFixedMmrHarness;
+
+    impl SyncTestHarness for OrderedFixedMmrHarness {
+        type Family = mmr::Family;
+        type Db = OrderedFixedDb<mmr::Family>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
             SyncDatabase::root(db)
@@ -188,14 +467,14 @@ mod harnesses {
         fn create_ops(
             n: usize,
         ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmr::Family, Digest, Digest>> {
-            crate::qmdb::any::ordered::fixed::test::create_test_ops(n)
+            create_ordered_fixed_ops::<mmr::Family>(n, 0)
         }
 
         fn create_ops_seeded(
             n: usize,
             seed: u64,
         ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmr::Family, Digest, Digest>> {
-            crate::qmdb::any::ordered::fixed::test::create_test_ops_seeded(n, seed)
+            create_ordered_fixed_ops::<mmr::Family>(n, seed)
         }
 
         async fn init_db(ctx: Context) -> Self::Db {
@@ -208,42 +487,62 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::ordered::fixed::Operation<mmr::Family, Digest, Digest>>,
         ) -> Self::Db {
-            use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
-            let mut batch = db.new_batch();
-            for op in ops {
-                match op {
-                    Operation::Update(Update { key, value, .. }) => {
-                        batch = batch.write(key, Some(value));
-                    }
-                    Operation::Delete(key) => {
-                        batch = batch.write(key, None);
-                    }
-                    Operation::CommitFloor(_, _) => {}
-                }
-            }
-            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db
+            apply_ordered_fixed_ops(db, ops).await
         }
     }
 
-    // ----- Ordered/Variable -----
+    pub struct OrderedFixedMmbHarness;
 
-    pub struct OrderedVariableHarness;
+    impl SyncTestHarness for OrderedFixedMmbHarness {
+        type Family = mmb::Family;
+        type Db = OrderedFixedDb<mmb::Family>;
 
-    impl SyncTestHarness for OrderedVariableHarness {
-        type Db = crate::qmdb::current::ordered::variable::Db<
-            mmr::Family,
-            Context,
-            Digest,
-            Digest,
-            commonware_cryptography::Sha256,
-            crate::translator::OneCap,
-            32,
-        >;
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            SyncDatabase::root(db)
+        }
+
+        fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
+            fixed_config::<crate::translator::OneCap>(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>> {
+            create_ordered_fixed_ops::<mmb::Family>(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>> {
+            create_ordered_fixed_ops::<mmb::Family>(n, seed)
+        }
+
+        async fn init_db(ctx: Context) -> Self::Db {
+            let cfg = fixed_config::<crate::translator::OneCap>("default", &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(ctx: Context, config: ConfigOf<Self>) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            db: Self::Db,
+            ops: Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            apply_ordered_fixed_ops(db, ops).await
+        }
+    }
+
+    pub struct OrderedVariableMmrHarness;
+
+    impl SyncTestHarness for OrderedVariableMmrHarness {
+        type Family = mmr::Family;
+        type Db = OrderedVariableDb<mmr::Family>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
             SyncDatabase::root(db)
@@ -257,7 +556,7 @@ mod harnesses {
             n: usize,
         ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmr::Family, Digest, Digest>>
         {
-            create_ordered_variable_ops(n, 0)
+            create_ordered_variable_ops::<mmr::Family>(n, 0)
         }
 
         fn create_ops_seeded(
@@ -265,7 +564,7 @@ mod harnesses {
             seed: u64,
         ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmr::Family, Digest, Digest>>
         {
-            create_ordered_variable_ops(n, seed)
+            create_ordered_variable_ops::<mmr::Family>(n, seed)
         }
 
         async fn init_db(ctx: Context) -> Self::Db {
@@ -278,82 +577,168 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::ordered::variable::Operation<mmr::Family, Digest, Digest>>,
         ) -> Self::Db {
-            use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
-            let mut batch = db.new_batch();
-            for op in ops {
-                match op {
-                    Operation::Update(Update { key, value, .. }) => {
-                        batch = batch.write(key, Some(value));
-                    }
-                    Operation::Delete(key) => {
-                        batch = batch.write(key, None);
-                    }
-                    Operation::CommitFloor(_, _) => {}
-                }
-            }
-            let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db
+            apply_ordered_variable_ops(db, ops).await
+        }
+    }
+
+    pub struct OrderedVariableMmbHarness;
+
+    impl SyncTestHarness for OrderedVariableMmbHarness {
+        type Family = mmb::Family;
+        type Db = OrderedVariableDb<mmb::Family>;
+
+        fn sync_target_root(db: &Self::Db) -> Digest {
+            SyncDatabase::root(db)
+        }
+
+        fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
+            variable_config::<crate::translator::OneCap>(suffix, pooler)
+        }
+
+        fn create_ops(
+            n: usize,
+        ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_ordered_variable_ops::<mmb::Family>(n, 0)
+        }
+
+        fn create_ops_seeded(
+            n: usize,
+            seed: u64,
+        ) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Digest>>
+        {
+            create_ordered_variable_ops::<mmb::Family>(n, seed)
+        }
+
+        async fn init_db(ctx: Context) -> Self::Db {
+            let cfg = variable_config::<crate::translator::OneCap>("default", &ctx);
+            Self::Db::init(ctx, cfg).await.unwrap()
+        }
+
+        async fn init_db_with_config(ctx: Context, config: ConfigOf<Self>) -> Self::Db {
+            Self::Db::init(ctx, config).await.unwrap()
+        }
+
+        async fn apply_ops(
+            db: Self::Db,
+            ops: Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Digest>>,
+        ) -> Self::Db {
+            apply_ordered_variable_ops(db, ops).await
         }
     }
 }
 
-// ===== Helper functions for creating test operations =====
+/// Regression test: sync a pruned MMB-backed current DB and verify the synced DB has the
+/// same canonical root, reopens cleanly, and returns the expected value.
+///
+/// The target DB commits the same key 100 times, forcing the inactivity floor past a full
+/// 256-bit chunk boundary. Without overlay-state in the sync protocol, the receiver
+/// re-derives `pruned_chunks` from `range.start / chunk_bits` and builds a grafted tree
+/// whose pinned nodes don't match the sender's. The canonical roots diverge.
+#[test_traced("INFO")]
+fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context: Context| async move {
+        type Db = crate::qmdb::current::unordered::variable::Db<
+            crate::merkle::mmb::Family,
+            Context,
+            Digest,
+            Digest,
+            Sha256,
+            crate::translator::TwoCap,
+            32,
+        >;
 
-/// Create test operations for unordered variable databases with Digest values.
-fn create_unordered_variable_ops(
-    n: usize,
-    seed: u64,
-) -> Vec<crate::qmdb::any::unordered::variable::Operation<mmr::Family, Digest, Digest>> {
-    use crate::qmdb::any::operation::{update::Unordered as Update, Operation};
-    use commonware_math::algebra::Random;
-    use commonware_utils::test_rng_seeded;
+        const COMMITS: u64 = 100;
 
-    let mut rng = test_rng_seeded(seed);
-    let mut prev_key = Digest::random(&mut rng);
-    let mut ops = Vec::new();
-    for i in 0..n {
-        let key = Digest::random(&mut rng);
-        if i % 10 == 0 && i > 0 {
-            ops.push(Operation::Delete(prev_key));
-        } else {
-            let value = Digest::random(&mut rng);
-            ops.push(Operation::Update(Update(key, value)));
-            prev_key = key;
+        let target_suffix = context.next_u64().to_string();
+        let target_context = context.with_label("target");
+        let mut target_db: Db = Db::init(
+            target_context.clone(),
+            variable_config::<crate::translator::TwoCap>(&target_suffix, &target_context),
+        )
+        .await
+        .unwrap();
+
+        let key = Digest::from([7u8; 32]);
+        let mut expected = None;
+        for round in 0..COMMITS {
+            expected = Some(Digest::from([round as u8; 32]));
+            let merkleized = target_db
+                .new_batch()
+                .write(key, expected)
+                .merkleize(&target_db, None)
+                .await
+                .unwrap();
+            target_db.apply_batch(merkleized).await.unwrap();
+            target_db.commit().await.unwrap();
         }
-    }
-    ops
-}
 
-/// Create test operations for ordered variable databases with Digest values.
-fn create_ordered_variable_ops(
-    n: usize,
-    seed: u64,
-) -> Vec<crate::qmdb::any::ordered::variable::Operation<mmr::Family, Digest, Digest>> {
-    use crate::qmdb::any::operation::{update::Ordered as Update, Operation};
-    use commonware_math::algebra::Random;
-    use commonware_utils::test_rng_seeded;
+        assert!(
+            *target_db.inactivity_floor_loc() >= 256,
+            "expected inactivity floor past chunk 0"
+        );
 
-    let mut rng = test_rng_seeded(seed);
-    let mut ops = Vec::new();
-    for i in 0..n {
-        let key = Digest::random(&mut rng);
-        if i % 10 == 0 && i > 0 {
-            ops.push(Operation::Delete(key));
-        } else {
-            let value = Digest::random(&mut rng);
-            let next_key = Digest::random(&mut rng);
-            ops.push(Operation::Update(Update {
-                key,
-                value,
-                next_key,
-            }));
-        }
-    }
-    ops
+        target_db
+            .prune(target_db.inactivity_floor_loc())
+            .await
+            .unwrap();
+
+        let sync_root = SyncDatabase::root(&target_db);
+        let verification_root = target_db.root();
+        let lower_bound = target_db.inactivity_floor_loc();
+        let upper_bound = target_db.bounds().await.end;
+
+        let client_suffix = context.next_u64().to_string();
+        let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+        let target_db = std::sync::Arc::new(target_db);
+        // Supply the trusted canonical root so `build_db`'s authentication check actually
+        // runs: this is the success-path coverage for the overlay-state authentication
+        // anchor. A bad-root rejection path test belongs with the focused sync tests.
+        let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
+            context: context.with_label("client"),
+            db_config: client_config.clone(),
+            fetch_batch_size: commonware_utils::NZU64!(64),
+            target: crate::qmdb::sync::Target {
+                root: sync_root,
+                range: commonware_utils::non_empty_range!(lower_bound, upper_bound),
+            },
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 4,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(SyncDatabase::root(&synced_db), sync_root);
+        assert_eq!(synced_db.root(), verification_root);
+        assert_eq!(synced_db.inactivity_floor_loc(), lower_bound);
+        assert_eq!(synced_db.get(&key).await.unwrap(), expected);
+
+        drop(synced_db);
+
+        let reopened: Db = Db::init(context.with_label("reopened"), client_config)
+            .await
+            .unwrap();
+        assert_eq!(SyncDatabase::root(&reopened), sync_root);
+        assert_eq!(reopened.root(), verification_root);
+        assert_eq!(reopened.inactivity_floor_loc(), lower_bound);
+        assert_eq!(reopened.get(&key).await.unwrap(), expected);
+
+        reopened.destroy().await.unwrap();
+        std::sync::Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
 }
 
 // ===== Test Generation Macro =====
@@ -491,7 +876,17 @@ macro_rules! current_sync_tests_for_harness {
     };
 }
 
-current_sync_tests_for_harness!(harnesses::UnorderedFixedHarness, unordered_fixed);
-current_sync_tests_for_harness!(harnesses::UnorderedVariableHarness, unordered_variable);
-current_sync_tests_for_harness!(harnesses::OrderedFixedHarness, ordered_fixed);
-current_sync_tests_for_harness!(harnesses::OrderedVariableHarness, ordered_variable);
+current_sync_tests_for_harness!(harnesses::UnorderedFixedMmrHarness, unordered_fixed_mmr);
+current_sync_tests_for_harness!(harnesses::UnorderedFixedMmbHarness, unordered_fixed_mmb);
+current_sync_tests_for_harness!(
+    harnesses::UnorderedVariableMmrHarness,
+    unordered_variable_mmr
+);
+current_sync_tests_for_harness!(
+    harnesses::UnorderedVariableMmbHarness,
+    unordered_variable_mmb
+);
+current_sync_tests_for_harness!(harnesses::OrderedFixedMmrHarness, ordered_fixed_mmr);
+current_sync_tests_for_harness!(harnesses::OrderedFixedMmbHarness, ordered_fixed_mmb);
+current_sync_tests_for_harness!(harnesses::OrderedVariableMmrHarness, ordered_variable_mmr);
+current_sync_tests_for_harness!(harnesses::OrderedVariableMmbHarness, ordered_variable_mmb);

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -194,6 +194,15 @@ where
         Location::new(bounds.start)..Location::new(bounds.end)
     }
 
+    /// Return the most recent location from which this database can safely be synced.
+    ///
+    /// Immutable databases have no inactivity concept; this returns the oldest retained
+    /// operation. Callers constructing a sync [`Target`](crate::qmdb::sync::Target) may use this
+    /// value or any later location as `range.start`.
+    pub async fn sync_boundary(&self) -> Location<F> {
+        self.bounds().await.start
+    }
+
     /// Get the value of `key` in the db, or None if it has no value or its corresponding operation
     /// has been pruned.
     pub async fn get(&self, key: &K) -> Result<Option<V::Value>, Error<F>> {

--- a/storage/src/qmdb/immutable/sync.rs
+++ b/storage/src/qmdb/immutable/sync.rs
@@ -33,12 +33,13 @@ where
     V: ValueEncoding,
     C: Mutable<Item = Operation<K, V>>
         + Persistable<Error = JournalError>
-        + sync::Journal<Context = E, Op = Operation<K, V>>,
+        + sync::Journal<mmr::Family, Context = E, Op = Operation<K, V>>,
     C::Item: EncodeShared,
     C::Config: Clone + Send,
     H: Hasher,
     T: Translator,
 {
+    type Family = mmr::Family;
     type Op = Operation<K, V>;
     type Journal = C;
     type Hasher = H;
@@ -67,7 +68,7 @@ where
         db_config: Self::Config,
         log: Self::Journal,
         pinned_nodes: Option<Vec<Self::Digest>>,
-        range: Range<mmr::Location>,
+        range: Range<Location<mmr::Family>>,
         apply_batch_size: usize,
     ) -> Result<Self, Error<mmr::Family>> {
         let hasher = StandardHasher::new();

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -149,6 +149,15 @@ where
         Location::new(bounds.start)..Location::new(bounds.end)
     }
 
+    /// Return the most recent location from which this database can safely be synced.
+    ///
+    /// Keyless databases have no inactivity concept; this returns the oldest retained
+    /// operation. Callers constructing a sync [`Target`](crate::qmdb::sync::Target) may use this
+    /// value or any later location as `range.start`.
+    pub async fn sync_boundary(&self) -> Location<F> {
+        self.bounds().await.start
+    }
+
     /// Get the metadata associated with the last commit.
     pub async fn get_metadata(&self) -> Result<Option<V::Value>, Error<F>> {
         let op = self

--- a/storage/src/qmdb/keyless/sync.rs
+++ b/storage/src/qmdb/keyless/sync.rs
@@ -5,8 +5,9 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
+        hasher::Standard as StandardHasher,
         journaled::{self, Journaled},
-        mmr::{self, Location, StandardHasher},
+        mmr, Location,
     },
     qmdb::{
         self,
@@ -27,11 +28,12 @@ where
     V: ValueEncoding + Codec,
     C: Mutable<Item = Operation<V>>
         + Persistable<Error = JournalError>
-        + sync::Journal<Context = E, Op = Operation<V>>,
+        + sync::Journal<mmr::Family, Context = E, Op = Operation<V>>,
     C::Config: Clone + Send,
     H: Hasher,
     Operation<V>: EncodeShared,
 {
+    type Family = mmr::Family;
     type Op = Operation<V>;
     type Journal = C;
     type Hasher = H;
@@ -59,7 +61,7 @@ where
         config: Self::Config,
         log: Self::Journal,
         pinned_nodes: Option<Vec<Self::Digest>>,
-        range: Range<Location>,
+        range: Range<Location<mmr::Family>>,
         apply_batch_size: usize,
     ) -> Result<Self, qmdb::Error<mmr::Family>> {
         let hasher = StandardHasher::<H>::new();
@@ -226,7 +228,7 @@ mod tests {
     fn test_sync_resolver_fails() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
-            let resolver = FailResolver::<VariableOp, sha256::Digest>::new();
+            let resolver = FailResolver::<mmr::Family, VariableOp, sha256::Digest>::new();
             let db_config = create_sync_config(&context.next_u64().to_string(), &context);
             let config = Config {
                 context: context.with_label("client"),

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -1,4 +1,8 @@
-use crate::{mmr::Location, qmdb::sync::Journal, translator::Translator};
+use crate::{
+    merkle::{Family, Location},
+    qmdb::sync::Journal,
+    translator::Translator,
+};
 use commonware_cryptography::Digest;
 use std::{future::Future, ops::Range};
 
@@ -30,10 +34,13 @@ impl<J: Clone> Config for crate::qmdb::keyless::Config<J> {
         self.log.clone()
     }
 }
+
 pub trait Database: Sized + Send {
+    /// The merkle family backing this database (e.g. MMR or MMB).
+    type Family: Family;
     type Op: Send;
-    type Journal: Journal<Context = Self::Context, Op = Self::Op>;
-    type Config: Config<JournalConfig = <Self::Journal as Journal>::Config>;
+    type Journal: Journal<Self::Family, Context = Self::Context, Op = Self::Op>;
+    type Config: Config<JournalConfig = <Self::Journal as Journal<Self::Family>>::Config>;
     type Digest: Digest;
     type Context: commonware_runtime::Storage
         + commonware_runtime::Clock
@@ -46,9 +53,9 @@ pub trait Database: Sized + Send {
         config: Self::Config,
         journal: Self::Journal,
         pinned_nodes: Option<Vec<Self::Digest>>,
-        range: Range<Location>,
+        range: Range<Location<Self::Family>>,
         apply_batch_size: usize,
-    ) -> impl Future<Output = Result<Self, crate::qmdb::Error<crate::merkle::mmr::Family>>> + Send;
+    ) -> impl Future<Output = Result<Self, crate::qmdb::Error<Self::Family>>> + Send;
 
     /// Get the root digest of the database for verification
     fn root(&self) -> Self::Digest;

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -1,6 +1,6 @@
 //! Core sync engine components that are shared across sync clients.
 use crate::{
-    merkle::mmr::{Location, StandardHasher},
+    merkle::{hasher::Standard as StandardHasher, Family, Location},
     qmdb::{
         self,
         sync::{
@@ -36,7 +36,8 @@ use std::{
 };
 
 /// Type alias for sync engine errors
-type Error<DB, R> = qmdb::sync::Error<<R as Resolver>::Error, <DB as Database>::Digest>;
+type Error<DB, R> =
+    qmdb::sync::Error<<DB as Database>::Family, <R as Resolver>::Error, <DB as Database>::Digest>;
 
 /// Whether sync should continue or complete
 #[derive(Debug)]
@@ -49,11 +50,11 @@ pub(crate) enum NextStep<C, D> {
 
 /// Events that can occur during synchronization
 #[derive(Debug)]
-enum Event<Op, D: Digest, E> {
+enum Event<F: Family, Op, D: Digest, E> {
     /// A target update was received
-    TargetUpdate(Target<D>),
+    TargetUpdate(Target<F, D>),
     /// A batch of operations was received
-    BatchReceived(IndexedFetchResult<Op, D, E>),
+    BatchReceived(IndexedFetchResult<F, Op, D, E>),
     /// The target update channel was closed
     UpdateChannelClosed,
     /// A finish signal was received
@@ -64,22 +65,22 @@ enum Event<Op, D: Digest, E> {
 
 /// Result from a fetch operation with its request ID and starting location.
 #[derive(Debug)]
-pub(super) struct IndexedFetchResult<Op, D: Digest, E> {
+pub(super) struct IndexedFetchResult<F: Family, Op, D: Digest, E> {
     /// Unique ID assigned when the request was scheduled.
     pub id: RequestId,
     /// The location of the first operation in the batch.
-    pub start_loc: Location,
+    pub start_loc: Location<F>,
     /// The result of the fetch operation.
-    pub result: Result<FetchResult<Op, D>, E>,
+    pub result: Result<FetchResult<F, Op, D>, E>,
 }
 
 /// Wait for the next synchronization event.
 /// Returns `None` when there are no outstanding requests and no channels to wait on.
-async fn wait_for_event<Op, D: Digest, E>(
-    update_rx: &mut Option<mpsc::Receiver<Target<D>>>,
+async fn wait_for_event<F: Family, Op, D: Digest, E>(
+    update_rx: &mut Option<mpsc::Receiver<Target<F, D>>>,
     finish_rx: &mut Option<mpsc::Receiver<()>>,
-    outstanding_requests: &mut Requests<Op, D, E>,
-) -> Option<Event<Op, D, E>> {
+    outstanding_requests: &mut Requests<F, Op, D, E>,
+) -> Option<Event<F, Op, D, E>> {
     if outstanding_requests.len() == 0 && update_rx.is_none() && finish_rx.is_none() {
         return None;
     }
@@ -115,7 +116,7 @@ async fn wait_for_event<Op, D: Digest, E>(
 pub struct Config<DB, R>
 where
     DB: Database,
-    R: Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     /// Runtime context for creating database components
@@ -123,7 +124,7 @@ where
     /// Network resolver for fetching operations and proofs
     pub resolver: R,
     /// Sync target (root digest and operation bounds)
-    pub target: Target<DB::Digest>,
+    pub target: Target<DB::Family, DB::Digest>,
     /// Maximum number of outstanding requests for operation batches
     pub max_outstanding_requests: usize,
     /// Maximum operations to fetch per batch
@@ -133,7 +134,7 @@ where
     /// Database-specific configuration
     pub db_config: DB::Config,
     /// Channel for receiving sync target updates
-    pub update_rx: Option<mpsc::Receiver<Target<DB::Digest>>>,
+    pub update_rx: Option<mpsc::Receiver<Target<DB::Family, DB::Digest>>>,
     /// Channel that requests sync completion once the current target is reached.
     ///
     /// When `None`, sync completes as soon as the target is reached.
@@ -144,7 +145,7 @@ where
     /// When `reached_target_tx` is `Some(...)`, this receiver must be actively
     /// drained by the observer. The engine awaits send capacity on this channel before
     /// proceeding, so backpressure can pause progress at target.
-    pub reached_target_tx: Option<mpsc::Sender<Target<DB::Digest>>>,
+    pub reached_target_tx: Option<mpsc::Sender<Target<DB::Family, DB::Digest>>>,
     /// Maximum number of previous roots to retain for verifying in-flight
     /// requests after target updates. Set to 0 to disable (all retained
     /// requests will be re-fetched).
@@ -154,18 +155,18 @@ where
 pub(crate) struct Engine<DB, R>
 where
     DB: Database,
-    R: Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     /// Tracks outstanding fetch requests and their futures
-    outstanding_requests: Requests<DB::Op, DB::Digest, R::Error>,
+    outstanding_requests: Requests<DB::Family, DB::Op, DB::Digest, R::Error>,
 
     /// Operations that have been fetched but not yet applied to the log.
     ///
     /// # Invariant
     ///
     /// The vectors in the map are non-empty.
-    fetched_operations: BTreeMap<Location, Vec<DB::Op>>,
+    fetched_operations: BTreeMap<Location<DB::Family>, Vec<DB::Op>>,
 
     /// Pinned MMR nodes extracted from proofs, used for database construction
     pinned_nodes: Option<Vec<DB::Digest>>,
@@ -175,17 +176,17 @@ where
     /// the MMR is append-only and validate_update rejects unchanged roots.
     /// When a retained request completes, proof.leaves identifies which
     /// historical root to verify against.
-    retained_roots: HashMap<Location, DB::Digest>,
+    retained_roots: HashMap<Location<DB::Family>, DB::Digest>,
 
     /// Tree sizes of retained roots in insertion order (oldest first),
     /// used for FIFO eviction when retained_roots exceeds capacity.
-    retained_roots_order: VecDeque<Location>,
+    retained_roots_order: VecDeque<Location<DB::Family>>,
 
     /// Maximum number of historical roots to retain
     max_retained_roots: usize,
 
     /// The current sync target (root digest and operation bounds)
-    target: Target<DB::Digest>,
+    target: Target<DB::Family, DB::Digest>,
 
     /// Maximum number of parallel outstanding requests
     max_outstanding_requests: usize,
@@ -212,7 +213,7 @@ where
     config: DB::Config,
 
     /// Optional receiver for target updates during sync
-    update_rx: Option<mpsc::Receiver<Target<DB::Digest>>>,
+    update_rx: Option<mpsc::Receiver<Target<DB::Family, DB::Digest>>>,
 
     /// Channel that requests sync completion once the current target is reached.
     ///
@@ -225,7 +226,7 @@ where
     /// When `reached_target_tx` is `Some(...)`, this receiver must be actively
     /// drained by the observer. The engine awaits send capacity on this channel before
     /// proceeding, so backpressure can pause progress at target.
-    reached_target_tx: Option<mpsc::Sender<Target<DB::Digest>>>,
+    reached_target_tx: Option<mpsc::Sender<Target<DB::Family, DB::Digest>>>,
 
     /// Whether explicit finish has been requested.
     finish_requested: bool,
@@ -238,7 +239,7 @@ where
 impl<DB, R> Engine<DB, R>
 where
     DB: Database,
-    R: Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     pub(crate) fn journal(&self) -> &DB::Journal {
@@ -249,7 +250,7 @@ where
 impl<DB, R> Engine<DB, R>
 where
     DB: Database,
-    R: Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     /// Create a new sync engine with the given configuration
@@ -262,7 +263,7 @@ where
         }
 
         // Create journal and verifier using the database's factory methods
-        let journal = <DB::Journal as Journal>::new(
+        let journal = <DB::Journal as Journal<DB::Family>>::new(
             config.context.with_label("journal"),
             config.db_config.journal_config(),
             config.target.range.clone().into(),
@@ -336,7 +337,7 @@ where
 
         for _ in 0..num_requests {
             // Convert fetched operations to operation counts for shared gap detection
-            let operation_counts: BTreeMap<Location, u64> = self
+            let operation_counts: BTreeMap<Location<DB::Family>, u64> = self
                 .fetched_operations
                 .iter()
                 .map(|(&start_loc, operations)| (start_loc, operations.len() as u64))
@@ -389,7 +390,7 @@ where
     /// `retained_roots`) so the fetched operations can still be used.
     pub async fn reset_for_target_update(
         mut self,
-        new_target: Target<DB::Digest>,
+        new_target: Target<DB::Family, DB::Digest>,
     ) -> Result<Self, Error<DB, R>> {
         self.journal.resize(new_target.range.start()).await?;
         // Remove requests at or before the new start. The request at start
@@ -472,7 +473,11 @@ where
     }
 
     /// Store a batch of fetched operations. If the input list is empty, this is a no-op.
-    pub(crate) fn store_operations(&mut self, start_loc: Location, operations: Vec<DB::Op>) {
+    pub(crate) fn store_operations(
+        &mut self,
+        start_loc: Location<DB::Family>,
+        operations: Vec<DB::Op>,
+    ) {
         if operations.is_empty() {
             return;
         }
@@ -569,7 +574,7 @@ where
     /// to a matching historical root from `retained_roots` if available.
     fn handle_fetch_result(
         &mut self,
-        fetch_result: IndexedFetchResult<DB::Op, DB::Digest, R::Error>,
+        fetch_result: IndexedFetchResult<DB::Family, DB::Op, DB::Digest, R::Error>,
     ) -> Result<(), Error<DB, R>> {
         // Discard results for stale requests (removed by a target update).
         // Using the request ID prevents a stale future from consuming the
@@ -656,7 +661,7 @@ where
     /// Handle a sync event and return the next engine state.
     async fn handle_event(
         mut self,
-        event: Event<DB::Op, DB::Digest, R::Error>,
+        event: Event<DB::Family, DB::Op, DB::Digest, R::Error>,
     ) -> Result<NextStep<Self, DB>, Error<DB, R>> {
         match event {
             Event::TargetUpdate(new_target) => {
@@ -767,16 +772,18 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::mmr::Proof;
+    use crate::merkle::mmr::{Family as MmrFamily, Proof};
     use commonware_cryptography::sha256;
     use commonware_utils::channel::oneshot;
     use std::{future::Future, pin::Pin};
 
     /// Create a no-op fetch result future for testing request tracking.
+    #[allow(clippy::type_complexity)]
     fn dummy_future(
         id: RequestId,
         loc: u64,
-    ) -> Pin<Box<dyn Future<Output = IndexedFetchResult<i32, sha256::Digest, ()>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = IndexedFetchResult<MmrFamily, i32, sha256::Digest, ()>> + Send>>
+    {
         Box::pin(async move {
             IndexedFetchResult {
                 id,
@@ -795,7 +802,7 @@ mod tests {
     }
 
     /// Helper to add a request at a given location.
-    fn add(requests: &mut Requests<i32, sha256::Digest, ()>, loc: u64) -> RequestId {
+    fn add(requests: &mut Requests<MmrFamily, i32, sha256::Digest, ()>, loc: u64) -> RequestId {
         let id = requests.next_id();
         requests.insert(
             id,
@@ -808,7 +815,7 @@ mod tests {
 
     #[test]
     fn test_add_and_remove() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<MmrFamily, i32, sha256::Digest, ()> = Requests::new();
         assert_eq!(requests.len(), 0);
 
         let id = add(&mut requests, 10);
@@ -822,7 +829,7 @@ mod tests {
 
     #[test]
     fn test_remove_before() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<MmrFamily, i32, sha256::Digest, ()> = Requests::new();
 
         add(&mut requests, 5);
         add(&mut requests, 10);
@@ -840,7 +847,7 @@ mod tests {
 
     #[test]
     fn test_remove_before_all() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<MmrFamily, i32, sha256::Digest, ()> = Requests::new();
 
         add(&mut requests, 5);
         add(&mut requests, 10);
@@ -852,14 +859,14 @@ mod tests {
 
     #[test]
     fn test_remove_before_empty() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<MmrFamily, i32, sha256::Digest, ()> = Requests::new();
         requests.remove_before(Location::new(10));
         assert_eq!(requests.len(), 0);
     }
 
     #[test]
     fn test_remove_before_none() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<MmrFamily, i32, sha256::Digest, ()> = Requests::new();
 
         add(&mut requests, 10);
         add(&mut requests, 20);
@@ -873,7 +880,7 @@ mod tests {
 
     #[test]
     fn test_superseded_request() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<MmrFamily, i32, sha256::Digest, ()> = Requests::new();
 
         // Old request at location 10
         let old_id = add(&mut requests, 10);
@@ -894,7 +901,7 @@ mod tests {
 
     #[test]
     fn test_stale_id_after_remove_before() {
-        let mut requests: Requests<i32, sha256::Digest, ()> = Requests::new();
+        let mut requests: Requests<MmrFamily, i32, sha256::Digest, ()> = Requests::new();
 
         let old_id = add(&mut requests, 5);
         add(&mut requests, 15);

--- a/storage/src/qmdb/sync/error.rs
+++ b/storage/src/qmdb/sync/error.rs
@@ -1,18 +1,21 @@
 //! Shared sync error types that can be used across different database implementations.
 
-use crate::{mmr::Location, qmdb::sync::Target};
+use crate::{
+    merkle::{Family, Location},
+    qmdb::sync::Target,
+};
 use commonware_cryptography::Digest;
 
 #[derive(Debug, thiserror::Error)]
-pub enum EngineError<D: Digest> {
+pub enum EngineError<F: Family, D: Digest> {
     /// Hash mismatch after sync
     #[error("root digest mismatch - expected {expected:?}, got {actual:?}")]
     RootMismatch { expected: D, actual: D },
     /// Invalid target parameters
     #[error("invalid bounds: lower bound {lower_bound_pos} > upper bound {upper_bound_pos}")]
     InvalidTarget {
-        lower_bound_pos: Location,
-        upper_bound_pos: Location,
+        lower_bound_pos: Location<F>,
+        upper_bound_pos: Location<F>,
     },
     /// Invalid client state
     #[error("invalid client state")]
@@ -22,7 +25,10 @@ pub enum EngineError<D: Digest> {
     SyncTargetRootUnchanged,
     /// Sync target moved backward
     #[error("sync target moved backward: {old:?} -> {new:?}")]
-    SyncTargetMovedBackward { old: Target<D>, new: Target<D> },
+    SyncTargetMovedBackward {
+        old: Target<F, D>,
+        new: Target<F, D>,
+    },
     /// Sync already completed
     #[error("sync already completed")]
     AlreadyComplete,
@@ -39,14 +45,15 @@ pub enum EngineError<D: Digest> {
 
 /// Errors that can occur during database synchronization.
 #[derive(Debug, thiserror::Error)]
-pub enum Error<U, D>
+pub enum Error<F, U, D>
 where
+    F: Family,
     U: std::error::Error + Send + 'static,
     D: Digest,
 {
     /// Database error
     #[error("database error: {0}")]
-    Database(crate::qmdb::Error<crate::merkle::mmr::Family>),
+    Database(crate::qmdb::Error<F>),
 
     /// Resolver error
     #[error("resolver error: {0:?}")]
@@ -54,14 +61,15 @@ where
 
     /// Engine error
     #[error("engine error: {0}")]
-    Engine(EngineError<D>),
+    Engine(EngineError<F, D>),
 }
 
-impl<T, U, D> From<T> for Error<U, D>
+impl<F, T, U, D> From<T> for Error<F, U, D>
 where
+    F: Family,
     U: std::error::Error + Send + 'static,
     D: Digest,
-    T: Into<crate::qmdb::Error<crate::merkle::mmr::Family>>,
+    T: Into<crate::qmdb::Error<F>>,
 {
     fn from(err: T) -> Self {
         Self::Database(err.into())

--- a/storage/src/qmdb/sync/gaps.rs
+++ b/storage/src/qmdb/sync/gaps.rs
@@ -1,6 +1,6 @@
 //! Gap detection algorithm for sync operations.
 
-use crate::merkle::mmr::Location;
+use crate::merkle::{Family, Location};
 use core::{num::NonZeroU64, ops::Range};
 use std::collections::BTreeMap;
 
@@ -23,18 +23,18 @@ use std::collections::BTreeMap;
 /// - All start locations in `fetched_operations` are in `range`
 /// - All start locations in `outstanding_requests` are in `range`
 /// - All operation counts in `fetched_operations` are > 0
-pub fn find_next<'a>(
-    range: Range<Location>,
-    fetched_operations: &BTreeMap<Location, u64>, // start_loc -> operation_count
-    outstanding_requests: impl IntoIterator<Item = &'a Location>,
+pub fn find_next<'a, F: Family>(
+    range: Range<Location<F>>,
+    fetched_operations: &BTreeMap<Location<F>, u64>, // start_loc -> operation_count
+    outstanding_requests: impl IntoIterator<Item = &'a Location<F>>,
     fetch_batch_size: NonZeroU64,
-) -> Option<Range<Location>> {
+) -> Option<Range<Location<F>>> {
     if range.is_empty() {
         return None;
     }
 
     // Track the next uncovered location (exclusive end of covered range)
-    let mut next_uncovered: Location = range.start;
+    let mut next_uncovered: Location<F> = range.start;
 
     // Create iterators for both data structures (already sorted)
     let mut fetched_ops_iter = fetched_operations
@@ -254,12 +254,13 @@ mod tests {
         expected: Some(0..1),
     })]
     fn test_find_next(#[case] test_case: FindNextTestCase) {
-        let fetched_ops: BTreeMap<Location, u64> = test_case
+        use crate::merkle::mmr::Family as MmrFamily;
+        let fetched_ops: BTreeMap<Location<MmrFamily>, u64> = test_case
             .fetched_ops
             .into_iter()
             .map(|(k, v)| (Location::new(k), v))
             .collect();
-        let outstanding_requests: Vec<Location> = test_case
+        let outstanding_requests: Vec<Location<MmrFamily>> = test_case
             .requested_ops
             .into_iter()
             .map(Location::new)

--- a/storage/src/qmdb/sync/journal.rs
+++ b/storage/src/qmdb/sync/journal.rs
@@ -1,8 +1,11 @@
-use crate::{journal::contiguous::Contiguous, mmr::Location};
+use crate::{
+    journal::contiguous::Contiguous,
+    merkle::{Family, Location},
+};
 use std::{future::Future, ops::Range};
 
 /// Journal of operations used by a [super::Database]
-pub trait Journal: Sized + Send {
+pub trait Journal<F: Family>: Sized + Send {
     /// The context of the journal
     type Context;
 
@@ -13,10 +16,7 @@ pub trait Journal: Sized + Send {
     type Op: Send;
 
     /// The error type returned by the journal
-    type Error: std::error::Error
-        + Send
-        + 'static
-        + Into<crate::qmdb::Error<crate::merkle::mmr::Family>>;
+    type Error: std::error::Error + Send + 'static + Into<crate::qmdb::Error<F>>;
 
     /// Create/open a journal for syncing the given range.
     ///
@@ -27,14 +27,17 @@ pub trait Journal: Sized + Send {
     fn new(
         context: Self::Context,
         config: Self::Config,
-        range: Range<Location>,
+        range: Range<Location<F>>,
     ) -> impl Future<Output = Result<Self, Self::Error>>;
 
     /// Discard all operations before the given location.
     ///
     /// If current `size() <= start`, initialize as empty at the given location.
     /// Otherwise prune data before the given location.
-    fn resize(&mut self, start: Location) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    fn resize(
+        &mut self,
+        start: Location<F>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Persist the journal.
     fn sync(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send;
@@ -46,8 +49,9 @@ pub trait Journal: Sized + Send {
     fn append(&mut self, op: Self::Op) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
-impl<E, V> Journal for crate::journal::contiguous::variable::Journal<E, V>
+impl<F, E, V> Journal<F> for crate::journal::contiguous::variable::Journal<E, V>
 where
+    F: Family,
     E: crate::Context,
     V: commonware_codec::CodecShared,
 {
@@ -59,13 +63,13 @@ where
     async fn new(
         context: Self::Context,
         config: Self::Config,
-        range: Range<Location>,
+        range: Range<Location<F>>,
     ) -> Result<Self, Self::Error> {
         Self::init_sync(context, config.clone(), *range.start..*range.end).await
     }
 
-    async fn resize(&mut self, start: Location) -> Result<(), Self::Error> {
-        if Contiguous::size(self).await <= start {
+    async fn resize(&mut self, start: Location<F>) -> Result<(), Self::Error> {
+        if Contiguous::size(self).await <= *start {
             self.clear_to_size(*start).await
         } else {
             self.prune(*start).await.map(|_| ())
@@ -85,8 +89,9 @@ where
     }
 }
 
-impl<E, A> Journal for crate::journal::contiguous::fixed::Journal<E, A>
+impl<F, E, A> Journal<F> for crate::journal::contiguous::fixed::Journal<E, A>
 where
+    F: Family,
     E: crate::Context,
     A: commonware_codec::CodecFixedShared,
 {
@@ -98,7 +103,7 @@ where
     async fn new(
         context: Self::Context,
         config: Self::Config,
-        range: Range<Location>,
+        range: Range<Location<F>>,
     ) -> Result<Self, Self::Error> {
         assert!(!range.is_empty(), "range must not be empty");
 
@@ -119,8 +124,8 @@ where
         Ok(journal)
     }
 
-    async fn resize(&mut self, start: Location) -> Result<(), Self::Error> {
-        if Contiguous::size(self).await <= start {
+    async fn resize(&mut self, start: Location<F>) -> Result<(), Self::Error> {
+        if Contiguous::size(self).await <= *start {
             self.clear_to_size(*start).await
         } else {
             self.prune(*start).await.map(|_| ())

--- a/storage/src/qmdb/sync/mod.rs
+++ b/storage/src/qmdb/sync/mod.rs
@@ -26,11 +26,13 @@ pub use target::Target;
 mod requests;
 
 /// Create/open a database and sync it to a target state
-pub async fn sync<DB, R>(config: Config<DB, R>) -> Result<DB, Error<R::Error, DB::Digest>>
+pub async fn sync<DB, R>(
+    config: Config<DB, R>,
+) -> Result<DB, Error<DB::Family, R::Error, DB::Digest>>
 where
     DB: Database,
     DB::Op: Encode,
-    R: resolver::Resolver<Op = DB::Op, Digest = DB::Digest>,
+    R: resolver::Resolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
 {
     Engine::new(config).await?.sync().await
 }

--- a/storage/src/qmdb/sync/requests.rs
+++ b/storage/src/qmdb/sync/requests.rs
@@ -3,7 +3,10 @@
 //! Each request is assigned a unique ID when added. This prevents stale futures
 //! from colliding with fresh requests at the same location after a target update.
 
-use crate::{mmr::Location, qmdb::sync::engine::IndexedFetchResult};
+use crate::{
+    merkle::{Family, Location},
+    qmdb::sync::engine::IndexedFetchResult,
+};
 use commonware_cryptography::Digest;
 use commonware_utils::channel::oneshot;
 use futures::stream::FuturesUnordered;
@@ -18,23 +21,24 @@ use std::{
 pub(super) struct Id(u64);
 
 /// Manages outstanding fetch requests.
-pub(super) struct Requests<Op, D: Digest, E> {
+pub(super) struct Requests<F: Family, Op, D: Digest, E> {
     /// Futures that will resolve to fetch results.
     #[allow(clippy::type_complexity)]
-    futures: FuturesUnordered<Pin<Box<dyn Future<Output = IndexedFetchResult<Op, D, E>> + Send>>>,
+    futures:
+        FuturesUnordered<Pin<Box<dyn Future<Output = IndexedFetchResult<F, Op, D, E>> + Send>>>,
 
     /// Counter for assigning unique request IDs.
     next_id: u64,
 
     /// Active requests keyed by ID. Removing an entry drops the cancel sender,
     /// causing the resolver's `cancel_rx.await` to return `Err`.
-    tracked: HashMap<Id, (Location, oneshot::Sender<()>)>,
+    tracked: HashMap<Id, (Location<F>, oneshot::Sender<()>)>,
 
     /// Reverse index from location to request ID, for gap detection.
-    by_location: BTreeMap<Location, Id>,
+    by_location: BTreeMap<Location<F>, Id>,
 }
 
-impl<Op, D: Digest, E> Requests<Op, D, E> {
+impl<F: Family, Op, D: Digest, E> Requests<F, Op, D, E> {
     pub fn new() -> Self {
         Self {
             futures: FuturesUnordered::new(),
@@ -55,12 +59,13 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
     /// Register a request with a previously allocated ID. If a request already
     /// exists at `start_loc`, the old one is superseded (its cancel sender is
     /// dropped and its future will be discarded when it completes).
+    #[allow(clippy::type_complexity)]
     pub fn insert(
         &mut self,
         id: Id,
-        start_loc: Location,
+        start_loc: Location<F>,
         cancel_tx: oneshot::Sender<()>,
-        future: Pin<Box<dyn Future<Output = IndexedFetchResult<Op, D, E>> + Send>>,
+        future: Pin<Box<dyn Future<Output = IndexedFetchResult<F, Op, D, E>> + Send>>,
     ) {
         if let Some(old_id) = self.by_location.insert(start_loc, id) {
             self.tracked.remove(&old_id);
@@ -85,7 +90,7 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
 
     /// Remove all requests at locations before `loc`. Dropped cancel senders
     /// signal resolvers to abort.
-    pub fn remove_before(&mut self, loc: Location) {
+    pub fn remove_before(&mut self, loc: Location<F>) {
         let keep = self.by_location.split_off(&loc);
         for id in self.by_location.values() {
             self.tracked.remove(id);
@@ -94,12 +99,12 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
     }
 
     /// Iterate over outstanding request locations in ascending order.
-    pub fn locations(&self) -> impl Iterator<Item = &Location> {
+    pub fn locations(&self) -> impl Iterator<Item = &Location<F>> {
         self.by_location.keys()
     }
 
     /// Check if a location has an outstanding request.
-    pub fn contains(&self, loc: &Location) -> bool {
+    pub fn contains(&self, loc: &Location<F>) -> bool {
         self.by_location.contains_key(loc)
     }
 
@@ -107,7 +112,7 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
     #[allow(clippy::type_complexity)]
     pub fn futures_mut(
         &mut self,
-    ) -> &mut FuturesUnordered<Pin<Box<dyn Future<Output = IndexedFetchResult<Op, D, E>> + Send>>>
+    ) -> &mut FuturesUnordered<Pin<Box<dyn Future<Output = IndexedFetchResult<F, Op, D, E>> + Send>>>
     {
         &mut self.futures
     }
@@ -118,7 +123,7 @@ impl<Op, D: Digest, E> Requests<Op, D, E> {
     }
 }
 
-impl<Op, D: Digest, E> Default for Requests<Op, D, E> {
+impl<F: Family, Op, D: Digest, E> Default for Requests<F, Op, D, E> {
     fn default() -> Self {
         Self::new()
     }

--- a/storage/src/qmdb/sync/resolver.rs
+++ b/storage/src/qmdb/sync/resolver.rs
@@ -1,5 +1,5 @@
 use crate::{
-    merkle::mmr::{self, Location, Proof},
+    merkle::{mmr, Family, Location, Proof},
     qmdb::{
         self,
         any::{
@@ -30,10 +30,13 @@ use commonware_cryptography::{Digest, Hasher};
 use commonware_utils::{channel::oneshot, sync::AsyncRwLock, Array};
 use std::{future::Future, num::NonZeroU64, sync::Arc};
 
-/// Result from a fetch operation
-pub struct FetchResult<Op, D: Digest> {
+/// Result from a fetch operation.
+///
+/// Parameterized over the merkle family `F` so the embedded `Proof<F, D>` matches
+/// the database being synced.
+pub struct FetchResult<F: Family, Op, D: Digest> {
     /// The proof for the operations
-    pub proof: Proof<D>,
+    pub proof: Proof<F, D>,
     /// The operations that were fetched
     pub operations: Vec<Op>,
     /// Channel to report success/failure back to resolver
@@ -42,7 +45,7 @@ pub struct FetchResult<Op, D: Digest> {
     pub pinned_nodes: Option<Vec<D>>,
 }
 
-impl<Op: std::fmt::Debug, D: Digest> std::fmt::Debug for FetchResult<Op, D> {
+impl<F: Family, Op: std::fmt::Debug, D: Digest> std::fmt::Debug for FetchResult<F, Op, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FetchResult")
             .field("proof", &self.proof)
@@ -53,8 +56,14 @@ impl<Op: std::fmt::Debug, D: Digest> std::fmt::Debug for FetchResult<Op, D> {
     }
 }
 
-/// Trait for network communication with the sync server
+/// Trait for network communication with the sync server.
+///
+/// The associated `Family` is the merkle family whose proofs this resolver serves.
+/// It must match the database being synced.
 pub trait Resolver: Send + Sync + Clone + 'static {
+    /// The merkle family backing the resolver's proofs.
+    type Family: Family;
+
     /// The digest type used in proofs returned by the resolver
     type Digest: Digest;
 
@@ -75,19 +84,21 @@ pub trait Resolver: Send + Sync + Clone + 'static {
     #[allow(clippy::type_complexity)]
     fn get_operations<'a>(
         &'a self,
-        op_count: Location,
-        start_loc: Location,
+        op_count: Location<Self::Family>,
+        start_loc: Location<Self::Family>,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
         cancel_rx: oneshot::Receiver<()>,
-    ) -> impl Future<Output = Result<FetchResult<Self::Op, Self::Digest>, Self::Error>> + Send + 'a;
+    ) -> impl Future<Output = Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error>>
+           + Send
+           + 'a;
 }
 
 macro_rules! impl_resolver {
     ($db:ident, $op:ident, $val_bound:ident) => {
-        impl<E, K, V, H, T> Resolver
-            for Arc<$db<crate::merkle::mmr::Family, E, K, V, H, T>>
+        impl<F, E, K, V, H, T> Resolver for Arc<$db<F, E, K, V, H, T>>
         where
+            F: Family,
             E: Context,
             K: Array,
             V: $val_bound + Send + Sync + 'static,
@@ -95,18 +106,19 @@ macro_rules! impl_resolver {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<crate::merkle::mmr::Family, K, V>;
-            type Error = qmdb::Error<crate::merkle::mmr::Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let (proof, operations) =
                     self.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -123,9 +135,9 @@ macro_rules! impl_resolver {
             }
         }
 
-        impl<E, K, V, H, T> Resolver
-            for Arc<AsyncRwLock<$db<crate::merkle::mmr::Family, E, K, V, H, T>>>
+        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T>>>
         where
+            F: Family,
             E: Context,
             K: Array,
             V: $val_bound + Send + Sync + 'static,
@@ -133,18 +145,19 @@ macro_rules! impl_resolver {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<crate::merkle::mmr::Family, K, V>;
-            type Error = qmdb::Error<crate::merkle::mmr::Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<crate::merkle::mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let db = self.read().await;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -161,9 +174,9 @@ macro_rules! impl_resolver {
             }
         }
 
-        impl<E, K, V, H, T> Resolver
-            for Arc<AsyncRwLock<Option<$db<crate::merkle::mmr::Family, E, K, V, H, T>>>>
+        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T>>>>
         where
+            F: Family,
             E: Context,
             K: Array,
             V: $val_bound + Send + Sync + 'static,
@@ -171,18 +184,19 @@ macro_rules! impl_resolver {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = F;
             type Digest = H::Digest;
-            type Op = $op<crate::merkle::mmr::Family, K, V>;
-            type Error = qmdb::Error<crate::merkle::mmr::Family>;
+            type Op = $op<F, K, V>;
+            type Error = qmdb::Error<F>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<crate::merkle::mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
@@ -227,18 +241,19 @@ macro_rules! impl_resolver_immutable {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<K, V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let (proof, operations) =
                     self.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -264,18 +279,19 @@ macro_rules! impl_resolver_immutable {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<K, V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let db = self.read().await;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -301,18 +317,19 @@ macro_rules! impl_resolver_immutable {
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<K, V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
@@ -347,18 +364,19 @@ macro_rules! impl_resolver_keyless {
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, Self::Error> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let (proof, operations) =
                     self.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -381,18 +399,19 @@ macro_rules! impl_resolver_keyless {
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let db = self.read().await;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
                 let pinned_nodes = if include_pinned_nodes {
@@ -415,18 +434,19 @@ macro_rules! impl_resolver_keyless {
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
         {
+            type Family = mmr::Family;
             type Digest = H::Digest;
             type Op = $op<V>;
             type Error = qmdb::Error<mmr::Family>;
 
             async fn get_operations(
                 &self,
-                op_count: Location,
-                start_loc: Location,
+                op_count: Location<Self::Family>,
+                start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<mmr::Family>> {
+            ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
                 let (proof, operations) = db.historical_proof(op_count, start_loc, max_ops).await?;
@@ -459,33 +479,34 @@ pub(crate) mod tests {
 
     /// A resolver that always fails.
     #[derive(Clone)]
-    pub struct FailResolver<Op, D> {
-        _phantom: PhantomData<(Op, D)>,
+    pub struct FailResolver<F: Family, Op, D> {
+        _phantom: PhantomData<(F, Op, D)>,
     }
 
-    impl<Op, D> Resolver for FailResolver<Op, D>
+    impl<F, Op, D> Resolver for FailResolver<F, Op, D>
     where
+        F: Family,
         D: Digest,
         Op: Send + Sync + Clone + 'static,
     {
+        type Family = F;
         type Digest = D;
         type Op = Op;
-        type Error = qmdb::Error<crate::merkle::mmr::Family>;
+        type Error = qmdb::Error<F>;
 
         async fn get_operations(
             &self,
-            _op_count: Location,
-            _start_loc: Location,
+            _op_count: Location<F>,
+            _start_loc: Location<F>,
             _max_ops: NonZeroU64,
             _include_pinned_nodes: bool,
             _cancel: oneshot::Receiver<()>,
-        ) -> Result<FetchResult<Self::Op, Self::Digest>, qmdb::Error<crate::merkle::mmr::Family>>
-        {
+        ) -> Result<FetchResult<F, Op, D>, qmdb::Error<F>> {
             Err(qmdb::Error::KeyNotFound) // Arbitrary dummy error
         }
     }
 
-    impl<Op, D> FailResolver<Op, D> {
+    impl<F: Family, Op, D> FailResolver<F, Op, D> {
         pub fn new() -> Self {
             Self {
                 _phantom: PhantomData,

--- a/storage/src/qmdb/sync/target.rs
+++ b/storage/src/qmdb/sync/target.rs
@@ -1,9 +1,5 @@
-#[cfg(feature = "arbitrary")]
-use crate::merkle::mmr::Family;
-#[cfg(feature = "arbitrary")]
-use crate::merkle::Family as _;
 use crate::{
-    merkle::mmr::Location,
+    merkle::{Family, Location},
     qmdb::sync::{self, error::EngineError},
 };
 use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
@@ -11,34 +7,56 @@ use commonware_cryptography::Digest;
 use commonware_runtime::{Buf, BufMut};
 use commonware_utils::range::NonEmptyRange;
 
-/// Target state to sync to
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Target<D: Digest> {
-    /// The root digest we're syncing to
+/// Target state to sync to.
+///
+/// `root` is the ops root that the sync engine verifies streaming batches against.
+///
+/// `PartialEq`, `Eq`, and `Clone` are implemented manually so they do not require
+/// `F: PartialEq + Clone`; the family `F` is a zero-sized marker.
+#[derive(Debug)]
+pub struct Target<F: Family, D: Digest> {
+    /// The ops root the sync engine verifies streaming batches against.
     pub root: D,
     /// Range of operations to sync
-    pub range: NonEmptyRange<Location>,
+    pub range: NonEmptyRange<Location<F>>,
 }
 
-impl<D: Digest> Write for Target<D> {
+impl<F: Family, D: Digest> Clone for Target<F, D> {
+    fn clone(&self) -> Self {
+        Self {
+            root: self.root,
+            range: self.range.clone(),
+        }
+    }
+}
+
+impl<F: Family, D: Digest> PartialEq for Target<F, D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root && self.range == other.range
+    }
+}
+
+impl<F: Family, D: Digest> Eq for Target<F, D> {}
+
+impl<F: Family, D: Digest> Write for Target<F, D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.root.write(buf);
         self.range.write(buf);
     }
 }
 
-impl<D: Digest> EncodeSize for Target<D> {
+impl<F: Family, D: Digest> EncodeSize for Target<F, D> {
     fn encode_size(&self) -> usize {
         self.root.encode_size() + self.range.encode_size()
     }
 }
 
-impl<D: Digest> Read for Target<D> {
+impl<F: Family, D: Digest> Read for Target<F, D> {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let root = D::read(buf)?;
-        let range = NonEmptyRange::<Location>::read(buf)?;
+        let range = NonEmptyRange::<Location<F>>::read(buf)?;
         if !range.start().is_valid() || !range.end().is_valid() {
             return Err(CodecError::Invalid(
                 "storage::qmdb::sync::Target",
@@ -50,13 +68,13 @@ impl<D: Digest> Read for Target<D> {
 }
 
 #[cfg(feature = "arbitrary")]
-impl<D: Digest> arbitrary::Arbitrary<'_> for Target<D>
+impl<F: Family, D: Digest> arbitrary::Arbitrary<'_> for Target<F, D>
 where
     D: for<'a> arbitrary::Arbitrary<'a>,
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         let root = u.arbitrary()?;
-        let max_loc = Family::MAX_LEAVES;
+        let max_loc = F::MAX_LEAVES;
         let lower = u.int_in_range(0..=*max_loc - 1)?;
         let upper = u.int_in_range(lower + 1..=*max_loc)?;
         Ok(Self {
@@ -67,11 +85,12 @@ where
 }
 
 /// Validate a target update against the current target
-pub fn validate_update<U, D>(
-    old_target: &Target<D>,
-    new_target: &Target<D>,
-) -> Result<(), sync::Error<U, D>>
+pub fn validate_update<F, U, D>(
+    old_target: &Target<F, D>,
+    new_target: &Target<F, D>,
+) -> Result<(), sync::Error<F, U, D>>
 where
+    F: Family,
     U: std::error::Error + Send + 'static,
     D: Digest,
 {
@@ -105,12 +124,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::merkle::mmr::Family as MmrFamily;
     use commonware_cryptography::sha256;
     use commonware_utils::non_empty_range;
     use rstest::rstest;
     use std::io::Cursor;
 
-    fn target(root: sha256::Digest, start: u64, end: u64) -> Target<sha256::Digest> {
+    fn target(root: sha256::Digest, start: u64, end: u64) -> Target<MmrFamily, sha256::Digest> {
         Target {
             root,
             range: non_empty_range!(Location::new(start), Location::new(end)),
@@ -143,12 +163,12 @@ mod tests {
         // Manually encode root + two Locations to bypass the Range write panic
         let mut buffer = Vec::new();
         sha256::Digest::from([42; 32]).write(&mut buffer);
-        Location::new(100).write(&mut buffer); // start
-        Location::new(50).write(&mut buffer); // end (< start = invalid)
+        Location::<MmrFamily>::new(100).write(&mut buffer); // start
+        Location::<MmrFamily>::new(50).write(&mut buffer); // end (< start = invalid)
 
         let mut cursor = Cursor::new(buffer);
         assert!(matches!(
-            Target::<sha256::Digest>::read(&mut cursor),
+            Target::<MmrFamily, sha256::Digest>::read(&mut cursor),
             Err(CodecError::Invalid("Range", "start must be <= end"))
         ));
 
@@ -156,16 +176,16 @@ mod tests {
         let root = sha256::Digest::from([42; 32]);
         let mut buffer = Vec::new();
         root.write(&mut buffer);
-        (Location::new(100)..Location::new(100)).write(&mut buffer);
+        (Location::<MmrFamily>::new(100)..Location::<MmrFamily>::new(100)).write(&mut buffer);
 
         let mut cursor = Cursor::new(buffer);
         assert!(matches!(
-            Target::<sha256::Digest>::read(&mut cursor),
+            Target::<MmrFamily, sha256::Digest>::read(&mut cursor),
             Err(CodecError::Invalid("NonEmptyRange", "start must be < end"))
         ));
     }
 
-    type TestError = sync::Error<std::io::Error, sha256::Digest>;
+    type TestError = sync::Error<MmrFamily, std::io::Error, sha256::Digest>;
 
     #[rstest]
     #[case::valid_update(
@@ -200,8 +220,8 @@ mod tests {
         Err(TestError::Engine(EngineError::SyncTargetRootUnchanged))
     )]
     fn test_validate_update(
-        #[case] old_target: Target<sha256::Digest>,
-        #[case] new_target: Target<sha256::Digest>,
+        #[case] old_target: Target<MmrFamily, sha256::Digest>,
+        #[case] new_target: Target<MmrFamily, sha256::Digest>,
         #[case] expected: Result<(), TestError>,
     ) {
         let result = validate_update(&old_target, &new_target);
@@ -246,7 +266,7 @@ mod tests {
         use commonware_codec::conformance::CodecConformance;
 
         commonware_conformance::conformance_tests! {
-            CodecConformance<Target<sha256::Digest>>,
+            CodecConformance<Target<MmrFamily, sha256::Digest>>,
         }
     }
 }

--- a/storage/src/qmdb/verify.rs
+++ b/storage/src/qmdb/verify.rs
@@ -25,9 +25,10 @@ where
 /// Verify that both a [Proof] and a set of pinned nodes are valid with respect to a target root.
 ///
 /// The `pinned_nodes` are the pruning-boundary peaks at `start_loc` (as returned by
-/// `nodes_to_pin`). These may be finer-grained than the prefix subtrees authenticated directly by
-/// the proof; the verifier reconstructs those prefix subtrees from the pins as needed. When
-/// `start_loc` is 0, `pinned_nodes` must be empty.
+/// `nodes_to_pin`). When the larger tree has merged smaller subtrees into a bigger parent, the
+/// pins sit below the prefix subtrees authenticated by the proof; the verifier hashes pairs of
+/// pins up to each authenticated subtree's root and compares. When `start_loc` is 0,
+/// `pinned_nodes` must be empty.
 pub fn verify_proof_and_pinned_nodes<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,


### PR DESCRIPTION
This PR generalizes the sync protocol across merkle family.  To support the current DB's grafted digest reconstruction, we change the current qmdb pruning function to restrict pruning to a point that may precede the inactivity floor by a slight amount (< 2*chunk_size). This guarantees the grafted digests can always be reconstructed from ops-tree digests alone, as required by the sync protocol.

Alternative to: https://github.com/commonwarexyz/monorepo/pull/3609