### PR TITLE
[storage] add get_many batch read API to qmdb variants

### DIFF
--- a/storage/src/journal/benches/fixed_read_random.rs
+++ b/storage/src/journal/benches/fixed_read_random.rs
@@ -53,11 +53,31 @@ async fn bench_run_concurrent(
     try_join_all(futures).await.expect("failed to read data");
 }
 
+/// Batch-read `items_to_read` random items via `read_many`.
+async fn bench_run_read_many(
+    journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
+    items_to_read: usize,
+) {
+    let reader = journal.reader().await;
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut positions: Vec<u64> = (0..items_to_read)
+        .map(|_| rng.gen_range(0..ITEMS_TO_WRITE))
+        .collect();
+    positions.sort_unstable();
+    positions.dedup();
+    black_box(
+        reader
+            .read_many(&positions)
+            .await
+            .expect("failed to read data"),
+    );
+}
+
 fn bench_fixed_read_random(c: &mut Criterion) {
     let cfg = Config::default();
     let mut initialized = false;
     let runner = tokio::Runner::new(cfg.clone());
-    for mode in ["serial", "concurrent"] {
+    for mode in ["serial", "concurrent", "read_many"] {
         for items_to_read in [100, 1_000, 10_000, 100_000] {
             c.bench_function(
                 &format!(
@@ -88,6 +108,7 @@ fn bench_fixed_read_random(c: &mut Criterion) {
                             match mode {
                                 "serial" => bench_run_serial(&j, items_to_read).await,
                                 "concurrent" => bench_run_concurrent(&j, items_to_read).await,
+                                "read_many" => bench_run_read_many(&j, items_to_read).await,
                                 _ => unreachable!(),
                             }
                             duration += start.elapsed();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -233,24 +233,44 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         let pruning_boundary = self.guard.pruning_boundary;
         let chunk_size = SegmentedJournal::<E, A>::CHUNK_SIZE;
 
-        // Group positions by section and translate to section-local positions.
-        let mut result = Vec::with_capacity(positions.len());
-        let mut reusable_buf = vec![0u8; positions.len() * chunk_size];
+        // Phase 1: Drain page-cache hits synchronously.
+        let mut result: Vec<Option<A>> = Vec::with_capacity(positions.len());
+        let mut miss_indices: Vec<usize> = Vec::new();
+        let mut miss_positions: Vec<u64> = Vec::new();
+
+        for (i, &pos) in positions.iter().enumerate() {
+            if let Some(item) = self.guard.try_read_sync(pos, items_per_blob) {
+                result.push(Some(item));
+            } else {
+                result.push(None);
+                miss_indices.push(i);
+                miss_positions.push(pos);
+            }
+        }
+
+        if miss_positions.is_empty() {
+            return Ok(result.into_iter().map(|r| r.unwrap()).collect());
+        }
+
+        // Phase 2: Read cache misses grouped by section (sequential).
+        let mut reusable_buf = vec![0u8; miss_positions.len() * chunk_size];
+        let mut disk_offset = 0;
 
         let mut group_start = 0;
-        while group_start < positions.len() {
-            let section = positions[group_start] / items_per_blob;
+        while group_start < miss_positions.len() {
+            let section = miss_positions[group_start] / items_per_blob;
             let section_start = section * items_per_blob;
             let first_in_section = pruning_boundary.max(section_start);
 
-            // Find the end of this section group (positions are sorted).
             let mut group_end = group_start + 1;
-            while group_end < positions.len() && positions[group_end] / items_per_blob == section {
+            while group_end < miss_positions.len()
+                && miss_positions[group_end] / items_per_blob == section
+            {
                 group_end += 1;
             }
 
             let group_len = group_end - group_start;
-            let section_positions: Vec<u64> = positions[group_start..group_end]
+            let section_positions: Vec<u64> = miss_positions[group_start..group_end]
                 .iter()
                 .map(|&pos| pos - first_in_section)
                 .collect();
@@ -270,11 +290,15 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                     other => other,
                 })?;
 
-            result.extend(items);
+            for (item, &miss_idx) in items.into_iter().zip(&miss_indices[disk_offset..]) {
+                result[miss_idx] = Some(item);
+            }
+
+            disk_offset += group_len;
             group_start = group_end;
         }
 
-        Ok(result)
+        Ok(result.into_iter().map(|r| r.unwrap()).collect())
     }
 
     fn try_read_sync(&self, pos: u64) -> Option<A> {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -789,6 +789,72 @@ where
         }
         db.get(key).await
     }
+
+    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    ///
+    /// Returns results in the same order as the input keys.
+    pub async fn get_many<E, C, I>(
+        &self,
+        keys: &[&U::Key],
+        db: &Db<F, E, C, I, H, U>,
+    ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Contiguous<Item = Operation<F, U>>,
+        I: UnorderedIndex<Value = Location<F>> + 'static,
+    {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut results: Vec<Option<U::Value>> = Vec::with_capacity(keys.len());
+        let mut db_indices = Vec::new();
+        let mut db_keys = Vec::new();
+
+        for (i, key) in keys.iter().enumerate() {
+            // Check local mutations.
+            if let Some(value) = self.mutations.get(*key) {
+                results.push(value.clone());
+                continue;
+            }
+
+            // Check parent diff chain.
+            let mut found = false;
+            if let Some(parent) = self.base.parent() {
+                if let Some(entry) = lookup_sorted(parent.diff.as_slice(), *key) {
+                    results.push(entry.value().cloned());
+                    found = true;
+                }
+                if !found {
+                    for batch in parent.ancestors() {
+                        if let Some(entry) = lookup_sorted(batch.diff.as_slice(), *key) {
+                            results.push(entry.value().cloned());
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if found {
+                continue;
+            }
+
+            // Need DB fallthrough.
+            db_indices.push(i);
+            db_keys.push(*key);
+            results.push(None); // placeholder
+        }
+
+        if !db_keys.is_empty() {
+            let db_results = db.get_many(&db_keys).await?;
+            for (slot, value) in db_indices.into_iter().zip(db_results) {
+                results[slot] = value;
+            }
+        }
+
+        Ok(results)
+    }
 }
 
 // Unordered-specific methods.
@@ -1348,6 +1414,65 @@ where
             }
         }
         db.get(key).await
+    }
+
+    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    ///
+    /// Returns results in the same order as the input keys.
+    pub async fn get_many<E, C, I, H>(
+        &self,
+        keys: &[&U::Key],
+        db: &Db<F, E, C, I, H, U>,
+    ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Contiguous<Item = Operation<F, U>>,
+        I: UnorderedIndex<Value = Location<F>> + 'static,
+        H: Hasher<Digest = D>,
+    {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut results: Vec<Option<U::Value>> = Vec::with_capacity(keys.len());
+        let mut db_indices = Vec::new();
+        let mut db_keys = Vec::new();
+
+        for (i, key) in keys.iter().enumerate() {
+            // Check local diff.
+            if let Some(entry) = lookup_sorted(self.diff.as_slice(), *key) {
+                results.push(entry.value().cloned());
+                continue;
+            }
+
+            // Walk parent chain.
+            let mut found = false;
+            for batch in self.ancestors() {
+                if let Some(entry) = lookup_sorted(batch.diff.as_slice(), *key) {
+                    results.push(entry.value().cloned());
+                    found = true;
+                    break;
+                }
+            }
+
+            if found {
+                continue;
+            }
+
+            // Need DB fallthrough.
+            db_indices.push(i);
+            db_keys.push(*key);
+            results.push(None); // placeholder
+        }
+
+        if !db_keys.is_empty() {
+            let db_results = db.get_many(&db_keys).await?;
+            for (slot, value) in db_indices.into_iter().zip(db_results) {
+                results[slot] = value;
+            }
+        }
+
+        Ok(results)
     }
 }
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -790,7 +790,7 @@ where
         db.get(key).await
     }
 
-    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many<E, C, I>(
@@ -843,7 +843,7 @@ where
             // Need DB fallthrough.
             db_indices.push(i);
             db_keys.push(*key);
-            results.push(None); // placeholder
+            results.push(None);
         }
 
         if !db_keys.is_empty() {
@@ -1416,7 +1416,7 @@ where
         db.get(key).await
     }
 
-    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many<E, C, I, H>(
@@ -1462,7 +1462,7 @@ where
             // Need DB fallthrough.
             db_indices.push(i);
             db_keys.push(*key);
-            results.push(None); // placeholder
+            results.push(None);
         }
 
         if !db_keys.is_empty() {
@@ -2509,6 +2509,88 @@ mod tests {
                 "root depended on pending-vs-committed parent path \
                  when re-creating a deleted key with collision siblings"
             );
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn get_many_resolves_mutation_parent_and_db() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = UnorderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+            >;
+
+            let config = fixed_db_config::<OneCap>("get-many-basic", &context);
+            let mut db = TestDb::init(context, config).await.unwrap();
+
+            let key_db = colliding_digest(0x40, 0);
+            let val_db = colliding_digest(0x40, 1);
+            let key_parent = colliding_digest(0x41, 0);
+            let val_parent = colliding_digest(0x41, 1);
+            let key_batch = colliding_digest(0x42, 0);
+            let val_batch = colliding_digest(0x42, 1);
+            let key_missing = colliding_digest(0x43, 0);
+
+            // Commit one key to disk.
+            let seed = db
+                .new_batch()
+                .write(key_db, Some(val_db))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            // DB-level get_many.
+            let results = db.get_many(&[&key_db, &key_missing]).await.unwrap();
+            assert_eq!(results, vec![Some(val_db), None]);
+
+            // Unmerkleized batch: mutation + DB fallthrough.
+            let batch = db.new_batch().write(key_batch, Some(val_batch));
+            let results = batch
+                .get_many(&[&key_batch, &key_db, &key_missing], &db)
+                .await
+                .unwrap();
+            assert_eq!(results, vec![Some(val_batch), Some(val_db), None]);
+
+            // Merkleized parent + child unmerkleized batch.
+            let parent = db
+                .new_batch()
+                .write(key_parent, Some(val_parent))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            let child = parent
+                .new_batch::<Sha256>()
+                .write(key_batch, Some(val_batch));
+            let results = child
+                .get_many(&[&key_batch, &key_parent, &key_db, &key_missing], &db)
+                .await
+                .unwrap();
+            assert_eq!(
+                results,
+                vec![Some(val_batch), Some(val_parent), Some(val_db), None]
+            );
+
+            // Merkleized batch get_many.
+            let results = parent
+                .get_many(&[&key_parent, &key_db, &key_missing], &db)
+                .await
+                .unwrap();
+            assert_eq!(results, vec![Some(val_parent), Some(val_db), None]);
+
+            // Empty input.
+            let results: Vec<Option<sha256::Digest>> =
+                db.get_many(&([] as [&sha256::Digest; 0])).await.unwrap();
+            assert!(results.is_empty());
 
             db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -162,7 +162,7 @@ where
         let mut results: Vec<Option<U::Value>> = vec![None; keys.len()];
 
         for (key_idx, key) in keys.iter().enumerate() {
-            for &loc in self.snapshot.get(*key) {
+            for &loc in self.snapshot.get(key) {
                 candidates.push((key_idx, *loc));
             }
         }

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -145,7 +145,7 @@ where
         Ok(None)
     }
 
-    /// Get values of multiple keys, amortizing reader lock acquisition and journal I/O.
+    /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many(

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -145,6 +145,65 @@ where
         Ok(None)
     }
 
+    /// Get values of multiple keys, amortizing reader lock acquisition and journal I/O.
+    ///
+    /// Returns results in the same order as the input keys.
+    pub async fn get_many(
+        &self,
+        keys: &[&U::Key],
+    ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Phase 1: Collect candidate locations from the in-memory index.
+        // Each key may map to multiple locations due to hash collisions.
+        let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
+        let mut results: Vec<Option<U::Value>> = vec![None; keys.len()];
+
+        for (key_idx, key) in keys.iter().enumerate() {
+            for &loc in self.snapshot.get(*key) {
+                candidates.push((key_idx, *loc));
+            }
+        }
+
+        if candidates.is_empty() {
+            return Ok(results);
+        }
+
+        // Phase 2: Sort by position for batched journal reads, then deduplicate.
+        candidates.sort_unstable_by_key(|&(_, pos)| pos);
+
+        let mut positions: Vec<u64> = Vec::with_capacity(candidates.len());
+        for &(_, pos) in &candidates {
+            if positions.last() != Some(&pos) {
+                positions.push(pos);
+            }
+        }
+
+        // Phase 3: Batch-read from the journal (one reader acquisition, one I/O batch).
+        let reader = self.log.reader().await;
+        let ops = reader.read_many(&positions).await?;
+
+        // Phase 4: Match operations back to keys via binary search (no HashMap).
+        for &(key_idx, pos) in &candidates {
+            if results[key_idx].is_some() {
+                continue;
+            }
+            let op_idx = positions
+                .binary_search(&pos)
+                .expect("position was deduped from candidates");
+            let Operation::Update(data) = &ops[op_idx] else {
+                panic!("location does not reference update operation. loc={pos}");
+            };
+            if data.key() == keys[key_idx] {
+                results[key_idx] = Some(data.value().clone());
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Return [start, end) where `start` and `end - 1` are the Locations of the oldest and newest
     /// retained operations respectively.
     pub async fn bounds(&self) -> std::ops::Range<Location<F>> {

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -389,7 +389,7 @@ where
         self.inner.get(key, &db.any).await
     }
 
-    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many<E, C, I>(
@@ -452,7 +452,7 @@ where
         self.inner.get(key, &db.any).await
     }
 
-    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many<E, C, I>(

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -389,6 +389,22 @@ where
         self.inner.get(key, &db.any).await
     }
 
+    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    ///
+    /// Returns results in the same order as the input keys.
+    pub async fn get_many<E, C, I>(
+        &self,
+        keys: &[&K],
+        db: &super::db::Db<F, E, C, I, H, update::Unordered<K, V>, N>,
+    ) -> Result<Vec<Option<V::Value>>, Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
+        I: UnorderedIndex<Value = Location<F>> + 'static,
+    {
+        self.inner.get_many(keys, &db.any).await
+    }
+
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     pub async fn merkleize<E, C, I>(
         self,
@@ -434,6 +450,22 @@ where
         I: crate::index::Ordered<Value = Location<F>> + 'static,
     {
         self.inner.get(key, &db.any).await
+    }
+
+    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    ///
+    /// Returns results in the same order as the input keys.
+    pub async fn get_many<E, C, I>(
+        &self,
+        keys: &[&K],
+        db: &super::db::Db<F, E, C, I, H, update::Ordered<K, V>, N>,
+    ) -> Result<Vec<Option<V::Value>>, Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
+        I: crate::index::Ordered<Value = Location<F>> + 'static,
+    {
+        self.inner.get_many(keys, &db.any).await
     }
 
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -955,6 +955,23 @@ where
     {
         self.inner.get(key, &db.any).await
     }
+
+    /// Batch read multiple keys.
+    ///
+    /// Returns results in the same order as the input keys.
+    pub async fn get_many<E, C, I, H>(
+        &self,
+        keys: &[&U::Key],
+        db: &super::db::Db<F, E, C, I, H, U, N>,
+    ) -> Result<Vec<Option<U::Value>>, Error<F>>
+    where
+        E: Context,
+        C: Contiguous<Item = Operation<F, U>>,
+        I: UnorderedIndex<Value = Location<F>> + 'static,
+        H: Hasher<Digest = D>,
+    {
+        self.inner.get_many(keys, &db.any).await
+    }
 }
 
 impl<F, E, C, I, H, U, const N: usize> super::db::Db<F, E, C, I, H, U, N>

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -166,7 +166,7 @@ where
         db.get(key).await
     }
 
-    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many<E, C, T>(
@@ -176,7 +176,7 @@ where
     ) -> Result<Vec<Option<V::Value>>, Error<F>>
     where
         E: Context,
-        C: Mutable<Item = Operation<K, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
         C::Item: EncodeShared,
         T: Translator,
     {
@@ -220,7 +220,7 @@ where
             // Need DB fallthrough.
             db_indices.push(i);
             db_keys.push(*key);
-            results.push(None); // placeholder
+            results.push(None);
         }
 
         if !db_keys.is_empty() {
@@ -342,7 +342,7 @@ where
         db.get(key).await
     }
 
-    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many<E, C, H, T>(
@@ -352,7 +352,7 @@ where
     ) -> Result<Vec<Option<V::Value>>, Error<F>>
     where
         E: Context,
-        C: Mutable<Item = Operation<K, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
         C::Item: EncodeShared,
         H: CHasher<Digest = D>,
         T: Translator,
@@ -389,7 +389,7 @@ where
             // Need DB fallthrough.
             db_indices.push(i);
             db_keys.push(*key);
-            results.push(None); // placeholder
+            results.push(None);
         }
 
         if !db_keys.is_empty() {

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -166,6 +166,73 @@ where
         db.get(key).await
     }
 
+    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    ///
+    /// Returns results in the same order as the input keys.
+    pub async fn get_many<E, C, T>(
+        &self,
+        keys: &[&K],
+        db: &Immutable<F, E, K, V, C, H, T>,
+    ) -> Result<Vec<Option<V::Value>>, Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<K, V>> + Persistable<Error = JournalError>,
+        C::Item: EncodeShared,
+        T: Translator,
+    {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut results: Vec<Option<V::Value>> = Vec::with_capacity(keys.len());
+        let mut db_indices = Vec::new();
+        let mut db_keys = Vec::new();
+
+        for (i, key) in keys.iter().enumerate() {
+            // Check local mutations.
+            if let Some(value) = self.mutations.get(*key) {
+                results.push(Some(value.clone()));
+                continue;
+            }
+
+            // Check parent diff chain.
+            let mut found = false;
+            if let Some(parent) = self.parent.as_ref() {
+                if let Some(entry) = lookup_sorted(parent.diff.as_slice(), *key) {
+                    results.push(Some(entry.value.clone()));
+                    found = true;
+                }
+                if !found {
+                    for batch in parent.ancestors() {
+                        if let Some(entry) = lookup_sorted(batch.diff.as_slice(), *key) {
+                            results.push(Some(entry.value.clone()));
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if found {
+                continue;
+            }
+
+            // Need DB fallthrough.
+            db_indices.push(i);
+            db_keys.push(*key);
+            results.push(None); // placeholder
+        }
+
+        if !db_keys.is_empty() {
+            let db_results = db.get_many(&db_keys).await?;
+            for (slot, value) in db_indices.into_iter().zip(db_results) {
+                results[slot] = value;
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     ///
     /// `inactivity_floor` declares that all operations before this location are inactive.
@@ -273,6 +340,66 @@ where
             }
         }
         db.get(key).await
+    }
+
+    /// Read multiple keys, amortizing DB lock acquisition for fallthrough reads.
+    ///
+    /// Returns results in the same order as the input keys.
+    pub async fn get_many<E, C, H, T>(
+        &self,
+        keys: &[&K],
+        db: &Immutable<F, E, K, V, C, H, T>,
+    ) -> Result<Vec<Option<V::Value>>, Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<K, V>> + Persistable<Error = JournalError>,
+        C::Item: EncodeShared,
+        H: CHasher<Digest = D>,
+        T: Translator,
+    {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut results: Vec<Option<V::Value>> = Vec::with_capacity(keys.len());
+        let mut db_indices = Vec::new();
+        let mut db_keys = Vec::new();
+
+        for (i, key) in keys.iter().enumerate() {
+            // Check local diff.
+            if let Some(entry) = lookup_sorted(self.diff.as_slice(), *key) {
+                results.push(Some(entry.value.clone()));
+                continue;
+            }
+
+            // Walk parent chain.
+            let mut found = false;
+            for batch in self.ancestors() {
+                if let Some(entry) = lookup_sorted(batch.diff.as_slice(), *key) {
+                    results.push(Some(entry.value.clone()));
+                    found = true;
+                    break;
+                }
+            }
+
+            if found {
+                continue;
+            }
+
+            // Need DB fallthrough.
+            db_indices.push(i);
+            db_keys.push(*key);
+            results.push(None); // placeholder
+        }
+
+        if !db_keys.is_empty() {
+            let db_results = db.get_many(&db_keys).await?;
+            for (slot, value) in db_indices.into_iter().zip(db_results) {
+                results[slot] = value;
+            }
+        }
+
+        Ok(results)
     }
 
     /// Create a new speculative batch of operations with this batch as its parent.

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -420,6 +420,14 @@ mod tests {
         });
     }
 
+    #[test_traced("INFO")]
+    fn test_fixed_get_many_unexpected_data() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            test::test_immutable_get_many_unexpected_data(ctx, open::<mmr::Family>).await;
+        });
+    }
+
     // -- MMB test wrappers --
 
     #[test_traced("WARN")]

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -412,6 +412,14 @@ mod tests {
         });
     }
 
+    #[test_traced("INFO")]
+    fn test_fixed_get_many() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            test::test_immutable_get_many(ctx, open::<mmr::Family>).await;
+        });
+    }
+
     // -- MMB test wrappers --
 
     #[test_traced("WARN")]

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -263,6 +263,62 @@ where
         Ok(None)
     }
 
+    /// Get values of multiple keys, amortizing reader lock acquisition and journal I/O.
+    ///
+    /// Returns results in the same order as the input keys.
+    pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
+        let mut results: Vec<Option<V::Value>> = vec![None; keys.len()];
+
+        let reader = self.journal.reader().await;
+        let oldest = reader.bounds().start;
+
+        for (key_idx, key) in keys.iter().enumerate() {
+            for &loc in self.snapshot.get(*key) {
+                if loc < oldest {
+                    continue;
+                }
+                candidates.push((key_idx, *loc));
+            }
+        }
+
+        if candidates.is_empty() {
+            return Ok(results);
+        }
+
+        candidates.sort_unstable_by_key(|&(_, pos)| pos);
+
+        let mut positions: Vec<u64> = Vec::with_capacity(candidates.len());
+        for &(_, pos) in &candidates {
+            if positions.last() != Some(&pos) {
+                positions.push(pos);
+            }
+        }
+
+        let ops = reader.read_many(&positions).await?;
+
+        for &(key_idx, pos) in &candidates {
+            if results[key_idx].is_some() {
+                continue;
+            }
+            let op_idx = positions
+                .binary_search(&pos)
+                .expect("position was deduped from candidates");
+            let Operation::Set(k, v) = &ops[op_idx] else {
+                continue;
+            };
+            if k == keys[key_idx] {
+                results[key_idx] = Some(v.clone());
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Get the value of the operation with location `loc` in the db if it matches `key`. Returns
     /// [`crate::qmdb::Error::OperationPruned`] if loc precedes the oldest retained location. The
     /// location is otherwise assumed valid.

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -278,7 +278,7 @@ where
         let oldest = reader.bounds().start;
 
         for (key_idx, key) in keys.iter().enumerate() {
-            for &loc in self.snapshot.get(*key) {
+            for &loc in self.snapshot.get(key) {
                 if loc < oldest {
                     continue;
                 }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -263,7 +263,7 @@ where
         Ok(None)
     }
 
-    /// Get values of multiple keys, amortizing reader lock acquisition and journal I/O.
+    /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
@@ -2799,6 +2799,69 @@ pub(super) mod test {
         // Follow-on commit replaced the anchor: its metadata was `None`, so `get_metadata`
         // should no longer return the original metadata.
         assert_eq!(db.get_metadata().await.unwrap(), None);
+
+        db.destroy().await.unwrap();
+    }
+
+    /// `get_many` on the DB and on unmerkleized/merkleized batches returns results
+    /// that match individual `get` calls.
+    pub(crate) async fn test_immutable_get_many<F: Family, V, C>(
+        context: deterministic::Context,
+        open_db: impl Fn(
+            deterministic::Context,
+        ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
+    ) where
+        V: ValueEncoding<Value = Digest>,
+        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C::Item: EncodeShared,
+    {
+        let mut db = open_db(context.with_label("db")).await;
+
+        let k1 = Sha256::fill(1u8);
+        let k2 = Sha256::fill(2u8);
+        let k3 = Sha256::fill(3u8);
+        let k_missing = Sha256::fill(99u8);
+
+        let v1 = Sha256::fill(11u8);
+        let v2 = Sha256::fill(12u8);
+        let v3 = Sha256::fill(13u8);
+
+        // Commit k1 and k2 to disk.
+        db.apply_batch(db.new_batch().set(k1, v1).set(k2, v2).merkleize(
+            &db,
+            None,
+            Location::new(0),
+        ))
+        .await
+        .unwrap();
+        db.commit().await.unwrap();
+
+        // DB-level get_many.
+        let results = db.get_many(&[&k1, &k2, &k_missing]).await.unwrap();
+        assert_eq!(results, vec![Some(v1), Some(v2), None]);
+
+        // Empty input.
+        let results = db.get_many(&([] as [&Digest; 0])).await.unwrap();
+        assert!(results.is_empty());
+
+        // Unmerkleized batch: mutations + DB fallthrough.
+        let batch = db.new_batch().set(k3, v3);
+        let results = batch.get_many(&[&k3, &k1, &k_missing], &db).await.unwrap();
+        assert_eq!(results, vec![Some(v3), Some(v1), None]);
+
+        // Merkleized batch: diff + parent chain + DB fallthrough.
+        let parent = db
+            .new_batch()
+            .set(k3, v3)
+            .merkleize(&db, None, Location::new(0));
+        let results = parent.get_many(&[&k1, &k3, &k_missing], &db).await.unwrap();
+        assert_eq!(results, vec![Some(v1), Some(v3), None]);
+
+        // Child of merkleized parent reads parent diff.
+        let v3_new = Sha256::fill(30u8);
+        let child = parent.new_batch::<Sha256>().set(k3, v3_new);
+        let results = child.get_many(&[&k1, &k3, &k_missing], &db).await.unwrap();
+        assert_eq!(results, vec![Some(v1), Some(v3_new), None]);
 
         db.destroy().await.unwrap();
     }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -309,7 +309,7 @@ where
                 .binary_search(&pos)
                 .expect("position was deduped from candidates");
             let Operation::Set(k, v) = &ops[op_idx] else {
-                continue;
+                return Err(Error::UnexpectedData(Location::new(pos)));
             };
             if k == keys[key_idx] {
                 results[key_idx] = Some(v.clone());
@@ -2830,7 +2830,7 @@ pub(super) mod test {
         db.apply_batch(db.new_batch().set(k1, v1).set(k2, v2).merkleize(
             &db,
             None,
-            Location::new(0),
+            db.inactivity_floor_loc(),
         ))
         .await
         .unwrap();
@@ -2853,7 +2853,7 @@ pub(super) mod test {
         let parent = db
             .new_batch()
             .set(k3, v3)
-            .merkleize(&db, None, Location::new(0));
+            .merkleize(&db, None, db.inactivity_floor_loc());
         let results = parent.get_many(&[&k1, &k3, &k_missing], &db).await.unwrap();
         assert_eq!(results, vec![Some(v1), Some(v3), None]);
 
@@ -2862,6 +2862,43 @@ pub(super) mod test {
         let child = parent.new_batch::<Sha256>().set(k3, v3_new);
         let results = child.get_many(&[&k1, &k3, &k_missing], &db).await.unwrap();
         assert_eq!(results, vec![Some(v1), Some(v3_new), None]);
+
+        db.destroy().await.unwrap();
+    }
+
+    /// `get_many` reports unexpected data when the snapshot points at a non-`Set` operation.
+    pub(crate) async fn test_immutable_get_many_unexpected_data<F: Family, V, C>(
+        context: deterministic::Context,
+        open_db: impl Fn(
+            deterministic::Context,
+        ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
+    ) where
+        V: ValueEncoding<Value = Digest>,
+        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C::Item: EncodeShared,
+    {
+        let mut db = open_db(context.with_label("db")).await;
+
+        let key = Sha256::fill(1u8);
+        let value = Sha256::fill(11u8);
+        db.apply_batch(db.new_batch().set(key, value).merkleize(
+            &db,
+            None,
+            db.inactivity_floor_loc(),
+        ))
+        .await
+        .unwrap();
+        db.commit().await.unwrap();
+
+        let bad_key = Sha256::fill(99u8);
+        let bad_loc = db.last_commit_loc;
+        db.snapshot.insert(&bad_key, bad_loc);
+
+        let err = db.get(&bad_key).await.unwrap_err();
+        assert!(matches!(err, Error::UnexpectedData(loc) if loc == bad_loc));
+
+        let err = db.get_many(&[&bad_key]).await.unwrap_err();
+        assert!(matches!(err, Error::UnexpectedData(loc) if loc == bad_loc));
 
         db.destroy().await.unwrap();
     }

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -435,6 +435,14 @@ mod tests {
         });
     }
 
+    #[test_traced("INFO")]
+    fn test_variable_get_many_unexpected_data() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            test::test_immutable_get_many_unexpected_data(ctx, open::<mmr::Family>).await;
+        });
+    }
+
     // -- MMB test wrappers --
 
     #[test_traced("WARN")]

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -427,6 +427,14 @@ mod tests {
         });
     }
 
+    #[test_traced("INFO")]
+    fn test_variable_get_many() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            test::test_immutable_get_many(ctx, open::<mmr::Family>).await;
+        });
+    }
+
     // -- MMB test wrappers --
 
     #[test_traced("WARN")]

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -191,10 +191,10 @@ where
         db.get(loc).await
     }
 
-    /// Read values at multiple locations.
+    /// Batch read values at multiple locations.
     ///
-    /// Acquires the journal reader once for all DB-fallthrough reads.
     /// Locations must be sorted in ascending order.
+    /// Returns results in the same order as the input locations.
     pub async fn get_many<E, C>(
         &self,
         locs: &[Location<F>],
@@ -207,6 +207,10 @@ where
         if locs.is_empty() {
             return Ok(Vec::new());
         }
+        debug_assert!(
+            locs.is_sorted(),
+            "locations must be sorted in ascending order"
+        );
         let mut results = Vec::with_capacity(locs.len());
         let mut db_indices = Vec::new();
         let mut db_locs = Vec::new();
@@ -238,7 +242,7 @@ where
             // Need DB fallthrough -- record index for reassembly.
             db_indices.push(i);
             db_locs.push(loc);
-            results.push(None); // placeholder
+            results.push(None);
         }
 
         if !db_locs.is_empty() {
@@ -343,10 +347,10 @@ where
         db.get(loc).await
     }
 
-    /// Read values at multiple locations.
+    /// Batch read values at multiple locations.
     ///
-    /// Acquires the journal reader once for all DB-fallthrough reads.
     /// Locations must be sorted in ascending order.
+    /// Returns results in the same order as the input locations.
     pub async fn get_many<E, H, C>(
         &self,
         locs: &[Location<F>],
@@ -360,6 +364,10 @@ where
         if locs.is_empty() {
             return Ok(Vec::new());
         }
+        debug_assert!(
+            locs.is_sorted(),
+            "locations must be sorted in ascending order"
+        );
         let mut results = Vec::with_capacity(locs.len());
         let mut db_indices = Vec::new();
         let mut db_locs = Vec::new();
@@ -376,7 +384,7 @@ where
 
             db_indices.push(i);
             db_locs.push(loc);
-            results.push(None); // placeholder
+            results.push(None);
         }
 
         if !db_locs.is_empty() {

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -191,6 +191,66 @@ where
         db.get(loc).await
     }
 
+    /// Read values at multiple locations.
+    ///
+    /// Acquires the journal reader once for all DB-fallthrough reads.
+    /// Locations must be sorted in ascending order.
+    pub async fn get_many<E, C>(
+        &self,
+        locs: &[Location<F>],
+        db: &Keyless<F, E, V, C, H>,
+    ) -> Result<Vec<Option<V::Value>>, Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<V>> + Persistable<Error = JournalError>,
+    {
+        if locs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut results = Vec::with_capacity(locs.len());
+        let mut db_indices = Vec::new();
+        let mut db_locs = Vec::new();
+
+        for (i, &loc) in locs.iter().enumerate() {
+            let loc_val = *loc;
+
+            // Check this batch's pending appends.
+            if loc_val >= self.base_size {
+                let idx = (loc_val - self.base_size) as usize;
+                results.push(if idx < self.appends.len() {
+                    Some(self.appends[idx].clone())
+                } else {
+                    None
+                });
+                continue;
+            }
+
+            // Check parent operation chain.
+            if let Some(parent) = self.parent.as_ref() {
+                if loc_val >= self.db_size {
+                    if let Some(op) = read_chain_op(parent, loc_val) {
+                        results.push(op.into_value());
+                        continue;
+                    }
+                }
+            }
+
+            // Need DB fallthrough -- record index for reassembly.
+            db_indices.push(i);
+            db_locs.push(loc);
+            results.push(None); // placeholder
+        }
+
+        if !db_locs.is_empty() {
+            let db_results = db.get_many(&db_locs).await?;
+            for (slot, value) in db_indices.into_iter().zip(db_results) {
+                results[slot] = value;
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Resolve appends into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     ///
     /// `inactivity_floor` is the application-declared floor embedded in the commit. It must
@@ -281,6 +341,52 @@ where
 
         // Fall through to base DB.
         db.get(loc).await
+    }
+
+    /// Read values at multiple locations.
+    ///
+    /// Acquires the journal reader once for all DB-fallthrough reads.
+    /// Locations must be sorted in ascending order.
+    pub async fn get_many<E, H, C>(
+        &self,
+        locs: &[Location<F>],
+        db: &Keyless<F, E, V, C, H>,
+    ) -> Result<Vec<Option<V::Value>>, Error<F>>
+    where
+        E: Context,
+        H: Hasher<Digest = D>,
+        C: Mutable<Item = Operation<V>> + Persistable<Error = JournalError>,
+    {
+        if locs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut results = Vec::with_capacity(locs.len());
+        let mut db_indices = Vec::new();
+        let mut db_locs = Vec::new();
+
+        for (i, &loc) in locs.iter().enumerate() {
+            let loc_val = *loc;
+
+            if loc_val >= self.db_size {
+                if let Some(op) = read_chain_op(self, loc_val) {
+                    results.push(op.into_value());
+                    continue;
+                }
+            }
+
+            db_indices.push(i);
+            db_locs.push(loc);
+            results.push(None); // placeholder
+        }
+
+        if !db_locs.is_empty() {
+            let db_results = db.get_many(&db_locs).await?;
+            for (slot, value) in db_indices.into_iter().zip(db_results) {
+                results[slot] = value;
+            }
+        }
+
+        Ok(results)
     }
 
     /// Create a new speculative batch of operations with this batch as its parent.

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -202,7 +202,7 @@ where
     ) -> Result<Vec<Option<V::Value>>, Error<F>>
     where
         E: Context,
-        C: Mutable<Item = Operation<V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
     {
         if locs.is_empty() {
             return Ok(Vec::new());
@@ -359,7 +359,7 @@ where
     where
         E: Context,
         H: Hasher<Digest = D>,
-        C: Mutable<Item = Operation<V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
     {
         if locs.is_empty() {
             return Ok(Vec::new());

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -226,6 +226,14 @@ mod test {
     }
 
     #[test_traced("INFO")]
+    fn test_keyless_fixed_get_many() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let db = open_db::<mmr::Family>(ctx.with_label("db")).await;
+            tests::test_keyless_get_many(db).await;
+        });
+    }
+
+    #[test_traced("INFO")]
     fn test_keyless_fixed_batch_chained() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.with_label("db")).await;

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -153,10 +153,10 @@ where
         Ok(op.into_value())
     }
 
-    /// Get values at multiple locations in the database.
+    /// Batch read values at multiple locations.
     ///
-    /// Acquires the journal reader once, amortizing lock overhead across all reads.
-    /// Positions must be sorted in ascending order.
+    /// Locations must be sorted in ascending order.
+    /// Returns results in the same order as the input locations.
     ///
     /// # Errors
     ///
@@ -165,6 +165,10 @@ where
         if locs.is_empty() {
             return Ok(Vec::new());
         }
+        debug_assert!(
+            locs.is_sorted(),
+            "locations must be sorted in ascending order"
+        );
         let reader = self.journal.reader().await;
         let op_count = reader.bounds().end;
         for &loc in locs {
@@ -978,6 +982,52 @@ pub(crate) mod tests {
             new_committed_size - 1,
             "Last commit location should be correct after multiple appends"
         );
+
+        db.destroy().await.unwrap();
+    }
+
+    /// `get_many` on the DB and on unmerkleized/merkleized batches returns
+    /// results consistent with individual `get` calls.
+    pub(crate) async fn test_keyless_get_many<F: Family, V, C>(
+        mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
+    ) where
+        V: ValueEncoding<Value: TestValue>,
+        C: Mutable<Item = Operation<V>> + Persistable<Error = JournalError>,
+        Operation<V>: EncodeShared,
+    {
+        let v1 = V::Value::make(1);
+        let v2 = V::Value::make(2);
+        let v3 = V::Value::make(3);
+
+        // Commit v1 and v2 to disk.
+        let batch = db.new_batch();
+        let loc1 = batch.size();
+        let batch = batch.append(v1.clone());
+        let loc2 = batch.size();
+        let batch = batch.append(v2.clone());
+        db.apply_batch(batch.merkleize(&db, None)).await.unwrap();
+        db.commit().await.unwrap();
+
+        // DB-level get_many.
+        let results = db.get_many(&[loc1, loc2]).await.unwrap();
+        assert_eq!(results, vec![Some(v1.clone()), Some(v2.clone())]);
+
+        // Empty input.
+        let results = db.get_many(&[]).await.unwrap();
+        assert!(results.is_empty());
+
+        // Unmerkleized batch: pending appends + DB fallthrough.
+        let batch = db.new_batch();
+        let loc3 = batch.size();
+        let batch = batch.append(v3.clone());
+        let results = batch.get_many(&[loc1, loc3], &db).await.unwrap();
+        assert_eq!(results, vec![Some(v1.clone()), Some(v3.clone())]);
+
+        // Merkleized batch: parent chain + DB fallthrough.
+        let parent = db.new_batch().append(v3.clone()).merkleize(&db, None);
+        let child = parent.new_batch::<Sha256>().append(V::Value::make(4));
+        let results = child.get_many(&[loc1, loc2], &db).await.unwrap();
+        assert_eq!(results, vec![Some(v1.clone()), Some(v2.clone())]);
 
         db.destroy().await.unwrap();
     }

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -153,6 +153,30 @@ where
         Ok(op.into_value())
     }
 
+    /// Get values at multiple locations in the database.
+    ///
+    /// Acquires the journal reader once, amortizing lock overhead across all reads.
+    /// Positions must be sorted in ascending order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::LocationOutOfBounds`] if any location >= `bounds().end`.
+    pub async fn get_many(&self, locs: &[Location<F>]) -> Result<Vec<Option<V::Value>>, Error<F>> {
+        if locs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let reader = self.journal.reader().await;
+        let op_count = reader.bounds().end;
+        for &loc in locs {
+            if loc >= op_count {
+                return Err(Error::LocationOutOfBounds(loc, Location::new(op_count)));
+            }
+        }
+        let positions: Vec<u64> = locs.iter().map(|loc| **loc).collect();
+        let ops = reader.read_many(&positions).await?;
+        Ok(ops.into_iter().map(|op| op.into_value()).collect())
+    }
+
     /// Returns the location of the last commit.
     pub const fn last_commit_loc(&self) -> Location<F> {
         self.last_commit_loc

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -992,8 +992,8 @@ pub(crate) mod tests {
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<V>> + Persistable<Error = JournalError>,
-        Operation<V>: EncodeShared,
+        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        Operation<F, V>: EncodeShared,
     {
         let v1 = V::Value::make(1);
         let v2 = V::Value::make(2);
@@ -1005,7 +1005,9 @@ pub(crate) mod tests {
         let batch = batch.append(v1.clone());
         let loc2 = batch.size();
         let batch = batch.append(v2.clone());
-        db.apply_batch(batch.merkleize(&db, None)).await.unwrap();
+        db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()))
+            .await
+            .unwrap();
         db.commit().await.unwrap();
 
         // DB-level get_many.
@@ -1024,7 +1026,10 @@ pub(crate) mod tests {
         assert_eq!(results, vec![Some(v1.clone()), Some(v3.clone())]);
 
         // Merkleized batch: parent chain + DB fallthrough.
-        let parent = db.new_batch().append(v3.clone()).merkleize(&db, None);
+        let parent = db
+            .new_batch()
+            .append(v3.clone())
+            .merkleize(&db, None, db.inactivity_floor_loc());
         let child = parent.new_batch::<Sha256>().append(V::Value::make(4));
         let results = child.get_many(&[loc1, loc2], &db).await.unwrap();
         assert_eq!(results, vec![Some(v1.clone()), Some(v2.clone())]);

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -1026,10 +1026,10 @@ pub(crate) mod tests {
         assert_eq!(results, vec![Some(v1.clone()), Some(v3.clone())]);
 
         // Merkleized batch: parent chain + DB fallthrough.
-        let parent = db
-            .new_batch()
-            .append(v3.clone())
-            .merkleize(&db, None, db.inactivity_floor_loc());
+        let parent =
+            db.new_batch()
+                .append(v3.clone())
+                .merkleize(&db, None, db.inactivity_floor_loc());
         let child = parent.new_batch::<Sha256>().append(V::Value::make(4));
         let results = child.get_many(&[loc1, loc2], &db).await.unwrap();
         assert_eq!(results, vec![Some(v1.clone()), Some(v2.clone())]);

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -237,6 +237,14 @@ mod test {
     }
 
     #[test_traced("INFO")]
+    fn test_keyless_get_many() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let db = open_db::<mmr::Family>(ctx.with_label("db")).await;
+            tests::test_keyless_get_many(db).await;
+        });
+    }
+
+    #[test_traced("INFO")]
     fn test_keyless_batch_chained() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.with_label("db")).await;


### PR DESCRIPTION
## Overview

Adds `get_many` functions to all QMDB variants' batch types.