### PR TITLE
[storage/fuzz] generalize fuzz tests on merkle family

### DIFF
--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -15,7 +15,7 @@ use commonware_runtime::{
 };
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    mmr::{self, journaled::Config as MmrConfig, Location},
+    merkle::{journaled::Config as MerkleConfig, mmb, mmr, Graftable, Location},
     qmdb::current::{unordered::variable::Db as Current, VariableConfig},
     translator::TwoCap,
 };
@@ -34,7 +34,7 @@ type RawValue = [u8; 32];
 /// Maximum write buffer size.
 const MAX_WRITE_BUF: usize = 2048;
 
-type Db = Current<mmr::Family, deterministic::Context, Key, Value, Sha256, TwoCap, 32>;
+type Db<F> = Current<F, deterministic::Context, Key, Value, Sha256, TwoCap, 32>;
 
 fn bounded_page_size(u: &mut Unstructured<'_>) -> Result<u16> {
     u.int_in_range(1..=256)
@@ -75,7 +75,7 @@ struct FuzzInput {
     #[arbitrary(with = bounded_page_cache_size)]
     page_cache_size: usize,
     #[arbitrary(with = bounded_items_per_blob)]
-    mmr_items_per_blob: u64,
+    merkle_items_per_blob: u64,
     #[arbitrary(with = bounded_items_per_blob)]
     log_items_per_blob: u64,
     #[arbitrary(with = bounded_write_buffer)]
@@ -92,16 +92,16 @@ fn make_config(
     suffix: &str,
     page_size: NonZeroU16,
     page_cache_size: NonZeroUsize,
-    mmr_items_per_blob: u64,
+    merkle_items_per_blob: u64,
     log_items_per_blob: u64,
     write_buffer: NonZeroUsize,
 ) -> VariableConfig<TwoCap, ((), ())> {
     let page_cache = CacheRef::from_pooler(ctx, page_size, page_cache_size);
     VariableConfig {
-        merkle_config: MmrConfig {
-            journal_partition: format!("crash-mmr-journal-{suffix}"),
-            metadata_partition: format!("crash-mmr-metadata-{suffix}"),
-            items_per_blob: NZU64!(mmr_items_per_blob),
+        merkle_config: MerkleConfig {
+            journal_partition: format!("crash-merkle-journal-{suffix}"),
+            metadata_partition: format!("crash-merkle-metadata-{suffix}"),
+            items_per_blob: NZU64!(merkle_items_per_blob),
             write_buffer,
             thread_pool: None,
             page_cache: page_cache.clone(),
@@ -114,7 +114,7 @@ fn make_config(
             codec_config: ((), ()),
             page_cache,
         },
-        grafted_metadata_partition: format!("crash-grafted-mmr-metadata-{suffix}"),
+        grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
     }
 }
@@ -147,8 +147,8 @@ fn apply_pending(
 }
 
 /// Commit pending writes. Returns `true` on success, `false` on error.
-async fn commit_pending(
-    db: &mut Db,
+async fn commit_pending<F: Graftable>(
+    db: &mut Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     pending: &mut HashMap<RawKey, Option<RawValue>>,
     committed: &mut HashMap<RawKey, RawValue>,
@@ -177,20 +177,20 @@ async fn commit_pending(
     true
 }
 
-fn fuzz(input: FuzzInput) {
+fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
     if input.operations.is_empty() {
         return;
     }
 
     let page_size = NonZeroU16::new(input.page_size).unwrap();
     let page_cache_size = NonZeroUsize::new(input.page_cache_size).unwrap();
-    let mmr_items_per_blob = input.mmr_items_per_blob;
+    let merkle_items_per_blob = input.merkle_items_per_blob;
     let log_items_per_blob = input.log_items_per_blob;
     let write_buffer = NonZeroUsize::new(input.write_buffer).unwrap();
     let sync_failure_rate = input.sync_failure_rate;
     let write_failure_rate = input.write_failure_rate;
-    let operations = input.operations;
-    let suffix = format!("current_{}", input.seed);
+    let operations = input.operations.clone();
+    let suffix = format!("{suffix_base}_{}", input.seed);
 
     let cfg = deterministic::Config::default().with_seed(input.seed);
     let runner = deterministic::Runner::new(cfg);
@@ -201,14 +201,14 @@ fn fuzz(input: FuzzInput) {
         let suffix = suffix.clone();
         let operations = operations.clone();
         async move {
-            let mut db = Db::init(
+            let mut db: Db<F> = Db::init(
                 ctx.with_label("db"),
                 make_config(
                     &ctx,
                     &suffix,
                     page_size,
                     page_cache_size,
-                    mmr_items_per_blob,
+                    merkle_items_per_blob,
                     log_items_per_blob,
                     write_buffer,
                 ),
@@ -283,14 +283,14 @@ fn fuzz(input: FuzzInput) {
         async move {
             *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
 
-            let mut db = Db::init(
+            let mut db: Db<F> = Db::init(
                 ctx.with_label("recovered"),
                 make_config(
                     &ctx,
                     &suffix,
                     page_size,
                     page_cache_size,
-                    mmr_items_per_blob,
+                    merkle_items_per_blob,
                     log_items_per_blob,
                     write_buffer,
                 ),
@@ -318,7 +318,7 @@ fn fuzz(input: FuzzInput) {
                     .await
                     .expect("proof generation should not fail for committed key");
                 assert!(
-                    Db::verify_key_value_proof(&mut hasher, k, v, &proof, &root),
+                    Db::<F>::verify_key_value_proof(&mut hasher, k, v, &proof, &root),
                     "key value proof failed to verify after crash recovery"
                 );
             }
@@ -327,13 +327,13 @@ fn fuzz(input: FuzzInput) {
             let floor = *db.sync_boundary();
             let size = *db.bounds().await.end;
             for i in floor..size {
-                let loc = Location::new(i);
+                let loc = Location::<F>::new(i);
                 let (proof, ops, chunks) = db
                     .range_proof(&mut hasher, loc, NZU64!(4))
                     .await
                     .expect("range proof should not fail after recovery");
                 assert!(
-                    Db::verify_range_proof(&mut hasher, &proof, loc, &ops, &chunks, &root),
+                    Db::<F>::verify_range_proof(&mut hasher, &proof, loc, &ops, &chunks, &root),
                     "range proof failed to verify after crash recovery at loc {loc}"
                 );
             }
@@ -362,5 +362,6 @@ fn fuzz(input: FuzzInput) {
 }
 
 fuzz_target!(|input: FuzzInput| {
-    fuzz(input);
+    fuzz_family::<mmr::Family>(&input, "current-crash-mmr");
+    fuzz_family::<mmb::Family>(&input, "current-crash-mmb");
 });

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
-    mmr::{self, journaled::Config as MmrConfig, Location},
+    merkle::{journaled::Config as MerkleConfig, mmb, mmr, Graftable, Location},
     qmdb::current::{ordered::fixed::Db as CurrentDb, FixedConfig as Config},
     translator::TwoCap,
 };
@@ -20,7 +20,7 @@ type Key = FixedBytes<32>;
 type Value = FixedBytes<32>;
 type RawKey = [u8; 32];
 type RawValue = [u8; 32];
-type Db = CurrentDb<mmr::Family, deterministic::Context, Key, Value, Sha256, TwoCap, 32>;
+type Db<F> = CurrentDb<F, deterministic::Context, Key, Value, Sha256, TwoCap, 32>;
 
 #[derive(Arbitrary, Debug, Clone)]
 enum CurrentOperation {
@@ -78,12 +78,12 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(91);
 const PAGE_CACHE_SIZE: usize = 8;
-const MMR_ITEMS_PER_BLOB: u64 = 11;
+const MERKLE_ITEMS_PER_BLOB: u64 = 11;
 const LOG_ITEMS_PER_BLOB: u64 = 7;
 const WRITE_BUFFER_SIZE: usize = 1024;
 
-async fn commit_pending(
-    db: &mut Db,
+async fn commit_pending<F: Graftable>(
+    db: &mut Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, RawValue>,
     pending_inserts: &mut HashMap<RawKey, RawValue>,
@@ -104,9 +104,11 @@ async fn commit_pending(
     committed_state.extend(pending_inserts.drain());
 }
 
-fn fuzz(data: FuzzInput) {
+fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
+    let suffix = suffix.to_string();
+    let operations = data.operations.clone();
     runner.start(|context| async move {
         let mut hasher = Sha256::new();
         let page_cache = CacheRef::from_pooler(
@@ -115,25 +117,25 @@ fn fuzz(data: FuzzInput) {
             NZUsize!(PAGE_CACHE_SIZE),
         );
         let cfg = Config {
-            merkle_config: MmrConfig {
-                journal_partition: "fuzz-current-mmr-journal".into(),
-                metadata_partition: "fuzz-current-mmr-metadata".into(),
-                items_per_blob: NZU64!(MMR_ITEMS_PER_BLOB),
+            merkle_config: MerkleConfig {
+                journal_partition: format!("fuzz-current-ord-{suffix}-merkle-journal"),
+                metadata_partition: format!("fuzz-current-ord-{suffix}-merkle-metadata"),
+                items_per_blob: NZU64!(MERKLE_ITEMS_PER_BLOB),
                 write_buffer: NZUsize!(WRITE_BUFFER_SIZE),
                 thread_pool: None,
                 page_cache: page_cache.clone(),
             },
             journal_config: FConfig {
-                partition: "fuzz-current-log-journal".into(),
+                partition: format!("fuzz-current-ord-{suffix}-log-journal"),
                 items_per_blob: NZU64!(LOG_ITEMS_PER_BLOB),
                 write_buffer: NZUsize!(WRITE_BUFFER_SIZE),
                 page_cache,
             },
-            grafted_metadata_partition: "fuzz-current-grafted-mmr-metadata".into(),
+            grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
         };
 
-        let mut db = Db::init(context.clone(), cfg)
+        let mut db: Db<F> = Db::init(context.clone(), cfg)
             .await
             .expect("Failed to initialize Current database");
 
@@ -144,9 +146,9 @@ fn fuzz(data: FuzzInput) {
         let mut pending_deletes: HashSet<RawKey> = HashSet::new();
         let mut all_keys = HashSet::new();
         let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
-        let mut committed_op_count = Location::new(1);
+        let mut committed_op_count = Location::<F>::new(1);
 
-        for op in &data.operations {
+        for op in &operations {
             match op {
                 CurrentOperation::Update { key, value } => {
                     let k = Key::new(*key);
@@ -241,7 +243,7 @@ fn fuzz(data: FuzzInput) {
                     let current_root = db.root();
 
                     let current_op_count = db.bounds().await.end;
-                    let start_loc = Location::new(start_loc % *current_op_count);
+                    let start_loc = Location::<F>::new(start_loc % *current_op_count);
 
                     let oldest_loc = db.sync_boundary();
                     if start_loc >= oldest_loc {
@@ -251,7 +253,7 @@ fn fuzz(data: FuzzInput) {
                             .expect("Range proof should not fail");
 
                         assert!(
-                            Db::verify_range_proof(
+                            Db::<F>::verify_range_proof(
                                 &mut hasher,
                                 &proof,
                                 start_loc,
@@ -276,7 +278,7 @@ fn fuzz(data: FuzzInput) {
                     committed_op_count = db.bounds().await.end;
 
                     let current_op_count = db.bounds().await.end;
-                    let start_loc = Location::new(start_loc % current_op_count.as_u64());
+                    let start_loc = Location::<F>::new(start_loc % current_op_count.as_u64());
                     let root = db.root();
 
                     if let Ok((range_proof, ops, chunks)) = db
@@ -287,7 +289,7 @@ fn fuzz(data: FuzzInput) {
                         if range_proof.proof.digests != bad_digests {
                             let mut bad_proof = range_proof.clone();
                             bad_proof.proof.digests = bad_digests;
-                            assert!(!Db::verify_range_proof(
+                            assert!(!Db::<F>::verify_range_proof(
                                 &mut hasher,
                                 &bad_proof,
                                 start_loc,
@@ -299,7 +301,7 @@ fn fuzz(data: FuzzInput) {
 
                         // Try to verify the proof when providing bad input chunks.
                         if &chunks != bad_chunks {
-                            assert!(!Db::verify_range_proof(
+                            assert!(!Db::<F>::verify_range_proof(
                                 &mut hasher,
                                 &range_proof,
                                 start_loc,
@@ -324,7 +326,7 @@ fn fuzz(data: FuzzInput) {
                     match db.key_value_proof(&mut hasher, k.clone()).await {
                         Ok(proof) => {
                             let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
-                            let verification_result = Db::verify_key_value_proof(
+                            let verification_result = Db::<F>::verify_key_value_proof(
                                 &mut hasher,
                                 k,
                                 value,
@@ -354,7 +356,7 @@ fn fuzz(data: FuzzInput) {
 
                     match db.exclusion_proof(&mut hasher, &k).await {
                         Ok(proof) => {
-                            let verification_result = Db::verify_exclusion_proof(
+                            let verification_result = Db::<F>::verify_exclusion_proof(
                                 &mut hasher,
                                 &k,
                                 &proof,
@@ -404,5 +406,6 @@ fn fuzz(data: FuzzInput) {
 }
 
 fuzz_target!(|input: FuzzInput| {
-    fuzz(input);
+    fuzz_family::<mmr::Family>(&input, "mmr");
+    fuzz_family::<mmb::Family>(&input, "mmb");
 });

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::Sha256;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Runner};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
-    mmr::{self, journaled::Config as MmrConfig},
+    merkle::{journaled::Config as MerkleConfig, mmb, mmr, Graftable},
     qmdb::current::{unordered::fixed::Db as CurrentDb, FixedConfig as Config},
     translator::OneCap,
 };
@@ -15,7 +15,7 @@ use std::num::NonZeroU16;
 
 type Key = FixedBytes<32>;
 type Value = FixedBytes<32>;
-type Db = CurrentDb<mmr::Family, deterministic::Context, Key, Value, Sha256, OneCap, 32>;
+type Db<F> = CurrentDb<F, deterministic::Context, Key, Value, Sha256, OneCap, 32>;
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(137);
 const COLLISION_GROUPS: u8 = 4;
@@ -76,8 +76,8 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap> {
     let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(2));
     Config {
-        merkle_config: MmrConfig {
-            journal_partition: format!("{name}-mmr"),
+        merkle_config: MerkleConfig {
+            journal_partition: format!("{name}-merkle"),
             metadata_partition: format!("{name}-meta"),
             items_per_blob: NZU64!(17),
             write_buffer: NZUsize!(1024),
@@ -107,12 +107,13 @@ fn value_from_bytes(bytes: [u8; 32]) -> Value {
     Value::new(bytes)
 }
 
-fn fuzz(input: FuzzInput) {
+fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
     let runner = deterministic::Runner::default();
 
+    let test_name = test_name.to_string();
     runner.start(|context| async move {
-        let cfg = test_config("fuzz-current-unordered-pending-vs-committed-root", &context);
-        let mut db = Db::init(context.clone(), cfg)
+        let cfg = test_config(&test_name, &context);
+        let mut db: Db<F> = Db::init(context.clone(), cfg)
             .await
             .expect("init current unordered db");
 
@@ -196,5 +197,6 @@ fn fuzz(input: FuzzInput) {
 }
 
 fuzz_target!(|input: FuzzInput| {
-    fuzz(input);
+    fuzz_family::<mmr::Family>(&input, "fuzz-mmr-current-unordered-batch-root");
+    fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-unordered-batch-root");
 });

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
-    mmr::{self, journaled::Config as MmrConfig, Location},
+    merkle::{journaled::Config as MerkleConfig, mmb, mmr, Graftable, Location},
     qmdb::current::{unordered::fixed::Db as CurrentDb, FixedConfig as Config},
     translator::TwoCap,
 };
@@ -20,7 +20,7 @@ type Key = FixedBytes<32>;
 type Value = FixedBytes<32>;
 type RawKey = [u8; 32];
 type RawValue = [u8; 32];
-type Db = CurrentDb<mmr::Family, deterministic::Context, Key, Value, Sha256, TwoCap, 32>;
+type Db<F> = CurrentDb<F, deterministic::Context, Key, Value, Sha256, TwoCap, 32>;
 
 #[derive(Arbitrary, Debug, Clone)]
 enum CurrentOperation {
@@ -72,12 +72,12 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(88);
 const PAGE_CACHE_SIZE: usize = 8;
-const MMR_ITEMS_PER_BLOB: u64 = 11;
+const MERKLE_ITEMS_PER_BLOB: u64 = 11;
 const LOG_ITEMS_PER_BLOB: u64 = 7;
 const WRITE_BUFFER_SIZE: usize = 1024;
 
-async fn commit_pending(
-    db: &mut Db,
+async fn commit_pending<F: Graftable>(
+    db: &mut Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, Option<RawValue>>,
     pending_expected: &mut HashMap<RawKey, Option<RawValue>>,
@@ -94,9 +94,11 @@ async fn commit_pending(
     committed_state.extend(pending_expected.drain());
 }
 
-fn fuzz(data: FuzzInput) {
+fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
+    let suffix = suffix.to_string();
+    let operations = data.operations.clone();
     runner.start(|context| async move {
         let mut hasher = Sha256::new();
         let page_cache = CacheRef::from_pooler(
@@ -105,25 +107,25 @@ fn fuzz(data: FuzzInput) {
             NZUsize!(PAGE_CACHE_SIZE),
         );
         let cfg = Config {
-            merkle_config: MmrConfig {
-                journal_partition: "fuzz-current-mmr-journal".into(),
-                metadata_partition: "fuzz-current-mmr-metadata".into(),
-                items_per_blob: NZU64!(MMR_ITEMS_PER_BLOB),
+            merkle_config: MerkleConfig {
+                journal_partition: format!("fuzz-current-{suffix}-merkle-journal"),
+                metadata_partition: format!("fuzz-current-{suffix}-merkle-metadata"),
+                items_per_blob: NZU64!(MERKLE_ITEMS_PER_BLOB),
                 write_buffer: NZUsize!(WRITE_BUFFER_SIZE),
                 thread_pool: None,
                 page_cache: page_cache.clone(),
             },
             journal_config: FConfig {
-                partition: "fuzz-current-log-journal".into(),
+                partition: format!("fuzz-current-{suffix}-log-journal"),
                 items_per_blob: NZU64!(LOG_ITEMS_PER_BLOB),
                 write_buffer: NZUsize!(WRITE_BUFFER_SIZE),
                 page_cache,
             },
-            grafted_metadata_partition: "fuzz-current-grafted-mmr-metadata".into(),
+            grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
         };
 
-        let mut db = Db::init(context.clone(), cfg)
+        let mut db: Db<F> = Db::init(context.clone(), cfg)
             .await
             .expect("Failed to initialize Current database");
 
@@ -133,9 +135,9 @@ fn fuzz(data: FuzzInput) {
         let mut pending_expected: HashMap<RawKey, Option<RawValue>> = HashMap::new();
         let mut all_keys = std::collections::HashSet::new();
         let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
-        let mut committed_op_count = Location::new(1);
+        let mut committed_op_count = Location::<F>::new(1);
 
-        for op in &data.operations {
+        for op in &operations {
             match op {
                 CurrentOperation::Update { key, value } => {
                     let k = Key::new(*key);
@@ -217,7 +219,7 @@ fn fuzz(data: FuzzInput) {
                     let current_root = db.root();
 
                     let current_op_count = db.bounds().await.end;
-                    let start_loc = Location::new(start_loc % *current_op_count);
+                    let start_loc = Location::<F>::new(start_loc % *current_op_count);
                     let oldest_loc = db.sync_boundary();
                     if start_loc >= oldest_loc {
                         let (proof, ops, chunks) = db
@@ -226,7 +228,7 @@ fn fuzz(data: FuzzInput) {
                             .expect("Range proof should not fail");
 
                         assert!(
-                            Db::verify_range_proof(
+                            Db::<F>::verify_range_proof(
                                 &mut hasher,
                                 &proof,
                                 start_loc,
@@ -248,7 +250,7 @@ fn fuzz(data: FuzzInput) {
                     committed_op_count = db.bounds().await.end;
 
                     let current_op_count = db.bounds().await.end;
-                    let start_loc = Location::new(start_loc % current_op_count.as_u64());
+                    let start_loc = Location::<F>::new(start_loc % current_op_count.as_u64());
                     let root = db.root();
 
                     if let Ok((range_proof, ops, chunks)) = db
@@ -259,7 +261,7 @@ fn fuzz(data: FuzzInput) {
                         if range_proof.proof.digests != bad_digests {
                             let mut bad_proof = range_proof.clone();
                             bad_proof.proof.digests = bad_digests;
-                            assert!(!Db::verify_range_proof(
+                            assert!(!Db::<F>::verify_range_proof(
                                 &mut hasher,
                                 &bad_proof,
                                 start_loc,
@@ -271,7 +273,7 @@ fn fuzz(data: FuzzInput) {
 
                         // Try to verify the proof when providing bad input chunks.
                         if &chunks != bad_chunks {
-                            assert!(!Db::verify_range_proof(
+                            assert!(!Db::<F>::verify_range_proof(
                                 &mut hasher,
                                 &range_proof,
                                 start_loc,
@@ -293,7 +295,7 @@ fn fuzz(data: FuzzInput) {
                     match db.key_value_proof(&mut hasher, k.clone()).await {
                         Ok(proof) => {
                             let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
-                            let verification_result = Db::verify_key_value_proof(
+                            let verification_result = Db::<F>::verify_key_value_proof(
                                 &mut hasher,
                                 k,
                                 value,
@@ -347,5 +349,6 @@ fn fuzz(data: FuzzInput) {
 }
 
 fuzz_target!(|input: FuzzInput| {
-    fuzz(input);
+    fuzz_family::<mmr::Family>(&input, "mmr");
+    fuzz_family::<mmb::Family>(&input, "mmb");
 });

--- a/storage/fuzz/fuzz_targets/proof_store.rs
+++ b/storage/fuzz/fuzz_targets/proof_store.rs
@@ -1,10 +1,11 @@
 #![no_main]
 
-use arbitrary::Arbitrary;
+use arbitrary::{Arbitrary, Unstructured};
 use commonware_codec::Encode as _;
 use commonware_cryptography::{sha256::Digest, Sha256};
-use commonware_storage::mmr::{
-    verification::ProofStore, Location, Position, Proof, StandardHasher as Standard,
+use commonware_storage::merkle::{
+    hasher::Standard, mmb, mmr, verification::ProofStore, Family as MerkleFamily, Location,
+    Position, Proof,
 };
 use libfuzzer_sys::fuzz_target;
 use std::ops::Range;
@@ -12,38 +13,40 @@ use std::ops::Range;
 const MAX_ITEMS: usize = 256;
 const MAX_PEAKS: usize = 64;
 
+// `proof_leaves` is typed `Location<F>` so `ProofStore::new` is reachable; the other
+// `u64` location/position fields stay raw to also exercise overflow rejection paths in
+// `range_proof`, `multi_proof`, and the `verify_*` entry points.
 #[derive(Debug)]
-struct FuzzInput {
-    proof: Proof<Digest>,
+struct FuzzInput<F: MerkleFamily> {
+    proof_leaves: Location<F>,
+    proof_digests: Vec<[u8; 32]>,
     elements: Vec<Vec<u8>>,
-    start_loc: Location,
-    root: Digest,
-    range: Range<Location>,
-    locations: Vec<Location>,
+    start_loc: u64,
+    root: [u8; 32],
+    range: Range<u64>,
+    locations: Vec<u64>,
     peaks: Vec<(u64, [u8; 32])>,
 }
 
-impl<'a> Arbitrary<'a> for FuzzInput {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+impl<'a, F: MerkleFamily> Arbitrary<'a> for FuzzInput<F> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let num_digests = u.int_in_range(0..=MAX_ITEMS)?;
         let num_elements = u.int_in_range(0..=MAX_ITEMS)?;
         let num_locations = u.int_in_range(0..=MAX_ITEMS)?;
         let num_peaks = u.int_in_range(0..=MAX_PEAKS)?;
         Ok(FuzzInput {
-            proof: Proof {
-                leaves: Location::from(u.arbitrary::<u64>()?),
-                digests: (0..num_digests)
-                    .map(|_| Ok(Digest::from(u.arbitrary::<[u8; 32]>()?)))
-                    .collect::<arbitrary::Result<Vec<_>>>()?,
-            },
+            proof_leaves: u.arbitrary()?,
+            proof_digests: (0..num_digests)
+                .map(|_| u.arbitrary::<[u8; 32]>())
+                .collect::<arbitrary::Result<Vec<_>>>()?,
             elements: (0..num_elements)
                 .map(|_| u.arbitrary::<Vec<u8>>())
                 .collect::<arbitrary::Result<Vec<_>>>()?,
-            start_loc: Location::from(u.arbitrary::<u64>()?),
-            root: Digest::from(u.arbitrary::<[u8; 32]>()?),
-            range: Location::from(u.arbitrary::<u64>()?)..Location::from(u.arbitrary::<u64>()?),
+            start_loc: u.arbitrary::<u64>()?,
+            root: u.arbitrary::<[u8; 32]>()?,
+            range: u.arbitrary::<u64>()?..u.arbitrary::<u64>()?,
             locations: (0..num_locations)
-                .map(|_| Ok(Location::from(u.arbitrary::<u64>()?)))
+                .map(|_| u.arbitrary::<u64>())
                 .collect::<arbitrary::Result<Vec<_>>>()?,
             peaks: (0..num_peaks)
                 .map(|_| Ok((u.arbitrary::<u64>()?, u.arbitrary::<[u8; 32]>()?)))
@@ -52,56 +55,72 @@ impl<'a> Arbitrary<'a> for FuzzInput {
     }
 }
 
-fn fuzz(input: FuzzInput) {
-    let hasher: Standard<Sha256> = Standard::new();
-    let Ok(proof_store) = ProofStore::new(
-        &hasher,
-        &input.proof,
-        &input.elements,
-        input.start_loc,
-        &input.root,
-    ) else {
+fn fuzz_family<F: MerkleFamily>(input: &FuzzInput<F>) {
+    let hasher = Standard::<Sha256>::new();
+    let proof = Proof::<F, Digest> {
+        leaves: input.proof_leaves,
+        digests: input
+            .proof_digests
+            .iter()
+            .copied()
+            .map(Digest::from)
+            .collect(),
+    };
+    let start_loc = Location::<F>::new(input.start_loc);
+    let root = Digest::from(input.root);
+    let range = Location::<F>::new(input.range.start)..Location::<F>::new(input.range.end);
+
+    let Ok(proof_store) = ProofStore::new(&hasher, &proof, &input.elements, start_loc, &root)
+    else {
         return;
     };
 
-    if let Ok(proof) = proof_store.range_proof(&hasher, input.range) {
-        let _ =
-            proof.verify_range_inclusion(&hasher, &input.elements, input.start_loc, &input.root);
-
+    if let Ok(proof) = proof_store.range_proof(&hasher, range) {
+        let _ = proof.verify_range_inclusion(&hasher, &input.elements, start_loc, &root);
         let _ = proof.verify_range_inclusion_and_extract_digests(
             &hasher,
             &input.elements,
-            input.start_loc,
-            &input.root,
+            start_loc,
+            &root,
         );
     }
 
-    let peaks: Vec<(Position, Digest)> = input
+    let peaks: Vec<(Position<F>, Digest)> = input
         .peaks
         .iter()
-        .map(|(pos, bytes)| (Position::from(*pos), Digest::from(*bytes)))
+        .map(|(pos, bytes)| (Position::<F>::new(*pos), Digest::from(*bytes)))
+        .collect();
+    let locations: Vec<Location<F>> = input
+        .locations
+        .iter()
+        .copied()
+        .map(Location::<F>::new)
         .collect();
 
-    if let Ok(proof) = proof_store.multi_proof(input.locations.as_slice(), &peaks) {
+    if let Ok(proof) = proof_store.multi_proof(&locations, &peaks) {
         let _ = proof.verify_multi_inclusion(
             &hasher,
-            &input
-                .locations
+            &locations
                 .iter()
                 .map(|loc| (loc.encode(), *loc))
                 .collect::<Vec<_>>(),
-            &input.root,
+            &root,
         );
 
         let _ = proof.verify_range_inclusion_and_extract_digests(
             &hasher,
             &input.elements,
-            input.start_loc,
-            &input.root,
+            start_loc,
+            &root,
         );
     }
 }
 
-fuzz_target!(|input: FuzzInput| {
-    fuzz(input);
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = FuzzInput::<mmr::Family>::arbitrary(&mut Unstructured::new(data)) {
+        fuzz_family::<mmr::Family>(&input);
+    }
+    if let Ok(input) = FuzzInput::<mmb::Family>::arbitrary(&mut Unstructured::new(data)) {
+        fuzz_family::<mmb::Family>(&input);
+    }
 });

--- a/storage/fuzz/fuzz_targets/proofs_malleability.rs
+++ b/storage/fuzz/fuzz_targets/proofs_malleability.rs
@@ -5,7 +5,7 @@ use commonware_codec::{Decode, Encode};
 use commonware_cryptography::{sha256::Digest, Hasher as _, Sha256};
 use commonware_storage::{
     bmt::Builder as BmtBuilder,
-    mmr::{mem::Mmr, Location, StandardHasher as Standard},
+    merkle::{hasher::Standard, mem::Mem, mmb, mmr, Family as MerkleFamily, Location},
 };
 use libfuzzer_sys::fuzz_target;
 use std::collections::HashSet;
@@ -23,8 +23,8 @@ enum Mutation {
 
 #[derive(Arbitrary, Debug)]
 enum ProofType {
-    Mmr,
-    MmrMulti,
+    Merkle,
+    MerkleMulti,
     Bmt,
     BmtMulti,
 }
@@ -118,88 +118,90 @@ where
     }
 }
 
-fn fuzz(input: FuzzInput) {
-    let digests: Vec<Digest> = input.elements.iter().map(|&v| Sha256::hash(&[v])).collect();
+fn fuzz_element_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
+    let hasher = Standard::<Sha256>::new();
+    let mut merkle = Mem::<F, Digest>::new(&hasher);
+    let batch = {
+        let mut batch = merkle.new_batch();
+        for digest in digests {
+            batch = batch.add(&hasher, digest);
+        }
+        batch.merkleize(&merkle, &hasher)
+    };
+    merkle.apply_batch(&batch).unwrap();
+    let root = merkle.root();
 
-    match input.proof {
-        ProofType::Mmr => {
-            let hasher = Standard::<Sha256>::new();
-            let mut mmr = Mmr::new(&hasher);
-            let batch = {
-                let mut batch = mmr.new_batch();
-                for digest in &digests {
-                    batch = batch.add(&hasher, digest);
-                }
-                batch.merkleize(&mmr, &hasher)
-            };
-            mmr.apply_batch(&batch).unwrap();
-            let root = mmr.root();
+    for (leaf, element) in digests.iter().enumerate() {
+        let loc = Location::<F>::new(leaf as u64);
+        let original_proof = merkle.proof(&hasher, loc).unwrap();
+        assert!(original_proof.verify_element_inclusion(&hasher, element, loc, root));
 
-            for (leaf, element) in digests.iter().enumerate() {
-                let loc = Location::new(leaf as u64);
-                let original_proof = mmr.proof(&hasher, loc).unwrap();
-                assert!(original_proof.verify_element_inclusion(&hasher, element, loc, root));
-
-                for mutation in &input.mutations {
-                    let mut mutated_proof = original_proof.clone();
-                    mutate_proof_bytes(&mut mutated_proof, mutation, &256);
-                    if mutated_proof != original_proof {
-                        assert!(
-                            !mutated_proof.verify_element_inclusion(&hasher, element, loc, root)
-                        );
-                    }
-                }
+        for mutation in &input.mutations {
+            let mut mutated_proof = original_proof.clone();
+            mutate_proof_bytes(&mut mutated_proof, mutation, &256);
+            if mutated_proof != original_proof {
+                assert!(!mutated_proof.verify_element_inclusion(&hasher, element, loc, root));
             }
         }
-        ProofType::MmrMulti => {
-            let hasher = Standard::<Sha256>::new();
-            let mut mmr = Mmr::new(&hasher);
-            let batch = {
-                let mut batch = mmr.new_batch();
-                for digest in &digests {
-                    batch = batch.add(&hasher, digest);
-                }
-                batch.merkleize(&mmr, &hasher)
-            };
-            mmr.apply_batch(&batch).unwrap();
-            let root = mmr.root();
+    }
+}
 
-            let (start_idx, range_len) = if digests.is_empty() || input.positions.is_empty() {
-                (0, 0)
-            } else if input.positions.len() == 1 {
-                let i = (input.positions[0] as usize) % digests.len();
-                (i, 1)
-            } else {
-                let i1 = (input.positions[0] as usize) % digests.len();
-                let i2 = (input.positions[1] as usize) % digests.len();
-                (i1.min(i2), i1.abs_diff(i2) + 1)
-            };
-            let start_loc = Location::new(start_idx as u64);
-            let Ok(original_proof) =
-                mmr.range_proof(&hasher, start_loc..start_loc + range_len as u64)
-            else {
-                return;
-            };
-            let range_elements: Vec<Digest> = digests[start_idx..start_idx + range_len].to_vec();
-            assert!(original_proof.verify_range_inclusion(
+fn fuzz_range_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
+    let hasher = Standard::<Sha256>::new();
+    let mut merkle = Mem::<F, Digest>::new(&hasher);
+    let batch = {
+        let mut batch = merkle.new_batch();
+        for digest in digests {
+            batch = batch.add(&hasher, digest);
+        }
+        batch.merkleize(&merkle, &hasher)
+    };
+    merkle.apply_batch(&batch).unwrap();
+    let root = merkle.root();
+
+    let (start_idx, range_len) = if digests.is_empty() || input.positions.is_empty() {
+        (0, 0)
+    } else if input.positions.len() == 1 {
+        let i = (input.positions[0] as usize) % digests.len();
+        (i, 1)
+    } else {
+        let i1 = (input.positions[0] as usize) % digests.len();
+        let i2 = (input.positions[1] as usize) % digests.len();
+        (i1.min(i2), i1.abs_diff(i2) + 1)
+    };
+    let start_loc = Location::<F>::new(start_idx as u64);
+    let Ok(original_proof) = merkle.range_proof(&hasher, start_loc..start_loc + range_len as u64)
+    else {
+        return;
+    };
+    let range_elements: Vec<Digest> = digests[start_idx..start_idx + range_len].to_vec();
+    assert!(original_proof.verify_range_inclusion(&hasher, &range_elements, start_loc, root));
+
+    for mutation in &input.mutations {
+        let mut mutated_proof = original_proof.clone();
+        mutate_proof_bytes(&mut mutated_proof, mutation, &256);
+        if mutated_proof != original_proof {
+            assert!(!mutated_proof.verify_range_inclusion(
                 &hasher,
                 &range_elements,
                 start_loc,
                 root
             ));
+        }
+    }
+}
 
-            for mutation in &input.mutations {
-                let mut mutated_proof = original_proof.clone();
-                mutate_proof_bytes(&mut mutated_proof, mutation, &256);
-                if mutated_proof != original_proof {
-                    assert!(!mutated_proof.verify_range_inclusion(
-                        &hasher,
-                        &range_elements,
-                        start_loc,
-                        root
-                    ));
-                }
-            }
+fn fuzz(input: FuzzInput) {
+    let digests: Vec<Digest> = input.elements.iter().map(|&v| Sha256::hash(&[v])).collect();
+
+    match input.proof {
+        ProofType::Merkle => {
+            fuzz_element_proof::<mmr::Family>(&input, &digests);
+            fuzz_element_proof::<mmb::Family>(&input, &digests);
+        }
+        ProofType::MerkleMulti => {
+            fuzz_range_proof::<mmr::Family>(&input, &digests);
+            fuzz_range_proof::<mmb::Family>(&input, &digests);
         }
         ProofType::Bmt => {
             let mut builder = BmtBuilder::<Sha256>::new(digests.len());

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -5,8 +5,7 @@ use commonware_cryptography::Sha256;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
-    merkle::mmr::Family,
-    mmr::journaled::Config as MmrConfig,
+    merkle::{journaled::Config as MerkleConfig, mmb, mmr, Family as MerkleFamily},
     qmdb::{
         any::{
             unordered::fixed::{Db, Operation as FixedOperation},
@@ -22,7 +21,7 @@ use std::{num::NonZeroU16, sync::Arc};
 
 type Key = FixedBytes<32>;
 type Value = FixedBytes<32>;
-type FixedDb = Db<Family, deterministic::Context, Key, Value, Sha256, TwoCap>;
+type FixedDb<F> = Db<F, deterministic::Context, Key, Value, Sha256, TwoCap>;
 
 const MAX_OPERATIONS: usize = 50;
 
@@ -94,8 +93,8 @@ const PAGE_SIZE: NonZeroU16 = NZU16!(129);
 fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap> {
     let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(1));
     Config {
-        merkle_config: MmrConfig {
-            journal_partition: format!("{test_name}-mmr"),
+        merkle_config: MerkleConfig {
+            journal_partition: format!("{test_name}-merkle"),
             metadata_partition: format!("{test_name}-meta"),
             items_per_blob: NZU64!(3),
             write_buffer: NZUsize!(1024),
@@ -112,24 +111,26 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap> {
     }
 }
 
-async fn test_sync<
-    R: sync::resolver::Resolver<
-        Family = Family,
-        Digest = commonware_cryptography::sha256::Digest,
-        Op = FixedOperation<Family, Key, Value>,
-    >,
->(
+async fn test_sync<F, R>(
     context: deterministic::Context,
     resolver: R,
-    target: sync::Target<Family, commonware_cryptography::sha256::Digest>,
+    target: sync::Target<F, commonware_cryptography::sha256::Digest>,
     fetch_batch_size: u64,
     test_name: &str,
     sync_id: usize,
-) -> bool {
+) -> bool
+where
+    F: MerkleFamily,
+    R: sync::resolver::Resolver<
+        Family = F,
+        Digest = commonware_cryptography::sha256::Digest,
+        Op = FixedOperation<F, Key, Value>,
+    >,
+{
     let db_config = test_config(test_name, &context);
     let expected_root = target.root;
 
-    let sync_config: sync::engine::Config<FixedDb, R> = sync::engine::Config {
+    let sync_config: sync::engine::Config<FixedDb<F>, R> = sync::engine::Config {
         context: context.with_label("sync").with_attribute("id", sync_id),
         update_rx: None,
         finish_rx: None,
@@ -156,14 +157,14 @@ async fn test_sync<
     }
 }
 
-const TEST_NAME: &str = "qmdb-any-fixed-fuzz-test";
-
-fn fuzz(mut input: FuzzInput) {
+fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
+    input.commit_counter = 0;
     let runner = deterministic::Runner::default();
 
+    let test_name = test_name.to_string();
     runner.start(|context| async move {
-        let cfg = test_config(TEST_NAME, &context);
-        let mut db = FixedDb::init(context.clone(), cfg)
+        let cfg = test_config(&test_name, &context);
+        let mut db: FixedDb<F> = Db::init(context.clone(), cfg)
             .await
             .expect("Failed to init source db");
         let mut restarts = 0usize;
@@ -245,7 +246,7 @@ fn fuzz(mut input: FuzzInput) {
                         wrapped_src.clone(),
                         target,
                         *fetch_batch_size,
-                        &format!("full_{sync_id}"),
+                        &format!("{test_name}-full_{sync_id}"),
                         sync_id,
                     )
                     .await;
@@ -259,8 +260,8 @@ fn fuzz(mut input: FuzzInput) {
                     pending_writes.clear();
                     drop(db);
 
-                    let cfg = test_config(TEST_NAME, &context);
-                    db = FixedDb::init(
+                    let cfg = test_config(&test_name, &context);
+                    db = Db::init(
                         context
                             .with_label("db")
                             .with_attribute("instance", restarts),
@@ -283,6 +284,11 @@ fn fuzz(mut input: FuzzInput) {
             .expect("commit should not fail");
         db.destroy().await.expect("Destroy should not fail");
     });
+}
+
+fn fuzz(mut input: FuzzInput) {
+    fuzz_family::<mmr::Family>(&mut input, "qmdb-any-fixed-fuzz-mmr");
+    fuzz_family::<mmb::Family>(&mut input, "qmdb-any-fixed-fuzz-mmb");
 }
 
 fuzz_target!(|input: FuzzInput| {

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -5,8 +5,10 @@ use commonware_cryptography::Sha256;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner};
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::Family as _,
-    mmr::{self, journaled::Config as MmrConfig, Family, StandardHasher as Standard},
+    merkle::{
+        hasher::Standard, journaled::Config as MerkleConfig, mmb, mmr, Family as MerkleFamily,
+        Location,
+    },
     qmdb::{
         any::{unordered::variable::Db, VariableConfig as Config},
         verify_proof,
@@ -15,7 +17,6 @@ use commonware_storage::{
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
 use libfuzzer_sys::fuzz_target;
-use mmr::Location;
 use std::{
     collections::BTreeMap,
     num::{NonZeroU16, NonZeroU64},
@@ -43,12 +44,12 @@ enum Operation {
     },
     GetMetadata,
     Proof {
-        start_loc: Location,
+        start_loc: u64,
         max_ops: NonZeroU64,
     },
     HistoricalProof {
         size: u64,
-        start_loc: Location,
+        start_loc: u64,
         max_ops: NonZeroU64,
     },
     Sync,
@@ -91,16 +92,14 @@ impl<'a> Arbitrary<'a> for Operation {
             }
             5 => Ok(Operation::GetMetadata),
             6 => {
-                let start_loc = u.arbitrary::<u64>()? % (*Family::MAX_LEAVES + 1);
-                let start_loc = Location::new(start_loc);
+                let start_loc = u.arbitrary::<u64>()?;
                 let max_ops = u.int_in_range(1..=u32::MAX)? as u64;
                 let max_ops = NZU64!(max_ops);
                 Ok(Operation::Proof { start_loc, max_ops })
             }
             7 => {
                 let size = u.arbitrary()?;
-                let start_loc = u.arbitrary::<u64>()? % (*Family::MAX_LEAVES + 1);
-                let start_loc = Location::new(start_loc);
+                let start_loc = u.arbitrary::<u64>()?;
                 let max_ops = u.int_in_range(1..=u32::MAX)? as u64;
                 let max_ops = NZU64!(max_ops);
                 Ok(Operation::HistoricalProof {
@@ -142,8 +141,8 @@ fn test_config(
 ) -> Config<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ()))> {
     let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(1));
     Config {
-        merkle_config: MmrConfig {
-            journal_partition: format!("{test_name}-mmr"),
+        merkle_config: MerkleConfig {
+            journal_partition: format!("{test_name}-merkle"),
             metadata_partition: format!("{test_name}-meta"),
             items_per_blob: NZU64!(3),
             write_buffer: NZUsize!(1024),
@@ -162,19 +161,20 @@ fn test_config(
     }
 }
 
-fn fuzz(input: FuzzInput) {
+fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
     let runner = deterministic::Runner::default();
 
+    let test_name = test_name.to_string();
     runner.start(|context| async move {
         let hasher = Standard::<Sha256>::new();
-        let cfg = test_config("qmdb-any-variable-fuzz-test", &context);
-        let mut db = Db::<Family, _, Key, Vec<u8>, Sha256, TwoCap>::init(context.clone(), cfg)
+        let cfg = test_config(&test_name, &context);
+        let mut db = Db::<F, _, Key, Vec<u8>, Sha256, TwoCap>::init(context.clone(), cfg)
             .await
             .expect("Failed to init source db");
         let mut restarts = 0usize;
 
         let mut historical_roots: BTreeMap<
-            Location,
+            Location<F>,
             <Sha256 as commonware_cryptography::Hasher>::Digest,
         > = BTreeMap::new();
 
@@ -229,12 +229,13 @@ fn fuzz(input: FuzzInput) {
                         .expect("commit should not fail");
                     db.commit().await.expect("Commit should not fail");
                     historical_roots.insert(db.bounds().await.end, db.root());
+                    let start_loc = Location::<F>::new(*start_loc % (*F::MAX_LEAVES + 1));
                     let op_count = db.bounds().await.end;
                     let oldest_retained_loc = db.sync_boundary();
-                    if *start_loc >= oldest_retained_loc && *start_loc < *op_count {
-                        if let Ok((proof, log)) = db.proof(*start_loc, *max_ops).await {
+                    if start_loc >= oldest_retained_loc && start_loc < op_count {
+                        if let Ok((proof, log)) = db.proof(start_loc, *max_ops).await {
                             let root = db.root();
-                            assert!(verify_proof(&hasher, &proof, *start_loc, &log, &root));
+                            assert!(verify_proof(&hasher, &proof, start_loc, &log, &root));
                         }
                     }
                 }
@@ -262,18 +263,19 @@ fn fuzz(input: FuzzInput) {
                             .nth(idx)
                             .expect("historical roots should contain at least one key")
                     };
+                    let start_loc = Location::<F>::new(*start_loc % (*F::MAX_LEAVES + 1));
 
-                    if *start_loc >= op_count || op_count > max_ops.get() {
+                    if start_loc >= op_count || op_count > max_ops.get() {
                         continue;
                     }
 
                     if let Ok((proof, log)) =
-                        db.historical_proof(op_count, *start_loc, *max_ops).await
+                        db.historical_proof(op_count, start_loc, *max_ops).await
                     {
                         let root = historical_roots
                             .get(&op_count)
                             .expect("historical root missing for known commit point");
-                        assert!(verify_proof(&hasher, &proof, *start_loc, &log, root));
+                        assert!(verify_proof(&hasher, &proof, start_loc, &log, root));
                     }
                 }
 
@@ -319,8 +321,8 @@ fn fuzz(input: FuzzInput) {
                     historical_roots.clear();
                     drop(db);
 
-                    let cfg = test_config("qmdb-any-variable-fuzz-test", &context);
-                    db = Db::<Family, _, Key, Vec<u8>, Sha256, TwoCap>::init(
+                    let cfg = test_config(&test_name, &context);
+                    db = Db::<F, _, Key, Vec<u8>, Sha256, TwoCap>::init(
                         context
                             .with_label("db")
                             .with_attribute("instance", restarts),
@@ -343,6 +345,11 @@ fn fuzz(input: FuzzInput) {
             .expect("commit should not fail");
         db.destroy().await.expect("Destroy should not fail");
     });
+}
+
+fn fuzz(input: FuzzInput) {
+    fuzz_family::<mmr::Family>(&input, "qmdb-any-variable-fuzz-mmr");
+    fuzz_family::<mmb::Family>(&input, "qmdb-any-variable-fuzz-mmb");
 }
 
 fuzz_target!(|input: FuzzInput| {

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -5,8 +5,7 @@ use commonware_cryptography::Sha256;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Runner};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
-    merkle::mmr::Family,
-    mmr::journaled::Config as MmrConfig,
+    merkle::{journaled::Config as MerkleConfig, mmb, mmr, Family as MerkleFamily},
     qmdb::any::{unordered::fixed::Db as AnyDb, FixedConfig as Config},
     translator::OneCap,
 };
@@ -16,7 +15,7 @@ use std::num::NonZeroU16;
 
 type Key = FixedBytes<32>;
 type Value = FixedBytes<32>;
-type Db = AnyDb<Family, deterministic::Context, Key, Value, Sha256, OneCap>;
+type Db<F> = AnyDb<F, deterministic::Context, Key, Value, Sha256, OneCap>;
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(131);
 const COLLISION_GROUPS: u8 = 4;
@@ -77,8 +76,8 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap> {
     let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(2));
     Config {
-        merkle_config: MmrConfig {
-            journal_partition: format!("{name}-mmr"),
+        merkle_config: MerkleConfig {
+            journal_partition: format!("{name}-merkle"),
             metadata_partition: format!("{name}-meta"),
             items_per_blob: NZU64!(17),
             write_buffer: NZUsize!(1024),
@@ -107,12 +106,12 @@ fn value_from_bytes(bytes: [u8; 32]) -> Value {
     Value::new(bytes)
 }
 
-fn fuzz(input: FuzzInput) {
+fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     runner.start(|context| async move {
-        let cfg = test_config("fuzz-qmdb-unordered-pending-vs-committed-root", &context);
-        let mut db = Db::init(context.clone(), cfg)
+        let cfg = test_config(suffix, &context);
+        let mut db: Db<F> = Db::init(context.clone(), cfg)
             .await
             .expect("init unordered any db");
 
@@ -188,5 +187,6 @@ fn fuzz(input: FuzzInput) {
 }
 
 fuzz_target!(|input: FuzzInput| {
-    fuzz(input);
+    fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-unordered-batch-root");
+    fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-batch-root");
 });

--- a/storage/fuzz/fuzz_targets/range_proof.rs
+++ b/storage/fuzz/fuzz_targets/range_proof.rs
@@ -1,41 +1,40 @@
 #![no_main]
 
 use arbitrary::{Arbitrary, Unstructured};
-use commonware_cryptography::Sha256;
-use commonware_storage::mmr::{
-    mem::{Config, Mmr},
-    Location, StandardHasher,
+use commonware_cryptography::{sha256::Digest, Sha256};
+use commonware_storage::merkle::{
+    hasher::Standard,
+    mem::{Config, Mem},
+    mmb, mmr, Family as MerkleFamily, Location,
 };
 use libfuzzer_sys::fuzz_target;
 
 #[derive(Arbitrary, Debug)]
 struct FuzzInput {
+    // Raw `u64` so we also exercise `Mem::init`'s overflow / near-overflow rejection paths
+    // for each family (`Location<F>: Arbitrary` would silently clamp to `F::MAX_LEAVES`).
     pruned_to: u64,
     nodes: Vec<[u8; 32]>,
     pinned_nodes: Vec<[u8; 32]>,
 }
 
-fn fuzz(input: FuzzInput) {
-    let nodes: Vec<_> = input
-        .nodes
-        .into_iter()
-        .map(<Sha256 as commonware_cryptography::Hasher>::Digest::from)
-        .collect();
-
-    let pinned_nodes: Vec<_> = input
+fn fuzz_family<F: MerkleFamily>(input: &FuzzInput) {
+    let nodes: Vec<Digest> = input.nodes.iter().copied().map(Digest::from).collect();
+    let pinned_nodes: Vec<Digest> = input
         .pinned_nodes
-        .into_iter()
-        .map(<Sha256 as commonware_cryptography::Hasher>::Digest::from)
+        .iter()
+        .copied()
+        .map(Digest::from)
         .collect();
 
-    let config = Config {
+    let config = Config::<F, Digest> {
         nodes,
-        pruning_boundary: Location::new(input.pruned_to),
+        pruning_boundary: Location::<F>::new(input.pruned_to),
         pinned_nodes,
     };
 
-    let hasher = StandardHasher::<Sha256>::new();
-    let Ok(mmr) = Mmr::init(config, &hasher) else {
+    let hasher = Standard::<Sha256>::new();
+    let Ok(merkle) = Mem::<F, Digest>::init(config, &hasher) else {
         return;
     };
 
@@ -43,10 +42,15 @@ fn fuzz(input: FuzzInput) {
         return;
     }
 
-    let leaves = mmr.leaves();
+    let leaves = merkle.leaves();
     if leaves > 0 {
-        let _ = mmr.range_proof(&hasher, Location::new(0)..leaves);
+        let _ = merkle.range_proof(&hasher, Location::<F>::new(0)..leaves);
     }
+}
+
+fn fuzz(input: FuzzInput) {
+    fuzz_family::<mmr::Family>(&input);
+    fuzz_family::<mmb::Family>(&input);
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/storage/fuzz/fuzz_targets/verify_proof.rs
+++ b/storage/fuzz/fuzz_targets/verify_proof.rs
@@ -3,7 +3,7 @@
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_storage::{
-    mmr::{Location, Proof, StandardHasher as Standard},
+    merkle::{hasher::Standard, mmb, mmr, Family as MerkleFamily, Location, Proof},
     qmdb::verify::verify_multi_proof,
 };
 use libfuzzer_sys::fuzz_target;
@@ -14,41 +14,55 @@ const MAX_OPERATION_BYTES: usize = 512;
 
 #[derive(Arbitrary, Debug)]
 struct OperationInput {
+    // Raw `u64` so we also exercise the per-op `is_valid()` rejection path.
     location: u64,
     payload: Vec<u8>,
 }
 
-#[derive(Arbitrary, Debug)]
-struct FuzzInput {
-    proof_leaves: Location,
+// `proof_leaves` is typed `Location<F>` so that `Arbitrary` bounds it to `F::MAX_LEAVES`;
+// otherwise `verify_multi_proof` would reject on overflow before exercising its inner logic.
+#[derive(Debug)]
+struct FuzzInput<F: MerkleFamily> {
+    proof_leaves: Location<F>,
     digests: Vec<[u8; 32]>,
     operations: Vec<OperationInput>,
     root: [u8; 32],
 }
 
-fn fuzz(input: FuzzInput) {
-    let hasher: Standard<Sha256> = Standard::new();
+impl<'a, F: MerkleFamily> Arbitrary<'a> for FuzzInput<F> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            proof_leaves: u.arbitrary()?,
+            digests: u.arbitrary()?,
+            operations: u.arbitrary()?,
+            root: u.arbitrary()?,
+        })
+    }
+}
 
-    let digests = input
+fn fuzz_family<F: MerkleFamily>(input: &FuzzInput<F>) {
+    let hasher = Standard::<Sha256>::new();
+
+    let digests: Vec<Digest> = input
         .digests
-        .into_iter()
+        .iter()
+        .copied()
         .take(MAX_DIGESTS)
         .map(Digest::from)
-        .collect::<Vec<_>>();
+        .collect();
 
-    let proof = Proof {
+    let proof = Proof::<F, Digest> {
         leaves: input.proof_leaves,
         digests,
     };
 
-    let mut operations = Vec::new();
-    for entry in input.operations.into_iter().take(MAX_OPERATIONS) {
-        let mut payload = entry.payload;
+    let mut operations: Vec<(Location<F>, Vec<u8>)> = Vec::new();
+    for entry in input.operations.iter().take(MAX_OPERATIONS) {
+        let mut payload = entry.payload.clone();
         if payload.len() > MAX_OPERATION_BYTES {
             payload.truncate(MAX_OPERATION_BYTES);
         }
-        // Only add operations with valid locations
-        let location = Location::new(entry.location);
+        let location = Location::<F>::new(entry.location);
         if location.is_valid() {
             operations.push((location, payload));
         }
@@ -59,9 +73,10 @@ fn fuzz(input: FuzzInput) {
 }
 
 fuzz_target!(|data: &[u8]| {
-    let mut unstructured = Unstructured::new(data);
-    let Ok(input) = FuzzInput::arbitrary(&mut unstructured) else {
-        return;
-    };
-    fuzz(input);
+    if let Ok(input) = FuzzInput::<mmr::Family>::arbitrary(&mut Unstructured::new(data)) {
+        fuzz_family::<mmr::Family>(&input);
+    }
+    if let Ok(input) = FuzzInput::<mmb::Family>::arbitrary(&mut Unstructured::new(data)) {
+        fuzz_family::<mmb::Family>(&input);
+    }
 });


### PR DESCRIPTION
Changes MMR-only fuzz tests to exercise both MMR and MMB where appropriate.