### PR TITLE
[storage/merkle] clarify batch invalidation

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -203,9 +203,8 @@ impl<F: Family, D: Digest, Item: Send + Sync> MerkleizedBatch<F, D, Item> {
 
     /// Create a new speculative batch of operations with this batch as its parent.
     ///
-    /// All uncommitted ancestors in the chain must be kept alive until the child (or any
-    /// descendant) is merkleized. Dropping an uncommitted ancestor causes data
-    /// loss detected at `apply_batch` time.
+    /// The batch becomes invalid if any ancestor is dropped before being applied, or a sibling
+    /// fork has been applied.
     pub fn new_batch<H: Hasher<Digest = D>>(self: &Arc<Self>) -> UnmerkleizedBatch<F, H, Item>
     where
         Item: Encode,
@@ -2380,11 +2379,11 @@ mod tests {
         let child_a = journal.merkle.with_mem(|mem| batch_a.merkleize(mem));
         let batch_b = parent.new_batch::<Sha256>().add(create_operation::<F>(30));
         let child_b = journal.merkle.with_mem(|mem| batch_b.merkleize(mem));
-        drop(parent);
 
         // Apply child_a, then child_b should be stale.
         journal.apply_batch(&child_a).await.unwrap();
         let result = journal.apply_batch(&child_b).await;
+        drop(parent);
         assert!(
             matches!(
                 result,

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -56,6 +56,12 @@
 //! For positions in the committed structure, callers fall through to [`Mem::get_node`]
 //! (or an adapter that layers a batch over a `Mem`).
 //!
+//! # Batch invalidation
+//!
+//! A batch becomes _invalid_ when an unapplied ancestor is dropped, or a sibling fork has been
+//! applied. Invalid batches must not be used: their methods may return incorrect data rather than
+//! erroring.
+//!
 //! # Example (MMR)
 //!
 //! ```ignore
@@ -590,9 +596,8 @@ impl<F: Family, D: Digest> MerkleizedBatch<F, D> {
 
     /// Create a child batch on top of this merkleized batch.
     ///
-    /// All uncommitted ancestors in the chain must be kept alive until the child (or any
-    /// descendant) is merkleized. Dropping an uncommitted ancestor causes data
-    /// loss detected at `apply_batch` time.
+    /// The batch becomes invalid if any ancestor is dropped before being applied, or a sibling
+    /// fork has been applied.
     pub fn new_batch(self: &Arc<Self>) -> UnmerkleizedBatch<F, D> {
         let batch = UnmerkleizedBatch::new(Arc::clone(self));
         #[cfg(feature = "std")]


### PR DESCRIPTION
Clarifies the documented contract for speculative batches in `merkle/batch.rs`  and `journal/authenticated.rs`. Some AIs expect "orphaned" batches to behave correctly, but they can't because of broken Weak parent chains.  This PR explicitly documents batch invalidation. No code changes.