### PR TITLE
[parallel] Add `spawn`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,6 +1519,8 @@ version = "2026.4.0"
 dependencies = [
  "cfg-if",
  "commonware-macros",
+ "commonware-utils",
+ "futures",
  "proptest",
  "rayon",
 ]

--- a/consensus/src/aggregation/config.rs
+++ b/consensus/src/aggregation/config.rs
@@ -8,7 +8,7 @@ use commonware_cryptography::{
     Digest,
 };
 use commonware_p2p::Blocker;
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_runtime::buffer::paged::CacheRef;
 use commonware_utils::NonZeroDuration;
 use std::num::{NonZeroU64, NonZeroUsize};
@@ -21,7 +21,7 @@ pub struct Config<
     Z: Reporter<Activity = Activity<P::Scheme, D>>,
     M: Monitor<Index = Epoch>,
     B: Blocker<PublicKey = <P::Scheme as Scheme>::PublicKey>,
-    T: Strategy,
+    T: Bridge,
 > {
     /// Tracks the current state of consensus (to determine which participants should
     /// be involved in the current broadcast attempt).

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -681,7 +681,7 @@ impl<
         // Validate signature
         let ack_clone = ack.clone();
         let scheme = scheme.clone();
-        let mut context = self.context.as_present().clone();
+        let mut context = self.context.with_label("verify");
         if !self.strategy.spawn(move |s| {
             ack_clone.verify(&mut context, &*scheme, &s)
         }).await {

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -682,9 +682,11 @@ impl<
         let ack_clone = ack.clone();
         let scheme = scheme.clone();
         let mut context = self.context.with_label("verify");
-        if !self.strategy.spawn(move |s| {
-            ack_clone.verify(&mut context, &*scheme, &s)
-        }).await {
+        if !self
+            .strategy
+            .spawn(move |s| ack_clone.verify(&mut context, &*scheme, &s))
+            .await
+        {
             return Err(Error::InvalidAckSignature);
         }
 

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -20,7 +20,7 @@ use commonware_p2p::{
     utils::codec::{wrap, WrappedSender},
     Blocker, Receiver, Recipients, Sender,
 };
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_runtime::{
     buffer::paged::CacheRef,
     spawn_cell,
@@ -78,7 +78,7 @@ pub struct Engine<
     Z: Reporter<Activity = Activity<P::Scheme, D>>,
     M: Monitor<Index = Epoch>,
     B: Blocker<PublicKey = <P::Scheme as Scheme>::PublicKey>,
-    T: Strategy,
+    T: Bridge,
 > {
     // ---------- Interfaces ----------
     context: ContextCell<E>,
@@ -161,7 +161,7 @@ impl<
         Z: Reporter<Activity = Activity<P::Scheme, D>>,
         M: Monitor<Index = Epoch>,
         B: Blocker<PublicKey = <P::Scheme as Scheme>::PublicKey>,
-        T: Strategy,
+        T: Bridge,
     > Engine<E, P, D, A, Z, M, B, T>
 {
     /// Creates a new engine with the given context and configuration.
@@ -385,7 +385,7 @@ impl<
                 }
 
                 // Validate that we need to process the ack
-                if let Err(err) = self.validate_ack(&ack, &sender) {
+                if let Err(err) = self.validate_ack(&ack, &sender).await {
                     if err.blockable() {
                         commonware_p2p::block!(
                             self.blocker,
@@ -613,7 +613,7 @@ impl<
     /// Takes a raw ack (from sender) from the p2p network and validates it.
     ///
     /// Returns an error if the ack is invalid.
-    fn validate_ack(
+    async fn validate_ack(
         &mut self,
         ack: &Ack<P::Scheme, D>,
         sender: &<P::Scheme as Scheme>::PublicKey,
@@ -679,7 +679,12 @@ impl<
         }
 
         // Validate signature
-        if !ack.verify(&mut self.context, &*scheme, &self.strategy) {
+        let ack_clone = ack.clone();
+        let scheme = scheme.clone();
+        let mut context = self.context.as_present().clone();
+        if !self.strategy.spawn(move |s| {
+            ack_clone.verify(&mut context, &*scheme, &s)
+        }).await {
             return Err(Error::InvalidAckSignature);
         }
 

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -106,7 +106,7 @@ use commonware_cryptography::{
     Committable, Digestible, Hasher,
 };
 use commonware_macros::select;
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_runtime::{
     telemetry::metrics::histogram::{Buckets, Timed},
     Clock, Metrics, Spawner, Storage,
@@ -140,7 +140,7 @@ where
     C: CodingScheme,
     H: Hasher,
     Z: Provider<Scope = Epoch, Scheme: Scheme<Commitment>>,
-    S: Strategy,
+    S: Bridge,
     ES: Epocher,
 {
     /// The underlying application to wrap.
@@ -173,7 +173,7 @@ where
     C: CodingScheme,
     H: Hasher,
     Z: Provider<Scope = Epoch, Scheme: Scheme<Commitment>>,
-    S: Strategy,
+    S: Bridge,
     ES: Epocher,
 {
     context: E,
@@ -206,7 +206,7 @@ where
     C: CodingScheme,
     H: Hasher,
     Z: Provider<Scope = Epoch, Scheme: Scheme<Commitment>>,
-    S: Strategy,
+    S: Bridge,
     ES: Epocher,
 {
     /// Creates a new [`Marshaled`] wrapper.
@@ -448,7 +448,7 @@ where
     C: CodingScheme,
     H: Hasher,
     Z: Provider<Scope = Epoch, Scheme: Scheme<Commitment>>,
-    S: Strategy,
+    S: Bridge,
     ES: Epocher,
 {
     type Digest = Commitment;
@@ -825,7 +825,7 @@ where
     C: CodingScheme,
     H: Hasher,
     Z: Provider<Scope = Epoch, Scheme: Scheme<Commitment>>,
-    S: Strategy,
+    S: Bridge,
     ES: Epocher,
 {
     async fn certify(&mut self, round: Round, payload: Self::Digest) -> oneshot::Receiver<bool> {
@@ -935,7 +935,7 @@ where
     C: CodingScheme,
     H: Hasher,
     Z: Provider<Scope = Epoch, Scheme: Scheme<Commitment>>,
-    S: Strategy,
+    S: Bridge,
     ES: Epocher,
 {
     type Digest = Commitment;
@@ -988,7 +988,7 @@ where
     C: CodingScheme,
     H: Hasher,
     Z: Provider<Scope = Epoch, Scheme: Scheme<Commitment>>,
-    S: Strategy,
+    S: Bridge,
     ES: Epocher,
 {
     type Activity = A::Activity;

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -596,9 +596,11 @@ where
         // recovery) so we can yield while it runs.
         let shards = state.take_checked_shards();
         let start = self.context.current();
-        let blob = self.strategy.spawn(move |s| {
-            C::decode(&commitment.config(), &commitment.root(), shards.iter(), &s)
-        }).await.map_err(Error::Coding)?;
+        let blob = self
+            .strategy
+            .spawn(move |s| C::decode(&commitment.config(), &commitment.root(), shards.iter(), &s))
+            .await
+            .map_err(Error::Coding)?;
         self.metrics
             .erasure_decode_duration
             .observe_between(start, self.context.current());
@@ -1230,17 +1232,19 @@ where
         // Spawn batch-validation of all pending weak shards so we can yield
         // while the work runs.
         let pending = std::mem::take(&mut self.pending_shards);
-        let (new_checked, to_block) = strategy.spawn(move |s| {
-            s.map_partition_collect_vec(pending, |(peer, shard)| {
-                let checked = C::check(
-                    &commitment.config(),
-                    &commitment.root(),
-                    shard.index,
-                    &shard.data,
-                );
-                (peer, checked.ok())
+        let (new_checked, to_block) = strategy
+            .spawn(move |s| {
+                s.map_partition_collect_vec(pending, |(peer, shard)| {
+                    let checked = C::check(
+                        &commitment.config(),
+                        &commitment.root(),
+                        shard.index,
+                        &shard.data,
+                    );
+                    (peer, checked.ok())
+                })
             })
-        }).await;
+            .await;
 
         for peer in to_block {
             commonware_p2p::block!(blocker, peer, "invalid shard received");

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -159,7 +159,7 @@ use commonware_p2p::{
     utils::codec::{WrappedBackgroundReceiver, WrappedSender},
     Blocker, Provider as PeerProvider, Receiver, Recipients, Sender,
 };
-use commonware_parallel::Strategy;
+use commonware_parallel::{Bridge, Strategy};
 use commonware_runtime::{
     spawn_cell,
     telemetry::metrics::{histogram::HistogramExt, status::GaugeExt},
@@ -219,7 +219,7 @@ where
     C: CodingScheme,
     H: Hasher,
     B: CertifiableBlock,
-    T: Strategy,
+    T: Bridge,
 {
     /// The scheme provider.
     pub scheme_provider: S,
@@ -280,7 +280,7 @@ where
     H: Hasher,
     B: CertifiableBlock,
     P: PublicKey,
-    T: Strategy,
+    T: Bridge,
 {
     /// Context held by the actor.
     context: ContextCell<E>,
@@ -367,7 +367,7 @@ where
     H: Hasher,
     B: CertifiableBlock,
     P: PublicKey,
-    T: Strategy,
+    T: Bridge,
 {
     /// Create a new [`Engine`] with the given configuration.
     pub fn new(context: E, config: Config<P, S, X, D, C, H, B, T>) -> (Self, Mailbox<B, C, H, P>) {
@@ -1268,22 +1268,22 @@ where
 struct InsertCtx<'a, Sch, S>
 where
     Sch: CertificateScheme,
-    S: Strategy,
+    S: Bridge,
 {
     scheme: &'a Sch,
     strategy: &'a S,
     participants_len: u64,
 }
 
-impl<Sch: CertificateScheme, S: Strategy> Clone for InsertCtx<'_, Sch, S> {
+impl<Sch: CertificateScheme, S: Bridge> Clone for InsertCtx<'_, Sch, S> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<Sch: CertificateScheme, S: Strategy> Copy for InsertCtx<'_, Sch, S> {}
+impl<Sch: CertificateScheme, S: Bridge> Copy for InsertCtx<'_, Sch, S> {}
 
-impl<'a, Sch: CertificateScheme, S: Strategy> InsertCtx<'a, Sch, S> {
+impl<'a, Sch: CertificateScheme, S: Bridge> InsertCtx<'a, Sch, S> {
     fn new(scheme: &'a Sch, strategy: &'a S) -> Self {
         let participants_len = u64::try_from(scheme.participants().len())
             .expect("participant count impossibly out of bounds");
@@ -1407,7 +1407,7 @@ where
     ) -> bool
     where
         Sch: CertificateScheme<PublicKey = P>,
-        S: Strategy,
+        S: Bridge,
         X: Blocker<PublicKey = P>,
     {
         let Some(sender_index) = ctx.scheme.participants().index(&sender) else {

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -159,7 +159,7 @@ use commonware_p2p::{
     utils::codec::{WrappedBackgroundReceiver, WrappedSender},
     Blocker, Provider as PeerProvider, Receiver, Recipients, Sender,
 };
-use commonware_parallel::{Bridge, Strategy};
+use commonware_parallel::Bridge;
 use commonware_runtime::{
     spawn_cell,
     telemetry::metrics::{histogram::HistogramExt, status::GaugeExt},
@@ -577,7 +577,7 @@ where
     /// - `Ok(None)` if reconstruction could not be attempted due to insufficient checked shards.
     /// - `Err(_)` if reconstruction was attempted but failed.
     #[allow(clippy::type_complexity)]
-    fn try_reconstruct(
+    async fn try_reconstruct(
         &mut self,
         commitment: Commitment,
     ) -> Result<Option<Arc<CodedBlock<B, C, H>>>, Error<C>> {
@@ -591,20 +591,19 @@ where
             debug!(%commitment, "not enough checked shards to reconstruct block");
             return Ok(None);
         }
-        // Attempt to reconstruct the encoded blob
+
+        // Spawn only the erasure decode (which uses the strategy for parallel
+        // recovery) so we can yield while it runs.
+        let shards = state.take_checked_shards();
         let start = self.context.current();
-        let blob = C::decode(
-            &commitment.config(),
-            &commitment.root(),
-            state.checked_shards().iter(),
-            &self.strategy,
-        )
-        .map_err(Error::Coding)?;
+        let blob = self.strategy.spawn(move |s| {
+            C::decode(&commitment.config(), &commitment.root(), shards.iter(), &s)
+        }).await.map_err(Error::Coding)?;
         self.metrics
             .erasure_decode_duration
             .observe_between(start, self.context.current());
 
-        // Attempt to decode the block from the encoded blob
+        // Decode the block and validate the reconstruction.
         let (inner, config): (B, CodingConfig) =
             Decode::decode_cfg(&mut blob.as_slice(), &(self.block_codec_cfg.clone(), ()))?;
 
@@ -872,7 +871,7 @@ where
             }
         }
 
-        match self.try_reconstruct(commitment) {
+        match self.try_reconstruct(commitment).await {
             Ok(Some(block)) => {
                 // Do not prune other reconstruction state here. A Byzantine
                 // leader can equivocate by proposing multiple commitments in
@@ -1220,7 +1219,7 @@ where
         &mut self,
         commitment: Commitment,
         participants_len: u64,
-        strategy: &impl Strategy,
+        strategy: &impl Bridge,
         blocker: &mut impl Blocker<PublicKey = P>,
     ) -> Option<ReadyState<P, C, H>> {
         let minimum = usize::from(commitment.config().minimum_shards.get());
@@ -1228,10 +1227,11 @@ where
             return None;
         }
 
-        // Batch-validate all pending weak shards in parallel.
+        // Spawn batch-validation of all pending weak shards so we can yield
+        // while the work runs.
         let pending = std::mem::take(&mut self.pending_shards);
-        let (new_checked, to_block) =
-            strategy.map_partition_collect_vec(pending, |(peer, shard)| {
+        let (new_checked, to_block) = strategy.spawn(move |s| {
+            s.map_partition_collect_vec(pending, |(peer, shard)| {
                 let checked = C::check(
                     &commitment.config(),
                     &commitment.root(),
@@ -1239,7 +1239,8 @@ where
                     &shard.data,
                 );
                 (peer, checked.ok())
-            });
+            })
+        }).await;
 
         for peer in to_block {
             commonware_p2p::block!(blocker, peer, "invalid shard received");
@@ -1343,6 +1344,11 @@ where
     /// Returns all verified shards accumulated for reconstruction.
     const fn checked_shards(&self) -> &[C::CheckedShard] {
         self.common().checked_shards.as_slice()
+    }
+
+    /// Takes the verified shards out of the state, leaving it empty.
+    fn take_checked_shards(&mut self) -> Vec<C::CheckedShard> {
+        std::mem::take(&mut self.common_mut().checked_shards)
     }
 
     /// Takes the pending action for this commitment's validated shard.

--- a/consensus/src/marshal/config.rs
+++ b/consensus/src/marshal/config.rs
@@ -3,7 +3,7 @@ use crate::{
     Block,
 };
 use commonware_cryptography::certificate::Provider;
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_runtime::buffer::paged::CacheRef;
 use std::num::{NonZeroU64, NonZeroUsize};
 
@@ -31,7 +31,7 @@ where
     B: Block,
     P: Provider<Scope = Epoch>,
     ES: Epocher,
-    T: Strategy,
+    T: Bridge,
 {
     /// Provider for epoch-specific signing schemes.
     ///

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -24,7 +24,7 @@ use commonware_cryptography::{
 };
 use commonware_macros::select_loop;
 use commonware_p2p::Recipients;
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_resolver::Resolver;
 use commonware_runtime::{
     spawn_cell, telemetry::metrics::status::GaugeExt, BufferPooler, Clock, ContextCell, Handle,
@@ -210,7 +210,7 @@ where
     >,
     FB: Blocks<Block = V::StoredBlock>,
     ES: Epocher,
-    T: Strategy,
+    T: Bridge,
     A: Acknowledgement,
 {
     // ---------- Context ----------
@@ -275,7 +275,7 @@ where
     >,
     FB: Blocks<Block = V::StoredBlock>,
     ES: Epocher,
-    T: Strategy,
+    T: Bridge,
     A: Acknowledgement,
 {
     /// Create a new application actor.

--- a/consensus/src/ordered_broadcast/config.rs
+++ b/consensus/src/ordered_broadcast/config.rs
@@ -4,7 +4,7 @@ use crate::{
     Automaton, Monitor, Relay, Reporter,
 };
 use commonware_cryptography::{certificate::Provider, Digest, Signer};
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_runtime::buffer::paged::CacheRef;
 use std::{
     num::{NonZeroU64, NonZeroUsize},
@@ -21,7 +21,7 @@ pub struct Config<
     R: Relay<Digest = D, PublicKey = C::PublicKey, Plan = ()>,
     Z: Reporter<Activity = Activity<C::PublicKey, P::Scheme, D>>,
     M: Monitor<Index = Epoch>,
-    T: Strategy,
+    T: Bridge,
 > {
     /// The signer used when this engine acts as a sequencer.
     ///

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -904,7 +904,7 @@ impl<
         let node = node.clone();
         let chunk_verifier = self.chunk_verifier.clone();
         let validators_provider = self.validators_provider.clone();
-        let mut context = self.context.as_present().clone();
+        let mut context = self.context.with_label("verify");
         self.strategy.spawn(move |s| {
             node.verify(&mut context, &chunk_verifier, &validators_provider, &s)
         }).await
@@ -966,7 +966,7 @@ impl<
         // Validate the vote signature
         let ack_clone = ack.clone();
         let scheme = scheme.clone();
-        let mut context = self.context.as_present().clone();
+        let mut context = self.context.with_label("verify");
         if !self.strategy.spawn(move |s| {
             ack_clone.verify(&mut context, &*scheme, &s)
         }).await {

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -905,9 +905,9 @@ impl<
         let chunk_verifier = self.chunk_verifier.clone();
         let validators_provider = self.validators_provider.clone();
         let mut context = self.context.with_label("verify");
-        self.strategy.spawn(move |s| {
-            node.verify(&mut context, &chunk_verifier, &validators_provider, &s)
-        }).await
+        self.strategy
+            .spawn(move |s| node.verify(&mut context, &chunk_verifier, &validators_provider, &s))
+            .await
     }
 
     /// Takes a raw ack (from sender) from the p2p network and validates it.
@@ -967,9 +967,11 @@ impl<
         let ack_clone = ack.clone();
         let scheme = scheme.clone();
         let mut context = self.context.with_label("verify");
-        if !self.strategy.spawn(move |s| {
-            ack_clone.verify(&mut context, &*scheme, &s)
-        }).await {
+        if !self
+            .strategy
+            .spawn(move |s| ack_clone.verify(&mut context, &*scheme, &s))
+            .await
+        {
             return Err(Error::InvalidAckSignature);
         }
 

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -29,7 +29,7 @@ use commonware_p2p::{
     utils::codec::{wrap, WrappedSender},
     Receiver, Recipients, Sender,
 };
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_runtime::{
     buffer::paged::CacheRef,
     spawn_cell,
@@ -72,7 +72,7 @@ pub struct Engine<
     R: Relay<Digest = D, PublicKey = C::PublicKey, Plan = ()>,
     Z: Reporter<Activity = Activity<C::PublicKey, P::Scheme, D>>,
     M: Monitor<Index = Epoch>,
-    T: Strategy,
+    T: Bridge,
 > {
     ////////////////////////////////////////
     // Interfaces
@@ -210,7 +210,7 @@ impl<
         R: Relay<Digest = D, PublicKey = C::PublicKey, Plan = ()>,
         Z: Reporter<Activity = Activity<C::PublicKey, P::Scheme, D>>,
         M: Monitor<Index = Epoch>,
-        T: Strategy,
+        T: Bridge,
     > Engine<E, C, S, P, D, A, R, Z, M, T>
 {
     /// Creates a new engine with the given context and configuration.
@@ -404,7 +404,7 @@ impl<
                         continue;
                     }
                 };
-                let result = match self.validate_node(&node, &sender) {
+                let result = match self.validate_node(&node, &sender).await {
                     Ok(result) => result,
                     Err(err) => {
                         debug!(?err, ?sender, "node validate failed");
@@ -453,7 +453,7 @@ impl<
                         continue;
                     }
                 };
-                if let Err(err) = self.validate_ack(&ack, &sender) {
+                if let Err(err) = self.validate_ack(&ack, &sender).await {
                     debug!(?err, ?sender, "ack validate failed");
                     continue;
                 };
@@ -879,7 +879,7 @@ impl<
     /// If valid (and not already the tracked tip for the sender), returns the implied
     /// parent chunk and its certificate.
     /// Else returns an error if the `Node` is invalid.
-    fn validate_node(
+    async fn validate_node(
         &mut self,
         node: &Node<C::PublicKey, P::Scheme, D>,
         sender: &C::PublicKey,
@@ -900,20 +900,21 @@ impl<
         // Validate chunk
         self.validate_chunk(&node.chunk, self.epoch)?;
 
-        // Verify the node
-        node.verify(
-            &mut self.context,
-            &self.chunk_verifier,
-            &self.validators_provider,
-            &self.strategy,
-        )
+        // Verify the node (spawned to avoid blocking the async worker)
+        let node = node.clone();
+        let chunk_verifier = self.chunk_verifier.clone();
+        let validators_provider = self.validators_provider.clone();
+        let mut context = self.context.as_present().clone();
+        self.strategy.spawn(move |s| {
+            node.verify(&mut context, &chunk_verifier, &validators_provider, &s)
+        }).await
     }
 
     /// Takes a raw ack (from sender) from the p2p network and validates it.
     ///
     /// Returns the chunk, epoch, and vote if the ack is valid.
     /// Returns an error if the ack is invalid.
-    fn validate_ack(
+    async fn validate_ack(
         &mut self,
         ack: &Ack<C::PublicKey, P::Scheme, D>,
         sender: &<P::Scheme as Scheme>::PublicKey,
@@ -963,7 +964,12 @@ impl<
         }
 
         // Validate the vote signature
-        if !ack.verify(&mut self.context, scheme.as_ref(), &self.strategy) {
+        let ack_clone = ack.clone();
+        let scheme = scheme.clone();
+        let mut context = self.context.as_present().clone();
+        if !self.strategy.spawn(move |s| {
+            ack_clone.verify(&mut context, &*scheme, &s)
+        }).await {
             return Err(Error::InvalidAckSignature);
         }
 

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -15,7 +15,7 @@ use crate::{
 use commonware_cryptography::Digest;
 use commonware_macros::select_loop;
 use commonware_p2p::{utils::codec::WrappedReceiver, Blocker, Receiver};
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_runtime::{
     spawn_cell,
     telemetry::metrics::{
@@ -51,7 +51,7 @@ where
     D: Digest,
     Re: Reporter<Activity = Activity<S, D>>,
     Rl: Relay,
-    T: Strategy,
+    T: Bridge,
 {
     context: ContextCell<E>,
 
@@ -88,7 +88,7 @@ where
     D: Digest,
     Re: Reporter<Activity = Activity<S, D>>,
     Rl: Relay<Digest = D, PublicKey = S::PublicKey, Plan = Plan<S::PublicKey>>,
-    T: Strategy,
+    T: Bridge,
 {
     pub fn new(context: E, cfg: Config<S, B, Re, Rl, T>) -> (Self, Mailbox<S, D>) {
         let participants = cfg.scheme.participants().clone();
@@ -424,7 +424,12 @@ where
                         }
 
                         // Verify the certificate
-                        if !notarization.verify(&mut self.context, &self.scheme, &self.strategy) {
+                        let n = notarization.clone();
+                        let scheme = self.scheme.clone();
+                        let mut context = self.context.as_present().clone();
+                        if !self.strategy.spawn(move |s| {
+                            n.verify(&mut context, &scheme, &s)
+                        }).await {
                             commonware_p2p::block!(self.blocker, sender, %view, "invalid notarization");
                             continue;
                         }
@@ -445,11 +450,12 @@ where
                         }
 
                         // Verify the certificate
-                        if !nullification.verify::<_, D>(
-                            &mut self.context,
-                            &self.scheme,
-                            &self.strategy,
-                        ) {
+                        let n = nullification.clone();
+                        let scheme = self.scheme.clone();
+                        let mut context = self.context.as_present().clone();
+                        if !self.strategy.spawn(move |s| {
+                            n.verify::<_, D>(&mut context, &scheme, &s)
+                        }).await {
                             commonware_p2p::block!(self.blocker, sender, %view, "invalid nullification");
                             continue;
                         }
@@ -470,7 +476,12 @@ where
                         }
 
                         // Verify the certificate
-                        if !finalization.verify(&mut self.context, &self.scheme, &self.strategy) {
+                        let f = finalization.clone();
+                        let scheme = self.scheme.clone();
+                        let mut context = self.context.as_present().clone();
+                        if !self.strategy.spawn(move |s| {
+                            f.verify(&mut context, &scheme, &s)
+                        }).await {
                             commonware_p2p::block!(self.blocker, sender, %view, "invalid finalization");
                             continue;
                         }

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -426,7 +426,7 @@ where
                         // Verify the certificate
                         let n = notarization.clone();
                         let scheme = self.scheme.clone();
-                        let mut context = self.context.as_present().clone();
+                        let mut context = self.context.with_label("verify");
                         if !self.strategy.spawn(move |s| {
                             n.verify(&mut context, &scheme, &s)
                         }).await {
@@ -452,7 +452,7 @@ where
                         // Verify the certificate
                         let n = nullification.clone();
                         let scheme = self.scheme.clone();
-                        let mut context = self.context.as_present().clone();
+                        let mut context = self.context.with_label("verify");
                         if !self.strategy.spawn(move |s| {
                             n.verify::<_, D>(&mut context, &scheme, &s)
                         }).await {
@@ -478,7 +478,7 @@ where
                         // Verify the certificate
                         let f = finalization.clone();
                         let scheme = self.scheme.clone();
-                        let mut context = self.context.as_present().clone();
+                        let mut context = self.context.with_label("verify");
                         if !self.strategy.spawn(move |s| {
                             f.verify(&mut context, &scheme, &s)
                         }).await {

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -11,12 +11,12 @@ use crate::{
 pub use actor::Actor;
 use commonware_cryptography::certificate::Scheme;
 use commonware_p2p::Blocker;
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 pub use ingress::{Mailbox, Message};
 pub use round::Round;
 pub use verifier::Verifier;
 
-pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
+pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Bridge> {
     pub scheme: S,
 
     pub blocker: B,

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -16,7 +16,7 @@ use commonware_codec::{Decode, Encode};
 use commonware_cryptography::Digest;
 use commonware_macros::select_loop;
 use commonware_p2p::{utils::StaticProvider, Blocker, Receiver, Sender};
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_resolver::p2p;
 use commonware_runtime::{spawn_cell, BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner};
 use commonware_utils::{
@@ -34,7 +34,7 @@ pub struct Actor<
     S: Scheme<D>,
     B: Blocker<PublicKey = S::PublicKey>,
     D: Digest,
-    T: Strategy,
+    T: Bridge,
 > {
     context: ContextCell<E>,
     scheme: S,
@@ -55,7 +55,7 @@ impl<
         S: Scheme<D>,
         B: Blocker<PublicKey = S::PublicKey>,
         D: Digest,
-        T: Strategy,
+        T: Bridge,
     > Actor<E, S, B, D, T>
 {
     pub fn new(context: E, cfg: Config<S, B, T>) -> (Self, Mailbox<S, D>) {
@@ -151,7 +151,7 @@ impl<
     }
 
     /// Validates an incoming message, returning the parsed message if valid.
-    fn validate(&mut self, view: View, data: Bytes) -> Option<Certificate<S, D>> {
+    async fn validate(&mut self, view: View, data: Bytes) -> Option<Certificate<S, D>> {
         // Decode message
         let incoming =
             Certificate::<S, D>::decode_cfg(data, &self.scheme.certificate_codec_config()).ok()?;
@@ -179,7 +179,12 @@ impl<
                     );
                     return None;
                 }
-                if !notarization.verify(&mut self.context, &self.scheme, &self.strategy) {
+                let n = notarization.clone();
+                let scheme = self.scheme.clone();
+                let mut context = self.context.as_present().clone();
+                if !self.strategy.spawn(move |s| {
+                    n.verify(&mut context, &scheme, &s)
+                }).await {
                     debug!(%view, "notarization failed verification");
                     return None;
                 }
@@ -199,7 +204,12 @@ impl<
                     );
                     return None;
                 }
-                if !finalization.verify(&mut self.context, &self.scheme, &self.strategy) {
+                let f = finalization.clone();
+                let scheme = self.scheme.clone();
+                let mut context = self.context.as_present().clone();
+                if !self.strategy.spawn(move |s| {
+                    f.verify(&mut context, &scheme, &s)
+                }).await {
                     debug!(%view, "finalization failed verification");
                     return None;
                 }
@@ -219,7 +229,12 @@ impl<
                     );
                     return None;
                 }
-                if !nullification.verify::<_, D>(&mut self.context, &self.scheme, &self.strategy) {
+                let n = nullification.clone();
+                let scheme = self.scheme.clone();
+                let mut context = self.context.as_present().clone();
+                if !self.strategy.spawn(move |s| {
+                    n.verify::<_, D>(&mut context, &scheme, &s)
+                }).await {
                     debug!(%view, "nullification failed verification");
                     return None;
                 }
@@ -243,7 +258,7 @@ impl<
                 response,
             } => {
                 // Validate incoming message
-                let Some(parsed) = self.validate(view, data) else {
+                let Some(parsed) = self.validate(view, data).await else {
                     // Resolver will block any peers that send invalid responses, so
                     // we don't need to do again here
                     response.send_lossy(false);

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -181,7 +181,7 @@ impl<
                 }
                 let n = notarization.clone();
                 let scheme = self.scheme.clone();
-                let mut context = self.context.as_present().clone();
+                let mut context = self.context.with_label("verify");
                 if !self.strategy.spawn(move |s| {
                     n.verify(&mut context, &scheme, &s)
                 }).await {
@@ -206,7 +206,7 @@ impl<
                 }
                 let f = finalization.clone();
                 let scheme = self.scheme.clone();
-                let mut context = self.context.as_present().clone();
+                let mut context = self.context.with_label("verify");
                 if !self.strategy.spawn(move |s| {
                     f.verify(&mut context, &scheme, &s)
                 }).await {
@@ -231,7 +231,7 @@ impl<
                 }
                 let n = nullification.clone();
                 let scheme = self.scheme.clone();
-                let mut context = self.context.as_present().clone();
+                let mut context = self.context.with_label("verify");
                 if !self.strategy.spawn(move |s| {
                     n.verify::<_, D>(&mut context, &scheme, &s)
                 }).await {

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -182,9 +182,11 @@ impl<
                 let n = notarization.clone();
                 let scheme = self.scheme.clone();
                 let mut context = self.context.with_label("verify");
-                if !self.strategy.spawn(move |s| {
-                    n.verify(&mut context, &scheme, &s)
-                }).await {
+                if !self
+                    .strategy
+                    .spawn(move |s| n.verify(&mut context, &scheme, &s))
+                    .await
+                {
                     debug!(%view, "notarization failed verification");
                     return None;
                 }
@@ -207,9 +209,11 @@ impl<
                 let f = finalization.clone();
                 let scheme = self.scheme.clone();
                 let mut context = self.context.with_label("verify");
-                if !self.strategy.spawn(move |s| {
-                    f.verify(&mut context, &scheme, &s)
-                }).await {
+                if !self
+                    .strategy
+                    .spawn(move |s| f.verify(&mut context, &scheme, &s))
+                    .await
+                {
                     debug!(%view, "finalization failed verification");
                     return None;
                 }
@@ -232,9 +236,11 @@ impl<
                 let n = nullification.clone();
                 let scheme = self.scheme.clone();
                 let mut context = self.context.with_label("verify");
-                if !self.strategy.spawn(move |s| {
-                    n.verify::<_, D>(&mut context, &scheme, &s)
-                }).await {
+                if !self
+                    .strategy
+                    .spawn(move |s| n.verify::<_, D>(&mut context, &scheme, &s))
+                    .await
+                {
                     debug!(%view, "nullification failed verification");
                     return None;
                 }

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -6,13 +6,13 @@ use crate::types::Epoch;
 pub use actor::Actor;
 use commonware_cryptography::certificate::Scheme;
 use commonware_p2p::Blocker;
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 pub use ingress::Mailbox;
 #[cfg(test)]
 pub use ingress::MailboxMessage;
 use std::time::Duration;
 
-pub struct Config<S: Scheme, B: Blocker, T: Strategy> {
+pub struct Config<S: Scheme, B: Blocker, T: Bridge> {
     pub scheme: S,
 
     pub blocker: B,

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use commonware_cryptography::{certificate::Scheme, Digest};
 use commonware_p2p::Blocker;
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_runtime::buffer::paged::CacheRef;
 use std::{num::NonZeroUsize, time::Duration};
 
@@ -50,7 +50,7 @@ where
     A: CertifiableAutomaton<Context = Context<D, S::PublicKey>>,
     R: Relay,
     F: Reporter<Activity = Activity<S, D>>,
-    T: Strategy,
+    T: Bridge,
 {
     /// Signing scheme for the consensus engine.
     ///
@@ -153,7 +153,7 @@ impl<
         A: CertifiableAutomaton<Context = Context<D, S::PublicKey>>,
         R: Relay,
         F: Reporter<Activity = Activity<S, D>>,
-        T: Strategy,
+        T: Bridge,
     > Config<S, L, B, D, A, R, F, T>
 {
     /// Assert enforces that all configuration values are valid.

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -11,7 +11,7 @@ use crate::{
 use commonware_cryptography::Digest;
 use commonware_macros::select;
 use commonware_p2p::{Blocker, Receiver, Sender};
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use commonware_runtime::{
     spawn_cell, BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner, Storage,
 };
@@ -28,7 +28,7 @@ pub struct Engine<
     A: CertifiableAutomaton<Context = Context<D, S::PublicKey>, Digest = D>,
     R: Relay<Digest = D, PublicKey = S::PublicKey, Plan = Plan<S::PublicKey>>,
     F: Reporter<Activity = Activity<S, D>>,
-    T: Strategy,
+    T: Bridge,
 > {
     context: ContextCell<E>,
 
@@ -51,7 +51,7 @@ impl<
         A: CertifiableAutomaton<Context = Context<D, S::PublicKey>, Digest = D>,
         R: Relay<Digest = D, PublicKey = S::PublicKey, Plan = Plan<S::PublicKey>>,
         F: Reporter<Activity = Activity<S, D>>,
-        T: Strategy,
+        T: Bridge,
     > Engine<E, S, L, B, D, A, R, F, T>
 {
     /// Create a new `simplex` consensus engine.

--- a/consensus/src/simplex/scheme/reporter.rs
+++ b/consensus/src/simplex/scheme/reporter.rs
@@ -87,9 +87,11 @@ impl<
             let a = activity.clone();
             let scheme = self.scheme.clone();
             let mut rng = self.rng.clone();
-            if !self.strategy.spawn(move |s| {
-                a.verify(&mut rng, &scheme, &s)
-            }).await {
+            if !self
+                .strategy
+                .spawn(move |s| a.verify(&mut rng, &scheme, &s))
+                .await
+            {
                 // Drop unverified peer activity
                 return;
             }

--- a/consensus/src/simplex/scheme/reporter.rs
+++ b/consensus/src/simplex/scheme/reporter.rs
@@ -23,7 +23,7 @@ use crate::{
     Reporter,
 };
 use commonware_cryptography::{certificate, Digest};
-use commonware_parallel::Strategy;
+use commonware_parallel::Bridge;
 use rand_core::CryptoRngCore;
 
 /// Reporter wrapper that filters and verifies activities based on scheme attributability.
@@ -36,7 +36,7 @@ pub struct AttributableReporter<
     E: Clone + CryptoRngCore + Send + 'static,
     S: certificate::Scheme,
     D: Digest,
-    T: Strategy,
+    T: Bridge,
     R: Reporter<Activity = Activity<S, D>>,
 > {
     /// RNG for certificate verification
@@ -55,7 +55,7 @@ impl<
         E: Clone + CryptoRngCore + Send + 'static,
         S: certificate::Scheme,
         D: Digest,
-        T: Strategy,
+        T: Bridge,
         R: Reporter<Activity = Activity<S, D>>,
     > AttributableReporter<E, S, D, T, R>
 {
@@ -75,7 +75,7 @@ impl<
         E: Clone + CryptoRngCore + Send + 'static,
         S: Scheme<D>,
         D: Digest,
-        T: Strategy,
+        T: Bridge,
         R: Reporter<Activity = Activity<S, D>>,
     > Reporter for AttributableReporter<E, S, D, T, R>
 {
@@ -83,12 +83,16 @@ impl<
 
     async fn report(&mut self, activity: Self::Activity) {
         // Verify peer activities if verification is enabled
-        if self.verify
-            && !activity.verified()
-            && !activity.verify(&mut self.rng, &self.scheme, &self.strategy)
-        {
-            // Drop unverified peer activity
-            return;
+        if self.verify && !activity.verified() {
+            let a = activity.clone();
+            let scheme = self.scheme.clone();
+            let mut rng = self.rng.clone();
+            if !self.strategy.spawn(move |s| {
+                a.verify(&mut rng, &scheme, &s)
+            }).await {
+                // Drop unverified peer activity
+                return;
+            }
         }
 
         // Filter based on scheme attributability

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -367,9 +367,7 @@ mod tests {
             F: FnOnce(Self) -> R + Send + 'static,
             R: Send + 'static,
         {
-            let (tx, rx) = commonware_utils::channel::oneshot::channel();
-            let _ = tx.send(f(*self));
-            rx.into()
+            commonware_parallel::SpawnHandle::ready(f(*self))
         }
     }
 

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -361,14 +361,6 @@ mod tests {
         fn parallelism_hint(&self) -> usize {
             self.0
         }
-
-        fn spawn<F, R>(&self, f: F) -> commonware_parallel::SpawnHandle<R>
-        where
-            F: FnOnce(Self) -> R + Send + 'static,
-            R: Send + 'static,
-        {
-            commonware_parallel::SpawnHandle::ready(f(*self))
-        }
     }
 
     #[derive(Debug)]

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -361,6 +361,16 @@ mod tests {
         fn parallelism_hint(&self) -> usize {
             self.0
         }
+
+        fn spawn<F, R>(&self, f: F) -> commonware_parallel::SpawnHandle<R>
+        where
+            F: FnOnce(Self) -> R + Send + 'static,
+            R: Send + 'static,
+        {
+            let (tx, rx) = commonware_utils::channel::oneshot::channel();
+            let _ = tx.send(f(*self));
+            rx.into()
+        }
     }
 
     #[derive(Debug)]

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -24,4 +24,9 @@ proptest.workspace = true
 
 [features]
 default = [ "std" ]
-std = [ "commonware-macros/std", "commonware-utils/std", "dep:commonware-utils", "dep:rayon" ]
+std = [
+	"commonware-macros/std",
+	"commonware-utils/std",
+	"dep:commonware-utils",
+	"dep:rayon",
+]

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -15,11 +15,13 @@ workspace = true
 [dependencies]
 cfg-if.workspace = true
 commonware-macros.workspace = true
+commonware-utils = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 
 [dev-dependencies]
+futures.workspace = true
 proptest.workspace = true
 
 [features]
 default = [ "std" ]
-std = [ "commonware-macros/std", "dep:rayon" ]
+std = [ "commonware-macros/std", "commonware-utils/std", "dep:commonware-utils", "dep:rayon" ]

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -83,13 +83,13 @@ commonware_macros::stability_scope!(BETA {
         }
     }
 
-    /// A handle to a computation dispatched via [`Strategy::spawn`].
+    /// A handle to a computation dispatched via [`Bridge::spawn`].
     ///
     /// `SpawnHandle` implements [`Future`] and resolves with the value returned by the
-    /// spawned closure. Strategies that complete their work inline (for example,
+    /// spawned closure. Implementations that complete their work inline (for example,
     /// [`Sequential`]) return an already-resolved handle via [`SpawnHandle::ready`];
-    /// strategies that defer work to another thread (for example, [`Rayon`]) return a
-    /// handle backed by a oneshot channel.
+    /// implementations that defer work to another thread (for example, [`Rayon`]) return
+    /// a handle backed by a oneshot channel.
     ///
     /// # Panics
     ///
@@ -110,7 +110,7 @@ commonware_macros::stability_scope!(BETA {
     impl<R> SpawnHandle<R> {
         /// Construct an already-resolved [`SpawnHandle`] from a value.
         ///
-        /// Intended for [`Strategy`] implementations that compute `f` inline and have the
+        /// Intended for [`Bridge`] implementations that compute `f` inline and have the
         /// result available before returning the handle (like [`Sequential`]). Available in
         /// `no_std` builds.
         pub const fn ready(value: R) -> Self {
@@ -139,7 +139,7 @@ commonware_macros::stability_scope!(BETA {
 
     /// Construct a pending [`SpawnHandle`] from a oneshot receiver.
     ///
-    /// Intended for implementors of [`Strategy::spawn`] that dispatch `f` to another
+    /// Intended for implementors of [`Bridge::spawn`] that dispatch `f` to another
     /// thread and deliver the result through a oneshot channel. Only available when the
     /// `std` feature is enabled, because the underlying channel requires `std`.
     #[cfg(feature = "std")]
@@ -481,30 +481,33 @@ commonware_macros::stability_scope!(BETA {
 
         /// Return the number of threads that are available, as a hint to chunking.
         fn parallelism_hint(&self) -> usize;
+    }
 
-        /// Dispatch `f` to the underlying executor and return a [`SpawnHandle`] that
-        /// resolves to its result.
+    /// A bridge between async runtimes and a [`Strategy`].
+    ///
+    /// Code that uses a [`Strategy`] directly is fully synchronous - it never
+    /// needs to `.await` anything. When callers in an async context want to
+    /// offload a [`Strategy`] computation without blocking the executor, they
+    /// can require `Bridge` instead and `.await` the returned [`SpawnHandle`].
+    pub trait Bridge: Strategy {
+        /// Dispatch `f` to the underlying executor and return a [`SpawnHandle`]
+        /// that resolves to its result.
         ///
-        /// The closure receives an owned clone of the strategy, which lets it invoke other
-        /// [`Strategy`] methods without the caller having to pre-clone `self`. The handle
-        /// is a [`Future`], so callers can `.await` it from async contexts without blocking
-        /// the calling thread.
-        ///
-        /// For [`Rayon`], `f` runs on a thread-pool worker (via [`rayon::ThreadPool::spawn`]),
-        /// so the caller's thread is free to make progress on other work while `f` executes.
-        /// For [`Sequential`], `f` runs inline on the calling thread before the handle is
-        /// returned; the handle is already resolved when the caller first polls it.
+        /// The closure receives an owned clone of the strategy, which lets it
+        /// invoke [`Strategy`] methods without the caller having to pre-clone
+        /// `self`.
         ///
         /// # Panics
         ///
-        /// If `f` panics, the spawned task's oneshot sender is dropped without sending a
-        /// value. The returned [`SpawnHandle`] will panic when polled in that case, matching
-        /// the behavior the caller would observe if they had invoked `f` inline.
+        /// If `f` panics, the spawned task's oneshot sender is dropped without
+        /// sending a value. The returned [`SpawnHandle`] will panic when polled
+        /// in that case, matching the behavior the caller would observe if they
+        /// had invoked `f` inline.
         ///
         /// # Examples
         ///
         /// ```
-        /// use commonware_parallel::{Strategy, Sequential};
+        /// use commonware_parallel::{Bridge, Sequential};
         /// use futures::executor::block_on;
         ///
         /// let strategy = Sequential;
@@ -580,7 +583,9 @@ commonware_macros::stability_scope!(BETA {
         fn parallelism_hint(&self) -> usize {
             1
         }
+    }
 
+    impl Bridge for Sequential {
         fn spawn<F, R>(&self, f: F) -> SpawnHandle<R>
         where
             F: FnOnce(Self) -> R + Send + 'static,
@@ -707,7 +712,9 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
         fn parallelism_hint(&self) -> usize {
             self.thread_pool.current_num_threads()
         }
+    }
 
+    impl Bridge for Rayon {
         fn spawn<F, R>(&self, f: F) -> SpawnHandle<R>
         where
             F: FnOnce(Self) -> R + Send + 'static,
@@ -725,7 +732,7 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
 
 #[cfg(test)]
 mod test {
-    use crate::{Rayon, Sequential, Strategy};
+    use crate::{Bridge, Rayon, Sequential, Strategy};
     use core::num::NonZeroUsize;
     use futures::executor::block_on;
     use proptest::prelude::*;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -66,11 +66,55 @@ commonware_macros::stability_scope!(BETA {
 
     cfg_if! {
         if #[cfg(feature = "std")] {
+            use commonware_utils::channel::oneshot;
             use rayon::{
                 iter::{IntoParallelIterator, ParallelIterator},
                 ThreadPool as RThreadPool, ThreadPoolBuildError, ThreadPoolBuilder,
             };
-            use std::{num::NonZeroUsize, sync::Arc};
+            use std::{
+                num::NonZeroUsize,
+                sync::Arc,
+                future::Future,
+                pin::Pin,
+                task::{Context, Poll},
+            };
+
+            /// A handle to computation dispatched via [`Strategy::spawn`].
+            ///
+            /// `SpawnHandle` implements [`Future`] and resolves with the value returned by
+            /// the spawned closure. A panic in the closure is treated as fatal: under
+            /// rayon's default behavior the worker aborts the process, so polling the
+            /// handle after such a panic is not observable in practice. If a custom
+            /// executor does let the sender drop without sending (e.g. a user-supplied
+            /// pool that installs its own panic handler), polling the handle panics.
+            #[derive(Debug)]
+            pub struct SpawnHandle<R> {
+                inner: oneshot::Receiver<R>,
+            }
+
+            /// Construct a [`SpawnHandle`] from a oneshot receiver.
+            ///
+            /// Intended for implementors of [`Strategy::spawn`] in other crates.
+            impl<R> From<oneshot::Receiver<R>> for SpawnHandle<R> {
+                fn from(receiver: oneshot::Receiver<R>) -> Self {
+                    Self { inner: receiver }
+                }
+            }
+
+            impl<R> Future for SpawnHandle<R> {
+                type Output = R;
+
+                fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
+                    let this = Pin::into_inner(self);
+                    match Pin::new(&mut this.inner).poll(cx) {
+                        Poll::Ready(Ok(value)) => Poll::Ready(value),
+                        Poll::Ready(Err(_)) => {
+                            panic!("commonware-parallel: worker panicked before sending result")
+                        }
+                        Poll::Pending => Poll::Pending,
+                    }
+                }
+            }
         } else {
             extern crate alloc;
             use alloc::vec::Vec;
@@ -380,6 +424,44 @@ commonware_macros::stability_scope!(BETA {
 
         /// Return the number of threads that are available, as a hint to chunking.
         fn parallelism_hint(&self) -> usize;
+
+        /// Dispatch `f` to the underlying executor and return a [`SpawnHandle`] that
+        /// resolves to its result.
+        ///
+        /// The closure receives an owned clone of the strategy, which lets it invoke other
+        /// [`Strategy`] methods without the caller having to pre-clone `self`. The handle
+        /// is a [`Future`], so callers can `.await` it from async contexts without blocking
+        /// the calling thread.
+        ///
+        /// For [`Rayon`], `f` runs on a thread-pool worker (via [`rayon::ThreadPool::spawn`]),
+        /// so the caller's thread is free to make progress on other work while `f` executes.
+        /// For [`Sequential`], `f` runs inline on the calling thread before the handle is
+        /// returned; the handle is already resolved when the caller first polls it.
+        ///
+        /// # Panics
+        ///
+        /// If `f` panics, the spawned task's oneshot sender is dropped without sending a
+        /// value. The returned [`SpawnHandle`] will panic when polled in that case, matching
+        /// the behavior the caller would observe if they had invoked `f` inline.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use commonware_parallel::{Strategy, Sequential};
+        /// use futures::executor::block_on;
+        ///
+        /// let strategy = Sequential;
+        /// let data = vec![1, 2, 3, 4, 5];
+        /// let handle = strategy.spawn(move |s| {
+        ///     s.fold(&data, || 0, |acc, &x| acc + x, |a, b| a + b)
+        /// });
+        /// assert_eq!(block_on(handle), 15);
+        /// ```
+        #[cfg(feature = "std")]
+        fn spawn<F, R>(&self, f: F) -> SpawnHandle<R>
+        where
+            F: FnOnce(Self) -> R + Send + 'static,
+            R: Send + 'static;
     }
 
     /// A sequential execution strategy.
@@ -441,6 +523,17 @@ commonware_macros::stability_scope!(BETA {
 
         fn parallelism_hint(&self) -> usize {
             1
+        }
+
+        #[cfg(feature = "std")]
+        fn spawn<F, R>(&self, f: F) -> SpawnHandle<R>
+        where
+            F: FnOnce(Self) -> R + Send + 'static,
+            R: Send + 'static,
+        {
+            let (tx, rx) = oneshot::channel();
+            let _ = tx.send(f(self.clone()));
+            rx.into()
         }
     }
 });
@@ -561,6 +654,19 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
         fn parallelism_hint(&self) -> usize {
             self.thread_pool.current_num_threads()
         }
+
+        fn spawn<F, R>(&self, f: F) -> SpawnHandle<R>
+        where
+            F: FnOnce(Self) -> R + Send + 'static,
+            R: Send + 'static,
+        {
+            let (tx, rx) = oneshot::channel();
+            let me = self.clone();
+            self.thread_pool.spawn(move || {
+                let _ = tx.send(f(me));
+            });
+            rx.into()
+        }
     }
 });
 
@@ -568,10 +674,20 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
 mod test {
     use crate::{Rayon, Sequential, Strategy};
     use core::num::NonZeroUsize;
+    use futures::executor::block_on;
     use proptest::prelude::*;
 
     fn parallel_strategy() -> Rayon {
         Rayon::new(NonZeroUsize::new(4).unwrap()).unwrap()
+    }
+
+    #[test]
+    #[should_panic(expected = "worker failure")]
+    fn spawn_sequential_panic_propagates() {
+        let s = Sequential;
+        // Sequential runs `f` inline before returning the handle, so a panic in `f`
+        // unwinds through `spawn` itself - the original payload propagates directly.
+        let _handle = s.spawn(|_| -> () { panic!("worker failure") });
     }
 
     proptest! {
@@ -661,6 +777,54 @@ mod test {
             );
 
             prop_assert_eq!(via_map, via_fold_init);
+        }
+
+        #[test]
+        fn spawn_sequential_matches_direct_fold(data in prop::collection::vec(any::<i32>(), 0..500)) {
+            let s = Sequential;
+
+            let direct: i32 = s.fold(
+                &data,
+                || 0i32,
+                |acc, &x| acc.wrapping_add(x),
+                |a, b| a.wrapping_add(b),
+            );
+
+            let handle = s.spawn(move |s| {
+                s.fold(
+                    &data,
+                    || 0i32,
+                    |acc, &x| acc.wrapping_add(x),
+                    |a, b| a.wrapping_add(b),
+                )
+            });
+            let via_spawn = block_on(handle);
+
+            prop_assert_eq!(direct, via_spawn);
+        }
+
+        #[test]
+        fn spawn_rayon_matches_direct_fold(data in prop::collection::vec(any::<i32>(), 0..500)) {
+            let s = parallel_strategy();
+
+            let direct: i32 = s.fold(
+                &data,
+                || 0i32,
+                |acc, &x| acc.wrapping_add(x),
+                |a, b| a.wrapping_add(b),
+            );
+
+            let handle = s.spawn(move |s| {
+                s.fold(
+                    &data,
+                    || 0i32,
+                    |acc, &x| acc.wrapping_add(x),
+                    |a, b| a.wrapping_add(b),
+                )
+            });
+            let via_spawn = block_on(handle);
+
+            prop_assert_eq!(direct, via_spawn);
         }
 
         #[test]

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -62,7 +62,12 @@
 
 commonware_macros::stability_scope!(BETA {
     use cfg_if::cfg_if;
-    use core::fmt;
+    use core::{
+        fmt,
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+    };
 
     cfg_if! {
         if #[cfg(feature = "std")] {
@@ -71,55 +76,107 @@ commonware_macros::stability_scope!(BETA {
                 iter::{IntoParallelIterator, ParallelIterator},
                 ThreadPool as RThreadPool, ThreadPoolBuildError, ThreadPoolBuilder,
             };
-            use std::{
-                num::NonZeroUsize,
-                sync::Arc,
-                future::Future,
-                pin::Pin,
-                task::{Context, Poll},
-            };
-
-            /// A handle to computation dispatched via [`Strategy::spawn`].
-            ///
-            /// `SpawnHandle` implements [`Future`] and resolves with the value returned by
-            /// the spawned closure. A panic in the closure is treated as fatal: under
-            /// rayon's default behavior the worker aborts the process, so polling the
-            /// handle after such a panic is not observable in practice. If a custom
-            /// executor does let the sender drop without sending (e.g. a user-supplied
-            /// pool that installs its own panic handler), polling the handle panics.
-            #[derive(Debug)]
-            pub struct SpawnHandle<R> {
-                inner: oneshot::Receiver<R>,
-            }
-
-            /// Construct a [`SpawnHandle`] from a oneshot receiver.
-            ///
-            /// Intended for implementors of [`Strategy::spawn`] in other crates.
-            impl<R> From<oneshot::Receiver<R>> for SpawnHandle<R> {
-                fn from(receiver: oneshot::Receiver<R>) -> Self {
-                    Self { inner: receiver }
-                }
-            }
-
-            impl<R> Future for SpawnHandle<R> {
-                type Output = R;
-
-                fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
-                    let this = Pin::into_inner(self);
-                    match Pin::new(&mut this.inner).poll(cx) {
-                        Poll::Ready(Ok(value)) => Poll::Ready(value),
-                        Poll::Ready(Err(_)) => {
-                            panic!("commonware-parallel: worker panicked before sending result")
-                        }
-                        Poll::Pending => Poll::Pending,
-                    }
-                }
-            }
+            use std::{num::NonZeroUsize, sync::Arc};
         } else {
             extern crate alloc;
             use alloc::vec::Vec;
         }
     }
+
+    /// A handle to a computation dispatched via [`Strategy::spawn`].
+    ///
+    /// `SpawnHandle` implements [`Future`] and resolves with the value returned by the
+    /// spawned closure. Strategies that complete their work inline (for example,
+    /// [`Sequential`]) return an already-resolved handle via [`SpawnHandle::ready`];
+    /// strategies that defer work to another thread (for example, [`Rayon`]) return a
+    /// handle backed by a oneshot channel.
+    ///
+    /// # Panics
+    ///
+    /// When the handle is backed by a channel, polling it panics if the sender is
+    /// dropped without sending a value. Under rayon's default behavior a worker panic
+    /// aborts the process before the sender can drop, so this branch is primarily a
+    /// safety net for custom executors that install their own panic handlers.
+    pub struct SpawnHandle<R> {
+        inner: SpawnHandleInner<R>,
+    }
+
+    enum SpawnHandleInner<R> {
+        Ready(Option<R>),
+        #[cfg(feature = "std")]
+        Pending(oneshot::Receiver<R>),
+    }
+
+    impl<R> SpawnHandle<R> {
+        /// Construct an already-resolved [`SpawnHandle`] from a value.
+        ///
+        /// Intended for [`Strategy`] implementations that compute `f` inline and have the
+        /// result available before returning the handle (like [`Sequential`]). Available in
+        /// `no_std` builds.
+        pub const fn ready(value: R) -> Self {
+            Self {
+                inner: SpawnHandleInner::Ready(Some(value)),
+            }
+        }
+    }
+
+    // `SpawnHandle` never structurally pins its inner variants: the `Ready` slot hands
+    // its value out by move, and `oneshot::Receiver` is itself `Unpin`. Opting into
+    // `Unpin` unconditionally frees callers from requiring `R: Unpin`.
+    impl<R> Unpin for SpawnHandle<R> {}
+
+    impl<R: fmt::Debug> fmt::Debug for SpawnHandle<R> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match &self.inner {
+                SpawnHandleInner::Ready(value) => {
+                    f.debug_tuple("SpawnHandle::Ready").field(value).finish()
+                }
+                #[cfg(feature = "std")]
+                SpawnHandleInner::Pending(_) => f.debug_struct("SpawnHandle::Pending").finish(),
+            }
+        }
+    }
+
+    /// Construct a pending [`SpawnHandle`] from a oneshot receiver.
+    ///
+    /// Intended for implementors of [`Strategy::spawn`] that dispatch `f` to another
+    /// thread and deliver the result through a oneshot channel. Only available when the
+    /// `std` feature is enabled, because the underlying channel requires `std`.
+    #[cfg(feature = "std")]
+    impl<R> From<oneshot::Receiver<R>> for SpawnHandle<R> {
+        fn from(receiver: oneshot::Receiver<R>) -> Self {
+            Self {
+                inner: SpawnHandleInner::Pending(receiver),
+            }
+        }
+    }
+
+    impl<R> Future for SpawnHandle<R> {
+        type Output = R;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
+            // The `Context` is only used by the `Pending` variant; silence any unused
+            // warnings in `no_std` builds where that variant does not exist.
+            #[cfg(not(feature = "std"))]
+            let _ = cx;
+
+            let this = Pin::into_inner(self);
+            match &mut this.inner {
+                SpawnHandleInner::Ready(slot) => {
+                    Poll::Ready(slot.take().expect("SpawnHandle polled after resolving"))
+                }
+                #[cfg(feature = "std")]
+                SpawnHandleInner::Pending(rx) => match Pin::new(rx).poll(cx) {
+                    Poll::Ready(Ok(value)) => Poll::Ready(value),
+                    Poll::Ready(Err(_)) => {
+                        panic!("commonware-parallel: worker panicked before sending result")
+                    }
+                    Poll::Pending => Poll::Pending,
+                },
+            }
+        }
+    }
+
     /// A strategy for executing fold operations.
     ///
     /// This trait abstracts over sequential and parallel execution, allowing algorithms
@@ -457,7 +514,6 @@ commonware_macros::stability_scope!(BETA {
         /// });
         /// assert_eq!(block_on(handle), 15);
         /// ```
-        #[cfg(feature = "std")]
         fn spawn<F, R>(&self, f: F) -> SpawnHandle<R>
         where
             F: FnOnce(Self) -> R + Send + 'static,
@@ -525,15 +581,12 @@ commonware_macros::stability_scope!(BETA {
             1
         }
 
-        #[cfg(feature = "std")]
         fn spawn<F, R>(&self, f: F) -> SpawnHandle<R>
         where
             F: FnOnce(Self) -> R + Send + 'static,
             R: Send + 'static,
         {
-            let (tx, rx) = oneshot::channel();
-            let _ = tx.send(f(self.clone()));
-            rx.into()
+            SpawnHandle::ready(f(self.clone()))
         }
     }
 });


### PR DESCRIPTION
## Overview

Adds a `spawn` function to the `Strategy` interface that accepts a closure containing a handle to the `Strategy` and returns a future containing the result. This interface allows composing `rayon::spawn(|| pool.install(|| {/* ... */}))` calls and awaiting a channel that contains the result, which prevents blocking the worker thread that kicked off the computation.