### PR TITLE
[runtime/iobuf/freelist] add loom model

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -1,0 +1,38 @@
+name: Loom
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-loom-${{ github.head_ref || github.ref_name || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  Tests:
+    name: "Loom Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - name: Clear disk space
+      uses: ./.github/actions/disk
+    - name: Run setup
+      uses: ./.github/actions/setup
+      with:
+        additional-cache-key: loom
+    - name: Install just & nextest
+      uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
+      with:
+        tool: just@1.43.0,cargo-nextest@0.9.129
+    - name: Run loom tests
+      run: just test-loom --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,7 @@ dependencies = [
  "governor",
  "io-uring",
  "libc",
+ "loom",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -2664,6 +2665,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3394,6 +3410,19 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru"
@@ -4595,6 +4624,12 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ hashbrown = { version = "0.16.1", default-features = false, features = ["default
 io-uring = "0.7.4"
 libc = "0.2.172"
 libfuzzer-sys = "0.4.9"
+loom = "0.7.2"
 num-bigint = { version = "0.4.6", default-features = false }
 num-integer = "0.1.46"
 num-rational = { version = "0.4.2", features = ["num-bigint"] }

--- a/justfile
+++ b/justfile
@@ -60,6 +60,10 @@ test-benches crate test_flags='' lint_flags='':
 test *args='':
     cargo nextest run $@
 
+# Run loom tests
+test-loom *args='':
+    cargo nextest run --release --features loom --lib {{ args }} ::loom_tests::
+
 # Test the Rust documentation
 test-docs *args='--all':
     cargo test --doc --locked $@

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,6 +30,7 @@ futures.workspace = true
 governor.workspace = true
 io-uring = { workspace = true, optional = true }
 libc.workspace = true
+loom = { workspace = true, optional = true }
 opentelemetry.workspace = true
 pin-project = { workspace = true, optional = true }
 prometheus-client.workspace = true
@@ -73,6 +74,7 @@ arbitrary = [
 ]
 bench = [ "dep:crossbeam-queue" ]
 external = [ "pin-project" ]
+loom = [ "dep:loom" ]
 test-utils = []
 iouring = [ "iouring-network", "iouring-storage" ]
 iouring-network = [ "io-uring" ]

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1155,7 +1155,8 @@ mod loom_tests {
     fn buffer() -> AlignedBuffer {
         // The payload itself is not important to the model. The aligned
         // allocation is enough to exercise ownership transfer through the
-        // parking cell and make double-reads/double-drops visible.
+        // parking cell. The per-test bitmasks and counts make duplicate
+        // ownership transfers visible.
         AlignedBuffer::new(64, 64)
     }
 
@@ -1263,6 +1264,141 @@ mod loom_tests {
                 4
             );
             assert_eq!(seen.load(Ordering::Relaxed), 0b1111);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
+    fn put_and_take_compose_on_partially_free_word() {
+        loom::model(|| {
+            let set = Arc::new(single_word_freelist(2));
+            set.put(0, buffer());
+
+            // Slot 0 starts free, then a producer returns slot 1 while `take`
+            // races on the same bitmap word. The producer's `fetch_or`
+            // must compose with the consumer's `fetch_and`: clearing the
+            // existing bit must not lose the newly published bit, and
+            // publishing the new bit must not resurrect a claimed bit.
+            let seen = Arc::new(AtomicUsize::new(0));
+
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put(1, buffer()))
+            };
+
+            let taker = {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                thread::spawn(move || {
+                    if let Some((slot, buffer)) = set.take() {
+                        drop(buffer);
+                        let mask = 1 << slot;
+                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                        assert_eq!(previous & mask, 0);
+                    }
+                })
+            };
+
+            writer.join().unwrap();
+            taker.join().unwrap();
+
+            // The taker may run before slot 1 is published. After the writer
+            // has joined, any slot not claimed during the race must still be
+            // available exactly once.
+            while let Some((slot, buffer)) = set.take() {
+                drop(buffer);
+                let mask = 1 << slot;
+                let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                assert_eq!(previous & mask, 0);
+            }
+
+            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
+    fn put_and_take_batch_compose_on_partially_free_word() {
+        loom::model(|| {
+            let set = Arc::new(single_word_freelist(2));
+            set.put(0, buffer());
+
+            // This is the batch-claim version of the partially-free word race:
+            // `take_batch` may speculatively choose candidates from a stale
+            // relaxed load while a producer publishes a different bit in the
+            // same word. Only bits actually cleared by the batch taker may
+            // drive callbacks, and missed bits must remain available.
+            let seen = Arc::new(AtomicUsize::new(0));
+
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put(1, buffer()))
+            };
+
+            let batch_taker = {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                thread::spawn(move || {
+                    let count = set.take_batch(2, |slot, buffer| {
+                        drop(buffer);
+                        let mask = 1 << slot;
+                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                        assert_eq!(previous & mask, 0);
+                    });
+                    assert!(count <= 2);
+                })
+            };
+
+            writer.join().unwrap();
+            batch_taker.join().unwrap();
+
+            // If the batch taker ran before slot 1 was published, the slot must
+            // still be visible after the writer completes.
+            while let Some((slot, buffer)) = set.take() {
+                drop(buffer);
+                let mask = 1 << slot;
+                let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                assert_eq!(previous & mask, 0);
+            }
+
+            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
+    fn put_batch_and_drain_compose_on_partially_free_word() {
+        loom::model(|| {
+            let set = Arc::new(single_word_freelist(3));
+            set.put(0, buffer());
+
+            // Slot 0 starts free, then a batch producer stages slots 1 and 2
+            // and publishes them with one `fetch_or`. A concurrent `drain`
+            // clears the whole word with `swap(0)`. The two RMWs must compose:
+            // the drainer may get only slot 0 or all three slots, but the slots
+            // it misses must remain available after the writer completes.
+            let drained = Arc::new(AtomicUsize::new(0));
+
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put_batch([(1, buffer()), (2, buffer())]))
+            };
+
+            let drainer = {
+                let set = Arc::clone(&set);
+                let drained = Arc::clone(&drained);
+                thread::spawn(move || {
+                    let count = set.drain();
+                    assert!(count <= 3);
+                    drained.store(count, Ordering::Relaxed);
+                })
+            };
+
+            writer.join().unwrap();
+            drainer.join().unwrap();
+
+            let total = drained.load(Ordering::Relaxed) + set.drain();
+            assert_eq!(total, 3);
             assert_eq!(set.drain(), 0);
         });
     }
@@ -1615,7 +1751,7 @@ mod loom_tests {
             let seen = Arc::new(AtomicUsize::new(0));
 
             // Publish one slot per bitmap word. The reader may observe any
-            // prefix of the per-word Release operations and must keep scanning
+            // subset of the per-word Release operations and must keep scanning
             // other stripes until it has claimed each slot exactly once.
             //
             // This complements the two-slot same-word models above: same-word

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1130,27 +1130,22 @@ mod loom_tests {
     };
     use std::num::{NonZeroU32, NonZeroUsize};
 
-    // These tests run the production `Freelist` implementation with loom's
-    // atomics, thread local storage, and `UnsafeCell` substituted under
-    // `cfg(feature = "loom")`. Targeted tests use small same-word or striped
-    // layouts to force specific RMW races, while geometry-matrix tests cover
-    // single-word/single-bit, single-word/multi-bit, multi-word/single-bit, and
-    // multi-word/multi-bit layouts.
+    // This module uses loom to model the freelist's ownership protocol between
+    // bitmap bits and parking cells: a producer parks a buffer, publishes its
+    // bit, and exactly one consumer clears that bit before reading the cell.
+    // The models keep capacities small so loom can exhaustively explore the
+    // interleavings that stress this protocol: same-word RMW composition,
+    // striped scans across independent bitmap words, stale relaxed candidate
+    // loads, and the Release/Acquire edge that makes a parked buffer visible
+    // after its bit is claimed. Geometry-matrix tests cover single-word/single-bit,
+    // single-word/multi-bit, multi-word/single-bit, and multi-word/multi-bit
+    // layouts so both degenerate and striped cases stay exercised.
+
     fn single_word_freelist(capacity: u32) -> Freelist {
-        // Use one stripe so every slot in the model shares one bitmap word.
-        // This keeps the model small enough for exhaustive exploration while
-        // covering the RMW contention that makes this freelist subtle.
         Freelist::new(
             NonZeroU32::new(capacity).unwrap(),
             NonZeroUsize::new(1).unwrap(),
         )
-    }
-
-    fn striped_freelist() -> Freelist {
-        // Four slots with four stripes puts each modeled slot in a distinct
-        // bitmap word. This covers cross-word scan and batch publication without
-        // blowing up the model.
-        Freelist::new(NonZeroU32::new(4).unwrap(), NonZeroUsize::new(4).unwrap())
     }
 
     fn buffer() -> AlignedBuffer {
@@ -1161,6 +1156,8 @@ mod loom_tests {
         AlignedBuffer::new(64, 64)
     }
 
+    // Each geometry gives a model a small bitmap layout: one or more active
+    // bitmap words, with either one or multiple free bits per active word.
     #[derive(Clone, Copy, Debug)]
     enum Geometry {
         SingleWordSingleBit,
@@ -1170,31 +1167,34 @@ mod loom_tests {
     }
 
     impl Geometry {
+        // Builds a freelist with this geometry's bitmap shape.
         fn freelist(self) -> Freelist {
             match self {
                 Self::SingleWordSingleBit => single_word_freelist(1),
                 Self::SingleWordMultiBit => single_word_freelist(2),
-                Self::MultiWordSingleBit => striped_freelist(),
-                // Two stripes and four active slots gives the model multiple
-                // bitmap words with multiple live bits in each touched word:
-                // slots 0/2 share word 0, and slots 1/3 share word 1.
+                Self::MultiWordSingleBit => {
+                    Freelist::new(NonZeroU32::new(4).unwrap(), NonZeroUsize::new(4).unwrap())
+                }
                 Self::MultiWordMultiBit => {
                     Freelist::new(NonZeroU32::new(4).unwrap(), NonZeroUsize::new(2).unwrap())
                 }
             }
         }
 
+        // Returns the slot ids that are active in this geometry. The order is
+        // used by batch tests, so layouts with multiple bits in a word keep
+        // same-word slots adjacent.
         fn slots(self) -> &'static [u32] {
             match self {
                 Self::SingleWordSingleBit => &[0],
                 Self::SingleWordMultiBit => &[0, 1],
                 Self::MultiWordSingleBit => &[0, 1, 2, 3],
-                // Keep same-word slots adjacent in the batch order. With two
-                // words, slots 0/2 map to word 0 and slots 1/3 map to word 1.
                 Self::MultiWordMultiBit => &[0, 2, 1, 3],
             }
         }
 
+        // Returns a bit mask of active slot ids for duplicate and completeness
+        // checks in the models.
         fn slot_mask(self) -> usize {
             self.slots()
                 .iter()
@@ -1221,24 +1221,20 @@ mod loom_tests {
     const MULTI_BIT_GEOMETRIES: [Geometry; 2] =
         [Geometry::SingleWordMultiBit, Geometry::MultiWordMultiBit];
 
-    fn model_geometry<F>(geometry: Geometry, test: F)
-    where
-        F: Fn(Geometry, Arc<Freelist>) + Send + Sync + 'static,
-    {
-        loom::model(move || {
-            test(geometry, Arc::new(geometry.freelist()));
-        });
-    }
-
-    fn model_geometries<F>(geometries: &[Geometry], test: F)
+    fn model<F>(geometries: &[Geometry], test: F)
     where
         F: Fn(Geometry, Arc<Freelist>) + Clone + Send + Sync + 'static,
     {
         for &geometry in geometries {
-            model_geometry(geometry, test.clone());
+            let test = test.clone();
+            loom::model(move || {
+                test(geometry, Arc::new(geometry.freelist()));
+            });
         }
     }
 
+    // Records a claimed slot and verifies that it belongs to the modeled slot
+    // set and has not already been claimed by another operation.
     fn record_expected_slot(seen: &AtomicUsize, expected: usize, slot: u32) {
         let mask = 1usize << slot;
         assert_ne!(expected & mask, 0);
@@ -1248,30 +1244,27 @@ mod loom_tests {
 
     #[test]
     fn put_publishes_before_take() {
-        model_geometries(&ALL_GEOMETRIES, |geometry, set| {
+        // `put` writes the parking cell before publishing the bit with a
+        // Release RMW. The taker spins until it can clear that bit with an
+        // Acquire RMW, then reads the same cell.
+        //
+        // If the publish/claim edge is weakened, loom should be able to
+        // schedule the cell read without seeing the prior cell write.
+        model(&ALL_GEOMETRIES, |geometry, freelist| {
             let slot = geometry.slots()[0];
 
-            // `put` writes the parking cell before publishing the bit with a
-            // Release RMW. The taker spins until it can clear that bit with an
-            // Acquire RMW, then reads the same cell.
-            //
-            // If the publish/claim edge is weakened, loom should be able to
-            // schedule the cell read without seeing the prior cell write.
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || set.put(slot, buffer()))
-            };
-            let reader = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || loop {
-                    if let Some((taken, buffer)) = set.take() {
-                        assert_eq!(taken, slot);
-                        drop(buffer);
-                        break;
-                    }
-                    thread::yield_now();
-                })
-            };
+            let writer = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put(slot, buffer())
+            });
+
+            let reader = thread::spawn(move || loop {
+                if let Some((taken, _)) = freelist.take() {
+                    assert_eq!(taken, slot);
+                    break;
+                }
+                thread::yield_now();
+            });
 
             writer.join().unwrap();
             reader.join().unwrap();
@@ -1280,110 +1273,100 @@ mod loom_tests {
 
     #[test]
     fn concurrent_puts_merge_disjoint_bits() {
+        // Two producers return different slots that live in the same bitmap
+        // word. Their atomic `fetch_or` operations must merge the bits: neither
+        // producer may overwrite the other's publication.
+        //
+        // The consumer runs after both producers finish so this test isolates
+        // lost producer updates from consumer-side claim races and from the
+        // publish/claim visibility tests below.
         loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
+            let freelist = Arc::new(single_word_freelist(2));
             let seen = Arc::new(AtomicUsize::new(0));
+            let expected = 0b11;
 
-            // Two producers return different slots that live in the same bitmap
-            // word. Their atomic `fetch_or` operations must merge the bits:
-            // neither producer may overwrite the other's publication.
-            //
-            // The consumer runs after both producers finish so this test
-            // isolates lost producer updates from consumer-side claim races and
-            // from the publish/claim visibility tests below.
-            let first = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || set.put(0, buffer()))
-            };
+            let first = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put(0, buffer())
+            });
 
-            let second = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || set.put(1, buffer()))
-            };
+            let second = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put(1, buffer())
+            });
 
             first.join().unwrap();
             second.join().unwrap();
 
             assert_eq!(
-                set.take_batch(2, |slot, buffer| {
-                    drop(buffer);
-                    let mask = 1 << slot;
-                    let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                    assert_eq!(previous & mask, 0);
-                }),
+                freelist.take_batch(2, |slot, _| record_expected_slot(&seen, expected, slot)),
                 2
             );
-            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn concurrent_put_batches_merge_disjoint_bits() {
+        // Each producer stages two slots and then publishes its per-word mask
+        // with one Release `fetch_or`. Because all four slots share a word,
+        // this specifically checks that two batch producers merge their masks
+        // instead of losing either batch.
         loom::model(|| {
-            let set = Arc::new(single_word_freelist(4));
+            let freelist = Arc::new(single_word_freelist(4));
             let seen = Arc::new(AtomicUsize::new(0));
+            let expected = 0b1111;
 
-            // Each producer stages two slots and then publishes its per-word
-            // mask with one Release `fetch_or`. Because all four slots share a
-            // word, this specifically checks that two batch producers merge
-            // their masks instead of losing either batch.
-            let first = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || set.put_batch([(0, buffer()), (1, buffer())]))
-            };
+            let first = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put_batch([(0, buffer()), (1, buffer())])
+            });
 
-            let second = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || set.put_batch([(2, buffer()), (3, buffer())]))
-            };
+            let second = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put_batch([(2, buffer()), (3, buffer())])
+            });
 
             first.join().unwrap();
             second.join().unwrap();
 
             assert_eq!(
-                set.take_batch(4, |slot, buffer| {
-                    drop(buffer);
-                    let mask = 1 << slot;
-                    let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                    assert_eq!(previous & mask, 0);
-                }),
+                freelist.take_batch(4, |slot, _| record_expected_slot(&seen, expected, slot)),
                 4
             );
-            assert_eq!(seen.load(Ordering::Relaxed), 0b1111);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn put_and_take_compose_on_partially_free_word() {
+        // Slot 0 starts free, then a producer returns slot 1 while `take` races
+        // on the same bitmap word. The producer's `fetch_or` must compose with
+        // the consumer's `fetch_and`: clearing the existing bit must not lose
+        // the newly published bit, and publishing the new bit must not
+        // resurrect a claimed bit.
         loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
-            set.put(0, buffer());
+            let freelist = Arc::new(single_word_freelist(2));
+            freelist.put(0, buffer());
 
-            // Slot 0 starts free, then a producer returns slot 1 while `take`
-            // races on the same bitmap word. The producer's `fetch_or`
-            // must compose with the consumer's `fetch_and`: clearing the
-            // existing bit must not lose the newly published bit, and
-            // publishing the new bit must not resurrect a claimed bit.
             let seen = Arc::new(AtomicUsize::new(0));
+            let expected = 0b11;
 
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || set.put(1, buffer()))
-            };
+            let writer = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put(1, buffer())
+            });
 
-            let taker = {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                thread::spawn(move || {
-                    let (slot, buffer) = set.take().expect("slot 0 starts free");
-                    drop(buffer);
-                    let mask = 1 << slot;
-                    let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                    assert_eq!(previous & mask, 0);
-                })
-            };
+            let taker = thread::spawn({
+                let freelist = freelist.clone();
+                let seen = seen.clone();
+                move || {
+                    let (slot, _) = freelist.take().expect("slot 0 starts free");
+                    record_expected_slot(&seen, expected, slot);
+                }
+            });
 
             writer.join().unwrap();
             taker.join().unwrap();
@@ -1391,127 +1374,119 @@ mod loom_tests {
             // The taker may run before slot 1 is published. After the writer
             // has joined, any slot not claimed during the race must still be
             // available exactly once.
-            while let Some((slot, buffer)) = set.take() {
-                drop(buffer);
-                let mask = 1 << slot;
-                let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                assert_eq!(previous & mask, 0);
+            while let Some((slot, _)) = freelist.take() {
+                record_expected_slot(&seen, expected, slot);
             }
 
-            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn put_and_take_batch_compose_on_partially_free_word() {
+        // This is the batch-claim version of the partially-free word race:
+        // `take_batch` may speculatively choose candidates from a stale relaxed
+        // load while a producer publishes a different bit in the same word.
+        // Only bits actually cleared by the batch taker may drive callbacks,
+        // and missed bits must remain available.
         loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
-            set.put(0, buffer());
+            let freelist = Arc::new(single_word_freelist(2));
+            freelist.put(0, buffer());
 
-            // This is the batch-claim version of the partially-free word race:
-            // `take_batch` may speculatively choose candidates from a stale
-            // relaxed load while a producer publishes a different bit in the
-            // same word. Only bits actually cleared by the batch taker may
-            // drive callbacks, and missed bits must remain available.
             let seen = Arc::new(AtomicUsize::new(0));
+            let expected = 0b11;
 
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || set.put(1, buffer()))
-            };
+            let writer = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put(1, buffer())
+            });
 
-            let batch_taker = {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                thread::spawn(move || {
-                    let count = set.take_batch(2, |slot, buffer| {
-                        drop(buffer);
-                        let mask = 1 << slot;
-                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                        assert_eq!(previous & mask, 0);
-                    });
+            let batch_taker = thread::spawn({
+                let freelist = freelist.clone();
+                let seen = seen.clone();
+                move || {
+                    let count = freelist
+                        .take_batch(2, |slot, _| record_expected_slot(&seen, expected, slot));
                     assert!((1..=2).contains(&count));
-                })
-            };
+                }
+            });
 
             writer.join().unwrap();
             batch_taker.join().unwrap();
 
             // If the batch taker ran before slot 1 was published, the slot must
             // still be visible after the writer completes.
-            while let Some((slot, buffer)) = set.take() {
-                drop(buffer);
-                let mask = 1 << slot;
-                let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                assert_eq!(previous & mask, 0);
+            while let Some((slot, _)) = freelist.take() {
+                record_expected_slot(&seen, expected, slot);
             }
 
-            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn put_batch_and_drain_compose_on_partially_free_word() {
+        // Slot 0 starts free, then a batch producer stages slots 1 and 2 and
+        // publishes them with one `fetch_or`. A concurrent `drain` clears the
+        // whole word with `swap(0)`. The two RMWs must compose: the drainer may
+        // get only slot 0 or all three slots, but the slots it misses must
+        // remain available after the writer completes.
         loom::model(|| {
-            let set = Arc::new(single_word_freelist(3));
-            set.put(0, buffer());
+            let freelist = Arc::new(single_word_freelist(3));
+            freelist.put(0, buffer());
 
-            // Slot 0 starts free, then a batch producer stages slots 1 and 2
-            // and publishes them with one `fetch_or`. A concurrent `drain`
-            // clears the whole word with `swap(0)`. The two RMWs must compose:
-            // the drainer may get only slot 0 or all three slots, but the slots
-            // it misses must remain available after the writer completes.
             let drained = Arc::new(AtomicUsize::new(0));
 
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || set.put_batch([(1, buffer()), (2, buffer())]))
-            };
+            let writer = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put_batch([(1, buffer()), (2, buffer())])
+            });
 
-            let drainer = {
-                let set = Arc::clone(&set);
-                let drained = Arc::clone(&drained);
-                thread::spawn(move || {
-                    let count = set.drain();
+            let drainer = thread::spawn({
+                let freelist = freelist.clone();
+                let drained = drained.clone();
+                move || {
+                    let count = freelist.drain();
                     assert!(matches!(count, 1 | 3));
                     drained.store(count, Ordering::Relaxed);
-                })
-            };
+                }
+            });
 
             writer.join().unwrap();
             drainer.join().unwrap();
 
-            let total = drained.load(Ordering::Relaxed) + set.drain();
+            let total = drained.load(Ordering::Relaxed) + freelist.drain();
             assert_eq!(total, 3);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn two_takers_cannot_claim_one_slot() {
+        // Both takers may observe the same relaxed non-zero candidate word.
+        // Only one may win the later `fetch_and` claim.
+        //
+        // This is the minimal stale-candidate case: the relaxed load is allowed
+        // to be old, but the returned value from `fetch_and` must decide
+        // ownership.
         loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
-            set.put(0, buffer());
+            let freelist = Arc::new(single_word_freelist(2));
+            freelist.put(0, buffer());
 
-            // Both takers may observe the same relaxed non-zero candidate
-            // word. Only one may win the later `fetch_and` claim.
-            //
-            // This is the minimal stale-candidate case: the relaxed load is
-            // allowed to be old, but the returned value from `fetch_and` must
-            // decide ownership.
-            let successes = Arc::new(AtomicUsize::new(0));
+            let seen = Arc::new(AtomicUsize::new(0));
+            let expected = 0b1;
             let mut handles = Vec::new();
 
             for _ in 0..2 {
-                let set = Arc::clone(&set);
-                let successes = Arc::clone(&successes);
-                handles.push(thread::spawn(move || {
-                    if let Some((slot, buffer)) = set.take() {
-                        assert_eq!(slot, 0);
-                        drop(buffer);
-                        successes.fetch_add(1, Ordering::Relaxed);
+                handles.push(thread::spawn({
+                    let freelist = freelist.clone();
+                    let seen = seen.clone();
+                    move || {
+                        if let Some((slot, _)) = freelist.take() {
+                            record_expected_slot(&seen, expected, slot);
+                        }
                     }
                 }));
             }
@@ -1520,39 +1495,39 @@ mod loom_tests {
                 handle.join().unwrap();
             }
 
-            assert_eq!(successes.load(Ordering::Relaxed), 1);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
         });
     }
 
     #[test]
     fn stale_candidate_can_claim_republished_same_slot() {
+        // A relaxed candidate load is not a reservation. One taker may observe
+        // slot 0 as free, lose the first claim race, and later clear a
+        // re-published bit for the same slot. The valid outcome is two
+        // sequential ownership transfers of slot 0, each synchronized by the
+        // Acquire claim that actually cleared the bit it returns.
         loom::model(|| {
-            let set = Arc::new(single_word_freelist(1));
-            set.put(0, buffer());
+            let freelist = Arc::new(single_word_freelist(1));
+            freelist.put(0, buffer());
 
-            // A relaxed candidate load is not a reservation. One taker may
-            // observe slot 0 as free, lose the first claim race, and later clear
-            // a re-published bit for the same slot. The valid outcome is two
-            // sequential ownership transfers of slot 0, each synchronized by the
-            // Acquire claim that actually cleared the bit it returns.
             let transfers = Arc::new(AtomicUsize::new(0));
-
             let mut handles = Vec::new();
+
             for _ in 0..2 {
-                let set = Arc::clone(&set);
-                let transfers = Arc::clone(&transfers);
-                handles.push(thread::spawn(move || loop {
-                    if let Some((slot, buffer)) = set.take() {
-                        assert_eq!(slot, 0);
-                        let transfer = transfers.fetch_add(1, Ordering::Relaxed) + 1;
-                        if transfer == 1 {
-                            set.put(slot, buffer);
-                        } else {
-                            drop(buffer);
+                handles.push(thread::spawn({
+                    let freelist = freelist.clone();
+                    let transfers = transfers.clone();
+                    move || loop {
+                        if let Some((slot, buffer)) = freelist.take() {
+                            assert_eq!(slot, 0);
+                            let transfer = transfers.fetch_add(1, Ordering::Relaxed) + 1;
+                            if transfer == 1 {
+                                freelist.put(slot, buffer);
+                            }
+                            break;
                         }
-                        break;
+                        thread::yield_now();
                     }
-                    thread::yield_now();
                 }));
             }
 
@@ -1561,36 +1536,37 @@ mod loom_tests {
             }
 
             assert_eq!(transfers.load(Ordering::Relaxed), 2);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn batch_claims_survive_intervening_rmw_sequence() {
+        // `put_batch` publishes both bits with one Release RMW. This model
+        // starts takers after publication to keep the state space small. The
+        // writer/reader visibility edge for batch publication is covered by
+        // `put_batch_publishes_to_take_batch`.
+        //
+        // What this case isolates is the two-taker claim sequence on the same
+        // word: one taker may clear one bit, then the other taker reads the
+        // word through that intervening RMW. Both slots must still be
+        // transferred exactly once.
         loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
-            set.put_batch([(0, buffer()), (1, buffer())]);
-            let seen = Arc::new(AtomicUsize::new(0));
+            let freelist = Arc::new(single_word_freelist(2));
+            freelist.put_batch([(0, buffer()), (1, buffer())]);
 
-            // `put_batch` publishes both bits with one Release RMW. This model
-            // starts takers after publication to keep the state space small;
-            // the writer/reader visibility edge for batch publication is
-            // covered by `put_batch_publishes_to_take_batch`.
-            //
-            // What this case isolates is the two-taker claim sequence on the
-            // same word: one taker may clear one bit, then the other taker
-            // reads the word through that intervening RMW. Both slots must
-            // still be transferred exactly once.
+            let seen = Arc::new(AtomicUsize::new(0));
+            let expected = 0b11;
             let mut handles = Vec::new();
+
             for _ in 0..2 {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                handles.push(thread::spawn(move || {
-                    if let Some((slot, buffer)) = set.take() {
-                        drop(buffer);
-                        let mask = 1 << slot;
-                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                        assert_eq!(previous & mask, 0);
+                handles.push(thread::spawn({
+                    let freelist = freelist.clone();
+                    let seen = seen.clone();
+                    move || {
+                        if let Some((slot, _)) = freelist.take() {
+                            record_expected_slot(&seen, expected, slot);
+                        }
                     }
                 }));
             }
@@ -1599,53 +1575,51 @@ mod loom_tests {
                 handle.join().unwrap();
             }
 
-            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
         });
     }
 
     #[test]
     fn take_and_take_batch_do_not_duplicate_slots() {
-        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+        // A single-slot claim and a batch claim race over the same free set.
+        // Each claimed slot is recorded once, any duplicate ownership transfer
+        // trips the `previous & mask == 0` assertion.
+        //
+        // This covers the speculative batch claim path, where `take_batch`
+        // first chooses candidate bits and then intersects them with the word
+        // value returned by `fetch_and`.
+        model(&BATCH_GEOMETRIES, |geometry, freelist| {
             let slots = geometry.slots();
             let expected = geometry.slot_mask();
-            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
+            freelist.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
-            // A single-slot claim and a batch claim race over the same free
-            // set. Each claimed slot is recorded once; any duplicate ownership
-            // transfer trips the `previous & mask == 0` assertion.
-            //
-            // This covers the speculative batch claim path, where `take_batch`
-            // first chooses candidate bits and then intersects them with the
-            // word value returned by `fetch_and`.
             let seen = Arc::new(AtomicUsize::new(0));
             let batch_count = Arc::new(AtomicUsize::new(0));
             let batch_callbacks = Arc::new(AtomicUsize::new(0));
 
-            let batch_taker = {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                let batch_count = Arc::clone(&batch_count);
-                let batch_callbacks = Arc::clone(&batch_callbacks);
-                thread::spawn(move || {
-                    let count = set.take_batch(slots.len(), |slot, buffer| {
-                        drop(buffer);
+            let batch_taker = thread::spawn({
+                let freelist = freelist.clone();
+                let seen = seen.clone();
+                let batch_count = batch_count.clone();
+                let batch_callbacks = batch_callbacks.clone();
+                move || {
+                    let count = freelist.take_batch(slots.len(), |slot, _| {
                         batch_callbacks.fetch_add(1, Ordering::Relaxed);
                         record_expected_slot(&seen, expected, slot);
                     });
                     batch_count.store(count, Ordering::Relaxed);
-                })
-            };
+                }
+            });
 
-            let single_taker = {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                thread::spawn(move || {
-                    if let Some((slot, buffer)) = set.take() {
-                        drop(buffer);
+            let single_taker = thread::spawn({
+                let freelist = freelist.clone();
+                let seen = seen.clone();
+                move || {
+                    if let Some((slot, _)) = freelist.take() {
                         record_expected_slot(&seen, expected, slot);
                     }
-                })
-            };
+                }
+            });
 
             batch_taker.join().unwrap();
             single_taker.join().unwrap();
@@ -1661,28 +1635,29 @@ mod loom_tests {
 
     #[test]
     fn two_take_batches_do_not_duplicate_slots() {
-        model_geometries(&MULTI_BIT_GEOMETRIES, |geometry, set| {
+        // Two batch refill paths can speculatively choose stale candidate bits
+        // from relaxed word loads. Each callback must still be driven only by
+        // bits that caller actually cleared with `fetch_and`.
+        model(&MULTI_BIT_GEOMETRIES, |geometry, freelist| {
             let slots = geometry.slots();
             let expected = geometry.slot_mask();
-            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
+            freelist.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
-            // Two batch refill paths can speculatively choose stale candidate
-            // bits from relaxed word loads. Each callback must still be driven
-            // only by bits that caller actually cleared with `fetch_and`.
             let seen = Arc::new(AtomicUsize::new(0));
             let total = Arc::new(AtomicUsize::new(0));
             let mut handles = Vec::new();
 
             for _ in 0..2 {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                let total = Arc::clone(&total);
-                handles.push(thread::spawn(move || {
-                    let count = set.take_batch(slots.len(), |slot, buffer| {
-                        drop(buffer);
-                        record_expected_slot(&seen, expected, slot);
-                    });
-                    total.fetch_add(count, Ordering::Relaxed);
+                handles.push(thread::spawn({
+                    let freelist = freelist.clone();
+                    let seen = seen.clone();
+                    let total = total.clone();
+                    move || {
+                        let count = freelist.take_batch(slots.len(), |slot, _| {
+                            record_expected_slot(&seen, expected, slot);
+                        });
+                        total.fetch_add(count, Ordering::Relaxed);
+                    }
                 }));
             }
 
@@ -1697,31 +1672,31 @@ mod loom_tests {
 
     #[test]
     fn two_take_batches_continue_after_losing_selected_bits() {
+        // Both batch takers can speculatively select the same first two bits
+        // from a stale relaxed word load. If one taker clears those bits first,
+        // the other must use the word value returned by `fetch_and` and
+        // continue on to the still-set third bit instead of stopping after a
+        // zero-sized successful claim.
         loom::model(|| {
-            let set = Arc::new(single_word_freelist(3));
-            set.put_batch([(0, buffer()), (1, buffer()), (2, buffer())]);
+            let freelist = Arc::new(single_word_freelist(3));
+            freelist.put_batch([(0, buffer()), (1, buffer()), (2, buffer())]);
 
-            // Both batch takers can speculatively select the same first two
-            // bits from a stale relaxed word load. If one taker clears those
-            // bits first, the other must use the word value returned by
-            // `fetch_and` and continue on to the still-set third bit instead of
-            // stopping after a zero-sized successful claim.
             let seen = Arc::new(AtomicUsize::new(0));
             let total = Arc::new(AtomicUsize::new(0));
+            let expected = 0b111;
             let mut handles = Vec::new();
 
             for _ in 0..2 {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                let total = Arc::clone(&total);
-                handles.push(thread::spawn(move || {
-                    let count = set.take_batch(2, |slot, buffer| {
-                        drop(buffer);
-                        let mask = 1 << slot;
-                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                        assert_eq!(previous & mask, 0);
-                    });
-                    total.fetch_add(count, Ordering::Relaxed);
+                handles.push(thread::spawn({
+                    let freelist = freelist.clone();
+                    let seen = seen.clone();
+                    let total = total.clone();
+                    move || {
+                        let count = freelist.take_batch(2, |slot, _| {
+                            record_expected_slot(&seen, expected, slot);
+                        });
+                        total.fetch_add(count, Ordering::Relaxed);
+                    }
                 }));
             }
 
@@ -1729,41 +1704,38 @@ mod loom_tests {
                 handle.join().unwrap();
             }
 
-            assert_eq!(seen.load(Ordering::Relaxed), 0b111);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
             assert_eq!(total.load(Ordering::Relaxed), 3);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn put_batch_publishes_to_take_batch() {
-        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+        // This exercises the batch-specific publish and claim path end to end
+        // across selected bitmap geometries: Release `fetch_or` publications
+        // make parked cells visible, and Acquire `fetch_and` claims may
+        // transfer one or more bits per word.
+        //
+        // The reader loops because loom may run it before the writer has
+        // published anything. A zero-sized claim is just a retry, not an
+        // observable failure.
+        model(&BATCH_GEOMETRIES, |geometry, freelist| {
             let seen = Arc::new(AtomicUsize::new(0));
             let slots = geometry.slots();
             let expected = geometry.slot_mask();
 
-            // This exercises the batch-specific publish and claim path end to
-            // end across selected bitmap geometries: Release `fetch_or`
-            // publications make parked cells visible, and Acquire `fetch_and`
-            // claims may transfer one or more bits per word.
-            //
-            // The reader loops because loom may run it before the writer has
-            // published anything. A zero-sized claim is just a retry, not an
-            // observable failure.
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || {
-                    set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())))
-                })
-            };
+            let writer = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put_batch(slots.iter().copied().map(|slot| (slot, buffer())))
+            });
 
-            let reader = {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                thread::spawn(move || {
+            let reader = thread::spawn({
+                let freelist = freelist.clone();
+                let seen = seen.clone();
+                move || {
                     while seen.load(Ordering::Relaxed) != expected {
-                        let claimed = set.take_batch(slots.len(), |slot, buffer| {
-                            drop(buffer);
+                        let claimed = freelist.take_batch(slots.len(), |slot, _| {
                             record_expected_slot(&seen, expected, slot);
                         });
 
@@ -1771,8 +1743,8 @@ mod loom_tests {
                             thread::yield_now();
                         }
                     }
-                })
-            };
+                }
+            });
 
             writer.join().unwrap();
             reader.join().unwrap();
@@ -1783,28 +1755,28 @@ mod loom_tests {
 
     #[test]
     fn put_publishes_to_drain() {
-        model_geometries(&ALL_GEOMETRIES, |geometry, set| {
+        // `drain` uses an Acquire whole-word swap. Run it concurrently with
+        // publication so this model checks the put-side Release edge rather
+        // than relying on thread-spawn visibility from pre-populated state.
+        //
+        // If the swap does not synchronize with the successful put, loom's
+        // tracked parking cell can observe the drainer reading the buffer
+        // without seeing the writer's earlier cell initialization.
+        model(&ALL_GEOMETRIES, |geometry, freelist| {
             let drained = Arc::new(AtomicUsize::new(0));
             let slot = geometry.slots()[0];
 
-            // `drain` uses an Acquire whole-word swap. Run it concurrently with
-            // publication so this model checks the put-side Release edge rather
-            // than relying on thread-spawn visibility from pre-populated state.
-            //
-            // If the swap does not synchronize with the successful put, loom's
-            // tracked parking cell can observe the drainer reading the buffer
-            // without seeing the writer's earlier cell initialization.
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || set.put(slot, buffer()))
-            };
+            let writer = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put(slot, buffer())
+            });
 
-            let drainer = {
-                let set = Arc::clone(&set);
-                let drained = Arc::clone(&drained);
-                thread::spawn(move || {
+            let drainer = thread::spawn({
+                let freelist = freelist.clone();
+                let drained = drained.clone();
+                move || {
                     while drained.load(Ordering::Relaxed) == 0 {
-                        let count = set.drain();
+                        let count = freelist.drain();
                         if count == 0 {
                             // The drainer may run before the writer publishes.
                             // A zero drain is a retry, not a failed assertion.
@@ -1814,44 +1786,42 @@ mod loom_tests {
                             drained.store(count, Ordering::Relaxed);
                         }
                     }
-                })
-            };
+                }
+            });
 
             writer.join().unwrap();
             drainer.join().unwrap();
 
             assert_eq!(drained.load(Ordering::Relaxed), 1);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn put_batch_publishes_to_drain() {
-        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+        // A batch publish parks multiple cells before publishing the touched
+        // bitmap word masks. The drainer loops until its Acquire swaps have
+        // observed every publication and dropped every parked buffer.
+        //
+        // This is the drain analogue of `put_batch_publishes_to_take_batch`:
+        // each whole-word swap must make all cells represented by the returned
+        // word visible before they are dropped.
+        model(&BATCH_GEOMETRIES, |geometry, freelist| {
             let drained = Arc::new(AtomicUsize::new(0));
             let slots = geometry.slots();
             let expected = slots.len();
 
-            // A batch publish parks multiple cells before publishing the touched
-            // bitmap word masks. The drainer loops until its Acquire swaps have
-            // observed every publication and dropped every parked buffer.
-            //
-            // This is the drain analogue of `put_batch_publishes_to_take_batch`:
-            // each whole-word swap must make all cells represented by the
-            // returned word visible before they are dropped.
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || {
-                    set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())))
-                })
-            };
+            let writer = thread::spawn({
+                let freelist = freelist.clone();
+                move || freelist.put_batch(slots.iter().copied().map(|slot| (slot, buffer())))
+            });
 
-            let drainer = {
-                let set = Arc::clone(&set);
-                let drained = Arc::clone(&drained);
-                thread::spawn(move || {
+            let drainer = thread::spawn({
+                let freelist = freelist.clone();
+                let drained = drained.clone();
+                move || {
                     while drained.load(Ordering::Relaxed) < expected {
-                        let count = set.drain();
+                        let count = freelist.drain();
                         if count == 0 {
                             // The drainer may run before the batch is published.
                             thread::yield_now();
@@ -1860,104 +1830,102 @@ mod loom_tests {
                             assert!(previous + count <= expected);
                         }
                     }
-                })
-            };
+                }
+            });
 
             writer.join().unwrap();
             drainer.join().unwrap();
 
             assert_eq!(drained.load(Ordering::Relaxed), expected);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn puts_and_take_scan_across_stripes() {
-        model_geometries(&STRIPED_GEOMETRIES, |geometry, set| {
+        // Publish slots across multiple bitmap words using the single-entry
+        // `put` path. The reader uses repeated `take` calls, not `take_batch`,
+        // so this checks that the single-slot scan path reaches every occupied
+        // stripe and that each independent Release publication synchronizes
+        // with the later Acquire claim.
+        model(&STRIPED_GEOMETRIES, |geometry, freelist| {
             let seen = Arc::new(AtomicUsize::new(0));
             let slots = geometry.slots();
             let expected = geometry.slot_mask();
 
-            // Publish slots across multiple bitmap words using the single-entry
-            // `put` path. The reader uses repeated `take` calls, not
-            // `take_batch`, so this checks that the single-slot scan path
-            // reaches every occupied stripe and that each independent Release
-            // publication synchronizes with the later Acquire claim.
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || {
+            let writer = thread::spawn({
+                let freelist = freelist.clone();
+                move || {
                     for &slot in slots {
-                        set.put(slot, buffer());
+                        freelist.put(slot, buffer());
                     }
-                })
-            };
+                }
+            });
 
-            let reader = {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                thread::spawn(move || {
+            let reader = thread::spawn({
+                let freelist = freelist.clone();
+                let seen = seen.clone();
+                move || {
                     while seen.load(Ordering::Relaxed) != expected {
-                        if let Some((slot, buffer)) = set.take() {
-                            drop(buffer);
+                        if let Some((slot, _)) = freelist.take() {
                             record_expected_slot(&seen, expected, slot);
                         } else {
                             thread::yield_now();
                         }
                     }
-                })
-            };
+                }
+            });
 
             writer.join().unwrap();
             reader.join().unwrap();
 
             assert_eq!(seen.load(Ordering::Relaxed), expected);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn drain_and_take_do_not_duplicate_or_lose_slots() {
-        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+        // `drain` clears a whole word with `swap(0)` while `take` clears one
+        // bit with `fetch_and`. Racing them should transfer ownership of each
+        // parked buffer exactly once and leave no free bits behind.
+        //
+        // This also covers the synchronization shape used by `Drop`, which
+        // drains any buffers that remain globally free.
+        model(&BATCH_GEOMETRIES, |geometry, freelist| {
             let slots = geometry.slots();
             let expected = slots.len();
             let expected_mask = geometry.slot_mask();
-            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
+            freelist.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
             let drained = Arc::new(AtomicUsize::new(0));
             let taken = Arc::new(AtomicUsize::new(0));
 
-            // `drain` clears a whole word with `swap(0)` while `take` clears
-            // one bit with `fetch_and`. Racing them should transfer ownership
-            // of each parked buffer exactly once and leave no free bits behind.
-            //
-            // This also covers the synchronization shape used by `Drop`, which
-            // drains any buffers that remain globally free.
-            let drainer = {
-                let set = Arc::clone(&set);
-                let drained = Arc::clone(&drained);
-                thread::spawn(move || {
-                    drained.store(set.drain(), Ordering::Relaxed);
-                })
-            };
+            let drainer = thread::spawn({
+                let freelist = freelist.clone();
+                let drained = drained.clone();
+                move || {
+                    drained.store(freelist.drain(), Ordering::Relaxed);
+                }
+            });
 
-            let taker = {
-                let set = Arc::clone(&set);
-                let taken = Arc::clone(&taken);
-                thread::spawn(move || {
-                    if let Some((slot, buffer)) = set.take() {
-                        assert_ne!(expected_mask & (1usize << slot), 0);
-                        drop(buffer);
-                        taken.store(1, Ordering::Relaxed);
+            let taker = thread::spawn({
+                let freelist = freelist.clone();
+                let taken = taken.clone();
+                move || {
+                    if let Some((slot, _)) = freelist.take() {
+                        record_expected_slot(&taken, expected_mask, slot);
                     }
-                })
-            };
+                }
+            });
 
             drainer.join().unwrap();
             taker.join().unwrap();
 
-            assert_eq!(set.drain(), 0);
+            assert_eq!(freelist.drain(), 0);
             assert_eq!(
-                drained.load(Ordering::Relaxed) + taken.load(Ordering::Relaxed),
+                drained.load(Ordering::Relaxed)
+                    + taken.load(Ordering::Relaxed).count_ones() as usize,
                 expected
             );
         });
@@ -1965,23 +1933,25 @@ mod loom_tests {
 
     #[test]
     fn two_drains_do_not_duplicate_or_lose_slots() {
-        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+        // `drain` is a public whole-word `swap(0)` operation over every bitmap
+        // word. Two drainers racing over the same free set must split ownership
+        // according to the values returned by their swaps, and the total must
+        // be exactly the original occupancy.
+        model(&BATCH_GEOMETRIES, |geometry, freelist| {
             let slots = geometry.slots();
             let expected = slots.len();
-            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
+            freelist.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
             let total = Arc::new(AtomicUsize::new(0));
             let mut handles = Vec::new();
 
-            // `drain` is a public whole-word `swap(0)` operation over every
-            // bitmap word. Two drainers racing over the same free set must
-            // split ownership according to the values returned by their swaps,
-            // and the total must be exactly the original occupancy.
             for _ in 0..2 {
-                let set = Arc::clone(&set);
-                let total = Arc::clone(&total);
-                handles.push(thread::spawn(move || {
-                    total.fetch_add(set.drain(), Ordering::Relaxed);
+                handles.push(thread::spawn({
+                    let freelist = freelist.clone();
+                    let total = total.clone();
+                    move || {
+                        total.fetch_add(freelist.drain(), Ordering::Relaxed);
+                    }
                 }));
             }
 
@@ -1990,49 +1960,54 @@ mod loom_tests {
             }
 
             assert_eq!(total.load(Ordering::Relaxed), expected);
-            assert_eq!(set.drain(), 0);
+            assert_eq!(freelist.drain(), 0);
         });
     }
 
     #[test]
     fn drain_and_take_batch_do_not_duplicate_or_lose_slots() {
-        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+        // This is the same whole-word `swap(0)` race as the single-slot drain
+        // test, but the competing operation clears a speculative multi-bit
+        // claim. It makes sure `take_batch` uses the word value returned by
+        // `fetch_and`, not just the earlier relaxed load.
+        model(&BATCH_GEOMETRIES, |geometry, freelist| {
             let slots = geometry.slots();
             let expected = slots.len();
             let expected_mask = geometry.slot_mask();
-            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
+            freelist.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
             let drained = Arc::new(AtomicUsize::new(0));
             let taken = Arc::new(AtomicUsize::new(0));
+            let taken_slots = Arc::new(AtomicUsize::new(0));
 
-            // This is the same whole-word `swap(0)` race as the single-slot
-            // drain test, but the competing operation clears a speculative
-            // multi-bit claim. It makes sure `take_batch` uses the word value
-            // returned by `fetch_and`, not just the earlier relaxed load.
-            let drainer = {
-                let set = Arc::clone(&set);
-                let drained = Arc::clone(&drained);
-                thread::spawn(move || {
-                    drained.store(set.drain(), Ordering::Relaxed);
-                })
-            };
+            let drainer = thread::spawn({
+                let freelist = freelist.clone();
+                let drained = drained.clone();
+                move || {
+                    drained.store(freelist.drain(), Ordering::Relaxed);
+                }
+            });
 
-            let batch_taker = {
-                let set = Arc::clone(&set);
-                let taken = Arc::clone(&taken);
-                thread::spawn(move || {
-                    let count = set.take_batch(expected, |slot, buffer| {
-                        assert_ne!(expected_mask & (1usize << slot), 0);
-                        drop(buffer);
+            let batch_taker = thread::spawn({
+                let freelist = freelist.clone();
+                let taken = taken.clone();
+                let taken_slots = taken_slots.clone();
+                move || {
+                    let count = freelist.take_batch(expected, |slot, _| {
+                        record_expected_slot(&taken_slots, expected_mask, slot);
                     });
                     taken.store(count, Ordering::Relaxed);
-                })
-            };
+                }
+            });
 
             drainer.join().unwrap();
             batch_taker.join().unwrap();
 
-            assert_eq!(set.drain(), 0);
+            assert_eq!(freelist.drain(), 0);
+            assert_eq!(
+                taken.load(Ordering::Relaxed),
+                taken_slots.load(Ordering::Relaxed).count_ones() as usize
+            );
             assert_eq!(
                 drained.load(Ordering::Relaxed) + taken.load(Ordering::Relaxed),
                 expected

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1291,12 +1291,11 @@ mod loom_tests {
                 let set = Arc::clone(&set);
                 let seen = Arc::clone(&seen);
                 thread::spawn(move || {
-                    if let Some((slot, buffer)) = set.take() {
-                        drop(buffer);
-                        let mask = 1 << slot;
-                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                        assert_eq!(previous & mask, 0);
-                    }
+                    let (slot, buffer) = set.take().expect("slot 0 starts free");
+                    drop(buffer);
+                    let mask = 1 << slot;
+                    let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                    assert_eq!(previous & mask, 0);
                 })
             };
 
@@ -1346,7 +1345,7 @@ mod loom_tests {
                         let previous = seen.fetch_or(mask, Ordering::Relaxed);
                         assert_eq!(previous & mask, 0);
                     });
-                    assert!(count <= 2);
+                    assert!((1..=2).contains(&count));
                 })
             };
 
@@ -1390,7 +1389,7 @@ mod loom_tests {
                 let drained = Arc::clone(&drained);
                 thread::spawn(move || {
                     let count = set.drain();
-                    assert!(count <= 3);
+                    assert!(matches!(count, 1 | 3));
                     drained.store(count, Ordering::Relaxed);
                 })
             };

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -102,26 +102,26 @@
 //! outside the freelist may access that slot's parking cell.
 use super::aligned::AlignedBuffer;
 use crossbeam_utils::CachePadded;
-// Build the same freelist code against loom primitives in model tests, so the
-// tests exercise the production ownership protocol instead of a mirror type.
-#[cfg(feature = "loom")]
-use loom::{
-    cell::UnsafeCell,
-    sync::atomic::{AtomicU64, AtomicUsize},
-    thread_local,
-};
 use std::{
     cell::Cell,
     mem::MaybeUninit,
     num::{NonZeroU32, NonZeroUsize},
     sync::atomic::Ordering,
 };
-#[cfg(not(feature = "loom"))]
-use std::{
-    cell::UnsafeCell,
-    sync::atomic::{AtomicU64, AtomicUsize},
-    thread_local,
-};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "loom")] {
+        use loom::{
+            cell::UnsafeCell,
+            sync::atomic::{AtomicU64, AtomicUsize},
+        };
+    } else {
+        use std::{
+            cell::UnsafeCell,
+            sync::atomic::{AtomicU64, AtomicUsize},
+        };
+    }
+}
 
 /// Number of slot bits tracked in each bitmap word.
 const SLOT_BITMAP_WORD_BITS: usize = u64::BITS as usize;
@@ -526,34 +526,30 @@ impl Freelist {
     /// this write completes.
     #[inline(always)]
     fn park(&self, slot: u32, buffer: AlignedBuffer) {
-        #[cfg(not(feature = "loom"))]
-        {
-            // SAFETY: the caller owns this slot while it is outside the freelist, so no
-            // other thread can access the parking cell until the slot bit is set.
-            unsafe {
-                (*self
-                    .storage
-                    .get(slot as usize)
-                    .expect("slot id must refer to an allocated slot")
-                    .get())
-                .write(buffer);
-            }
-        }
+        let cell = self
+            .storage
+            .get(slot as usize)
+            .expect("slot id must refer to an allocated slot");
 
-        #[cfg(feature = "loom")]
-        {
-            // Use loom's tracked cell API so the model can detect a parking-cell
-            // access that is not synchronized by the bitmap bit transition.
-            let cell = self
-                .storage
-                .get(slot as usize)
-                .expect("slot id must refer to an allocated slot");
-            cell.with_mut(|ptr| {
+        cfg_if::cfg_if! {
+            if #[cfg(not(feature = "loom"))] {
                 // SAFETY: the caller owns this slot while it is outside the
-                // freelist, so no other thread can access the parking cell
-                // until the slot bit is set.
-                unsafe { (*ptr).write(buffer) };
-            });
+                // freelist, so no other thread can access the parking cell until
+                // the slot bit is set.
+                unsafe {
+                    (*cell.get()).write(buffer);
+                }
+            } else {
+                // Use loom's tracked cell API so the model can detect a
+                // parking-cell access that is not synchronized by the bitmap bit
+                // transition.
+                cell.with_mut(|ptr| {
+                    // SAFETY: the caller owns this slot while it is outside the
+                    // freelist, so no other thread can access the parking cell
+                    // until the slot bit is set.
+                    unsafe { (*ptr).write(buffer) };
+                });
+            }
         }
     }
 
@@ -562,35 +558,28 @@ impl Freelist {
     /// The caller must have cleared the slot's bit before reading the cell.
     #[inline(always)]
     fn unpark(&self, slot: u32) -> AlignedBuffer {
-        #[cfg(not(feature = "loom"))]
-        {
-            // SAFETY: a successful bit clear removes this slot from the free set,
-            // so we have exclusive access to the initialized buffer that was
-            // made available by the matching put.
-            unsafe {
-                (*self
-                    .storage
-                    .get(slot as usize)
-                    .expect("slot id must refer to an allocated slot")
-                    .get())
-                .assume_init_read()
-            }
-        }
+        let cell = self
+            .storage
+            .get(slot as usize)
+            .expect("slot id must refer to an allocated slot");
 
-        #[cfg(feature = "loom")]
-        {
-            // Use loom's tracked cell API so the model can detect a parking-cell
-            // access that is not synchronized by the bitmap bit transition.
-            let cell = self
-                .storage
-                .get(slot as usize)
-                .expect("slot id must refer to an allocated slot");
-            cell.with_mut(|ptr| {
-                // SAFETY: a successful bit clear removes this slot from the
-                // free set, so we have exclusive access to the initialized
-                // buffer that was made available by the matching put.
-                unsafe { (*ptr).assume_init_read() }
-            })
+        cfg_if::cfg_if! {
+            if #[cfg(not(feature = "loom"))] {
+                // SAFETY: a successful bit clear removes this slot from the free
+                // set, so we have exclusive access to the initialized buffer that
+                // was made available by the matching put.
+                unsafe { (*cell.get()).assume_init_read() }
+            } else {
+                // Use loom's tracked cell API so the model can detect a
+                // parking-cell access that is not synchronized by the bitmap bit
+                // transition.
+                cell.with_mut(|ptr| {
+                    // SAFETY: a successful bit clear removes this slot from the
+                    // free set, so we have exclusive access to the initialized
+                    // buffer that was made available by the matching put.
+                    unsafe { (*ptr).assume_init_read() }
+                })
+            }
         }
     }
 }
@@ -616,41 +605,58 @@ struct SlotBitmapProbe {
 }
 
 // Monotonic source for per-thread probe ids.
-#[cfg(not(feature = "loom"))]
-static NEXT_SLOT_BITMAP_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
-
-#[cfg(feature = "loom")]
-loom::lazy_static! {
-    static ref NEXT_SLOT_BITMAP_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+cfg_if::cfg_if! {
+    if #[cfg(not(feature = "loom"))] {
+        static NEXT_SLOT_BITMAP_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+    } else {
+        loom::lazy_static! {
+            // Loom's `AtomicUsize::new` is not const, so the modeled global
+            // counter has to be initialized through `lazy_static!`.
+            static ref NEXT_SLOT_BITMAP_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+        }
+    }
 }
 
-#[cfg(feature = "loom")]
-thread_local! {
-    // Loom's `thread_local!` macro does not accept const initializers or
-    // associated static items. Keep this loom-only declaration separate from
-    // the production TLS declaration below.
-    static TLS_SLOT_BITMAP_THREAD_ID: Cell<Option<usize>> = Cell::new(None);
+cfg_if::cfg_if! {
+    if #[cfg(not(feature = "loom"))] {
+        thread_local! {
+            // The per-thread probe id gives each thread a stable starting point for
+            // bitmap scans.
+            //
+            // Keep this const-initialized so the TLS value has no destructor. The
+            // cold path initializes the id explicitly instead of using a lazy TLS
+            // initializer.
+            static TLS_SLOT_BITMAP_THREAD_ID: Cell<Option<usize>> = const { Cell::new(None) };
+        }
+    } else {
+        loom::thread_local! {
+            // Loom's `thread_local!` macro does not accept const initializers or
+            // associated static items.
+            static TLS_SLOT_BITMAP_THREAD_ID: Cell<Option<usize>> = Cell::new(None);
+        }
+    }
 }
 
 impl SlotBitmapProbe {
-    #[cfg(not(feature = "loom"))]
-    thread_local! {
-        // The per-thread probe id gives each thread a stable starting point for
-        // bitmap scans.
-        //
-        // Keep this const-initialized so the TLS value has no destructor. The
-        // cold path initializes the id explicitly instead of using a lazy TLS
-        // initializer.
-        static TLS_SLOT_BITMAP_THREAD_ID: Cell<Option<usize>> = const { Cell::new(None) };
-    }
-
     /// Builds probe state for the current thread and freelist layout.
     ///
     /// The thread's stable id chooses both its home word and its preferred bit
     /// offset inside each word.
     #[inline(always)]
     fn new(word_mask: usize, word_shift: u32) -> Self {
-        let thread_id = Self::thread_id();
+        let thread_id = TLS_SLOT_BITMAP_THREAD_ID.with(|thread_id| {
+            if let Some(id) = thread_id.get() {
+                return id;
+            }
+
+            // Relaxed ordering is enough because probe ids only spread starting
+            // points across bitmap words, they do not synchronize buffer
+            // ownership.
+            let id = NEXT_SLOT_BITMAP_THREAD_ID.fetch_add(1, Ordering::Relaxed);
+            thread_id.set(Some(id));
+            id
+        });
+
         Self {
             // Low id bits choose the first bitmap word this thread probes.
             // With a power-of-two word count, masking is equivalent to modulo
@@ -661,34 +667,6 @@ impl SlotBitmapProbe {
             // bits within that word.
             bit_offset: Self::bit_offset(thread_id, word_shift),
         }
-    }
-
-    /// Returns the stable probe id assigned to the current thread.
-    #[inline(always)]
-    fn thread_id() -> usize {
-        #[cfg(not(feature = "loom"))]
-        {
-            Self::TLS_SLOT_BITMAP_THREAD_ID.with(Self::thread_id_from_cell)
-        }
-
-        #[cfg(feature = "loom")]
-        {
-            TLS_SLOT_BITMAP_THREAD_ID.with(Self::thread_id_from_cell)
-        }
-    }
-
-    /// Initializes the thread-local probe id on first use.
-    #[inline(always)]
-    fn thread_id_from_cell(thread_id: &Cell<Option<usize>>) -> usize {
-        if let Some(id) = thread_id.get() {
-            return id;
-        }
-
-        // Relaxed ordering is enough because probe ids only spread starting
-        // points across bitmap words, they do not synchronize buffer ownership.
-        let id = NEXT_SLOT_BITMAP_THREAD_ID.fetch_add(1, Ordering::Relaxed);
-        thread_id.set(Some(id));
-        id
     }
 
     /// Returns the bit offset for this thread's home-word collision group.
@@ -1164,6 +1142,13 @@ mod loom_tests {
         Freelist::new(NonZeroU32::new(2).unwrap(), NonZeroUsize::new(1).unwrap())
     }
 
+    fn striped_freelist() -> Freelist {
+        // Four slots with four stripes puts each modeled slot in a distinct
+        // bitmap word. This covers cross-word scan and batch publication without
+        // blowing up the model.
+        Freelist::new(NonZeroU32::new(4).unwrap(), NonZeroUsize::new(4).unwrap())
+    }
+
     fn buffer() -> AlignedBuffer {
         // The payload itself is not important to the model. The aligned
         // allocation is enough to exercise ownership transfer through the
@@ -1172,7 +1157,7 @@ mod loom_tests {
     }
 
     #[test]
-    fn loom_put_publishes_before_take() {
+    fn put_publishes_before_take() {
         loom::model(|| {
             let set = Arc::new(freelist());
 
@@ -1204,7 +1189,7 @@ mod loom_tests {
     }
 
     #[test]
-    fn loom_two_takers_cannot_claim_one_slot() {
+    fn two_takers_cannot_claim_one_slot() {
         loom::model(|| {
             let set = Arc::new(freelist());
             set.put(0, buffer());
@@ -1239,7 +1224,7 @@ mod loom_tests {
     }
 
     #[test]
-    fn loom_batch_claims_survive_intervening_rmw_sequence() {
+    fn batch_claims_survive_intervening_rmw_sequence() {
         loom::model(|| {
             let set = Arc::new(freelist());
             set.put_batch([(0, buffer()), (1, buffer())]);
@@ -1248,7 +1233,7 @@ mod loom_tests {
             // `put_batch` publishes both bits with one Release RMW. This model
             // starts takers after publication to keep the state space small;
             // the writer/reader visibility edge for batch publication is
-            // covered by `loom_put_batch_publishes_to_take_batch`.
+            // covered by `put_batch_publishes_to_take_batch`.
             //
             // What this case isolates is the two-taker claim sequence on the
             // same word: one taker may clear one bit, then the other taker
@@ -1277,7 +1262,7 @@ mod loom_tests {
     }
 
     #[test]
-    fn loom_take_and_take_batch_do_not_duplicate_slots() {
+    fn take_and_take_batch_do_not_duplicate_slots() {
         loom::model(|| {
             let set = Arc::new(freelist());
             set.put_batch([(0, buffer()), (1, buffer())]);
@@ -1329,7 +1314,7 @@ mod loom_tests {
     }
 
     #[test]
-    fn loom_two_take_batches_do_not_duplicate_slots() {
+    fn two_take_batches_do_not_duplicate_slots() {
         loom::model(|| {
             let set = Arc::new(freelist());
             set.put_batch([(0, buffer()), (1, buffer())]);
@@ -1366,7 +1351,7 @@ mod loom_tests {
     }
 
     #[test]
-    fn loom_put_batch_publishes_to_take_batch() {
+    fn put_batch_publishes_to_take_batch() {
         loom::model(|| {
             let set = Arc::new(freelist());
             let seen = Arc::new(AtomicUsize::new(0));
@@ -1410,7 +1395,143 @@ mod loom_tests {
     }
 
     #[test]
-    fn loom_drain_and_take_do_not_duplicate_or_lose_slots() {
+    fn put_publishes_to_drain() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+            let drained = Arc::new(AtomicUsize::new(0));
+
+            // `drain` uses an Acquire whole-word swap. Run it concurrently with
+            // publication so this model checks the put-side Release edge rather
+            // than relying on thread-spawn visibility from pre-populated state.
+            //
+            // If the swap does not synchronize with the successful put, loom's
+            // tracked parking cell can observe the drainer reading the buffer
+            // without seeing the writer's earlier cell initialization.
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put(0, buffer()))
+            };
+
+            let drainer = {
+                let set = Arc::clone(&set);
+                let drained = Arc::clone(&drained);
+                thread::spawn(move || {
+                    while drained.load(Ordering::Relaxed) == 0 {
+                        let count = set.drain();
+                        if count == 0 {
+                            // The drainer may run before the writer publishes.
+                            // A zero drain is a retry, not a failed assertion.
+                            thread::yield_now();
+                        } else {
+                            assert_eq!(count, 1);
+                            drained.store(count, Ordering::Relaxed);
+                        }
+                    }
+                })
+            };
+
+            writer.join().unwrap();
+            drainer.join().unwrap();
+
+            assert_eq!(drained.load(Ordering::Relaxed), 1);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
+    fn put_batch_publishes_to_drain() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+            let drained = Arc::new(AtomicUsize::new(0));
+
+            // A batch publish parks multiple cells before one Release RMW. The
+            // drainer loops until its Acquire swap observes that publication and
+            // then drops every parked buffer it claimed.
+            //
+            // This is the drain analogue of `put_batch_publishes_to_take_batch`:
+            // the whole-word swap must make all cells represented by the returned
+            // word visible before they are dropped.
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put_batch([(0, buffer()), (1, buffer())]))
+            };
+
+            let drainer = {
+                let set = Arc::clone(&set);
+                let drained = Arc::clone(&drained);
+                thread::spawn(move || {
+                    while drained.load(Ordering::Relaxed) < 2 {
+                        let count = set.drain();
+                        if count == 0 {
+                            // The drainer may run before the batch is published.
+                            thread::yield_now();
+                        } else {
+                            let previous = drained.fetch_add(count, Ordering::Relaxed);
+                            assert!(previous + count <= 2);
+                        }
+                    }
+                })
+            };
+
+            writer.join().unwrap();
+            drainer.join().unwrap();
+
+            assert_eq!(drained.load(Ordering::Relaxed), 2);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
+    fn put_batch_and_take_batch_across_stripes() {
+        loom::model(|| {
+            let set = Arc::new(striped_freelist());
+            let seen = Arc::new(AtomicUsize::new(0));
+
+            // Publish one slot per bitmap word. The reader may observe any
+            // prefix of the per-word Release operations and must keep scanning
+            // other stripes until it has claimed each slot exactly once.
+            //
+            // This complements the two-slot same-word models above: same-word
+            // tests cover RMW contention on one atomic word, while this checks
+            // that the striped scan does not stop after the first word and that
+            // each per-word batch publication independently synchronizes with a
+            // later claim.
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || {
+                    set.put_batch([(0, buffer()), (1, buffer()), (2, buffer()), (3, buffer())])
+                })
+            };
+
+            let reader = {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                thread::spawn(move || {
+                    while seen.load(Ordering::Relaxed) != 0b1111 {
+                        let claimed = set.take_batch(4, |slot, buffer| {
+                            drop(buffer);
+                            let mask = 1 << slot;
+                            let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                            assert_eq!(previous & mask, 0);
+                        });
+
+                        if claimed == 0 {
+                            thread::yield_now();
+                        }
+                    }
+                })
+            };
+
+            writer.join().unwrap();
+            reader.join().unwrap();
+
+            assert_eq!(seen.load(Ordering::Relaxed), 0b1111);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
+    fn drain_and_take_do_not_duplicate_or_lose_slots() {
         loom::model(|| {
             let set = Arc::new(freelist());
             set.put_batch([(0, buffer()), (1, buffer())]);
@@ -1455,7 +1576,7 @@ mod loom_tests {
     }
 
     #[test]
-    fn loom_drain_and_take_batch_do_not_duplicate_or_lose_slots() {
+    fn drain_and_take_batch_do_not_duplicate_or_lose_slots() {
         loom::model(|| {
             let set = Arc::new(freelist());
             set.put_batch([(0, buffer()), (1, buffer())]);

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -630,8 +630,7 @@ cfg_if::cfg_if! {
         }
     } else {
         loom::thread_local! {
-            // Loom's `thread_local!` macro does not accept const initializers or
-            // associated static items.
+            // Loom's `thread_local!` macro does not accept const initializers.
             static TLS_SLOT_BITMAP_THREAD_ID: Cell<Option<usize>> = Cell::new(None);
         }
     }

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1199,11 +1199,12 @@ mod loom_tests {
             let seen = Arc::new(AtomicUsize::new(0));
 
             // Two producers return different slots that live in the same bitmap
-            // word. Their Release `fetch_or` operations must merge the bits:
+            // word. Their atomic `fetch_or` operations must merge the bits:
             // neither producer may overwrite the other's publication.
             //
             // The consumer runs after both producers finish so this test
-            // isolates lost producer updates from consumer-side claim races.
+            // isolates lost producer updates from consumer-side claim races and
+            // from the publish/claim visibility tests below.
             let first = {
                 let set = Arc::clone(&set);
                 thread::spawn(move || set.put(0, buffer()))
@@ -1740,6 +1741,52 @@ mod loom_tests {
             drainer.join().unwrap();
 
             assert_eq!(drained.load(Ordering::Relaxed), 2);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
+    fn puts_and_take_scan_across_stripes() {
+        loom::model(|| {
+            let set = Arc::new(striped_freelist());
+            let seen = Arc::new(AtomicUsize::new(0));
+
+            // Publish one slot per bitmap word using the single-entry `put`
+            // path. The reader uses repeated `take` calls, not `take_batch`, so
+            // this checks that the single-slot scan path reaches every stripe
+            // and that each independent Release publication synchronizes with
+            // the later Acquire claim for that slot.
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || {
+                    for slot in 0..4 {
+                        set.put(slot, buffer());
+                    }
+                })
+            };
+
+            let reader = {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                thread::spawn(move || {
+                    while seen.load(Ordering::Relaxed) != 0b1111 {
+                        if let Some((slot, buffer)) = set.take() {
+                            assert!(slot < 4);
+                            drop(buffer);
+                            let mask = 1usize << slot;
+                            let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                            assert_eq!(previous & mask, 0);
+                        } else {
+                            thread::yield_now();
+                        }
+                    }
+                })
+            };
+
+            writer.join().unwrap();
+            reader.join().unwrap();
+
+            assert_eq!(seen.load(Ordering::Relaxed), 0b1111);
             assert_eq!(set.drain(), 0);
         });
     }

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1132,13 +1132,17 @@ mod loom_tests {
 
     // These tests run the production `Freelist` implementation with loom's
     // atomics, thread local storage, and `UnsafeCell` substituted under
-    // `cfg(feature = "loom")`. The goal is to check the real memory-ordering boundaries,
-    // not a separate simplified model of the data structure.
-    fn freelist() -> Freelist {
-        // Keep the model small enough for exhaustive exploration while forcing
-        // both slots into the same bitmap word. That covers the RMW contention
-        // that makes this freelist subtle.
-        Freelist::new(NonZeroU32::new(2).unwrap(), NonZeroUsize::new(1).unwrap())
+    // `cfg(feature = "loom")`. They use two small bitmap geometries: a
+    // single-word freelist for same-word RMW races, and a striped freelist for
+    // cross-word publication and scan races.
+    fn single_word_freelist(capacity: u32) -> Freelist {
+        // Use one stripe so every slot in the model shares one bitmap word.
+        // This keeps the model small enough for exhaustive exploration while
+        // covering the RMW contention that makes this freelist subtle.
+        Freelist::new(
+            NonZeroU32::new(capacity).unwrap(),
+            NonZeroUsize::new(1).unwrap(),
+        )
     }
 
     fn striped_freelist() -> Freelist {
@@ -1158,7 +1162,7 @@ mod loom_tests {
     #[test]
     fn put_publishes_before_take() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
 
             // `put` writes the parking cell before publishing the bit with a
             // Release RMW. The taker spins until it can clear that bit with an
@@ -1188,9 +1192,85 @@ mod loom_tests {
     }
 
     #[test]
+    fn concurrent_puts_merge_disjoint_bits() {
+        loom::model(|| {
+            let set = Arc::new(single_word_freelist(2));
+            let seen = Arc::new(AtomicUsize::new(0));
+
+            // Two producers return different slots that live in the same bitmap
+            // word. Their Release `fetch_or` operations must merge the bits:
+            // neither producer may overwrite the other's publication.
+            //
+            // The consumer runs after both producers finish so this test
+            // isolates lost producer updates from consumer-side claim races.
+            let first = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put(0, buffer()))
+            };
+
+            let second = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put(1, buffer()))
+            };
+
+            first.join().unwrap();
+            second.join().unwrap();
+
+            assert_eq!(
+                set.take_batch(2, |slot, buffer| {
+                    drop(buffer);
+                    let mask = 1 << slot;
+                    let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                    assert_eq!(previous & mask, 0);
+                }),
+                2
+            );
+            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
+    fn concurrent_put_batches_merge_disjoint_bits() {
+        loom::model(|| {
+            let set = Arc::new(single_word_freelist(4));
+            let seen = Arc::new(AtomicUsize::new(0));
+
+            // Each producer stages two slots and then publishes its per-word
+            // mask with one Release `fetch_or`. Because all four slots share a
+            // word, this specifically checks that two batch producers merge
+            // their masks instead of losing either batch.
+            let first = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put_batch([(0, buffer()), (1, buffer())]))
+            };
+
+            let second = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put_batch([(2, buffer()), (3, buffer())]))
+            };
+
+            first.join().unwrap();
+            second.join().unwrap();
+
+            assert_eq!(
+                set.take_batch(4, |slot, buffer| {
+                    drop(buffer);
+                    let mask = 1 << slot;
+                    let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                    assert_eq!(previous & mask, 0);
+                }),
+                4
+            );
+            assert_eq!(seen.load(Ordering::Relaxed), 0b1111);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
     fn two_takers_cannot_claim_one_slot() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
             set.put(0, buffer());
 
             // Both takers may observe the same relaxed non-zero candidate
@@ -1225,7 +1305,7 @@ mod loom_tests {
     #[test]
     fn batch_claims_survive_intervening_rmw_sequence() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
             set.put_batch([(0, buffer()), (1, buffer())]);
             let seen = Arc::new(AtomicUsize::new(0));
 
@@ -1263,7 +1343,7 @@ mod loom_tests {
     #[test]
     fn take_and_take_batch_do_not_duplicate_slots() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
             set.put_batch([(0, buffer()), (1, buffer())]);
 
             // A single-slot claim and a multi-bit claim race on the same word.
@@ -1275,14 +1355,17 @@ mod loom_tests {
             // word value returned by `fetch_and`.
             let seen = Arc::new(AtomicUsize::new(0));
             let batch_count = Arc::new(AtomicUsize::new(0));
+            let batch_callbacks = Arc::new(AtomicUsize::new(0));
 
             let batch_taker = {
                 let set = Arc::clone(&set);
                 let seen = Arc::clone(&seen);
                 let batch_count = Arc::clone(&batch_count);
+                let batch_callbacks = Arc::clone(&batch_callbacks);
                 thread::spawn(move || {
                     let count = set.take_batch(2, |slot, buffer| {
                         drop(buffer);
+                        batch_callbacks.fetch_add(1, Ordering::Relaxed);
                         let mask = 1 << slot;
                         let previous = seen.fetch_or(mask, Ordering::Relaxed);
                         assert_eq!(previous & mask, 0);
@@ -1309,13 +1392,17 @@ mod loom_tests {
 
             assert_eq!(seen.load(Ordering::Relaxed), 0b11);
             assert!(batch_count.load(Ordering::Relaxed) <= 2);
+            assert_eq!(
+                batch_count.load(Ordering::Relaxed),
+                batch_callbacks.load(Ordering::Relaxed)
+            );
         });
     }
 
     #[test]
     fn two_take_batches_do_not_duplicate_slots() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
             set.put_batch([(0, buffer()), (1, buffer())]);
 
             // Two batch refill paths can speculatively choose the same bits
@@ -1350,9 +1437,49 @@ mod loom_tests {
     }
 
     #[test]
+    fn two_take_batches_continue_after_losing_selected_bits() {
+        loom::model(|| {
+            let set = Arc::new(single_word_freelist(3));
+            set.put_batch([(0, buffer()), (1, buffer()), (2, buffer())]);
+
+            // Both batch takers can speculatively select the same first two
+            // bits from a stale relaxed word load. If one taker clears those
+            // bits first, the other must use the word value returned by
+            // `fetch_and` and continue on to the still-set third bit instead of
+            // stopping after a zero-sized successful claim.
+            let seen = Arc::new(AtomicUsize::new(0));
+            let total = Arc::new(AtomicUsize::new(0));
+            let mut handles = Vec::new();
+
+            for _ in 0..2 {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                let total = Arc::clone(&total);
+                handles.push(thread::spawn(move || {
+                    let count = set.take_batch(2, |slot, buffer| {
+                        drop(buffer);
+                        let mask = 1 << slot;
+                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                        assert_eq!(previous & mask, 0);
+                    });
+                    total.fetch_add(count, Ordering::Relaxed);
+                }));
+            }
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+
+            assert_eq!(seen.load(Ordering::Relaxed), 0b111);
+            assert_eq!(total.load(Ordering::Relaxed), 3);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
     fn put_batch_publishes_to_take_batch() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
             let seen = Arc::new(AtomicUsize::new(0));
 
             // This exercises the batch-specific publish and claim path end to
@@ -1396,7 +1523,7 @@ mod loom_tests {
     #[test]
     fn put_publishes_to_drain() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
             let drained = Arc::new(AtomicUsize::new(0));
 
             // `drain` uses an Acquire whole-word swap. Run it concurrently with
@@ -1440,7 +1567,7 @@ mod loom_tests {
     #[test]
     fn put_batch_publishes_to_drain() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
             let drained = Arc::new(AtomicUsize::new(0));
 
             // A batch publish parks multiple cells before one Release RMW. The
@@ -1465,6 +1592,7 @@ mod loom_tests {
                             // The drainer may run before the batch is published.
                             thread::yield_now();
                         } else {
+                            assert_eq!(count, 2);
                             let previous = drained.fetch_add(count, Ordering::Relaxed);
                             assert!(previous + count <= 2);
                         }
@@ -1530,9 +1658,52 @@ mod loom_tests {
     }
 
     #[test]
+    fn put_batch_publishes_to_drain_across_stripes() {
+        loom::model(|| {
+            let set = Arc::new(striped_freelist());
+            let drained = Arc::new(AtomicUsize::new(0));
+
+            // A striped batch publishes one Release `fetch_or` per touched word.
+            // The drainer may observe any subset of those per-word publications
+            // in one pass, then must keep scanning future passes until every
+            // published cell has been acquired and dropped exactly once.
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || {
+                    set.put_batch([(0, buffer()), (1, buffer()), (2, buffer()), (3, buffer())])
+                })
+            };
+
+            let drainer = {
+                let set = Arc::clone(&set);
+                let drained = Arc::clone(&drained);
+                thread::spawn(move || {
+                    while drained.load(Ordering::Relaxed) < 4 {
+                        let count = set.drain();
+                        if count == 0 {
+                            // The drainer may run before the writer has
+                            // published another stripe.
+                            thread::yield_now();
+                        } else {
+                            let previous = drained.fetch_add(count, Ordering::Relaxed);
+                            assert!(previous + count <= 4);
+                        }
+                    }
+                })
+            };
+
+            writer.join().unwrap();
+            drainer.join().unwrap();
+
+            assert_eq!(drained.load(Ordering::Relaxed), 4);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
     fn drain_and_take_do_not_duplicate_or_lose_slots() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
             set.put_batch([(0, buffer()), (1, buffer())]);
 
             let drained = Arc::new(AtomicUsize::new(0));
@@ -1575,9 +1746,39 @@ mod loom_tests {
     }
 
     #[test]
+    fn two_drains_do_not_duplicate_or_lose_slots() {
+        loom::model(|| {
+            let set = Arc::new(single_word_freelist(2));
+            set.put_batch([(0, buffer()), (1, buffer())]);
+
+            let total = Arc::new(AtomicUsize::new(0));
+            let mut handles = Vec::new();
+
+            // `drain` is a public whole-word `swap(0)` operation. Two drainers
+            // racing on the same word must split ownership according to the
+            // values returned by their swaps: one may drain both slots and the
+            // other none, but the total must be exactly the original occupancy.
+            for _ in 0..2 {
+                let set = Arc::clone(&set);
+                let total = Arc::clone(&total);
+                handles.push(thread::spawn(move || {
+                    total.fetch_add(set.drain(), Ordering::Relaxed);
+                }));
+            }
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+
+            assert_eq!(total.load(Ordering::Relaxed), 2);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
     fn drain_and_take_batch_do_not_duplicate_or_lose_slots() {
         loom::model(|| {
-            let set = Arc::new(freelist());
+            let set = Arc::new(single_word_freelist(2));
             set.put_batch([(0, buffer()), (1, buffer())]);
 
             let drained = Arc::new(AtomicUsize::new(0));

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -102,11 +102,25 @@
 //! outside the freelist may access that slot's parking cell.
 use super::aligned::AlignedBuffer;
 use crossbeam_utils::CachePadded;
+// Build the same freelist code against loom primitives in model tests, so the
+// tests exercise the production ownership protocol instead of a mirror type.
+#[cfg(feature = "loom")]
+use loom::{
+    cell::UnsafeCell,
+    sync::atomic::{AtomicU64, AtomicUsize},
+    thread_local,
+};
 use std::{
-    cell::{Cell, UnsafeCell},
+    cell::Cell,
     mem::MaybeUninit,
     num::{NonZeroU32, NonZeroUsize},
-    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+    sync::atomic::Ordering,
+};
+#[cfg(not(feature = "loom"))]
+use std::{
+    cell::UnsafeCell,
+    sync::atomic::{AtomicU64, AtomicUsize},
+    thread_local,
 };
 
 /// Number of slot bits tracked in each bitmap word.
@@ -512,15 +526,34 @@ impl Freelist {
     /// this write completes.
     #[inline(always)]
     fn park(&self, slot: u32, buffer: AlignedBuffer) {
-        // SAFETY: the caller owns this slot while it is outside the freelist, so no
-        // other thread can access the parking cell until the slot bit is set.
-        unsafe {
-            (*self
+        #[cfg(not(feature = "loom"))]
+        {
+            // SAFETY: the caller owns this slot while it is outside the freelist, so no
+            // other thread can access the parking cell until the slot bit is set.
+            unsafe {
+                (*self
+                    .storage
+                    .get(slot as usize)
+                    .expect("slot id must refer to an allocated slot")
+                    .get())
+                .write(buffer);
+            }
+        }
+
+        #[cfg(feature = "loom")]
+        {
+            // Use loom's tracked cell API so the model can detect a parking-cell
+            // access that is not synchronized by the bitmap bit transition.
+            let cell = self
                 .storage
                 .get(slot as usize)
-                .expect("slot id must refer to an allocated slot")
-                .get())
-            .write(buffer);
+                .expect("slot id must refer to an allocated slot");
+            cell.with_mut(|ptr| {
+                // SAFETY: the caller owns this slot while it is outside the
+                // freelist, so no other thread can access the parking cell
+                // until the slot bit is set.
+                unsafe { (*ptr).write(buffer) };
+            });
         }
     }
 
@@ -529,16 +562,35 @@ impl Freelist {
     /// The caller must have cleared the slot's bit before reading the cell.
     #[inline(always)]
     fn unpark(&self, slot: u32) -> AlignedBuffer {
-        // SAFETY: a successful bit clear removes this slot from the free set,
-        // so we have exclusive access to the initialized buffer that was
-        // made available by the matching put.
-        unsafe {
-            (*self
+        #[cfg(not(feature = "loom"))]
+        {
+            // SAFETY: a successful bit clear removes this slot from the free set,
+            // so we have exclusive access to the initialized buffer that was
+            // made available by the matching put.
+            unsafe {
+                (*self
+                    .storage
+                    .get(slot as usize)
+                    .expect("slot id must refer to an allocated slot")
+                    .get())
+                .assume_init_read()
+            }
+        }
+
+        #[cfg(feature = "loom")]
+        {
+            // Use loom's tracked cell API so the model can detect a parking-cell
+            // access that is not synchronized by the bitmap bit transition.
+            let cell = self
                 .storage
                 .get(slot as usize)
-                .expect("slot id must refer to an allocated slot")
-                .get())
-            .assume_init_read()
+                .expect("slot id must refer to an allocated slot");
+            cell.with_mut(|ptr| {
+                // SAFETY: a successful bit clear removes this slot from the
+                // free set, so we have exclusive access to the initialized
+                // buffer that was made available by the matching put.
+                unsafe { (*ptr).assume_init_read() }
+            })
         }
     }
 }
@@ -564,9 +616,24 @@ struct SlotBitmapProbe {
 }
 
 // Monotonic source for per-thread probe ids.
+#[cfg(not(feature = "loom"))]
 static NEXT_SLOT_BITMAP_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
 
+#[cfg(feature = "loom")]
+loom::lazy_static! {
+    static ref NEXT_SLOT_BITMAP_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+}
+
+#[cfg(feature = "loom")]
+thread_local! {
+    // Loom's `thread_local!` macro does not accept const initializers or
+    // associated static items. Keep this loom-only declaration separate from
+    // the production TLS declaration below.
+    static TLS_SLOT_BITMAP_THREAD_ID: Cell<Option<usize>> = Cell::new(None);
+}
+
 impl SlotBitmapProbe {
+    #[cfg(not(feature = "loom"))]
     thread_local! {
         // The per-thread probe id gives each thread a stable starting point for
         // bitmap scans.
@@ -583,18 +650,7 @@ impl SlotBitmapProbe {
     /// offset inside each word.
     #[inline(always)]
     fn new(word_mask: usize, word_shift: u32) -> Self {
-        let thread_id = Self::TLS_SLOT_BITMAP_THREAD_ID.with(|thread_id| {
-            if let Some(id) = thread_id.get() {
-                return id;
-            }
-
-            // Relaxed ordering is enough because probe ids only spread starting
-            // points across bitmap words, they do not synchronize buffer
-            // ownership.
-            let id = NEXT_SLOT_BITMAP_THREAD_ID.fetch_add(1, Ordering::Relaxed);
-            thread_id.set(Some(id));
-            id
-        });
+        let thread_id = Self::thread_id();
         Self {
             // Low id bits choose the first bitmap word this thread probes.
             // With a power-of-two word count, masking is equivalent to modulo
@@ -605,6 +661,34 @@ impl SlotBitmapProbe {
             // bits within that word.
             bit_offset: Self::bit_offset(thread_id, word_shift),
         }
+    }
+
+    /// Returns the stable probe id assigned to the current thread.
+    #[inline(always)]
+    fn thread_id() -> usize {
+        #[cfg(not(feature = "loom"))]
+        {
+            Self::TLS_SLOT_BITMAP_THREAD_ID.with(Self::thread_id_from_cell)
+        }
+
+        #[cfg(feature = "loom")]
+        {
+            TLS_SLOT_BITMAP_THREAD_ID.with(Self::thread_id_from_cell)
+        }
+    }
+
+    /// Initializes the thread-local probe id on first use.
+    #[inline(always)]
+    fn thread_id_from_cell(thread_id: &Cell<Option<usize>>) -> usize {
+        if let Some(id) = thread_id.get() {
+            return id;
+        }
+
+        // Relaxed ordering is enough because probe ids only spread starting
+        // points across bitmap words, they do not synchronize buffer ownership.
+        let id = NEXT_SLOT_BITMAP_THREAD_ID.fetch_add(1, Ordering::Relaxed);
+        thread_id.set(Some(id));
+        id
     }
 
     /// Returns the bit offset for this thread's home-word collision group.
@@ -1054,5 +1138,362 @@ pub(super) mod tests {
         set.put(0, AlignedBuffer::new(64, 64));
         set.put(1, AlignedBuffer::new(64, 64));
         drop(set);
+    }
+}
+
+#[cfg(all(test, feature = "loom"))]
+mod loom_tests {
+    use super::*;
+    use loom::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        thread,
+    };
+    use std::num::{NonZeroU32, NonZeroUsize};
+
+    // These tests run the production `Freelist` implementation with loom's
+    // atomics, thread local storage, and `UnsafeCell` substituted under
+    // `cfg(feature = "loom")`. The goal is to check the real memory-ordering boundaries,
+    // not a separate simplified model of the data structure.
+    fn freelist() -> Freelist {
+        // Keep the model small enough for exhaustive exploration while forcing
+        // both slots into the same bitmap word. That covers the RMW contention
+        // that makes this freelist subtle.
+        Freelist::new(NonZeroU32::new(2).unwrap(), NonZeroUsize::new(1).unwrap())
+    }
+
+    fn buffer() -> AlignedBuffer {
+        // The payload itself is not important to the model. The aligned
+        // allocation is enough to exercise ownership transfer through the
+        // parking cell and make double-reads/double-drops visible.
+        AlignedBuffer::new(64, 64)
+    }
+
+    #[test]
+    fn loom_put_publishes_before_take() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+
+            // `put` writes the parking cell before publishing the bit with a
+            // Release RMW. The taker spins until it can clear that bit with an
+            // Acquire RMW, then reads the same cell.
+            //
+            // If the publish/claim edge is weakened, loom should be able to
+            // schedule the cell read without seeing the prior cell write.
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put(0, buffer()))
+            };
+            let reader = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || loop {
+                    if let Some((slot, buffer)) = set.take() {
+                        assert_eq!(slot, 0);
+                        drop(buffer);
+                        break;
+                    }
+                    thread::yield_now();
+                })
+            };
+
+            writer.join().unwrap();
+            reader.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn loom_two_takers_cannot_claim_one_slot() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+            set.put(0, buffer());
+
+            // Both takers may observe the same relaxed non-zero candidate
+            // word. Only one may win the later `fetch_and` claim.
+            //
+            // This is the minimal stale-candidate case: the relaxed load is
+            // allowed to be old, but the returned value from `fetch_and` must
+            // decide ownership.
+            let successes = Arc::new(AtomicUsize::new(0));
+            let mut handles = Vec::new();
+
+            for _ in 0..2 {
+                let set = Arc::clone(&set);
+                let successes = Arc::clone(&successes);
+                handles.push(thread::spawn(move || {
+                    if let Some((slot, buffer)) = set.take() {
+                        assert_eq!(slot, 0);
+                        drop(buffer);
+                        successes.fetch_add(1, Ordering::Relaxed);
+                    }
+                }));
+            }
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+
+            assert_eq!(successes.load(Ordering::Relaxed), 1);
+        });
+    }
+
+    #[test]
+    fn loom_batch_claims_survive_intervening_rmw_sequence() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+            set.put_batch([(0, buffer()), (1, buffer())]);
+            let seen = Arc::new(AtomicUsize::new(0));
+
+            // `put_batch` publishes both bits with one Release RMW. This model
+            // starts takers after publication to keep the state space small;
+            // the writer/reader visibility edge for batch publication is
+            // covered by `loom_put_batch_publishes_to_take_batch`.
+            //
+            // What this case isolates is the two-taker claim sequence on the
+            // same word: one taker may clear one bit, then the other taker
+            // reads the word through that intervening RMW. Both slots must
+            // still be transferred exactly once.
+            let mut handles = Vec::new();
+            for _ in 0..2 {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                handles.push(thread::spawn(move || {
+                    if let Some((slot, buffer)) = set.take() {
+                        drop(buffer);
+                        let mask = 1 << slot;
+                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                        assert_eq!(previous & mask, 0);
+                    }
+                }));
+            }
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+
+            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
+        });
+    }
+
+    #[test]
+    fn loom_take_and_take_batch_do_not_duplicate_slots() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+            set.put_batch([(0, buffer()), (1, buffer())]);
+
+            // A single-slot claim and a multi-bit claim race on the same word.
+            // Each claimed slot is recorded once; any duplicate ownership
+            // transfer trips the `previous & mask == 0` assertion.
+            //
+            // This covers the speculative batch claim path, where `take_batch`
+            // first chooses candidate bits and then intersects them with the
+            // word value returned by `fetch_and`.
+            let seen = Arc::new(AtomicUsize::new(0));
+            let batch_count = Arc::new(AtomicUsize::new(0));
+
+            let batch_taker = {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                let batch_count = Arc::clone(&batch_count);
+                thread::spawn(move || {
+                    let count = set.take_batch(2, |slot, buffer| {
+                        drop(buffer);
+                        let mask = 1 << slot;
+                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                        assert_eq!(previous & mask, 0);
+                    });
+                    batch_count.store(count, Ordering::Relaxed);
+                })
+            };
+
+            let single_taker = {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                thread::spawn(move || {
+                    if let Some((slot, buffer)) = set.take() {
+                        drop(buffer);
+                        let mask = 1 << slot;
+                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                        assert_eq!(previous & mask, 0);
+                    }
+                })
+            };
+
+            batch_taker.join().unwrap();
+            single_taker.join().unwrap();
+
+            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
+            assert!(batch_count.load(Ordering::Relaxed) <= 2);
+        });
+    }
+
+    #[test]
+    fn loom_two_take_batches_do_not_duplicate_slots() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+            set.put_batch([(0, buffer()), (1, buffer())]);
+
+            // Two batch refill paths can speculatively choose the same bits
+            // from the relaxed word load. Each callback must still be driven
+            // only by bits that caller actually cleared with `fetch_and`.
+            let seen = Arc::new(AtomicUsize::new(0));
+            let total = Arc::new(AtomicUsize::new(0));
+            let mut handles = Vec::new();
+
+            for _ in 0..2 {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                let total = Arc::clone(&total);
+                handles.push(thread::spawn(move || {
+                    let count = set.take_batch(2, |slot, buffer| {
+                        drop(buffer);
+                        let mask = 1 << slot;
+                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                        assert_eq!(previous & mask, 0);
+                    });
+                    total.fetch_add(count, Ordering::Relaxed);
+                }));
+            }
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+
+            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
+            assert_eq!(total.load(Ordering::Relaxed), 2);
+        });
+    }
+
+    #[test]
+    fn loom_put_batch_publishes_to_take_batch() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+            let seen = Arc::new(AtomicUsize::new(0));
+
+            // This exercises the batch-specific publish and claim path end to
+            // end: one Release `fetch_or` makes multiple parked cells visible,
+            // and one Acquire `fetch_and` may claim multiple bits.
+            //
+            // The reader loops because loom may run it before the writer has
+            // published anything. A zero-sized claim is just a retry, not an
+            // observable failure.
+            let writer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put_batch([(0, buffer()), (1, buffer())]))
+            };
+
+            let reader = {
+                let set = Arc::clone(&set);
+                let seen = Arc::clone(&seen);
+                thread::spawn(move || {
+                    while seen.load(Ordering::Relaxed) != 0b11 {
+                        let claimed = set.take_batch(2, |slot, buffer| {
+                            drop(buffer);
+                            let mask = 1 << slot;
+                            let previous = seen.fetch_or(mask, Ordering::Relaxed);
+                            assert_eq!(previous & mask, 0);
+                        });
+
+                        if claimed == 0 {
+                            thread::yield_now();
+                        }
+                    }
+                })
+            };
+
+            writer.join().unwrap();
+            reader.join().unwrap();
+
+            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
+        });
+    }
+
+    #[test]
+    fn loom_drain_and_take_do_not_duplicate_or_lose_slots() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+            set.put_batch([(0, buffer()), (1, buffer())]);
+
+            let drained = Arc::new(AtomicUsize::new(0));
+            let taken = Arc::new(AtomicUsize::new(0));
+
+            // `drain` clears a whole word with `swap(0)` while `take` clears
+            // one bit with `fetch_and`. Racing them should transfer ownership
+            // of each parked buffer exactly once and leave no free bits behind.
+            //
+            // This also covers the synchronization shape used by `Drop`, which
+            // drains any buffers that remain globally free.
+            let drainer = {
+                let set = Arc::clone(&set);
+                let drained = Arc::clone(&drained);
+                thread::spawn(move || {
+                    drained.store(set.drain(), Ordering::Relaxed);
+                })
+            };
+
+            let taker = {
+                let set = Arc::clone(&set);
+                let taken = Arc::clone(&taken);
+                thread::spawn(move || {
+                    if let Some((_slot, buffer)) = set.take() {
+                        drop(buffer);
+                        taken.store(1, Ordering::Relaxed);
+                    }
+                })
+            };
+
+            drainer.join().unwrap();
+            taker.join().unwrap();
+
+            assert_eq!(set.drain(), 0);
+            assert_eq!(
+                drained.load(Ordering::Relaxed) + taken.load(Ordering::Relaxed),
+                2
+            );
+        });
+    }
+
+    #[test]
+    fn loom_drain_and_take_batch_do_not_duplicate_or_lose_slots() {
+        loom::model(|| {
+            let set = Arc::new(freelist());
+            set.put_batch([(0, buffer()), (1, buffer())]);
+
+            let drained = Arc::new(AtomicUsize::new(0));
+            let taken = Arc::new(AtomicUsize::new(0));
+
+            // This is the same whole-word `swap(0)` race as the single-slot
+            // drain test, but the competing operation clears a speculative
+            // multi-bit claim. It makes sure `take_batch` uses the word value
+            // returned by `fetch_and`, not just the earlier relaxed load.
+            let drainer = {
+                let set = Arc::clone(&set);
+                let drained = Arc::clone(&drained);
+                thread::spawn(move || {
+                    drained.store(set.drain(), Ordering::Relaxed);
+                })
+            };
+
+            let batch_taker = {
+                let set = Arc::clone(&set);
+                let taken = Arc::clone(&taken);
+                thread::spawn(move || {
+                    let count = set.take_batch(2, |_slot, buffer| {
+                        drop(buffer);
+                    });
+                    taken.store(count, Ordering::Relaxed);
+                })
+            };
+
+            drainer.join().unwrap();
+            batch_taker.join().unwrap();
+
+            assert_eq!(set.drain(), 0);
+            assert_eq!(
+                drained.load(Ordering::Relaxed) + taken.load(Ordering::Relaxed),
+                2
+            );
+        });
     }
 }

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1160,10 +1160,93 @@ mod loom_tests {
         AlignedBuffer::new(64, 64)
     }
 
+    #[derive(Clone, Copy, Debug)]
+    enum Geometry {
+        SingleWordSingleBit,
+        SingleWordMultiBit,
+        MultiWordSingleBit,
+        MultiWordMultiBit,
+    }
+
+    impl Geometry {
+        fn freelist(self) -> Freelist {
+            match self {
+                Self::SingleWordSingleBit => single_word_freelist(1),
+                Self::SingleWordMultiBit => single_word_freelist(2),
+                Self::MultiWordSingleBit => striped_freelist(),
+                // Two stripes and four active slots gives the model multiple
+                // bitmap words with multiple live bits in each touched word:
+                // slots 0/2 share word 0, and slots 1/3 share word 1.
+                Self::MultiWordMultiBit => {
+                    Freelist::new(NonZeroU32::new(4).unwrap(), NonZeroUsize::new(2).unwrap())
+                }
+            }
+        }
+
+        fn slots(self) -> &'static [u32] {
+            match self {
+                Self::SingleWordSingleBit => &[0],
+                Self::SingleWordMultiBit => &[0, 1],
+                Self::MultiWordSingleBit => &[0, 1, 2, 3],
+                Self::MultiWordMultiBit => &[0, 2, 1, 3],
+            }
+        }
+
+        fn slot_mask(self) -> usize {
+            self.slots()
+                .iter()
+                .fold(0usize, |mask, &slot| mask | (1usize << slot))
+        }
+    }
+
+    const ALL_GEOMETRIES: [Geometry; 4] = [
+        Geometry::SingleWordSingleBit,
+        Geometry::SingleWordMultiBit,
+        Geometry::MultiWordSingleBit,
+        Geometry::MultiWordMultiBit,
+    ];
+
+    const BATCH_GEOMETRIES: [Geometry; 3] = [
+        Geometry::SingleWordMultiBit,
+        Geometry::MultiWordSingleBit,
+        Geometry::MultiWordMultiBit,
+    ];
+
+    const STRIPED_GEOMETRIES: [Geometry; 2] =
+        [Geometry::MultiWordSingleBit, Geometry::MultiWordMultiBit];
+
+    const MULTI_BIT_GEOMETRIES: [Geometry; 2] =
+        [Geometry::SingleWordMultiBit, Geometry::MultiWordMultiBit];
+
+    fn model_geometry<F>(geometry: Geometry, test: F)
+    where
+        F: Fn(Geometry, Arc<Freelist>) + Send + Sync + 'static,
+    {
+        loom::model(move || {
+            test(geometry, Arc::new(geometry.freelist()));
+        });
+    }
+
+    fn model_geometries<F>(geometries: &[Geometry], test: F)
+    where
+        F: Fn(Geometry, Arc<Freelist>) + Clone + Send + Sync + 'static,
+    {
+        for &geometry in geometries {
+            model_geometry(geometry, test.clone());
+        }
+    }
+
+    fn record_expected_slot(seen: &AtomicUsize, expected: usize, slot: u32) {
+        let mask = 1usize << slot;
+        assert_ne!(expected & mask, 0);
+        let previous = seen.fetch_or(mask, Ordering::Relaxed);
+        assert_eq!(previous & mask, 0);
+    }
+
     #[test]
     fn put_publishes_before_take() {
-        loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
+        model_geometries(&ALL_GEOMETRIES, |geometry, set| {
+            let slot = geometry.slots()[0];
 
             // `put` writes the parking cell before publishing the bit with a
             // Release RMW. The taker spins until it can clear that bit with an
@@ -1173,13 +1256,13 @@ mod loom_tests {
             // schedule the cell read without seeing the prior cell write.
             let writer = {
                 let set = Arc::clone(&set);
-                thread::spawn(move || set.put(0, buffer()))
+                thread::spawn(move || set.put(slot, buffer()))
             };
             let reader = {
                 let set = Arc::clone(&set);
                 thread::spawn(move || loop {
-                    if let Some((slot, buffer)) = set.take() {
-                        assert_eq!(slot, 0);
+                    if let Some((taken, buffer)) = set.take() {
+                        assert_eq!(taken, slot);
                         drop(buffer);
                         break;
                     }
@@ -1439,6 +1522,47 @@ mod loom_tests {
     }
 
     #[test]
+    fn stale_candidate_can_claim_republished_same_slot() {
+        loom::model(|| {
+            let set = Arc::new(single_word_freelist(1));
+            set.put(0, buffer());
+
+            // A relaxed candidate load is not a reservation. One taker may
+            // observe slot 0 as free, lose the first claim race, and later clear
+            // a re-published bit for the same slot. The valid outcome is two
+            // sequential ownership transfers of slot 0, each synchronized by the
+            // Acquire claim that actually cleared the bit it returns.
+            let transfers = Arc::new(AtomicUsize::new(0));
+
+            let mut handles = Vec::new();
+            for _ in 0..2 {
+                let set = Arc::clone(&set);
+                let transfers = Arc::clone(&transfers);
+                handles.push(thread::spawn(move || loop {
+                    if let Some((slot, buffer)) = set.take() {
+                        assert_eq!(slot, 0);
+                        let transfer = transfers.fetch_add(1, Ordering::Relaxed) + 1;
+                        if transfer == 1 {
+                            set.put(slot, buffer);
+                        } else {
+                            drop(buffer);
+                        }
+                        break;
+                    }
+                    thread::yield_now();
+                }));
+            }
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+
+            assert_eq!(transfers.load(Ordering::Relaxed), 2);
+            assert_eq!(set.drain(), 0);
+        });
+    }
+
+    #[test]
     fn batch_claims_survive_intervening_rmw_sequence() {
         loom::model(|| {
             let set = Arc::new(single_word_freelist(2));
@@ -1478,12 +1602,13 @@ mod loom_tests {
 
     #[test]
     fn take_and_take_batch_do_not_duplicate_slots() {
-        loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
-            set.put_batch([(0, buffer()), (1, buffer())]);
+        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+            let slots = geometry.slots();
+            let expected = geometry.slot_mask();
+            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
-            // A single-slot claim and a multi-bit claim race on the same word.
-            // Each claimed slot is recorded once; any duplicate ownership
+            // A single-slot claim and a batch claim race over the same free
+            // set. Each claimed slot is recorded once; any duplicate ownership
             // transfer trips the `previous & mask == 0` assertion.
             //
             // This covers the speculative batch claim path, where `take_batch`
@@ -1499,12 +1624,10 @@ mod loom_tests {
                 let batch_count = Arc::clone(&batch_count);
                 let batch_callbacks = Arc::clone(&batch_callbacks);
                 thread::spawn(move || {
-                    let count = set.take_batch(2, |slot, buffer| {
+                    let count = set.take_batch(slots.len(), |slot, buffer| {
                         drop(buffer);
                         batch_callbacks.fetch_add(1, Ordering::Relaxed);
-                        let mask = 1 << slot;
-                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                        assert_eq!(previous & mask, 0);
+                        record_expected_slot(&seen, expected, slot);
                     });
                     batch_count.store(count, Ordering::Relaxed);
                 })
@@ -1516,9 +1639,7 @@ mod loom_tests {
                 thread::spawn(move || {
                     if let Some((slot, buffer)) = set.take() {
                         drop(buffer);
-                        let mask = 1 << slot;
-                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                        assert_eq!(previous & mask, 0);
+                        record_expected_slot(&seen, expected, slot);
                     }
                 })
             };
@@ -1526,8 +1647,8 @@ mod loom_tests {
             batch_taker.join().unwrap();
             single_taker.join().unwrap();
 
-            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
-            assert!(batch_count.load(Ordering::Relaxed) <= 2);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
+            assert!(batch_count.load(Ordering::Relaxed) <= slots.len());
             assert_eq!(
                 batch_count.load(Ordering::Relaxed),
                 batch_callbacks.load(Ordering::Relaxed)
@@ -1537,12 +1658,13 @@ mod loom_tests {
 
     #[test]
     fn two_take_batches_do_not_duplicate_slots() {
-        loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
-            set.put_batch([(0, buffer()), (1, buffer())]);
+        model_geometries(&MULTI_BIT_GEOMETRIES, |geometry, set| {
+            let slots = geometry.slots();
+            let expected = geometry.slot_mask();
+            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
-            // Two batch refill paths can speculatively choose the same bits
-            // from the relaxed word load. Each callback must still be driven
+            // Two batch refill paths can speculatively choose stale candidate
+            // bits from relaxed word loads. Each callback must still be driven
             // only by bits that caller actually cleared with `fetch_and`.
             let seen = Arc::new(AtomicUsize::new(0));
             let total = Arc::new(AtomicUsize::new(0));
@@ -1553,11 +1675,9 @@ mod loom_tests {
                 let seen = Arc::clone(&seen);
                 let total = Arc::clone(&total);
                 handles.push(thread::spawn(move || {
-                    let count = set.take_batch(2, |slot, buffer| {
+                    let count = set.take_batch(slots.len(), |slot, buffer| {
                         drop(buffer);
-                        let mask = 1 << slot;
-                        let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                        assert_eq!(previous & mask, 0);
+                        record_expected_slot(&seen, expected, slot);
                     });
                     total.fetch_add(count, Ordering::Relaxed);
                 }));
@@ -1567,8 +1687,8 @@ mod loom_tests {
                 handle.join().unwrap();
             }
 
-            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
-            assert_eq!(total.load(Ordering::Relaxed), 2);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
+            assert_eq!(total.load(Ordering::Relaxed), slots.len());
         });
     }
 
@@ -1614,32 +1734,34 @@ mod loom_tests {
 
     #[test]
     fn put_batch_publishes_to_take_batch() {
-        loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
+        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
             let seen = Arc::new(AtomicUsize::new(0));
+            let slots = geometry.slots();
+            let expected = geometry.slot_mask();
 
             // This exercises the batch-specific publish and claim path end to
-            // end: one Release `fetch_or` makes multiple parked cells visible,
-            // and one Acquire `fetch_and` may claim multiple bits.
+            // end across selected bitmap geometries: Release `fetch_or`
+            // publications make parked cells visible, and Acquire `fetch_and`
+            // claims may transfer one or more bits per word.
             //
             // The reader loops because loom may run it before the writer has
             // published anything. A zero-sized claim is just a retry, not an
             // observable failure.
             let writer = {
                 let set = Arc::clone(&set);
-                thread::spawn(move || set.put_batch([(0, buffer()), (1, buffer())]))
+                thread::spawn(move || {
+                    set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())))
+                })
             };
 
             let reader = {
                 let set = Arc::clone(&set);
                 let seen = Arc::clone(&seen);
                 thread::spawn(move || {
-                    while seen.load(Ordering::Relaxed) != 0b11 {
-                        let claimed = set.take_batch(2, |slot, buffer| {
+                    while seen.load(Ordering::Relaxed) != expected {
+                        let claimed = set.take_batch(slots.len(), |slot, buffer| {
                             drop(buffer);
-                            let mask = 1 << slot;
-                            let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                            assert_eq!(previous & mask, 0);
+                            record_expected_slot(&seen, expected, slot);
                         });
 
                         if claimed == 0 {
@@ -1652,15 +1774,15 @@ mod loom_tests {
             writer.join().unwrap();
             reader.join().unwrap();
 
-            assert_eq!(seen.load(Ordering::Relaxed), 0b11);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
         });
     }
 
     #[test]
     fn put_publishes_to_drain() {
-        loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
+        model_geometries(&ALL_GEOMETRIES, |geometry, set| {
             let drained = Arc::new(AtomicUsize::new(0));
+            let slot = geometry.slots()[0];
 
             // `drain` uses an Acquire whole-word swap. Run it concurrently with
             // publication so this model checks the put-side Release edge rather
@@ -1671,7 +1793,7 @@ mod loom_tests {
             // without seeing the writer's earlier cell initialization.
             let writer = {
                 let set = Arc::clone(&set);
-                thread::spawn(move || set.put(0, buffer()))
+                thread::spawn(move || set.put(slot, buffer()))
             };
 
             let drainer = {
@@ -1702,35 +1824,37 @@ mod loom_tests {
 
     #[test]
     fn put_batch_publishes_to_drain() {
-        loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
+        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
             let drained = Arc::new(AtomicUsize::new(0));
+            let slots = geometry.slots();
+            let expected = slots.len();
 
-            // A batch publish parks multiple cells before one Release RMW. The
-            // drainer loops until its Acquire swap observes that publication and
-            // then drops every parked buffer it claimed.
+            // A batch publish parks multiple cells before publishing the touched
+            // bitmap word masks. The drainer loops until its Acquire swaps have
+            // observed every publication and dropped every parked buffer.
             //
             // This is the drain analogue of `put_batch_publishes_to_take_batch`:
-            // the whole-word swap must make all cells represented by the returned
-            // word visible before they are dropped.
+            // each whole-word swap must make all cells represented by the
+            // returned word visible before they are dropped.
             let writer = {
                 let set = Arc::clone(&set);
-                thread::spawn(move || set.put_batch([(0, buffer()), (1, buffer())]))
+                thread::spawn(move || {
+                    set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())))
+                })
             };
 
             let drainer = {
                 let set = Arc::clone(&set);
                 let drained = Arc::clone(&drained);
                 thread::spawn(move || {
-                    while drained.load(Ordering::Relaxed) < 2 {
+                    while drained.load(Ordering::Relaxed) < expected {
                         let count = set.drain();
                         if count == 0 {
                             // The drainer may run before the batch is published.
                             thread::yield_now();
                         } else {
-                            assert_eq!(count, 2);
                             let previous = drained.fetch_add(count, Ordering::Relaxed);
-                            assert!(previous + count <= 2);
+                            assert!(previous + count <= expected);
                         }
                     }
                 })
@@ -1739,26 +1863,27 @@ mod loom_tests {
             writer.join().unwrap();
             drainer.join().unwrap();
 
-            assert_eq!(drained.load(Ordering::Relaxed), 2);
+            assert_eq!(drained.load(Ordering::Relaxed), expected);
             assert_eq!(set.drain(), 0);
         });
     }
 
     #[test]
     fn puts_and_take_scan_across_stripes() {
-        loom::model(|| {
-            let set = Arc::new(striped_freelist());
+        model_geometries(&STRIPED_GEOMETRIES, |geometry, set| {
             let seen = Arc::new(AtomicUsize::new(0));
+            let slots = geometry.slots();
+            let expected = geometry.slot_mask();
 
-            // Publish one slot per bitmap word using the single-entry `put`
-            // path. The reader uses repeated `take` calls, not `take_batch`, so
-            // this checks that the single-slot scan path reaches every stripe
-            // and that each independent Release publication synchronizes with
-            // the later Acquire claim for that slot.
+            // Publish slots across multiple bitmap words using the single-entry
+            // `put` path. The reader uses repeated `take` calls, not
+            // `take_batch`, so this checks that the single-slot scan path
+            // reaches every occupied stripe and that each independent Release
+            // publication synchronizes with the later Acquire claim.
             let writer = {
                 let set = Arc::clone(&set);
                 thread::spawn(move || {
-                    for slot in 0..4 {
+                    for &slot in slots {
                         set.put(slot, buffer());
                     }
                 })
@@ -1768,13 +1893,10 @@ mod loom_tests {
                 let set = Arc::clone(&set);
                 let seen = Arc::clone(&seen);
                 thread::spawn(move || {
-                    while seen.load(Ordering::Relaxed) != 0b1111 {
+                    while seen.load(Ordering::Relaxed) != expected {
                         if let Some((slot, buffer)) = set.take() {
-                            assert!(slot < 4);
                             drop(buffer);
-                            let mask = 1usize << slot;
-                            let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                            assert_eq!(previous & mask, 0);
+                            record_expected_slot(&seen, expected, slot);
                         } else {
                             thread::yield_now();
                         }
@@ -1785,108 +1907,18 @@ mod loom_tests {
             writer.join().unwrap();
             reader.join().unwrap();
 
-            assert_eq!(seen.load(Ordering::Relaxed), 0b1111);
-            assert_eq!(set.drain(), 0);
-        });
-    }
-
-    #[test]
-    fn put_batch_and_take_batch_across_stripes() {
-        loom::model(|| {
-            let set = Arc::new(striped_freelist());
-            let seen = Arc::new(AtomicUsize::new(0));
-
-            // Publish one slot per bitmap word. The reader may observe any
-            // subset of the per-word Release operations and must keep scanning
-            // other stripes until it has claimed each slot exactly once.
-            //
-            // This complements the two-slot same-word models above: same-word
-            // tests cover RMW contention on one atomic word, while this checks
-            // that the striped scan does not stop after the first word and that
-            // each per-word batch publication independently synchronizes with a
-            // later claim.
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || {
-                    set.put_batch([(0, buffer()), (1, buffer()), (2, buffer()), (3, buffer())])
-                })
-            };
-
-            let reader = {
-                let set = Arc::clone(&set);
-                let seen = Arc::clone(&seen);
-                thread::spawn(move || {
-                    while seen.load(Ordering::Relaxed) != 0b1111 {
-                        let claimed = set.take_batch(4, |slot, buffer| {
-                            drop(buffer);
-                            let mask = 1 << slot;
-                            let previous = seen.fetch_or(mask, Ordering::Relaxed);
-                            assert_eq!(previous & mask, 0);
-                        });
-
-                        if claimed == 0 {
-                            thread::yield_now();
-                        }
-                    }
-                })
-            };
-
-            writer.join().unwrap();
-            reader.join().unwrap();
-
-            assert_eq!(seen.load(Ordering::Relaxed), 0b1111);
-            assert_eq!(set.drain(), 0);
-        });
-    }
-
-    #[test]
-    fn put_batch_publishes_to_drain_across_stripes() {
-        loom::model(|| {
-            let set = Arc::new(striped_freelist());
-            let drained = Arc::new(AtomicUsize::new(0));
-
-            // A striped batch publishes one Release `fetch_or` per touched word.
-            // The drainer may observe any subset of those per-word publications
-            // in one pass, then must keep scanning future passes until every
-            // published cell has been acquired and dropped exactly once.
-            let writer = {
-                let set = Arc::clone(&set);
-                thread::spawn(move || {
-                    set.put_batch([(0, buffer()), (1, buffer()), (2, buffer()), (3, buffer())])
-                })
-            };
-
-            let drainer = {
-                let set = Arc::clone(&set);
-                let drained = Arc::clone(&drained);
-                thread::spawn(move || {
-                    while drained.load(Ordering::Relaxed) < 4 {
-                        let count = set.drain();
-                        if count == 0 {
-                            // The drainer may run before the writer has
-                            // published another stripe.
-                            thread::yield_now();
-                        } else {
-                            let previous = drained.fetch_add(count, Ordering::Relaxed);
-                            assert!(previous + count <= 4);
-                        }
-                    }
-                })
-            };
-
-            writer.join().unwrap();
-            drainer.join().unwrap();
-
-            assert_eq!(drained.load(Ordering::Relaxed), 4);
+            assert_eq!(seen.load(Ordering::Relaxed), expected);
             assert_eq!(set.drain(), 0);
         });
     }
 
     #[test]
     fn drain_and_take_do_not_duplicate_or_lose_slots() {
-        loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
-            set.put_batch([(0, buffer()), (1, buffer())]);
+        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+            let slots = geometry.slots();
+            let expected = slots.len();
+            let expected_mask = geometry.slot_mask();
+            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
             let drained = Arc::new(AtomicUsize::new(0));
             let taken = Arc::new(AtomicUsize::new(0));
@@ -1909,7 +1941,8 @@ mod loom_tests {
                 let set = Arc::clone(&set);
                 let taken = Arc::clone(&taken);
                 thread::spawn(move || {
-                    if let Some((_slot, buffer)) = set.take() {
+                    if let Some((slot, buffer)) = set.take() {
+                        assert_ne!(expected_mask & (1usize << slot), 0);
                         drop(buffer);
                         taken.store(1, Ordering::Relaxed);
                     }
@@ -1922,24 +1955,25 @@ mod loom_tests {
             assert_eq!(set.drain(), 0);
             assert_eq!(
                 drained.load(Ordering::Relaxed) + taken.load(Ordering::Relaxed),
-                2
+                expected
             );
         });
     }
 
     #[test]
     fn two_drains_do_not_duplicate_or_lose_slots() {
-        loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
-            set.put_batch([(0, buffer()), (1, buffer())]);
+        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+            let slots = geometry.slots();
+            let expected = slots.len();
+            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
             let total = Arc::new(AtomicUsize::new(0));
             let mut handles = Vec::new();
 
-            // `drain` is a public whole-word `swap(0)` operation. Two drainers
-            // racing on the same word must split ownership according to the
-            // values returned by their swaps: one may drain both slots and the
-            // other none, but the total must be exactly the original occupancy.
+            // `drain` is a public whole-word `swap(0)` operation over every
+            // bitmap word. Two drainers racing over the same free set must
+            // split ownership according to the values returned by their swaps,
+            // and the total must be exactly the original occupancy.
             for _ in 0..2 {
                 let set = Arc::clone(&set);
                 let total = Arc::clone(&total);
@@ -1952,16 +1986,18 @@ mod loom_tests {
                 handle.join().unwrap();
             }
 
-            assert_eq!(total.load(Ordering::Relaxed), 2);
+            assert_eq!(total.load(Ordering::Relaxed), expected);
             assert_eq!(set.drain(), 0);
         });
     }
 
     #[test]
     fn drain_and_take_batch_do_not_duplicate_or_lose_slots() {
-        loom::model(|| {
-            let set = Arc::new(single_word_freelist(2));
-            set.put_batch([(0, buffer()), (1, buffer())]);
+        model_geometries(&BATCH_GEOMETRIES, |geometry, set| {
+            let slots = geometry.slots();
+            let expected = slots.len();
+            let expected_mask = geometry.slot_mask();
+            set.put_batch(slots.iter().copied().map(|slot| (slot, buffer())));
 
             let drained = Arc::new(AtomicUsize::new(0));
             let taken = Arc::new(AtomicUsize::new(0));
@@ -1982,7 +2018,8 @@ mod loom_tests {
                 let set = Arc::clone(&set);
                 let taken = Arc::clone(&taken);
                 thread::spawn(move || {
-                    let count = set.take_batch(2, |_slot, buffer| {
+                    let count = set.take_batch(expected, |slot, buffer| {
+                        assert_ne!(expected_mask & (1usize << slot), 0);
                         drop(buffer);
                     });
                     taken.store(count, Ordering::Relaxed);
@@ -1995,7 +2032,7 @@ mod loom_tests {
             assert_eq!(set.drain(), 0);
             assert_eq!(
                 drained.load(Ordering::Relaxed) + taken.load(Ordering::Relaxed),
-                2
+                expected
             );
         });
     }

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1132,9 +1132,10 @@ mod loom_tests {
 
     // These tests run the production `Freelist` implementation with loom's
     // atomics, thread local storage, and `UnsafeCell` substituted under
-    // `cfg(feature = "loom")`. They use two small bitmap geometries: a
-    // single-word freelist for same-word RMW races, and a striped freelist for
-    // cross-word publication and scan races.
+    // `cfg(feature = "loom")`. Targeted tests use small same-word or striped
+    // layouts to force specific RMW races, while geometry-matrix tests cover
+    // single-word/single-bit, single-word/multi-bit, multi-word/single-bit, and
+    // multi-word/multi-bit layouts.
     fn single_word_freelist(capacity: u32) -> Freelist {
         // Use one stripe so every slot in the model shares one bitmap word.
         // This keeps the model small enough for exhaustive exploration while
@@ -1188,6 +1189,8 @@ mod loom_tests {
                 Self::SingleWordSingleBit => &[0],
                 Self::SingleWordMultiBit => &[0, 1],
                 Self::MultiWordSingleBit => &[0, 1, 2, 3],
+                // Keep same-word slots adjacent in the batch order. With two
+                // words, slots 0/2 map to word 0 and slots 1/3 map to word 1.
                 Self::MultiWordMultiBit => &[0, 2, 1, 3],
             }
         }


### PR DESCRIPTION
This PR adds loom coverage for the runtime buffer freelist, which relies on lock-free bitmap updates to transfer ownership of parked buffers between producers and consumers. The tests model the production freelist with loom atomics, thread-local probe state, and tracked `UnsafeCell` access so that missing synchronization around parking cells can be caught.

The models cover the main ownership-transfer paths: `put` publishing to `take`, `put_batch` publishing to `take_batch`, and both publish paths racing with `drain`. They also exercise same-word RMW races, stale relaxed candidate loads, concurrent producers merging disjoint bits, overlapping single and batch consumers, two batch consumers claiming from the same word, and concurrent drains.

The goal is to make the freelist's concurrency contract explicit: every free slot must be handed out at most once, no published slot may be lost, batch callbacks must only receive bits actually claimed by that caller, and buffer cell reads must be synchronized with the write that parked the buffer.