### PR TITLE
[storage] report qmdb sync progress

### DIFF
--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -941,6 +941,145 @@ where
     });
 }
 
+async fn wait_for_reached_progress<F: merkle::Family>(
+    context: deterministic::Context,
+    target: &Target<F, Digest>,
+) {
+    let target_end = *target.range.end();
+    let journal_size = format!("client_journal_size {target_end}");
+    let target_end = format!("client_target_end {target_end}");
+    loop {
+        let metrics = context.encode();
+        if metrics.contains(&journal_size) && metrics.contains(&target_end) {
+            return;
+        }
+        context.sleep(Duration::from_millis(1)).await;
+    }
+}
+
+/// Test progress metrics for reached targets across target updates and explicit finish.
+pub(crate) fn test_sync_reports_progress_for_reached_targets_before_explicit_finish<
+    H: SyncTestHarness,
+>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.with_label("target")).await;
+
+        target_db = H::apply_ops(target_db, H::create_ops(8)).await;
+        let initial_target = Target {
+            root: H::sync_target_root(&target_db),
+            range: non_empty_range!(
+                target_db.sync_boundary().await,
+                target_db.bounds().await.end
+            ),
+        };
+
+        target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
+        let first_update = Target {
+            root: H::sync_target_root(&target_db),
+            range: non_empty_range!(
+                target_db.sync_boundary().await,
+                target_db.bounds().await.end
+            ),
+        };
+
+        target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 2)).await;
+        let second_update = Target {
+            root: H::sync_target_root(&target_db),
+            range: non_empty_range!(
+                target_db.sync_boundary().await,
+                target_db.bounds().await.end
+            ),
+        };
+        let final_root = target_db.root();
+
+        let (update_sender, update_receiver) = mpsc::channel(1);
+        let (finish_sender, finish_receiver) = mpsc::channel(1);
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.with_label("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(2),
+            target: initial_target.clone(),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: Some(update_receiver),
+            finish_rx: Some(finish_receiver),
+            reached_target_tx: None,
+            max_retained_roots: 1,
+        };
+
+        let sync_handle = sync::sync(config);
+        pin_mut!(sync_handle);
+
+        select! {
+            _ = sync_handle.as_mut() => {
+                panic!("sync completed before explicit finish signal");
+            },
+            _ = wait_for_reached_progress(context.clone(), &initial_target) => {},
+        }
+        assert!(
+            sync_handle.as_mut().now_or_never().is_none(),
+            "sync must wait for a target update or explicit finish after reaching the initial target"
+        );
+
+        update_sender
+            .send(first_update.clone())
+            .await
+            .expect("target update channel should be open");
+        select! {
+            _ = sync_handle.as_mut() => {
+                panic!("sync completed before explicit finish signal after first update");
+            },
+            _ = wait_for_reached_progress(context.clone(), &first_update) => {},
+        }
+        assert!(
+            sync_handle.as_mut().now_or_never().is_none(),
+            "sync must wait for another update or explicit finish after reaching the first update"
+        );
+
+        update_sender
+            .send(second_update.clone())
+            .await
+            .expect("target update channel should be open");
+        select! {
+            _ = sync_handle.as_mut() => {
+                panic!("sync completed before explicit finish signal after second update");
+            },
+            _ = wait_for_reached_progress(context.clone(), &second_update) => {},
+        }
+        assert!(
+            sync_handle.as_mut().now_or_never().is_none(),
+            "sync must wait for explicit finish after reporting final progress"
+        );
+
+        finish_sender
+            .send(())
+            .await
+            .expect("finish signal channel should be open");
+
+        let synced_db: H::Db = sync_handle
+            .await
+            .expect("sync should succeed after finish signal");
+        assert_eq!(synced_db.root(), final_root);
+        assert_eq!(synced_db.bounds().await.end, *second_update.range.end());
+        assert_eq!(synced_db.sync_boundary().await, *second_update.range.start());
+
+        synced_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
 /// Test that a finish signal received before target completion still allows full sync.
 pub(crate) fn test_sync_handles_early_finish_signal<H: SyncTestHarness>()
 where
@@ -2676,6 +2815,13 @@ macro_rules! sync_tests_for_harness {
             #[test_traced]
             fn test_sync_waits_for_explicit_finish() {
                 super::test_sync_waits_for_explicit_finish::<$harness>();
+            }
+
+            #[test_traced]
+            fn test_sync_reports_progress_for_reached_targets_before_explicit_finish() {
+                super::test_sync_reports_progress_for_reached_targets_before_explicit_finish::<
+                    $harness,
+                >();
             }
 
             #[test_traced]

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -16,7 +16,10 @@ use crate::{
 use commonware_codec::Encode;
 use commonware_cryptography::Digest;
 use commonware_macros::select;
-use commonware_runtime::{telemetry::metrics::status::GaugeExt, Metrics as _};
+use commonware_runtime::{
+    telemetry::metrics::{Gauge, GaugeExt, MetricsExt},
+    Metrics as _,
+};
 use commonware_utils::{
     channel::{
         fallible::{AsyncFallibleExt, OneshotExt as _},
@@ -29,7 +32,6 @@ use futures::{
     StreamExt,
 };
 use mpsc::error::TryRecvError;
-use prometheus_client::metrics::gauge::Gauge;
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     fmt::Debug,
@@ -73,19 +75,9 @@ struct ProgressMetrics {
 impl ProgressMetrics {
     /// Register sync progress metrics on the provided context.
     fn new(context: &impl commonware_runtime::Metrics) -> Self {
-        let journal_size = Gauge::default();
-        context.register(
-            "journal_size",
-            "Current journal size (operations applied)",
-            journal_size.clone(),
-        );
-
-        let target_end = Gauge::default();
-        context.register(
-            "target_end",
-            "Target range end (operations needed)",
-            target_end.clone(),
-        );
+        let journal_size =
+            context.gauge("journal_size", "Current journal size (operations applied)");
+        let target_end = context.gauge("target_end", "Target range end (operations needed)");
 
         Self {
             journal_size,
@@ -526,7 +518,7 @@ where
     }
 
     /// Record a progress snapshot in metrics.
-    async fn record_progress(&mut self) {
+    async fn record_progress(&self) {
         self.progress_metrics
             .record(self.journal.size().await, *self.target.range.end());
     }

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -16,7 +16,7 @@ use crate::{
 use commonware_codec::Encode;
 use commonware_cryptography::Digest;
 use commonware_macros::select;
-use commonware_runtime::Metrics as _;
+use commonware_runtime::{telemetry::metrics::status::GaugeExt, Metrics as _};
 use commonware_utils::{
     channel::{
         fallible::{AsyncFallibleExt, OneshotExt as _},
@@ -29,6 +29,7 @@ use futures::{
     StreamExt,
 };
 use mpsc::error::TryRecvError;
+use prometheus_client::metrics::gauge::Gauge;
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     fmt::Debug,
@@ -61,6 +62,42 @@ enum Event<F: Family, Op, D: Digest, E> {
     FinishRequested,
     /// The finish signal channel was closed
     FinishChannelClosed,
+}
+
+/// Progress gauges updated by the sync engine.
+struct ProgressMetrics {
+    journal_size: Gauge,
+    target_end: Gauge,
+}
+
+impl ProgressMetrics {
+    /// Register sync progress metrics on the provided context.
+    fn new(context: &impl commonware_runtime::Metrics) -> Self {
+        let journal_size = Gauge::default();
+        context.register(
+            "journal_size",
+            "Current journal size (operations applied) per database",
+            journal_size.clone(),
+        );
+
+        let target_end = Gauge::default();
+        context.register(
+            "target_end",
+            "Target range end (operations needed) per database",
+            target_end.clone(),
+        );
+
+        Self {
+            journal_size,
+            target_end,
+        }
+    }
+
+    /// Update progress gauges from the current engine snapshot.
+    fn record(&self, journal_size: u64, target_end: u64) {
+        let _ = self.journal_size.try_set(journal_size);
+        let _ = self.target_end.try_set(target_end);
+    }
 }
 
 /// Result from a fetch operation with its request ID and starting location.
@@ -230,6 +267,9 @@ where
     /// proceeding, so backpressure can pause progress at target.
     reached_target_tx: Option<mpsc::Sender<Target<DB::Family, DB::Digest>>>,
 
+    /// Progress gauges updated after target updates and batch application.
+    progress_metrics: ProgressMetrics,
+
     /// Whether explicit finish has been requested.
     finish_requested: bool,
 
@@ -285,6 +325,7 @@ where
         )
         .await?;
 
+        let progress_metrics = ProgressMetrics::new(&config.context);
         let mut engine = Self {
             outstanding_requests: Requests::new(),
             fetched_operations: BTreeMap::new(),
@@ -307,6 +348,7 @@ where
             reached_target_tx: config.reached_target_tx,
             finish_requested: false,
             reached_current_target_reported: false,
+            progress_metrics,
         };
         engine.schedule_requests().await?;
         Ok(engine)
@@ -481,6 +523,12 @@ where
             }
         }
         self.reached_current_target_reported = true;
+    }
+
+    /// Record a progress snapshot in metrics.
+    async fn record_progress(&mut self) {
+        self.progress_metrics
+            .record(self.journal.size().await, *self.target.range.end());
     }
 
     /// Store a batch of fetched operations. If the input list is empty, this is a no-op.
@@ -708,6 +756,7 @@ where
                 validate_update(&self.target, &new_target)?;
 
                 let mut updated_self = self.reset_for_target_update(new_target).await?;
+                updated_self.record_progress().await;
                 updated_self.schedule_requests().await?;
                 Ok(NextStep::Continue(updated_self))
             }
@@ -724,6 +773,7 @@ where
                 self.handle_fetch_result(fetch_result)?;
                 self.schedule_requests().await?;
                 self.apply_operations().await?;
+                self.record_progress().await;
                 Ok(NextStep::Continue(self))
             }
         }

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -343,6 +343,7 @@ where
             progress_metrics,
         };
         engine.schedule_requests().await?;
+        engine.record_progress().await;
         Ok(engine)
     }
 

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -76,14 +76,14 @@ impl ProgressMetrics {
         let journal_size = Gauge::default();
         context.register(
             "journal_size",
-            "Current journal size (operations applied) per database",
+            "Current journal size (operations applied)",
             journal_size.clone(),
         );
 
         let target_end = Gauge::default();
         context.register(
             "target_end",
-            "Target range end (operations needed) per database",
+            "Target range end (operations needed)",
             target_end.clone(),
         );
 


### PR DESCRIPTION
## Overview

Adds metrics to the QMDB sync engine for the current size of the journal as well as the operations required per the current sync target. Metrics are updated every time a batch of operations is ingested or the sync target is updated.