### PR TITLE
[storage/qmdb] document ordered stream_range Send boundary

### DIFF
--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -81,6 +81,29 @@ where
 
     /// Streams all active (key, value) pairs in the database in key order, starting from the first
     /// active key greater than or equal to `start`.
+    ///
+    /// This currently does not compose cleanly with `Send`-required futures because the returned
+    /// stream borrows `&self`.
+    ///
+    /// ```compile_fail
+    /// use commonware_cryptography::{sha256::Digest, Sha256};
+    /// use commonware_runtime::deterministic;
+    /// use commonware_storage::{mmr, qmdb::current::ordered::variable::Db, translator::OneCap};
+    /// use futures::StreamExt;
+    ///
+    /// type CurrentTest =
+    ///     Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, OneCap, 32>;
+    ///
+    /// fn require_send_future<F: core::future::Future + Send>(_: F) {}
+    ///
+    /// fn check(db: &CurrentTest, start: Digest) {
+    ///     require_send_future(async move {
+    ///         let stream = db.stream_range(start).await.unwrap();
+    ///         futures::pin_mut!(stream);
+    ///         let _ = stream.next().await;
+    ///     });
+    /// }
+    /// ```
     pub async fn stream_range<'a>(
         &'a self,
         start: K,

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -119,6 +119,74 @@ mod test {
     type CurrentTest =
         super::Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, OneCap, 32>;
 
+    #[allow(dead_code)]
+    type CurrentTokio = super::Db<
+        mmr::Family,
+        commonware_runtime::tokio::Context,
+        Digest,
+        Digest,
+        Sha256,
+        OneCap,
+        32,
+    >;
+    fn _assert_send<T: Send>() {}
+    fn _assert_sync<T: Sync>() {}
+    fn _check_current_ordered_send_sync() {
+        _assert_send::<CurrentTest>();
+        _assert_sync::<CurrentTest>();
+        _assert_send::<CurrentTokio>();
+        _assert_sync::<CurrentTokio>();
+    }
+
+    fn assert_send<T: Send>(_: T) {}
+    fn require_send_future<F: core::future::Future + Send>(_: F) {}
+
+    #[allow(dead_code)]
+    fn _check_current_ordered_ref_send_and_futures(db: &CurrentTokio, key: &Digest) {
+        assert_send(db);
+        assert_send(db.get(key));
+        assert_send(db.get_metadata());
+        assert_send(db.bounds());
+        assert_send(db.sync());
+    }
+
+    #[allow(dead_code)]
+    async fn _current_ordered_pipeline_3_reads(
+        db: &CurrentTokio,
+        k1: &Digest,
+        k2: &Digest,
+        k3: &Digest,
+    ) {
+        let _ = db.get(k1).await;
+        let _ = db.get(k2).await;
+        let _ = db.get(k3).await;
+    }
+
+    #[allow(dead_code)]
+    async fn _current_ordered_pipeline_merkleize(db: &CurrentTokio, key: Digest, value: Digest) {
+        let batch = db.new_batch().write(key, Some(value));
+        let _ = batch.merkleize(db, None).await;
+    }
+
+    #[allow(dead_code)]
+    fn _check_current_ordered_pipeline_send(
+        db: &CurrentTokio,
+        k1: &Digest,
+        k2: &Digest,
+        k3: &Digest,
+    ) {
+        assert_send(_current_ordered_pipeline_3_reads(db, k1, k2, k3));
+        require_send_future(async move {
+            let _ = db.get(k1).await;
+            let _ = db.get(k2).await;
+        });
+        require_send_future(_current_ordered_pipeline_merkleize(
+            db,
+            k1.clone(),
+            k2.clone(),
+        ));
+    }
+
     /// Return a [Db] database initialized with a variable config.
     async fn open_db(context: deterministic::Context, partition_prefix: String) -> CurrentTest {
         let cfg = variable_config::<OneCap>(&partition_prefix, &context);


### PR DESCRIPTION
## Summary

Adds a pure in-tree example for the ordered QMDB `Send` boundary:

- compile-time assertions that ordered variable QMDB point reads and batch merkleization compose with `Send`
- a `compile_fail` doctest showing that `stream_range(...)` still does not compose cleanly with a `Send`-required future

This is intended to complement `#3669`, which asserts the `Db` / `get` side of the story. This PR captures the narrower remaining boundary around ordered streaming.

## Why

Downstream consumers were still treating QMDB as broadly `!Sync` / `!Send`-hostile, but the current published crate already supports `Send` composition for:

- `&Db`
- `db.get(...)`
- caller futures that hold `&Db` across multiple awaited point reads
- `new_batch().merkleize(&db, ...)`

What still fails is the ordered streaming shape:

```rust
async move {
    let stream = db.stream_range(start).await.unwrap();
    futures::pin_mut!(stream);
    let _ = stream.next().await;
}
```

when that caller future must itself be `Send`.

## Validation

- `cargo test -p commonware-storage --doc --manifest-path /tmp/commonware-monorepo/Cargo.toml stream_range`
- the added compile-time helper assertions build as part of storage test compilation
