### PR TITLE
[consensus/marshal] Cache Proposed Block

### DIFF
--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -656,7 +656,7 @@ where
 
                 let commitment = coded_block.commitment();
                 let round = consensus_context.round;
-                if !marshal.verified(round, coded_block).await {
+                if !marshal.proposed(round, coded_block).await {
                     debug!(?round, ?commitment, "marshal rejected proposed block");
                     return;
                 }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -559,24 +559,31 @@ where
                         };
                         buffer.send(round, block, recipients).await;
                     }
+                    Message::Proposed { round, block, ack } => {
+                        // Mirror `Verified`: persist durably before acking so
+                        // the proposer can rely on the block surviving a
+                        // restart. Uses the reference-taking store path so
+                        // we do not clone the block's transient data (e.g.
+                        // erasure-coded shards) just to drop them on the
+                        // `V::Block -> V::StoredBlock` conversion.
+                        let commitment = V::commitment(&block);
+                        let digest = block.digest();
+                        self.notify_subscribers(&block);
+                        self.cache
+                            .put_verified(round, digest, V::stored_from_ref(&block))
+                            .await;
+                        // Retain the block in memory so the subsequent
+                        // `Forward` can broadcast it without reloading from
+                        // storage. An older retained proposal (if any) is
+                        // overwritten.
+                        self.proposed_block = Some((round, commitment, block));
+                        ack.send_lossy(());
+                    }
                     Message::Verified { round, block, ack } => {
                         // If the round has already been pruned by tip advancement,
                         // `cache_verified` is a no-op because the round is below
                         // the retention floor (and no longer is required by consensus
                         // to make progress).
-                        self.cache_verified(round, block.digest(), block).await;
-                        ack.send_lossy(());
-                    }
-                    Message::Proposed { round, block, ack } => {
-                        // Retain the block in memory so the subsequent
-                        // `Forward` can broadcast it without reloading from
-                        // storage. An older retained proposal (if any) is
-                        // overwritten.
-                        let commitment = V::commitment(&block);
-                        self.proposed_block = Some((round, commitment, block.clone()));
-                        // Mirror `Verified`: persist durably before acking so
-                        // the proposer can rely on the block surviving a
-                        // restart.
                         self.cache_verified(round, block.digest(), block).await;
                         ack.send_lossy(());
                     }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -559,12 +559,12 @@ where
                         // `cache_verified` is a no-op because the round is below
                         // the retention floor (and no longer is required by consensus
                         // to make progress).
-                        let commitment = V::commitment(&block);
                         self.cache_verified(round, block.digest(), block.clone()).await;
                         // Retain the block in memory so the subsequent
                         // `Forward` can broadcast it without reloading from
                         // storage. An older retained proposal (if any) is
                         // overwritten.
+                        let commitment = V::commitment(&block);
                         self.last_proposed_block = Some((round, commitment, block));
                         ack.send_lossy(());
                     }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -235,6 +235,8 @@ where
     strategy: T,
 
     // ---------- State ----------
+    // Last proposed block
+    last_proposed_block: Option<(Round, V::Commitment, V::Block)>,
     // Last view processed
     last_processed_round: Round,
     // Last height processed by the application
@@ -245,13 +247,6 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: BTreeMap<BlockSubscriptionKeyFor<V>, BlockSubscription<V>>,
-    // The most recently locally-proposed block, keyed by (round, commitment)
-    // and retained until a matching `Forward` consumes it (or a newer
-    // proposal overwrites it). Lets broadcast avoid reloading the block from
-    // storage, and for the coding variant avoids recomputing erasure-coded
-    // shards. The commitment is cached alongside the block to avoid
-    // recomputing V::commitment() (which hashes the block) on every lookup.
-    proposed_block: Option<(Round, V::Commitment, V::Block)>,
 
     // ---------- Storage ----------
     // Prunable cache
@@ -350,12 +345,12 @@ where
                 max_repair: config.max_repair,
                 block_codec_config: config.block_codec_config,
                 strategy: config.strategy,
+                last_proposed_block: None,
                 last_processed_round: Round::zero(),
                 last_processed_height,
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
                 tip: Height::zero(),
                 block_subscriptions: BTreeMap::new(),
-                proposed_block: None,
                 cache,
                 application_metadata,
                 finalizations_by_height,
@@ -560,19 +555,17 @@ where
                         buffer.send(round, block, recipients).await;
                     }
                     Message::Proposed { round, block, ack } => {
-                        // Mirror `Verified`: persist durably before acking so
-                        // the proposer can rely on the block surviving a
-                        // restart. Uses the reference-taking store path so
-                        // we do not clone the block's transient data (e.g.
-                        // erasure-coded shards) just to drop them on the
-                        // `V::Block -> V::StoredBlock` conversion.
+                        // If the round has already been pruned by tip advancement,
+                        // `cache_verified` is a no-op because the round is below
+                        // the retention floor (and no longer is required by consensus
+                        // to make progress).
                         let commitment = V::commitment(&block);
-                        self.cache_verified(round, block.digest(), block).await;
+                        self.cache_verified(round, block.digest(), block.clone()).await;
                         // Retain the block in memory so the subsequent
                         // `Forward` can broadcast it without reloading from
                         // storage. An older retained proposal (if any) is
                         // overwritten.
-                        self.proposed_block = Some((round, commitment, block));
+                        self.last_proposed_block = Some((round, commitment, block));
                         ack.send_lossy(());
                     }
                     Message::Verified { round, block, ack } => {
@@ -1373,15 +1366,13 @@ where
     }
 
     /// If a block previously accepted via [`Message::Proposed`] matches the
-    /// supplied `(round, commitment)`, remove and return it. Called from the
-    /// `Forward` handler so a proposer broadcasts its just-built block
-    /// straight from memory.
+    /// supplied `(round, commitment)`, remove and return it.
     fn take_proposed(&mut self, round: Round, commitment: V::Commitment) -> Option<V::Block> {
-        let (cached_round, cached_commitment, _) = self.proposed_block.as_ref()?;
+        let (cached_round, cached_commitment, _) = self.last_proposed_block.as_ref()?;
         if *cached_round != round || *cached_commitment != commitment {
             return None;
         }
-        self.proposed_block.take().map(|(_, _, block)| block)
+        self.last_proposed_block.take().map(|(_, _, block)| block)
     }
 
     /// Add a notarized block to the prunable archive.

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -245,6 +245,13 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: BTreeMap<BlockSubscriptionKeyFor<V>, BlockSubscription<V>>,
+    // The most recently locally-proposed block, keyed by (round, commitment)
+    // and retained until a matching `Forward` consumes it (or a newer
+    // proposal overwrites it). Lets broadcast avoid reloading the block from
+    // storage, and for the coding variant avoids recomputing erasure-coded
+    // shards. The commitment is cached alongside the block to avoid
+    // recomputing V::commitment() (which hashes the block) on every lookup.
+    proposed_block: Option<(Round, V::Commitment, V::Block)>,
 
     // ---------- Storage ----------
     // Prunable cache
@@ -348,6 +355,7 @@ where
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
                 tip: Height::zero(),
                 block_subscriptions: BTreeMap::new(),
+                proposed_block: None,
                 cache,
                 application_metadata,
                 finalizations_by_height,
@@ -537,10 +545,17 @@ where
                         if matches!(&recipients, Recipients::Some(peers) if peers.is_empty()) {
                             continue;
                         }
-                        let Some(block) = self.find_block_by_commitment(&buffer, commitment).await
-                        else {
-                            debug!(?commitment, "block not found for forwarding");
-                            continue;
+                        let block = match self.take_proposed(round, commitment) {
+                            Some(block) => block,
+                            None => {
+                                let Some(block) =
+                                    self.find_block_by_commitment(&buffer, commitment).await
+                                else {
+                                    debug!(?commitment, "block not found for forwarding");
+                                    continue;
+                                };
+                                block
+                            }
                         };
                         buffer.send(round, block, recipients).await;
                     }
@@ -549,6 +564,19 @@ where
                         // `cache_verified` is a no-op because the round is below
                         // the retention floor (and no longer is required by consensus
                         // to make progress).
+                        self.cache_verified(round, block.digest(), block).await;
+                        ack.send_lossy(());
+                    }
+                    Message::Proposed { round, block, ack } => {
+                        // Retain the block in memory so the subsequent
+                        // `Forward` can broadcast it without reloading from
+                        // storage. An older retained proposal (if any) is
+                        // overwritten.
+                        let commitment = V::commitment(&block);
+                        self.proposed_block = Some((round, commitment, block.clone()));
+                        // Mirror `Verified`: persist durably before acking so
+                        // the proposer can rely on the block surviving a
+                        // restart.
                         self.cache_verified(round, block.digest(), block).await;
                         ack.send_lossy(());
                     }
@@ -1339,6 +1367,18 @@ where
     ) {
         self.notify_subscribers(&block);
         self.cache.put_verified(round, digest, block.into()).await;
+    }
+
+    /// If a block previously accepted via [`Message::Proposed`] matches the
+    /// supplied `(round, commitment)`, remove and return it. Called from the
+    /// `Forward` handler so a proposer broadcasts its just-built block
+    /// straight from memory.
+    fn take_proposed(&mut self, round: Round, commitment: V::Commitment) -> Option<V::Block> {
+        let (cached_round, cached_commitment, _) = self.proposed_block.as_ref()?;
+        if *cached_round != round || *cached_commitment != commitment {
+            return None;
+        }
+        self.proposed_block.take().map(|(_, _, block)| block)
     }
 
     /// Add a notarized block to the prunable archive.

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -567,11 +567,7 @@ where
                         // erasure-coded shards) just to drop them on the
                         // `V::Block -> V::StoredBlock` conversion.
                         let commitment = V::commitment(&block);
-                        let digest = block.digest();
-                        self.notify_subscribers(&block);
-                        self.cache
-                            .put_verified(round, digest, V::stored_from_ref(&block))
-                            .await;
+                        self.cache_verified(round, block.digest(), block).await;
                         // Retain the block in memory so the subsequent
                         // `Forward` can broadcast it without reloading from
                         // storage. An older retained proposal (if any) is

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -111,6 +111,20 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// A channel signaled once the block is durably stored.
         ack: oneshot::Sender<()>,
     },
+    /// A notification that a block has been locally proposed by this node.
+    ///
+    /// Durably persists the block like [`Self::Verified`] and additionally
+    /// retains it in memory so a subsequent [`Self::Forward`] can broadcast
+    /// without reloading from storage (or, for the coding variant,
+    /// recomputing erasure-coded shards).
+    Proposed {
+        /// The round in which the block was proposed.
+        round: Round,
+        /// The proposed block.
+        block: V::Block,
+        /// A channel signaled once the block is durably stored.
+        ack: oneshot::Sender<()>,
+    },
     /// A notification that a block has been certified by the application.
     Certified {
         /// The round in which the block was certified.
@@ -309,6 +323,23 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     pub async fn verified(&self, round: Round, block: V::Block) -> bool {
         self.sender
             .request(|ack| Message::Verified { round, block, ack })
+            .await
+            .is_some()
+    }
+
+    /// Notifies the actor that a block has been locally proposed, awaiting
+    /// the actor's confirmation that the block has been durably persisted
+    /// before returning.
+    ///
+    /// Equivalent to [`Self::verified`] for durability, with the additional
+    /// guarantee that the block is retained in memory until a subsequent
+    /// [`Self::forward`] for the same `(round, commitment)` consumes it.
+    /// This lets the broadcast path reuse the in-memory block instead of
+    /// reloading from storage.
+    #[must_use = "callers must consider block durability before proceeding"]
+    pub async fn proposed(&self, round: Round, block: V::Block) -> bool {
+        self.sender
+            .request(|ack| Message::Proposed { round, block, ack })
             .await
             .is_some()
     }

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -103,11 +103,6 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         recipients: Recipients<S::PublicKey>,
     },
     /// A notification that a block has been locally proposed by this node.
-    ///
-    /// Durably persists the block like [`Self::Verified`] and additionally
-    /// retains it in memory so a subsequent [`Self::Forward`] can broadcast
-    /// without reloading from storage (or, for the coding variant,
-    /// recomputing erasure-coded shards).
     Proposed {
         /// The round in which the block was proposed.
         round: Round,
@@ -320,12 +315,6 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     /// Notifies the actor that a block has been locally proposed, awaiting
     /// the actor's confirmation that the block has been durably persisted
     /// before returning.
-    ///
-    /// Equivalent to [`Self::verified`] for durability, with the additional
-    /// guarantee that the block is retained in memory until a subsequent
-    /// [`Self::forward`] for the same `(round, commitment)` consumes it.
-    /// This lets the broadcast path reuse the in-memory block instead of
-    /// reloading from storage.
     #[must_use = "callers must consider block durability before proceeding"]
     pub async fn proposed(&self, round: Round, block: V::Block) -> bool {
         self.sender

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -102,15 +102,6 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The recipients to forward the block to.
         recipients: Recipients<S::PublicKey>,
     },
-    /// A notification that a block has been verified by the application.
-    Verified {
-        /// The round in which the block was verified.
-        round: Round,
-        /// The verified block.
-        block: V::Block,
-        /// A channel signaled once the block is durably stored.
-        ack: oneshot::Sender<()>,
-    },
     /// A notification that a block has been locally proposed by this node.
     ///
     /// Durably persists the block like [`Self::Verified`] and additionally
@@ -121,6 +112,15 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The round in which the block was proposed.
         round: Round,
         /// The proposed block.
+        block: V::Block,
+        /// A channel signaled once the block is durably stored.
+        ack: oneshot::Sender<()>,
+    },
+    /// A notification that a block has been verified by the application.
+    Verified {
+        /// The round in which the block was verified.
+        round: Round,
+        /// The verified block.
         block: V::Block,
         /// A channel signaled once the block is durably stored.
         ack: oneshot::Sender<()>,
@@ -317,16 +317,6 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
             .flatten()
     }
 
-    /// Notifies the actor that a block has been verified, awaiting the actor's
-    /// confirmation that the block has been durably persisted before returning.
-    #[must_use = "callers must consider block durability before proceeding"]
-    pub async fn verified(&self, round: Round, block: V::Block) -> bool {
-        self.sender
-            .request(|ack| Message::Verified { round, block, ack })
-            .await
-            .is_some()
-    }
-
     /// Notifies the actor that a block has been locally proposed, awaiting
     /// the actor's confirmation that the block has been durably persisted
     /// before returning.
@@ -340,6 +330,16 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     pub async fn proposed(&self, round: Round, block: V::Block) -> bool {
         self.sender
             .request(|ack| Message::Proposed { round, block, ack })
+            .await
+            .is_some()
+    }
+
+    /// Notifies the actor that a block has been verified, awaiting the actor's
+    /// confirmation that the block has been durably persisted before returning.
+    #[must_use = "callers must consider block durability before proceeding"]
+    pub async fn verified(&self, round: Round, block: V::Block) -> bool {
+        self.sender
+            .request(|ack| Message::Verified { round, block, ack })
             .await
             .is_some()
     }

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -848,7 +848,7 @@ pub fn hailstorm<H: TestHarness>(
     })
 }
 
-/// Contract: `marshal.verified(...)=true` means the block survives an
+/// Contract: `marshal.proposed(...)=true` means the block survives an
 /// immediate crash and repeated recoveries.
 pub fn proposed_success_implies_recoverable_after_restart<H: TestHarness>(
     seeds: impl IntoIterator<Item = u64>,
@@ -931,7 +931,7 @@ pub fn proposed_success_implies_recoverable_after_restart<H: TestHarness>(
                                 .await
                                 .unwrap_or_else(|| {
                                     panic!(
-                                        "marshal.verified() returning true must imply \
+                                        "marshal.proposed() returning true must imply \
                                      get_verified(round) recovers the block after restart \
                                      (seed={seed}, cycle={cycle})"
                                     )
@@ -1722,7 +1722,7 @@ impl TestHarness for StandardHarness {
     }
 
     async fn propose(handle: &mut ValidatorHandle<Self>, round: Round, block: &B) {
-        assert!(handle.mailbox.verified(round, block.clone()).await);
+        assert!(handle.mailbox.proposed(round, block.clone()).await);
     }
 
     async fn verify(
@@ -2546,7 +2546,7 @@ impl TestHarness for CodingHarness {
         round: Round,
         block: &CodedBlock<CodingB, ReedSolomon<Sha256>, Sha256>,
     ) {
-        assert!(handle.mailbox.verified(round, block.clone()).await);
+        assert!(handle.mailbox.proposed(round, block.clone()).await);
     }
 
     async fn verify(

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -429,7 +429,7 @@ where
                 build_timer.observe();
 
                 let digest = built_block.digest();
-                if !marshal.verified(consensus_context.round, built_block).await {
+                if !marshal.proposed(consensus_context.round, built_block).await {
                     debug!(
                         round = ?consensus_context.round,
                         ?digest,

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -345,7 +345,7 @@ where
                 build_timer.observe();
 
                 let digest = built_block.digest();
-                if !marshal.verified(consensus_context.round, built_block).await {
+                if !marshal.proposed(consensus_context.round, built_block).await {
                     debug!(
                         round = ?consensus_context.round,
                         ?digest,

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -2258,6 +2258,69 @@ mod tests {
         });
     }
 
+    /// A block admitted via `Proposed` must be broadcast straight from the
+    /// in-memory cache when `Forward` arrives: the `RecordingBuffer` reports
+    /// no `find_by_commitment` hits, so if the forward dispatches a block it
+    /// must have come from the in-memory slot populated by `Proposed`.
+    /// A subsequent `Forward` for the same `(round, commitment)` falls
+    /// through to storage because the slot is consumed.
+    #[test_traced("WARN")]
+    fn test_standard_proposed_is_served_from_in_memory_cache() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let me = participants[0].clone();
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(Sha256::hash(b""), Height::new(1), 100);
+            let digest = block.digest();
+
+            let (mailbox, buffer, _resolver, _actor_handle) = start_standard_actor(
+                context.with_label("validator_0"),
+                &format!("proposed-cache-{me}"),
+                ConstantProvider::new(schemes[0].clone()),
+                Application::<B>::manual_ack(),
+                RecordingBuffer::default(),
+            )
+            .await;
+
+            assert!(mailbox.proposed(round, block.clone()).await);
+
+            let targets = vec![participants[1].clone()];
+            mailbox
+                .forward(round, digest, Recipients::Some(targets.clone()))
+                .await;
+
+            wait_until(&context, Duration::from_secs(5), "first forward", || {
+                !buffer.sends.lock().is_empty()
+            })
+            .await;
+
+            let sends = buffer.sends();
+            assert_eq!(sends.len(), 1, "cached proposal must dispatch exactly once");
+            assert_eq!(sends[0].0, round);
+            assert_eq!(sends[0].1.digest(), digest);
+
+            // The in-memory slot was consumed; a second forward for the same
+            // commitment must still succeed by falling back to storage (the
+            // block was persisted by `Proposed`, mirroring `Verified`).
+            mailbox
+                .forward(round, digest, Recipients::Some(targets))
+                .await;
+            wait_until(&context, Duration::from_secs(5), "second forward", || {
+                buffer.sends.lock().len() >= 2
+            })
+            .await;
+
+            let sends = buffer.sends();
+            assert_eq!(sends.len(), 2);
+            assert_eq!(sends[1].1.digest(), digest);
+        });
+    }
+
     /// `Forward` for a block that marshal has cached must dispatch that block
     /// to exactly the provided peer set via the buffer.
     #[test_traced("WARN")]


### PR DESCRIPTION
Related: #3543

The old logic cached proposed blocks before broadcast, saving considerable resources in coding.