### PR TITLE
[Storage] Make QMDB `stream_range: Send`

### DIFF
--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -156,8 +156,9 @@ where
     where
         V: 'a,
     {
-        let start_iter = self.snapshot.get(&start);
-        let mut init_pending = self.fetch_all_updates(start_iter).await?;
+        // Collect to avoid holding a borrow across await points (rust-lang/rust#100013).
+        let start_locs: Vec<Location<F>> = self.snapshot.get(&start).copied().collect();
+        let mut init_pending = self.fetch_all_updates(start_locs.iter()).await?;
         init_pending.retain(|x| x.key >= start);
 
         Ok(stream::unfold(
@@ -168,16 +169,21 @@ where
                     return Some((Ok((item.key, item.value)), (driver_key, pending)));
                 }
 
-                let Some((iter, wrapped)) = self.snapshot.next_translated_key(&driver_key) else {
-                    return None; // DB is empty
+                // Collect to avoid holding a borrow across await points (rust-lang/rust#100013).
+                let locs: Vec<Location<F>> = {
+                    let Some((iter, wrapped)) = self.snapshot.next_translated_key(&driver_key)
+                    else {
+                        return None; // DB is empty
+                    };
+                    if wrapped {
+                        return None; // End of DB
+                    }
+                    iter.copied().collect()
                 };
-                if wrapped {
-                    return None; // End of DB
-                }
 
                 // TODO(https://github.com/commonwarexyz/monorepo/issues/2527): concurrently
                 // fetch a much larger batch of "pending" keys.
-                match self.fetch_all_updates(iter).await {
+                match self.fetch_all_updates(locs.iter()).await {
                     Ok(mut pending) => {
                         let item = pending.pop().expect("pending is not empty");
                         let key = item.key.clone();

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -119,6 +119,16 @@ mod test {
     type CurrentTest =
         super::Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, OneCap, 32>;
 
+    #[allow(dead_code)]
+    fn _assert_stream_range_is_send(db: &CurrentTest, start: Digest) {
+        fn require_send<F: core::future::Future + Send>(_: F) {}
+        require_send(async move {
+            let stream = db.stream_range(start).await.unwrap();
+            futures::pin_mut!(stream);
+            let _ = futures::StreamExt::next(&mut stream).await;
+        });
+    }
+
     /// Return a [Db] database initialized with a variable config.
     async fn open_db(context: deterministic::Context, partition_prefix: String) -> CurrentTest {
         let cfg = variable_config::<OneCap>(&partition_prefix, &context);


### PR DESCRIPTION
Closes #3666.

## Problem

`stream_range` on the ordered QMDB returned a `!Send` future, so it could not be used inside `Send`-bounded callers (e.g. `tokio::spawn`'d tasks or multi-step async pipelines). Two await sites held an iterator borrowed from `self.snapshot` across the `.await`:

1. The initial fetch: `let start_iter = self.snapshot.get(&start); ... fetch_all_updates(start_iter).await`.
2. The per-item fetch inside the `unfold` closure: `let Some((iter, _)) = self.snapshot.next_translated_key(...); ... fetch_all_updates(iter).await`.

Even though each iterator is moved into `fetch_all_updates` before the suspend, rustc's auto-trait analysis for async state machines is conservative about when borrows die (rust-lang/rust#100013) and treats the snapshot borrow as live across the suspend, poisoning `Send`.

## Fix

Materialize the snapshot iterator into an owned `Vec<Location<F>>` on a single line, so the borrow is born and dies inside that statement and never crosses an await. This is the same pattern `get_span` and `get_with_loc` already use in this file:

```rust
// Collect to avoid holding a borrow across await points (rust-lang/rust#100013).
let start_locs: Vec<Location<F>> = self.snapshot.get(&start).copied().collect();
let mut init_pending = self.fetch_all_updates(start_locs.iter()).await?;
```

Inside the `unfold` closure, the `next_translated_key` lookup and `wrapped` check are wrapped in an inner block whose final expression is `iter.copied().collect()`, so the borrow ends before the await.

A compile-time `_assert_stream_range_is_send` helper is added in `current/ordered/variable.rs` to regression-proof the property.

No public API changes, new dependencies, behavior changes.

## Result

- `db.stream_range(start).await` returns a `Send` future and composes with `tokio::spawn` and any `Send`-bounded async pipeline.
- Downstream wrappers no longer need `block_in_place(|| block_on(...))` or `unsafe impl Sync` shims for the streaming path.
- `cargo build -p commonware-storage --tests` succeeds with the `Send` assertion in place; the same code on `main` does not.