### PR TITLE
[storage/qmdb] Optimized ordered+chained path with sorted vectors instead of BTreeMap

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -25,7 +25,7 @@ use commonware_cryptography::{Digest, Hasher};
 use core::{iter, ops::Range};
 use futures::future::try_join_all;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::{Arc, Weak},
 };
 use tracing::debug;
@@ -1081,21 +1081,22 @@ where
             prev_candidates.push((data.key, (data.value, old_loc)));
         }
 
-        // Add ancestor-diff keys that may be predecessors or successors of this batch's
-        // mutations but are invisible to the base-DB-only `prev_translated_key` lookup above.
-        // Each ancestor's diff is already sorted by key; walk them directly and skip entries
-        // shadowed by a closer (earlier-in-list) ancestor.
+        // Add ancestor-diff keys that may be predecessors or successors of this batch's mutations
+        // but are invisible to the base-DB-only `prev_translated_key` lookup above.
         //
-        // The skip-shadowed check uses binary_search, which is cheap compared to the
-        // previous BTreeMap::entry(k).or_insert build since it short-circuits per key.
+        // Walk ancestors closest-first; a BTreeSet tracks keys already seen so each key is
+        // processed only once (closest-ancestor's entry wins). BTreeSet is faster than HashMap
+        // for 32-byte Digest keys because Digest cmp (~5ns, SIMD) is cheaper than SipHash
+        // (~200ns) per op at the sizes involved.
+        //
+        // Depth-1 chains skip the BTreeSet entirely — a single ancestor can't shadow itself,
+        // and each diff's keys are unique by construction.
+        let track_shadow = m.ancestors.len() > 1;
+        let mut seen: BTreeSet<&K> = BTreeSet::new();
         let mut ancestor_deleted: Vec<K> = Vec::new();
-        for (i, batch) in m.ancestors.iter().enumerate() {
+        for batch in m.ancestors.iter() {
             for (key, entry) in batch.diff.iter() {
-                // Skip if a closer ancestor (earlier in `m.ancestors`) already has this key.
-                if m.ancestors[..i]
-                    .iter()
-                    .any(|b| lookup_sorted(b.diff.as_slice(), key).is_some())
-                {
+                if track_shadow && !seen.insert(key) {
                     continue;
                 }
                 // Skip keys already handled by this batch's mutations.
@@ -1716,7 +1717,7 @@ mod tests {
                 },
             ),
         ];
-        base_diff.sort_by(|a, b| a.0.cmp(&b.0));
+        base_diff.sort_by_key(|a| a.0);
 
         let creates = extract_parent_deleted_creates(&mut mutations, &base_diff);
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -25,7 +25,7 @@ use commonware_cryptography::{Digest, Hasher};
 use core::{iter, ops::Range};
 use futures::future::try_join_all;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::{Arc, Weak},
 };
 use tracing::debug;
@@ -35,6 +35,10 @@ const MAX_CONCURRENT_READS: u64 = 64;
 
 type DiffVec<K, F, V> = Vec<(K, DiffEntry<F, V>)>;
 type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
+
+/// Sorted `(key, (value, loc))` vec consulted by `find_prev_key` to find the predecessor
+/// of a given key during ordered merkleization.
+type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
 
 /// Strategy for finding the next active location during floor raising.
 pub(crate) trait FloorScan<F: Family> {
@@ -985,9 +989,11 @@ where
         let locations = m.gather_existing_locations(&mutations, db, true);
         let reader = db.log.reader().await;
 
-        // Classify mutations into deleted, created, updated.
-        let mut next_candidates: BTreeSet<K> = BTreeSet::new();
-        let mut prev_candidates: BTreeMap<K, (V::Value, Location<F>)> = BTreeMap::new();
+        // Classify mutations into deleted, created, updated. `next_candidates` and
+        // `prev_candidates` are built as unsorted `Vec`s here and sorted+deduped once below,
+        // before `find_next_key` / `find_prev_key` binary-search them.
+        let mut next_candidates: Vec<K> = Vec::new();
+        let mut prev_candidates: PrevCandidates<K, F, V::Value> = Vec::new();
         let mut deleted: Vec<(K, Location<F>)> = Vec::new();
         let mut updated: Vec<(K, V::Value, Location<F>)> = Vec::new();
 
@@ -1005,10 +1011,10 @@ where
                 Operation::Update(data) => data,
                 _ => unreachable!("snapshot should only reference Update operations"),
             };
-            next_candidates.insert(next_key);
+            next_candidates.push(next_key);
 
             let mutation = mutations.remove(&key);
-            prev_candidates.insert(key.clone(), (value, old_loc));
+            prev_candidates.push((key.clone(), (value, old_loc)));
 
             let Some(mutation) = mutation else {
                 // Snapshot index collision: this operation's key does not match
@@ -1040,11 +1046,11 @@ where
             let Some(value) = value else {
                 continue; // delete of non-existent key
             };
-            next_candidates.insert(key.clone());
+            next_candidates.push(key.clone());
             created.push((key, value, None));
         }
         for (key, value, base_old_loc) in parent_deleted_creates {
-            next_candidates.insert(key.clone());
+            next_candidates.push(key.clone());
             created.push((key, value, base_old_loc));
         }
         created.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
@@ -1071,60 +1077,82 @@ where
                 Operation::Update(data) => data,
                 _ => unreachable!("expected update operation"),
             };
-            next_candidates.insert(data.next_key);
-            prev_candidates.insert(data.key, (data.value, old_loc));
+            next_candidates.push(data.next_key);
+            prev_candidates.push((data.key, (data.value, old_loc)));
         }
 
-        // Add ancestor-diff-created keys to candidate sets. These keys may be predecessors
-        // or successors of this batch's mutations but are invisible to the base-DB-only
-        // prev_translated_key lookup above. Walk the parent chain to collect the effective
-        // state for each key (closest ancestor wins).
-        let ancestor_entries = {
-            let mut entries: BTreeMap<&K, &DiffEntry<F, V::Value>> = BTreeMap::new();
-            for batch in &m.ancestors {
-                for (key, entry) in batch.diff.iter() {
-                    entries.entry(key).or_insert(entry);
+        // Add ancestor-diff keys that may be predecessors or successors of this batch's
+        // mutations but are invisible to the base-DB-only `prev_translated_key` lookup above.
+        // Each ancestor's diff is already sorted by key; walk them directly and skip entries
+        // shadowed by a closer (earlier-in-list) ancestor.
+        //
+        // The skip-shadowed check uses binary_search, which is cheap compared to the
+        // previous BTreeMap::entry(k).or_insert build since it short-circuits per key.
+        let mut ancestor_deleted: Vec<K> = Vec::new();
+        for (i, batch) in m.ancestors.iter().enumerate() {
+            for (key, entry) in batch.diff.iter() {
+                // Skip if a closer ancestor (earlier in `m.ancestors`) already has this key.
+                if m.ancestors[..i]
+                    .iter()
+                    .any(|b| lookup_sorted(b.diff.as_slice(), key).is_some())
+                {
+                    continue;
+                }
+                // Skip keys already handled by this batch's mutations.
+                if updated.binary_search_by(|(k, _, _)| k.cmp(key)).is_ok()
+                    || created.binary_search_by(|(k, _, _)| k.cmp(key)).is_ok()
+                    || deleted.binary_search_by(|(k, _)| k.cmp(key)).is_ok()
+                {
+                    continue;
+                }
+                match entry {
+                    DiffEntry::Active { value, loc, .. } => {
+                        let op = m.read_op(*loc, &[], &reader).await?;
+                        let data = match op {
+                            Operation::Update(data) => data,
+                            _ => unreachable!("ancestor diff Active should reference Update op"),
+                        };
+                        next_candidates.push(key.clone());
+                        next_candidates.push(data.next_key);
+                        prev_candidates.push((key.clone(), (value.clone(), *loc)));
+                    }
+                    DiffEntry::Deleted { .. } => {
+                        ancestor_deleted.push(key.clone());
+                    }
                 }
             }
-            entries
-        };
-
-        for (key, entry) in &ancestor_entries {
-            // Skip keys already handled by this batch's mutations.
-            if updated.binary_search_by(|(k, _, _)| k.cmp(*key)).is_ok()
-                || created.binary_search_by(|(k, _, _)| k.cmp(*key)).is_ok()
-                || deleted.binary_search_by(|(k, _)| k.cmp(*key)).is_ok()
-            {
-                continue;
-            }
-            if let DiffEntry::Active { value, loc, .. } = entry {
-                let op = m.read_op(*loc, &[], &reader).await?;
-                let data = match op {
-                    Operation::Update(data) => data,
-                    _ => unreachable!("ancestor diff Active should reference Update op"),
-                };
-                next_candidates.insert((*key).clone());
-                next_candidates.insert(data.next_key);
-                prev_candidates.insert((*key).clone(), (value.clone(), *loc));
-            }
         }
+        ancestor_deleted.sort();
+        ancestor_deleted.dedup();
+
+        // Sort + dedup candidate sets now so find_next_key/find_prev_key can binary-search.
+        next_candidates.sort();
+        next_candidates.dedup();
+        // For `prev_candidates`, duplicates can occur when the same key is pushed from multiple
+        // sources (main scan, prev_results, ancestor walk). Later pushes carry the freshest state
+        // (ancestor walk runs last), so dedup keeps the LAST push per key. `dedup_by` retains the
+        // first of each consecutive run; swap so the retained slot holds the later push.
+        prev_candidates.sort_by(|a, b| a.0.cmp(&b.0));
+        prev_candidates.dedup_by(|a, b| {
+            if a.0 == b.0 {
+                std::mem::swap(a, b);
+                true
+            } else {
+                false
+            }
+        });
 
         // Remove all known-deleted keys from possible_* sets. The prev_translated_key lookup
         // already did this for this batch's deletes, but the ancestor diff incorporation may
         // have re-added them via next_key references. Also remove parent-deleted keys that the
         // base DB lookup may have added.
-        for (key, _) in &deleted {
-            prev_candidates.remove(key);
-            next_candidates.remove(key);
-        }
-        for (key, entry) in &ancestor_entries {
-            if matches!(entry, DiffEntry::Deleted { .. })
-                && created.binary_search_by(|(k, _, _)| k.cmp(*key)).is_err()
-            {
-                prev_candidates.remove(*key);
-                next_candidates.remove(*key);
-            }
-        }
+        let is_deleted = |k: &K| -> bool {
+            deleted.binary_search_by(|(dk, _)| dk.cmp(k)).is_ok()
+                || (ancestor_deleted.binary_search(k).is_ok()
+                    && created.binary_search_by(|(ck, _, _)| ck.cmp(k)).is_err())
+        };
+        next_candidates.retain(|k| !is_deleted(k));
+        prev_candidates.retain(|(k, _)| !is_deleted(k));
 
         // Generate operations.
         let mut ops: Vec<Operation<F, update::Ordered<K, V>>> =

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -213,12 +213,7 @@ where
 ///
 /// Panics if `possible_next` is empty.
 pub(crate) fn find_next_key<K: Ord + Clone>(key: &K, possible_next: &[K]) -> K {
-    // Find the first index with entry > key. `binary_search` returns Ok on exact hit (jump past)
-    // or Err on no hit (insertion point).
-    let idx = match possible_next.binary_search(key) {
-        Ok(i) => i + 1,
-        Err(i) => i,
-    };
+    let idx = possible_next.partition_point(|k| k <= key);
     if idx < possible_next.len() {
         return possible_next[idx].clone();
     }
@@ -238,17 +233,14 @@ pub(crate) fn find_prev_key<'a, K: Ord, V>(
     key: &K,
     possible_previous: &'a [(K, V)],
 ) -> (&'a K, &'a V) {
-    let idx = match possible_previous.binary_search_by(|(k, _)| k.cmp(key)) {
-        Ok(i) => i,
-        Err(i) => i,
+    let idx = possible_previous.partition_point(|(k, _)| k < key);
+    let (k, v) = if idx > 0 {
+        &possible_previous[idx - 1]
+    } else {
+        possible_previous
+            .last()
+            .expect("possible_previous should not be empty")
     };
-    if idx > 0 {
-        let (k, v) = &possible_previous[idx - 1];
-        return (k, v);
-    }
-    let (k, v) = possible_previous
-        .last()
-        .expect("possible_previous should not be empty");
     (k, v)
 }
 

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -16,10 +16,6 @@ use futures::{
     future::try_join_all,
     stream::{self, Stream},
 };
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    ops::Bound,
-};
 
 pub mod fixed;
 pub mod variable;
@@ -210,18 +206,21 @@ where
     }
 }
 
-/// Returns the next key to `key` within `possible_next`. The result will "cycle around" to the
-/// first key if `key` is the last key.
+/// Returns the next key to `key` within `possible_next` (a sorted, deduplicated slice). The
+/// result will "cycle around" to the first key if `key` is the last key.
 ///
 /// # Panics
 ///
 /// Panics if `possible_next` is empty.
-pub(crate) fn find_next_key<K: Ord + Clone>(key: &K, possible_next: &BTreeSet<K>) -> K {
-    let next = possible_next
-        .range((Bound::Excluded(key), Bound::Unbounded))
-        .next();
-    if let Some(next) = next {
-        return next.clone();
+pub(crate) fn find_next_key<K: Ord + Clone>(key: &K, possible_next: &[K]) -> K {
+    // Find the first index with entry > key. `binary_search` returns Ok on exact hit (jump past)
+    // or Err on no hit (insertion point).
+    let idx = match possible_next.binary_search(key) {
+        Ok(i) => i + 1,
+        Err(i) => i,
+    };
+    if idx < possible_next.len() {
+        return possible_next[idx].clone();
     }
     possible_next
         .first()
@@ -229,26 +228,28 @@ pub(crate) fn find_next_key<K: Ord + Clone>(key: &K, possible_next: &BTreeSet<K>
         .clone()
 }
 
-/// Returns the previous key to `key` within `possible_previous`. The result will "cycle around"
-/// to the last key if `key` is the first key.
+/// Returns the previous key to `key` within `possible_previous` (sorted by `.0`, deduplicated).
+/// The result will "cycle around" to the last entry if `key` is the first key.
 ///
 /// # Panics
 ///
 /// Panics if `possible_previous` is empty.
 pub(crate) fn find_prev_key<'a, K: Ord, V>(
     key: &K,
-    possible_previous: &'a BTreeMap<K, V>,
+    possible_previous: &'a [(K, V)],
 ) -> (&'a K, &'a V) {
-    let prev = possible_previous
-        .range((Bound::Unbounded, Bound::Excluded(key)))
-        .next_back();
-    if let Some(prev) = prev {
-        return prev;
+    let idx = match possible_previous.binary_search_by(|(k, _)| k.cmp(key)) {
+        Ok(i) => i,
+        Err(i) => i,
+    };
+    if idx > 0 {
+        let (k, v) = &possible_previous[idx - 1];
+        return (k, v);
     }
-    possible_previous
-        .iter()
-        .next_back()
-        .expect("possible_previous should not be empty")
+    let (k, v) = possible_previous
+        .last()
+        .expect("possible_previous should not be empty");
+    (k, v)
 }
 
 #[cfg(any(test, feature = "test-traits"))]

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -1253,12 +1253,12 @@ pub(super) mod test {
         let mut kvs_first: Vec<(Digest, Digest)> = (0u64..5)
             .map(|i| (Sha256::hash(&i.to_be_bytes()), Sha256::fill(i as u8)))
             .collect();
-        kvs_first.sort_by(|a, b| a.0.cmp(&b.0));
+        kvs_first.sort_by_key(|a| a.0);
 
         let mut kvs_second: Vec<(Digest, Digest)> = (5u64..10)
             .map(|i| (Sha256::hash(&i.to_be_bytes()), Sha256::fill(i as u8)))
             .collect();
-        kvs_second.sort_by(|a, b| a.0.cmp(&b.0));
+        kvs_second.sort_by_key(|a| a.0);
 
         // Parent batch: set keys 0..5.
         let mut parent = db.new_batch();


### PR DESCRIPTION
| Variant | Chained | Time (median) | Change |
  | --- | --- | --- | --- |
  | `any::ordered::fixed::mmb` | false | 106.58 ms | −7.57% |
  | `any::ordered::fixed::mmb` | true | 146.08 ms | −22.55% |
  | `current::ordered::fixed::mmb chunk=32` | false | 113.25 ms | −9.09% |
  | `current::ordered::fixed::mmb chunk=32` | true | 158.60 ms | −21.59% |                                                                                                   
  | `current::ordered::fixed::mmb chunk=256` | false | 109.54 ms | −10.19% |                                                                                                 
  | `current::ordered::fixed::mmb chunk=256` | true | 155.45 ms | −22.09% |                                                                                                  
  | `any::unordered::fixed::mmb` | false | 98.64 ms | −0.62% (n.s.) |                                                                                                        
  | `any::unordered::fixed::mmb` | true | 119.18 ms | −0.04% (n.s.) |
  | `current::unordered::fixed::mmb chunk=32` | false | 106.05 ms | −2.67% (noise) |                                                                                         
  | `current::unordered::fixed::mmb chunk=32` | true | 132.24 ms | −0.60% (noise) |                                                                                          
  | `current::unordered::fixed::mmb chunk=256` | false | 102.60 ms | −1.15% (noise) |                                                                                        
  | `current::unordered::fixed::mmb chunk=256` | true | 129.25 ms | −2.51% (n.s.) |                                                                                          
                                                                                                                                                                             
  All runs: num_keys=1000000, 10 samples each. (n.s.) = not statistically significant (p > 0.05); (noise) = statistically significant but flagged within criterion's noise   
  threshold.                               

Resolves: https://github.com/commonwarexyz/monorepo/issues/3592