### PR TITLE
Increase Curve25519 backend opt level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,3 +194,6 @@ debug = true
 # Although overflow checks are enabled by default in "test", we explicitly
 # enable them here for clarity.
 overflow-checks = true
+
+[profile.test.package.curve25519-dalek]
+opt-level = 3


### PR DESCRIPTION
This seems to have been the culprit for the slow tests.