### PR TITLE
[codec] specialize codec for byte containers

### DIFF
--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -1,7 +1,11 @@
 //! Core traits for encoding and decoding.
 
 use crate::error::Error;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 /// Trait for types with a known, fixed encoded size.
 ///
@@ -23,19 +27,85 @@ pub trait EncodeSize {
     /// Returns the encoded size of this value (in bytes).
     fn encode_size(&self) -> usize;
 
+    /// Returns the total encoded size of a sequence, excluding any container-specific length
+    /// prefix.
+    ///
+    /// Container implementations call this hook so element types can provide a more efficient
+    /// aggregate size calculation. The default preserves normal element-by-element sizing.
+    /// Fixed-size implementations compute `SIZE * len`, which avoids an O(n) sizing prepass
+    /// before containers such as `Vec<T>` allocate their output buffer.
+    ///
+    /// This hook exists because stable Rust cannot express the overlapping specialized
+    /// container impls that would otherwise provide this aggregate path directly.
+    ///
+    /// This is hidden from generated documentation because it is an implementation hook for
+    /// codec's container types, not part of the intended user-facing API. Most users should
+    /// implement [EncodeSize::encode_size] or [FixedSize] instead.
+    #[doc(hidden)]
+    #[inline]
+    fn encode_size_slice(values: &[Self]) -> usize
+    where
+        Self: Sized,
+    {
+        values.iter().map(EncodeSize::encode_size).sum()
+    }
+
     /// Returns the encoded size excluding bytes passed to [`BufsMut::push`]
     /// during [`Write::write_bufs`]. Used to size the working buffer for inline
     /// writes. Override alongside [`Write::write_bufs`] for types where large
     /// [`Bytes`] fields go via push; failing to do so will over-allocate.
+    #[inline]
     fn encode_inline_size(&self) -> usize {
         self.encode_size()
+    }
+
+    /// Returns the total inline encoded size of a sequence, excluding any container-specific
+    /// length prefix.
+    ///
+    /// This hidden hook is the slice equivalent of [EncodeSize::encode_inline_size]. The
+    /// default preserves normal element-by-element sizing. Fixed-size implementations override
+    /// this to compute `SIZE * len`, matching [EncodeSize::encode_size_slice] for the
+    /// [`Write::write_bufs`] path.
+    ///
+    /// This hook exists because stable Rust cannot express the overlapping specialized
+    /// container impls that would otherwise provide this aggregate path directly.
+    ///
+    /// This is hidden from generated documentation for the same reason as
+    /// [EncodeSize::encode_size_slice].
+    #[doc(hidden)]
+    #[inline]
+    fn encode_inline_size_slice(values: &[Self]) -> usize
+    where
+        Self: Sized,
+    {
+        values
+            .iter()
+            .map(EncodeSize::encode_inline_size)
+            .sum::<usize>()
     }
 }
 
 // Automatically implement `EncodeSize` for types that are `FixedSize`.
 impl<T: FixedSize> EncodeSize for T {
+    #[inline]
     fn encode_size(&self) -> usize {
         Self::SIZE
+    }
+
+    #[inline]
+    fn encode_size_slice(values: &[Self]) -> usize
+    where
+        Self: Sized,
+    {
+        Self::SIZE * values.len()
+    }
+
+    #[inline]
+    fn encode_inline_size_slice(values: &[Self]) -> usize
+    where
+        Self: Sized,
+    {
+        Self::encode_size_slice(values)
     }
 }
 
@@ -46,11 +116,56 @@ pub trait Write {
     /// Implementations should panic if the buffer doesn't have enough capacity.
     fn write(&self, buf: &mut impl BufMut);
 
+    /// Writes the encoded payload for a sequence, excluding any container-specific length
+    /// prefix.
+    ///
+    /// Container implementations call this hook so element types can provide a more efficient
+    /// aggregate write path. The default preserves normal element-by-element encoding.
+    ///
+    /// This hook exists because stable Rust cannot express the overlapping specialized
+    /// container impls that would otherwise provide this aggregate path directly.
+    ///
+    /// This is hidden from generated documentation because it is an implementation hook for
+    /// codec's container types, not part of the intended user-facing API. Most users should
+    /// implement [Write::write] instead.
+    #[doc(hidden)]
+    #[inline]
+    fn write_slice(values: &[Self], buf: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        for item in values {
+            item.write(buf);
+        }
+    }
+
     /// Writes to a [`BufsMut`], allowing existing [`Bytes`] chunks to be
     /// appended via [`BufsMut::push`] instead of written inline. Must encode
     /// to the same format as [`Write::write`]. Defaults to [`Write::write`].
+    #[inline]
     fn write_bufs(&self, buf: &mut impl BufsMut) {
         self.write(buf);
+    }
+
+    /// Writes the encoded payload for a sequence to a [`BufsMut`], excluding any
+    /// container-specific length prefix.
+    ///
+    /// This hidden hook is the slice equivalent of [Write::write_bufs]. The default preserves
+    /// normal element-by-element encoding.
+    ///
+    /// This hook exists because stable Rust cannot express the overlapping specialized
+    /// container impls that would otherwise provide this aggregate path directly.
+    ///
+    /// This is hidden from generated documentation for the same reason as [Write::write_slice].
+    #[doc(hidden)]
+    #[inline]
+    fn write_slice_bufs(values: &[Self], buf: &mut impl BufsMut)
+    where
+        Self: Sized,
+    {
+        for item in values {
+            item.write_bufs(buf);
+        }
     }
 }
 
@@ -71,6 +186,44 @@ pub trait Read: Sized {
     /// Returns [Error] if decoding fails due to invalid data, insufficient bytes in the buffer,
     /// or violation of constraints imposed by the `cfg`.
     fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, Error>;
+
+    /// Reads `len` values from the buffer into a vector.
+    ///
+    /// Container implementations call this hook so element types can provide a more efficient
+    /// vector read path. The default preserves normal element-by-element decoding.
+    ///
+    /// This hook exists because stable Rust cannot express the overlapping specialized
+    /// container impls that would otherwise provide this aggregate path directly.
+    ///
+    /// This is hidden from generated documentation because it is an implementation hook for
+    /// codec's container types, not part of the intended user-facing API. Most users should
+    /// implement [Read::read_cfg] instead.
+    #[doc(hidden)]
+    #[inline]
+    fn read_vec(buf: &mut impl Buf, len: usize, cfg: &Self::Cfg) -> Result<Vec<Self>, Error> {
+        let mut values = Vec::with_capacity(len);
+        for _ in 0..len {
+            values.push(Self::read_cfg(buf, cfg)?);
+        }
+        Ok(values)
+    }
+
+    /// Reads exactly `N` values from the buffer into an array.
+    ///
+    /// This hidden hook is the array equivalent of [Read::read_vec]. The default preserves
+    /// normal element-by-element decoding.
+    ///
+    /// This hook exists because stable Rust cannot express the overlapping specialized array
+    /// impls that would otherwise provide this aggregate path directly.
+    ///
+    /// This is hidden from generated documentation for the same reason as [Read::read_vec].
+    #[doc(hidden)]
+    #[inline]
+    fn read_array<const N: usize>(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<[Self; N], Error> {
+        Ok(Self::read_vec(buf, N, cfg)?
+            .try_into()
+            .unwrap_or_else(|_| unreachable!("array length should match capacity")))
+    }
 }
 
 /// Trait combining [Write] and [EncodeSize] for types that can be fully encoded.

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -32,7 +32,7 @@
 //!   that the entire buffer is consumed.
 //! - [Codec]: Combines [Encode] + [Decode].
 //!
-//! # Implementation Notes
+//! # Specialization
 //!
 //! Byte-oriented container paths use hidden trait hooks on [Write], [Read], and [EncodeSize] to
 //! select bulk-copy implementations while keeping generic fallbacks. Container implementations
@@ -56,13 +56,8 @@
 //!   [u8], [u16], [u32], [u64], [u128],
 //!   [i8], [i16], [i32], [i64], [i128],
 //!   [f32], [f64], and [usize] (must fit within a [u32] for cross-platform compatibility).
-//! - Arrays: `[T; N]` implements [Write] and [Read] when `T` does. That means arrays with
-//!   variable-size elements, such as `[Vec<u8>; N]`, can be written, read, and decoded through
-//!   [Decode]. Arrays implement [FixedSize] only when `T: FixedSize`, preserving [Encode],
-//!   [Codec], [EncodeFixed], and [CodecFixed] for `[u8; N]` and other fixed-size arrays.
-//!   Variable-size arrays do not implement [Encode] or [Codec], because a generic array
-//!   [EncodeSize] implementation would overlap with the blanket [EncodeSize] implementation for
-//!   all [FixedSize] types.
+//! - Arrays: `[T; N]` supports [Write] and [Read] when `T` does, and supports [FixedSize],
+//!   [Encode], [Codec], [EncodeFixed], and [CodecFixed] when `T: FixedSize`.
 //! - Collections: [`Vec`], [`Option`], `BTreeMap`, `BTreeSet`
 //! - Tuples: `(T1, T2, ...)` (up to 12 elements)
 //! - Common External Types: [::bytes::Bytes]

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -32,14 +32,37 @@
 //!   that the entire buffer is consumed.
 //! - [Codec]: Combines [Encode] + [Decode].
 //!
+//! # Implementation Notes
+//!
+//! Byte-oriented container paths use hidden trait hooks on [Write], [Read], and [EncodeSize] to
+//! select bulk-copy implementations while keeping generic fallbacks. Container implementations
+//! call hooks such as `T::write_slice`, `T::read_vec`, and `T::encode_size_slice`. The default
+//! methods preserve element-by-element behavior, while concrete element implementations can
+//! override only the paths they can make faster.
+//!
+//! Encoding specialization has two parts: aggregate sizing and aggregate writing. For example,
+//! `Vec<u8>::encode()` first asks for the output size, then writes the bytes. The [EncodeSize]
+//! slice hooks let fixed-size elements compute `SIZE * len` without scanning every element, while
+//! the [Write] slice hooks let byte containers write the payload with one bulk copy.
+//!
+//! These hooks keep the container code generic: a container like `Vec<T>` calls one element-level
+//! method for sizing, writing, or reading, and the element implementation decides whether the
+//! default element-by-element behavior or a bulk path applies.
+//!
 //! # Supported Types
 //!
 //! Natively supports encoding/decoding for:
 //! - Primitives: [bool],
 //!   [u8], [u16], [u32], [u64], [u128],
 //!   [i8], [i16], [i32], [i64], [i128],
-//!   [f32], [f64], [u8; N],
-//!   and [usize] (must fit within a [u32] for cross-platform compatibility).
+//!   [f32], [f64], and [usize] (must fit within a [u32] for cross-platform compatibility).
+//! - Arrays: `[T; N]` implements [Write] and [Read] when `T` does. That means arrays with
+//!   variable-size elements, such as `[Vec<u8>; N]`, can be written, read, and decoded through
+//!   [Decode]. Arrays implement [FixedSize] only when `T: FixedSize`, preserving [Encode],
+//!   [Codec], [EncodeFixed], and [CodecFixed] for `[u8; N]` and other fixed-size arrays.
+//!   Variable-size arrays do not implement [Encode] or [Codec], because a generic array
+//!   [EncodeSize] implementation would overlap with the blanket [EncodeSize] implementation for
+//!   all [FixedSize] types.
 //! - Collections: [`Vec`], [`Option`], `BTreeMap`, `BTreeSet`
 //! - Tuples: `(T1, T2, ...)` (up to 12 elements)
 //! - Common External Types: [::bytes::Bytes]

--- a/codec/src/types/mod.rs
+++ b/codec/src/types/mod.rs
@@ -143,6 +143,8 @@ pub(crate) mod tests {
         pub put_slice_calls: usize,
         /// Number of single-byte writes.
         pub put_u8_calls: usize,
+        /// Number of externally pushed chunks.
+        pub push_calls: usize,
     }
 
     impl TrackingWriteBuf {
@@ -151,6 +153,7 @@ pub(crate) mod tests {
                 inner: BytesMut::new(),
                 put_slice_calls: 0,
                 put_u8_calls: 0,
+                push_calls: 0,
             }
         }
     }
@@ -188,6 +191,7 @@ pub(crate) mod tests {
     impl BufsMut for TrackingWriteBuf {
         fn push(&mut self, bytes: impl Into<Bytes>) {
             let bytes = bytes.into();
+            self.push_calls += 1;
             self.inner.extend_from_slice(&bytes);
         }
     }

--- a/codec/src/types/mod.rs
+++ b/codec/src/types/mod.rs
@@ -156,6 +156,10 @@ pub(crate) mod tests {
                 push_calls: 0,
             }
         }
+
+        pub fn freeze(self) -> Bytes {
+            self.inner.freeze()
+        }
     }
 
     // SAFETY: `TrackingWriteBuf` delegates storage and cursor management to

--- a/codec/src/types/mod.rs
+++ b/codec/src/types/mod.rs
@@ -105,3 +105,137 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::{BufsMut, Error, Read, Write};
+    use bytes::{buf::UninitSlice, Buf, BufMut, Bytes, BytesMut};
+
+    /// One-byte test type that uses the default aggregate hooks.
+    ///
+    /// This lets tests distinguish the generic per-element path from the
+    /// specialized `u8` path while keeping the same encoded representation.
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct Byte(pub u8);
+
+    impl Write for Byte {
+        fn write(&self, buf: &mut impl BufMut) {
+            buf.put_u8(self.0);
+        }
+    }
+
+    impl Read for Byte {
+        type Cfg = ();
+
+        fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
+            Ok(Self(<u8 as Read>::read_cfg(buf, &())?))
+        }
+    }
+
+    /// Test [`BufMut`] implementation that records how values are written.
+    ///
+    /// Specialization-selection tests use this to assert whether a container
+    /// wrote its payload with one aggregate [`BufMut::put_slice`] call or with
+    /// per-element [`BufMut::put_u8`] calls.
+    pub struct TrackingWriteBuf {
+        inner: BytesMut,
+        /// Number of aggregate slice writes.
+        pub put_slice_calls: usize,
+        /// Number of single-byte writes.
+        pub put_u8_calls: usize,
+    }
+
+    impl TrackingWriteBuf {
+        pub fn new() -> Self {
+            Self {
+                inner: BytesMut::new(),
+                put_slice_calls: 0,
+                put_u8_calls: 0,
+            }
+        }
+    }
+
+    // SAFETY: `TrackingWriteBuf` delegates storage and cursor management to
+    // `BytesMut`, which upholds the `BufMut` invariants. The overridden write
+    // methods only count calls before forwarding.
+    unsafe impl BufMut for TrackingWriteBuf {
+        fn remaining_mut(&self) -> usize {
+            self.inner.remaining_mut()
+        }
+
+        fn chunk_mut(&mut self) -> &mut UninitSlice {
+            self.inner.chunk_mut()
+        }
+
+        unsafe fn advance_mut(&mut self, cnt: usize) {
+            // SAFETY: The caller guarantees that `cnt` bytes in the current
+            // chunk were initialized. `BytesMut` owns the cursor state and
+            // enforces the remaining invariants.
+            unsafe { self.inner.advance_mut(cnt) }
+        }
+
+        fn put_slice(&mut self, src: &[u8]) {
+            self.put_slice_calls += 1;
+            self.inner.put_slice(src);
+        }
+
+        fn put_u8(&mut self, n: u8) {
+            self.put_u8_calls += 1;
+            self.inner.put_u8(n);
+        }
+    }
+
+    impl BufsMut for TrackingWriteBuf {
+        fn push(&mut self, bytes: impl Into<Bytes>) {
+            let bytes = bytes.into();
+            self.inner.extend_from_slice(&bytes);
+        }
+    }
+
+    /// Test [`Buf`] implementation that records how values are read.
+    ///
+    /// Specialization-selection tests use this to assert whether a container
+    /// read its payload with one aggregate [`Buf::copy_to_slice`] call or with
+    /// per-element [`Buf::get_u8`] calls.
+    pub struct TrackingReadBuf {
+        inner: Bytes,
+        /// Number of aggregate slice reads.
+        pub copy_to_slice_calls: usize,
+        /// Number of single-byte reads.
+        pub get_u8_calls: usize,
+    }
+
+    impl TrackingReadBuf {
+        pub fn new(bytes: &'static [u8]) -> Self {
+            Self {
+                inner: Bytes::from_static(bytes),
+                copy_to_slice_calls: 0,
+                get_u8_calls: 0,
+            }
+        }
+    }
+
+    impl Buf for TrackingReadBuf {
+        fn remaining(&self) -> usize {
+            self.inner.remaining()
+        }
+
+        fn chunk(&self) -> &[u8] {
+            self.inner.chunk()
+        }
+
+        fn advance(&mut self, cnt: usize) {
+            self.inner.advance(cnt)
+        }
+
+        fn copy_to_slice(&mut self, dst: &mut [u8]) {
+            self.copy_to_slice_calls += 1;
+            self.inner.copy_to_slice(dst);
+        }
+
+        fn get_u8(&mut self) -> u8 {
+            self.get_u8_calls += 1;
+            self.inner.get_u8()
+        }
+    }
+}

--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -22,8 +22,12 @@ use crate::{
     util::at_least, varint::UInt, BufsMut, EncodeSize, Error, FixedSize, RangeCfg, Read, ReadExt,
     Write,
 };
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
 use bytes::{Buf, BufMut};
 use core::num::{NonZeroU16, NonZeroU32, NonZeroU64};
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
 // Numeric types implementation
 macro_rules! impl_numeric {
@@ -50,7 +54,6 @@ macro_rules! impl_numeric {
     };
 }
 
-impl_numeric!(u8, get_u8, put_u8);
 impl_numeric!(u16, get_u16, put_u16);
 impl_numeric!(u32, get_u32, put_u32);
 impl_numeric!(u64, get_u64, put_u64);
@@ -62,6 +65,53 @@ impl_numeric!(i64, get_i64, put_i64);
 impl_numeric!(i128, get_i128, put_i128);
 impl_numeric!(f32, get_f32, put_f32);
 impl_numeric!(f64, get_f64, put_f64);
+
+impl Write for u8 {
+    #[inline]
+    fn write(&self, buf: &mut impl BufMut) {
+        buf.put_u8(*self);
+    }
+
+    #[inline]
+    fn write_slice(values: &[Self], buf: &mut impl BufMut) {
+        buf.put_slice(values);
+    }
+
+    #[inline]
+    fn write_slice_bufs(values: &[Self], buf: &mut impl BufsMut) {
+        buf.put_slice(values);
+    }
+}
+
+impl Read for u8 {
+    type Cfg = ();
+
+    #[inline]
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
+        at_least(buf, 1)?;
+        Ok(buf.get_u8())
+    }
+
+    #[inline]
+    fn read_vec(buf: &mut impl Buf, len: usize, _: &()) -> Result<Vec<Self>, Error> {
+        at_least(buf, len)?;
+        let mut values = vec![0; len];
+        buf.copy_to_slice(&mut values);
+        Ok(values)
+    }
+
+    #[inline]
+    fn read_array<const N: usize>(buf: &mut impl Buf, _: &()) -> Result<[Self; N], Error> {
+        at_least(buf, N)?;
+        let mut values = [0; N];
+        buf.copy_to_slice(&mut values);
+        Ok(values)
+    }
+}
+
+impl FixedSize for u8 {
+    const SIZE: usize = 1;
+}
 
 macro_rules! impl_nonzero {
     ($nz:ty, $inner:ty, $name:expr) => {
@@ -147,27 +197,29 @@ impl FixedSize for bool {
     const SIZE: usize = 1;
 }
 
-// Constant-size array implementation
-impl<const N: usize> Write for [u8; N] {
+// Arrays can always be written and read when their element can. This gives arrays
+// with variable-size elements `Write`, `Read`, and therefore `Decode`, but not
+// `Encode`. A generic `EncodeSize for [T; N]` would overlap with the blanket
+// `EncodeSize` implementation for all `FixedSize` types, so only arrays whose
+// elements are fixed-size become `FixedSize` and therefore `Encode`/`Codec`.
+impl<T: Write, const N: usize> Write for [T; N] {
     #[inline]
     fn write(&self, buf: &mut impl BufMut) {
-        buf.put(&self[..]);
+        T::write_slice(self, buf);
     }
 }
 
-impl<const N: usize> Read for [u8; N] {
-    type Cfg = ();
+impl<T: Read, const N: usize> Read for [T; N] {
+    type Cfg = T::Cfg;
+
     #[inline]
-    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
-        at_least(buf, N)?;
-        let mut dst = [0; N];
-        buf.copy_to_slice(&mut dst);
-        Ok(dst)
+    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, Error> {
+        T::read_array(buf, cfg)
     }
 }
 
-impl<const N: usize> FixedSize for [u8; N] {
-    const SIZE: usize = N;
+impl<T: FixedSize, const N: usize> FixedSize for [T; N] {
+    const SIZE: usize = T::SIZE * N;
 }
 
 impl Write for () {

--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -287,9 +287,12 @@ impl<T: Read> Read for Option<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{Decode, DecodeExt, Encode, EncodeFixed};
-    use bytes::{Bytes, BytesMut};
+    use super::{
+        super::tests::{Byte, TrackingReadBuf, TrackingWriteBuf},
+        *,
+    };
+    use crate::{CodecFixed, Decode, DecodeExt, Encode, EncodeFixed};
+    use bytes::{Buf, Bytes, BytesMut};
     use paste::paste;
 
     // Float tests
@@ -386,10 +389,92 @@ mod tests {
 
     #[test]
     fn test_array() {
-        let values = [1u8, 2, 3];
-        let encoded = values.encode();
+        // Arrays whose elements are fixed-size get the full `Codec` stack.
+        fn assert_codec_fixed<T: CodecFixed<Cfg = ()>>() {}
+        assert_codec_fixed::<[u8; 3]>();
+        assert_codec_fixed::<[u16; 3]>();
+
+        // `[u8; N]` encodes exactly N payload bytes, with no length prefix.
+        let bytes = [1u8, 2, 3];
+        let encoded = bytes.encode();
         let decoded = <[u8; 3]>::decode(encoded).unwrap();
-        assert_eq!(values, decoded);
+        assert_eq!(bytes, decoded);
+        assert_eq!(<[u8; 3] as FixedSize>::SIZE, 3);
+
+        // Fixed-size array decoding must reject both truncated payloads and trailing data.
+        assert!(matches!(
+            <[u8; 3]>::decode([0x01, 0x02].as_slice()),
+            Err(Error::EndOfBuffer)
+        ));
+        assert!(matches!(
+            <[u8; 3]>::decode([0x01, 0x02, 0x03, 0x04].as_slice()),
+            Err(Error::ExtraData(1))
+        ));
+
+        // Larger fixed-size elements compose normally and preserve big-endian encoding.
+        let words = [0x0102u16, 0x0304u16, 0x0506u16];
+        let encoded = words.encode();
+        assert_eq!(encoded, &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06][..]);
+        let decoded = <[u16; 3]>::decode(encoded).unwrap();
+        assert_eq!(words, decoded);
+        assert_eq!(words.encode_size(), 6);
+        assert_eq!(<[u16; 3] as FixedSize>::SIZE, 6);
+
+        // Nested arrays inherit the same fixed-size encoding from their elements.
+        let nested = [[0x0102u16, 0x0304u16], [0x0506u16, 0x0708u16]];
+        let encoded = nested.encode();
+        assert_eq!(
+            encoded,
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08][..]
+        );
+        let decoded = <[[u16; 2]; 2]>::decode(encoded).unwrap();
+        assert_eq!(nested, decoded);
+
+        // Arrays of configurable elements pass the element config through each read.
+        let decoded =
+            <[usize; 2]>::decode_cfg(Bytes::from_static(&[0x01, 0x02]), &(..).into()).unwrap();
+        assert_eq!(decoded, [1, 2]);
+
+        // Arrays with variable-size elements can still be written and read, even though
+        // they cannot use `Encode` because they do not have a generic `EncodeSize` impl.
+        let variable = [vec![1u8, 2], vec![3u8, 4, 5]];
+        let mut encoded = BytesMut::new();
+        variable.write(&mut encoded);
+        assert_eq!(encoded, &[0x02, 0x01, 0x02, 0x03, 0x03, 0x04, 0x05][..]);
+
+        let mut encoded = encoded.freeze();
+        let decoded = <[Vec<u8>; 2]>::read_cfg(&mut encoded, &((..).into(), ())).unwrap();
+        assert_eq!(variable, decoded);
+        assert_eq!(encoded.remaining(), 0);
+    }
+
+    #[test]
+    fn test_array_specialization_selection() {
+        // `[u8; N]` has no length prefix, so the entire write is one bulk payload write.
+        let mut buf = TrackingWriteBuf::new();
+        [1u8, 2, 3].write(&mut buf);
+        assert_eq!(buf.put_slice_calls, 1);
+        assert_eq!(buf.put_u8_calls, 0);
+
+        // Other array element types keep the generic per-element write path.
+        let mut buf = TrackingWriteBuf::new();
+        [Byte(1), Byte(2), Byte(3)].write(&mut buf);
+        assert_eq!(buf.put_slice_calls, 0);
+        assert_eq!(buf.put_u8_calls, 3);
+
+        // `[u8; N]` reads the fixed-size payload with one bulk copy.
+        let mut buf = TrackingReadBuf::new(&[0x01, 0x02, 0x03]);
+        let value = <[u8; 3]>::read_cfg(&mut buf, &()).unwrap();
+        assert_eq!(value, [1, 2, 3]);
+        assert_eq!(buf.copy_to_slice_calls, 1);
+        assert_eq!(buf.get_u8_calls, 0);
+
+        // Other array element types still read one element at a time.
+        let mut buf = TrackingReadBuf::new(&[0x01, 0x02, 0x03]);
+        let value = <[Byte; 3]>::read_cfg(&mut buf, &()).unwrap();
+        assert_eq!(value, [Byte(1), Byte(2), Byte(3)]);
+        assert_eq!(buf.copy_to_slice_calls, 0);
+        assert_eq!(buf.get_u8_calls, 3);
     }
 
     #[test]
@@ -565,8 +650,8 @@ mod tests {
         );
 
         // Fixed-size array
-        assert_eq!([1, 2, 3].encode(), &[0x01, 0x02, 0x03][..]);
-        assert_eq!([].encode(), &[][..]);
+        assert_eq!([1u8, 2, 3].encode(), &[0x01, 0x02, 0x03][..]);
+        assert_eq!([0u8; 0].encode(), &[][..]);
 
         // Option
         assert_eq!(Some(42u32).encode(), &[0x01, 0x00, 0x00, 0x00, 0x2A][..]);

--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -501,6 +501,27 @@ mod tests {
     }
 
     #[test]
+    fn test_array_write_bufs_equivalence() {
+        fn assert_equivalent<T: Write>(value: &T) {
+            let mut write = BytesMut::new();
+            value.write(&mut write);
+
+            let mut write_bufs = TrackingWriteBuf::new();
+            value.write_bufs(&mut write_bufs);
+
+            assert_eq!(write.freeze(), write_bufs.freeze());
+        }
+
+        assert_equivalent(&[1u8, 2, 3]);
+        assert_equivalent(&[0x0102u16, 0x0304, 0x0506]);
+        assert_equivalent(&[Byte(1), Byte(2), Byte(3)]);
+        assert_equivalent(&[
+            Bytes::from_static(&[1u8, 2, 3]),
+            Bytes::from_static(&[4u8, 5, 6]),
+        ]);
+    }
+
+    #[test]
     fn test_option() {
         let option_values = [Some(42u32), None];
         for value in option_values {

--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -207,6 +207,11 @@ impl<T: Write, const N: usize> Write for [T; N] {
     fn write(&self, buf: &mut impl BufMut) {
         T::write_slice(self, buf);
     }
+
+    #[inline]
+    fn write_bufs(&self, buf: &mut impl BufsMut) {
+        T::write_slice_bufs(self, buf);
+    }
 }
 
 impl<T: Read, const N: usize> Read for [T; N] {
@@ -461,6 +466,24 @@ mod tests {
         [Byte(1), Byte(2), Byte(3)].write(&mut buf);
         assert_eq!(buf.put_slice_calls, 0);
         assert_eq!(buf.put_u8_calls, 3);
+
+        // `write_bufs` mirrors `write` for byte arrays.
+        let mut buf = TrackingWriteBuf::new();
+        [1u8, 2, 3].write_bufs(&mut buf);
+        assert_eq!(buf.put_slice_calls, 1);
+        assert_eq!(buf.put_u8_calls, 0);
+        assert_eq!(buf.push_calls, 0);
+
+        // Arrays delegate `write_bufs` to element implementations that push chunks.
+        let mut buf = TrackingWriteBuf::new();
+        [
+            Bytes::from_static(&[1u8, 2, 3]),
+            Bytes::from_static(&[4u8, 5, 6]),
+        ]
+        .write_bufs(&mut buf);
+        assert_eq!(buf.put_slice_calls, 0);
+        assert_eq!(buf.put_u8_calls, 2);
+        assert_eq!(buf.push_calls, 2);
 
         // `[u8; N]` reads the fixed-size payload with one bulk copy.
         let mut buf = TrackingReadBuf::new(&[0x01, 0x02, 0x03]);

--- a/codec/src/types/vec.rs
+++ b/codec/src/types/vec.rs
@@ -36,33 +36,25 @@ impl<T: Write> Write for &[T] {
     #[inline]
     fn write(&self, buf: &mut impl BufMut) {
         self.len().write(buf);
-        for item in self.iter() {
-            item.write(buf);
-        }
+        T::write_slice(self, buf);
     }
 
     #[inline]
     fn write_bufs(&self, buf: &mut impl BufsMut) {
         self.len().write(buf);
-        for item in self.iter() {
-            item.write_bufs(buf);
-        }
+        T::write_slice_bufs(self, buf);
     }
 }
 
 impl<T: EncodeSize> EncodeSize for &[T] {
     #[inline]
     fn encode_size(&self) -> usize {
-        self.len().encode_size() + self.iter().map(EncodeSize::encode_size).sum::<usize>()
+        self.len().encode_size() + T::encode_size_slice(self)
     }
 
     #[inline]
     fn encode_inline_size(&self) -> usize {
-        self.len().encode_size()
-            + self
-                .iter()
-                .map(EncodeSize::encode_inline_size)
-                .sum::<usize>()
+        self.len().encode_size() + T::encode_inline_size_slice(self)
     }
 }
 
@@ -72,11 +64,7 @@ impl<T: Read> Read for Vec<T> {
     #[inline]
     fn read_cfg(buf: &mut impl Buf, (range, cfg): &Self::Cfg) -> Result<Self, Error> {
         let len = usize::read_cfg(buf, range)?;
-        let mut vec = Self::with_capacity(len);
-        for _ in 0..len {
-            vec.push(T::read_cfg(buf, cfg)?);
-        }
-        Ok(vec)
+        T::read_vec(buf, len, cfg)
     }
 }
 

--- a/codec/src/types/vec.rs
+++ b/codec/src/types/vec.rs
@@ -71,7 +71,10 @@ impl<T: Read> Read for Vec<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DecodeRangeExt, Encode};
+    use crate::{
+        types::tests::{Byte, TrackingReadBuf, TrackingWriteBuf},
+        DecodeRangeExt, Encode,
+    };
 
     #[test]
     fn test_vec() {
@@ -97,6 +100,27 @@ mod tests {
                 Err(Error::InvalidLength(_))
             ));
         }
+
+        // The length prefix advertises two payload bytes, but only one byte follows.
+        assert!(matches!(
+            Vec::<u8>::decode_range([0x02, 0x01].as_slice(), ..),
+            Err(Error::EndOfBuffer)
+        ));
+        assert!(matches!(
+            Vec::<Byte>::decode_range([0x02, 0x01].as_slice(), ..),
+            Err(Error::EndOfBuffer)
+        ));
+
+        // The length prefix advertises two payload bytes, and one extra byte remains after
+        // those two payload bytes are consumed.
+        assert!(matches!(
+            Vec::<u8>::decode_range([0x02, 0x01, 0x02, 0x03].as_slice(), ..),
+            Err(Error::ExtraData(1))
+        ));
+        assert!(matches!(
+            Vec::<Byte>::decode_range([0x02, 0x01, 0x02, 0x03].as_slice(), ..),
+            Err(Error::ExtraData(1))
+        ));
     }
 
     #[test]
@@ -124,6 +148,61 @@ mod tests {
                 Err(Error::InvalidLength(_))
             ));
         }
+    }
+
+    #[test]
+    fn test_specialization_selection() {
+        // `Vec<u8>` writes the length prefix, then the payload in one bulk write.
+        let mut buf = TrackingWriteBuf::new();
+        vec![1u8, 2, 3].write(&mut buf);
+        assert_eq!(buf.put_slice_calls, 1);
+        assert_eq!(buf.put_u8_calls, 1);
+
+        // Other one-byte element types keep the generic per-element path.
+        let mut buf = TrackingWriteBuf::new();
+        vec![Byte(1), Byte(2), Byte(3)].write(&mut buf);
+        assert_eq!(buf.put_slice_calls, 0);
+        assert_eq!(buf.put_u8_calls, 4);
+
+        // Slices use the same bulk payload path as vectors.
+        let values = [1u8, 2, 3];
+        let mut buf = TrackingWriteBuf::new();
+        values.as_slice().write(&mut buf);
+        assert_eq!(buf.put_slice_calls, 1);
+        assert_eq!(buf.put_u8_calls, 1);
+
+        // Non-`u8` slices keep the generic per-element path.
+        let values = [Byte(1), Byte(2), Byte(3)];
+        let mut buf = TrackingWriteBuf::new();
+        values.as_slice().write(&mut buf);
+        assert_eq!(buf.put_slice_calls, 0);
+        assert_eq!(buf.put_u8_calls, 4);
+
+        // `write_bufs` mirrors `write` for byte vectors.
+        let mut buf = TrackingWriteBuf::new();
+        vec![1u8, 2, 3].write_bufs(&mut buf);
+        assert_eq!(buf.put_slice_calls, 1);
+        assert_eq!(buf.put_u8_calls, 1);
+
+        // The `write_bufs` fallback remains element-by-element.
+        let mut buf = TrackingWriteBuf::new();
+        vec![Byte(1), Byte(2), Byte(3)].write_bufs(&mut buf);
+        assert_eq!(buf.put_slice_calls, 0);
+        assert_eq!(buf.put_u8_calls, 4);
+
+        // `Vec<u8>` reads the length prefix, then bulk-copies the payload.
+        let mut buf = TrackingReadBuf::new(&[0x03, 0x01, 0x02, 0x03]);
+        let value = Vec::<u8>::read_cfg(&mut buf, &((..).into(), ())).unwrap();
+        assert_eq!(value, vec![1, 2, 3]);
+        assert_eq!(buf.copy_to_slice_calls, 1);
+        assert_eq!(buf.get_u8_calls, 1);
+
+        // Other element types still read one element at a time.
+        let mut buf = TrackingReadBuf::new(&[0x03, 0x01, 0x02, 0x03]);
+        let value = Vec::<Byte>::read_cfg(&mut buf, &((..).into(), ())).unwrap();
+        assert_eq!(value, vec![Byte(1), Byte(2), Byte(3)]);
+        assert_eq!(buf.copy_to_slice_calls, 0);
+        assert_eq!(buf.get_u8_calls, 4);
     }
 
     #[test]

--- a/codec/src/types/vec.rs
+++ b/codec/src/types/vec.rs
@@ -75,6 +75,7 @@ mod tests {
         types::tests::{Byte, TrackingReadBuf, TrackingWriteBuf},
         DecodeRangeExt, Encode,
     };
+    use bytes::{Bytes, BytesMut};
 
     #[test]
     fn test_vec() {
@@ -203,6 +204,42 @@ mod tests {
         assert_eq!(value, vec![Byte(1), Byte(2), Byte(3)]);
         assert_eq!(buf.copy_to_slice_calls, 0);
         assert_eq!(buf.get_u8_calls, 4);
+    }
+
+    #[test]
+    fn test_write_bufs_equivalence() {
+        fn assert_equivalent<T: Write>(value: &T) {
+            let mut write = BytesMut::new();
+            value.write(&mut write);
+
+            let mut write_bufs = TrackingWriteBuf::new();
+            value.write_bufs(&mut write_bufs);
+
+            assert_eq!(write.freeze(), write_bufs.freeze());
+        }
+
+        assert_equivalent(&vec![1u8, 2, 3]);
+        assert_equivalent(&vec![0x0102u16, 0x0304, 0x0506]);
+        assert_equivalent(&vec![Byte(1), Byte(2), Byte(3)]);
+        assert_equivalent(&vec![
+            Bytes::from_static(&[1u8, 2, 3]),
+            Bytes::from_static(&[4u8, 5, 6]),
+        ]);
+
+        let values = [1u8, 2, 3];
+        assert_equivalent(&values.as_slice());
+
+        let values = [0x0102u16, 0x0304, 0x0506];
+        assert_equivalent(&values.as_slice());
+
+        let values = [Byte(1), Byte(2), Byte(3)];
+        assert_equivalent(&values.as_slice());
+
+        let values = [
+            Bytes::from_static(&[1u8, 2, 3]),
+            Bytes::from_static(&[4u8, 5, 6]),
+        ];
+        assert_equivalent(&values.as_slice());
     }
 
     #[test]


### PR DESCRIPTION
This PR adds aggregate container hooks to `EncodeSize`, `Write`, and `Read` so generic containers can delegate sizing, writing, and reading to the element implementation. This lets `Vec<T>`, `&[T]`, and `[T; N]` keep a single generic implementation while `u8` provides bulk-copy paths for byte containers on stable Rust, where overlapping specialized container impls are not available.

| Operation | Len | Before ns | After ns | Speedup |
|---|---:|---:|---:|---:|
| encode_vec_u8 | 32 | 88.35 | 23.94 | 3.69x |
| encode_vec_u8 | 1024 | 2440.80 | 29.04 | 84.05x |
| encode_vec_u8 | 65536 | 147560.00 | 749.56 | 196.86x |
| decode_vec_u8 | 32 | 38.07 | 22.26 | 1.71x |
| decode_vec_u8 | 1024 | 601.25 | 40.79 | 14.74x |
| decode_vec_u8 | 65536 | 37834.00 | 862.00 | 43.89x |
| encode_slice_u8 | 32 | 90.72 | 23.69 | 3.83x |
| encode_slice_u8 | 1024 | 2541.70 | 28.96 | 87.77x |
| encode_slice_u8 | 65536 | 161200.00 | 762.36 | 211.45x |

This also generalizes array support: `[T; N]` now implements `Write` and `Read` whenever `T` does. Fixed-size arrays continue to get `FixedSize`, and therefore `Encode`/`Codec`, while arrays of variable-size elements can be written/read/decoded but not encoded because a generic `EncodeSize` for `[T; N]` would overlap with the blanket `EncodeSize` for `T where T: FixedSize`.

Related #725.