### PR TITLE
[Storage] Use bitmap for merkleization in `qmdb::any`

### DIFF
--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -103,10 +103,9 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 translator: EightCap,
             };
 
-            let mut db: GenericDb<F> =
-                commonware_storage::qmdb::any::init(context.clone(), cfg, None, |_, _| {})
-                    .await
-                    .expect("init qmdb");
+            let mut db: GenericDb<F> = commonware_storage::qmdb::any::init(context.clone(), cfg)
+                .await
+                .expect("init qmdb");
             let mut last_commit = None;
             let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
 

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -132,7 +132,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             };
 
             let mut db: GenericDb<F> =
-                commonware_storage::qmdb::any::init(context.clone(), cfg, None, |_, _| {})
+                commonware_storage::qmdb::any::init(context.clone(), cfg)
                     .await
                     .expect("init qmdb");
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -107,7 +107,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             };
 
             let mut db: GenericDb<F> =
-                commonware_storage::qmdb::any::init(context.clone(), cfg, None, |_, _| {})
+                commonware_storage::qmdb::any::init(context.clone(), cfg)
                     .await
                     .expect("init qmdb");
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -14,7 +14,7 @@ use crate::{
             ordered::{find_next_key, find_prev_key},
             ValueEncoding,
         },
-        bitmap::{BitmapReadable, Shared},
+        bitmap::Shared,
         delete_known_loc,
         operation::{Key, Operation as OperationTrait},
         update_known_loc,
@@ -23,7 +23,7 @@ use crate::{
 };
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
-use commonware_utils::bitmap::Prunable;
+use commonware_utils::bitmap;
 use core::{iter, ops::Range};
 use futures::future::try_join_all;
 use std::{
@@ -285,9 +285,11 @@ where
     None
 }
 
-/// Apply a single diff entry to the snapshot index.
-fn apply_snapshot_diff<F: Family, V, I: UnorderedIndex<Value = Location<F>>>(
+/// Apply a single diff entry to the snapshot index and activity bitmap in lockstep:
+/// install the winning `Active` location and clear the prior committed location.
+fn apply_diff<F: Family, V, I: UnorderedIndex<Value = Location<F>>, const N: usize>(
     snapshot: &mut I,
+    bitmap: &mut bitmap::Prunable<N>,
     key: &impl Key,
     entry: &DiffEntry<F, V>,
     base_old_loc: Option<Location<F>>,
@@ -303,24 +305,7 @@ fn apply_snapshot_diff<F: Family, V, I: UnorderedIndex<Value = Location<F>>>(
             }
         }
     }
-}
-
-/// Mirror a single diff transition into the activity bitmap: set the
-/// winning Active location to 1 (if present), clear the prior committed
-/// location to 0 (if present).
-fn apply_bitmap_diff<F: Family, V, const N: usize>(
-    bitmap: &mut Prunable<N>,
-    entry: &DiffEntry<F, V>,
-    base_old_loc: Option<Location<F>>,
-) {
-    let new_loc = entry.loc();
-    if let (Some(new), Some(old)) = (new_loc, base_old_loc) {
-        debug_assert_ne!(
-            new, old,
-            "same location cannot be both active and superseded",
-        );
-    }
-    if let Some(loc) = new_loc {
+    if let Some(loc) = entry.loc() {
         bitmap.set_bit(*loc, true);
     }
     if let Some(loc) = base_old_loc {
@@ -342,7 +327,7 @@ fn next_candidate<F: Family, const N: usize>(
     tip: u64,
 ) -> Option<Location<F>> {
     let floor = *floor;
-    let bitmap_len = BitmapReadable::<N>::len(bitmap);
+    let bitmap_len = bitmap::Readable::<N>::len(bitmap);
     let committed_end = bitmap_len.min(tip);
     if floor < committed_end {
         if let Some(idx) = bitmap.next_one_from(floor) {
@@ -655,6 +640,10 @@ where
                     let Some(key) = op.key().cloned() else {
                         continue; // skip CommitFloor and other non-keyed ops
                     };
+                    // `is_active_at` is required even for set bits in the committed bitmap
+                    // range: this batch's own diff or an uncommitted ancestor diff may
+                    // supersede the committed location, and neither source is reflected in
+                    // the bitmap.
                     if !self.is_active_at(&key, candidate, &diff, db) {
                         continue;
                     }
@@ -1612,8 +1601,7 @@ where
                     .get(key)
                     .copied()
                     .unwrap_or_else(|| entry.base_old_loc());
-                apply_snapshot_diff(&mut self.snapshot, key, entry, base_old_loc);
-                apply_bitmap_diff(&mut bitmap, entry, base_old_loc);
+                apply_diff(&mut self.snapshot, &mut bitmap, key, entry, base_old_loc);
             }
 
             // Apply uncommitted ancestor diffs (skip committed batches, skip seen keys).
@@ -1627,8 +1615,7 @@ where
                             .get(key)
                             .copied()
                             .unwrap_or_else(|| entry.base_old_loc());
-                        apply_snapshot_diff(&mut self.snapshot, key, entry, base_old_loc);
-                        apply_bitmap_diff(&mut bitmap, entry, base_old_loc);
+                        apply_diff(&mut self.snapshot, &mut bitmap, key, entry, base_old_loc);
                     } else if let Some(loc) = entry.loc() {
                         debug_assert!(
                             !bitmap.get_bit(*loc),
@@ -1856,7 +1843,7 @@ mod tests {
     use commonware_cryptography::{sha256, Sha256};
     use commonware_runtime::{deterministic, Runner as _};
 
-    const BITMAP_CHUNK_BITS: u64 = Prunable::<BITMAP_CHUNK_BYTES>::CHUNK_SIZE_BITS;
+    const BITMAP_CHUNK_BITS: u64 = bitmap::Prunable::<BITMAP_CHUNK_BYTES>::CHUNK_SIZE_BITS;
 
     fn loc(n: u64) -> Location<mmr::Family> {
         Location::new(n)
@@ -1864,9 +1851,9 @@ mod tests {
 
     fn shared_with<F>(build: F) -> Shared<BITMAP_CHUNK_BYTES>
     where
-        F: FnOnce(&mut Prunable<BITMAP_CHUNK_BYTES>),
+        F: FnOnce(&mut bitmap::Prunable<BITMAP_CHUNK_BYTES>),
     {
-        let mut bm = Prunable::<BITMAP_CHUNK_BYTES>::new();
+        let mut bm = bitmap::Prunable::<BITMAP_CHUNK_BYTES>::new();
         build(&mut bm);
         Shared::new(bm)
     }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -14,6 +14,7 @@ use crate::{
             ordered::{find_next_key, find_prev_key},
             ValueEncoding,
         },
+        bitmap::{BitmapReadable, Shared},
         delete_known_loc,
         operation::{Key, Operation as OperationTrait},
         update_known_loc,
@@ -22,6 +23,7 @@ use crate::{
 };
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
+use commonware_utils::bitmap::Prunable;
 use core::{iter, ops::Range};
 use futures::future::try_join_all;
 use std::{
@@ -39,27 +41,6 @@ type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 /// Sorted `(key, (value, loc))` vec consulted by `find_prev_key` to find the predecessor
 /// of a given key during ordered merkleization.
 type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
-
-/// Strategy for finding the next active location during floor raising.
-pub(crate) trait FloorScan<F: Family> {
-    /// Return the next location at or after `floor` that might be active,
-    /// below `tip`. Returns `None` if no candidate exists in `[floor, tip)`.
-    fn next_candidate(&mut self, floor: Location<F>, tip: u64) -> Option<Location<F>>;
-}
-
-/// Sequential scan: every location is a candidate.
-// TODO(#1829): Always use bitmap for floor raising.
-pub(crate) struct SequentialScan;
-
-impl<F: Family> FloorScan<F> for SequentialScan {
-    fn next_candidate(&mut self, floor: Location<F>, tip: u64) -> Option<Location<F>> {
-        if *floor < tip {
-            Some(floor)
-        } else {
-            None
-        }
-    }
-}
 
 /// What happened to a key in this batch.
 #[derive(Clone)]
@@ -324,6 +305,56 @@ fn apply_snapshot_diff<F: Family, V, I: UnorderedIndex<Value = Location<F>>>(
     }
 }
 
+/// Mirror a single diff transition into the activity bitmap: set the
+/// winning Active location to 1 (if present), clear the prior committed
+/// location to 0 (if present).
+fn apply_bitmap_diff<F: Family, V, const N: usize>(
+    bitmap: &mut Prunable<N>,
+    entry: &DiffEntry<F, V>,
+    base_old_loc: Option<Location<F>>,
+) {
+    let new_loc = entry.loc();
+    if let (Some(new), Some(old)) = (new_loc, base_old_loc) {
+        debug_assert_ne!(
+            new, old,
+            "same location cannot be both active and superseded",
+        );
+    }
+    if let Some(loc) = new_loc {
+        bitmap.set_bit(*loc, true);
+    }
+    if let Some(loc) = base_old_loc {
+        bitmap.set_bit(*loc, false);
+    }
+}
+
+/// Return the next floor-raise candidate in `[floor, tip)`.
+///
+/// The committed prefix is indexed by `bitmap`, so unset bits can be skipped without reading
+/// their operations. Locations beyond the bitmap's length are uncommitted ancestor operations
+/// and remain sequential candidates.
+///
+/// `current::batch::next_candidate` mirrors this contract over a layered `BitmapBatch` chain;
+/// both must obey it.
+fn next_candidate<F: Family, const N: usize>(
+    bitmap: &Shared<N>,
+    floor: Location<F>,
+    tip: u64,
+) -> Option<Location<F>> {
+    let floor = *floor;
+    let bitmap_len = BitmapReadable::<N>::len(bitmap);
+    let committed_end = bitmap_len.min(tip);
+    if floor < committed_end {
+        if let Some(idx) = bitmap.next_one_from(floor) {
+            if idx < committed_end {
+                return Some(Location::new(idx));
+            }
+        }
+    }
+    let candidate = floor.max(bitmap_len);
+    (candidate < tip).then(|| Location::new(candidate))
+}
+
 /// Resolve `loc` to an op within the in-memory ancestor region
 /// `[db_size, ancestors[0].journal_batch.size())`, walked parent-first.
 ///
@@ -469,10 +500,10 @@ where
     /// bucket for collision siblings (other keys sharing the same translated-key bucket). The
     /// ordered path needs these so their `next_key` pointers are rewritten when a sibling is
     /// deleted; the unordered path can skip them.
-    fn gather_existing_locations<E, C, I>(
+    fn gather_existing_locations<E, C, I, const N: usize>(
         &self,
         mutations: &BTreeMap<U::Key, Option<U::Value>>,
-        db: &Db<F, E, C, I, H, U>,
+        db: &Db<F, E, C, I, H, U, N>,
         include_active_collision_siblings: bool,
     ) -> Vec<Location<F>>
     where
@@ -518,12 +549,12 @@ where
     }
 
     /// Check if the operation at `loc` for `key` is still active.
-    fn is_active_at<E, C, I>(
+    fn is_active_at<E, C, I, const N: usize>(
         &self,
         key: &U::Key,
         loc: Location<F>,
         batch_diff: &DiffSlice<U::Key, F, U::Value>,
-        db: &Db<F, E, C, I, H, U>,
+        db: &Db<F, E, C, I, H, U, N>,
     ) -> bool
     where
         E: Context,
@@ -566,22 +597,21 @@ where
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
-    async fn finish<E, C, I, S, R>(
+    async fn finish<E, C, I, R, const N: usize>(
         self,
         mut ops: Vec<Operation<F, U>>,
         mut diff: DiffVec<U::Key, F, U::Value>,
         active_keys_delta: isize,
         user_steps: u64,
         metadata: Option<U::Value>,
-        mut scan: S,
+        mut next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
         reader: R,
-        db: &Db<F, E, C, I, H, U>,
+        db: &Db<F, E, C, I, H, U, N>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U>>, crate::qmdb::Error<F>>
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>>,
-        S: FloorScan<F>,
         R: Reader<Item = Operation<F, U>>,
     {
         // Floor raise.
@@ -605,7 +635,7 @@ where
                 let limit = ((total_steps - moved) as usize).min(MAX_CONCURRENT_READS as usize);
                 let mut candidates = Vec::with_capacity(limit);
                 while candidates.len() < limit {
-                    let Some(candidate) = scan.next_candidate(scan_from, fixed_tip) else {
+                    let Some(candidate) = next_candidate(scan_from, fixed_tip) else {
                         break;
                     };
                     candidates.push(candidate);
@@ -764,10 +794,10 @@ where
     Operation<F, U>: Codec,
 {
     /// Read through: mutations -> ancestor diffs -> committed DB.
-    pub async fn get<E, C, I>(
+    pub async fn get<E, C, I, const N: usize>(
         &self,
         key: &U::Key,
-        db: &Db<F, E, C, I, H, U>,
+        db: &Db<F, E, C, I, H, U, N>,
     ) -> Result<Option<U::Value>, crate::qmdb::Error<F>>
     where
         E: Context,
@@ -793,10 +823,10 @@ where
     /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
-    pub async fn get_many<E, C, I>(
+    pub async fn get_many<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
-        db: &Db<F, E, C, I, H, U>,
+        db: &Db<F, E, C, I, H, U, N>,
     ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>>
     where
         E: Context,
@@ -866,9 +896,9 @@ where
     Operation<F, update::Unordered<K, V>>: Codec,
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
-    pub async fn merkleize<E, C, I>(
+    pub async fn merkleize<E, C, I, const N: usize>(
         self,
-        db: &Db<F, E, C, I, H, update::Unordered<K, V>>,
+        db: &Db<F, E, C, I, H, update::Unordered<K, V>, N>,
         metadata: Option<V::Value>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>>>, crate::qmdb::Error<F>>
     where
@@ -876,17 +906,23 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(db, metadata, SequentialScan)
-            .await
+        self.merkleize_with_floor_scan(db, metadata, |floor, tip| {
+            next_candidate(&db.bitmap, floor, tip)
+        })
+        .await
     }
 
-    /// Like [`merkleize`](Self::merkleize) but accepts a custom [`FloorScan`]
-    /// to accelerate floor raising.
-    pub(crate) async fn merkleize_with_floor_scan<E, C, I, S: FloorScan<F>>(
+    /// Like [`merkleize`](Self::merkleize), but accepts the floor-raise candidate source.
+    ///
+    /// The callback may skip locations only when it knows they are inactive. The floor-raise
+    /// loop revalidates each returned candidate via `is_active_at` because the bitmap reflects
+    /// committed state only — uncommitted ancestor ops aren't tracked, and bits can be set for
+    /// locations superseded by an overlay in this chain.
+    pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
-        db: &Db<F, E, C, I, H, update::Unordered<K, V>>,
+        db: &Db<F, E, C, I, H, update::Unordered<K, V>, N>,
         metadata: Option<V::Value>,
-        scan: S,
+        next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>>>, crate::qmdb::Error<F>>
     where
         E: Context,
@@ -1005,7 +1041,7 @@ where
             active_keys_delta,
             user_steps,
             metadata,
-            scan,
+            next_candidate,
             reader,
             db,
         )
@@ -1022,9 +1058,9 @@ where
     Operation<F, update::Ordered<K, V>>: Codec,
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
-    pub async fn merkleize<E, C, I>(
+    pub async fn merkleize<E, C, I, const N: usize>(
         self,
-        db: &Db<F, E, C, I, H, update::Ordered<K, V>>,
+        db: &Db<F, E, C, I, H, update::Ordered<K, V>, N>,
         metadata: Option<V::Value>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Ordered<K, V>>>, crate::qmdb::Error<F>>
     where
@@ -1032,17 +1068,23 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(db, metadata, SequentialScan)
-            .await
+        self.merkleize_with_floor_scan(db, metadata, |floor, tip| {
+            next_candidate(&db.bitmap, floor, tip)
+        })
+        .await
     }
 
-    /// Like [`merkleize`](Self::merkleize) but accepts a custom [`FloorScan`]
-    /// to accelerate floor raising.
-    pub(crate) async fn merkleize_with_floor_scan<E, C, I, S: FloorScan<F>>(
+    /// Like [`merkleize`](Self::merkleize), but accepts the floor-raise candidate source.
+    ///
+    /// The callback may skip locations only when it knows they are inactive. The floor-raise
+    /// loop revalidates each returned candidate via `is_active_at` because the bitmap reflects
+    /// committed state only — uncommitted ancestor ops aren't tracked, and bits can be set for
+    /// locations superseded by an overlay in this chain.
+    pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
-        db: &Db<F, E, C, I, H, update::Ordered<K, V>>,
+        db: &Db<F, E, C, I, H, update::Ordered<K, V>, N>,
         metadata: Option<V::Value>,
-        scan: S,
+        next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Ordered<K, V>>>, crate::qmdb::Error<F>>
     where
         E: Context,
@@ -1342,7 +1384,7 @@ where
             active_keys_delta,
             user_steps,
             metadata,
-            scan,
+            next_candidate,
             reader,
             db,
         )
@@ -1392,10 +1434,10 @@ where
     }
 
     /// Read through: local diff -> parent chain -> committed DB.
-    pub async fn get<E, C, I, H>(
+    pub async fn get<E, C, I, H, const N: usize>(
         &self,
         key: &U::Key,
-        db: &Db<F, E, C, I, H, U>,
+        db: &Db<F, E, C, I, H, U, N>,
     ) -> Result<Option<U::Value>, crate::qmdb::Error<F>>
     where
         E: Context,
@@ -1419,10 +1461,10 @@ where
     /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys.
-    pub async fn get_many<E, C, I, H>(
+    pub async fn get_many<E, C, I, H, const N: usize>(
         &self,
         keys: &[&U::Key],
-        db: &Db<F, E, C, I, H, U>,
+        db: &Db<F, E, C, I, H, U, N>,
     ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>>
     where
         E: Context,
@@ -1476,7 +1518,7 @@ where
     }
 }
 
-impl<F, E, C, I, H, U> Db<F, E, C, I, H, U>
+impl<F, E, C, I, H, U, const N: usize> Db<F, E, C, I, H, U, N>
 where
     F: Family,
     E: Context,
@@ -1502,7 +1544,7 @@ where
     }
 }
 
-impl<F, E, C, I, H, U> Db<F, E, C, I, H, U>
+impl<F, E, C, I, H, U, const N: usize> Db<F, E, C, I, H, U, N>
 where
     F: Family,
     E: Context,
@@ -1540,12 +1582,12 @@ where
         }
         let start_loc = Location::new(db_size);
 
-        // 1. Apply journal (handles its own partial ancestor skipping).
+        // Apply journal (handles its own partial ancestor skipping).
         self.log.apply_batch(&batch.journal_batch).await?;
 
-        // 2. Build committed_locs: for each key in a committed ancestor batch, record the nearest
-        //    (to child) committed ancestor's final state. Some(loc) = Active at loc, None =
-        //    Deleted. It's safe to use a hashmap here since we don't rely on iteration order.
+        // Build committed_locs: for each key in a committed ancestor batch, record the nearest
+        // (to child) committed ancestor's final state. Some(loc) = Active at loc, None =
+        // Deleted. It's safe to use a hashmap here since we don't rely on iteration order.
         let mut committed_locs: HashMap<&U::Key, Option<Location<F>>> = HashMap::new();
         for (i, ancestor_diff) in batch.ancestor_diffs.iter().enumerate() {
             if batch.ancestor_diff_ends[i] <= db_size {
@@ -1556,47 +1598,64 @@ where
             }
         }
 
-        // 3. Apply child's diff (child wins via seen set). Safe to use a HashSet here since we
-        //    don't rely on iteration order.
-        let mut seen = HashSet::<&U::Key>::new();
-        for (key, entry) in batch.diff.iter() {
-            seen.insert(key);
-            let base_old_loc = committed_locs
-                .get(key)
-                .copied()
-                .unwrap_or_else(|| entry.base_old_loc());
-            apply_snapshot_diff(&mut self.snapshot, key, entry, base_old_loc);
-        }
+        // Apply diffs to snapshot and bitmap under one write lock (sync, no await).
+        {
+            let mut bitmap = self.bitmap.write();
+            bitmap.extend_to(*batch.new_last_commit_loc + 1);
 
-        // 4. Apply uncommitted ancestor diffs (skip committed batches, skip seen keys).
-        for (i, ancestor_diff) in batch.ancestor_diffs.iter().enumerate() {
-            if batch.ancestor_diff_ends[i] <= db_size {
-                continue;
-            }
-            for (key, entry) in ancestor_diff.iter() {
-                if !seen.insert(key) {
-                    continue;
-                }
+            // Apply child's diff (child wins via seen set). Safe to use a HashSet here since we
+            // don't rely on iteration order.
+            let mut seen = HashSet::<&U::Key>::new();
+            for (key, entry) in batch.diff.iter() {
+                seen.insert(key);
                 let base_old_loc = committed_locs
                     .get(key)
                     .copied()
                     .unwrap_or_else(|| entry.base_old_loc());
                 apply_snapshot_diff(&mut self.snapshot, key, entry, base_old_loc);
+                apply_bitmap_diff(&mut bitmap, entry, base_old_loc);
             }
+
+            // Apply uncommitted ancestor diffs (skip committed batches, skip seen keys).
+            for (i, ancestor_diff) in batch.ancestor_diffs.iter().enumerate() {
+                if batch.ancestor_diff_ends[i] <= db_size {
+                    continue;
+                }
+                for (key, entry) in ancestor_diff.iter() {
+                    if seen.insert(key) {
+                        let base_old_loc = committed_locs
+                            .get(key)
+                            .copied()
+                            .unwrap_or_else(|| entry.base_old_loc());
+                        apply_snapshot_diff(&mut self.snapshot, key, entry, base_old_loc);
+                        apply_bitmap_diff(&mut bitmap, entry, base_old_loc);
+                    } else if let Some(loc) = entry.loc() {
+                        debug_assert!(
+                            !bitmap.get_bit(*loc),
+                            "farther ancestor location should remain inactive",
+                        );
+                    }
+                }
+            }
+
+            // CommitFloor: bit = 1 only on the current last commit. Demote the previous and
+            // set the new; earlier ancestor commits between them are already 0 from `extend_to`.
+            bitmap.set_bit(*self.last_commit_loc, false);
+            bitmap.set_bit(*batch.new_last_commit_loc, true);
         }
 
-        // 5. Update DB metadata.
+        // Update DB metadata.
         self.active_keys = batch.total_active_keys;
         self.inactivity_floor_loc = batch.new_inactivity_floor_loc;
         self.last_commit_loc = batch.new_last_commit_loc;
 
-        // 6. Return range of operations that were written to the log.
+        // Return range of operations that were written to the log.
         let end_loc = Location::new(*self.last_commit_loc + 1);
         Ok(start_loc..end_loc)
     }
 }
 
-impl<F: Family, E, C, I, H, U> Db<F, E, C, I, H, U>
+impl<F: Family, E, C, I, H, U, const N: usize> Db<F, E, C, I, H, U, N>
 where
     E: Context,
     U: update::Update + Send + Sync,
@@ -1790,11 +1849,103 @@ mod tests {
             ordered::fixed::Db as OrderedFixedDb,
             test::{colliding_digest, fixed_db_config},
             unordered::fixed::Db as UnorderedFixedDb,
+            BITMAP_CHUNK_BYTES,
         },
         translator::OneCap,
     };
     use commonware_cryptography::{sha256, Sha256};
     use commonware_runtime::{deterministic, Runner as _};
+
+    const BITMAP_CHUNK_BITS: u64 = Prunable::<BITMAP_CHUNK_BYTES>::CHUNK_SIZE_BITS;
+
+    fn loc(n: u64) -> Location<mmr::Family> {
+        Location::new(n)
+    }
+
+    fn shared_with<F>(build: F) -> Shared<BITMAP_CHUNK_BYTES>
+    where
+        F: FnOnce(&mut Prunable<BITMAP_CHUNK_BYTES>),
+    {
+        let mut bm = Prunable::<BITMAP_CHUNK_BYTES>::new();
+        build(&mut bm);
+        Shared::new(bm)
+    }
+
+    #[test]
+    fn bitmap_scan_empty() {
+        let bitmap = shared_with(|_| {});
+        assert_eq!(next_candidate(&bitmap, loc(0), 0), None);
+    }
+
+    #[test]
+    fn bitmap_scan_uncommitted_tail() {
+        let bitmap = shared_with(|_| {});
+        assert_eq!(next_candidate(&bitmap, loc(0), 3), Some(loc(0)));
+        assert_eq!(next_candidate(&bitmap, loc(1), 3), Some(loc(1)));
+        assert_eq!(next_candidate(&bitmap, loc(2), 3), Some(loc(2)));
+        assert_eq!(next_candidate(&bitmap, loc(3), 3), None);
+    }
+
+    #[test]
+    fn bitmap_scan_committed_region() {
+        let bitmap = shared_with(|bm| {
+            bm.extend_to(10);
+            bm.set_bit(*loc(3), true);
+            bm.set_bit(*loc(7), true);
+        });
+
+        assert_eq!(next_candidate(&bitmap, loc(0), 10), Some(loc(3)));
+        assert_eq!(next_candidate(&bitmap, loc(4), 10), Some(loc(7)));
+        assert_eq!(next_candidate(&bitmap, loc(8), 10), None);
+        assert_eq!(next_candidate(&bitmap, loc(0), 5), Some(loc(3)));
+        assert_eq!(next_candidate(&bitmap, loc(4), 5), None);
+    }
+
+    #[test]
+    fn bitmap_scan_transitions_into_tail() {
+        let bitmap = shared_with(|bm| {
+            bm.extend_to(5);
+            bm.set_bit(*loc(2), true);
+        });
+
+        assert_eq!(next_candidate(&bitmap, loc(0), 8), Some(loc(2)));
+        assert_eq!(next_candidate(&bitmap, loc(3), 8), Some(loc(5)));
+        assert_eq!(next_candidate(&bitmap, loc(6), 8), Some(loc(6)));
+        assert_eq!(next_candidate(&bitmap, loc(8), 8), None);
+    }
+
+    #[test]
+    fn bitmap_scan_after_prune() {
+        let bitmap = shared_with(|bm| {
+            bm.extend_to(BITMAP_CHUNK_BITS * 3);
+            bm.set_bit(*loc(BITMAP_CHUNK_BITS * 2 + 5), true);
+            bm.prune_to_bit(BITMAP_CHUNK_BITS * 2);
+        });
+
+        assert_eq!(
+            commonware_utils::bitmap::Readable::pruned_chunks(&bitmap),
+            2
+        );
+        assert_eq!(
+            next_candidate(&bitmap, loc(BITMAP_CHUNK_BITS * 2), BITMAP_CHUNK_BITS * 3),
+            Some(loc(BITMAP_CHUNK_BITS * 2 + 5))
+        );
+    }
+
+    #[test]
+    fn bitmap_scan_after_truncate() {
+        let bitmap = shared_with(|bm| {
+            bm.extend_to(BITMAP_CHUNK_BITS * 2);
+            bm.set_bit(*loc(BITMAP_CHUNK_BITS + 3), true);
+            bm.truncate(BITMAP_CHUNK_BITS);
+        });
+
+        assert_eq!(
+            commonware_utils::bitmap::Readable::<BITMAP_CHUNK_BYTES>::len(&bitmap),
+            BITMAP_CHUNK_BITS
+        );
+        assert_eq!(next_candidate(&bitmap, loc(0), BITMAP_CHUNK_BITS), None);
+    }
 
     /// Test helper: same logic as `Merkleizer::extract_parent_deleted_creates`
     /// but without requiring a full Merkleizer instance.

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -15,16 +15,14 @@ use crate::{
     },
     merkle::{Family, Location, Proof},
     qmdb::{
-        bitmap::{BitmapReadable, Shared},
-        build_snapshot_from_log, delete_known_loc,
-        operation::Operation as OperationTrait,
-        update_known_loc, Error,
+        bitmap::Shared, build_snapshot_from_log, delete_known_loc,
+        operation::Operation as OperationTrait, update_known_loc, Error,
     },
     Context, Persistable,
 };
 use commonware_codec::{Codec, CodecShared};
 use commonware_cryptography::Hasher;
-use commonware_utils::bitmap::Prunable as BitMap;
+use commonware_utils::bitmap;
 use core::num::NonZeroU64;
 use std::{collections::HashMap, sync::Arc};
 
@@ -526,8 +524,9 @@ where
             // [pruned_bits, bounds.start) correspond to pruned operations and remain 0; replay
             // appends bits from the inactivity floor onward.
             let bitmap = shared_bitmap.unwrap_or_else(|| {
-                let pruned_chunks = (bounds.start / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
-                let bm = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
+                let pruned_chunks =
+                    (bounds.start / bitmap::Prunable::<N>::CHUNK_SIZE_BITS) as usize;
+                let bm = bitmap::Prunable::<N>::new_with_pruned_chunks(pruned_chunks)
                     .expect("pruned chunk count fits in u64 bits");
                 Arc::new(Shared::new(bm))
             });
@@ -580,7 +579,7 @@ where
         };
 
         // The bitmap must have exactly one bit per retained log location.
-        if BitmapReadable::<N>::len(bitmap.as_ref()) != log.size().await {
+        if bitmap::Readable::<N>::len(bitmap.as_ref()) != log.size().await {
             return Err(crate::qmdb::Error::DataCorrupted(
                 "bitmap length diverged from log size during init",
             ));

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     merkle::{Family, Location, Proof},
     qmdb::{
-        bitmap::{BitMap, BitmapReadable, Shared},
+        bitmap::{BitmapReadable, Shared},
         build_snapshot_from_log, delete_known_loc,
         operation::Operation as OperationTrait,
         update_known_loc, Error,
@@ -24,6 +24,7 @@ use crate::{
 };
 use commonware_codec::{Codec, CodecShared};
 use commonware_cryptography::Hasher;
+use commonware_utils::bitmap::Prunable as BitMap;
 use core::num::NonZeroU64;
 use std::{collections::HashMap, sync::Arc};
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -2,7 +2,10 @@
 //!
 //! The impl blocks in this file define shared functionality across all Any QMDB variants.
 
-use super::operation::{update::Update, Operation};
+use super::{
+    operation::{update::Update, Operation},
+    BITMAP_CHUNK_BYTES,
+};
 use crate::{
     index::Unordered as UnorderedIndex,
     journal::{
@@ -12,7 +15,9 @@ use crate::{
     },
     merkle::{Family, Location, Proof},
     qmdb::{
-        build_snapshot_from_log, delete_known_loc, operation::Operation as OperationTrait,
+        bitmap::{BitMap, BitmapReadable, Shared},
+        build_snapshot_from_log, delete_known_loc,
+        operation::Operation as OperationTrait,
         update_known_loc, Error,
     },
     Context, Persistable,
@@ -20,7 +25,7 @@ use crate::{
 use commonware_codec::{Codec, CodecShared};
 use commonware_cryptography::Hasher;
 use core::num::NonZeroU64;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 /// Type alias for the authenticated journal used by [Db].
 pub(crate) type AuthenticatedLog<F, E, C, H> = authenticated::Journal<F, E, C, H>;
@@ -48,6 +53,9 @@ enum SnapshotUndo<F: Family, K> {
 /// - [crate::qmdb::any::ordered::variable::Db]
 /// - [crate::qmdb::any::unordered::fixed::Db]
 /// - [crate::qmdb::any::unordered::variable::Db]
+///
+/// `N` is the bitmap chunk size in bytes; defaults to `BITMAP_CHUNK_BYTES`. `current::Db`
+/// overrides `N` to match its grafted-tree configuration.
 pub struct Db<
     F: Family,
     E: Context,
@@ -55,6 +63,7 @@ pub struct Db<
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
     U: Send + Sync,
+    const N: usize = BITMAP_CHUNK_BYTES,
 > {
     /// A (pruned) log of all operations in order of their application. The index of each
     /// operation in the log is called its _location_, which is a stable identifier.
@@ -83,12 +92,25 @@ pub struct Db<
     /// The number of active keys in the snapshot.
     pub(crate) active_keys: usize,
 
+    /// Activity bitmap over committed operations. Rebuilt from the journal on init; never
+    /// persisted. A hint for floor-raise scans; merkleization re-verifies via `is_active_at`.
+    /// When wrapped by `current::Db`, this is also the bitmap that `current` reads for grafted-
+    /// tree leaves and proofs.
+    ///
+    /// # Invariants
+    ///
+    /// - `bitmap.len() == log.size()`.
+    /// - `bitmap[i] == 0` implies location `i` is inactive (false negatives are forbidden).
+    /// - CommitFloor: only the current `last_commit_loc` carries bit = 1; earlier commits
+    ///   are 0.
+    pub(crate) bitmap: Arc<Shared<N>>,
+
     /// Marker for the update type parameter.
     pub(crate) _update: core::marker::PhantomData<U>,
 }
 
 // Shared read-only functionality.
-impl<F, E, U, C, I, H> Db<F, E, C, I, H, U>
+impl<F, E, U, C, I, H, const N: usize> Db<F, E, C, I, H, U, N>
 where
     F: Family,
     E: Context,
@@ -233,7 +255,7 @@ where
 }
 
 // Functionality requiring Mutable journal.
-impl<F, E, U, C, I, H> Db<F, E, C, I, H, U>
+impl<F, E, U, C, I, H, const N: usize> Db<F, E, C, I, H, U, N>
 where
     F: Family,
     E: Context,
@@ -243,14 +265,22 @@ where
     H: Hasher,
     Operation<F, U>: Codec,
 {
-    /// Prunes historical operations prior to `prune_loc`. This does not affect the db's root or
-    /// snapshot.
+    /// Prune the bitmap to `prune_loc`, rounded down to a chunk boundary. Skips the
+    /// inactivity-floor check.
+    pub(crate) fn prune_bitmap(&mut self, prune_loc: Location<F>) {
+        self.bitmap.write().prune_to_bit(*prune_loc);
+    }
+
+    /// Prune the operations log to `prune_loc`. Does not touch the bitmap.
     ///
     /// # Errors
     ///
     /// - Returns [crate::qmdb::Error::PruneBeyondMinRequired] if `prune_loc` > inactivity floor.
     /// - Returns [`crate::merkle::Error::LocationOverflow`] if `prune_loc` > [`crate::merkle::Family::MAX_LEAVES`].
-    pub async fn prune(&mut self, prune_loc: Location<F>) -> Result<(), crate::qmdb::Error<F>> {
+    pub(crate) async fn prune_log(
+        &mut self,
+        prune_loc: Location<F>,
+    ) -> Result<(), crate::qmdb::Error<F>> {
         if prune_loc > self.inactivity_floor_loc {
             return Err(crate::qmdb::Error::PruneBeyondMinRequired(
                 prune_loc,
@@ -260,6 +290,14 @@ where
 
         self.log.prune(prune_loc).await?;
 
+        Ok(())
+    }
+
+    /// Prune historical operations prior to `prune_loc`. This does not affect the db's root or
+    /// snapshot.
+    pub async fn prune(&mut self, prune_loc: Location<F>) -> Result<(), crate::qmdb::Error<F>> {
+        self.prune_log(prune_loc).await?;
+        self.prune_bitmap(prune_loc);
         Ok(())
     }
 
@@ -301,16 +339,14 @@ where
     /// all in-memory structures are rebuilt. Callers must drop this database handle after any `Err`
     /// from `rewind` and reopen from storage.
     ///
-    /// Returns the list of locations restored to active state in the snapshot.
-    ///
     /// A successful rewind is not restart-stable until a subsequent [`Db::commit`] or
     /// [`Db::sync`].
-    pub async fn rewind(&mut self, size: Location<F>) -> Result<Vec<Location<F>>, Error<F>> {
+    pub async fn rewind(&mut self, size: Location<F>) -> Result<(), Error<F>> {
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
 
         if rewind_size == current_size {
-            return Ok(Vec::new());
+            return Ok(());
         }
         if rewind_size == 0 || rewind_size > current_size {
             return Err(Error::Journal(JournalError::InvalidRewind(rewind_size)));
@@ -395,29 +431,48 @@ where
         // restart-stable until a later commit/sync boundary.
         self.log.rewind(rewind_size).await?;
 
-        let mut restored_locs = Vec::new();
-        for undo in undos {
-            match undo {
-                SnapshotUndo::Replace {
-                    key,
-                    old_loc,
-                    new_loc,
-                } => {
-                    if new_loc < rewind_size {
-                        restored_locs.push(new_loc);
+        // Drop bitmap bits for ops at or above the rewind target. Restored locs below
+        // rewind_size flip back to active in the loop below. `rewind_size >= bitmap.pruned_bits()`
+        // is enforced upstream: directly via the `bounds.start` check above, or via
+        // `current::Db::rewind`'s explicit `pruned_bits` precondition. The debug_assert catches
+        // regressions.
+        {
+            let mut bitmap = self.bitmap.write();
+            debug_assert!(
+                bitmap.pruned_bits() <= rewind_size,
+                "bitmap pruned boundary exceeded journal retained start",
+            );
+            bitmap.truncate(rewind_size);
+
+            for undo in undos {
+                match undo {
+                    SnapshotUndo::Replace {
+                        key,
+                        old_loc,
+                        new_loc,
+                    } => {
+                        if new_loc < rewind_size {
+                            bitmap.set_bit(*new_loc, true);
+                        }
+                        update_known_loc(&mut self.snapshot, &key, old_loc, new_loc);
                     }
-                    update_known_loc(&mut self.snapshot, &key, old_loc, new_loc);
-                }
-                SnapshotUndo::Remove { key, old_loc } => {
-                    delete_known_loc(&mut self.snapshot, &key, old_loc)
-                }
-                SnapshotUndo::Insert { key, new_loc } => {
-                    if new_loc < rewind_size {
-                        restored_locs.push(new_loc);
+                    SnapshotUndo::Remove { key, old_loc } => {
+                        delete_known_loc(&mut self.snapshot, &key, old_loc)
                     }
-                    self.snapshot.insert(&key, new_loc);
+                    SnapshotUndo::Insert { key, new_loc } => {
+                        if new_loc < rewind_size {
+                            bitmap.set_bit(*new_loc, true);
+                        }
+                        self.snapshot.insert(&key, new_loc);
+                    }
                 }
             }
+
+            // The rewound tail's preceding op (validated above) is the new `last_commit_loc`.
+            // Set its bit to 1 to match the CommitFloor convention; previous intermediate
+            // commits in the truncated range stay at 0 from `truncate`. `rewind_size > 0` is
+            // guaranteed by the early-return at the top of this function.
+            bitmap.set_bit(rewind_size - 1, true);
         }
 
         self.active_keys = self
@@ -429,12 +484,12 @@ where
         self.last_commit_loc = Location::new(rewind_size - 1);
         self.inactivity_floor_loc = rewind_floor;
 
-        Ok(restored_locs)
+        Ok(())
     }
 }
 
 // Functionality requiring Mutable + Persistable journal.
-impl<F, E, U, C, I, H> Db<F, E, C, I, H, U>
+impl<F, E, U, C, I, H, const N: usize> Db<F, E, C, I, H, U, N>
 where
     F: Family,
     E: Context,
@@ -444,46 +499,89 @@ where
     H: Hasher,
     Operation<F, U>: Codec,
 {
-    /// Returns a [Db] initialized from `log`, using `callback` to report snapshot
-    /// building events.
+    /// Returns a [Db] initialized from `log`. `shared_bitmap = None` allocates a fresh bitmap;
+    /// `Some(b)` adopts a pre-allocated bitmap (used by `current::Db`, which sizes pruned chunks
+    /// from grafted metadata).
     ///
     /// # Panics
     ///
-    /// Panics if the log is empty or the last operation is not a commit floor operation.
-    pub async fn init_from_log<Cb>(
+    /// Panics if the last operation is not a commit floor operation. Empty logs are handled
+    /// upstream by [`crate::qmdb::any::init_with_bitmap`].
+    pub(crate) async fn init_from_log(
         mut index: I,
         log: AuthenticatedLog<F, E, C, H>,
-        known_inactivity_floor: Option<Location<F>>,
-        mut callback: Cb,
-    ) -> Result<Self, crate::qmdb::Error<F>>
-    where
-        Cb: FnMut(bool, Option<Location<F>>),
-    {
-        // If the last-known inactivity floor is behind the current floor, then invoke the callback
-        // appropriately to report the inactive bits.
-        let (last_commit_loc, inactivity_floor_loc, active_keys) = {
+        shared_bitmap: Option<Arc<Shared<N>>>,
+    ) -> Result<Self, crate::qmdb::Error<F>> {
+        let (last_commit_loc, inactivity_floor_loc, active_keys, bitmap) = {
             let reader = log.reader().await;
-            let last_commit_loc = reader
-                .bounds()
-                .end
-                .checked_sub(1)
-                .expect("commit should exist");
+            let bounds = reader.bounds();
+            let last_commit_loc = bounds.end.checked_sub(1).expect("commit should exist");
             let last_commit = reader.read(last_commit_loc).await?;
             let inactivity_floor_loc = last_commit.has_floor().expect("should be a commit");
-            if let Some(known_inactivity_floor) = known_inactivity_floor {
-                (*known_inactivity_floor..*inactivity_floor_loc)
-                    .for_each(|_| callback(false, None));
+
+            // Seed the bitmap so its pruned prefix matches the retained log boundary. Bits in
+            // [pruned_bits, bounds.start) correspond to pruned operations and remain 0; replay
+            // appends bits from the inactivity floor onward.
+            let bitmap = shared_bitmap.unwrap_or_else(|| {
+                let pruned_chunks = (bounds.start / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
+                let bm = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
+                    .expect("pruned chunk count fits in u64 bits");
+                Arc::new(Shared::new(bm))
+            });
+
+            // Extend the bitmap up to the inactivity floor (zero-fill).
+            {
+                let mut guard = bitmap.write();
+                // A caller-supplied bitmap must be pruned to a chunk boundary at or below the
+                // inactivity floor; otherwise `extend_to` would silently leave gaps.
+                debug_assert!(
+                    guard.pruned_bits() <= *inactivity_floor_loc,
+                    "shared_bitmap pruned_bits {} exceeds inactivity_floor_loc {}",
+                    guard.pruned_bits(),
+                    *inactivity_floor_loc,
+                );
+                guard.extend_to(*inactivity_floor_loc);
             }
 
-            let active_keys =
-                build_snapshot_from_log(inactivity_floor_loc, &reader, &mut index, callback)
-                    .await?;
+            // Replay through `build_snapshot_from_log`. The closure fires synchronously between
+            // the helper's awaits, so each invocation does its own brief lock-update-release.
+            // Holding the guard across `.await` would not be `Send`-safe.
+            let active_keys = {
+                let bitmap = &bitmap;
+                build_snapshot_from_log(
+                    inactivity_floor_loc,
+                    &reader,
+                    &mut index,
+                    |is_active, old_loc| {
+                        let mut guard = bitmap.write();
+                        guard.push(is_active);
+                        if let Some(loc) = old_loc {
+                            guard.set_bit(*loc, false);
+                        }
+                    },
+                )
+                .await?
+            };
+
+            // CommitFloor convention: only the current `last_commit_loc` carries bit=1; earlier
+            // CommitFloors are 0. `build_snapshot_from_log` reports `is_active = (loc ==
+            // last_commit_loc)` for each CommitFloor op, so the per-op push above already
+            // encodes this.
+
             (
                 Location::new(last_commit_loc),
                 inactivity_floor_loc,
                 active_keys,
+                bitmap,
             )
         };
+
+        // The bitmap must have exactly one bit per retained log location.
+        if BitmapReadable::<N>::len(bitmap.as_ref()) != log.size().await {
+            return Err(crate::qmdb::Error::DataCorrupted(
+                "bitmap length diverged from log size during init",
+            ));
+        }
 
         Ok(Self {
             log,
@@ -491,6 +589,7 @@ where
             snapshot: index,
             last_commit_loc,
             active_keys,
+            bitmap,
             _update: core::marker::PhantomData,
         })
     }
@@ -512,7 +611,7 @@ where
     }
 }
 
-impl<F, E, U, C, I, H> Persistable for Db<F, E, C, I, H, U>
+impl<F, E, U, C, I, H, const N: usize> Persistable for Db<F, E, C, I, H, U, N>
 where
     F: Family,
     E: Context,

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -274,6 +274,10 @@ where
 
     /// Prune the operations log to `prune_loc`. Does not touch the bitmap.
     ///
+    /// Journal pruning is section-granular, so the actual pruned boundary may be less than
+    /// the requested `prune_loc`. Returns that actual boundary so callers can keep the bitmap
+    /// aligned with the journal's retained start.
+    ///
     /// # Errors
     ///
     /// - Returns [crate::qmdb::Error::PruneBeyondMinRequired] if `prune_loc` > inactivity floor.
@@ -281,7 +285,7 @@ where
     pub(crate) async fn prune_log(
         &mut self,
         prune_loc: Location<F>,
-    ) -> Result<(), crate::qmdb::Error<F>> {
+    ) -> Result<Location<F>, crate::qmdb::Error<F>> {
         if prune_loc > self.inactivity_floor_loc {
             return Err(crate::qmdb::Error::PruneBeyondMinRequired(
                 prune_loc,
@@ -289,16 +293,14 @@ where
             ));
         }
 
-        self.log.prune(prune_loc).await?;
-
-        Ok(())
+        Ok(self.log.prune(prune_loc).await?)
     }
 
     /// Prune historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
     pub async fn prune(&mut self, prune_loc: Location<F>) -> Result<(), crate::qmdb::Error<F>> {
-        self.prune_log(prune_loc).await?;
-        self.prune_bitmap(prune_loc);
+        let actual_pruned = self.prune_log(prune_loc).await?;
+        self.prune_bitmap(actual_pruned);
         Ok(())
     }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -72,6 +72,7 @@ use crate::{
     merkle::{full::Config as MerkleConfig, Family, Location},
     qmdb::{
         any::operation::{Operation, Update},
+        bitmap::Shared,
         operation::Committable,
     },
     translator::Translator,
@@ -79,6 +80,7 @@ use crate::{
 };
 use commonware_codec::CodecShared;
 use commonware_cryptography::Hasher;
+use std::sync::Arc;
 use tracing::warn;
 
 pub mod batch;
@@ -91,6 +93,8 @@ pub use value::{FixedValue, ValueEncoding, VariableValue};
 pub mod ordered;
 pub(crate) mod sync;
 pub mod unordered;
+
+const BITMAP_CHUNK_BYTES: usize = 64;
 
 /// Configuration for an `Any` authenticated db.
 #[derive(Clone)]
@@ -112,11 +116,9 @@ pub type FixedConfig<T> = Config<T, FConfig>;
 pub type VariableConfig<T, C> = Config<T, VConfig<C>>;
 
 /// Initialize an `Any` authenticated db from the given config.
-pub async fn init<F, E, U, H, T, I, J, Cb>(
+pub async fn init<F, E, U, H, T, I, J>(
     context: E,
     cfg: Config<T, J::Config>,
-    known_inactivity_floor: Option<Location<F>>,
-    callback: Cb,
 ) -> Result<db::Db<F, E, J, I, H, U>, crate::qmdb::Error<F>>
 where
     F: Family,
@@ -127,7 +129,26 @@ where
     I: IndexFactory<T, Value = Location<F>>,
     J: Inner<E, Item = Operation<F, U>>,
     Operation<F, U>: Committable + CodecShared,
-    Cb: FnMut(bool, Option<Location<F>>),
+{
+    init_with_bitmap::<F, E, U, H, T, I, J, BITMAP_CHUNK_BYTES>(context, cfg, None).await
+}
+
+/// Like [`init`] but accepts a pre-allocated bitmap (used by `current::Db`, which sizes pruned
+/// chunks from grafted metadata). `bitmap = None` allocates internally.
+pub(crate) async fn init_with_bitmap<F, E, U, H, T, I, J, const N: usize>(
+    context: E,
+    cfg: Config<T, J::Config>,
+    bitmap: Option<Arc<Shared<N>>>,
+) -> Result<db::Db<F, E, J, I, H, U, N>, crate::qmdb::Error<F>>
+where
+    F: Family,
+    E: Context,
+    U: Update + Send + Sync,
+    H: Hasher,
+    T: Translator,
+    I: IndexFactory<T, Value = Location<F>>,
+    J: Inner<E, Item = Operation<F, U>>,
+    Operation<F, U>: Committable + CodecShared,
 {
     let mut log = J::init::<F, H>(
         context.with_label("log"),
@@ -145,7 +166,7 @@ where
     }
 
     let index = I::new(context.with_label("index"), cfg.translator);
-    db::Db::init_from_log(index, log, known_inactivity_floor, callback).await
+    db::Db::init_from_log(index, log, bitmap).await
 }
 
 #[cfg(test)]
@@ -2079,11 +2100,7 @@ pub(crate) mod test {
 
             let root_before = db.root();
             let size_before = db.size().await;
-            let no_op_locs = db.rewind(size_before).await.unwrap();
-            assert!(
-                no_op_locs.is_empty(),
-                "expected no-op rewind to return no restored locations"
-            );
+            db.rewind(size_before).await.unwrap();
             assert_eq!(db.root(), root_before);
             assert_eq!(db.size().await, size_before);
 
@@ -2207,7 +2224,7 @@ pub(crate) mod test {
 
     async fn open_mmb_db(context: Context, suffix: &str) -> MmbVariable {
         let cfg = variable_db_config::<OneCap>(suffix, &context);
-        super::init(context, cfg, None, |_, _| {}).await.unwrap()
+        super::init(context, cfg).await.unwrap()
     }
 
     async fn commit_writes_mmb(
@@ -2375,6 +2392,244 @@ pub(crate) mod test {
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
 
+            db.destroy().await.unwrap();
+        });
+    }
+}
+
+#[cfg(test)]
+mod bitmap_tests {
+    //! Regression tests for activity-bitmap maintenance in `any::Db`.
+    //!
+    //! The bitmap is mutated by `apply_batch`, `prune_bitmap`, and `rewind`. These tests target
+    //! maintenance logic shared across all `any::Db` variants — the mutation code is parametric
+    //! on bitmap geometry alone, not on key/value/journal types — so one variant
+    //! (`unordered::variable`) suffices as the test bed.
+    //!
+    //! Each test ends with an *oracle round-trip*: commit the in-memory state, drop the handle,
+    //! reopen via `init_from_log`, and assert the rebuilt bitmap is byte-identical to what apply
+    //! produced. That catches divergence between the apply-time and init-time paths — divergence
+    //! that's otherwise silent because proofs verify roots, not bitmap byte-equality.
+    use crate::{
+        merkle::Location,
+        qmdb::any::unordered::variable::test::{create_test_config, AnyTest},
+    };
+    use commonware_cryptography::{Hasher, Sha256};
+    use commonware_macros::test_traced;
+    use commonware_runtime::{
+        deterministic::{self, Context},
+        Metrics, Runner as _,
+    };
+    use commonware_utils::bitmap::Readable as _;
+
+    /// Open a fresh test DB.
+    async fn open_db(context: Context) -> AnyTest {
+        let cfg = create_test_config(0, &context);
+        AnyTest::init(context, cfg).await.unwrap()
+    }
+
+    /// Active locations (bit=1) in `[pruned_bits, len)` of `db.bitmap`.
+    fn bitmap_active_locs(db: &AnyTest) -> Vec<u64> {
+        let b = &db.bitmap;
+        (b.pruned_bits()..b.len())
+            .filter(|loc| b.get_bit(*loc))
+            .collect()
+    }
+
+    /// Commit, drop, reopen, and assert the rebuilt bitmap matches the in-memory bitmap.
+    async fn assert_oracle_round_trip(db: AnyTest, context: Context, label: &str) -> AnyTest {
+        let pre_active = bitmap_active_locs(&db);
+        let pre_len = db.bitmap.len();
+        let pre_pruned = db.bitmap.pruned_bits();
+
+        db.commit().await.unwrap();
+        drop(db);
+
+        let db = open_db(context.with_label(label)).await;
+
+        assert_eq!(
+            db.bitmap.pruned_bits(),
+            pre_pruned,
+            "pruned_bits diverged on reopen",
+        );
+        assert_eq!(db.bitmap.len(), pre_len, "bitmap len diverged on reopen");
+        assert_eq!(
+            bitmap_active_locs(&db),
+            pre_active,
+            "active locations diverged on reopen",
+        );
+        db
+    }
+
+    /// CommitFloor convention: only the *current* `last_commit_loc` carries bit=1; every earlier
+    /// (now intermediate) commit boundary carries bit=0.
+    ///
+    /// Maintained by `apply_batch`'s explicit demote-then-promote pair on CommitFloor bits. If
+    /// the demote step were missed, intermediate commits would persist at bit=1.
+    #[test_traced]
+    fn current_commit_floor_bit_is_one_others_zero() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db = open_db(context.clone()).await;
+
+            // Apply three single-write batches; each produces one CommitFloor op.
+            let mut commit_locs = Vec::new();
+            for i in 0..3u64 {
+                let key = Sha256::hash(&i.to_be_bytes());
+                let batch = db
+                    .new_batch()
+                    .write(key, Some(vec![i as u8]))
+                    .merkleize(&db, None)
+                    .await
+                    .unwrap();
+                commit_locs.push(batch.new_last_commit_loc);
+                db.apply_batch(batch).await.unwrap();
+            }
+            db.commit().await.unwrap();
+
+            // Setup sanity: three strictly-increasing commit locations, all within the bitmap.
+            assert_eq!(commit_locs.len(), 3);
+            assert!(*commit_locs[0] < *commit_locs[1]);
+            assert!(*commit_locs[1] < *commit_locs[2]);
+            assert!(*commit_locs[2] < db.bitmap.len());
+
+            // Earlier two commits are intermediate -> bit=0.
+            assert!(!db.bitmap.get_bit(*commit_locs[0]));
+            assert!(!db.bitmap.get_bit(*commit_locs[1]));
+            // Most recent commit is current -> bit=1.
+            assert!(db.bitmap.get_bit(*commit_locs[2]));
+
+            let db = assert_oracle_round_trip(db, context, "commit_floor").await;
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// `any::Db::rewind` restores bitmap state correctly.
+    ///
+    /// Pre-PR, `current::Db::rewind` patched the bitmap using the `restored_locs` Vec returned
+    /// by `any::Db::rewind`. This PR moved the fixup into `any::rewind` itself; it must:
+    ///   1. truncate the bitmap to the rewind size,
+    ///   2. flip restored locs (committed snapshot entries the rewound tail had superseded) back
+    ///      to active,
+    ///   3. set the rewound tail's CommitFloor bit to 1 (the new current commit).
+    ///
+    /// The oracle round-trip catches all three: any divergence from `init_from_log`'s rebuild
+    /// fails the comparison.
+    #[test_traced]
+    fn rewind_restores_bitmap_to_target_commit() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db = open_db(context.clone()).await;
+            let k1 = Sha256::hash(&[1]);
+            let k2 = Sha256::hash(&[2]);
+
+            // Two committed batches; remember the size after the first.
+            let b1 = db
+                .new_batch()
+                .write(k1, Some(vec![10]))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            db.apply_batch(b1).await.unwrap();
+            db.commit().await.unwrap();
+            let size_after_first = Location::new(*db.last_commit_loc + 1);
+
+            let b2 = db
+                .new_batch()
+                .write(k2, Some(vec![20]))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            db.apply_batch(b2).await.unwrap();
+
+            // Setup sanity: both keys present, db has advanced past size_after_first.
+            assert_eq!(db.get(&k1).await.unwrap(), Some(vec![10]));
+            assert_eq!(db.get(&k2).await.unwrap(), Some(vec![20]));
+            assert!(*db.last_commit_loc + 1 > *size_after_first);
+
+            // Rewind to the state after the first commit.
+            db.rewind(size_after_first).await.unwrap();
+
+            // Post-rewind: k2 gone, k1 remains.
+            assert_eq!(db.get(&k1).await.unwrap(), Some(vec![10]));
+            assert!(db.get(&k2).await.unwrap().is_none());
+
+            let db = assert_oracle_round_trip(db, context, "rewind").await;
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Floor-scan falls through to the uncommitted tail when the committed bitmap region runs
+    /// out of active bits.
+    ///
+    /// `next_candidate` returns set-bit locations within `[floor, bitmap.len)` (skipping inactive
+    /// ones), then sequential candidates beyond `bitmap.len` (uncommitted ancestor ops not
+    /// tracked in the bitmap). `is_active_at` revalidation in the floor-raise loop is the only
+    /// thing that prevents stale ancestor locations from being moved when a child batch
+    /// supersedes the same key.
+    ///
+    /// Setup: 1 committed key + uncommitted parent re-touching that key + uncommitted child that
+    /// supersedes the key AND writes many other keys. The added user mutations push
+    /// `total_steps` past the active bits available in the committed region, forcing the scan
+    /// to walk into the tail.
+    ///
+    /// Failure modes caught:
+    /// - tail-fallthrough boundary off-by-one → wrong root,
+    /// - missing `is_active_at` revalidation → parent's superseded loc gets moved → divergent
+    ///   root,
+    /// - bitmap state inconsistent with `init_from_log` → oracle reopen mismatch.
+    #[test_traced]
+    fn floor_scan_falls_through_to_uncommitted_tail() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db = open_db(context.clone()).await;
+            let anchor = Sha256::hash(&[0xAA]);
+
+            // Commit one key.
+            let b = db
+                .new_batch()
+                .write(anchor, Some(vec![1]))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            db.apply_batch(b).await.unwrap();
+
+            // Setup sanity: anchor in committed snapshot.
+            assert_eq!(db.get(&anchor).await.unwrap(), Some(vec![1]));
+            let committed_bitmap_len = db.bitmap.len();
+
+            // Uncommitted parent: re-touch anchor at a location above the committed bitmap.
+            let parent = db
+                .new_batch()
+                .write(anchor, Some(vec![2]))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            assert!(
+                parent.total_size > committed_bitmap_len,
+                "parent must extend past committed bitmap to exercise the tail path",
+            );
+
+            // Uncommitted child: supersede anchor + add 16 more writes. The extra user_steps
+            // ensure `total_steps` exceeds active bits in the committed region, forcing the
+            // floor-raise scan into the uncommitted tail.
+            let mut child_batch = parent.new_batch::<Sha256>();
+            child_batch = child_batch.write(anchor, Some(vec![3]));
+            for i in 0..16u64 {
+                let k = Sha256::hash(&(1000 + i).to_be_bytes());
+                child_batch = child_batch.write(k, Some(vec![i as u8]));
+            }
+            let child = child_batch.merkleize(&db, None).await.unwrap();
+            assert!(
+                child.total_size > committed_bitmap_len,
+                "child must include an uncommitted tail beyond committed bitmap",
+            );
+            let expected_root = child.root();
+
+            // Apply. If tail-fallthrough or revalidation were wrong, the produced root would
+            // diverge from the merkleize-time root.
+            db.apply_batch(child).await.unwrap();
+            assert_eq!(db.root(), expected_root);
+            assert_eq!(db.get(&anchor).await.unwrap(), Some(vec![3]));
+
+            let db = assert_oracle_round_trip(db, context, "tail").await;
             db.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2218,7 +2218,7 @@ pub(crate) mod test {
             // forcing the journal to retain from 0 even when prune is requested past the first
             // bitmap chunk boundary.
             const ITEMS_PER_SECTION: u64 = 2048;
-            assert!(ITEMS_PER_SECTION > BITMAP_CHUNK_BITS);
+            const { assert!(ITEMS_PER_SECTION > BITMAP_CHUNK_BITS) };
 
             let ctx = context.with_label("db");
             let mut cfg = variable_db_config::<OneCap>("rg", &ctx);
@@ -2491,8 +2491,8 @@ pub(crate) mod test {
 #[cfg(test)]
 mod bitmap_tests {
     //! Regression tests for activity-bitmap maintenance in `any::Db`. The mutation code in
-    //! `apply_batch`, `prune_bitmap`, and `rewind` is parametric on bitmap geometry alone, so one
-    //! variant (`unordered::variable`) suffices as the test bed.
+    //! `apply_batch`, `prune_bitmap`, and `rewind` is independent of the snapshot index variant,
+    //! so one variant (`unordered::variable`) suffices as the test bed.
     use crate::{
         merkle::Location,
         qmdb::any::unordered::variable::test::{create_test_config, AnyTest},

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -28,8 +28,8 @@
 //! let fork_a = parent.new_batch::<Sha256>().write(k2, Some(v2)).merkleize(&db, None).await?;
 //! let fork_b = parent.new_batch::<Sha256>().write(k3, Some(v3)).merkleize(&db, None).await?;
 //!
-//! db.apply_batch(fork_a).await?;           // OK -- includes parent
-//! assert!(db.apply_batch(fork_b).is_err()) // StaleBatch
+//! db.apply_batch(fork_a).await?;                 // OK -- includes parent
+//! assert!(db.apply_batch(fork_b).await.is_err()); // StaleBatch
 //! ```
 //!
 //! ```ignore
@@ -47,8 +47,8 @@
 //! let parent = db.new_batch().write(k1, Some(v1)).merkleize(&db, None).await?;
 //! let child = parent.new_batch::<Sha256>().write(k2, Some(v2)).merkleize(&db, None).await?;
 //!
-//! db.apply_batch(child).await?;            // OK -- includes parent
-//! assert!(db.apply_batch(parent).is_err()) // StaleBatch
+//! db.apply_batch(child).await?;                  // OK -- includes parent
+//! assert!(db.apply_batch(parent).await.is_err()); // StaleBatch
 //! ```
 //!
 //! ```ignore
@@ -59,8 +59,8 @@
 //! let b1 = db.new_batch().write(k3, Some(v3)).merkleize(&db, None).await?;
 //! let b2 = b1.new_batch::<Sha256>().write(k4, Some(v4)).merkleize(&db, None).await?;
 //!
-//! db.apply_batch(a2).await?;               // OK -- includes a1
-//! assert!(db.apply_batch(b2).is_err())     // StaleBatch
+//! db.apply_batch(a2).await?;                 // OK -- includes a1
+//! assert!(db.apply_batch(b2).await.is_err()); // StaleBatch
 //! ```
 
 use crate::{
@@ -2399,17 +2399,9 @@ pub(crate) mod test {
 
 #[cfg(test)]
 mod bitmap_tests {
-    //! Regression tests for activity-bitmap maintenance in `any::Db`.
-    //!
-    //! The bitmap is mutated by `apply_batch`, `prune_bitmap`, and `rewind`. These tests target
-    //! maintenance logic shared across all `any::Db` variants — the mutation code is parametric
-    //! on bitmap geometry alone, not on key/value/journal types — so one variant
-    //! (`unordered::variable`) suffices as the test bed.
-    //!
-    //! Each test ends with an *oracle round-trip*: commit the in-memory state, drop the handle,
-    //! reopen via `init_from_log`, and assert the rebuilt bitmap is byte-identical to what apply
-    //! produced. That catches divergence between the apply-time and init-time paths — divergence
-    //! that's otherwise silent because proofs verify roots, not bitmap byte-equality.
+    //! Regression tests for activity-bitmap maintenance in `any::Db`. The mutation code in
+    //! `apply_batch`, `prune_bitmap`, and `rewind` is parametric on bitmap geometry alone, so one
+    //! variant (`unordered::variable`) suffices as the test bed.
     use crate::{
         merkle::Location,
         qmdb::any::unordered::variable::test::{create_test_config, AnyTest},
@@ -2505,8 +2497,7 @@ mod bitmap_tests {
 
     /// `any::Db::rewind` restores bitmap state correctly.
     ///
-    /// Pre-PR, `current::Db::rewind` patched the bitmap using the `restored_locs` Vec returned
-    /// by `any::Db::rewind`. This PR moved the fixup into `any::rewind` itself; it must:
+    /// `any::rewind` is the sole writer of the bitmap during rewind; it must:
     ///   1. truncate the bitmap to the rewind size,
     ///   2. flip restored locs (committed snapshot entries the rewound tail had superseded) back
     ///      to active,

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2201,6 +2201,97 @@ pub(crate) mod test {
         });
     }
 
+    /// `prune()` must advance the bitmap only as far as the authenticated journal actually
+    /// pruned. Journal pruning is section-granular while bitmap pruning rounds to chunk
+    /// boundaries, so a coarse `items_per_section` can leave the journal retaining from the
+    /// start while the bitmap has already crossed the next chunk boundary. A subsequent
+    /// `rewind()` to a still-retained early commit must still succeed.
+    #[test_traced("INFO")]
+    fn test_any_prune_keeps_bitmap_aligned_with_journal() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Bitmap chunk size in bits. The bug requires the bitmap to round across at least
+            // one chunk boundary while the journal cannot prune any section.
+            const BITMAP_CHUNK_BITS: u64 =
+                commonware_utils::bitmap::Prunable::<BITMAP_CHUNK_BYTES>::CHUNK_SIZE_BITS;
+            // Items-per-section is chosen so that no full section fits in the test's op count,
+            // forcing the journal to retain from 0 even when prune is requested past the first
+            // bitmap chunk boundary.
+            const ITEMS_PER_SECTION: u64 = 2048;
+            assert!(ITEMS_PER_SECTION > BITMAP_CHUNK_BITS);
+
+            let ctx = context.with_label("db");
+            let mut cfg = variable_db_config::<OneCap>("rg", &ctx);
+            cfg.journal_config.items_per_section = NZU64!(ITEMS_PER_SECTION);
+
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), cfg).await.unwrap();
+
+            commit_writes(&mut db, (0..100).map(|i| (key(i), Some(val(i)))), None).await;
+            let rewind_target = db.size().await;
+            // Rewind target must lie below the chunk boundary the buggy prune would advance
+            // to; otherwise the unfixed code would not panic on truncate.
+            assert!(
+                *rewind_target < BITMAP_CHUNK_BITS,
+                "rewind_target {rewind_target:?} must be < {BITMAP_CHUNK_BITS} for the bug to manifest"
+            );
+            let root_at_target = db.root();
+
+            commit_writes(
+                &mut db,
+                (0..700).map(|i| (key(i), Some(val(1_000 + i)))),
+                None,
+            )
+            .await;
+            commit_writes(
+                &mut db,
+                (0..700).map(|i| (key(i), Some(val(10_000 + i)))),
+                None,
+            )
+            .await;
+
+            // Pre-rewind size must actually exceed the rewind target so the rewind is not a
+            // no-op.
+            let pre_prune_size = db.size().await;
+            assert!(pre_prune_size > rewind_target);
+
+            let prune_loc = Location::new(600);
+            // prune_loc must cross at least one bitmap chunk boundary; otherwise the buggy
+            // bitmap prune would correctly stay at 0 and the test would pass even unfixed.
+            assert!(
+                *prune_loc > BITMAP_CHUNK_BITS,
+                "prune_loc {prune_loc:?} must exceed one bitmap chunk ({BITMAP_CHUNK_BITS} bits)"
+            );
+            // prune_loc must lie within the first journal section so the journal cannot
+            // prune any section, leaving bounds.start at 0 to expose the bitmap drift.
+            assert!(
+                *prune_loc < ITEMS_PER_SECTION,
+                "prune_loc {prune_loc:?} must be < {ITEMS_PER_SECTION} so the journal retains section 0"
+            );
+            assert!(db.inactivity_floor_loc() >= prune_loc);
+
+            db.prune(prune_loc).await.unwrap();
+
+            // Journal could not prune any section, so it still retains from 0. The bitmap
+            // must therefore also remain at 0.
+            let bounds = db.bounds().await;
+            assert_eq!(bounds.start, Location::new(0));
+            assert_eq!(
+                db.bitmap.pruned_bits(),
+                0,
+                "bitmap pruned past journal retained start"
+            );
+
+            // Rewind to the still-retained early commit must succeed and restore visible
+            // state (root match implies the snapshot was rebuilt correctly).
+            db.rewind(rewind_target).await.unwrap();
+            assert_eq!(db.size().await, rewind_target);
+            assert_eq!(db.root(), root_at_target);
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     // --- MMB family tests ---
     //
     // The tests above use MMR-backed databases (via the concrete Db type aliases). The tests

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -32,22 +32,7 @@ impl<F: merkle::Family, E: Context, K: Array, V: FixedValue, H: Hasher, T: Trans
     /// Returns a [Db] qmdb initialized from `cfg`. Any uncommitted log operations will be
     /// discarded and the state of the db will be as of the last committed operation.
     pub async fn init(context: E, cfg: Config<T>) -> Result<Self, Error<F>> {
-        Self::init_with_callback(context, cfg, None, |_, _| {}).await
-    }
-
-    /// Initialize the DB, invoking `callback` for each operation processed during recovery.
-    ///
-    /// If `known_inactivity_floor` is provided and is less than the log's actual inactivity floor,
-    /// `callback` is invoked with `(false, None)` for each location in the gap. Then, as the
-    /// snapshot is built from the log, `callback` is invoked for each operation with its activity
-    /// status and previous location (if any).
-    pub(crate) async fn init_with_callback(
-        context: E,
-        cfg: Config<T>,
-        known_inactivity_floor: Option<Location<F>>,
-        callback: impl FnMut(bool, Option<Location<F>>),
-    ) -> Result<Self, Error<F>> {
-        crate::qmdb::any::init(context, cfg, known_inactivity_floor, callback).await
+        crate::qmdb::any::init(context, cfg).await
     }
 }
 
@@ -103,22 +88,7 @@ pub mod partitioned {
         /// Returns a [Db] QMDB initialized from `cfg`. Uncommitted log operations will be
         /// discarded and the state of the db will be as of the last committed operation.
         pub async fn init(context: E, cfg: Config<T>) -> Result<Self, Error<F>> {
-            Self::init_with_callback(context, cfg, None, |_, _| {}).await
-        }
-
-        /// Initialize the DB, invoking `callback` for each operation processed during recovery.
-        ///
-        /// If `known_inactivity_floor` is provided and is less than the log's actual inactivity floor,
-        /// `callback` is invoked with `(false, None)` for each location in the gap. Then, as the
-        /// snapshot is built from the log, `callback` is invoked for each operation with its activity
-        /// status and previous location (if any).
-        pub(crate) async fn init_with_callback(
-            context: E,
-            cfg: Config<T>,
-            known_inactivity_floor: Option<Location<F>>,
-            callback: impl FnMut(bool, Option<Location<F>>),
-        ) -> Result<Self, Error<F>> {
-            crate::qmdb::any::init(context, cfg, known_inactivity_floor, callback).await
+            crate::qmdb::any::init(context, cfg).await
         }
     }
 
@@ -193,9 +163,7 @@ pub(crate) mod test {
         context: deterministic::Context,
     ) -> AnyTestGeneric<F> {
         let cfg = fixed_db_config::<TwoCap>("partition", &context);
-        crate::qmdb::any::init(context, cfg, None, |_, _| {})
-            .await
-            .unwrap()
+        crate::qmdb::any::init(context, cfg).await.unwrap()
     }
 
     /// Return an `Any` database initialized with a fixed config.

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -33,7 +33,8 @@ impl<
         C: Contiguous<Item = Operation<F, K, V>>,
         I: Index<Value = Location<F>>,
         H: Hasher,
-    > Db<F, E, C, I, H, Update<K, V>>
+        const N: usize,
+    > Db<F, E, C, I, H, Update<K, V>, N>
 where
     Operation<F, K, V>: Codec,
 {

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -39,22 +39,7 @@ where
         context: E,
         cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg>,
     ) -> Result<Self, Error<F>> {
-        Self::init_with_callback(context, cfg, None, |_, _| {}).await
-    }
-
-    /// Initialize the DB, invoking `callback` for each operation processed during recovery.
-    ///
-    /// If `known_inactivity_floor` is provided and is less than the log's actual inactivity floor,
-    /// `callback` is invoked with `(false, None)` for each location in the gap. Then, as the
-    /// snapshot is built from the log, `callback` is invoked for each operation with its activity
-    /// status and previous location (if any).
-    pub(crate) async fn init_with_callback(
-        context: E,
-        cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg>,
-        known_inactivity_floor: Option<Location<F>>,
-        callback: impl FnMut(bool, Option<Location<F>>),
-    ) -> Result<Self, Error<F>> {
-        crate::qmdb::any::init(context, cfg, known_inactivity_floor, callback).await
+        crate::qmdb::any::init(context, cfg).await
     }
 }
 
@@ -116,22 +101,7 @@ pub mod partitioned {
             context: E,
             cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg>,
         ) -> Result<Self, Error<F>> {
-            Self::init_with_callback(context, cfg, None, |_, _| {}).await
-        }
-
-        /// Initialize the DB, invoking `callback` for each operation processed during recovery.
-        ///
-        /// If `known_inactivity_floor` is provided and is less than the log's actual inactivity floor,
-        /// `callback` is invoked with `(false, None)` for each location in the gap. Then, as the
-        /// snapshot is built from the log, `callback` is invoked for each operation with its activity
-        /// status and previous location (if any).
-        pub(crate) async fn init_with_callback(
-            context: E,
-            cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg>,
-            known_inactivity_floor: Option<Location<F>>,
-            callback: impl FnMut(bool, Option<Location<F>>),
-        ) -> Result<Self, Error<F>> {
-            crate::qmdb::any::init(context, cfg, known_inactivity_floor, callback).await
+            crate::qmdb::any::init(context, cfg).await
         }
     }
 

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -123,7 +123,7 @@ where
         apply_batch_size as u64,
     )
     .await?;
-    let db = Db::init_from_log(index, log, Some(range.start()), |_, _| {}).await?;
+    let db = Db::init_from_log(index, log, None).await?;
 
     Ok(db)
 }

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -28,22 +28,7 @@ impl<F: merkle::Family, E: Context, K: Array, V: FixedValue, H: Hasher, T: Trans
     /// Returns a [Db] QMDB initialized from `cfg`. Uncommitted log operations will be
     /// discarded and the state of the db will be as of the last committed operation.
     pub async fn init(context: E, cfg: Config<T>) -> Result<Self, Error<F>> {
-        Self::init_with_callback(context, cfg, None, |_, _| {}).await
-    }
-
-    /// Initialize the DB, invoking `callback` for each operation processed during recovery.
-    ///
-    /// If `known_inactivity_floor` is provided and is less than the log's actual inactivity floor,
-    /// `callback` is invoked with `(false, None)` for each location in the gap. Then, as the snapshot
-    /// is built from the log, `callback` is invoked for each operation with its activity status and
-    /// previous location (if any).
-    pub(crate) async fn init_with_callback(
-        context: E,
-        cfg: Config<T>,
-        known_inactivity_floor: Option<Location<F>>,
-        callback: impl FnMut(bool, Option<Location<F>>),
-    ) -> Result<Self, Error<F>> {
-        crate::qmdb::any::init(context, cfg, known_inactivity_floor, callback).await
+        crate::qmdb::any::init(context, cfg).await
     }
 }
 
@@ -99,22 +84,7 @@ pub mod partitioned {
         /// Returns a [Db] QMDB initialized from `cfg`. Uncommitted log operations will be
         /// discarded and the state of the db will be as of the last committed operation.
         pub async fn init(context: E, cfg: Config<T>) -> Result<Self, Error<F>> {
-            Self::init_with_callback(context, cfg, None, |_, _| {}).await
-        }
-
-        /// Initialize the DB, invoking `callback` for each operation processed during recovery.
-        ///
-        /// If `known_inactivity_floor` is provided and is less than the log's actual inactivity floor,
-        /// `callback` is invoked with `(false, None)` for each location in the gap. Then, as the snapshot
-        /// is built from the log, `callback` is invoked for each operation with its activity status and
-        /// previous location (if any).
-        pub(crate) async fn init_with_callback(
-            context: E,
-            cfg: Config<T>,
-            known_inactivity_floor: Option<Location<F>>,
-            callback: impl FnMut(bool, Option<Location<F>>),
-        ) -> Result<Self, Error<F>> {
-            crate::qmdb::any::init(context, cfg, known_inactivity_floor, callback).await
+            crate::qmdb::any::init(context, cfg).await
         }
     }
 
@@ -182,9 +152,7 @@ pub(crate) mod test {
         context: deterministic::Context,
     ) -> AnyTestGeneric<F> {
         let cfg = fixed_db_config::<TwoCap>("partition", &context);
-        crate::qmdb::any::init(context, cfg, None, |_, _| {})
-            .await
-            .unwrap()
+        crate::qmdb::any::init(context, cfg).await.unwrap()
     }
 
     /// Create a test database with unique partition names

--- a/storage/src/qmdb/any/unordered/mod.rs
+++ b/storage/src/qmdb/any/unordered/mod.rs
@@ -26,7 +26,8 @@ impl<
         C: Contiguous<Item = Operation<F, K, V>>,
         I: Index<Value = Location<F>>,
         H: Hasher,
-    > Db<F, E, C, I, H, Update<K, V>>
+        const N: usize,
+    > Db<F, E, C, I, H, Update<K, V>, N>
 where
     Operation<F, K, V>: Codec,
 {

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -38,22 +38,7 @@ where
         context: E,
         cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg>,
     ) -> Result<Self, Error<F>> {
-        Self::init_with_callback(context, cfg, None, |_, _| {}).await
-    }
-
-    /// Initialize the DB, invoking `callback` for each operation processed during recovery.
-    ///
-    /// If `known_inactivity_floor` is provided and is less than the log's actual inactivity floor,
-    /// `callback` is invoked with `(false, None)` for each location in the gap. Then, as the
-    /// snapshot is built from the log, `callback` is invoked for each operation with its activity
-    /// status and previous location (if any).
-    pub(crate) async fn init_with_callback(
-        context: E,
-        cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg>,
-        known_inactivity_floor: Option<Location<F>>,
-        callback: impl FnMut(bool, Option<Location<F>>),
-    ) -> Result<Self, Error<F>> {
-        crate::qmdb::any::init(context, cfg, known_inactivity_floor, callback).await
+        crate::qmdb::any::init(context, cfg).await
     }
 }
 
@@ -115,22 +100,7 @@ pub mod partitioned {
             context: E,
             cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg>,
         ) -> Result<Self, Error<F>> {
-            Self::init_with_callback(context, cfg, None, |_, _| {}).await
-        }
-
-        /// Initialize the DB, invoking `callback` for each operation processed during recovery.
-        ///
-        /// If `known_inactivity_floor` is provided and is less than the log's actual inactivity floor,
-        /// `callback` is invoked with `(false, None)` for each location in the gap. Then, as the
-        /// snapshot is built from the log, `callback` is invoked for each operation with its activity
-        /// status and previous location (if any).
-        pub(crate) async fn init_with_callback(
-            context: E,
-            cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg>,
-            known_inactivity_floor: Option<Location<F>>,
-            callback: impl FnMut(bool, Option<Location<F>>),
-        ) -> Result<Self, Error<F>> {
-            crate::qmdb::any::init(context, cfg, known_inactivity_floor, callback).await
+            crate::qmdb::any::init(context, cfg).await
         }
     }
 

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -1,10 +1,11 @@
 //! Benchmarks for speculative batch merkleization.
 //!
-//! Measures the time required to create a speculative batch (applying random updates equal to 10%
-//! of the total key count, sampled with replacement), merkleize it, and compute its root. The
-//! database is initialized with N unique keys having random digests as values. Database
-//! initialization time is not included in the benchmark. The page cache is large enough to hold the
-//! entire active key set to eliminate disk access delays from affecting the results.
+//! Each iteration creates a speculative batch (10% random updates, sampled with replacement),
+//! merkleizes it, and reads the root. The DB is seeded with N unique keys; setup is not timed.
+//!
+//! - [`bench_merkleize`]: steady-state timing on a freshly seeded DB.
+//! - [`bench_merkleize_churned`]: timing after overwrite batches accumulate inactive update
+//!   operations above the inactivity floor for the floor-raise scan to skip.
 
 use crate::common::{seed_db, write_random_updates, Digest, CHUNK_SIZE, WRITE_BUFFER_SIZE};
 use commonware_cryptography::Sha256;
@@ -252,7 +253,10 @@ type CurOVar256Mmb = commonware_storage::qmdb::current::ordered::variable::Db<
 const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(10_000_000);
 const THREADS: NonZeroUsize = NZUsize!(8);
 const PAGE_SIZE: NonZeroU16 = NZU16!(4096);
+// Very large so all state is in memory.
 const LARGE_PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(131_072);
+// Very small so most reads miss the cache.
+const SMALL_PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(32);
 const PARTITION: &str = "bench-merkleize";
 
 fn merkle_cfg(ctx: &(impl BufferPooler + ThreadPooler), pc: CacheRef) -> full::Config {
@@ -286,16 +290,13 @@ fn var_log_cfg(pc: CacheRef) -> VConfig<((), ())> {
     }
 }
 
-fn pc(ctx: &impl BufferPooler) -> CacheRef {
-    CacheRef::from_pooler(ctx, PAGE_SIZE, LARGE_PAGE_CACHE_SIZE)
-}
-
 // -- DB constructors (eliminates repeated config boilerplate in match arms) --
 
 fn any_fix_cfg(
     ctx: &(impl BufferPooler + ThreadPooler),
+    cache_size: NonZeroUsize,
 ) -> commonware_storage::qmdb::any::FixedConfig<EightCap> {
-    let pc = pc(ctx);
+    let pc = CacheRef::from_pooler(ctx, PAGE_SIZE, cache_size);
     commonware_storage::qmdb::any::FixedConfig {
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
@@ -305,8 +306,9 @@ fn any_fix_cfg(
 
 fn any_var_cfg(
     ctx: &(impl BufferPooler + ThreadPooler),
+    cache_size: NonZeroUsize,
 ) -> commonware_storage::qmdb::any::VariableConfig<EightCap, ((), ())> {
-    let pc = pc(ctx);
+    let pc = CacheRef::from_pooler(ctx, PAGE_SIZE, cache_size);
     commonware_storage::qmdb::any::VariableConfig {
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
@@ -316,8 +318,9 @@ fn any_var_cfg(
 
 fn cur_fix_cfg(
     ctx: &(impl BufferPooler + ThreadPooler),
+    cache_size: NonZeroUsize,
 ) -> commonware_storage::qmdb::current::FixedConfig<EightCap> {
-    let pc = pc(ctx);
+    let pc = CacheRef::from_pooler(ctx, PAGE_SIZE, cache_size);
     commonware_storage::qmdb::current::FixedConfig {
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
@@ -328,8 +331,9 @@ fn cur_fix_cfg(
 
 fn cur_var_cfg(
     ctx: &(impl BufferPooler + ThreadPooler),
+    cache_size: NonZeroUsize,
 ) -> commonware_storage::qmdb::current::VariableConfig<EightCap, ((), ())> {
-    let pc = pc(ctx);
+    let pc = CacheRef::from_pooler(ctx, PAGE_SIZE, cache_size);
     commonware_storage::qmdb::current::VariableConfig {
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
@@ -358,6 +362,40 @@ async fn run_bench<F: merkle::Family, C: DbAny<F, Key = Digest, Value = Digest>>
     }
     let num_updates = num_keys / 10;
     let mut rng = StdRng::seed_from_u64(99);
+    let mut total = Duration::ZERO;
+    for _ in 0..iters {
+        let start = Instant::now();
+        let batch = write_random_updates(db.new_batch(), num_updates, num_keys, &mut rng);
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        black_box(merkleized.root());
+        total += start.elapsed();
+    }
+    db.destroy().await.unwrap();
+    total
+}
+
+/// Apply overwrite batches before timing merkleization.
+///
+/// This leaves inactive update operations above the inactivity floor, matching
+/// the workload optimized by bitmap-backed floor raising.
+async fn run_churned_bench<F: merkle::Family, C: DbAny<F, Key = Digest, Value = Digest>>(
+    mut db: C,
+    num_keys: u64,
+    churn_batches: u64,
+    iters: u64,
+) -> Duration {
+    seed_db(&mut db, num_keys).await;
+    let num_updates = num_keys / 10;
+    let mut rng = StdRng::seed_from_u64(99);
+
+    for _ in 0..churn_batches {
+        let batch = write_random_updates(db.new_batch(), num_updates, num_keys, &mut rng);
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+    }
+    db.commit().await.unwrap();
+    db.sync().await.unwrap();
+
     let mut total = Duration::ZERO;
     for _ in 0..iters {
         let start = Instant::now();
@@ -417,7 +455,7 @@ macro_rules! variants {
         $(
             $entry:ident {
                 name: $name:literal,
-                init: |$ctx:ident| $init:expr,
+                init: |$ctx:ident, $cache:ident| $init:expr,
             }
         )+
     ) => {
@@ -432,20 +470,26 @@ macro_rules! variants {
                     $(Self::$entry => $name),+
                 }
             }
+
+            /// Whether this is an `any::*` variant (vs `current::*`).
+            fn is_any(&self) -> bool {
+                self.name().starts_with("any::")
+            }
         }
 
         const VARIANTS: &[Variant] = &[
             $(Variant::$entry),+
         ];
 
-        /// Dispatch a variant to its concrete DB type and config, then execute `$body` with `db`
-        /// bound.
+        /// Dispatch a variant to its concrete DB type, initialize it with the given page-cache
+        /// size, and run `$body` with the resulting `db` in scope.
         macro_rules! dispatch_variant {
-            ($ctx_expr:expr, $variant_expr:expr, |$db_name:ident| $body:expr) => {
+            ($ctx_expr:expr, $variant_expr:expr, $cache_size:expr, |$db_name:ident| $body:expr) => {
                 match $variant_expr {
                     $(
                         Variant::$entry => {
                             let $ctx = $ctx_expr;
+                            let $cache = $cache_size;
                             let $db_name = $init.await.unwrap();
                             $body
                         }
@@ -459,99 +503,99 @@ macro_rules! variants {
 variants! {
     AnyFixed {
         name: "any::unordered::fixed::mmr",
-        init: |ctx| AnyUFix::init(ctx.clone(), any_fix_cfg(&ctx)),
+        init: |ctx, cache_size| AnyUFix::init(ctx.clone(), any_fix_cfg(&ctx, cache_size)),
     }
     AnyVariable {
         name: "any::unordered::variable::mmr",
-        init: |ctx| AnyUVar::init(ctx.clone(), any_var_cfg(&ctx)),
+        init: |ctx, cache_size| AnyUVar::init(ctx.clone(), any_var_cfg(&ctx, cache_size)),
     }
     AnyFixedMmb {
         name: "any::unordered::fixed::mmb",
-        init: |ctx| AnyUFixMmb::init(ctx.clone(), any_fix_cfg(&ctx)),
+        init: |ctx, cache_size| AnyUFixMmb::init(ctx.clone(), any_fix_cfg(&ctx, cache_size)),
     }
     AnyVariableMmb {
         name: "any::unordered::variable::mmb",
-        init: |ctx| AnyUVarMmb::init(ctx.clone(), any_var_cfg(&ctx)),
+        init: |ctx, cache_size| AnyUVarMmb::init(ctx.clone(), any_var_cfg(&ctx, cache_size)),
     }
     AnyOrderedFixed {
         name: "any::ordered::fixed::mmr",
-        init: |ctx| AnyOFix::init(ctx.clone(), any_fix_cfg(&ctx)),
+        init: |ctx, cache_size| AnyOFix::init(ctx.clone(), any_fix_cfg(&ctx, cache_size)),
     }
     AnyOrderedVariable {
         name: "any::ordered::variable::mmr",
-        init: |ctx| AnyOVar::init(ctx.clone(), any_var_cfg(&ctx)),
+        init: |ctx, cache_size| AnyOVar::init(ctx.clone(), any_var_cfg(&ctx, cache_size)),
     }
     AnyOrderedFixedMmb {
         name: "any::ordered::fixed::mmb",
-        init: |ctx| AnyOFixMmb::init(ctx.clone(), any_fix_cfg(&ctx)),
+        init: |ctx, cache_size| AnyOFixMmb::init(ctx.clone(), any_fix_cfg(&ctx, cache_size)),
     }
     AnyOrderedVariableMmb {
         name: "any::ordered::variable::mmb",
-        init: |ctx| AnyOVarMmb::init(ctx.clone(), any_var_cfg(&ctx)),
+        init: |ctx, cache_size| AnyOVarMmb::init(ctx.clone(), any_var_cfg(&ctx, cache_size)),
     }
     CurrentFixed32 {
         name: "current::unordered::fixed::mmr chunk=32",
-        init: |ctx| CurUFix32::init(ctx.clone(), cur_fix_cfg(&ctx)),
+        init: |ctx, cache_size| CurUFix32::init(ctx.clone(), cur_fix_cfg(&ctx, cache_size)),
     }
     CurrentVariable32 {
         name: "current::unordered::variable::mmr chunk=32",
-        init: |ctx| CurUVar32::init(ctx.clone(), cur_var_cfg(&ctx)),
+        init: |ctx, cache_size| CurUVar32::init(ctx.clone(), cur_var_cfg(&ctx, cache_size)),
     }
     CurrentFixed32Mmb {
         name: "current::unordered::fixed::mmb chunk=32",
-        init: |ctx| CurUFix32Mmb::init(ctx.clone(), cur_fix_cfg(&ctx)),
+        init: |ctx, cache_size| CurUFix32Mmb::init(ctx.clone(), cur_fix_cfg(&ctx, cache_size)),
     }
     CurrentVariable32Mmb {
         name: "current::unordered::variable::mmb chunk=32",
-        init: |ctx| CurUVar32Mmb::init(ctx.clone(), cur_var_cfg(&ctx)),
+        init: |ctx, cache_size| CurUVar32Mmb::init(ctx.clone(), cur_var_cfg(&ctx, cache_size)),
     }
     CurrentFixed256 {
         name: "current::unordered::fixed::mmr chunk=256",
-        init: |ctx| CurUFix256::init(ctx.clone(), cur_fix_cfg(&ctx)),
+        init: |ctx, cache_size| CurUFix256::init(ctx.clone(), cur_fix_cfg(&ctx, cache_size)),
     }
     CurrentVariable256 {
         name: "current::unordered::variable::mmr chunk=256",
-        init: |ctx| CurUVar256::init(ctx.clone(), cur_var_cfg(&ctx)),
+        init: |ctx, cache_size| CurUVar256::init(ctx.clone(), cur_var_cfg(&ctx, cache_size)),
     }
     CurrentFixed256Mmb {
         name: "current::unordered::fixed::mmb chunk=256",
-        init: |ctx| CurUFix256Mmb::init(ctx.clone(), cur_fix_cfg(&ctx)),
+        init: |ctx, cache_size| CurUFix256Mmb::init(ctx.clone(), cur_fix_cfg(&ctx, cache_size)),
     }
     CurrentVariable256Mmb {
         name: "current::unordered::variable::mmb chunk=256",
-        init: |ctx| CurUVar256Mmb::init(ctx.clone(), cur_var_cfg(&ctx)),
+        init: |ctx, cache_size| CurUVar256Mmb::init(ctx.clone(), cur_var_cfg(&ctx, cache_size)),
     }
     CurrentOrderedFixed32 {
         name: "current::ordered::fixed::mmr chunk=32",
-        init: |ctx| CurOFix32::init(ctx.clone(), cur_fix_cfg(&ctx)),
+        init: |ctx, cache_size| CurOFix32::init(ctx.clone(), cur_fix_cfg(&ctx, cache_size)),
     }
     CurrentOrderedVariable32 {
         name: "current::ordered::variable::mmr chunk=32",
-        init: |ctx| CurOVar32::init(ctx.clone(), cur_var_cfg(&ctx)),
+        init: |ctx, cache_size| CurOVar32::init(ctx.clone(), cur_var_cfg(&ctx, cache_size)),
     }
     CurrentOrderedFixed32Mmb {
         name: "current::ordered::fixed::mmb chunk=32",
-        init: |ctx| CurOFix32Mmb::init(ctx.clone(), cur_fix_cfg(&ctx)),
+        init: |ctx, cache_size| CurOFix32Mmb::init(ctx.clone(), cur_fix_cfg(&ctx, cache_size)),
     }
     CurrentOrderedVariable32Mmb {
         name: "current::ordered::variable::mmb chunk=32",
-        init: |ctx| CurOVar32Mmb::init(ctx.clone(), cur_var_cfg(&ctx)),
+        init: |ctx, cache_size| CurOVar32Mmb::init(ctx.clone(), cur_var_cfg(&ctx, cache_size)),
     }
     CurrentOrderedFixed256 {
         name: "current::ordered::fixed::mmr chunk=256",
-        init: |ctx| CurOFix256::init(ctx.clone(), cur_fix_cfg(&ctx)),
+        init: |ctx, cache_size| CurOFix256::init(ctx.clone(), cur_fix_cfg(&ctx, cache_size)),
     }
     CurrentOrderedVariable256 {
         name: "current::ordered::variable::mmr chunk=256",
-        init: |ctx| CurOVar256::init(ctx.clone(), cur_var_cfg(&ctx)),
+        init: |ctx, cache_size| CurOVar256::init(ctx.clone(), cur_var_cfg(&ctx, cache_size)),
     }
     CurrentOrderedFixed256Mmb {
         name: "current::ordered::fixed::mmb chunk=256",
-        init: |ctx| CurOFix256Mmb::init(ctx.clone(), cur_fix_cfg(&ctx)),
+        init: |ctx, cache_size| CurOFix256Mmb::init(ctx.clone(), cur_fix_cfg(&ctx, cache_size)),
     }
     CurrentOrderedVariable256Mmb {
         name: "current::ordered::variable::mmb chunk=256",
-        init: |ctx| CurOVar256Mmb::init(ctx.clone(), cur_var_cfg(&ctx)),
+        init: |ctx, cache_size| CurOVar256Mmb::init(ctx.clone(), cur_var_cfg(&ctx, cache_size)),
     }
 }
 
@@ -578,7 +622,7 @@ fn bench_merkleize(c: &mut Criterion) {
                         |b| {
                             b.to_async(&runner).iter_custom(|iters| async move {
                                 let ctx = context::get::<Context>();
-                                dispatch_variant!(ctx, variant, |db| {
+                                dispatch_variant!(ctx, variant, LARGE_PAGE_CACHE_SIZE, |db| {
                                     if chained {
                                         run_chained_bench(db, num_keys, iters, seed_sync, |p| {
                                             p.new_batch()
@@ -597,8 +641,41 @@ fn bench_merkleize(c: &mut Criterion) {
     }
 }
 
+/// Overwrite batches applied before timing the churned benchmark.
+const CHURN_BATCHES: u64 = 50;
+
+/// Time merkleization after repeatedly overwriting existing keys.
+///
+/// The overwrite batches create inactive log entries that floor raising must
+/// scan past. The smaller cache makes unnecessary reads of those entries show
+/// up in the benchmark.
+fn bench_merkleize_churned(c: &mut Criterion) {
+    let runner = tokio::Runner::new(Config::default());
+    let cache_pages = SMALL_PAGE_CACHE_SIZE.get();
+    for num_keys in NUM_KEYS {
+        // `current::*` already used a bitmap; only `any::*` exercises the new scan path.
+        for variant in VARIANTS.iter().copied().filter(Variant::is_any) {
+            c.bench_function(
+                &format!(
+                    "{}/variant={} keys={num_keys} churn={CHURN_BATCHES} cache_pages={cache_pages}",
+                    module_path!(),
+                    variant.name(),
+                ),
+                |b| {
+                    b.to_async(&runner).iter_custom(|iters| async move {
+                        let ctx = context::get::<Context>();
+                        dispatch_variant!(ctx, variant, SMALL_PAGE_CACHE_SIZE, |db| {
+                            run_churned_bench(db, num_keys, CHURN_BATCHES, iters).await
+                        })
+                    });
+                },
+            );
+        }
+    }
+}
+
 criterion_group! {
     name = benches;
-    config = Criterion::default().sample_size(10);
-    targets = bench_merkleize
+    config = Criterion::default().sample_size(30);
+    targets = bench_merkleize, bench_merkleize_churned
 }

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -1,11 +1,13 @@
 //! Benchmarks for speculative batch merkleization.
 //!
 //! Each iteration creates a speculative batch (10% random updates, sampled with replacement),
-//! merkleizes it, and reads the root. The DB is seeded with N unique keys; setup is not timed.
+//! merkleizes it, and reads the root. The per-iteration `write_random_updates` + `merkleize` +
+//! `root()` is timed; one-time setup (seed, churn batches, sync) is not.
 //!
-//! - [`bench_merkleize`]: steady-state timing on a freshly seeded DB.
-//! - [`bench_merkleize_churned`]: timing after overwrite batches accumulate inactive update
-//!   operations above the inactivity floor for the floor-raise scan to skip.
+//! - [`bench_merkleize`]: timing on a freshly seeded DB (no prior overwrites).
+//! - [`bench_merkleize_churned`]: timing after overwrite batches have accumulated inactive
+//!   update operations above the inactivity floor — the workload the floor-raise bitmap-skip
+//!   optimizes for.
 
 use crate::common::{seed_db, write_random_updates, Digest, CHUNK_SIZE, WRITE_BUFFER_SIZE};
 use commonware_cryptography::Sha256;

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -1,0 +1,93 @@
+//! Activity-status bitmap. Owned by [`any::Db`](super::any::db::Db) and shared with live
+//! [`MerkleizedBatch`](super::current::batch::MerkleizedBatch)es via `Arc<Shared<N>>`.
+//!
+//! `any::Db` mutates the inner [`Prunable`] under a [`RwLock`] during `apply_batch` / `prune` /
+//! `rewind` while live batches read concurrently. Locking (not snapshotting) keeps memory at
+//! O(bitmap size); snapshots would couple memory to live-batch count and lifetime.
+//!
+//! Reads through an invalidated `MerkleizedBatch` (see its "Branch validity" docs) return
+//! inconsistent bytes; callers must drop invalid batches.
+
+pub(crate) use commonware_utils::bitmap::Readable as BitmapReadable;
+use commonware_utils::{
+    bitmap::Prunable,
+    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+
+/// A [`Prunable`] bitmap.
+pub(crate) type BitMap<const N: usize> = Prunable<N>;
+
+/// The committed bitmap shared between `any::Db` and `current::Db`.
+pub(crate) struct Shared<const N: usize> {
+    inner: RwLock<BitMap<N>>,
+}
+
+impl<const N: usize> Shared<N> {
+    pub(crate) const fn new(bitmap: BitMap<N>) -> Self {
+        Self {
+            inner: RwLock::new(bitmap),
+        }
+    }
+
+    /// Acquire a shared read guard over the committed bitmap. Kept private so external callers
+    /// go through [`BitmapReadable`] (which doesn't expose a guard across `.await`).
+    fn read(&self) -> RwLockReadGuard<'_, BitMap<N>> {
+        self.inner.read()
+    }
+
+    /// Acquire an exclusive write guard. By convention only the inner-`any` mutators
+    /// (`apply_batch`, `prune_bitmap`, `rewind`) hold the write lock.
+    pub(crate) fn write(&self) -> RwLockWriteGuard<'_, BitMap<N>> {
+        self.inner.write()
+    }
+
+    /// Single-lock alternative to `BitmapReadable::ones_iter_from(from).next()`.
+    pub(crate) fn next_one_from(&self, from: u64) -> Option<u64> {
+        self.read().ones_iter_from(from).next()
+    }
+
+    /// Return the number of pruned bits. Acquires the read lock briefly.
+    #[cfg(any(test, feature = "test-traits"))]
+    pub(crate) fn pruned_bits(&self) -> u64 {
+        self.read().pruned_bits()
+    }
+
+    /// Return the value of the bit at `loc`. Acquires the read lock briefly.
+    #[cfg(any(test, feature = "test-traits"))]
+    pub(crate) fn get_bit(&self, loc: u64) -> bool {
+        self.read().get_bit(loc)
+    }
+}
+
+impl<const N: usize> std::fmt::Debug for Shared<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Shared")
+            .field("bitmap_len", &BitmapReadable::<N>::len(&*self.read()))
+            .finish()
+    }
+}
+
+/// [`BitmapReadable`] over the DB's committed bitmap. Each call acquires the read lock briefly.
+impl<const N: usize> BitmapReadable<N> for Shared<N> {
+    fn complete_chunks(&self) -> usize {
+        self.read().complete_chunks()
+    }
+
+    fn get_chunk(&self, idx: usize) -> [u8; N] {
+        *self.read().get_chunk(idx)
+    }
+
+    fn last_chunk(&self) -> ([u8; N], u64) {
+        let guard = self.read();
+        let (chunk, bits) = guard.last_chunk();
+        (*chunk, bits)
+    }
+
+    fn pruned_chunks(&self) -> usize {
+        self.read().pruned_chunks()
+    }
+
+    fn len(&self) -> u64 {
+        BitmapReadable::<N>::len(&*self.read())
+    }
+}

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -14,16 +14,12 @@ use commonware_utils::{
     sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-/// A [`Prunable`] bitmap.
-pub(crate) type BitMap<const N: usize> = Prunable<N>;
-
-/// The committed bitmap shared between `any::Db` and `current::Db`.
 pub(crate) struct Shared<const N: usize> {
-    inner: RwLock<BitMap<N>>,
+    inner: RwLock<Prunable<N>>,
 }
 
 impl<const N: usize> Shared<N> {
-    pub(crate) const fn new(bitmap: BitMap<N>) -> Self {
+    pub(crate) const fn new(bitmap: Prunable<N>) -> Self {
         Self {
             inner: RwLock::new(bitmap),
         }
@@ -31,13 +27,13 @@ impl<const N: usize> Shared<N> {
 
     /// Acquire a shared read guard over the committed bitmap. Kept private so external callers
     /// go through [`BitmapReadable`] (which doesn't expose a guard across `.await`).
-    fn read(&self) -> RwLockReadGuard<'_, BitMap<N>> {
+    fn read(&self) -> RwLockReadGuard<'_, Prunable<N>> {
         self.inner.read()
     }
 
     /// Acquire an exclusive write guard. By convention only the inner-`any` mutators
     /// (`apply_batch`, `prune_bitmap`, `rewind`) hold the write lock.
-    pub(crate) fn write(&self) -> RwLockWriteGuard<'_, BitMap<N>> {
+    pub(crate) fn write(&self) -> RwLockWriteGuard<'_, Prunable<N>> {
         self.inner.write()
     }
 

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -1,43 +1,42 @@
 //! Activity-status bitmap. Owned by [`any::Db`](super::any::db::Db) and shared with live
 //! [`MerkleizedBatch`](super::current::batch::MerkleizedBatch)es via `Arc<Shared<N>>`.
 //!
-//! `any::Db` mutates the inner [`Prunable`] under a [`RwLock`] during `apply_batch` / `prune` /
-//! `rewind` while live batches read concurrently. Locking (not snapshotting) keeps memory at
-//! O(bitmap size); snapshots would couple memory to live-batch count and lifetime.
+//! `any::Db` mutates the inner [`bitmap::Prunable`] under a [`RwLock`] during `apply_batch` /
+//! `prune` / `rewind` while live batches read concurrently. Locking (not snapshotting) keeps
+//! memory at O(bitmap size); snapshots would couple memory to live-batch count and lifetime.
 //!
 //! Reads through an invalidated `MerkleizedBatch` (see its "Branch validity" docs) return
 //! inconsistent bytes; callers must drop invalid batches.
 
-pub(crate) use commonware_utils::bitmap::Readable as BitmapReadable;
 use commonware_utils::{
-    bitmap::Prunable,
+    bitmap::{self, Readable as _},
     sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
 pub(crate) struct Shared<const N: usize> {
-    inner: RwLock<Prunable<N>>,
+    inner: RwLock<bitmap::Prunable<N>>,
 }
 
 impl<const N: usize> Shared<N> {
-    pub(crate) const fn new(bitmap: Prunable<N>) -> Self {
+    pub(crate) const fn new(bitmap: bitmap::Prunable<N>) -> Self {
         Self {
             inner: RwLock::new(bitmap),
         }
     }
 
     /// Acquire a shared read guard over the committed bitmap. Kept private so external callers
-    /// go through [`BitmapReadable`] (which doesn't expose a guard across `.await`).
-    fn read(&self) -> RwLockReadGuard<'_, Prunable<N>> {
+    /// go through [`bitmap::Readable`] (which doesn't expose a guard across `.await`).
+    fn read(&self) -> RwLockReadGuard<'_, bitmap::Prunable<N>> {
         self.inner.read()
     }
 
     /// Acquire an exclusive write guard. By convention only the inner-`any` mutators
     /// (`apply_batch`, `prune_bitmap`, `rewind`) hold the write lock.
-    pub(crate) fn write(&self) -> RwLockWriteGuard<'_, Prunable<N>> {
+    pub(crate) fn write(&self) -> RwLockWriteGuard<'_, bitmap::Prunable<N>> {
         self.inner.write()
     }
 
-    /// Single-lock alternative to `BitmapReadable::ones_iter_from(from).next()`.
+    /// Single-lock alternative to `bitmap::Readable::ones_iter_from(from).next()`.
     pub(crate) fn next_one_from(&self, from: u64) -> Option<u64> {
         self.read().ones_iter_from(from).next()
     }
@@ -58,13 +57,13 @@ impl<const N: usize> Shared<N> {
 impl<const N: usize> std::fmt::Debug for Shared<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Shared")
-            .field("bitmap_len", &BitmapReadable::<N>::len(&*self.read()))
+            .field("bitmap_len", &bitmap::Readable::<N>::len(&*self.read()))
             .finish()
     }
 }
 
-/// [`BitmapReadable`] over the DB's committed bitmap. Each call acquires the read lock briefly.
-impl<const N: usize> BitmapReadable<N> for Shared<N> {
+/// [`bitmap::Readable`] over the DB's committed bitmap. Each call acquires the read lock briefly.
+impl<const N: usize> bitmap::Readable<N> for Shared<N> {
     fn complete_chunks(&self) -> usize {
         self.read().complete_chunks()
     }
@@ -84,6 +83,6 @@ impl<const N: usize> BitmapReadable<N> for Shared<N> {
     }
 
     fn len(&self) -> u64 {
-        BitmapReadable::<N>::len(&*self.read())
+        bitmap::Readable::<N>::len(&*self.read())
     }
 }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -12,10 +12,11 @@ use crate::{
     qmdb::{
         any::{
             self,
-            batch::{lookup_sorted, DiffEntry, FloorScan},
+            batch::{lookup_sorted, DiffEntry},
             operation::{update, Operation},
             ValueEncoding,
         },
+        bitmap::Shared,
         current::{
             db::{compute_db_root, compute_grafted_leaves},
             grafting,
@@ -28,10 +29,7 @@ use crate::{
 use ahash::AHasher;
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
-use commonware_utils::{
-    bitmap::{Prunable as BitMap, Readable as BitmapReadable},
-    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
-};
+use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
 use std::{
     collections::{BTreeSet, HashMap},
     hash::BuildHasherDefault,
@@ -113,48 +111,30 @@ impl<const N: usize> ChunkOverlay<N> {
     }
 }
 
-/// Bitmap-accelerated floor scan. Skips locations where the bitmap bit is
-/// unset, avoiding I/O reads for inactive operations.
-pub(crate) struct BitmapScan<'a, B, const N: usize> {
-    bitmap: &'a B,
-}
-
-impl<'a, B: BitmapReadable<N>, const N: usize> BitmapScan<'a, B, N> {
-    pub(crate) const fn new(bitmap: &'a B) -> Self {
-        Self { bitmap }
-    }
-}
-
-impl<F: Graftable, B: BitmapReadable<N>, const N: usize> FloorScan<F> for BitmapScan<'_, B, N> {
-    fn next_candidate(&mut self, floor: Location<F>, tip: u64) -> Option<Location<F>> {
-        let loc = *floor;
-        if loc >= tip {
-            return None;
-        }
-        let bitmap_len = self.bitmap.len();
-        // Within the bitmap: find the next set bit at or after floor. ones_iter_from returns
-        // set indices in ascending order so the first result is the only possible candidate
-        // below bound. tip >= bitmap_len always holds (base_size == bitmap_parent.len()), so
-        // bound == bitmap_len and the length check inside the iterator prevents scanning past
-        // bound.
-        if loc < bitmap_len {
-            let bound = bitmap_len.min(tip);
-            if let Some(idx) = self.bitmap.ones_iter_from(loc).next() {
-                if idx < bound {
-                    return Some(Location::<F>::new(idx));
-                }
+/// Bitmap-accelerated floor scan over a layered `BitmapBatch` chain. Skips locations where the
+/// bitmap bit is unset, avoiding I/O reads for inactive operations.
+///
+/// Mirrors the contract on `any::batch::next_candidate`: may return only locations that are
+/// *possibly* active in `[floor, tip)`, may skip locations only when known inactive.
+/// `is_active_at` revalidates each candidate, so false positives are tolerated; false negatives
+/// are forbidden.
+pub(crate) fn next_candidate<F: Graftable, B: BitmapReadable<N>, const N: usize>(
+    bitmap: &B,
+    floor: Location<F>,
+    tip: u64,
+) -> Option<Location<F>> {
+    let floor = *floor;
+    let bitmap_len = bitmap.len();
+    let committed_end = bitmap_len.min(tip);
+    if floor < committed_end {
+        if let Some(idx) = bitmap.ones_iter_from(floor).next() {
+            if idx < committed_end {
+                return Some(Location::<F>::new(idx));
             }
         }
-        // Beyond the bitmap: uncommitted ops from prior batches in the chain that aren't
-        // tracked by the bitmap yet. Conservatively treat them as candidates.
-        if bitmap_len < tip {
-            let candidate = loc.max(bitmap_len);
-            if candidate < tip {
-                return Some(Location::<F>::new(candidate));
-            }
-        }
-        None
     }
+    let candidate = floor.max(bitmap_len);
+    (candidate < tip).then(|| Location::<F>::new(candidate))
 }
 
 /// Adapter that resolves ops MMR nodes for a batch's `compute_current_layer`.
@@ -421,9 +401,11 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let scan = BitmapScan::new(&bitmap_parent);
+        // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(&db.any, metadata, scan)
+            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip| {
+                next_candidate(&bitmap_parent, floor, tip)
+            })
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }
@@ -484,9 +466,11 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let scan = BitmapScan::new(&bitmap_parent);
+        // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(&db.any, metadata, scan)
+            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip| {
+                next_candidate(&bitmap_parent, floor, tip)
+            })
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }
@@ -706,95 +690,15 @@ where
     }))
 }
 
-/// The committed bitmap shared between the [`Db`](super::db::Db) and live batches.
-///
-/// Wrapped in a [`RwLock`] so that [`Db::apply_batch`](super::db::Db::apply_batch),
-/// [`Db::prune`](super::db::Db::prune), and [`Db::rewind`](super::db::Db::rewind) can mutate
-/// the bitmap in place while live batches concurrently read through it.
-///
-/// # Why in-place mutation under a lock
-///
-/// Snapshot-based alternatives (per-apply clone, page-level copy-on-write, etc.) all require
-/// cloning at least the bitmap's top-level pointer structure on every apply. For large DBs that
-/// cost grows linearly with the total bit count and every live batch retains its snapshot's
-/// memory until dropped, so memory use would grow with both bitmap size and batch lifetime.
-/// Mutating in place keeps memory bounded by the actual bitmap size regardless of how many
-/// batches are alive or how long they live. The per-call read lock is the cost we pay for that.
-///
-/// # Reading through invalid batches
-///
-/// The bitmap behind this lock represents *committed* state. If a caller holds a
-/// [`MerkleizedBatch`] that has become invalid (see its "Branch validity" docs for the
-/// conditions), reads through that batch's chain will silently return inconsistent data (the
-/// chain's overlays mixed with post-divergence committed chunks). The library does not guard
-/// against this; callers must avoid reading through invalid batches.
-pub(crate) struct SharedBitmap<const N: usize> {
-    inner: RwLock<BitMap<N>>,
-}
-
-impl<const N: usize> SharedBitmap<N> {
-    pub(crate) const fn new(bitmap: BitMap<N>) -> Self {
-        Self {
-            inner: RwLock::new(bitmap),
-        }
-    }
-
-    /// Acquire a shared read guard over the committed bitmap. Kept private so external callers
-    /// go through [`BitmapReadable`] (which doesn't expose a guard across `.await`).
-    fn read(&self) -> RwLockReadGuard<'_, BitMap<N>> {
-        self.inner.read()
-    }
-
-    /// Acquire an exclusive write guard. By convention only
-    /// [`Db::apply_batch`](super::db::Db::apply_batch), [`Db::prune`](super::db::Db::prune), and
-    /// [`Db::rewind`](super::db::Db::rewind) mutate the shared bitmap.
-    pub(super) fn write(&self) -> RwLockWriteGuard<'_, BitMap<N>> {
-        self.inner.write()
-    }
-}
-
-impl<const N: usize> std::fmt::Debug for SharedBitmap<N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SharedBitmap")
-            .field("bitmap_len", &BitmapReadable::<N>::len(&*self.read()))
-            .finish()
-    }
-}
-
-/// [`BitmapReadable`] over the DB's committed bitmap. Each call acquires the read lock briefly.
-impl<const N: usize> BitmapReadable<N> for SharedBitmap<N> {
-    fn complete_chunks(&self) -> usize {
-        self.read().complete_chunks()
-    }
-
-    fn get_chunk(&self, idx: usize) -> [u8; N] {
-        *self.read().get_chunk(idx)
-    }
-
-    fn last_chunk(&self) -> ([u8; N], u64) {
-        let guard = self.read();
-        let (chunk, bits) = guard.last_chunk();
-        (*chunk, bits)
-    }
-
-    fn pruned_chunks(&self) -> usize {
-        self.read().pruned_chunks()
-    }
-
-    fn len(&self) -> u64 {
-        BitmapReadable::<N>::len(&*self.read())
-    }
-}
-
 /// A view of the committed bitmap plus zero or more speculative overlay `Layer`s.
 ///
 /// The chain terminates in a `Base` that references the shared committed bitmap. No validity
 /// check is performed. Callers must ensure they only read through batches whose chains are
-/// still valid prefixes of committed state (see [`SharedBitmap`]'s docs).
+/// still valid prefixes of committed state (see [`Shared`]'s docs).
 #[derive(Clone, Debug)]
 pub(crate) enum BitmapBatch<const N: usize> {
     /// Chain terminal: shared reference to the committed bitmap.
-    Base(Arc<SharedBitmap<N>>),
+    Base(Arc<Shared<N>>),
     /// Speculative layer on top of a parent batch.
     Layer(Arc<BitmapBatchLayer<N>>),
 }
@@ -805,16 +709,16 @@ pub(crate) struct BitmapBatchLayer<const N: usize> {
     pub(crate) parent: BitmapBatch<N>,
     /// Chunk-level overlay: materialized bytes for every chunk that differs from parent.
     pub(crate) overlay: Arc<ChunkOverlay<N>>,
-    /// Cached terminal [`SharedBitmap`] so [`BitmapBatch::shared`] and
+    /// Cached terminal [`Shared`] so [`BitmapBatch::shared`] and
     /// [`BitmapBatch::pruned_chunks`] answer in O(1) instead of walking the chain.
-    pub(crate) shared: Arc<SharedBitmap<N>>,
+    pub(crate) shared: Arc<Shared<N>>,
 }
 
 impl<const N: usize> BitmapBatch<N> {
     const CHUNK_SIZE_BITS: u64 = BitMap::<N>::CHUNK_SIZE_BITS;
 
-    /// Return the terminal [`SharedBitmap`] at the bottom of the chain.
-    fn shared(&self) -> &Arc<SharedBitmap<N>> {
+    /// Return the terminal [`Shared`] at the bottom of the chain.
+    fn shared(&self) -> &Arc<Shared<N>> {
         match self {
             Self::Base(s) => s,
             Self::Layer(layer) => &layer.shared,
@@ -826,7 +730,7 @@ impl<const N: usize> BitmapBatch<N> {
     /// contiguous prefixes, committed `Layer`s are always at the bottom of the chain.
     fn trim_committed(&self) -> Self {
         let shared = self.shared();
-        let committed = shared.read().len();
+        let committed = BitmapReadable::<N>::len(shared.as_ref());
         let mut kept = Vec::new();
         let mut current = self;
         while let Self::Layer(layer) = current {
@@ -994,7 +898,7 @@ where
         Arc::new(MerkleizedBatch {
             inner: self.any.to_batch(),
             grafted,
-            bitmap: BitmapBatch::Base(Arc::clone(&self.status)),
+            bitmap: BitmapBatch::Base(Arc::clone(&self.any.bitmap)),
             canonical_root: self.root,
         })
     }
@@ -1324,115 +1228,68 @@ mod tests {
         assert_eq!(c0[2], 0x07);
     }
 
-    // ---- FloorScan tests ----
+    // ---- next_candidate tests ----
 
-    use crate::qmdb::any::batch::{FloorScan, SequentialScan};
-
-    #[test]
-    fn sequential_scan_returns_floor_when_below_tip() {
-        let mut scan = SequentialScan;
-        assert_eq!(
-            scan.next_candidate(Location::new(5), 10),
-            Some(Location::new(5))
-        );
-    }
-
-    #[test]
-    fn sequential_scan_returns_none_at_tip() {
-        let mut scan = SequentialScan;
-        assert_eq!(scan.next_candidate(Location::new(10), 10), None);
-        assert_eq!(scan.next_candidate(Location::new(11), 10), None);
+    fn nc(bm: &Bm, floor: u64, tip: u64) -> Option<Location> {
+        next_candidate::<mmr::Family, _, N>(bm, Location::new(floor), tip)
     }
 
     #[test]
     fn bitmap_scan_all_active() {
         let bm = make_bitmap(&[true; 8]);
-        let mut scan = BitmapScan::<Bm, N>::new(&bm);
         for i in 0..8 {
-            assert_eq!(
-                scan.next_candidate(Location::new(i), 8),
-                Some(Location::new(i))
-            );
+            assert_eq!(nc(&bm, i, 8), Some(Location::new(i)));
         }
-        assert_eq!(scan.next_candidate(Location::new(8), 8), None);
+        assert_eq!(nc(&bm, 8, 8), None);
     }
 
     #[test]
     fn bitmap_scan_all_inactive() {
         let bm = make_bitmap(&[false; 8]);
-        let mut scan = BitmapScan::<Bm, N>::new(&bm);
-        assert_eq!(scan.next_candidate(Location::new(0), 8), None);
+        assert_eq!(nc(&bm, 0, 8), None);
     }
 
     #[test]
     fn bitmap_scan_skips_inactive() {
         // Pattern: inactive, inactive, active, inactive, active
         let bm = make_bitmap(&[false, false, true, false, true]);
-        let mut scan = BitmapScan::<Bm, N>::new(&bm);
-
-        assert_eq!(
-            scan.next_candidate(Location::new(0), 5),
-            Some(Location::new(2))
-        );
-        assert_eq!(
-            scan.next_candidate(Location::new(3), 5),
-            Some(Location::new(4))
-        );
-        assert_eq!(scan.next_candidate(Location::new(5), 5), None);
+        assert_eq!(nc(&bm, 0, 5), Some(Location::new(2)));
+        assert_eq!(nc(&bm, 3, 5), Some(Location::new(4)));
+        assert_eq!(nc(&bm, 5, 5), None);
     }
 
     #[test]
     fn bitmap_scan_beyond_bitmap_len_returns_candidate() {
-        // Bitmap has 4 bits, but tip is 8. Locations 4..8 are beyond the
-        // bitmap and should be returned as candidates.
+        // Bitmap has 4 bits, but tip is 8. Locations 4..8 are beyond the bitmap and should be
+        // returned as candidates.
         let bm = make_bitmap(&[false; 4]);
-        let mut scan = BitmapScan::<Bm, N>::new(&bm);
-
-        // All bitmap bits are unset, so 0..4 are skipped.
-        // Location 4 is beyond bitmap -> candidate.
-        assert_eq!(
-            scan.next_candidate(Location::new(0), 8),
-            Some(Location::new(4))
-        );
-        assert_eq!(
-            scan.next_candidate(Location::new(6), 8),
-            Some(Location::new(6))
-        );
+        // All bitmap bits are unset, so 0..4 are skipped; loc 4 is beyond bitmap -> candidate.
+        assert_eq!(nc(&bm, 0, 8), Some(Location::new(4)));
+        assert_eq!(nc(&bm, 6, 8), Some(Location::new(6)));
     }
 
     #[test]
     fn bitmap_scan_respects_tip() {
         let bm = make_bitmap(&[false, false, false, true]);
-        let mut scan = BitmapScan::<Bm, N>::new(&bm);
-
         // Active bit at 3, but tip is 3 so it's excluded.
-        assert_eq!(scan.next_candidate(Location::new(0), 3), None);
+        assert_eq!(nc(&bm, 0, 3), None);
         // With tip=4, bit 3 is included.
-        assert_eq!(
-            scan.next_candidate(Location::new(0), 4),
-            Some(Location::new(3))
-        );
+        assert_eq!(nc(&bm, 0, 4), Some(Location::new(3)));
     }
 
     #[test]
     fn bitmap_scan_floor_at_tip() {
         let bm = make_bitmap(&[true; 4]);
-        let mut scan = BitmapScan::<Bm, N>::new(&bm);
-        assert_eq!(scan.next_candidate(Location::new(4), 4), None);
+        assert_eq!(nc(&bm, 4, 4), None);
     }
 
     #[test]
     fn bitmap_scan_empty_bitmap() {
         let bm = Bm::new();
-        let mut scan = BitmapScan::<Bm, N>::new(&bm);
-
         // Empty bitmap, but tip > 0: all locations are beyond bitmap.
-        assert_eq!(
-            scan.next_candidate(Location::new(0), 5),
-            Some(Location::new(0))
-        );
+        assert_eq!(nc(&bm, 0, 5), Some(Location::new(0)));
         // Empty bitmap, tip = 0: no candidates.
-        assert_eq!(scan.next_candidate(Location::new(0), 0), None);
+        assert_eq!(nc(&bm, 0, 0), None);
     }
 
     // ---- trim_committed tests ----
@@ -1447,7 +1304,7 @@ mod tests {
     /// Build a chain `Base(shared) -> Layer(len=L1) -> Layer(len=L2) -> ...` from a list of
     /// overlay lengths (bottom to top). Each constructed `Layer` caches `shared` per the
     /// struct's invariant.
-    fn make_chain(shared: &Arc<SharedBitmap<N>>, overlay_lens: &[u64]) -> BitmapBatch<N> {
+    fn make_chain(shared: &Arc<Shared<N>>, overlay_lens: &[u64]) -> BitmapBatch<N> {
         let mut chain = BitmapBatch::Base(Arc::clone(shared));
         for &len in overlay_lens {
             chain = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
@@ -1476,11 +1333,11 @@ mod tests {
 
     /// Input is already a bare `Base` with no speculative layers on top — the loop body never
     /// runs, `kept` stays empty, and the result is a freshly constructed `Base` pointing at the
-    /// same `SharedBitmap`. Real-world trigger: `MerkleizedBatch::new_batch` on a batch whose
+    /// same `Shared`. Real-world trigger: `MerkleizedBatch::new_batch` on a batch whose
     /// chain was previously trimmed flat (e.g., immediately after an apply collapsed everything).
     #[test]
     fn trim_committed_already_base() {
-        let shared = Arc::new(SharedBitmap::<N>::new(make_bitmap(&[true; 64])));
+        let shared = Arc::new(Shared::<N>::new(make_bitmap(&[true; 64])));
         let base = BitmapBatch::Base(Arc::clone(&shared));
         let result = base.trim_committed();
         // Still `Base`, pointing at the same shared terminal.
@@ -1498,7 +1355,7 @@ mod tests {
     #[test]
     fn trim_committed_all_committed() {
         // `shared.len() == 64`; the single layer's `overlay.len == 32 (<= 64)`, so it's committed.
-        let shared = Arc::new(SharedBitmap::<N>::new(make_bitmap(&[true; 64])));
+        let shared = Arc::new(Shared::<N>::new(make_bitmap(&[true; 64])));
         let chain = make_chain(&shared, &[32]);
         let result = chain.trim_committed();
         // Collapsed to a bare Base, pointing at the original shared.
@@ -1515,7 +1372,7 @@ mod tests {
     #[test]
     fn trim_committed_none_committed() {
         // `shared.len() == 32`; both overlays have `len > 32`, so neither is committed.
-        let shared = Arc::new(SharedBitmap::<N>::new(make_bitmap(&[true; 32])));
+        let shared = Arc::new(Shared::<N>::new(make_bitmap(&[true; 32])));
         let chain = make_chain(&shared, &[64, 96]);
         let result = chain.trim_committed();
         // Structure must be preserved in bottom-to-top order.
@@ -1530,7 +1387,7 @@ mod tests {
     #[test]
     fn trim_committed_exactly_one_uncommitted() {
         // `shared.len() == 64`; committed layer (`overlay.len == 64`) + uncommitted (`96`).
-        let shared = Arc::new(SharedBitmap::<N>::new(make_bitmap(&[true; 64])));
+        let shared = Arc::new(Shared::<N>::new(make_bitmap(&[true; 64])));
         let chain = make_chain(&shared, &[64, 96]);
         let result = chain.trim_committed();
         // The committed layer is gone; only the uncommitted overlay remains.
@@ -1546,7 +1403,7 @@ mod tests {
     #[test]
     fn trim_committed_multiple_uncommitted() {
         // `shared.len() == 64`; committed layer (64), then two uncommitted (96, 128).
-        let shared = Arc::new(SharedBitmap::<N>::new(make_bitmap(&[true; 64])));
+        let shared = Arc::new(Shared::<N>::new(make_bitmap(&[true; 64])));
         let chain = make_chain(&shared, &[64, 96, 128]);
         let result = chain.trim_committed();
         // Committed layer dropped; uncommitted pair preserved in order.

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1230,32 +1230,37 @@ mod tests {
 
     // ---- next_candidate tests ----
 
-    fn nc(bm: &Bm, floor: u64, tip: u64) -> Option<Location> {
-        next_candidate::<mmr::Family, _, N>(bm, Location::new(floor), tip)
-    }
-
     #[test]
     fn bitmap_scan_all_active() {
         let bm = make_bitmap(&[true; 8]);
         for i in 0..8 {
-            assert_eq!(nc(&bm, i, 8), Some(Location::new(i)));
+            assert_eq!(
+                next_candidate(&bm, Location::new(i), 8),
+                Some(Location::new(i))
+            );
         }
-        assert_eq!(nc(&bm, 8, 8), None);
+        assert_eq!(next_candidate(&bm, Location::new(8), 8), None);
     }
 
     #[test]
     fn bitmap_scan_all_inactive() {
         let bm = make_bitmap(&[false; 8]);
-        assert_eq!(nc(&bm, 0, 8), None);
+        assert_eq!(next_candidate(&bm, Location::new(0), 8), None);
     }
 
     #[test]
     fn bitmap_scan_skips_inactive() {
         // Pattern: inactive, inactive, active, inactive, active
         let bm = make_bitmap(&[false, false, true, false, true]);
-        assert_eq!(nc(&bm, 0, 5), Some(Location::new(2)));
-        assert_eq!(nc(&bm, 3, 5), Some(Location::new(4)));
-        assert_eq!(nc(&bm, 5, 5), None);
+        assert_eq!(
+            next_candidate(&bm, Location::new(0), 5),
+            Some(Location::new(2))
+        );
+        assert_eq!(
+            next_candidate(&bm, Location::new(3), 5),
+            Some(Location::new(4))
+        );
+        assert_eq!(next_candidate(&bm, Location::new(5), 5), None);
     }
 
     #[test]
@@ -1264,32 +1269,44 @@ mod tests {
         // returned as candidates.
         let bm = make_bitmap(&[false; 4]);
         // All bitmap bits are unset, so 0..4 are skipped; loc 4 is beyond bitmap -> candidate.
-        assert_eq!(nc(&bm, 0, 8), Some(Location::new(4)));
-        assert_eq!(nc(&bm, 6, 8), Some(Location::new(6)));
+        assert_eq!(
+            next_candidate(&bm, Location::new(0), 8),
+            Some(Location::new(4))
+        );
+        assert_eq!(
+            next_candidate(&bm, Location::new(6), 8),
+            Some(Location::new(6))
+        );
     }
 
     #[test]
     fn bitmap_scan_respects_tip() {
         let bm = make_bitmap(&[false, false, false, true]);
         // Active bit at 3, but tip is 3 so it's excluded.
-        assert_eq!(nc(&bm, 0, 3), None);
+        assert_eq!(next_candidate(&bm, Location::new(0), 3), None);
         // With tip=4, bit 3 is included.
-        assert_eq!(nc(&bm, 0, 4), Some(Location::new(3)));
+        assert_eq!(
+            next_candidate(&bm, Location::new(0), 4),
+            Some(Location::new(3))
+        );
     }
 
     #[test]
     fn bitmap_scan_floor_at_tip() {
         let bm = make_bitmap(&[true; 4]);
-        assert_eq!(nc(&bm, 4, 4), None);
+        assert_eq!(next_candidate(&bm, Location::new(4), 4), None);
     }
 
     #[test]
     fn bitmap_scan_empty_bitmap() {
         let bm = Bm::new();
         // Empty bitmap, but tip > 0: all locations are beyond bitmap.
-        assert_eq!(nc(&bm, 0, 5), Some(Location::new(0)));
+        assert_eq!(
+            next_candidate(&bm, Location::new(0), 5),
+            Some(Location::new(0))
+        );
         // Empty bitmap, tip = 0: no candidates.
-        assert_eq!(nc(&bm, 0, 0), None);
+        assert_eq!(next_candidate(&bm, Location::new(0), 0), None);
     }
 
     // ---- trim_committed tests ----

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -29,7 +29,7 @@ use crate::{
 use ahash::AHasher;
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
-use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
+use commonware_utils::bitmap::{self, Readable as _};
 use std::{
     collections::{BTreeSet, HashMap},
     hash::BuildHasherDefault,
@@ -53,7 +53,7 @@ pub(crate) struct ChunkOverlay<const N: usize> {
 }
 
 impl<const N: usize> ChunkOverlay<N> {
-    const CHUNK_BITS: u64 = BitMap::<N>::CHUNK_SIZE_BITS;
+    const CHUNK_BITS: u64 = bitmap::Prunable::<N>::CHUNK_SIZE_BITS;
 
     fn new(len: u64) -> Self {
         Self {
@@ -64,7 +64,7 @@ impl<const N: usize> ChunkOverlay<N> {
 
     /// Load-or-create a chunk: returns a mutable reference to the materialized chunk bytes. On
     /// first access for an existing chunk, reads from `base`.
-    fn chunk_mut<B: BitmapReadable<N>>(&mut self, base: &B, idx: usize) -> &mut [u8; N] {
+    fn chunk_mut<B: bitmap::Readable<N>>(&mut self, base: &B, idx: usize) -> &mut [u8; N] {
         self.chunks.entry(idx).or_insert_with(|| {
             let base_len = base.len();
             let base_complete = base.complete_chunks();
@@ -80,8 +80,8 @@ impl<const N: usize> ChunkOverlay<N> {
     }
 
     /// Set a single bit (used for pushes and active operations).
-    fn set_bit<B: BitmapReadable<N>>(&mut self, base: &B, loc: u64) {
-        let idx = BitMap::<N>::to_chunk_index(loc);
+    fn set_bit<B: bitmap::Readable<N>>(&mut self, base: &B, loc: u64) {
+        let idx = bitmap::Prunable::<N>::to_chunk_index(loc);
         let rel = (loc % Self::CHUNK_BITS) as usize;
         let chunk = self.chunk_mut(base, idx);
         chunk[rel / 8] |= 1 << (rel % 8);
@@ -90,8 +90,8 @@ impl<const N: usize> ChunkOverlay<N> {
     /// Clear a single bit (used for superseded locations). `pruned_chunks` is passed in by the
     /// caller so the hot loop in `build_chunk_overlay` reads it once rather than per call.
     /// Skips locations in pruned chunks since those bits are already inactive.
-    fn clear_bit<B: BitmapReadable<N>>(&mut self, base: &B, pruned_chunks: usize, loc: u64) {
-        let idx = BitMap::<N>::to_chunk_index(loc);
+    fn clear_bit<B: bitmap::Readable<N>>(&mut self, base: &B, pruned_chunks: usize, loc: u64) {
+        let idx = bitmap::Prunable::<N>::to_chunk_index(loc);
         if idx < pruned_chunks {
             return;
         }
@@ -118,7 +118,13 @@ impl<const N: usize> ChunkOverlay<N> {
 /// *possibly* active in `[floor, tip)`, may skip locations only when known inactive.
 /// `is_active_at` revalidates each candidate, so false positives are tolerated; false negatives
 /// are forbidden.
-pub(crate) fn next_candidate<F: Graftable, B: BitmapReadable<N>, const N: usize>(
+///
+/// False positives can arise two ways:
+/// - In the committed prefix, an uncommitted ancestor batch in the chain may have superseded
+///   the location — the committed bitmap doesn't reflect uncommitted shadows.
+/// - Beyond the committed bitmap, locations are returned as sequential candidates (one per
+///   index) without per-location filtering, so any inactive uncommitted op shows up here.
+pub(crate) fn next_candidate<F: Graftable, B: bitmap::Readable<N>, const N: usize>(
     bitmap: &B,
     floor: Location<F>,
     tip: u64,
@@ -486,7 +492,7 @@ where
 /// search back through ancestors to find the most recent active location; if none exists, we clear
 /// the committed DB location (`base_old_loc`).
 #[allow(clippy::type_complexity)]
-fn build_chunk_overlay<F: Graftable, U, B: BitmapReadable<N>, const N: usize>(
+fn build_chunk_overlay<F: Graftable, U, B: bitmap::Readable<N>, const N: usize>(
     base: &B,
     batch_len: usize,
     batch_base: u64,
@@ -715,7 +721,7 @@ pub(crate) struct BitmapBatchLayer<const N: usize> {
 }
 
 impl<const N: usize> BitmapBatch<N> {
-    const CHUNK_SIZE_BITS: u64 = BitMap::<N>::CHUNK_SIZE_BITS;
+    const CHUNK_SIZE_BITS: u64 = bitmap::Prunable::<N>::CHUNK_SIZE_BITS;
 
     /// Return the terminal [`Shared`] at the bottom of the chain.
     fn shared(&self) -> &Arc<Shared<N>> {
@@ -730,7 +736,7 @@ impl<const N: usize> BitmapBatch<N> {
     /// contiguous prefixes, committed `Layer`s are always at the bottom of the chain.
     fn trim_committed(&self) -> Self {
         let shared = self.shared();
-        let committed = BitmapReadable::<N>::len(shared.as_ref());
+        let committed = bitmap::Readable::<N>::len(shared.as_ref());
         let mut kept = Vec::new();
         let mut current = self;
         while let Self::Layer(layer) = current {
@@ -752,7 +758,7 @@ impl<const N: usize> BitmapBatch<N> {
     }
 }
 
-impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
+impl<const N: usize> bitmap::Readable<N> for BitmapBatch<N> {
     fn complete_chunks(&self) -> usize {
         (self.len() / Self::CHUNK_SIZE_BITS) as usize
     }
@@ -795,7 +801,7 @@ impl<const N: usize> BitmapReadable<N> for BitmapBatch<N> {
 
     fn len(&self) -> u64 {
         match self {
-            Self::Base(shared) => BitmapReadable::<N>::len(shared.as_ref()),
+            Self::Base(shared) => bitmap::Readable::<N>::len(shared.as_ref()),
             Self::Layer(layer) => layer.overlay.len,
         }
     }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -386,7 +386,8 @@ where
             return Ok(());
         }
 
-        let prune_pos = Position::try_from(prune_loc).expect("valid leaf count");
+        let prune_pos = Position::try_from(prune_loc)
+            .map_err(|_| Error::<F>::DataCorrupted("prune location overflow"))?;
         let root = *self.grafted_tree.root();
         let size = self.grafted_tree.size();
 
@@ -424,6 +425,8 @@ where
     /// - Returns [Error::PruneBeyondMinRequired] if `prune_loc` > [`Self::sync_boundary`].
     /// - Returns [`crate::merkle::Error::LocationOverflow`] if `prune_loc` >
     ///   [crate::merkle::Family::MAX_LEAVES].
+    /// - Returns [Error::DataCorrupted] if internal grafted-tree state is inconsistent (a pinned
+    ///   or retained node is missing, or the prune location overflows a [Position]).
     pub async fn prune(&mut self, prune_loc: Location<F>) -> Result<(), Error<F>> {
         let sync_boundary = self.sync_boundary();
         if prune_loc > sync_boundary {

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -374,6 +374,44 @@ where
         Self::pair_absorption_threshold(self.any.bitmap.pruned_chunks() as u64)
     }
 
+    /// Prune the grafted tree to match the committed bitmap's pruned chunks.
+    fn prune_grafted_tree_to_bitmap(&mut self) -> Result<(), Error<F>> {
+        let pruned_chunks = self.any.bitmap.pruned_chunks() as u64;
+        if pruned_chunks == 0 {
+            return Ok(());
+        }
+
+        let prune_loc = Location::<F>::new(pruned_chunks);
+        if prune_loc <= self.grafted_tree.bounds().start {
+            return Ok(());
+        }
+
+        let prune_pos = Position::try_from(prune_loc).expect("valid leaf count");
+        let root = *self.grafted_tree.root();
+        let size = self.grafted_tree.size();
+
+        let mut pinned = BTreeMap::new();
+        for pos in F::nodes_to_pin(prune_loc) {
+            let digest = self
+                .grafted_tree
+                .get_node(pos)
+                .ok_or(Error::<F>::DataCorrupted("missing grafted pinned node"))?;
+            pinned.insert(pos, digest);
+        }
+
+        let mut retained = Vec::with_capacity((*size - *prune_pos) as usize);
+        for p in *prune_pos..*size {
+            let digest = self
+                .grafted_tree
+                .get_node(Position::new(p))
+                .ok_or(Error::<F>::DataCorrupted("missing retained grafted node"))?;
+            retained.push(digest);
+        }
+
+        self.grafted_tree = Mem::from_pruned_with_retained(root, prune_pos, pinned, retained);
+        Ok(())
+    }
+
     /// Prunes historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
     ///
@@ -394,39 +432,7 @@ where
 
         // Prune the bitmap to the sync boundary (most aggressive safe location).
         self.any.prune_bitmap(sync_boundary);
-
-        // Prune the grafted tree to match the bitmap's pruned chunks.
-        let pruned_chunks = self.any.bitmap.pruned_chunks() as u64;
-        if pruned_chunks > 0 {
-            let prune_loc_grafted = Location::<F>::new(pruned_chunks);
-            let bounds_start = self.grafted_tree.bounds().start;
-            let grafted_prune_pos =
-                Position::try_from(prune_loc_grafted).expect("valid leaf count");
-            if prune_loc_grafted > bounds_start {
-                let root = *self.grafted_tree.root();
-                let size = self.grafted_tree.size();
-
-                let mut pinned = BTreeMap::new();
-                for pos in F::nodes_to_pin(prune_loc_grafted) {
-                    pinned.insert(
-                        pos,
-                        self.grafted_tree
-                            .get_node(pos)
-                            .expect("pinned peak must exist"),
-                    );
-                }
-                let mut retained = Vec::with_capacity((*size - *grafted_prune_pos) as usize);
-                for p in *grafted_prune_pos..*size {
-                    retained.push(
-                        self.grafted_tree
-                            .get_node(Position::new(p))
-                            .expect("retained node must exist"),
-                    );
-                }
-                self.grafted_tree =
-                    Mem::from_pruned_with_retained(root, grafted_prune_pos, pinned, retained);
-            }
-        }
+        self.prune_grafted_tree_to_bitmap()?;
 
         // Persist grafted tree pruning state before pruning the ops log. If the subsequent
         // `any.prune_log` fails, the metadata is ahead of the log, which is safe: on recovery,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -19,7 +19,7 @@ use crate::{
             operation::{update::Update, Operation},
         },
         current::{
-            batch::{BitmapBatch, SharedBitmap},
+            batch::BitmapBatch,
             grafting,
             proof::{OperationProof, OpsRootWitness, RangeProof},
         },
@@ -59,16 +59,9 @@ pub struct Db<
     const N: usize,
 > {
     /// An authenticated database that provides the ability to prove whether a key ever had a
-    /// specific value.
-    pub(super) any: any::db::Db<F, E, C, I, H, U>,
-
-    /// The bitmap over the activity status of each operation. Supports augmenting [Db] proofs in
-    /// order to further prove whether a key _currently_ has a specific value.
-    ///
-    /// Shared behind an `Arc<RwLock<..>>` so that live batches can hold a reference to the
-    /// committed bitmap while [`Db::apply_batch`] mutates it in place under the write lock. See
-    /// [`SharedBitmap`]'s doc for the branch-validity caveat that callers must respect.
-    pub(super) status: Arc<SharedBitmap<N>>,
+    /// specific value. Owns the activity-status bitmap (`any.bitmap`) that this layer reads to
+    /// install grafted-tree updates and serve proofs.
+    pub(super) any: any::db::Db<F, E, C, I, H, U, N>,
 
     /// Each leaf corresponds to a complete bitmap chunk at the grafting height.
     /// See the [grafted leaf formula](super) in the module documentation.
@@ -187,8 +180,9 @@ where
     ) -> Result<OpsRootWitness<H::Digest>, Error<F>> {
         let storage = self.grafted_storage();
         let grafted_root =
-            compute_grafted_root::<F, H, _, _, N>(hasher, self.status.as_ref(), &storage).await?;
-        let partial_chunk = partial_chunk::<_, N>(self.status.as_ref())
+            compute_grafted_root::<F, H, _, _, N>(hasher, self.any.bitmap.as_ref(), &storage)
+                .await?;
+        let partial_chunk = partial_chunk::<_, N>(self.any.bitmap.as_ref())
             .map(|(chunk, next_bit)| (next_bit, hasher.digest(&chunk)));
         Ok(OpsRootWitness {
             grafted_root,
@@ -206,7 +200,7 @@ where
         super::batch::UnmerkleizedBatch::new(
             self.any.new_batch(),
             self.grafted_snapshot(),
-            BitmapBatch::Base(Arc::clone(&self.status)),
+            BitmapBatch::Base(Arc::clone(&self.any.bitmap)),
         )
     }
 
@@ -218,7 +212,7 @@ where
     ) -> Result<OperationProof<F, H::Digest, N>, Error<F>> {
         let storage = self.grafted_storage();
         let ops_root = self.any.log.root();
-        OperationProof::new(hasher, self.status.as_ref(), &storage, loc, ops_root).await
+        OperationProof::new(hasher, self.any.bitmap.as_ref(), &storage, loc, ops_root).await
     }
 
     /// Returns a proof that the specified range of operations are part of the database, along with
@@ -242,7 +236,7 @@ where
         let ops_root = self.any.log.root();
         RangeProof::new_with_ops(
             hasher,
-            self.status.as_ref(),
+            self.any.bitmap.as_ref(),
             &storage,
             &self.any.log,
             start_loc,
@@ -377,7 +371,7 @@ where
     ///
     /// Returns `None` for families without delayed merges.
     fn delayed_merge_rewind_floor(&self) -> Option<u64> {
-        Self::pair_absorption_threshold(self.status.pruned_chunks() as u64)
+        Self::pair_absorption_threshold(self.any.bitmap.pruned_chunks() as u64)
     }
 
     /// Prunes historical operations prior to `prune_loc`. This does not affect the db's root or
@@ -398,11 +392,11 @@ where
             return Err(Error::PruneBeyondMinRequired(prune_loc, sync_boundary));
         }
 
-        // Prune bitmap chunks to the sync boundary (most aggressive safe location).
-        self.status.write().prune_to_bit(*sync_boundary);
+        // Prune the bitmap to the sync boundary (most aggressive safe location).
+        self.any.prune_bitmap(sync_boundary);
 
         // Prune the grafted tree to match the bitmap's pruned chunks.
-        let pruned_chunks = self.status.pruned_chunks() as u64;
+        let pruned_chunks = self.any.bitmap.pruned_chunks() as u64;
         if pruned_chunks > 0 {
             let prune_loc_grafted = Location::<F>::new(pruned_chunks);
             let bounds_start = self.grafted_tree.bounds().start;
@@ -435,13 +429,13 @@ where
         }
 
         // Persist grafted tree pruning state before pruning the ops log. If the subsequent
-        // `any.prune` fails, the metadata is ahead of the log, which is safe: on recovery,
+        // `any.prune_log` fails, the metadata is ahead of the log, which is safe: on recovery,
         // `build_grafted_tree` will recompute from the (un-pruned) log and the metadata
         // simply records peaks that haven't been pruned yet. The reverse order would be unsafe:
         // a pruned log with stale metadata would lose peak digests permanently.
         self.sync_metadata().await?;
 
-        self.any.prune(prune_loc).await
+        self.any.prune_log(prune_loc).await
     }
 
     /// Rewind the database to `size` operations, where `size` is the location of the next append.
@@ -467,14 +461,19 @@ where
     pub async fn rewind(&mut self, size: Location<F>) -> Result<(), Error<F>> {
         let rewind_size = *size;
         let current_size = *self.any.last_commit_loc + 1;
+        // No-op short-circuit. Avoids the post-rewind grafted-tree rebuild and the validation
+        // and journal-read overhead below. Validation runs after this on the non-no-op path.
         if rewind_size == current_size {
             return Ok(());
         }
+        // Reject zero / out-of-range up front: lines below compute `rewind_size - 1`, which
+        // underflows when `rewind_size == 0`. `any::Db::rewind` would catch these, but it isn't
+        // called until after those subtractions.
         if rewind_size == 0 || rewind_size > current_size {
             return Err(Error::Journal(JournalError::InvalidRewind(rewind_size)));
         }
 
-        let pruned_chunks = self.status.pruned_chunks();
+        let pruned_chunks = self.any.bitmap.pruned_chunks();
         let pruned_bits = (pruned_chunks as u64)
             .checked_mul(BitMap::<N>::CHUNK_SIZE_BITS)
             .ok_or_else(|| Error::DataCorrupted("pruned ops leaves overflow"))?;
@@ -519,26 +518,15 @@ where
             Vec::new()
         };
 
-        // Rewind underlying ops log + Any state. If a later overlay rebuild step fails, this
-        // handle may be internally diverged and must be dropped by the caller.
-        let restored_locs = self.any.rewind(size).await?;
-
-        // Patch shared bitmap under the write lock: truncate to rewound size, then mark restored
-        // locations as active. Live batches built pre-rewind will silently return wrong data on
-        // any chunk read that falls through to the committed bitmap; callers must drop them.
-        {
-            let mut guard = self.status.write();
-            guard.truncate(rewind_size);
-            for loc in &restored_locs {
-                guard.set_bit(**loc, true);
-            }
-            guard.set_bit(rewind_size - 1, true);
-        }
+        // `any.rewind` rewinds the log and patches the shared bitmap (truncate + restore active
+        // bits + set the rewound tail's CommitFloor). Live pre-rewind batches must be dropped by
+        // the caller; reads through them now return inconsistent data.
+        self.any.rewind(size).await?;
 
         let hasher = StandardHasher::<H>::new();
         let grafted_tree = build_grafted_tree::<F, H, N>(
             &hasher,
-            self.status.as_ref(),
+            self.any.bitmap.as_ref(),
             &pinned_nodes,
             &self.any.log.merkle,
             self.thread_pool.as_ref(),
@@ -550,11 +538,11 @@ where
             &self.any.log.merkle,
             hasher.clone(),
         );
-        let partial_chunk = partial_chunk(self.status.as_ref());
+        let partial_chunk = partial_chunk(self.any.bitmap.as_ref());
         let ops_root = self.any.log.root();
         let root = compute_db_root(
             &hasher,
-            self.status.as_ref(),
+            self.any.bitmap.as_ref(),
             &storage,
             partial_chunk,
             &ops_root,
@@ -573,7 +561,7 @@ where
         metadata.clear();
 
         // Snapshot the pruning boundary under the read lock; the guard drops before any await.
-        let pruned_chunks_u64 = self.status.pruned_chunks() as u64;
+        let pruned_chunks_u64 = self.any.bitmap.pruned_chunks() as u64;
 
         // Write the number of pruned chunks.
         let key = U64::new(PRUNED_CHUNKS_PREFIX, 0);
@@ -652,52 +640,9 @@ where
         &mut self,
         batch: Arc<super::batch::MerkleizedBatch<F, H::Digest, U, N>>,
     ) -> Result<Range<Location<F>>, Error<F>> {
-        // Staleness is checked by self.any.apply_batch() below.
-        let db_size = *self.any.last_commit_loc + 1;
-
-        // 1. Apply inner any-layer batch (handles snapshot + journal partial skipping).
         let range = self.any.apply_batch(Arc::clone(&batch.inner)).await?;
-
-        // 2. Collect bitmap overlays from the batch chain. The `Arc<ChunkOverlay>`s we push here
-        //    are independent of the batch's layer chain, so the batch can be dropped before we
-        //    touch the shared bitmap below.
-        let mut overlays = Vec::new();
-        let mut current = &batch.bitmap;
-        while let super::batch::BitmapBatch::Layer(layer) = current {
-            if layer.overlay.len <= db_size {
-                break;
-            }
-            overlays.push(Arc::clone(&layer.overlay));
-            current = &layer.parent;
-        }
-
-        // 3. Apply grafted tree (merkle layer handles partial ancestor skipping).
         self.grafted_tree.apply_batch(&batch.grafted)?;
-
-        // 4. Snapshot the canonical root before releasing the batch.
-        let canonical_root = batch.canonical_root;
-
-        // 5. Release the batch so its chain's refs drop before we mutate the shared bitmap.
-        drop(batch);
-
-        // 6. Apply overlays in place under the write lock.
-        {
-            let mut guard = self.status.write();
-            if let Some(newest) = overlays.first() {
-                guard.extend_to(newest.len);
-            }
-            let pruned = guard.pruned_chunks();
-            for overlay in overlays.into_iter().rev() {
-                for (&idx, chunk) in &overlay.chunks {
-                    if idx >= pruned {
-                        guard.set_chunk_by_index(idx, chunk);
-                    }
-                }
-            }
-        }
-
-        self.root = canonical_root;
-
+        self.root = batch.canonical_root;
         Ok(range)
     }
 }
@@ -1176,7 +1121,7 @@ mod tests {
             let mut next_idx = 0;
             populate_fixed_db::<mmr::Family, _>(&mut db, next_idx, 256).await;
             next_idx += 256;
-            while partial_chunk::<_, 32>(db.status.as_ref()).is_some() {
+            while partial_chunk::<_, 32>(db.any.bitmap.as_ref()).is_some() {
                 populate_fixed_db::<mmr::Family, _>(&mut db, next_idx, 1).await;
                 next_idx += 1;
             }
@@ -1258,7 +1203,7 @@ mod tests {
             }
             db.prune(db.sync_boundary()).await.unwrap();
             assert!(
-                db.status.pruned_chunks() > 0,
+                db.any.bitmap.pruned_chunks() > 0,
                 "test requires at least one pruned chunk to exercise the zero-chunk path"
             );
 

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -32,7 +32,7 @@ use commonware_codec::{Codec, CodecShared, DecodeExt};
 use commonware_cryptography::{Digest, DigestOf, Hasher};
 use commonware_parallel::ThreadPool;
 use commonware_utils::{
-    bitmap::{Prunable as BitMap, Readable as BitmapReadable},
+    bitmap::{self, Readable as _},
     sequence::prefixed_u64::U64,
     sync::AsyncMutex,
 };
@@ -307,7 +307,7 @@ where
     /// the chunk's last leaf, so condition (1) always holds and the function returns the
     /// inactivity floor rounded down to the nearest chunk boundary.
     pub fn sync_boundary(&self) -> Location<F> {
-        let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
+        let chunk_bits = bitmap::Prunable::<N>::CHUNK_SIZE_BITS;
         let mut pruned_chunks = *self.any.inactivity_floor_loc / chunk_bits;
 
         let ops_leaves = *self.any.last_commit_loc + 1;
@@ -485,7 +485,7 @@ where
 
         let pruned_chunks = self.any.bitmap.pruned_chunks();
         let pruned_bits = (pruned_chunks as u64)
-            .checked_mul(BitMap::<N>::CHUNK_SIZE_BITS)
+            .checked_mul(bitmap::Prunable::<N>::CHUNK_SIZE_BITS)
             .ok_or_else(|| Error::DataCorrupted("pruned ops leaves overflow"))?;
         if rewind_size < pruned_bits {
             return Err(Error::Journal(JournalError::ItemPruned(rewind_size - 1)));
@@ -684,11 +684,11 @@ where
 
 /// Returns `Some((last_chunk, next_bit))` if the bitmap has an incomplete trailing chunk, or
 /// `None` if all bits fall on complete chunk boundaries.
-pub(super) fn partial_chunk<B: BitmapReadable<N>, const N: usize>(
+pub(super) fn partial_chunk<B: bitmap::Readable<N>, const N: usize>(
     bitmap: &B,
 ) -> Option<([u8; N], u64)> {
     let (last_chunk, next_bit) = bitmap.last_chunk();
-    if next_bit == BitMap::<N>::CHUNK_SIZE_BITS {
+    if next_bit == bitmap::Prunable::<N>::CHUNK_SIZE_BITS {
         None
     } else {
         Some((last_chunk, next_bit))
@@ -724,7 +724,7 @@ pub(super) fn combine_roots<H: Hasher>(
 pub(super) async fn compute_db_root<
     F: merkle::Graftable,
     H: Hasher,
-    B: BitmapReadable<N>,
+    B: bitmap::Readable<N>,
     S: MerkleStorage<F, Digest = H::Digest>,
     const N: usize,
 >(
@@ -759,7 +759,7 @@ pub(super) async fn compute_db_root<
 pub(super) async fn compute_grafted_root<
     F: merkle::Graftable,
     H: Hasher,
-    B: BitmapReadable<N>,
+    B: bitmap::Readable<N>,
     S: MerkleStorage<F, Digest = H::Digest>,
     const N: usize,
 >(
@@ -888,7 +888,7 @@ pub(super) async fn compute_grafted_leaves<F: merkle::Graftable, H: Hasher, cons
 /// (i.e., not pruned from the journal).
 pub(super) async fn build_grafted_tree<F: merkle::Graftable, H: Hasher, const N: usize>(
     hasher: &StandardHasher<H>,
-    bitmap: &impl BitmapReadable<N>,
+    bitmap: &impl bitmap::Readable<N>,
     pinned_nodes: &[H::Digest],
     ops_tree: &impl MerkleStorage<F, Digest = H::Digest>,
     pool: Option<&ThreadPool>,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -444,7 +444,8 @@ where
         // a pruned log with stale metadata would lose peak digests permanently.
         self.sync_metadata().await?;
 
-        self.any.prune_log(prune_loc).await
+        self.any.prune_log(prune_loc).await?;
+        Ok(())
     }
 
     /// Rewind the database to `size` operations, where `size` is the location of the next append.

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1014,9 +1014,10 @@ pub mod tests {
         });
     }
 
-    use crate::{qmdb::bitmap::BitmapReadable, translator::OneCap};
+    use crate::translator::OneCap;
     use commonware_cryptography::{sha256::Digest, Hasher as _, Sha256};
     use commonware_macros::{test_group, test_traced};
+    use commonware_utils::bitmap::Readable;
 
     type OrderedFixedDb =
         ordered::fixed::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 32>;
@@ -3573,7 +3574,7 @@ pub mod tests {
 
             // Setup sanity: the committed bitmap spans at least two chunks.
             assert!(
-                BitmapReadable::<N>::len(db.any.bitmap.as_ref()) > CHUNK_SIZE_BITS,
+                Readable::<N>::len(db.any.bitmap.as_ref()) > CHUNK_SIZE_BITS,
                 "setup must cross a chunk boundary",
             );
 
@@ -3605,10 +3606,10 @@ pub mod tests {
 
             // Snapshot every chunk in the speculative `BitmapBatch` chain (read through child).
             let speculative_chunks: Vec<[u8; N]> = {
-                let len = BitmapReadable::<N>::len(&child.bitmap);
+                let len = Readable::<N>::len(&child.bitmap);
                 let chunk_count = len.div_ceil(CHUNK_SIZE_BITS) as usize;
                 (0..chunk_count)
-                    .map(|idx| BitmapReadable::<N>::get_chunk(&child.bitmap, idx))
+                    .map(|idx| Readable::<N>::get_chunk(&child.bitmap, idx))
                     .collect()
             };
             // Setup sanity: speculative state spans at least two chunks.
@@ -3619,10 +3620,10 @@ pub mod tests {
             // `batch.canonical_root` is no longer valid against the post-apply state.
             db.apply_batch(child).await.unwrap();
             let committed_chunks: Vec<[u8; N]> = {
-                let len = BitmapReadable::<N>::len(db.any.bitmap.as_ref());
+                let len = Readable::<N>::len(db.any.bitmap.as_ref());
                 let chunk_count = len.div_ceil(CHUNK_SIZE_BITS) as usize;
                 (0..chunk_count)
-                    .map(|idx| BitmapReadable::<N>::get_chunk(db.any.bitmap.as_ref(), idx))
+                    .map(|idx| Readable::<N>::get_chunk(db.any.bitmap.as_ref(), idx))
                     .collect()
             };
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -258,6 +258,7 @@ use crate::{
             operation::{Operation, Update},
             Config as AnyConfig,
         },
+        bitmap::Shared,
         operation::Committable,
     },
     translator::Translator,
@@ -350,7 +351,7 @@ where
     // populates it during snapshot rebuild.
     let bitmap = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
         .map_err(|_| crate::qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
-    let bitmap = Arc::new(crate::qmdb::bitmap::Shared::<N>::new(bitmap));
+    let bitmap = Arc::new(Shared::<N>::new(bitmap));
 
     let any = any::init_with_bitmap(context.with_label("any"), config.into(), Some(bitmap)).await?;
 
@@ -3037,8 +3038,9 @@ pub mod tests {
             // Sanity: c's pending write is still readable via the any-layer diff chain.
             assert_eq!(c.get(&key(250), &db).await.unwrap(), Some(val(99_999)));
 
-            // The actual prune-interaction test: apply c after prune. apply_batch skips overlay
-            // chunks below the current pruned boundary.
+            // The actual prune-interaction test: apply c after prune. `any.apply_batch` writes
+            // diff entries directly into the (now more-pruned) bitmap; bits for locations below
+            // the pruning boundary cannot exist and are filtered by snapshot precedence.
             db.apply_batch(c).await.unwrap();
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(10_000)));
             assert_eq!(db.get(&key(250)).await.unwrap(), Some(val(99_999)));
@@ -3345,15 +3347,17 @@ pub mod tests {
         });
     }
 
-    /// Regression: C's precomputed bitmap clears can target a chunk that
-    /// was pruned after parent P was committed.
+    /// Regression: C's diff entry has a stale `base_old_loc` (255) pointing into a chunk that
+    /// was pruned after parent P was committed. `committed_locs` precedence in
+    /// `any::Db::apply_batch` must override the stale value with P's rewrite location, so the
+    /// `set_bit(false)` call targets P's (post-floor-raise) loc, not the pruned chunk.
     ///
-    /// With N=32, CHUNK_SIZE_BITS=256. Seed places key(0) at loc 255
-    /// (end of chunk 0). P overwrites keys 1..254, whose floor raise
-    /// moves key(0) from 255 to tip, pushing the floor past chunk 0.
-    /// C is built from P and writes key(0); its base_old_loc is 255.
-    /// After committing P and pruning chunk 0, C's clear at 255 targets
-    /// the pruned chunk.
+    /// With N=32, CHUNK_SIZE_BITS=256. Seed places key(0) at loc 255 (end of chunk 0). P
+    /// overwrites keys 1..254; P's floor-raise moves key(0) from 255 to a fresh loc above 255.
+    /// C is built from P and writes key(0) again. After committing P and pruning chunk 0, C's
+    /// pre-merkleize `base_old_loc=255` is no longer the right clear target — `committed_locs`
+    /// substitutes P's rewrite loc instead. If that precedence path broke, apply would panic
+    /// (`set_bit` on a pruned bit).
     #[test_traced("WARN")]
     fn test_current_stale_bitmap_clears_after_prune() {
         let executor = deterministic::Runner::default();
@@ -3540,9 +3544,19 @@ pub mod tests {
     /// merkleize must equal the bytes that `any::Db::apply_batch` writes via diff-driven
     /// updates. `current::Db::apply_batch` relies on this equivalence to install the precomputed
     /// `batch.grafted` against the now-current bitmap.
+    ///
+    /// The workload spans multiple bitmap chunks and exercises:
+    /// - parent/child same-key overwrite (`committed_locs` precedence path),
+    /// - parent-create then child-delete (uncommitted-ancestor precedence),
+    /// - mixed deletes and overwrites in different chunks (clear-bit + set-bit paths).
     #[test_traced("INFO")]
     fn test_current_apply_chunks_match_speculative_chunks() {
-        const CHUNK_SIZE_BITS: u64 = commonware_utils::bitmap::Prunable::<32>::CHUNK_SIZE_BITS;
+        const N: usize = 32;
+        const CHUNK_SIZE_BITS: u64 = commonware_utils::bitmap::Prunable::<N>::CHUNK_SIZE_BITS;
+        // Seed enough keys to cross at least one chunk boundary. Each batch also produces a
+        // CommitFloor op, so the bitmap grows past the user-visible key count.
+        const SEED_KEYS: u64 = CHUNK_SIZE_BITS + 50;
+
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
@@ -3551,56 +3565,70 @@ pub mod tests {
                     .await
                     .unwrap();
 
-            // Seed two committed batches so the chain has multiple ancestor diffs to merge.
-            for i in 0..4u64 {
-                let b = db
-                    .new_batch()
-                    .write(key(i), Some(val(i)))
-                    .merkleize(&db, None)
-                    .await
-                    .unwrap();
-                db.apply_batch(b).await.unwrap();
-            }
+            // Seed all keys in one committed batch.
+            let seed = (0..SEED_KEYS).fold(db.new_batch(), |b, i| b.write(key(i), Some(val(i))));
+            let seed = seed.merkleize(&db, None).await.unwrap();
+            db.apply_batch(seed).await.unwrap();
             db.commit().await.unwrap();
 
-            // Build a chain: parent overwrites two keys, child overwrites two more.
+            // Setup sanity: the committed bitmap spans at least two chunks.
+            assert!(
+                BitmapReadable::<N>::len(db.any.bitmap.as_ref()) > CHUNK_SIZE_BITS,
+                "setup must cross a chunk boundary",
+            );
+
+            // Parent (uncommitted): overwrites + delete + creates spread across the bitmap.
             let parent = db
                 .new_batch()
-                .write(key(0), Some(val(10)))
-                .write(key(1), Some(val(11)))
+                .write(key(10), Some(val(110))) // overwrite (low chunk)
+                .write(key(50), None) // delete (low chunk)
+                .write(key(CHUNK_SIZE_BITS + 5), Some(val(120))) // overwrite (high chunk)
+                .write(key(SEED_KEYS), Some(val(130))) // create new key
+                .write(key(SEED_KEYS + 1), Some(val(131))) // create new key
                 .merkleize(&db, None)
                 .await
                 .unwrap();
+
+            // Child (uncommitted, descendant of parent):
+            //   - same-key overwrite of parent's key(10)        -> committed_locs precedence
+            //   - delete of parent's just-created key(SEED_KEYS) -> uncommitted-create-child-delete
+            //   - additional delete + overwrite in mixed chunks -> set-bit + clear-bit coverage
             let child = parent
                 .new_batch::<Sha256>()
-                .write(key(2), Some(val(12)))
-                .write(key(3), Some(val(13)))
+                .write(key(10), Some(val(210)))
+                .write(key(SEED_KEYS), None)
+                .write(key(75), None)
+                .write(key(CHUNK_SIZE_BITS + 30), Some(val(220)))
                 .merkleize(&db, None)
                 .await
                 .unwrap();
 
-            // Snapshot every chunk in the speculative `BitmapBatch` chain.
-            let speculative_chunks: Vec<[u8; 32]> = {
-                let len = BitmapReadable::<32>::len(&child.bitmap);
+            // Snapshot every chunk in the speculative `BitmapBatch` chain (read through child).
+            let speculative_chunks: Vec<[u8; N]> = {
+                let len = BitmapReadable::<N>::len(&child.bitmap);
                 let chunk_count = len.div_ceil(CHUNK_SIZE_BITS) as usize;
                 (0..chunk_count)
-                    .map(|idx| BitmapReadable::<32>::get_chunk(&child.bitmap, idx))
+                    .map(|idx| BitmapReadable::<N>::get_chunk(&child.bitmap, idx))
                     .collect()
             };
+            // Setup sanity: speculative state spans at least two chunks.
+            assert!(speculative_chunks.len() >= 2);
 
-            // Apply and re-read the same chunks from the committed bitmap.
+            // Apply child (commits parent + child) and re-read every chunk from the committed
+            // bitmap. The two views must be byte-identical; otherwise the precomputed
+            // `batch.canonical_root` is no longer valid against the post-apply state.
             db.apply_batch(child).await.unwrap();
-            let committed_chunks: Vec<[u8; 32]> = {
-                let len = BitmapReadable::<32>::len(db.any.bitmap.as_ref());
+            let committed_chunks: Vec<[u8; N]> = {
+                let len = BitmapReadable::<N>::len(db.any.bitmap.as_ref());
                 let chunk_count = len.div_ceil(CHUNK_SIZE_BITS) as usize;
                 (0..chunk_count)
-                    .map(|idx| BitmapReadable::<32>::get_chunk(db.any.bitmap.as_ref(), idx))
+                    .map(|idx| BitmapReadable::<N>::get_chunk(db.any.bitmap.as_ref(), idx))
                     .collect()
             };
 
             assert_eq!(
                 speculative_chunks, committed_chunks,
-                "speculative chunks must equal post-apply committed chunks"
+                "speculative chunks must equal post-apply committed chunks across all chunks",
             );
 
             db.destroy().await.unwrap();

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -47,6 +47,14 @@
 //!   operation _i_ is active, 0 otherwise. The bitmap is divided into fixed-size chunks of `N`
 //!   bytes (i.e. `N * 8` bits each). `N` must be a power of two.
 //!
+//!   One exception by convention: the *current* `last_commit_loc` carries bit = 1 even though
+//!   a CommitFloor is not an active update — earlier (intermediate) CommitFloors carry bit =
+//!   0. Maintaining this makes the chunk containing the latest commit deterministic across
+//!   init and `apply_batch`.
+//!
+//!   The bitmap lives on the inner `any::Db.bitmap`; `current::Db` reads through it for
+//!   grafted-tree leaves and proofs.
+//!
 //! - **Grafted tree**: An in-memory Merkle structure of digests at and above the
 //!   _grafting height_ in the ops tree. This is the core of how bitmap and ops state are combined
 //!   into a single authenticated structure (see below).
@@ -337,30 +345,20 @@ where
     let (metadata, pruned_chunks, pinned_nodes) =
         db::init_metadata(context.with_label("metadata"), &metadata_partition).await?;
 
-    // Initialize the activity status bitmap.
-    let mut status = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
+    // Pre-build the activity-status bitmap with the known pruned-chunk count from grafted
+    // metadata, then hand it to `any` which becomes the sole owner. `any::init_from_log`
+    // populates it during snapshot rebuild.
+    let bitmap = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
         .map_err(|_| crate::qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
+    let bitmap = Arc::new(crate::qmdb::bitmap::Shared::<N>::new(bitmap));
 
-    // Initialize the anydb with a callback that populates the status bitmap.
-    let last_known_inactivity_floor = Location::new(status.len());
-    let any = any::init(
-        context.with_label("any"),
-        config.into(),
-        Some(last_known_inactivity_floor),
-        |append: bool, loc: Option<Location<F>>| {
-            status.push(append);
-            if let Some(loc) = loc {
-                status.set_bit(*loc, false);
-            }
-        },
-    )
-    .await?;
+    let any = any::init_with_bitmap(context.with_label("any"), config.into(), Some(bitmap)).await?;
 
     // Build the grafted tree from the bitmap and ops tree.
     let hasher = StandardHasher::<H>::new();
     let grafted_tree = db::build_grafted_tree::<F, H, N>(
         &hasher,
-        &status,
+        any.bitmap.as_ref(),
         &pinned_nodes,
         &any.log.merkle,
         thread_pool.as_ref(),
@@ -374,13 +372,19 @@ where
         &any.log.merkle,
         hasher.clone(),
     );
-    let partial_chunk = db::partial_chunk(&status);
+    let partial_chunk = db::partial_chunk(any.bitmap.as_ref());
     let ops_root = any.log.root();
-    let root = db::compute_db_root(&hasher, &status, &storage, partial_chunk, &ops_root).await?;
+    let root = db::compute_db_root(
+        &hasher,
+        any.bitmap.as_ref(),
+        &storage,
+        partial_chunk,
+        &ops_root,
+    )
+    .await?;
 
     Ok(db::Db {
         any,
-        status: Arc::new(batch::SharedBitmap::new(status)),
         grafted_tree,
         metadata: AsyncMutex::new(metadata),
         thread_pool,
@@ -1009,7 +1013,7 @@ pub mod tests {
         });
     }
 
-    use crate::translator::OneCap;
+    use crate::{qmdb::bitmap::BitmapReadable, translator::OneCap};
     use commonware_cryptography::{sha256::Digest, Hasher as _, Sha256};
     use commonware_macros::{test_group, test_traced};
 
@@ -3529,6 +3533,77 @@ pub mod tests {
 
             db.destroy().await.unwrap();
             ref_db.destroy().await.unwrap();
+        });
+    }
+
+    /// Regression: the bitmap chunks produced by the speculative `BitmapBatch` chain during
+    /// merkleize must equal the bytes that `any::Db::apply_batch` writes via diff-driven
+    /// updates. `current::Db::apply_batch` relies on this equivalence to install the precomputed
+    /// `batch.grafted` against the now-current bitmap.
+    #[test_traced("INFO")]
+    fn test_current_apply_chunks_match_speculative_chunks() {
+        const CHUNK_SIZE_BITS: u64 = commonware_utils::bitmap::Prunable::<32>::CHUNK_SIZE_BITS;
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let ctx = context.with_label("db");
+            let mut db: UnorderedVariableDb =
+                UnorderedVariableDb::init(ctx.clone(), variable_config::<OneCap>("spec_eq", &ctx))
+                    .await
+                    .unwrap();
+
+            // Seed two committed batches so the chain has multiple ancestor diffs to merge.
+            for i in 0..4u64 {
+                let b = db
+                    .new_batch()
+                    .write(key(i), Some(val(i)))
+                    .merkleize(&db, None)
+                    .await
+                    .unwrap();
+                db.apply_batch(b).await.unwrap();
+            }
+            db.commit().await.unwrap();
+
+            // Build a chain: parent overwrites two keys, child overwrites two more.
+            let parent = db
+                .new_batch()
+                .write(key(0), Some(val(10)))
+                .write(key(1), Some(val(11)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let child = parent
+                .new_batch::<Sha256>()
+                .write(key(2), Some(val(12)))
+                .write(key(3), Some(val(13)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Snapshot every chunk in the speculative `BitmapBatch` chain.
+            let speculative_chunks: Vec<[u8; 32]> = {
+                let len = BitmapReadable::<32>::len(&child.bitmap);
+                let chunk_count = len.div_ceil(CHUNK_SIZE_BITS) as usize;
+                (0..chunk_count)
+                    .map(|idx| BitmapReadable::<32>::get_chunk(&child.bitmap, idx))
+                    .collect()
+            };
+
+            // Apply and re-read the same chunks from the committed bitmap.
+            db.apply_batch(child).await.unwrap();
+            let committed_chunks: Vec<[u8; 32]> = {
+                let len = BitmapReadable::<32>::len(db.any.bitmap.as_ref());
+                let chunk_count = len.div_ceil(CHUNK_SIZE_BITS) as usize;
+                (0..chunk_count)
+                    .map(|idx| BitmapReadable::<32>::get_chunk(db.any.bitmap.as_ref(), idx))
+                    .collect()
+            };
+
+            assert_eq!(
+                speculative_chunks, committed_chunks,
+                "speculative chunks must equal post-apply committed chunks"
+            );
+
+            db.destroy().await.unwrap();
         });
     }
 }

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -162,7 +162,7 @@ pub mod test {
             db.prune(db.sync_boundary()).await.unwrap();
 
             assert!(
-                db.status.pruned_chunks() > 0,
+                db.any.bitmap.pruned_chunks() > 0,
                 "expected at least one pruned chunk"
             );
 

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -485,8 +485,8 @@ pub mod tests {
             assert!(matches!(res, Err(Error::KeyNotFound)));
 
             let start = *db.inactivity_floor_loc();
-            for i in start..db.status.len() {
-                if !db.status.get_bit(i) {
+            for i in start..db.any.bitmap.len() {
+                if !db.any.bitmap.get_bit(i) {
                     continue;
                 }
                 // Found an active operation! Create a proof for its active current key/value if

--- a/storage/src/qmdb/current/ordered/test_trait_impls.rs
+++ b/storage/src/qmdb/current/ordered/test_trait_impls.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use commonware_codec::Codec;
 use commonware_cryptography::Hasher;
-use commonware_utils::{bitmap::Readable as _, Array};
+use commonware_utils::Array;
 
 // =============================================================================
 // Fixed variant test trait implementations
@@ -65,11 +65,11 @@ impl<
     > BitmapPrunedBits for fixed::Db<F, E, K, V, H, T, N>
 {
     fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+        self.any.bitmap.pruned_bits()
     }
 
     fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+        self.any.bitmap.get_bit(index)
     }
 
     async fn oldest_retained(&self) -> u64 {
@@ -90,11 +90,11 @@ where
     VariableOperation<F, K, V>: Codec,
 {
     fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+        self.any.bitmap.pruned_bits()
     }
 
     fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+        self.any.bitmap.get_bit(index)
     }
 
     async fn oldest_retained(&self) -> u64 {
@@ -132,11 +132,11 @@ impl<
     > BitmapPrunedBits for fixed::partitioned::Db<F, E, K, V, H, T, P, N>
 {
     fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+        self.any.bitmap.pruned_bits()
     }
 
     fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+        self.any.bitmap.get_bit(index)
     }
 
     async fn oldest_retained(&self) -> u64 {
@@ -177,11 +177,11 @@ where
     VariableOperation<F, K, V>: Codec,
 {
     fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+        self.any.bitmap.pruned_bits()
     }
 
     fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+        self.any.bitmap.get_bit(index)
     }
 
     async fn oldest_retained(&self) -> u64 {

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -142,26 +142,13 @@ where
     // init_from_log, which pads the gap between `pruned_chunks * CHUNK_SIZE_BITS` and the
     // journal's inactivity floor with inactive (false) bits.
     let pruned_chunks = (*range.start() / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
-    let mut status = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
+    let bitmap = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
         .map_err(|_| qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
+    let bitmap = Arc::new(crate::qmdb::bitmap::Shared::<N>::new(bitmap));
 
-    // Build any::Db with bitmap callback.
-    //
-    // init_from_log replays the operations, building the snapshot (index) and invoking
-    // our callback for each operation to populate the bitmap.
-    let known_inactivity_floor = Location::<F>::new(status.len());
-    let any: AnyDb<F, E, J, I, H, U> = AnyDb::init_from_log(
-        index,
-        log,
-        Some(known_inactivity_floor),
-        |is_active: bool, old_loc: Option<Location<F>>| {
-            status.push(is_active);
-            if let Some(loc) = old_loc {
-                status.set_bit(*loc, false);
-            }
-        },
-    )
-    .await?;
+    // Build any::Db, handing it the pre-allocated bitmap. `init_from_log` populates the bitmap
+    // during replay.
+    let any: AnyDb<F, E, J, I, H, U, N> = AnyDb::init_from_log(index, log, Some(bitmap)).await?;
 
     // Fetch grafted pinned nodes from the ops tree. For each position the grafted family
     // needs at its pruning boundary, source the digest from the ops tree via the zero-chunk
@@ -191,7 +178,7 @@ where
     let hasher = StandardHasher::<H>::new();
     let grafted_tree = db::build_grafted_tree::<F, H, N>(
         &hasher,
-        &status,
+        any.bitmap.as_ref(),
         &grafted_pinned_nodes,
         &any.log.merkle,
         thread_pool.as_ref(),
@@ -207,8 +194,8 @@ where
         &any.log.merkle,
         hasher.clone(),
     );
-    let partial = db::partial_chunk(&status);
-    let grafted_root = db::compute_grafted_root(&hasher, &status, &storage).await?;
+    let partial = db::partial_chunk(any.bitmap.as_ref());
+    let grafted_root = db::compute_grafted_root(&hasher, any.bitmap.as_ref(), &storage).await?;
     let ops_root = any.log.root();
     let partial_digest = partial.map(|(chunk, next_bit)| {
         let digest = hasher.digest(&chunk);
@@ -228,7 +215,6 @@ where
 
     let current_db = db::Db {
         any,
-        status: Arc::new(crate::qmdb::current::batch::SharedBitmap::new(status)),
         grafted_tree,
         metadata: AsyncMutex::new(metadata),
         thread_pool,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -51,6 +51,7 @@ use crate::{
             },
             FixedValue, VariableValue,
         },
+        bitmap::Shared,
         current::{
             db, grafting,
             ordered::{
@@ -144,7 +145,7 @@ where
     let pruned_chunks = (*range.start() / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
     let bitmap = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
         .map_err(|_| qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
-    let bitmap = Arc::new(crate::qmdb::bitmap::Shared::<N>::new(bitmap));
+    let bitmap = Arc::new(Shared::<N>::new(bitmap));
 
     // Build any::Db, handing it the pre-allocated bitmap. `init_from_log` populates the bitmap
     // during replay.

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -441,8 +441,8 @@ pub mod tests {
             assert!(matches!(res, Err(Error::KeyNotFound)));
 
             let start = *db.inactivity_floor_loc();
-            for i in start..db.status.len() {
-                if !db.status.get_bit(i) {
+            for i in start..db.any.bitmap.len() {
+                if !db.any.bitmap.get_bit(i) {
                     continue;
                 }
                 // Found an active operation! Create a proof for its active current key/value if

--- a/storage/src/qmdb/current/unordered/test_trait_impls.rs
+++ b/storage/src/qmdb/current/unordered/test_trait_impls.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use commonware_codec::Read;
 use commonware_cryptography::Hasher;
-use commonware_utils::{bitmap::Readable as _, Array};
+use commonware_utils::Array;
 
 // =============================================================================
 // Fixed variant test trait implementations
@@ -64,11 +64,11 @@ impl<
     > BitmapPrunedBits for fixed::Db<F, E, K, V, H, T, N>
 {
     fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+        self.any.bitmap.pruned_bits()
     }
 
     fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+        self.any.bitmap.get_bit(index)
     }
 
     async fn oldest_retained(&self) -> u64 {
@@ -89,11 +89,11 @@ where
     VariableOperation<F, K, V>: Read,
 {
     fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+        self.any.bitmap.pruned_bits()
     }
 
     fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+        self.any.bitmap.get_bit(index)
     }
 
     async fn oldest_retained(&self) -> u64 {
@@ -130,11 +130,11 @@ impl<
     > BitmapPrunedBits for fixed::partitioned::Db<F, E, K, V, H, T, P, N>
 {
     fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+        self.any.bitmap.pruned_bits()
     }
 
     fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+        self.any.bitmap.get_bit(index)
     }
 
     async fn oldest_retained(&self) -> u64 {
@@ -175,11 +175,11 @@ where
     VariableOperation<F, K, V>: Read,
 {
     fn pruned_bits(&self) -> u64 {
-        self.status.pruned_bits()
+        self.any.bitmap.pruned_bits()
     }
 
     fn get_bit(&self, index: u64) -> bool {
-        self.status.get_bit(index)
+        self.any.bitmap.get_bit(index)
     }
 
     async fn oldest_retained(&self) -> u64 {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -54,6 +54,7 @@ use futures::{pin_mut, StreamExt as _};
 use thiserror::Error;
 
 pub mod any;
+pub(crate) mod bitmap;
 pub(crate) mod compact_witness;
 #[cfg(test)]
 mod conformance;


### PR DESCRIPTION
Closes #1829.

## Summary

This PR accelerates inactivity-floor raising in `qmdb::any` with a committed-state activity bitmap. During floor raising, `qmdb::any` now jumps between active committed operations using `ones_iter_from()` instead of treating every retained log location as a candidate.

The bitmap is owned by `any::Db.bitmap` (an `Arc<Shared<N>>`) and shared with `qmdb::current`, which reads it for grafted-tree leaves and proofs. For `any` alone the bitmap is an internal optimization: not authenticated, not persisted separately, rebuilt from the retained journal on init. For `current`, the bitmap chunks feed into the canonical root via the grafted Merkle tree.

## Motivation

`qmdb::any` advances its inactivity floor during batch merkleization. Previously, every location from the current floor up to the fixed tip was a candidate. The floor-raise loop read each operation and rejected it if the key had since been superseded.

That is correct but expensive when the retained log contains many stale updates. In update-heavy workloads, most operations below the tip are inactive, so the scan can spend most of its time reading operations that cannot advance the floor.

The scan range naturally splits into two regions:

- **Committed** (within `bitmap.len()`): indexed by the bitmap.
- **Uncommitted tail** (beyond `bitmap.len()`): in-memory ancestor batch operations not yet tracked. Handled conservatively with sequential candidates.

The existing `is_active_at()` post-filter rejects false-positive candidates, so bitmap maintenance only has to avoid false negatives (a still-active location whose bit was prematurely cleared would lose the move and corrupt the floor).

## Design

The bitmap is a `Prunable<N>` with one bit per log operation in the committed state. Standalone `any::Db` defaults to `N = BITMAP_CHUNK_BYTES` (64 bytes, 512 bits per chunk); `current::Db` overrides `N` to match its grafted-tree configuration.

- `1` for an active `Update` whose key currently resolves to that location.
- `1` for the *current* `last_commit_loc` only — earlier (intermediate) `CommitFloor`s carry `0`. This single-CommitFloor exception keeps the chunk containing the latest commit deterministic across init and `apply_batch`.
- `0` for superseded `Update`s, all `Delete`s, and all intermediate `CommitFloor`s.

A private helper supplies floor-raise candidates during merkleization:

- In `[floor, min(bitmap.len(), tip))`, it uses `ones_iter_from()` to jump to the next set bit.
- In `[bitmap.len(), tip)`, it returns sequential candidates and relies on `is_active_at()` to filter stale ones.

The any-side scan helper is independent of `qmdb::current`'s `BitmapBatch` overlay chain (used for speculative reads during merkleize). The bitmap *data* is shared between layers; the scan *strategies* are layer-specific.

## Bitmap Maintenance

`Db::apply_batch()` mirrors snapshot transitions into the bitmap under a single write lock, after the journal batch is applied:

- Extends the bitmap to `new_last_commit_loc + 1` (zero-fill).
- Sets winning active locations to `1`, clears superseded locations to `0`.
- Demotes the previous CommitFloor bit (now intermediate) to `0`, promotes the new one to `1`.

When a child batch implicitly commits one or more parent batches, bitmap updates follow the same precedence as the snapshot update: child wins first, then nearest uncommitted ancestor, with already-committed ancestor state tracked through `committed_locs`.

`Db::rewind()` truncates the bitmap, restores previously-superseded committed locations to `1` while applying snapshot undos, and sets the rewound tail's CommitFloor bit to `1`.

`Db::prune()` is split into `prune_log` and `prune_bitmap`:

- Standalone `any::Db::prune` calls them back-to-back, both targeting `prune_loc`.
- `current::Db::prune` interleaves: `prune_bitmap(sync_boundary)` → grafted-tree prune → `sync_metadata` → `prune_log(prune_loc)`. The order matters for crash safety: metadata must be persisted before the log is pruned, and bitmap pruning is more aggressive than log pruning when wrapped by `current`.

`Db::init_from_log()` rebuilds the bitmap from the retained journal alongside the snapshot, then checks that `bitmap.len() == log.size()`.

## Related cleanups

- Removes `current::Db.status` (was a separate `Arc` to a duplicate bitmap). `current` now reads through `any.bitmap` directly.
- Removes the chunk-overlay rewrite path in `current::Db::apply_batch`. Bitmap mutation is fully diff-driven in `any::Db::apply_batch`, so the bytes flow consistently through to `current` reads.
- Removes the dead public/init `callback`/`known_inactivity_floor` plumbing on `init`/`init_with_bitmap`/`init_from_log` and the four vestigial `init_with_callback` wrappers per variant. (`build_snapshot_from_log` still takes an internal closure for the in-process replay step.)
