### PR TITLE
[Storage] `qmdb::current`: faster `ChunkOverlay` map, iterative `get_chunk`

### DIFF
--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -44,9 +44,8 @@ use std::{
 pub(crate) struct ChunkOverlay<const N: usize> {
     /// Dirty chunks: chunk_idx -> materialized chunk bytes.
     ///
-    /// `ahash` (fast on integer keys) with `BuildHasherDefault` (fixed compile-time seeds,
-    /// no per-construction RNG sampling). Keys are internal chunk indices, not external
-    /// input, so HashDoS is not a concern. Iteration order is not observed by any consumer.
+    /// `ahash` (fast on integer keys) with `BuildHasherDefault` (no per-construction RNG
+    /// sampling). Iteration order is not observed by any consumer.
     pub(crate) chunks: HashMap<usize, [u8; N], BuildHasherDefault<AHasher>>,
     /// Total number of bits (parent + new operations).
     pub(crate) len: u64,
@@ -671,9 +670,8 @@ impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
     }
 
     fn get_chunk(&self, idx: usize) -> [u8; N] {
-        // Iterative walk of the layer chain. Each layer's overlay either holds the chunk
-        // (return it) or doesn't (descend). Equivalent to recursing into `layer.parent`
-        // but with no per-level stack frame and no reliance on tail-call optimization.
+        // Walk the layer chain. Each layer's overlay either holds the chunk (return it) or
+        // doesn't (descend).
         let mut current = self;
         loop {
             match current {

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -590,6 +590,7 @@ where
     // compute_db_root sees newly completed chunks. Using bitmap_parent alone would miss chunks
     // that transitioned from partial to complete in this batch.
     let bitmap_batch = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+        pruned_chunks: bitmap_parent.pruned_chunks(),
         parent: bitmap_parent.clone(),
         overlay: Arc::new(overlay),
     }));
@@ -648,6 +649,10 @@ pub(crate) struct BitmapBatchLayer<const N: usize> {
     pub(crate) parent: BitmapBatch<N>,
     /// Chunk-level overlay: materialized bytes for every chunk that differs from parent.
     pub(crate) overlay: Arc<ChunkOverlay<N>>,
+    /// Pruned-chunk count, copied from `parent` at construction. Invariant across the whole
+    /// layer chain (pruning only happens on the committed base), so caching here lets
+    /// `BitmapBatch::pruned_chunks` return in O(1) instead of walking to the Base.
+    pub(crate) pruned_chunks: usize,
 }
 
 impl<const N: usize> BitmapBatch<N> {
@@ -691,7 +696,7 @@ impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
     fn pruned_chunks(&self) -> usize {
         match self {
             Self::Base(bm) => bm.pruned_chunks(),
-            Self::Layer(layer) => layer.parent.pruned_chunks(),
+            Self::Layer(layer) => layer.pruned_chunks,
         }
     }
 
@@ -723,8 +728,13 @@ impl<const N: usize> BitmapBatch<N> {
         }
 
         // Slow path: create a new layer.
+        let pruned_chunks = self.pruned_chunks();
         let parent = self.clone();
-        *self = Self::Layer(Arc::new(BitmapBatchLayer { parent, overlay }));
+        *self = Self::Layer(Arc::new(BitmapBatchLayer {
+            parent,
+            overlay,
+            pruned_chunks,
+        }));
     }
 
     /// Flatten all layers back to a single `Base(Arc<BitMap<N>>)`.

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -25,11 +25,13 @@ use crate::{
     },
     Context,
 };
+use ahash::AHasher;
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeSet, HashMap},
+    hash::BuildHasherDefault,
     sync::Arc,
 };
 
@@ -41,7 +43,11 @@ use std::{
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ChunkOverlay<const N: usize> {
     /// Dirty chunks: chunk_idx -> materialized chunk bytes.
-    pub(crate) chunks: BTreeMap<usize, [u8; N]>,
+    ///
+    /// `ahash` (fast on integer keys) with `BuildHasherDefault` (fixed compile-time seeds,
+    /// no per-construction RNG sampling). Keys are internal chunk indices, not external
+    /// input, so HashDoS is not a concern. Iteration order is not observed by any consumer.
+    pub(crate) chunks: HashMap<usize, [u8; N], BuildHasherDefault<AHasher>>,
     /// Total number of bits (parent + new operations).
     pub(crate) len: u64,
 }
@@ -49,9 +55,9 @@ pub(crate) struct ChunkOverlay<const N: usize> {
 impl<const N: usize> ChunkOverlay<N> {
     const CHUNK_BITS: u64 = BitMap::<N>::CHUNK_SIZE_BITS;
 
-    const fn new(len: u64) -> Self {
+    fn new(len: u64) -> Self {
         Self {
-            chunks: BTreeMap::new(),
+            chunks: HashMap::default(),
             len,
         }
     }
@@ -665,14 +671,18 @@ impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
     }
 
     fn get_chunk(&self, idx: usize) -> [u8; N] {
-        match self {
-            Self::Base(bm) => *bm.get_chunk(idx),
-            Self::Layer(layer) => {
-                // Check overlay first; fall through to parent if unmodified.
-                if let Some(&chunk) = layer.overlay.get(idx) {
-                    chunk
-                } else {
-                    layer.parent.get_chunk(idx)
+        // Iterative walk of the layer chain. Each layer's overlay either holds the chunk
+        // (return it) or doesn't (descend). Equivalent to recursing into `layer.parent`
+        // but with no per-level stack frame and no reliance on tail-call optimization.
+        let mut current = self;
+        loop {
+            match current {
+                Self::Base(bm) => return *bm.get_chunk(idx),
+                Self::Layer(layer) => {
+                    if let Some(&chunk) = layer.overlay.get(idx) {
+                        return chunk;
+                    }
+                    current = &layer.parent;
                 }
             }
         }

--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -967,7 +967,13 @@ pub trait Readable<const N: usize> {
     where
         Self: Sized,
     {
-        OnesIter { bitmap: self, pos }
+        let len = self.len();
+        let pruned_start = (self.pruned_chunks() as u64) * BitMap::<N>::CHUNK_SIZE_BITS;
+        OnesIter {
+            bitmap: self,
+            pos: pos.max(pruned_start),
+            len,
+        }
     }
 }
 
@@ -1002,19 +1008,19 @@ impl<const N: usize> Readable<N> for BitMap<N> {
 pub struct OnesIter<'a, B, const N: usize> {
     bitmap: &'a B,
     pos: u64,
+    /// Cached `bitmap.len()` at iterator construction. The underlying bitmap is borrowed
+    /// immutably for the iterator's lifetime, so this can never change mid-iteration.
+    /// For layered bitmaps (e.g. `BitmapBatch`), `len()` walks the layer chain, so caching
+    /// this avoids that walk on every `next`.
+    len: u64,
 }
 
 impl<B: Readable<N>, const N: usize> iter::Iterator for OnesIter<'_, B, N> {
     type Item = u64;
 
     fn next(&mut self) -> Option<u64> {
-        let len = self.bitmap.len();
         let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
-        let pruned_start = self.bitmap.pruned_chunks() as u64 * chunk_bits;
-        if self.pos < pruned_start {
-            self.pos = pruned_start;
-        }
-        while self.pos < len {
+        while self.pos < self.len {
             let chunk_idx = BitMap::<N>::to_chunk_index(self.pos);
             let chunk = self.bitmap.get_chunk(chunk_idx);
             let chunk_start = chunk_idx as u64 * chunk_bits;
@@ -1027,7 +1033,7 @@ impl<B: Readable<N>, const N: usize> iter::Iterator for OnesIter<'_, B, N> {
                     let found = chunk_start
                         + (byte_idx * 8 + bit_in_byte) as u64
                         + masked.trailing_zeros() as u64;
-                    if found >= len {
+                    if found >= self.len {
                         return None;
                     }
                     self.pos = found + 1;


### PR DESCRIPTION
## 1. `ChunkOverlay.chunks`: `BTreeMap` → `HashMap`

`build_chunk_overlay` hits the overlay map twice per diff entry (`set_bit`, `clear_bit`), each going through `BTreeMap::entry` — O(log n) node descents plus allocations on node splits. Swap it for `HashMap<usize, [u8; N], BuildHasherDefault<AHasher>>`:

- **`ahash`** instead of `SipHash`: integer keys, no adversarial input, ~3x faster per probe. The crate is already a transitive dependency of `commonware-storage`.
- **`BuildHasherDefault`** instead of `ahash::RandomState`: fixed compile-time seeds, no OS RNG sample per `HashMap::new()`. A `ChunkOverlay` is allocated per batch, so per-construction randomness would be pure overhead.
- **Safe**: keys are chunk indices we compute ourselves, never external input, so HashDoS is not a concern.

No consumer observes iteration order: `compute_current_layer` re-sorts into a `BTreeSet`; `apply_overlay` and `flatten` write chunk-by-chunk with writes that are independent per index.

## 2. `BitmapBatch::get_chunk`: recursion → iteration

Same shape as the earlier `pruned_chunks` fix. The layer chain is walked with a `loop { match current { ... } }` instead of recursing into `layer.parent.get_chunk(idx)`. Same complexity and semantics, but no per-level stack frame, no reliance on LLVM tail-call optimization, and no unbounded recursion risk under deep chains.