### PR TITLE
[Storage] Flatten RootSpec from enum to struct

### DIFF
--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -49,7 +49,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator> {
         },
         translator: Translator::default(),
         split_root: true,
-        root_bagging: <mmr::Family as RootSpec>::root_spec(0).bagging(),
+        root_bagging: <mmr::Family as RootSpec>::root_spec(0).bagging,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/proofs_malleability.rs
+++ b/storage/fuzz/fuzz_targets/proofs_malleability.rs
@@ -137,9 +137,7 @@ fn supported_root_specs<F: MerkleFamily>(merkle: &Mem<F, Digest>) -> Vec<RootSpe
     };
 
     push_unique(RootSpec::FULL_FORWARD);
-    push_unique(RootSpec::Full {
-        bagging: Bagging::BackwardFold,
-    });
+    push_unique(RootSpec::full(Bagging::BackwardFold));
     for inactive_peaks in 0..=peak_count {
         push_unique(RootSpec::split_forward(inactive_peaks));
         push_unique(RootSpec::split_backward(inactive_peaks));

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -109,7 +109,7 @@ fn test_config<F: RootSpec>(test_name: &str, pooler: &impl BufferPooler) -> Conf
         },
         translator: TwoCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: F::root_spec(0).bagging,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -158,7 +158,7 @@ fn test_config<F: RootSpec>(
         },
         translator: TwoCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: F::root_spec(0).bagging,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -105,7 +105,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 split_root: true,
-                root_bagging: F::root_spec(0).bagging(),
+                root_bagging: F::root_spec(0).bagging,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -130,7 +130,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 split_root: true,
-                root_bagging: F::root_spec(0).bagging(),
+                root_bagging: F::root_spec(0).bagging,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -95,7 +95,7 @@ fn test_config<F: RootSpec>(name: &str, pooler: &impl BufferPooler) -> Config<On
         },
         translator: OneCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: F::root_spec(0).bagging,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -105,7 +105,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 split_root: true,
-                root_bagging: F::root_spec(0).bagging(),
+                root_bagging: F::root_spec(0).bagging,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/range_proof.rs
+++ b/storage/fuzz/fuzz_targets/range_proof.rs
@@ -31,9 +31,7 @@ fn supported_root_specs<F: MerkleFamily>(merkle: &Mem<F, Digest>) -> Vec<RootSpe
         }
     };
     push_unique(RootSpec::FULL_FORWARD);
-    push_unique(RootSpec::Full {
-        bagging: Bagging::BackwardFold,
-    });
+    push_unique(RootSpec::full(Bagging::BackwardFold));
     for inactive_peaks in 0..=peak_count {
         push_unique(RootSpec::split_forward(inactive_peaks));
         push_unique(RootSpec::split_backward(inactive_peaks));

--- a/storage/src/merkle/hasher.rs
+++ b/storage/src/merkle/hasher.rs
@@ -59,7 +59,7 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
         I: IntoIterator<Item = &'a Self::Digest>,
         I::IntoIter: ExactSizeIterator,
     {
-        self.root_with_inactive_prefix(leaves, spec.inactive_peaks(), spec.bagging(), peak_digests)
+        self.root_with_inactive_prefix(leaves, spec.inactive_peaks, spec.bagging, peak_digests)
     }
 
     /// Computes a root where the oldest `inactive_peaks` are forward-bagged into a single

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -47,48 +47,48 @@ pub enum Bagging {
 
 /// Fully specifies how to compute a Merkle root from the current peak set.
 ///
+/// The inactive prefix (the leading `inactive_peaks` peaks) is always forward-folded into a
+/// single accumulator, regardless of `bagging`; `bagging` applies only to the remaining peaks.
+/// When `inactive_peaks == 0`, no boundary is committed and the root is byte-equivalent to
+/// bagging the full peak list with `bagging`.
+///
 /// Generic Merkle storage does not cache roots or remember this value. Callers choose a
 /// concrete spec whenever they compute a root or construct a proof.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum RootSpec {
-    /// Bag every peak with `bagging`. No inactive prefix.
-    Full {
-        /// Bagging applied to the full peak list.
-        bagging: Bagging,
-    },
-    /// Forward-fold the inactive prefix, then bag the remaining peaks with `bagging`.
-    ///
-    /// The inactive prefix bagging is not configurable: it always uses forward bagging
-    /// (left-folded) into a single accumulator. Only the remaining peak bagging is selectable.
-    /// The inactive boundary is committed into the root.
-    ///
-    /// When `inactive_peaks == 0`, no boundary is committed. For an empty inactive prefix, a
-    /// split root is byte-equivalent to the corresponding full root with the same bagging.
-    Split {
-        /// Number of oldest peaks included in the inactive prefix.
-        inactive_peaks: usize,
-        /// Bagging applied to the remaining peaks after the inactive prefix has been folded.
-        bagging: Bagging,
-    },
+pub struct RootSpec {
+    /// Number of oldest peaks committed as a forward-folded inactive prefix.
+    /// `0` means there is no inactive prefix; the boundary is not committed into the root.
+    pub inactive_peaks: usize,
+    /// Bagging applied to the active suffix (or the full peak list when `inactive_peaks == 0`).
+    pub bagging: Bagging,
 }
 
 impl RootSpec {
-    /// `Full { bagging: ForwardFold }`: the default for plain Merkle structures.
-    pub const FULL_FORWARD: Self = Self::Full {
+    /// No inactive prefix, forward-bagged: the default for plain Merkle structures.
+    pub const FULL_FORWARD: Self = Self {
+        inactive_peaks: 0,
         bagging: Bagging::ForwardFold,
     };
 
-    /// `Split { inactive_peaks, bagging: ForwardFold }`.
+    /// No inactive prefix, with the given bagging.
+    pub const fn full(bagging: Bagging) -> Self {
+        Self {
+            inactive_peaks: 0,
+            bagging,
+        }
+    }
+
+    /// Inactive prefix of `inactive_peaks`, forward-bagged active suffix.
     pub const fn split_forward(inactive_peaks: usize) -> Self {
-        Self::Split {
+        Self {
             inactive_peaks,
             bagging: Bagging::ForwardFold,
         }
     }
 
-    /// `Split { inactive_peaks, bagging: BackwardFold }`.
+    /// Inactive prefix of `inactive_peaks`, backward-bagged active suffix.
     pub const fn split_backward(inactive_peaks: usize) -> Self {
-        Self::Split {
+        Self {
             inactive_peaks,
             bagging: Bagging::BackwardFold,
         }
@@ -101,35 +101,9 @@ impl RootSpec {
         bagging: Bagging,
         inactive_peaks: usize,
     ) -> Self {
-        if split_root {
-            Self::Split {
-                inactive_peaks,
-                bagging,
-            }
-        } else {
-            Self::Full { bagging }
-        }
-    }
-
-    /// True if this spec splits an inactive prefix off from the remaining peaks.
-    pub const fn has_inactive_prefix(self) -> bool {
-        matches!(self, Self::Split { .. })
-    }
-
-    /// Number of inactive peaks committed into the root.
-    pub const fn inactive_peaks(self) -> usize {
-        match self {
-            Self::Full { .. } => 0,
-            Self::Split { inactive_peaks, .. } => inactive_peaks,
-        }
-    }
-
-    /// The bagging policy applied to the bag step. For `Full`, this bags every peak; for
-    /// `Split`, this bags only the remaining peaks (the inactive prefix uses forward bagging
-    /// separately and unconditionally).
-    pub const fn bagging(self) -> Bagging {
-        match self {
-            Self::Full { bagging } | Self::Split { bagging, .. } => bagging,
+        Self {
+            inactive_peaks: if split_root { inactive_peaks } else { 0 },
+            bagging,
         }
     }
 }

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -164,10 +164,10 @@ impl<F: Family, D: Digest> Proof<F, D> {
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if self.inactive_peaks != spec.inactive_peaks() {
+        if self.inactive_peaks != spec.inactive_peaks {
             return false;
         }
-        self.verify_range_inclusion_using_policy(hasher, elements, start_loc, root, spec.bagging())
+        self.verify_range_inclusion_using_policy(hasher, elements, start_loc, root, spec.bagging)
     }
 
     /// Verify a range proof using a decomposed bagging policy supplied by the caller.
@@ -340,10 +340,10 @@ impl<F: Family, D: Digest> Proof<F, D> {
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if self.inactive_peaks != spec.inactive_peaks() {
+        if self.inactive_peaks != spec.inactive_peaks {
             return false;
         }
-        self.verify_multi_inclusion_using_policy(hasher, elements, root, spec.bagging())
+        self.verify_multi_inclusion_using_policy(hasher, elements, root, spec.bagging)
     }
 
     /// Reconstruct the root digest from this proof and the given consecutive elements using `spec`,
@@ -359,10 +359,10 @@ impl<F: Family, D: Digest> Proof<F, D> {
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if self.inactive_peaks != spec.inactive_peaks() {
+        if self.inactive_peaks != spec.inactive_peaks {
             return Err(ReconstructionError::InvalidProof);
         }
-        self.reconstruct_root_using_policy(hasher, elements, start_loc, spec.bagging())
+        self.reconstruct_root_using_policy(hasher, elements, start_loc, spec.bagging)
     }
 
     /// Reconstruct a root from a range proof using a decomposed bagging policy.
@@ -435,7 +435,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if self.inactive_peaks != spec.inactive_peaks() {
+        if self.inactive_peaks != spec.inactive_peaks {
             return Err(Error::InvalidProof);
         }
         self.verify_range_inclusion_and_extract_digests_using_policy(
@@ -443,7 +443,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
             elements,
             start_loc,
             root,
-            spec.bagging(),
+            spec.bagging,
         )
     }
 
@@ -492,7 +492,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if self.inactive_peaks != spec.inactive_peaks() {
+        if self.inactive_peaks != spec.inactive_peaks {
             return false;
         }
         self.verify_proof_and_pinned_nodes_using_policy(
@@ -501,7 +501,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
             start_loc,
             pinned_nodes,
             root,
-            spec.bagging(),
+            spec.bagging,
         )
     }
 
@@ -1214,9 +1214,9 @@ where
     H: Hasher<F, Digest = D>,
     E: From<super::Error<F>>,
 {
-    Blueprint::new_using_policy(leaves, spec.inactive_peaks(), spec.bagging(), range)?.build_proof(
+    Blueprint::new_using_policy(leaves, spec.inactive_peaks, spec.bagging, range)?.build_proof(
         hasher,
-        spec.inactive_peaks(),
+        spec.inactive_peaks,
         get_node,
         element_pruned,
     )
@@ -1335,12 +1335,7 @@ mod tests {
         let mut specs = Vec::new();
 
         push_unique_spec(&mut specs, RootSpec::FULL_FORWARD);
-        push_unique_spec(
-            &mut specs,
-            RootSpec::Full {
-                bagging: Bagging::BackwardFold,
-            },
-        );
+        push_unique_spec(&mut specs, RootSpec::full(Bagging::BackwardFold));
         for inactive_peaks in 0..=peak_count {
             push_unique_spec(&mut specs, RootSpec::split_forward(inactive_peaks));
             push_unique_spec(&mut specs, RootSpec::split_backward(inactive_peaks));
@@ -1361,7 +1356,7 @@ mod tests {
         spec: RootSpec,
         width: u64,
     ) -> Location<F> {
-        let start = inactive_leaf_floor::<F>(leaves, spec.inactive_peaks());
+        let start = inactive_leaf_floor::<F>(leaves, spec.inactive_peaks);
         if start + width <= *leaves {
             return Location::new(start);
         }
@@ -1390,14 +1385,14 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(proof.inactive_peaks, spec.inactive_peaks());
+            assert_eq!(proof.inactive_peaks, spec.inactive_peaks);
             assert!(
                 proof.verify_range_inclusion(&hasher, &elements, range.start, &root, spec,),
                 "range proof should verify for {spec:?}",
             );
 
             let mut tampered_boundary = proof.clone();
-            tampered_boundary.inactive_peaks = if spec.inactive_peaks() == 0 { 1 } else { 0 };
+            tampered_boundary.inactive_peaks = if spec.inactive_peaks == 0 { 1 } else { 0 };
             assert!(
                 !tampered_boundary.verify_range_inclusion(
                     &hasher,
@@ -1436,14 +1431,14 @@ mod tests {
             let locations = [first, first + 5, first + 11];
             let nodes = nodes_required_for_multi_proof(
                 leaves,
-                spec.inactive_peaks(),
-                spec.bagging(),
+                spec.inactive_peaks,
+                spec.bagging,
                 &locations,
             )
             .expect("test locations valid");
             let proof = Proof {
                 leaves,
-                inactive_peaks: spec.inactive_peaks(),
+                inactive_peaks: spec.inactive_peaks,
                 digests: nodes
                     .into_iter()
                     .map(|pos| mem.get_node(pos).unwrap())
@@ -1461,7 +1456,7 @@ mod tests {
             );
 
             let mut tampered_boundary = proof.clone();
-            tampered_boundary.inactive_peaks = if spec.inactive_peaks() == 0 { 1 } else { 0 };
+            tampered_boundary.inactive_peaks = if spec.inactive_peaks == 0 { 1 } else { 0 };
             assert!(
                 !tampered_boundary.verify_multi_inclusion(&hasher, &elements, &root, spec,),
                 "inactive_peaks mutation should fail for {spec:?}",
@@ -1541,9 +1536,7 @@ mod tests {
     fn full_backward_root_spec_proves_like_split_zero() {
         let hasher = H::new();
         let mem = build_raw::<mmb::Family>(&hasher, 123);
-        let full_backward = RootSpec::Full {
-            bagging: Bagging::BackwardFold,
-        };
+        let full_backward = RootSpec::full(Bagging::BackwardFold);
         let range = Location::new(2)..Location::new(3);
 
         let generated: Result<Proof<mmb::Family, D>, Error<mmb::Family>> = build_range_proof(

--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -62,10 +62,10 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if proof.inactive_peaks != spec.inactive_peaks() {
+        if proof.inactive_peaks != spec.inactive_peaks {
             return Err(Error::InvalidProof);
         }
-        Self::new_using_policy(hasher, proof, elements, start_loc, root, spec.bagging())
+        Self::new_using_policy(hasher, proof, elements, start_loc, root, spec.bagging)
     }
 
     pub(crate) fn new_using_policy<H, E>(
@@ -341,8 +341,8 @@ pub async fn historical_range_proof<
         hasher,
         merkle,
         leaves,
-        spec.inactive_peaks(),
-        spec.bagging(),
+        spec.inactive_peaks,
+        spec.bagging,
         range,
     )
     .await
@@ -406,7 +406,7 @@ pub async fn multi_proof<F: Family, D: Digest, S: Storage<F, Digest = D>>(
     spec: RootSpec,
     locations: &[Location<F>],
 ) -> Result<Proof<F, D>, Error<F>> {
-    multi_proof_using_policy(merkle, spec.inactive_peaks(), spec.bagging(), locations).await
+    multi_proof_using_policy(merkle, spec.inactive_peaks, spec.bagging, locations).await
 }
 
 /// Return a multi proof for the elements at the specified locations using decomposed root bagging

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -221,7 +221,7 @@ pub(crate) mod test {
             },
             translator: T::default(),
             split_root: true,
-            root_bagging: F::root_spec(0).bagging(),
+            root_bagging: F::root_spec(0).bagging,
         }
     }
 
@@ -249,7 +249,7 @@ pub(crate) mod test {
             },
             translator: T::default(),
             split_root: true,
-            root_bagging: F::root_spec(0).bagging(),
+            root_bagging: F::root_spec(0).bagging,
         }
     }
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -205,7 +205,7 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             split_root: true,
-            root_bagging: <mmr::Family as crate::qmdb::RootSpec>::root_spec(0).bagging(),
+            root_bagging: <mmr::Family as crate::qmdb::RootSpec>::root_spec(0).bagging,
         }
     }
 

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -190,7 +190,7 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             split_root: true,
-            root_bagging: <mmr::Family as crate::qmdb::RootSpec>::root_spec(0).bagging(),
+            root_bagging: <mmr::Family as crate::qmdb::RootSpec>::root_spec(0).bagging,
         }
     }
 

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -120,7 +120,7 @@ pub fn any_fix_cfg(ctx: &(impl BufferPooler + ThreadPooler)) -> AnyFixedConfig<E
         split_root: true,
         root_bagging:
             <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+                .bagging,
     }
 }
 
@@ -145,7 +145,7 @@ pub fn any_var_digest_cfg(
         split_root: true,
         root_bagging:
             <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+                .bagging,
     }
 }
 
@@ -172,7 +172,7 @@ pub fn any_var_vec_cfg(
         split_root: true,
         root_bagging:
             <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+                .bagging,
     }
 }
 

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -303,7 +303,7 @@ fn any_fix_cfg(
         split_root: true,
         root_bagging:
             <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+                .bagging,
     }
 }
 
@@ -318,7 +318,7 @@ fn any_var_cfg(
         split_root: true,
         root_bagging:
             <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+                .bagging,
     }
 }
 

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -150,7 +150,7 @@ fn any_fixed_config<F: qmdb::RootSpec>(
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: F::root_spec(0).bagging,
     }
 }
 
@@ -164,7 +164,7 @@ fn any_variable_config<F: qmdb::RootSpec>(
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: F::root_spec(0).bagging,
     }
 }
 


### PR DESCRIPTION
Follow up to #3667.

## Summary

`RootSpec` was introduced as a 2-variant enum:

```rust
pub enum RootSpec {
    Full  { bagging: Bagging },
    Split { inactive_peaks: usize, bagging: Bagging },
}
```

Per the type's docs and `hasher.rs`, `Full { F }` and `Split { 0, F }` produce **byte-identical roots** — the boundary commitment is keyed on the count, not the variant tag. The enum had two encodings of the same value.

This PR collapses it to a plain struct:

```rust
pub struct RootSpec {
    pub inactive_peaks: usize,
    pub bagging: Bagging,
}
```

## What changes

- **Type definition** (`merkle/mod.rs`). `pub enum` → `pub struct` with two public fields. Constants and constructors (`FULL_FORWARD`, `full`, `split_forward`, `split_backward`, `from_split_policy`) are kept. The trivial accessor methods (`bagging()`, `inactive_peaks()`, `has_inactive_prefix()`) are dropped — callers read fields directly.
- **`qmdb/any/db.rs`**. The `if self.split_root { Split{..} } else { Full{..} }` branch — which existed only because the enum forced two encodings — collapses into a single `RootSpec::from_split_policy(...)` call.
- **Variant constructions** (~7 sites). `RootSpec::Full { bagging }` → `RootSpec::full(bagging)`; `Split { .. }` → struct literal.
- **Accessor calls** (~25 sites across `merkle/`, `qmdb/`, fuzz targets, benches, the sync example). `spec.bagging()` → `spec.bagging`; `spec.inactive_peaks()` → `spec.inactive_peaks`.

## Why

- **One representation per spec.** No more "is this `Full { F }` or `Split { 0, F }`?" — the question goes away.
- **Smaller API surface to maintain.** Three method definitions and a redundant variant deleted.