### PR TITLE
[Storage] Fix merkle::update benchmark misuse of iter_custom

### DIFF
--- a/storage/src/merkle/benches/update.rs
+++ b/storage/src/merkle/benches/update.rs
@@ -44,7 +44,7 @@ fn bench_update_family<F: Family>(c: &mut Criterion, runner: &tokio::Runner, fam
                         module_path!(),
                     ),
                     |b| {
-                        b.to_async(runner).iter_custom(|_iters| async move {
+                        b.to_async(runner).iter_custom(|iters| async move {
                             let pool = match strategy {
                                 Strategy::BatchedParallel => {
                                     let ctx = context::get::<commonware_runtime::tokio::Context>();
@@ -74,43 +74,45 @@ fn bench_update_family<F: Family>(c: &mut Criterion, runner: &tokio::Runner, fam
 
                             // Randomly update leaves -- this is what we are benchmarking.
                             let start = Instant::now();
+                            for _ in 0..iters {
+                                // Simulate leaf-batching being the responsibility of the caller.
+                                let mut leaf_map = HashMap::new();
+                                for _ in 0..updates {
+                                    let rand_leaf_num = sampler.gen_range(0..leaves);
+                                    let rand_leaf_loc = leaf_locations[rand_leaf_num];
+                                    let rand_leaf_swap = sampler.gen_range(0..elements.len());
+                                    let new_element = &elements[rand_leaf_swap];
+                                    leaf_map.insert(rand_leaf_loc, *new_element);
+                                }
 
-                            // Simulate leaf-batching being the responsibility of the caller.
-                            let mut leaf_map = HashMap::new();
-                            for _ in 0..updates {
-                                let rand_leaf_num = sampler.gen_range(0..leaves);
-                                let rand_leaf_loc = leaf_locations[rand_leaf_num];
-                                let rand_leaf_swap = sampler.gen_range(0..elements.len());
-                                let new_element = &elements[rand_leaf_swap];
-                                leaf_map.insert(rand_leaf_loc, *new_element);
-                            }
-
-                            match strategy {
-                                Strategy::NoBatching => {
-                                    for (loc, element) in &leaf_map {
-                                        let batch =
-                                            mem.new_batch().update_leaf(&h, *loc, element).unwrap();
-                                        let batch = batch.merkleize(&mem, &h);
+                                match strategy {
+                                    Strategy::NoBatching => {
+                                        for (loc, element) in &leaf_map {
+                                            let batch = mem
+                                                .new_batch()
+                                                .update_leaf(&h, *loc, element)
+                                                .unwrap();
+                                            let batch = batch.merkleize(&mem, &h);
+                                            mem.apply_batch(&batch).unwrap();
+                                        }
+                                    }
+                                    _ => {
+                                        let updates: Vec<(
+                                            Location<F>,
+                                            commonware_cryptography::sha256::Digest,
+                                        )> = leaf_map.into_iter().collect();
+                                        let batch = {
+                                            let mut batch = mem.new_batch();
+                                            if let Some(ref p) = pool {
+                                                batch = batch.with_pool(Some(p.clone()));
+                                            }
+                                            batch = batch.update_leaf_batched(&updates).unwrap();
+                                            batch.merkleize(&mem, &h)
+                                        };
                                         mem.apply_batch(&batch).unwrap();
                                     }
                                 }
-                                _ => {
-                                    let updates: Vec<(
-                                        Location<F>,
-                                        commonware_cryptography::sha256::Digest,
-                                    )> = leaf_map.into_iter().collect();
-                                    let batch = {
-                                        let mut batch = mem.new_batch();
-                                        if let Some(ref p) = pool {
-                                            batch = batch.with_pool(Some(p.clone()));
-                                        }
-                                        batch = batch.update_leaf_batched(&updates).unwrap();
-                                        batch.merkleize(&mem, &h)
-                                    };
-                                    mem.apply_batch(&batch).unwrap();
-                                }
                             }
-
                             start.elapsed()
                         });
                     },


### PR DESCRIPTION
# Fix `merkle::update` benchmark misuse of `iter_custom`

## Problem

The `merkle::update` benchmark in `storage/src/merkle/benches/update.rs` uses Criterion's `iter_custom` but ignores the `iters` parameter:

```rust
b.to_async(runner).iter_custom(|_iters| async move {
    // ... build a fresh tree ...
    let start = Instant::now();
    // ... apply one batch of `updates` mutations ...
    start.elapsed()
});
```

`iter_custom` requires the closure to run the routine `iters` times and return total elapsed time. Criterion then divides by `iters` to compute per-iteration time. Because the closure runs the routine exactly once regardless of `iters`, the reported numbers are `(time for 1 run) / iters` and the bench produces wrong timings.

## Fix

Wrap the timed body in `for _ in 0..iters { ... }` so the routine actually runs `iters` times inside the timed region:

```rust
let start = Instant::now();
for _ in 0..iters {
    // ... apply one batch of `updates` mutations ...
}
start.elapsed()
```

The expensive setup (random tree of `leaves` leaves, thread pool) stays outside the `iters` loop and runs once per Criterion sample, as intended. Each iteration mutates the same `Mem` instance; this is fine because every iteration generates a fresh random `updates`-sized leaf-update map, so the workload per iteration remains "apply N random leaf updates to an M-leaf tree."

## Before / after

On my machine:

| family | updates | strategy        | origin/main (broken) | this PR (fixed) |
|--------|---------|-----------------|----------------------|-----------------|
| mmr    | 1,000,000 | NoBatching      | 234.86 ms            | 629.14 ms       |
| mmr    | 1,000,000 | BatchedSerial   | **489.40 ns**        | 97.20 ms        |
| mmr    | 1,000,000 | BatchedParallel | **10.73 ns**         | 74.36 ms        |
| mmr    | 100,000   | NoBatching      | 84.83 ms             | 392.04 ms       |
| mmr    | 100,000   | BatchedSerial   | **201.93 ns**        | 54.53 ms        |
| mmr    | 100,000   | BatchedParallel | **381.06 ns**        | 32.19 ms        |
| mmb    | 1,000,000 | NoBatching      | 1.304 s              | 899.08 ms       |
| mmb    | 1,000,000 | BatchedSerial   | **22.02 µs**         | 104.57 ms       |
| mmb    | 1,000,000 | BatchedParallel | **43.84 µs**         | 79.66 ms        |
| mmb    | 100,000   | NoBatching      | 234.00 ms            | 543.79 ms       |
| mmb    | 100,000   | BatchedSerial   | **4.66 ns**          | 59.13 ms        |
| mmb    | 100,000   | BatchedParallel | **31.07 ps**         | 34.98 ms        |

The bolded `origin/main` values are impossible for the workload (the bench claims to merkleize 100k-1M leaf updates in picoseconds). They confirm the `iters`-divisor bug. After the fix, all timings sit in a sensible millisecond range.

The `NoBatching` arm in the broken bench reports millisecond-range numbers because each "iteration" of its body internally loops `updates` times itself, so per-iter time is dominated by that inner work rather than by the divisor; the reported values are still wrong (different scaling than after the fix), they just don't look obviously absurd.