### PR TITLE
[storage] Generalize benchmarks on Merkle family

### DIFF
--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -282,7 +282,7 @@ crate::qmdb::any::traits::impl_provable! {
 mod test {
     use super::*;
     use crate::{
-        merkle::mmr,
+        merkle::Family,
         qmdb::any::traits::{DbAny, UnmerkleizedBatch as _},
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
@@ -291,7 +291,8 @@ mod test {
     use core::{future::Future, pin::Pin};
 
     pub(crate) async fn test_ordered_any_db_empty<
-        D: DbAny<mmr::Family, Key = FixedBytes<4>, Value = Digest, Digest = Digest>,
+        F: Family,
+        D: DbAny<F, Key = FixedBytes<4>, Value = Digest, Digest = Digest>,
     >(
         context: Context,
         mut db: D,
@@ -341,7 +342,8 @@ mod test {
     }
 
     pub(crate) async fn test_ordered_any_db_basic<
-        D: DbAny<mmr::Family, Key = FixedBytes<4>, Value = Digest, Digest = Digest>,
+        F: Family,
+        D: DbAny<F, Key = FixedBytes<4>, Value = Digest, Digest = Digest>,
     >(
         context: Context,
         mut db: D,
@@ -543,7 +545,8 @@ mod test {
     /// Builds a db with colliding keys to make sure the "cycle around when there are translated
     /// key collisions" edge case is exercised.
     pub(crate) async fn test_ordered_any_update_collision_edge_case<
-        D: DbAny<mmr::Family, Key = FixedBytes<4>, Value = Digest, Digest = Digest>,
+        F: Family,
+        D: DbAny<F, Key = FixedBytes<4>, Value = Digest, Digest = Digest>,
     >(
         mut db: D,
     ) {

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -246,66 +246,36 @@ pub(crate) fn find_prev_key<'a, K: Ord, V>(
 
 #[cfg(any(test, feature = "test-traits"))]
 crate::qmdb::any::traits::impl_db_any! {
-    [E, K, V, C, I, H] Db<crate::merkle::mmr::Family, E, C, I, H, Update<K, V>>
+    [F, E, K, V, C, I, H] Db<F, E, C, I, H, Update<K, V>>
     where {
+        F: crate::merkle::Family,
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<crate::merkle::mmr::Family, K, V>>,
-        I: Index<Value = crate::mmr::Location> + 'static,
+        C: PersistableMutableLog<Operation<F, K, V>>,
+        I: Index<Value = crate::merkle::Location<F>> + 'static,
         H: Hasher,
-        Operation<crate::merkle::mmr::Family, K, V>: Codec,
+        Operation<F, K, V>: Codec,
         V::Value: Send + Sync,
     }
-    Family = crate::merkle::mmr::Family, Key = K, Value = V::Value, Digest = H::Digest
+    Family = F, Key = K, Value = V::Value, Digest = H::Digest
 }
 
 #[cfg(any(test, feature = "test-traits"))]
 crate::qmdb::any::traits::impl_provable! {
-    [E, K, V, C, I, H] Db<crate::merkle::mmr::Family, E, C, I, H, Update<K, V>>
+    [F, E, K, V, C, I, H] Db<F, E, C, I, H, Update<K, V>>
     where {
+        F: crate::merkle::Family,
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<crate::merkle::mmr::Family, K, V>>,
-        I: Index<Value = crate::mmr::Location> + 'static,
+        C: PersistableMutableLog<Operation<F, K, V>>,
+        I: Index<Value = crate::merkle::Location<F>> + 'static,
         H: Hasher,
-        Operation<crate::merkle::mmr::Family, K, V>: Codec,
+        Operation<F, K, V>: Codec,
         V::Value: Send + Sync,
     }
-    Family = crate::merkle::mmr::Family, Operation = Operation<crate::merkle::mmr::Family, K, V>
-}
-
-#[cfg(any(test, feature = "test-traits"))]
-crate::qmdb::any::traits::impl_db_any! {
-    [E, K, V, C, I, H] Db<crate::merkle::mmb::Family, E, C, I, H, Update<K, V>>
-    where {
-        E: Context,
-        K: Key,
-        V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<crate::merkle::mmb::Family, K, V>>,
-        I: Index<Value = crate::merkle::Location<crate::merkle::mmb::Family>> + 'static,
-        H: Hasher,
-        Operation<crate::merkle::mmb::Family, K, V>: Codec,
-        V::Value: Send + Sync,
-    }
-    Family = crate::merkle::mmb::Family, Key = K, Value = V::Value, Digest = H::Digest
-}
-
-#[cfg(any(test, feature = "test-traits"))]
-crate::qmdb::any::traits::impl_provable! {
-    [E, K, V, C, I, H] Db<crate::merkle::mmb::Family, E, C, I, H, Update<K, V>>
-    where {
-        E: Context,
-        K: Key,
-        V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<crate::merkle::mmb::Family, K, V>>,
-        I: Index<Value = crate::merkle::Location<crate::merkle::mmb::Family>> + 'static,
-        H: Hasher,
-        Operation<crate::merkle::mmb::Family, K, V>: Codec,
-        V::Value: Send + Sync,
-    }
-    Family = crate::merkle::mmb::Family, Operation = Operation<crate::merkle::mmb::Family, K, V>
+    Family = F, Operation = Operation<F, K, V>
 }
 
 #[cfg(test)]

--- a/storage/src/qmdb/any/unordered/mod.rs
+++ b/storage/src/qmdb/any/unordered/mod.rs
@@ -57,64 +57,34 @@ where
 
 #[cfg(any(test, feature = "test-traits"))]
 crate::qmdb::any::traits::impl_db_any! {
-    [E, K, V, C, I, H] Db<crate::merkle::mmr::Family, E, C, I, H, Update<K, V>>
+    [F, E, K, V, C, I, H] Db<F, E, C, I, H, Update<K, V>>
     where {
+        F: crate::merkle::Family,
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<crate::merkle::mmr::Family, K, V>>,
-        I: Index<Value = crate::mmr::Location> + Send + Sync + 'static,
+        C: PersistableMutableLog<Operation<F, K, V>>,
+        I: Index<Value = crate::merkle::Location<F>> + Send + Sync + 'static,
         H: Hasher,
-        Operation<crate::merkle::mmr::Family, K, V>: Codec,
+        Operation<F, K, V>: Codec,
         V::Value: Send + Sync,
     }
-    Family = crate::merkle::mmr::Family, Key = K, Value = V::Value, Digest = H::Digest
+    Family = F, Key = K, Value = V::Value, Digest = H::Digest
 }
 
 #[cfg(any(test, feature = "test-traits"))]
 crate::qmdb::any::traits::impl_provable! {
-    [E, K, V, C, I, H] Db<crate::merkle::mmr::Family, E, C, I, H, Update<K, V>>
+    [F, E, K, V, C, I, H] Db<F, E, C, I, H, Update<K, V>>
     where {
+        F: crate::merkle::Family,
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<crate::merkle::mmr::Family, K, V>>,
-        I: Index<Value = crate::mmr::Location> + Send + Sync + 'static,
+        C: PersistableMutableLog<Operation<F, K, V>>,
+        I: Index<Value = crate::merkle::Location<F>> + Send + Sync + 'static,
         H: Hasher,
-        Operation<crate::merkle::mmr::Family, K, V>: Codec,
+        Operation<F, K, V>: Codec,
         V::Value: Send + Sync,
     }
-    Family = crate::merkle::mmr::Family, Operation = Operation<crate::merkle::mmr::Family, K, V>
-}
-
-#[cfg(any(test, feature = "test-traits"))]
-crate::qmdb::any::traits::impl_db_any! {
-    [E, K, V, C, I, H] Db<crate::merkle::mmb::Family, E, C, I, H, Update<K, V>>
-    where {
-        E: Context,
-        K: Key,
-        V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<crate::merkle::mmb::Family, K, V>>,
-        I: Index<Value = crate::merkle::Location<crate::merkle::mmb::Family>> + Send + Sync + 'static,
-        H: Hasher,
-        Operation<crate::merkle::mmb::Family, K, V>: Codec,
-        V::Value: Send + Sync,
-    }
-    Family = crate::merkle::mmb::Family, Key = K, Value = V::Value, Digest = H::Digest
-}
-
-#[cfg(any(test, feature = "test-traits"))]
-crate::qmdb::any::traits::impl_provable! {
-    [E, K, V, C, I, H] Db<crate::merkle::mmb::Family, E, C, I, H, Update<K, V>>
-    where {
-        E: Context,
-        K: Key,
-        V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<crate::merkle::mmb::Family, K, V>>,
-        I: Index<Value = crate::merkle::Location<crate::merkle::mmb::Family>> + Send + Sync + 'static,
-        H: Hasher,
-        Operation<crate::merkle::mmb::Family, K, V>: Codec,
-        V::Value: Send + Sync,
-    }
-    Family = crate::merkle::mmb::Family, Operation = Operation<crate::merkle::mmb::Family, K, V>
+    Family = F, Operation = Operation<F, K, V>
 }

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -5,10 +5,7 @@ use commonware_cryptography::{Hasher, Sha256};
 use commonware_runtime::{buffer::paged::CacheRef, tokio::Context, BufferPooler, ThreadPooler};
 use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
-    merkle::{
-        self,
-        mmr::{journaled::Config as MmrConfig, Family},
-    },
+    merkle::{self, journaled::Config as MerkleConfig, Family},
     qmdb::{
         any::{
             ordered::{fixed::Db as OFixed, variable::Db as OVariable},
@@ -42,35 +39,33 @@ pub const WRITE_BUFFER_SIZE: NonZeroUsize = NZUsize!(1024);
 
 // -- Fixed value (Digest), fixed storage layout --
 
-pub type AnyUFixDb = UFixed<Family, Context, Digest, Digest, Sha256, EightCap>;
-pub type AnyOFixDb = OFixed<Family, Context, Digest, Digest, Sha256, EightCap>;
-pub type CurUFixDb = UCFixed<Family, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE>;
-pub type CurOFixDb = OCFixed<Family, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE>;
+pub type AnyUFixDb<F> = UFixed<F, Context, Digest, Digest, Sha256, EightCap>;
+pub type AnyOFixDb<F> = OFixed<F, Context, Digest, Digest, Sha256, EightCap>;
+pub type CurUFixDb<F> = UCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE>;
+pub type CurOFixDb<F> = OCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE>;
 
 // -- Fixed value (Digest), variable storage layout --
 // Measures overhead of variable-capable storage when values are fixed-size.
 
-pub type AnyUVarDigestDb = UVariable<Family, Context, Digest, Digest, Sha256, EightCap>;
-pub type AnyOVarDigestDb = OVariable<Family, Context, Digest, Digest, Sha256, EightCap>;
-pub type CurUVarDigestDb =
-    UCVariable<Family, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE>;
-pub type CurOVarDigestDb =
-    OCVariable<Family, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE>;
+pub type AnyUVarDigestDb<F> = UVariable<F, Context, Digest, Digest, Sha256, EightCap>;
+pub type AnyOVarDigestDb<F> = OVariable<F, Context, Digest, Digest, Sha256, EightCap>;
+pub type CurUVarDigestDb<F> = UCVariable<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE>;
+pub type CurOVarDigestDb<F> = OCVariable<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE>;
 
 // -- Variable value (Vec<u8>), variable storage layout --
 
-pub type AnyUVarVecDb = UVariable<Family, Context, Digest, Vec<u8>, Sha256, EightCap>;
-pub type AnyOVarVecDb = OVariable<Family, Context, Digest, Vec<u8>, Sha256, EightCap>;
-pub type CurUVarVecDb = UCVariable<Family, Context, Digest, Vec<u8>, Sha256, EightCap, CHUNK_SIZE>;
-pub type CurOVarVecDb = OCVariable<Family, Context, Digest, Vec<u8>, Sha256, EightCap, CHUNK_SIZE>;
+pub type AnyUVarVecDb<F> = UVariable<F, Context, Digest, Vec<u8>, Sha256, EightCap>;
+pub type AnyOVarVecDb<F> = OVariable<F, Context, Digest, Vec<u8>, Sha256, EightCap>;
+pub type CurUVarVecDb<F> = UCVariable<F, Context, Digest, Vec<u8>, Sha256, EightCap, CHUNK_SIZE>;
+pub type CurOVarVecDb<F> = OCVariable<F, Context, Digest, Vec<u8>, Sha256, EightCap, CHUNK_SIZE>;
 
 // -- Keyless --
 
-pub type KeylessDb = Keyless<Family, Context, Vec<u8>, Sha256>;
+pub type KeylessDb<F> = Keyless<F, Context, Vec<u8>, Sha256>;
 
-pub async fn open_keyless_db(ctx: Context) -> KeylessDb {
+pub async fn open_keyless_db<F: Family>(ctx: Context) -> KeylessDb<F> {
     let cfg = keyless_cfg(&ctx);
-    KeylessDb::init(ctx, cfg).await.unwrap()
+    KeylessDb::<F>::init(ctx, cfg).await.unwrap()
 }
 
 // -- Variant enums --
@@ -145,12 +140,12 @@ const PARTITION_FIX: &str = "bench-fixed";
 const PARTITION_VAR: &str = "bench-variable";
 const PARTITION_KEYLESS: &str = "bench-keyless";
 
-fn mmr_cfg(
+fn merkle_cfg(
     suffix: &str,
     ctx: &(impl BufferPooler + ThreadPooler),
     page_cache: CacheRef,
-) -> MmrConfig {
-    MmrConfig {
+) -> MerkleConfig {
+    MerkleConfig {
         journal_partition: format!("journal-{suffix}"),
         metadata_partition: format!("metadata-{suffix}"),
         items_per_blob: ITEMS_PER_BLOB,
@@ -183,7 +178,7 @@ fn var_log_cfg<C>(suffix: &str, page_cache: CacheRef, codec_config: C) -> VConfi
 pub fn any_fix_cfg(ctx: &(impl BufferPooler + ThreadPooler)) -> AnyFixedConfig<EightCap> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyFixedConfig {
-        merkle_config: mmr_cfg(PARTITION_FIX, ctx, page_cache.clone()),
+        merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone()),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache),
         translator: EightCap,
     }
@@ -192,9 +187,9 @@ pub fn any_fix_cfg(ctx: &(impl BufferPooler + ThreadPooler)) -> AnyFixedConfig<E
 pub fn cur_fix_cfg(ctx: &(impl BufferPooler + ThreadPooler)) -> CurrentFixedConfig<EightCap> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentFixedConfig {
-        merkle_config: mmr_cfg(PARTITION_FIX, ctx, page_cache.clone()),
+        merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone()),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache),
-        grafted_metadata_partition: format!("grafted-mmr-metadata-{PARTITION_FIX}"),
+        grafted_metadata_partition: format!("grafted-metadata-{PARTITION_FIX}"),
         translator: EightCap,
     }
 }
@@ -204,7 +199,7 @@ pub fn any_var_digest_cfg(
 ) -> AnyVariableConfig<EightCap, ((), ())> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
-        merkle_config: mmr_cfg(PARTITION_VAR, ctx, page_cache.clone()),
+        merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone()),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ())),
         translator: EightCap,
     }
@@ -215,9 +210,9 @@ pub fn cur_var_digest_cfg(
 ) -> CurrentVariableConfig<EightCap, ((), ())> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
-        merkle_config: mmr_cfg(PARTITION_VAR, ctx, page_cache.clone()),
+        merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone()),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ())),
-        grafted_metadata_partition: format!("grafted-mmr-metadata-{PARTITION_VAR}"),
+        grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
     }
 }
@@ -227,7 +222,7 @@ pub fn any_var_vec_cfg(
 ) -> AnyVariableConfig<EightCap, ((), (commonware_codec::RangeCfg<usize>, ()))> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
-        merkle_config: mmr_cfg(PARTITION_VAR, ctx, page_cache.clone()),
+        merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone()),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ((0..=10000).into(), ()))),
         translator: EightCap,
     }
@@ -238,9 +233,9 @@ pub fn cur_var_vec_cfg(
 ) -> CurrentVariableConfig<EightCap, ((), (commonware_codec::RangeCfg<usize>, ()))> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
-        merkle_config: mmr_cfg(PARTITION_VAR, ctx, page_cache.clone()),
+        merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone()),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ((0..=10000).into(), ()))),
-        grafted_metadata_partition: format!("grafted-mmr-metadata-{PARTITION_VAR}"),
+        grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
     }
 }
@@ -250,7 +245,7 @@ pub fn keyless_cfg(
 ) -> KeylessConfig<(commonware_codec::RangeCfg<usize>, ())> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     KeylessConfig {
-        merkle: mmr_cfg(PARTITION_KEYLESS, ctx, page_cache.clone()),
+        merkle: merkle_cfg(PARTITION_KEYLESS, ctx, page_cache.clone()),
         log: var_log_cfg(PARTITION_KEYLESS, page_cache, ((0..=10000).into(), ())),
     }
 }
@@ -270,63 +265,63 @@ macro_rules! dispatch_arm {
 
 /// Construct a fixed-value database for the given variant, bind it as `$db`, execute `$body`.
 macro_rules! with_fixed_value_db {
-    ($ctx:expr, $variant:expr, |mut $db:ident| $body:expr) => {{
+    ($ctx:expr, $F:ty, $variant:expr, |mut $db:ident| $body:expr) => {{
         use $crate::common::FixedValueVariant::*;
         match $variant {
             AnyUnorderedFixed => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyUFixDb,
+                $crate::common::AnyUFixDb<$F>,
                 any_fix_cfg
             ),
             AnyOrderedFixed => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyOFixDb,
+                $crate::common::AnyOFixDb<$F>,
                 any_fix_cfg
             ),
             AnyUnorderedVariable => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyUVarDigestDb,
+                $crate::common::AnyUVarDigestDb<$F>,
                 any_var_digest_cfg
             ),
             AnyOrderedVariable => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyOVarDigestDb,
+                $crate::common::AnyOVarDigestDb<$F>,
                 any_var_digest_cfg
             ),
             CurrentUnorderedFixed => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurUFixDb,
+                $crate::common::CurUFixDb<$F>,
                 cur_fix_cfg
             ),
             CurrentOrderedFixed => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurOFixDb,
+                $crate::common::CurOFixDb<$F>,
                 cur_fix_cfg
             ),
             CurrentUnorderedVariable => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurUVarDigestDb,
+                $crate::common::CurUVarDigestDb<$F>,
                 cur_var_digest_cfg
             ),
             CurrentOrderedVariable => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurOVarDigestDb,
+                $crate::common::CurOVarDigestDb<$F>,
                 cur_var_digest_cfg
             ),
         }
@@ -336,35 +331,35 @@ macro_rules! with_fixed_value_db {
 /// Construct a variable-value (Vec<u8>) database for the given variant, bind it as `$db`,
 /// execute `$body`.
 macro_rules! with_var_value_db {
-    ($ctx:expr, $variant:expr, |mut $db:ident| $body:expr) => {{
+    ($ctx:expr, $F:ty, $variant:expr, |mut $db:ident| $body:expr) => {{
         use $crate::common::VarValueVariant::*;
         match $variant {
             AnyUnordered => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyUVarVecDb,
+                $crate::common::AnyUVarVecDb<$F>,
                 any_var_vec_cfg
             ),
             AnyOrdered => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyOVarVecDb,
+                $crate::common::AnyOVarVecDb<$F>,
                 any_var_vec_cfg
             ),
             CurrentUnordered => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurUVarVecDb,
+                $crate::common::CurUVarVecDb<$F>,
                 cur_var_vec_cfg
             ),
             CurrentOrdered => $crate::common::dispatch_arm!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurOVarVecDb,
+                $crate::common::CurOVarVecDb<$F>,
                 cur_var_vec_cfg
             ),
         }
@@ -386,7 +381,7 @@ macro_rules! dispatch_arm_with_cfg {
 
 /// Like `with_fixed_value_db!` but takes pre-built configs to avoid rebuilding them each call.
 macro_rules! with_fixed_value_db_cfg {
-    ($ctx:expr, $variant:expr, $any_fixed:expr, $current_fixed:expr,
+    ($ctx:expr, $F:ty, $variant:expr, $any_fixed:expr, $current_fixed:expr,
      $any_var:expr, $current_var:expr, |mut $db:ident| $body:expr) => {{
         use $crate::common::FixedValueVariant::*;
         match $variant {
@@ -394,56 +389,56 @@ macro_rules! with_fixed_value_db_cfg {
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyUFixDb,
+                $crate::common::AnyUFixDb<$F>,
                 $any_fixed
             ),
             AnyOrderedFixed => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyOFixDb,
+                $crate::common::AnyOFixDb<$F>,
                 $any_fixed
             ),
             AnyUnorderedVariable => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyUVarDigestDb,
+                $crate::common::AnyUVarDigestDb<$F>,
                 $any_var
             ),
             AnyOrderedVariable => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyOVarDigestDb,
+                $crate::common::AnyOVarDigestDb<$F>,
                 $any_var
             ),
             CurrentUnorderedFixed => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurUFixDb,
+                $crate::common::CurUFixDb<$F>,
                 $current_fixed
             ),
             CurrentOrderedFixed => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurOFixDb,
+                $crate::common::CurOFixDb<$F>,
                 $current_fixed
             ),
             CurrentUnorderedVariable => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurUVarDigestDb,
+                $crate::common::CurUVarDigestDb<$F>,
                 $current_var
             ),
             CurrentOrderedVariable => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurOVarDigestDb,
+                $crate::common::CurOVarDigestDb<$F>,
                 $current_var
             ),
         }
@@ -452,7 +447,7 @@ macro_rules! with_fixed_value_db_cfg {
 
 /// Like `with_var_value_db!` but takes pre-built configs to avoid rebuilding them each call.
 macro_rules! with_var_value_db_cfg {
-    ($ctx:expr, $variant:expr, $any_var:expr, $current_var:expr,
+    ($ctx:expr, $F:ty, $variant:expr, $any_var:expr, $current_var:expr,
      |mut $db:ident| $body:expr) => {{
         use $crate::common::VarValueVariant::*;
         match $variant {
@@ -460,28 +455,28 @@ macro_rules! with_var_value_db_cfg {
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyUVarVecDb,
+                $crate::common::AnyUVarVecDb<$F>,
                 $any_var
             ),
             AnyOrdered => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::AnyOVarVecDb,
+                $crate::common::AnyOVarVecDb<$F>,
                 $any_var
             ),
             CurrentUnordered => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurUVarVecDb,
+                $crate::common::CurUVarVecDb<$F>,
                 $current_var
             ),
             CurrentOrdered => $crate::common::dispatch_arm_with_cfg!(
                 $ctx,
                 $db,
                 $body,
-                $crate::common::CurOVarVecDb,
+                $crate::common::CurOVarVecDb<$F>,
                 $current_var
             ),
         }
@@ -496,14 +491,15 @@ pub(crate) use with_var_value_db_cfg;
 
 /// Seed a database with `num_elements` entries, then perform `num_operations` random
 /// updates/deletes. Commits periodically when `commit_frequency` is `Some`.
-pub async fn gen_random_kv<M>(
+pub async fn gen_random_kv<F, M>(
     db: &mut M,
     num_elements: u64,
     num_operations: u64,
     commit_frequency: Option<u32>,
     make_value: impl Fn(&mut StdRng) -> M::Value,
 ) where
-    M: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest>,
+    F: Family,
+    M: DbAny<F, Key = Digest>,
 {
     let mut rng = StdRng::seed_from_u64(42);
 

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -68,72 +68,6 @@ pub async fn open_keyless_db<F: Family>(ctx: Context) -> KeylessDb<F> {
     KeylessDb::<F>::init(ctx, cfg).await.unwrap()
 }
 
-// -- Variant enums --
-
-#[derive(Debug, Clone, Copy)]
-pub enum FixedValueVariant {
-    AnyUnorderedFixed,
-    AnyOrderedFixed,
-    AnyUnorderedVariable,
-    AnyOrderedVariable,
-    CurrentUnorderedFixed,
-    CurrentOrderedFixed,
-    CurrentUnorderedVariable,
-    CurrentOrderedVariable,
-}
-
-impl FixedValueVariant {
-    pub const fn name(self) -> &'static str {
-        match self {
-            Self::AnyUnorderedFixed => "any::unordered::fixed",
-            Self::AnyOrderedFixed => "any::ordered::fixed",
-            Self::AnyUnorderedVariable => "any::unordered::variable",
-            Self::AnyOrderedVariable => "any::ordered::variable",
-            Self::CurrentUnorderedFixed => "current::unordered::fixed",
-            Self::CurrentOrderedFixed => "current::ordered::fixed",
-            Self::CurrentUnorderedVariable => "current::unordered::variable",
-            Self::CurrentOrderedVariable => "current::ordered::variable",
-        }
-    }
-}
-
-pub const FIXED_VALUE_VARIANTS: [FixedValueVariant; 8] = [
-    FixedValueVariant::AnyUnorderedFixed,
-    FixedValueVariant::AnyOrderedFixed,
-    FixedValueVariant::AnyUnorderedVariable,
-    FixedValueVariant::AnyOrderedVariable,
-    FixedValueVariant::CurrentUnorderedFixed,
-    FixedValueVariant::CurrentOrderedFixed,
-    FixedValueVariant::CurrentUnorderedVariable,
-    FixedValueVariant::CurrentOrderedVariable,
-];
-
-#[derive(Debug, Clone, Copy)]
-pub enum VarValueVariant {
-    AnyUnordered,
-    AnyOrdered,
-    CurrentUnordered,
-    CurrentOrdered,
-}
-
-impl VarValueVariant {
-    pub const fn name(self) -> &'static str {
-        match self {
-            Self::AnyUnordered => "any::unordered",
-            Self::AnyOrdered => "any::ordered",
-            Self::CurrentUnordered => "current::unordered",
-            Self::CurrentOrdered => "current::ordered",
-        }
-    }
-}
-
-pub const VAR_VALUE_VARIANTS: [VarValueVariant; 4] = [
-    VarValueVariant::AnyUnordered,
-    VarValueVariant::AnyOrdered,
-    VarValueVariant::CurrentUnordered,
-    VarValueVariant::CurrentOrdered,
-];
-
 // -- Config builders --
 
 const PARTITION_FIX: &str = "bench-fixed";
@@ -250,242 +184,265 @@ pub fn keyless_cfg(
     }
 }
 
-// -- Dispatch macros --
+// -- Shared variant definitions --
 
-/// Internal helper: construct a db, bind it, execute body.
-macro_rules! dispatch_arm {
-    ($ctx:expr, $db:ident, $body:expr, $DbType:ty, $cfg_fn:ident) => {{
-        #[allow(unused_mut)]
-        let mut $db = <$DbType>::init($ctx.clone(), $crate::common::$cfg_fn(&$ctx))
-            .await
-            .unwrap();
-        $body
-    }};
-}
-
-/// Construct a fixed-value database for the given variant, bind it as `$db`, execute `$body`.
-macro_rules! with_fixed_value_db {
-    ($ctx:expr, $F:ty, $variant:expr, |mut $db:ident| $body:expr) => {{
-        use $crate::common::FixedValueVariant::*;
-        match $variant {
-            AnyUnorderedFixed => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyUFixDb<$F>,
-                any_fix_cfg
-            ),
-            AnyOrderedFixed => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyOFixDb<$F>,
-                any_fix_cfg
-            ),
-            AnyUnorderedVariable => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyUVarDigestDb<$F>,
-                any_var_digest_cfg
-            ),
-            AnyOrderedVariable => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyOVarDigestDb<$F>,
-                any_var_digest_cfg
-            ),
-            CurrentUnorderedFixed => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurUFixDb<$F>,
-                cur_fix_cfg
-            ),
-            CurrentOrderedFixed => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurOFixDb<$F>,
-                cur_fix_cfg
-            ),
-            CurrentUnorderedVariable => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurUVarDigestDb<$F>,
-                cur_var_digest_cfg
-            ),
-            CurrentOrderedVariable => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurOVarDigestDb<$F>,
-                cur_var_digest_cfg
-            ),
+macro_rules! define_db_variants {
+    (
+        enum $enum_name:ident;
+        const $variants_name:ident;
+        dispatch $dispatch_name:ident;
+        timed_dispatch $timed_dispatch_name:ident;
+        entries = [
+            $(
+                {
+                    entry: $entry:ident,
+                    name: $name:literal,
+                    db: $db:ty,
+                    cfg: $cfg:path,
+                }
+            )+
+        ];
+    ) => {
+        #[derive(Debug, Clone, Copy)]
+        enum $enum_name {
+            $($entry),+
         }
-    }};
-}
 
-/// Construct a variable-value (Vec<u8>) database for the given variant, bind it as `$db`,
-/// execute `$body`.
-macro_rules! with_var_value_db {
-    ($ctx:expr, $F:ty, $variant:expr, |mut $db:ident| $body:expr) => {{
-        use $crate::common::VarValueVariant::*;
-        match $variant {
-            AnyUnordered => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyUVarVecDb<$F>,
-                any_var_vec_cfg
-            ),
-            AnyOrdered => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyOVarVecDb<$F>,
-                any_var_vec_cfg
-            ),
-            CurrentUnordered => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurUVarVecDb<$F>,
-                cur_var_vec_cfg
-            ),
-            CurrentOrdered => $crate::common::dispatch_arm!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurOVarVecDb<$F>,
-                cur_var_vec_cfg
-            ),
+        impl $enum_name {
+            const fn name(self) -> &'static str {
+                match self {
+                    $(Self::$entry => $name),+
+                }
+            }
         }
-    }};
-}
 
-pub(crate) use dispatch_arm;
-pub(crate) use with_fixed_value_db;
-pub(crate) use with_var_value_db;
+        const $variants_name: &[$enum_name] = &[$($enum_name::$entry),+];
 
-/// Internal helper: construct a db from a pre-built config, bind it, execute body.
-macro_rules! dispatch_arm_with_cfg {
-    ($ctx:expr, $db:ident, $body:expr, $DbType:ty, $cfg:expr) => {{
-        #[allow(unused_mut)]
-        let mut $db = <$DbType>::init($ctx.clone(), $cfg.clone()).await.unwrap();
-        $body
-    }};
-}
-
-/// Like `with_fixed_value_db!` but takes pre-built configs to avoid rebuilding them each call.
-macro_rules! with_fixed_value_db_cfg {
-    ($ctx:expr, $F:ty, $variant:expr, $any_fixed:expr, $current_fixed:expr,
-     $any_var:expr, $current_var:expr, |mut $db:ident| $body:expr) => {{
-        use $crate::common::FixedValueVariant::*;
-        match $variant {
-            AnyUnorderedFixed => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyUFixDb<$F>,
-                $any_fixed
-            ),
-            AnyOrderedFixed => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyOFixDb<$F>,
-                $any_fixed
-            ),
-            AnyUnorderedVariable => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyUVarDigestDb<$F>,
-                $any_var
-            ),
-            AnyOrderedVariable => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyOVarDigestDb<$F>,
-                $any_var
-            ),
-            CurrentUnorderedFixed => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurUFixDb<$F>,
-                $current_fixed
-            ),
-            CurrentOrderedFixed => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurOFixDb<$F>,
-                $current_fixed
-            ),
-            CurrentUnorderedVariable => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurUVarDigestDb<$F>,
-                $current_var
-            ),
-            CurrentOrderedVariable => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurOVarDigestDb<$F>,
-                $current_var
-            ),
+        macro_rules! $dispatch_name {
+            ($ctx_expr:expr, $variant_expr:expr, |$db_name:ident| $body:expr) => {
+                match $variant_expr {
+                    $(
+                        $enum_name::$entry => {
+                            let ctx = $ctx_expr;
+                            let cfg = $cfg(&ctx);
+                            #[allow(unused_mut)]
+                            let mut $db_name = <$db>::init(ctx.clone(), cfg).await.unwrap();
+                            $body
+                        }
+                    )+
+                }
+            };
         }
-    }};
-}
 
-/// Like `with_var_value_db!` but takes pre-built configs to avoid rebuilding them each call.
-macro_rules! with_var_value_db_cfg {
-    ($ctx:expr, $F:ty, $variant:expr, $any_var:expr, $current_var:expr,
-     |mut $db:ident| $body:expr) => {{
-        use $crate::common::VarValueVariant::*;
-        match $variant {
-            AnyUnordered => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyUVarVecDb<$F>,
-                $any_var
-            ),
-            AnyOrdered => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::AnyOVarVecDb<$F>,
-                $any_var
-            ),
-            CurrentUnordered => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurUVarVecDb<$F>,
-                $current_var
-            ),
-            CurrentOrdered => $crate::common::dispatch_arm_with_cfg!(
-                $ctx,
-                $db,
-                $body,
-                $crate::common::CurOVarVecDb<$F>,
-                $current_var
-            ),
+        #[allow(unused_macros)]
+        macro_rules! $timed_dispatch_name {
+            ($ctx_expr:expr, $variant_expr:expr, $iters:expr, |$db_name:ident| $body:expr) => {
+                match $variant_expr {
+                    $(
+                        $enum_name::$entry => {
+                            let ctx = $ctx_expr;
+                            let cfg = $cfg(&ctx);
+                            let start = std::time::Instant::now();
+                            for _ in 0..$iters {
+                                #[allow(unused_mut)]
+                                let mut $db_name =
+                                    <$db>::init(ctx.clone(), cfg.clone()).await.unwrap();
+                                $body
+                            }
+                            start.elapsed()
+                        }
+                    )+
+                }
+            };
         }
-    }};
+    };
 }
 
-pub(crate) use dispatch_arm_with_cfg;
-pub(crate) use with_fixed_value_db_cfg;
-pub(crate) use with_var_value_db_cfg;
+pub(crate) use define_db_variants;
+
+macro_rules! define_fixed_variants {
+    (
+        enum $enum_name:ident;
+        const $variants_name:ident;
+        dispatch $dispatch_name:ident;
+        timed_dispatch $timed_dispatch_name:ident;
+    ) => {
+        $crate::common::define_db_variants! {
+            enum $enum_name;
+            const $variants_name;
+            dispatch $dispatch_name;
+            timed_dispatch $timed_dispatch_name;
+            entries = [
+                {
+                    entry: AnyUnorderedFixedMmr,
+                    name: "any::unordered::fixed::mmr",
+                    db: $crate::common::AnyUFixDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::any_fix_cfg,
+                }
+                {
+                    entry: AnyUnorderedFixedMmb,
+                    name: "any::unordered::fixed::mmb",
+                    db: $crate::common::AnyUFixDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::any_fix_cfg,
+                }
+                {
+                    entry: AnyOrderedFixedMmr,
+                    name: "any::ordered::fixed::mmr",
+                    db: $crate::common::AnyOFixDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::any_fix_cfg,
+                }
+                {
+                    entry: AnyOrderedFixedMmb,
+                    name: "any::ordered::fixed::mmb",
+                    db: $crate::common::AnyOFixDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::any_fix_cfg,
+                }
+                {
+                    entry: AnyUnorderedVariableMmr,
+                    name: "any::unordered::variable::mmr",
+                    db: $crate::common::AnyUVarDigestDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::any_var_digest_cfg,
+                }
+                {
+                    entry: AnyUnorderedVariableMmb,
+                    name: "any::unordered::variable::mmb",
+                    db: $crate::common::AnyUVarDigestDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::any_var_digest_cfg,
+                }
+                {
+                    entry: AnyOrderedVariableMmr,
+                    name: "any::ordered::variable::mmr",
+                    db: $crate::common::AnyOVarDigestDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::any_var_digest_cfg,
+                }
+                {
+                    entry: AnyOrderedVariableMmb,
+                    name: "any::ordered::variable::mmb",
+                    db: $crate::common::AnyOVarDigestDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::any_var_digest_cfg,
+                }
+                {
+                    entry: CurrentUnorderedFixedMmr,
+                    name: "current::unordered::fixed::mmr",
+                    db: $crate::common::CurUFixDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::cur_fix_cfg,
+                }
+                {
+                    entry: CurrentUnorderedFixedMmb,
+                    name: "current::unordered::fixed::mmb",
+                    db: $crate::common::CurUFixDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::cur_fix_cfg,
+                }
+                {
+                    entry: CurrentOrderedFixedMmr,
+                    name: "current::ordered::fixed::mmr",
+                    db: $crate::common::CurOFixDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::cur_fix_cfg,
+                }
+                {
+                    entry: CurrentOrderedFixedMmb,
+                    name: "current::ordered::fixed::mmb",
+                    db: $crate::common::CurOFixDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::cur_fix_cfg,
+                }
+                {
+                    entry: CurrentUnorderedVariableMmr,
+                    name: "current::unordered::variable::mmr",
+                    db: $crate::common::CurUVarDigestDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::cur_var_digest_cfg,
+                }
+                {
+                    entry: CurrentUnorderedVariableMmb,
+                    name: "current::unordered::variable::mmb",
+                    db: $crate::common::CurUVarDigestDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::cur_var_digest_cfg,
+                }
+                {
+                    entry: CurrentOrderedVariableMmr,
+                    name: "current::ordered::variable::mmr",
+                    db: $crate::common::CurOVarDigestDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::cur_var_digest_cfg,
+                }
+                {
+                    entry: CurrentOrderedVariableMmb,
+                    name: "current::ordered::variable::mmb",
+                    db: $crate::common::CurOVarDigestDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::cur_var_digest_cfg,
+                }
+            ];
+        }
+    };
+}
+
+pub(crate) use define_fixed_variants;
+
+macro_rules! define_vec_variants {
+    (
+        enum $enum_name:ident;
+        const $variants_name:ident;
+        dispatch $dispatch_name:ident;
+        timed_dispatch $timed_dispatch_name:ident;
+    ) => {
+        $crate::common::define_db_variants! {
+            enum $enum_name;
+            const $variants_name;
+            dispatch $dispatch_name;
+            timed_dispatch $timed_dispatch_name;
+            entries = [
+                {
+                    entry: AnyUnorderedMmr,
+                    name: "any::unordered::variable-vec::mmr",
+                    db: $crate::common::AnyUVarVecDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::any_var_vec_cfg,
+                }
+                {
+                    entry: AnyUnorderedMmb,
+                    name: "any::unordered::variable-vec::mmb",
+                    db: $crate::common::AnyUVarVecDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::any_var_vec_cfg,
+                }
+                {
+                    entry: AnyOrderedMmr,
+                    name: "any::ordered::variable-vec::mmr",
+                    db: $crate::common::AnyOVarVecDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::any_var_vec_cfg,
+                }
+                {
+                    entry: AnyOrderedMmb,
+                    name: "any::ordered::variable-vec::mmb",
+                    db: $crate::common::AnyOVarVecDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::any_var_vec_cfg,
+                }
+                {
+                    entry: CurrentUnorderedMmr,
+                    name: "current::unordered::variable-vec::mmr",
+                    db: $crate::common::CurUVarVecDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::cur_var_vec_cfg,
+                }
+                {
+                    entry: CurrentUnorderedMmb,
+                    name: "current::unordered::variable-vec::mmb",
+                    db: $crate::common::CurUVarVecDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::cur_var_vec_cfg,
+                }
+                {
+                    entry: CurrentOrderedMmr,
+                    name: "current::ordered::variable-vec::mmr",
+                    db: $crate::common::CurOVarVecDb<commonware_storage::merkle::mmr::Family>,
+                    cfg: $crate::common::cur_var_vec_cfg,
+                }
+                {
+                    entry: CurrentOrderedMmb,
+                    name: "current::ordered::variable-vec::mmb",
+                    db: $crate::common::CurOVarVecDb<commonware_storage::merkle::mmb::Family>,
+                    cfg: $crate::common::cur_var_vec_cfg,
+                }
+            ];
+        }
+    };
+}
+
+pub(crate) use define_vec_variants;
 
 // -- Data generation --
 

--- a/storage/src/qmdb/benches/generate.rs
+++ b/storage/src/qmdb/benches/generate.rs
@@ -4,15 +4,15 @@
 //! variants (fixed-value, variable-value) and the keyless variant.
 
 use crate::common::{
-    gen_random_kv, make_fixed_value, make_var_value, open_keyless_db, with_fixed_value_db,
-    with_var_value_db, Digest, FIXED_VALUE_VARIANTS, VAR_VALUE_VARIANTS,
+    define_fixed_variants, define_vec_variants, gen_random_kv, make_fixed_value, make_var_value,
+    open_keyless_db, Digest,
 };
 use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::{Config, Context},
 };
 use commonware_storage::{
-    merkle::{mmb, mmr, Family, Graftable},
+    merkle::{mmb, mmr, Family},
     qmdb::any::traits::DbAny,
 };
 use criterion::{criterion_group, Criterion};
@@ -48,14 +48,23 @@ async fn bench_db<F: Family, C: DbAny<F, Key = Digest>>(
     elapsed
 }
 
-fn bench_fixed_value_generate_family<F: Graftable>(c: &mut Criterion, family: &str) {
+// -- Fixed-value variants (16 = 8 db shapes x 2 merkle families) --
+
+define_fixed_variants! {
+    enum FixedVariant;
+    const FIXED_VARIANTS;
+    dispatch dispatch_fixed;
+    timed_dispatch dispatch_fixed_timed_init;
+}
+
+fn bench_fixed_value_generate(c: &mut Criterion) {
     let runner = tokio::Runner::new(Config::default());
     for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 10] {
         for operations in [NUM_OPERATIONS, NUM_OPERATIONS * 10] {
-            for variant in FIXED_VALUE_VARIANTS {
+            for &variant in FIXED_VARIANTS {
                 c.bench_function(
                     &format!(
-                        "{}/variant={} family={family} elements={elements} operations={operations}",
+                        "{}/variant={} elements={elements} operations={operations}",
                         module_path!(),
                         variant.name(),
                     ),
@@ -65,8 +74,8 @@ fn bench_fixed_value_generate_family<F: Graftable>(c: &mut Criterion, family: &s
                             let commit_freq = (operations / COMMITS_PER_ITERATION) as u32;
                             let mut total = Duration::ZERO;
                             for _ in 0..iters {
-                                total += with_fixed_value_db!(ctx, F, variant, |mut db| {
-                                    bench_db::<F, _>(
+                                total += dispatch_fixed!(ctx.clone(), variant, |db| {
+                                    bench_db(
                                         db,
                                         elements,
                                         operations,
@@ -85,19 +94,23 @@ fn bench_fixed_value_generate_family<F: Graftable>(c: &mut Criterion, family: &s
     }
 }
 
-fn bench_fixed_value_generate(c: &mut Criterion) {
-    bench_fixed_value_generate_family::<mmr::Family>(c, "mmr");
-    bench_fixed_value_generate_family::<mmb::Family>(c, "mmb");
+// -- Variable-value variants (8 = 4 db shapes x 2 merkle families) --
+
+define_vec_variants! {
+    enum VarVariant;
+    const VEC_VARIANTS;
+    dispatch dispatch_var;
+    timed_dispatch dispatch_var_timed_init;
 }
 
-fn bench_var_value_generate_family<F: Graftable>(c: &mut Criterion, family: &str) {
+fn bench_var_value_generate(c: &mut Criterion) {
     let runner = tokio::Runner::new(Config::default());
     for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 10] {
         for operations in [NUM_OPERATIONS, NUM_OPERATIONS * 10] {
-            for variant in VAR_VALUE_VARIANTS {
+            for &variant in VEC_VARIANTS {
                 c.bench_function(
                     &format!(
-                        "{}/variant={} family={family} elements={elements} operations={operations}",
+                        "{}/variant={} elements={elements} operations={operations}",
                         module_path!(),
                         variant.name(),
                     ),
@@ -107,15 +120,9 @@ fn bench_var_value_generate_family<F: Graftable>(c: &mut Criterion, family: &str
                             let commit_freq = (operations / COMMITS_PER_ITERATION) as u32;
                             let mut total = Duration::ZERO;
                             for _ in 0..iters {
-                                total += with_var_value_db!(ctx, F, variant, |mut db| {
-                                    bench_db::<F, _>(
-                                        db,
-                                        elements,
-                                        operations,
-                                        commit_freq,
-                                        make_var_value,
-                                    )
-                                    .await
+                                total += dispatch_var!(ctx.clone(), variant, |db| {
+                                    bench_db(db, elements, operations, commit_freq, make_var_value)
+                                        .await
                                 });
                             }
                             total
@@ -127,59 +134,106 @@ fn bench_var_value_generate_family<F: Graftable>(c: &mut Criterion, family: &str
     }
 }
 
-fn bench_var_value_generate(c: &mut Criterion) {
-    bench_var_value_generate_family::<mmr::Family>(c, "mmr");
-    bench_var_value_generate_family::<mmb::Family>(c, "mmb");
-}
+// -- Keyless variants --
 
 const KEYLESS_OPS: u64 = 10_000;
 const KEYLESS_COMMIT_FREQ: u32 = 25;
 
-fn bench_keyless_generate_family<F: Family>(c: &mut Criterion, family: &str) {
-    let runner = tokio::Runner::new(Config::default());
-    for operations in [KEYLESS_OPS, KEYLESS_OPS * 2] {
-        c.bench_function(
-            &format!(
-                "{}/variant=keyless family={family} operations={operations}",
-                module_path!()
-            ),
-            |b| {
-                b.to_async(&runner).iter_custom(|iters| async move {
-                    let ctx = context::get::<Context>();
-                    let mut total = Duration::ZERO;
-                    for _ in 0..iters {
-                        let start = Instant::now();
+macro_rules! keyless_variants {
+    (
+        $(
+            $entry:ident {
+                name: $name:literal,
+                init: |$ctx:ident| $init:expr,
+            }
+        )+
+    ) => {
+        #[derive(Debug, Clone, Copy)]
+        enum KeylessVariant {
+            $($entry),+
+        }
 
-                        let mut db = open_keyless_db::<F>(ctx.clone()).await;
-                        let mut rng = StdRng::seed_from_u64(42);
-                        let mut batch = db.new_batch();
-                        for _ in 0u64..operations {
-                            let v = make_var_value(&mut rng);
-                            batch = batch.append(v);
-                            if rng.next_u32() % KEYLESS_COMMIT_FREQ == 0 {
-                                let merkleized =
-                                    batch.merkleize(&db, None, db.inactivity_floor_loc());
-                                db.apply_batch(merkleized).await.unwrap();
-                                batch = db.new_batch();
-                            }
+        impl KeylessVariant {
+            const fn name(self) -> &'static str {
+                match self {
+                    $(Self::$entry => $name),+
+                }
+            }
+        }
+
+        const KEYLESS_VARIANTS: &[KeylessVariant] = &[$(KeylessVariant::$entry),+];
+
+        macro_rules! dispatch_keyless {
+            ($ctx_expr:expr, $variant_expr:expr, |$db_name:ident| $body:expr) => {
+                match $variant_expr {
+                    $(
+                        KeylessVariant::$entry => {
+                            let $ctx = $ctx_expr;
+                            let mut $db_name = $init.await;
+                            $body
                         }
-                        let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc());
-                        db.apply_batch(merkleized).await.unwrap();
-                        db.sync().await.unwrap();
+                    )+
+                }
+            };
+        }
+    };
+}
 
-                        total += start.elapsed();
-                        db.destroy().await.unwrap();
-                    }
-                    total
-                });
-            },
-        );
+keyless_variants! {
+    Mmr {
+        name: "keyless::mmr",
+        init: |ctx| open_keyless_db::<mmr::Family>(ctx.clone()),
+    }
+    Mmb {
+        name: "keyless::mmb",
+        init: |ctx| open_keyless_db::<mmb::Family>(ctx.clone()),
     }
 }
 
 fn bench_keyless_generate(c: &mut Criterion) {
-    bench_keyless_generate_family::<mmr::Family>(c, "mmr");
-    bench_keyless_generate_family::<mmb::Family>(c, "mmb");
+    let runner = tokio::Runner::new(Config::default());
+    for operations in [KEYLESS_OPS, KEYLESS_OPS * 2] {
+        for &variant in KEYLESS_VARIANTS {
+            c.bench_function(
+                &format!(
+                    "{}/variant={} operations={operations}",
+                    module_path!(),
+                    variant.name(),
+                ),
+                |b| {
+                    b.to_async(&runner).iter_custom(|iters| async move {
+                        let ctx = context::get::<Context>();
+                        let mut total = Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = Instant::now();
+                            dispatch_keyless!(ctx.clone(), variant, |db| {
+                                let mut rng = StdRng::seed_from_u64(42);
+                                let mut batch = db.new_batch();
+                                for _ in 0u64..operations {
+                                    let v = make_var_value(&mut rng);
+                                    batch = batch.append(v);
+                                    if rng.next_u32() % KEYLESS_COMMIT_FREQ == 0 {
+                                        let merkleized =
+                                            batch.merkleize(&db, None, db.inactivity_floor_loc());
+                                        db.apply_batch(merkleized).await.unwrap();
+                                        batch = db.new_batch();
+                                    }
+                                }
+                                let merkleized =
+                                    batch.merkleize(&db, None, db.inactivity_floor_loc());
+                                db.apply_batch(merkleized).await.unwrap();
+                                db.sync().await.unwrap();
+
+                                total += start.elapsed();
+                                db.destroy().await.unwrap();
+                            });
+                        }
+                        total
+                    });
+                },
+            );
+        }
+    }
 }
 
 criterion_group! {

--- a/storage/src/qmdb/benches/generate.rs
+++ b/storage/src/qmdb/benches/generate.rs
@@ -12,7 +12,7 @@ use commonware_runtime::{
     tokio::{Config, Context},
 };
 use commonware_storage::{
-    merkle::{mmb, mmr, Graftable},
+    merkle::{mmb, mmr, Family, Graftable},
     qmdb::any::traits::DbAny,
 };
 use criterion::{criterion_group, Criterion};
@@ -25,7 +25,7 @@ const COMMITS_PER_ITERATION: u64 = 100;
 
 /// Benchmark a populated database: generate data, prune, sync. Returns elapsed time (excluding
 /// destroy).
-async fn bench_db<F: Graftable, C: DbAny<F, Key = Digest>>(
+async fn bench_db<F: Family, C: DbAny<F, Key = Digest>>(
     mut db: C,
     elements: u64,
     operations: u64,
@@ -135,7 +135,7 @@ fn bench_var_value_generate(c: &mut Criterion) {
 const KEYLESS_OPS: u64 = 10_000;
 const KEYLESS_COMMIT_FREQ: u32 = 25;
 
-fn bench_keyless_generate_family<F: Graftable>(c: &mut Criterion, family: &str) {
+fn bench_keyless_generate_family<F: Family>(c: &mut Criterion, family: &str) {
     let runner = tokio::Runner::new(Config::default());
     for operations in [KEYLESS_OPS, KEYLESS_OPS * 2] {
         c.bench_function(

--- a/storage/src/qmdb/benches/generate.rs
+++ b/storage/src/qmdb/benches/generate.rs
@@ -11,7 +11,10 @@ use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::{Config, Context},
 };
-use commonware_storage::qmdb::any::traits::DbAny;
+use commonware_storage::{
+    merkle::{mmb, mmr, Graftable},
+    qmdb::any::traits::DbAny,
+};
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use std::time::{Duration, Instant};
@@ -22,7 +25,7 @@ const COMMITS_PER_ITERATION: u64 = 100;
 
 /// Benchmark a populated database: generate data, prune, sync. Returns elapsed time (excluding
 /// destroy).
-async fn bench_db<C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest>>(
+async fn bench_db<F: Graftable, C: DbAny<F, Key = Digest>>(
     mut db: C,
     elements: u64,
     operations: u64,
@@ -30,7 +33,7 @@ async fn bench_db<C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest
     make_value: impl Fn(&mut StdRng) -> C::Value,
 ) -> Duration {
     let start = Instant::now();
-    gen_random_kv(
+    gen_random_kv::<F, _>(
         &mut db,
         elements,
         operations,
@@ -45,14 +48,14 @@ async fn bench_db<C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest
     elapsed
 }
 
-fn bench_fixed_value_generate(c: &mut Criterion) {
+fn bench_fixed_value_generate_family<F: Graftable>(c: &mut Criterion, family: &str) {
     let runner = tokio::Runner::new(Config::default());
     for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 10] {
         for operations in [NUM_OPERATIONS, NUM_OPERATIONS * 10] {
             for variant in FIXED_VALUE_VARIANTS {
                 c.bench_function(
                     &format!(
-                        "{}/variant={} elements={elements} operations={operations}",
+                        "{}/variant={} family={family} elements={elements} operations={operations}",
                         module_path!(),
                         variant.name(),
                     ),
@@ -62,8 +65,8 @@ fn bench_fixed_value_generate(c: &mut Criterion) {
                             let commit_freq = (operations / COMMITS_PER_ITERATION) as u32;
                             let mut total = Duration::ZERO;
                             for _ in 0..iters {
-                                total += with_fixed_value_db!(ctx, variant, |mut db| {
-                                    bench_db(
+                                total += with_fixed_value_db!(ctx, F, variant, |mut db| {
+                                    bench_db::<F, _>(
                                         db,
                                         elements,
                                         operations,
@@ -82,14 +85,19 @@ fn bench_fixed_value_generate(c: &mut Criterion) {
     }
 }
 
-fn bench_var_value_generate(c: &mut Criterion) {
+fn bench_fixed_value_generate(c: &mut Criterion) {
+    bench_fixed_value_generate_family::<mmr::Family>(c, "mmr");
+    bench_fixed_value_generate_family::<mmb::Family>(c, "mmb");
+}
+
+fn bench_var_value_generate_family<F: Graftable>(c: &mut Criterion, family: &str) {
     let runner = tokio::Runner::new(Config::default());
     for elements in [NUM_ELEMENTS, NUM_ELEMENTS * 10] {
         for operations in [NUM_OPERATIONS, NUM_OPERATIONS * 10] {
             for variant in VAR_VALUE_VARIANTS {
                 c.bench_function(
                     &format!(
-                        "{}/variant={} elements={elements} operations={operations}",
+                        "{}/variant={} family={family} elements={elements} operations={operations}",
                         module_path!(),
                         variant.name(),
                     ),
@@ -99,9 +107,15 @@ fn bench_var_value_generate(c: &mut Criterion) {
                             let commit_freq = (operations / COMMITS_PER_ITERATION) as u32;
                             let mut total = Duration::ZERO;
                             for _ in 0..iters {
-                                total += with_var_value_db!(ctx, variant, |mut db| {
-                                    bench_db(db, elements, operations, commit_freq, make_var_value)
-                                        .await
+                                total += with_var_value_db!(ctx, F, variant, |mut db| {
+                                    bench_db::<F, _>(
+                                        db,
+                                        elements,
+                                        operations,
+                                        commit_freq,
+                                        make_var_value,
+                                    )
+                                    .await
                                 });
                             }
                             total
@@ -113,14 +127,22 @@ fn bench_var_value_generate(c: &mut Criterion) {
     }
 }
 
+fn bench_var_value_generate(c: &mut Criterion) {
+    bench_var_value_generate_family::<mmr::Family>(c, "mmr");
+    bench_var_value_generate_family::<mmb::Family>(c, "mmb");
+}
+
 const KEYLESS_OPS: u64 = 10_000;
 const KEYLESS_COMMIT_FREQ: u32 = 25;
 
-fn bench_keyless_generate(c: &mut Criterion) {
+fn bench_keyless_generate_family<F: Graftable>(c: &mut Criterion, family: &str) {
     let runner = tokio::Runner::new(Config::default());
     for operations in [KEYLESS_OPS, KEYLESS_OPS * 2] {
         c.bench_function(
-            &format!("{}/variant=keyless operations={operations}", module_path!()),
+            &format!(
+                "{}/variant=keyless family={family} operations={operations}",
+                module_path!()
+            ),
             |b| {
                 b.to_async(&runner).iter_custom(|iters| async move {
                     let ctx = context::get::<Context>();
@@ -128,7 +150,7 @@ fn bench_keyless_generate(c: &mut Criterion) {
                     for _ in 0..iters {
                         let start = Instant::now();
 
-                        let mut db = open_keyless_db(ctx.clone()).await;
+                        let mut db = open_keyless_db::<F>(ctx.clone()).await;
                         let mut rng = StdRng::seed_from_u64(42);
                         let mut batch = db.new_batch();
                         for _ in 0u64..operations {
@@ -153,6 +175,11 @@ fn bench_keyless_generate(c: &mut Criterion) {
             },
         );
     }
+}
+
+fn bench_keyless_generate(c: &mut Criterion) {
+    bench_keyless_generate_family::<mmr::Family>(c, "mmr");
+    bench_keyless_generate_family::<mmb::Family>(c, "mmb");
 }
 
 criterion_group! {

--- a/storage/src/qmdb/benches/init.rs
+++ b/storage/src/qmdb/benches/init.rs
@@ -4,22 +4,16 @@
 //! inside `bench_function` so criterion's name filter can skip them entirely.
 
 use crate::common::{
-    any_fix_cfg, any_var_digest_cfg, any_var_vec_cfg, cur_fix_cfg, cur_var_digest_cfg,
-    cur_var_vec_cfg, gen_random_kv, make_fixed_value, make_var_value, with_fixed_value_db,
-    with_fixed_value_db_cfg, with_var_value_db, with_var_value_db_cfg, Digest,
-    FIXED_VALUE_VARIANTS, VAR_VALUE_VARIANTS,
+    define_fixed_variants, define_vec_variants, gen_random_kv, make_fixed_value, make_var_value,
+    Digest,
 };
 use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::{Config, Context},
     Runner as _,
 };
-use commonware_storage::{
-    merkle::{mmb, mmr, Family, Graftable},
-    qmdb::any::traits::DbAny,
-};
+use commonware_storage::{merkle::Family, qmdb::any::traits::DbAny};
 use criterion::{criterion_group, Criterion};
-use std::time::Instant;
 
 const NUM_ELEMENTS: u64 = 100_000;
 const NUM_OPERATIONS: u64 = 1_000_000;
@@ -47,16 +41,25 @@ async fn populate_and_sync<F: Family, C: DbAny<F, Key = Digest>>(
     db.sync().await.unwrap();
 }
 
-fn bench_fixed_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) {
+// -- Fixed-value variants (16 = 8 db shapes x 2 merkle families) --
+
+define_fixed_variants! {
+    enum FixedVariant;
+    const FIXED_VARIANTS;
+    dispatch dispatch_fixed;
+    timed_dispatch dispatch_fixed_timed_init;
+}
+
+fn bench_fixed_value_init(c: &mut Criterion) {
     let cfg = Config::default();
     for elements in ELEMENTS {
         for operations in OPERATIONS {
-            for variant in FIXED_VALUE_VARIANTS {
+            for &variant in FIXED_VARIANTS {
                 let mut initialized = false;
                 let runner = tokio::Runner::new(cfg.clone());
                 c.bench_function(
                     &format!(
-                        "{}/variant={} family={family} elements={elements} operations={operations}",
+                        "{}/variant={} elements={elements} operations={operations}",
                         module_path!(),
                         variant.name(),
                     ),
@@ -65,8 +68,8 @@ fn bench_fixed_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) 
                         if !initialized {
                             commonware_runtime::tokio::Runner::new(cfg.clone()).start(
                                 |ctx| async move {
-                                    with_fixed_value_db!(ctx, F, variant, |mut db| {
-                                        populate_and_sync::<F, _>(
+                                    dispatch_fixed!(ctx, variant, |db| {
+                                        populate_and_sync(
                                             &mut db,
                                             elements,
                                             operations,
@@ -82,26 +85,9 @@ fn bench_fixed_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) 
                         // Benchmark: measure init time.
                         b.to_async(&runner).iter_custom(|iters| async move {
                             let ctx = context::get::<Context>();
-                            let af = any_fix_cfg(&ctx);
-                            let cf = cur_fix_cfg(&ctx);
-                            let av = any_var_digest_cfg(&ctx);
-                            let cv = cur_var_digest_cfg(&ctx);
-                            let start = Instant::now();
-                            for _ in 0..iters {
-                                with_fixed_value_db_cfg!(
-                                    ctx,
-                                    F,
-                                    variant,
-                                    af,
-                                    cf,
-                                    av,
-                                    cv,
-                                    |mut db| {
-                                        assert_ne!(db.bounds().await.end, 0);
-                                    }
-                                );
-                            }
-                            start.elapsed()
+                            dispatch_fixed_timed_init!(ctx, variant, iters, |db| {
+                                assert_ne!(db.bounds().await.end, 0);
+                            })
                         });
                     },
                 );
@@ -109,7 +95,7 @@ fn bench_fixed_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) 
                 // Cleanup: destroy database.
                 if initialized {
                     commonware_runtime::tokio::Runner::new(cfg.clone()).start(|ctx| async move {
-                        with_fixed_value_db!(ctx, F, variant, |mut db| {
+                        dispatch_fixed!(ctx, variant, |db| {
                             db.destroy().await.unwrap();
                         });
                     });
@@ -119,21 +105,25 @@ fn bench_fixed_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) 
     }
 }
 
-fn bench_fixed_value_init(c: &mut Criterion) {
-    bench_fixed_value_init_family::<mmr::Family>(c, "mmr");
-    bench_fixed_value_init_family::<mmb::Family>(c, "mmb");
+// -- Variable-value variants (8 = 4 db shapes x 2 merkle families) --
+
+define_vec_variants! {
+    enum VarVariant;
+    const VEC_VARIANTS;
+    dispatch dispatch_var;
+    timed_dispatch dispatch_var_timed_init;
 }
 
-fn bench_var_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) {
+fn bench_var_value_init(c: &mut Criterion) {
     let cfg = Config::default();
     for elements in ELEMENTS {
         for operations in OPERATIONS {
-            for variant in VAR_VALUE_VARIANTS {
+            for &variant in VEC_VARIANTS {
                 let mut initialized = false;
                 let runner = tokio::Runner::new(cfg.clone());
                 c.bench_function(
                     &format!(
-                        "{}/variant={} family={family} elements={elements} operations={operations}",
+                        "{}/variant={} elements={elements} operations={operations}",
                         module_path!(),
                         variant.name(),
                     ),
@@ -142,8 +132,8 @@ fn bench_var_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) {
                         if !initialized {
                             commonware_runtime::tokio::Runner::new(cfg.clone()).start(
                                 |ctx| async move {
-                                    with_var_value_db!(ctx, F, variant, |mut db| {
-                                        populate_and_sync::<F, _>(
+                                    dispatch_var!(ctx, variant, |db| {
+                                        populate_and_sync(
                                             &mut db,
                                             elements,
                                             operations,
@@ -159,15 +149,9 @@ fn bench_var_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) {
                         // Benchmark: measure init time.
                         b.to_async(&runner).iter_custom(|iters| async move {
                             let ctx = context::get::<Context>();
-                            let av = any_var_vec_cfg(&ctx);
-                            let cv = cur_var_vec_cfg(&ctx);
-                            let start = Instant::now();
-                            for _ in 0..iters {
-                                with_var_value_db_cfg!(ctx, F, variant, av, cv, |mut db| {
-                                    assert_ne!(db.bounds().await.end, 0);
-                                });
-                            }
-                            start.elapsed()
+                            dispatch_var_timed_init!(ctx, variant, iters, |db| {
+                                assert_ne!(db.bounds().await.end, 0);
+                            })
                         });
                     },
                 );
@@ -175,7 +159,7 @@ fn bench_var_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) {
                 // Cleanup: destroy database.
                 if initialized {
                     commonware_runtime::tokio::Runner::new(cfg.clone()).start(|ctx| async move {
-                        with_var_value_db!(ctx, F, variant, |mut db| {
+                        dispatch_var!(ctx, variant, |db| {
                             db.destroy().await.unwrap();
                         });
                     });
@@ -183,11 +167,6 @@ fn bench_var_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) {
             }
         }
     }
-}
-
-fn bench_var_value_init(c: &mut Criterion) {
-    bench_var_value_init_family::<mmr::Family>(c, "mmr");
-    bench_var_value_init_family::<mmb::Family>(c, "mmb");
 }
 
 criterion_group! {

--- a/storage/src/qmdb/benches/init.rs
+++ b/storage/src/qmdb/benches/init.rs
@@ -14,7 +14,10 @@ use commonware_runtime::{
     tokio::{Config, Context},
     Runner as _,
 };
-use commonware_storage::qmdb::any::traits::DbAny;
+use commonware_storage::{
+    merkle::{mmb, mmr, Graftable},
+    qmdb::any::traits::DbAny,
+};
 use criterion::{criterion_group, Criterion};
 use std::time::Instant;
 
@@ -33,18 +36,18 @@ cfg_if::cfg_if! {
 }
 
 /// Populate, prune, and sync a database (used in setup phase).
-async fn populate_and_sync<C: DbAny<commonware_storage::merkle::mmr::Family, Key = Digest>>(
+async fn populate_and_sync<F: Graftable, C: DbAny<F, Key = Digest>>(
     db: &mut C,
     elements: u64,
     operations: u64,
     make_value: impl Fn(&mut rand::rngs::StdRng) -> C::Value,
 ) {
-    gen_random_kv(db, elements, operations, Some(COMMIT_FREQUENCY), make_value).await;
+    gen_random_kv::<F, _>(db, elements, operations, Some(COMMIT_FREQUENCY), make_value).await;
     db.prune(db.sync_boundary().await).await.unwrap();
     db.sync().await.unwrap();
 }
 
-fn bench_fixed_value_init(c: &mut Criterion) {
+fn bench_fixed_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) {
     let cfg = Config::default();
     for elements in ELEMENTS {
         for operations in OPERATIONS {
@@ -53,7 +56,7 @@ fn bench_fixed_value_init(c: &mut Criterion) {
                 let runner = tokio::Runner::new(cfg.clone());
                 c.bench_function(
                     &format!(
-                        "{}/variant={} elements={elements} operations={operations}",
+                        "{}/variant={} family={family} elements={elements} operations={operations}",
                         module_path!(),
                         variant.name(),
                     ),
@@ -62,8 +65,8 @@ fn bench_fixed_value_init(c: &mut Criterion) {
                         if !initialized {
                             commonware_runtime::tokio::Runner::new(cfg.clone()).start(
                                 |ctx| async move {
-                                    with_fixed_value_db!(ctx, variant, |mut db| {
-                                        populate_and_sync(
+                                    with_fixed_value_db!(ctx, F, variant, |mut db| {
+                                        populate_and_sync::<F, _>(
                                             &mut db,
                                             elements,
                                             operations,
@@ -85,9 +88,18 @@ fn bench_fixed_value_init(c: &mut Criterion) {
                             let cv = cur_var_digest_cfg(&ctx);
                             let start = Instant::now();
                             for _ in 0..iters {
-                                with_fixed_value_db_cfg!(ctx, variant, af, cf, av, cv, |mut db| {
-                                    assert_ne!(db.bounds().await.end, 0);
-                                });
+                                with_fixed_value_db_cfg!(
+                                    ctx,
+                                    F,
+                                    variant,
+                                    af,
+                                    cf,
+                                    av,
+                                    cv,
+                                    |mut db| {
+                                        assert_ne!(db.bounds().await.end, 0);
+                                    }
+                                );
                             }
                             start.elapsed()
                         });
@@ -97,7 +109,7 @@ fn bench_fixed_value_init(c: &mut Criterion) {
                 // Cleanup: destroy database.
                 if initialized {
                     commonware_runtime::tokio::Runner::new(cfg.clone()).start(|ctx| async move {
-                        with_fixed_value_db!(ctx, variant, |mut db| {
+                        with_fixed_value_db!(ctx, F, variant, |mut db| {
                             db.destroy().await.unwrap();
                         });
                     });
@@ -107,7 +119,12 @@ fn bench_fixed_value_init(c: &mut Criterion) {
     }
 }
 
-fn bench_var_value_init(c: &mut Criterion) {
+fn bench_fixed_value_init(c: &mut Criterion) {
+    bench_fixed_value_init_family::<mmr::Family>(c, "mmr");
+    bench_fixed_value_init_family::<mmb::Family>(c, "mmb");
+}
+
+fn bench_var_value_init_family<F: Graftable>(c: &mut Criterion, family: &str) {
     let cfg = Config::default();
     for elements in ELEMENTS {
         for operations in OPERATIONS {
@@ -116,7 +133,7 @@ fn bench_var_value_init(c: &mut Criterion) {
                 let runner = tokio::Runner::new(cfg.clone());
                 c.bench_function(
                     &format!(
-                        "{}/variant={} elements={elements} operations={operations}",
+                        "{}/variant={} family={family} elements={elements} operations={operations}",
                         module_path!(),
                         variant.name(),
                     ),
@@ -125,8 +142,8 @@ fn bench_var_value_init(c: &mut Criterion) {
                         if !initialized {
                             commonware_runtime::tokio::Runner::new(cfg.clone()).start(
                                 |ctx| async move {
-                                    with_var_value_db!(ctx, variant, |mut db| {
-                                        populate_and_sync(
+                                    with_var_value_db!(ctx, F, variant, |mut db| {
+                                        populate_and_sync::<F, _>(
                                             &mut db,
                                             elements,
                                             operations,
@@ -146,7 +163,7 @@ fn bench_var_value_init(c: &mut Criterion) {
                             let cv = cur_var_vec_cfg(&ctx);
                             let start = Instant::now();
                             for _ in 0..iters {
-                                with_var_value_db_cfg!(ctx, variant, av, cv, |mut db| {
+                                with_var_value_db_cfg!(ctx, F, variant, av, cv, |mut db| {
                                     assert_ne!(db.bounds().await.end, 0);
                                 });
                             }
@@ -158,7 +175,7 @@ fn bench_var_value_init(c: &mut Criterion) {
                 // Cleanup: destroy database.
                 if initialized {
                     commonware_runtime::tokio::Runner::new(cfg.clone()).start(|ctx| async move {
-                        with_var_value_db!(ctx, variant, |mut db| {
+                        with_var_value_db!(ctx, F, variant, |mut db| {
                             db.destroy().await.unwrap();
                         });
                     });
@@ -166,6 +183,11 @@ fn bench_var_value_init(c: &mut Criterion) {
             }
         }
     }
+}
+
+fn bench_var_value_init(c: &mut Criterion) {
+    bench_var_value_init_family::<mmr::Family>(c, "mmr");
+    bench_var_value_init_family::<mmb::Family>(c, "mmb");
 }
 
 criterion_group! {

--- a/storage/src/qmdb/benches/init.rs
+++ b/storage/src/qmdb/benches/init.rs
@@ -15,7 +15,7 @@ use commonware_runtime::{
     Runner as _,
 };
 use commonware_storage::{
-    merkle::{mmb, mmr, Graftable},
+    merkle::{mmb, mmr, Family, Graftable},
     qmdb::any::traits::DbAny,
 };
 use criterion::{criterion_group, Criterion};
@@ -36,7 +36,7 @@ cfg_if::cfg_if! {
 }
 
 /// Populate, prune, and sync a database (used in setup phase).
-async fn populate_and_sync<F: Graftable, C: DbAny<F, Key = Digest>>(
+async fn populate_and_sync<F: Family, C: DbAny<F, Key = Digest>>(
     db: &mut C,
     elements: u64,
     operations: u64,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -242,8 +242,8 @@ use crate::{
         authenticated::Inner,
         contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     },
-    merkle::{self, Location},
-    mmr::{journaled::Config as MmrConfig, StandardHasher},
+    merkle::{self, journaled::Config as MerkleConfig, Location},
+    mmr::StandardHasher,
     qmdb::{
         any::{
             self,
@@ -273,7 +273,7 @@ pub mod unordered;
 #[derive(Clone)]
 pub struct Config<T: Translator, J> {
     /// Configuration for the Merkle structure backing the authenticated journal.
-    pub merkle_config: MmrConfig,
+    pub merkle_config: MerkleConfig,
 
     /// Configuration for the operations log journal.
     pub journal_config: J,
@@ -406,7 +406,7 @@ pub mod tests {
     //! Shared test utilities for Current QMDB variants.
 
     pub use super::BitmapPrunedBits;
-    use super::{ordered, unordered, FConfig, FixedConfig, MmrConfig, VConfig, VariableConfig};
+    use super::{ordered, unordered, FConfig, FixedConfig, MerkleConfig, VConfig, VariableConfig};
     use crate::{
         merkle::{self, mmb, mmr},
         qmdb::{
@@ -447,7 +447,7 @@ pub mod tests {
     ) -> FixedConfig<T> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            merkle_config: MmrConfig {
+            merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
                 items_per_blob: NZU64!(11),
@@ -473,7 +473,7 @@ pub mod tests {
     ) -> VariableConfig<T, ((), ())> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            merkle_config: MmrConfig {
+            merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
                 items_per_blob: NZU64!(11),

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -59,7 +59,7 @@ impl<
 mod tests {
     use super::*;
     use crate::{
-        merkle::{journaled::Config as MmrConfig, mmb, mmr},
+        merkle::{journaled::Config as MerkleConfig, mmb, mmr},
         qmdb::immutable::test,
         translator::TwoCap,
     };
@@ -76,7 +76,7 @@ mod tests {
     fn config(suffix: &str, pooler: &impl BufferPooler) -> Config<TwoCap> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         Config {
-            merkle_config: MmrConfig {
+            merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),
                 items_per_blob: NZU64!(11),

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -84,7 +84,7 @@ use crate::{
         contiguous::{Contiguous, Mutable, Reader},
         Error as JournalError,
     },
-    merkle::{journaled::Config as MmrConfig, Family, Location, Proof},
+    merkle::{journaled::Config as MerkleConfig, Family, Location, Proof},
     qmdb::{
         any::ValueEncoding,
         build_snapshot_from_log,
@@ -111,7 +111,7 @@ pub use operation::Operation;
 #[derive(Clone)]
 pub struct Config<T: Translator, J> {
     /// Configuration for the Merkle structure backing the authenticated journal.
-    pub merkle_config: MmrConfig,
+    pub merkle_config: MerkleConfig,
 
     /// Configuration for the operations log journal.
     pub log: J,

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -64,7 +64,7 @@ mod tests {
     use super::*;
     use crate::{
         journal::contiguous::variable::Config as JournalConfig,
-        merkle::{journaled::Config as MmrConfig, mmb, mmr},
+        merkle::{journaled::Config as MerkleConfig, mmb, mmr},
         qmdb::immutable::test,
         translator::TwoCap,
     };
@@ -81,7 +81,7 @@ mod tests {
     fn config(suffix: &str, pooler: &impl BufferPooler) -> Config<TwoCap, ((), ())> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         super::BaseConfig {
-            merkle_config: MmrConfig {
+            merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),
                 items_per_blob: NZU64!(11),


### PR DESCRIPTION
- generalized qmdb benchmarks to run over variants that include both merkle families
- tweaked the name of the variants that use variable vector values to avoid confusion with the variants that use fixed values with a variable-capable database (`variable-vec` vs plan `variable`)