### PR TITLE
[Storage] Cache `pruned_chunks` in `BitmapBatchLayer`; `len` in `OnesIter`

### DIFF
--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -590,6 +590,7 @@ where
     // compute_db_root sees newly completed chunks. Using bitmap_parent alone would miss chunks
     // that transitioned from partial to complete in this batch.
     let bitmap_batch = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+        pruned_chunks: bitmap_parent.pruned_chunks(),
         parent: bitmap_parent.clone(),
         overlay: Arc::new(overlay),
     }));
@@ -648,6 +649,10 @@ pub(crate) struct BitmapBatchLayer<const N: usize> {
     pub(crate) parent: BitmapBatch<N>,
     /// Chunk-level overlay: materialized bytes for every chunk that differs from parent.
     pub(crate) overlay: Arc<ChunkOverlay<N>>,
+    /// Pruned-chunk count, copied from `parent` at construction. Invariant across the whole
+    /// layer chain (pruning only happens on the committed base), so caching here lets
+    /// `BitmapBatch::pruned_chunks` return in O(1) instead of walking to the Base.
+    pub(crate) pruned_chunks: usize,
 }
 
 impl<const N: usize> BitmapBatch<N> {
@@ -691,7 +696,7 @@ impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
     fn pruned_chunks(&self) -> usize {
         match self {
             Self::Base(bm) => bm.pruned_chunks(),
-            Self::Layer(layer) => layer.parent.pruned_chunks(),
+            Self::Layer(layer) => layer.pruned_chunks,
         }
     }
 
@@ -723,8 +728,13 @@ impl<const N: usize> BitmapBatch<N> {
         }
 
         // Slow path: create a new layer.
+        let pruned_chunks = self.pruned_chunks();
         let parent = self.clone();
-        *self = Self::Layer(Arc::new(BitmapBatchLayer { parent, overlay }));
+        *self = Self::Layer(Arc::new(BitmapBatchLayer {
+            parent,
+            overlay,
+            pruned_chunks,
+        }));
     }
 
     /// Flatten all layers back to a single `Base(Arc<BitMap<N>>)`.

--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -967,7 +967,13 @@ pub trait Readable<const N: usize> {
     where
         Self: Sized,
     {
-        OnesIter { bitmap: self, pos }
+        let len = self.len();
+        let pruned_start = (self.pruned_chunks() as u64) * BitMap::<N>::CHUNK_SIZE_BITS;
+        OnesIter {
+            bitmap: self,
+            pos: pos.max(pruned_start),
+            len,
+        }
     }
 }
 
@@ -1002,19 +1008,19 @@ impl<const N: usize> Readable<N> for BitMap<N> {
 pub struct OnesIter<'a, B, const N: usize> {
     bitmap: &'a B,
     pos: u64,
+    /// Cached `bitmap.len()` at iterator construction. The underlying bitmap is borrowed
+    /// immutably for the iterator's lifetime, so this can never change mid-iteration.
+    /// For layered bitmaps (e.g. `BitmapBatch`), `len()` walks the layer chain, so caching
+    /// this avoids that walk on every `next`.
+    len: u64,
 }
 
 impl<B: Readable<N>, const N: usize> iter::Iterator for OnesIter<'_, B, N> {
     type Item = u64;
 
     fn next(&mut self) -> Option<u64> {
-        let len = self.bitmap.len();
         let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
-        let pruned_start = self.bitmap.pruned_chunks() as u64 * chunk_bits;
-        if self.pos < pruned_start {
-            self.pos = pruned_start;
-        }
-        while self.pos < len {
+        while self.pos < self.len {
             let chunk_idx = BitMap::<N>::to_chunk_index(self.pos);
             let chunk = self.bitmap.get_chunk(chunk_idx);
             let chunk_start = chunk_idx as u64 * chunk_bits;
@@ -1027,7 +1033,7 @@ impl<B: Readable<N>, const N: usize> iter::Iterator for OnesIter<'_, B, N> {
                     let found = chunk_start
                         + (byte_idx * 8 + bit_in_byte) as u64
                         + masked.trailing_zeros() as u64;
-                    if found >= len {
+                    if found >= self.len {
                         return None;
                     }
                     self.pos = found + 1;


### PR DESCRIPTION
## Problem

`<BitmapBatch as Readable>::pruned_chunks` recursed the full speculative-layer chain on every call:

```rust
Self::Layer(layer) => layer.parent.pruned_chunks(),
```

Two hot callers hit it per-item:

- `ChunkOverlay::clear_bit` — once per diff entry in `build_chunk_overlay`.
- `OnesIter::next` — once per iteration, driving `BitmapScan::next_candidate` inside `merkleize_with_floor_scan`. `next` also re-fetched `bitmap.len()` each call.

Each call walked the entire `Arc<BitmapBatchLayer>` chain down to the `Base`, so cost was `O(depth)` per call in a tight loop.

## Fix

1. **Cache `pruned_chunks` on `BitmapBatchLayer`** (`storage/src/qmdb/current/batch.rs`). Pruning only happens on the committed `Base`, so the value is invariant across the chain. Store it at layer construction; lookup becomes O(1).

2. **Hoist `len` and pruned-prefix skip out of `OnesIter::next`** (`utils/src/bitmap/mod.rs`). Both are fixed for the iterator's lifetime. Compute once in `ones_iter_from`, store `len` on the iterator, fold the pruned-prefix skip into the initial `pos`.
