### PR TITLE
[storage/qmdb/current] support split (pyramid) bagging in qmdb-current

### DIFF
--- a/.github/benchmark-tracking.toml
+++ b/.github/benchmark-tracking.toml
@@ -52,4 +52,5 @@ name = "qmdb"
 criterion_args = ["--sample-size", "100", "--significance-level", "0.01"]
 variants = [
   "qmdb::merkleize/variant=any::unordered::fixed::mmr keys=10000 ch=false sync=false",
+  "qmdb::merkleize/variant=current::ordered::fixed::mmb keys=10000 ch=true sync=false",
 ]

--- a/.github/benchmark-tracking.toml
+++ b/.github/benchmark-tracking.toml
@@ -49,6 +49,7 @@ cargo_flags = ["--features", "test-traits"]
 
 [[packages.benchmarks]]
 name = "qmdb"
+criterion_args = ["--sample-size", "100", "--significance-level", "0.01"]
 variants = [
   "qmdb::merkleize/variant=any::unordered::fixed::mmr keys=10000 ch=false sync=false",
 ]

--- a/.github/benchmark-tracking.toml
+++ b/.github/benchmark-tracking.toml
@@ -52,5 +52,5 @@ name = "qmdb"
 criterion_args = ["--sample-size", "100", "--significance-level", "0.01"]
 variants = [
   "qmdb::merkleize/variant=any::unordered::fixed::mmr keys=10000 ch=false sync=false",
-  "qmdb::merkleize/variant=current::ordered::fixed::mmb keys=10000 ch=true sync=false",
+  "qmdb::merkleize/variant=current::ordered::fixed::mmb chunk=256 keys=10000 ch=true sync=false",
 ]

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -7,9 +7,9 @@
 //! documentation for more details.
 //!
 //! For sync, the engine targets the **ops root** (not the canonical root). The operations and proof
-//! format are identical to `any` -- the bitmap is reconstructed deterministically from the
-//! operations after sync completes. See the [Root structure](commonware_storage::qmdb::current)
-//! module documentation for details.
+//! format are identical to `any`; direct proof verifiers should use `qmdb::hasher`. The bitmap is
+//! reconstructed deterministically from the operations after sync completes. See the
+//! [Root structure](commonware_storage::qmdb::current) module documentation for details.
 //!
 //! This module re-uses the same [`Operation`] type as [`super::any`] since the underlying
 //! operations log is the same.

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -184,19 +184,19 @@ hash = "c46b60791c970b54e936d47a8e2eaae45e9e34c9fb0e1278e678f378392a02f1"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrOrderedFixedConf"]
 n_cases = 200
-hash = "c343e3779b03cb33bba2b8e8fc3e7f4e333bd6dda919bc52bdc6c8385e0fa6dc"
+hash = "0e5264ac6a0c0d56ace9ebc986635b128f9d7a118471875ad874b08e80f66ebb"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrOrderedVariableConf"]
 n_cases = 200
-hash = "6cb0dd9ab52acd83bab9d20f69aa0ef18c6e61020ce8ea118601f608f751f6cd"
+hash = "66cd3cc0299ef062e23d4f9812d5d45896cd808ee0bc65d9745a4265895ae8b5"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrUnorderedFixedConf"]
 n_cases = 200
-hash = "dfebe6590b0c02f3441ae6f76d5ee11d148839a847884df2f18032c46f1b9fc9"
+hash = "8ce052fef8ce8e4d817a2961144cf3a28aec4bd6eb75d32b013499116a6981da"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrUnorderedVariableConf"]
 n_cases = 200
-hash = "092416c17d1a0bb69234756ff8cf83e2b4ca8fec2a97c5ca2ecdf20b53b913ef"
+hash = "0d0591823b7d5ed8dcb940d086ec214062eb3cfffd018e9fbadf9e16ce8da0f7"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmbCompactFixedConf"]
 n_cases = 200

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -168,35 +168,35 @@ hash = "22374a7cbdfa0bdac17e2e285422a54375fec27017942ef7abea2cf8da298c70"
 
 ["commonware_storage::qmdb::conformance::CurrentMmbOrderedFixedConf"]
 n_cases = 200
-hash = "f265ca1f2f7f571230ef4e576b949d3699b619f108cb0a4e2e28c352f7b32aee"
+hash = "c13c9100d657cd01fdf4cff19985bba9e65b7c057391785c5d401a13c976b0af"
 
 ["commonware_storage::qmdb::conformance::CurrentMmbOrderedVariableConf"]
 n_cases = 200
-hash = "74d3a4b1721216ed1bdfc564f5ae07759476b0ceae7dbd1e953c35538a1b0755"
+hash = "8fed62bd40fa5ef36f6aebff5152e37d1089e4a66f8dfb9eec8cb00132487efb"
 
 ["commonware_storage::qmdb::conformance::CurrentMmbUnorderedFixedConf"]
 n_cases = 200
-hash = "92b2d71ff19a0f24f337a934d43ee06e3f81a155cd4adc97c58b27cef5cde435"
+hash = "81fb100d508803580ae22a96b76955b6480f3526254703c9d75ebb56f0f053f1"
 
 ["commonware_storage::qmdb::conformance::CurrentMmbUnorderedVariableConf"]
 n_cases = 200
-hash = "bad7ded44c7cedc95d202dc3334e3de88877d3aeb63b5808b18bd12c2f59c0d9"
+hash = "c46b60791c970b54e936d47a8e2eaae45e9e34c9fb0e1278e678f378392a02f1"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrOrderedFixedConf"]
 n_cases = 200
-hash = "95dc738adeb88d6546c62828e448213fe723d600f57bb4660ecf982ee76e29ef"
+hash = "c343e3779b03cb33bba2b8e8fc3e7f4e333bd6dda919bc52bdc6c8385e0fa6dc"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrOrderedVariableConf"]
 n_cases = 200
-hash = "a52a284b8aec813f99234a0545d7c8e651b6f6c93d1912394be3e46075a2681d"
+hash = "6cb0dd9ab52acd83bab9d20f69aa0ef18c6e61020ce8ea118601f608f751f6cd"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrUnorderedFixedConf"]
 n_cases = 200
-hash = "537f4c63d903b112fc045ed47f0127da3e2ca70e38c8406e6535a94b2dddc693"
+hash = "dfebe6590b0c02f3441ae6f76d5ee11d148839a847884df2f18032c46f1b9fc9"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrUnorderedVariableConf"]
 n_cases = 200
-hash = "93926373351527268aead35fc1884ff27ae2a154df38309dbed50c2c388d4870"
+hash = "092416c17d1a0bb69234756ff8cf83e2b4ca8fec2a97c5ca2ecdf20b53b913ef"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmbCompactFixedConf"]
 n_cases = 200

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -51,6 +51,8 @@ enum CurrentOperation {
         bad_digests: Vec<[u8; 32]>,
         max_ops: NonZeroU64,
         bad_chunks: Vec<[u8; 32]>,
+        bad_prefix_peaks: Vec<[u8; 32]>,
+        bad_suffix_peaks: Vec<[u8; 32]>,
     },
     GetSpan {
         key: RawKey,
@@ -267,7 +269,14 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     }
                 }
 
-                CurrentOperation::ArbitraryProof {start_loc, bad_digests, max_ops, bad_chunks} => {
+                CurrentOperation::ArbitraryProof {
+                    start_loc,
+                    bad_digests,
+                    max_ops,
+                    bad_chunks,
+                    bad_prefix_peaks,
+                    bad_suffix_peaks,
+                } => {
                     let current_op_count = db.bounds().await.end;
                     if current_op_count == 0 {
                         continue;
@@ -310,6 +319,36 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                                 bad_chunks,
                                 &root
                             ), "proof with bad chunks should not verify");
+                        }
+
+                        let bad_prefix_peaks =
+                            bad_prefix_peaks.iter().map(|d| Digest::from(*d)).collect();
+                        if range_proof.unfolded_prefix_peaks != bad_prefix_peaks {
+                            let mut bad_proof = range_proof.clone();
+                            bad_proof.unfolded_prefix_peaks = bad_prefix_peaks;
+                            assert!(!Db::<F>::verify_range_proof(
+                                &mut hasher,
+                                &bad_proof,
+                                start_loc,
+                                &ops,
+                                &chunks,
+                                &root
+                            ), "proof with bad prefix peaks should not verify");
+                        }
+
+                        let bad_suffix_peaks =
+                            bad_suffix_peaks.iter().map(|d| Digest::from(*d)).collect();
+                        if range_proof.unfolded_suffix_peaks != bad_suffix_peaks {
+                            let mut bad_proof = range_proof.clone();
+                            bad_proof.unfolded_suffix_peaks = bad_suffix_peaks;
+                            assert!(!Db::<F>::verify_range_proof(
+                                &mut hasher,
+                                &bad_proof,
+                                start_loc,
+                                &ops,
+                                &chunks,
+                                &root
+                            ), "proof with bad suffix peaks should not verify");
                         }
                     }
                 }

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -51,6 +51,8 @@ enum CurrentOperation {
         bad_digests: Vec<[u8; 32]>,
         max_ops: NonZeroU64,
         bad_chunks: Vec<[u8; 32]>,
+        bad_prefix_peaks: Vec<[u8; 32]>,
+        bad_suffix_peaks: Vec<[u8; 32]>,
     },
 }
 
@@ -242,7 +244,14 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     }
                 }
 
-                CurrentOperation::ArbitraryProof {start_loc, bad_digests, max_ops, bad_chunks} => {
+                CurrentOperation::ArbitraryProof {
+                    start_loc,
+                    bad_digests,
+                    max_ops,
+                    bad_chunks,
+                    bad_prefix_peaks,
+                    bad_suffix_peaks,
+                } => {
                     let current_op_count = db.bounds().await.end;
                     if current_op_count == 0 {
                         continue;
@@ -282,6 +291,36 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                                 bad_chunks,
                                 &root
                             ), "proof with bad chunks should not verify");
+                        }
+
+                        let bad_prefix_peaks =
+                            bad_prefix_peaks.iter().map(|d| Digest::from(*d)).collect();
+                        if range_proof.unfolded_prefix_peaks != bad_prefix_peaks {
+                            let mut bad_proof = range_proof.clone();
+                            bad_proof.unfolded_prefix_peaks = bad_prefix_peaks;
+                            assert!(!Db::<F>::verify_range_proof(
+                                &mut hasher,
+                                &bad_proof,
+                                start_loc,
+                                &ops,
+                                &chunks,
+                                &root
+                            ), "proof with bad prefix peaks should not verify");
+                        }
+
+                        let bad_suffix_peaks =
+                            bad_suffix_peaks.iter().map(|d| Digest::from(*d)).collect();
+                        if range_proof.unfolded_suffix_peaks != bad_suffix_peaks {
+                            let mut bad_proof = range_proof.clone();
+                            bad_proof.unfolded_suffix_peaks = bad_suffix_peaks;
+                            assert!(!Db::<F>::verify_range_proof(
+                                &mut hasher,
+                                &bad_proof,
+                                start_loc,
+                                &ops,
+                                &chunks,
+                                &root
+                            ), "proof with bad suffix peaks should not verify");
                         }
                     }
                 }

--- a/storage/fuzz/fuzz_targets/merkle_family_operations.rs
+++ b/storage/fuzz/fuzz_targets/merkle_family_operations.rs
@@ -4,7 +4,8 @@ use arbitrary::Arbitrary;
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_runtime::{deterministic, Runner};
 use commonware_storage::merkle::{
-    hasher::Standard, mem::Mem, mmb, mmr, Error, Family as MerkleFamily, Location, Position,
+    hasher::Standard, mem::Mem, mmb, mmr, Bagging::ForwardFold, Error, Family as MerkleFamily,
+    Location, Position,
 };
 use core::any::type_name;
 use libfuzzer_sys::fuzz_target;
@@ -128,7 +129,7 @@ fn fuzz_family<F: MerkleFamily>(operations: &[MerkleOperation]) {
     let runner = deterministic::Runner::default();
 
     runner.start(|_context| async move {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut merkle = Mem::<F, Digest>::new();
         let mut reference = ReferenceMerkle::<F>::new();
 

--- a/storage/fuzz/fuzz_targets/merkle_full.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full.rs
@@ -5,8 +5,8 @@ use commonware_cryptography::Sha256;
 use commonware_parallel::Sequential;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner};
 use commonware_storage::merkle::{
-    full::Config, hasher::Standard, mem::Mem, mmb, mmr, Error, Family as MerkleFamily, Location,
-    LocationRangeExt as _, Position,
+    full::Config, hasher::Standard, mem::Mem, mmb, mmr, Bagging::ForwardFold, Error,
+    Family as MerkleFamily, Location, LocationRangeExt as _, Position,
 };
 use commonware_utils::{non_empty_range, NZUsize, NZU16, NZU64};
 use libfuzzer_sys::fuzz_target;
@@ -92,7 +92,7 @@ fn historical_root<F: MerkleFamily>(
     leaves: &[Vec<u8>],
     requested_leaves: Location<F>,
 ) -> <Sha256 as commonware_cryptography::Hasher>::Digest {
-    let hasher = Standard::<Sha256>::new();
+    let hasher = Standard::<Sha256>::new(ForwardFold);
     let mut mem = Mem::<F, _>::new();
     let batch = {
         let mut batch = mem.new_batch();
@@ -115,7 +115,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
         let operations = input.operations.clone();
         async move {
             let mut leaves = Vec::new();
-            let hasher = Standard::<Sha256>::new();
+            let hasher = Standard::<Sha256>::new(ForwardFold);
             let mut merkle =
                 Merkle::<F, _, _>::init(context.clone(), &hasher, test_config(suffix, &context))
                     .await
@@ -258,7 +258,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             .await;
                         match result {
                             Ok(historical_proof) => {
-                                let verify_hasher = Standard::<Sha256>::new();
+                                let verify_hasher = Standard::<Sha256>::new(ForwardFold);
                                 assert!(historical_proof.verify_range_inclusion(
                                     &verify_hasher,
                                     &leaves[range.to_usize_range()],

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -10,7 +10,8 @@ use commonware_runtime::{
     buffer::paged::CacheRef, deterministic, BufferPooler, Metrics as _, Runner,
 };
 use commonware_storage::merkle::{
-    full::Config, hasher::Standard as StandardHasher, mmb, mmr, Family as MerkleFamily, Location,
+    full::Config, hasher::Standard as StandardHasher, mmb, mmr, Bagging::ForwardFold,
+    Family as MerkleFamily, Location,
 };
 use commonware_utils::NZU64;
 use libfuzzer_sys::fuzz_target;
@@ -235,7 +236,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
         let partition_suffix = partition_suffix.clone();
         let operations = operations.clone();
         async move {
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let mut merkle = Merkle::<F>::init(
                 ctx.with_label("merkle"),
                 &hasher,
@@ -267,7 +268,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
     runner.start(|ctx| async move {
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
 
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut merkle = Merkle::<F>::init(
             ctx.with_label("recovered"),
             &hasher,

--- a/storage/fuzz/fuzz_targets/mmr_bitmap.rs
+++ b/storage/fuzz/fuzz_targets/mmr_bitmap.rs
@@ -4,7 +4,7 @@ use arbitrary::Arbitrary;
 use commonware_cryptography::{sha256, Digest, Sha256};
 use commonware_parallel::Sequential;
 use commonware_runtime::{deterministic, Clock, Metrics, Runner, Storage};
-use commonware_storage::{MerkleizedBitMap, UnmerkleizedBitMap};
+use commonware_storage::{merkle::Bagging::ForwardFold, MerkleizedBitMap, UnmerkleizedBitMap};
 use commonware_utils::bitmap::BitMap;
 use libfuzzer_sys::fuzz_target;
 
@@ -59,7 +59,7 @@ fn fuzz(input: FuzzInput) {
     const PARTITION: &str = "fuzz-mmr-bitmap-test-partition";
 
     runner.start(|context| async move {
-        let hasher = commonware_storage::mmr::StandardHasher::<Sha256>::new();
+        let hasher = commonware_storage::mmr::StandardHasher::<Sha256>::new(ForwardFold);
         let init_bitmap = MerkleizedBitMap::<_, _, CHUNK_SIZE>::init(
             context.with_label("bitmap"),
             PARTITION,

--- a/storage/fuzz/fuzz_targets/proof_store.rs
+++ b/storage/fuzz/fuzz_targets/proof_store.rs
@@ -4,7 +4,8 @@ use arbitrary::{Arbitrary, Unstructured};
 use commonware_codec::Encode as _;
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_storage::merkle::{
-    self, mmb, mmr, verification::ProofStore, Family as MerkleFamily, Location, Position, Proof,
+    self, mmb, mmr, verification::ProofStore, Bagging::BackwardFold, Family as MerkleFamily,
+    Location, Position, Proof,
 };
 use libfuzzer_sys::fuzz_target;
 use std::ops::Range;
@@ -57,7 +58,7 @@ impl<'a, F: MerkleFamily> Arbitrary<'a> for FuzzInput<F> {
 }
 
 fn fuzz_family<F: MerkleFamily>(input: &FuzzInput<F>) {
-    let hasher = merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+    let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
     let proof = Proof::<F, Digest> {
         leaves: input.proof_leaves,
         inactive_peaks: input.inactive_peaks,

--- a/storage/fuzz/fuzz_targets/proofs_malleability.rs
+++ b/storage/fuzz/fuzz_targets/proofs_malleability.rs
@@ -6,8 +6,8 @@ use commonware_cryptography::{sha256::Digest, Hasher as _, Sha256};
 use commonware_storage::{
     bmt::Builder as BmtBuilder,
     merkle::{
-        hasher::Standard, mem::Mem, mmb, mmr, verification, Bagging, Family as MerkleFamily,
-        Location,
+        hasher::Standard, mem::Mem, mmb, mmr, verification, Bagging, Bagging::ForwardFold,
+        Family as MerkleFamily, Location,
     },
 };
 use futures::executor::block_on;
@@ -143,7 +143,7 @@ fn supported_root_specs<F: MerkleFamily>(merkle: &Mem<F, Digest>) -> Vec<(Baggin
 }
 
 fn fuzz_element_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
-    let build_hasher = Standard::<Sha256>::new();
+    let build_hasher = Standard::<Sha256>::new(ForwardFold);
     let mut merkle = Mem::<F, Digest>::new();
     let batch = {
         let mut batch = merkle.new_batch();
@@ -155,7 +155,7 @@ fn fuzz_element_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
     merkle.apply_batch(&batch).unwrap();
 
     for (bagging, inactive_peaks) in supported_root_specs(&merkle) {
-        let hasher = Standard::<Sha256>::with_bagging(bagging);
+        let hasher = Standard::<Sha256>::new(bagging);
         let root = merkle.root(&hasher, inactive_peaks).unwrap();
         for (leaf, element) in digests.iter().enumerate() {
             let loc = Location::<F>::new(leaf as u64);
@@ -179,7 +179,7 @@ fn fuzz_element_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
 }
 
 fn fuzz_range_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
-    let hasher = Standard::<Sha256>::new();
+    let hasher = Standard::<Sha256>::new(ForwardFold);
     let mut merkle = Mem::<F, Digest>::new();
     let batch = {
         let mut batch = merkle.new_batch();
@@ -229,7 +229,7 @@ fn fuzz_range_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
     }
 
     for (bagging, inactive_peaks) in supported_root_specs(&merkle) {
-        let hasher = Standard::<Sha256>::with_bagging(bagging);
+        let hasher = Standard::<Sha256>::new(bagging);
         let root = merkle.root(&hasher, inactive_peaks).unwrap();
         let Ok(original_proof) = block_on(verification::historical_range_proof(
             &hasher,

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -6,7 +6,10 @@ use commonware_parallel::Sequential;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner};
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::{self, full::Config as MerkleConfig, mmb, mmr, Family as MerkleFamily, Location},
+    merkle::{
+        self, full::Config as MerkleConfig, mmb, mmr, Bagging::BackwardFold,
+        Family as MerkleFamily, Location,
+    },
     qmdb::{
         any::{unordered::variable::Db, VariableConfig as Config},
         verify_proof,
@@ -164,8 +167,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
 
     let test_name = test_name.to_string();
     runner.start(|context| async move {
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
         let cfg = test_config(&test_name, &context);
         let mut db = Db::<F, _, Key, Vec<u8>, Sha256, TwoCap>::init(context.clone(), cfg)
             .await

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -7,7 +7,7 @@ use commonware_parallel::Sequential;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Runner};
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::{self, mmb, mmr, Family as MerkleFamily, Location},
+    merkle::{self, mmb, mmr, Bagging::BackwardFold, Family as MerkleFamily, Location},
     mmr::full::Config as MerkleConfig,
     qmdb::{
         immutable::{variable::Db as Immutable, Config},
@@ -151,8 +151,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 .await
                 .unwrap();
 
-            let hasher =
-                merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
             let mut keys_set: Vec<(Digest, Location<F>)> = Vec::new();
             let mut set_locations: Vec<(Digest, Location<F>)> = Vec::new();
             let mut last_commit_loc: Option<Location<F>> = None;

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -6,7 +6,9 @@ use commonware_parallel::Sequential;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner};
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::{self, full::Config as MerkleConfig, mmb, mmr, Family, Location},
+    merkle::{
+        self, full::Config as MerkleConfig, mmb, mmr, Bagging::BackwardFold, Family, Location,
+    },
     qmdb::{
         keyless::variable::{Config, Db as Keyless},
         verify_proof, Error,
@@ -216,7 +218,7 @@ fn fuzz_family<F: Family>(input: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     runner.start(|context| async move {
-        let hasher = merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
         let cfg = test_config(suffix, &context);
         let mut db: Db<F> = Db::init(context.clone(), cfg)
             .await

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -7,7 +7,7 @@ use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner};
 use commonware_storage::{
     index::ordered::Index,
     journal::contiguous::fixed::{Config as FConfig, Journal},
-    merkle::{self, mmb, mmr, Family as MerkleFamily, Location, Proof},
+    merkle::{self, mmb, mmr, Bagging::BackwardFold, Family as MerkleFamily, Location, Proof},
     mmr::full::Config as MerkleConfig,
     qmdb::{
         any::{
@@ -103,7 +103,7 @@ async fn commit_pending<F: MerkleFamily>(
 }
 
 fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
-    let hasher = merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+    let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
     let runner = deterministic::Runner::default();
 
     runner.start(|context| {

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -7,7 +7,7 @@ use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner};
 use commonware_storage::{
     index::unordered::Index,
     journal::contiguous::fixed::{Config as FConfig, Journal},
-    merkle::{self, mmb, mmr, Family as MerkleFamily, Location},
+    merkle::{self, mmb, mmr, Bagging::BackwardFold, Family as MerkleFamily, Location},
     mmr::full::Config as MerkleConfig,
     qmdb::{
         any::{
@@ -78,7 +78,7 @@ async fn commit_pending<F: MerkleFamily>(
 }
 
 fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
-    let hasher = merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+    let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
     let runner = deterministic::Runner::default();
 
     runner.start(|context| {

--- a/storage/fuzz/fuzz_targets/range_proof.rs
+++ b/storage/fuzz/fuzz_targets/range_proof.rs
@@ -65,7 +65,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput) {
     }
     let start = Location::<F>::new(input.range_start % *leaves);
     for (bagging, inactive_peaks) in supported_root_specs::<F>(&merkle) {
-        let hasher = Standard::<Sha256>::with_bagging(bagging);
+        let hasher = Standard::<Sha256>::new(bagging);
         let _ = merkle.range_proof(&hasher, start..leaves, inactive_peaks);
     }
 }

--- a/storage/fuzz/fuzz_targets/verify_proof.rs
+++ b/storage/fuzz/fuzz_targets/verify_proof.rs
@@ -3,7 +3,7 @@
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_storage::{
-    merkle::{self, mmb, mmr, Family as MerkleFamily, Location, Proof},
+    merkle::{self, mmb, mmr, Bagging::BackwardFold, Family as MerkleFamily, Location, Proof},
     qmdb::verify::verify_multi_proof,
 };
 use libfuzzer_sys::fuzz_target;
@@ -43,7 +43,7 @@ impl<'a, F: MerkleFamily> Arbitrary<'a> for FuzzInput<F> {
 }
 
 fn fuzz_family<F: MerkleFamily>(input: &FuzzInput<F>) {
-    let hasher = merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+    let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
 
     let digests: Vec<Digest> = input
         .digests

--- a/storage/src/bitmap/authenticated.rs
+++ b/storage/src/bitmap/authenticated.rs
@@ -644,6 +644,7 @@ impl<E: Context, D: Digest, const N: usize, S: Strategy> Storage<mmr::Family>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::merkle::Bagging::ForwardFold;
     use commonware_codec::FixedSize;
     use commonware_cryptography::{sha256, Hasher, Sha256};
     use commonware_macros::test_traced;
@@ -693,7 +694,7 @@ mod tests {
     fn test_bitmap_verify_empty_proof() {
         let executor = deterministic::Runner::default();
         executor.start(|_context| async move {
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let proof = Proof {
                 leaves: Location::new(100),
                 inactive_peaks: 0,
@@ -718,7 +719,7 @@ mod tests {
     fn test_bitmap_verify_rejects_nonzero_inactive_peaks() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let mut bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("bitmap"),
                 "inactive_peaks_canonical",
@@ -764,7 +765,7 @@ mod tests {
     fn test_bitmap_empty_then_one() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let mut bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("bitmap"),
                 "test",
@@ -841,7 +842,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let test_chunk = test_chunk(b"test");
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
 
             // Add each bit one at a time after the first chunk.
             let bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
@@ -913,7 +914,7 @@ mod tests {
     fn test_bitmap_build_chunked_panic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
             let bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("bitmap"),
                 "test",
@@ -934,7 +935,7 @@ mod tests {
     fn test_bitmap_build_byte_panic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
             let bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("bitmap"),
                 "test",
@@ -955,7 +956,7 @@ mod tests {
     fn test_bitmap_get_out_of_bounds_bit_panic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
             let bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("bitmap"),
                 "test",
@@ -975,7 +976,7 @@ mod tests {
     fn test_bitmap_get_pruned_bit_panic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
             let bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("bitmap"),
                 "test",
@@ -999,7 +1000,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Build a starting test MMR with two chunks worth of bits.
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("bitmap"),
                 "test",
@@ -1055,7 +1056,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Build a test MMR with a few chunks worth of bits.
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("bitmap"),
                 "test",
@@ -1133,7 +1134,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Build a bitmap with 10 chunks worth of bits.
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let bitmap: MerkleizedBitMap<TestContext, sha256::Digest, N> =
                 MerkleizedBitMap::init(context.with_label("bitmap"), "test", Sequential, &hasher)
                     .await
@@ -1189,7 +1190,7 @@ mod tests {
 
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             // Initializing from an empty partition should result in an empty bitmap.
             let bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("initial"),
@@ -1262,7 +1263,7 @@ mod tests {
     fn test_bitmap_proof_out_of_bounds() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let bitmap: TestMerkleizedBitMap<SHA256_SIZE> = TestMerkleizedBitMap::init(
                 context.with_label("bitmap"),
                 "test",

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -15,8 +15,7 @@ use crate::{
         full::Merkle,
         hasher::{Hasher as _, Standard as StandardHasher},
         mem::Mem,
-        Bagging::ForwardFold,
-        Family, Location, Position, Proof, Readable,
+        Bagging, Family, Location, Position, Proof, Readable,
     },
     Context, Persistable,
 };
@@ -109,6 +108,7 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         let ancestor_items = Self::collect_ancestor_items(&parent);
         Arc::new(MerkleizedBatch {
             inner: merkle,
+            bagging: hasher.root_bagging(),
             items,
             parent: parent.as_ref().map(Arc::downgrade),
             ancestor_items,
@@ -153,6 +153,7 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         let ancestor_items = Self::collect_ancestor_items(&self.parent);
         Arc::new(MerkleizedBatch {
             inner: merkle,
+            bagging: self.hasher.root_bagging(),
             items,
             parent: self.parent.as_ref().map(Arc::downgrade),
             ancestor_items,
@@ -165,6 +166,8 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
 pub struct MerkleizedBatch<F: Family, D: Digest, Item: Send + Sync, S: Strategy = Sequential> {
     /// The inner batch of Merkle leaf digests.
     pub(crate) inner: Arc<batch::MerkleizedBatch<F, D, S>>,
+    /// The peak bagging policy inherited from the parent journal or batch.
+    bagging: Bagging,
     /// The items to append from this batch.
     items: Arc<Vec<Item>>,
     /// This batch's parent, or None if the parent is the journal itself.
@@ -227,7 +230,7 @@ impl<F: Family, D: Digest, Item: Send + Sync, S: Strategy> MerkleizedBatch<F, D,
     {
         UnmerkleizedBatch {
             inner: self.inner.new_batch(),
-            hasher: StandardHasher::new(ForwardFold),
+            hasher: StandardHasher::new(self.bagging),
             items: Vec::new(),
             parent: Some(Arc::clone(self)),
         }
@@ -319,7 +322,7 @@ where
         let root = self.merkle.to_batch();
         UnmerkleizedBatch {
             inner: root.new_batch(),
-            hasher: StandardHasher::new(ForwardFold),
+            hasher: StandardHasher::new(self.hasher.root_bagging()),
             items: Vec::new(),
             parent: None,
         }
@@ -337,6 +340,7 @@ where
     pub(crate) fn to_merkleized_batch(&self) -> Arc<MerkleizedBatch<F, H::Digest, C::Item, S>> {
         Arc::new(MerkleizedBatch {
             inner: self.merkle.to_batch(),
+            bagging: self.hasher.root_bagging(),
             items: Arc::new(Vec::new()),
             parent: None,
             ancestor_items: Vec::new(),
@@ -852,6 +856,7 @@ mod tests {
         merkle::{
             full::{Config as MerkleConfig, Merkle},
             mmb, mmr,
+            Bagging::{BackwardFold, ForwardFold},
         },
         qmdb::{
             any::{
@@ -939,6 +944,31 @@ mod tests {
         )
         .await
         .unwrap()
+    }
+
+    #[test]
+    fn test_batches_inherit_journal_bagging() {
+        deterministic::Runner::default().start(|context| async move {
+            let merkle_cfg = merkle_config("batch-bagging", &context);
+            let journal_cfg = journal_config("batch-bagging", &context);
+            let journal = TestJournal::<mmr::Family>::new(
+                context,
+                merkle_cfg,
+                journal_cfg,
+                |op: &TestOp<mmr::Family>| op.is_commit(),
+                BackwardFold,
+            )
+            .await
+            .unwrap();
+
+            let batch = journal.new_batch();
+            assert_eq!(batch.hasher.root_bagging(), BackwardFold);
+
+            let merkleized = journal.merkle.with_mem(|mem| batch.merkleize(mem));
+            let child: UnmerkleizedBatch<mmr::Family, Sha256, TestOp<mmr::Family>> =
+                merkleized.new_batch();
+            assert_eq!(child.hasher.root_bagging(), BackwardFold);
+        });
     }
 
     /// Create a test operation with predictable values based on index.

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -15,6 +15,7 @@ use crate::{
         full::Merkle,
         hasher::{Hasher as _, Standard as StandardHasher},
         mem::Mem,
+        Bagging::ForwardFold,
         Family, Location, Position, Proof, Readable,
     },
     Context, Persistable,
@@ -226,7 +227,7 @@ impl<F: Family, D: Digest, Item: Send + Sync, S: Strategy> MerkleizedBatch<F, D,
     {
         UnmerkleizedBatch {
             inner: self.inner.new_batch(),
-            hasher: StandardHasher::new(),
+            hasher: StandardHasher::new(ForwardFold),
             items: Vec::new(),
             parent: Some(Arc::clone(self)),
         }
@@ -318,7 +319,7 @@ where
         let root = self.merkle.to_batch();
         UnmerkleizedBatch {
             inner: root.new_batch(),
-            hasher: StandardHasher::new(),
+            hasher: StandardHasher::new(ForwardFold),
             items: Vec::new(),
             parent: None,
         }
@@ -709,7 +710,7 @@ macro_rules! impl_journal_new {
                     $journal_mod::Journal::init(context.with_label("journal"), journal_cfg).await?;
                 journal.rewind_to(rewind_predicate).await?;
 
-                let hasher = StandardHasher::<H>::with_bagging(bagging);
+                let hasher = StandardHasher::<H>::new(bagging);
                 let mut merkle =
                     Merkle::init(context.with_label("merkle"), &hasher, merkle_cfg).await?;
                 Self::align(&mut merkle, &journal, &hasher, APPLY_BATCH_SIZE).await?;
@@ -934,7 +935,7 @@ mod tests {
             merkle_cfg,
             journal_cfg,
             |op: &TestOp<F>| op.is_commit(),
-            crate::merkle::Bagging::ForwardFold,
+            ForwardFold,
         )
         .await
         .unwrap()
@@ -981,7 +982,7 @@ mod tests {
         ContiguousJournal<deterministic::Context, TestOp<F>>,
         StandardHasher<Sha256>,
     ) {
-        let hasher = StandardHasher::new();
+        let hasher = StandardHasher::new(ForwardFold);
         let merkle = Merkle::<F, _, Digest>::init(
             context.with_label("mmr"),
             &hasher,
@@ -1378,7 +1379,7 @@ mod tests {
                 merkle_cfg,
                 journal_cfg,
                 |op| op.is_commit(),
-                crate::merkle::Bagging::ForwardFold,
+                ForwardFold,
             )
             .await
             .unwrap();
@@ -1958,7 +1959,7 @@ mod tests {
         }
 
         // Verify the proof is valid
-        let hasher = StandardHasher::new();
+        let hasher = StandardHasher::new(ForwardFold);
         let root = journal_root(&journal);
         assert!(verify_proof(
             &proof,
@@ -2000,7 +2001,7 @@ mod tests {
         }
 
         // Verify the proof is valid
-        let hasher = StandardHasher::new();
+        let hasher = StandardHasher::new(ForwardFold);
         let root = journal_root(&journal);
         assert!(verify_proof(
             &proof,
@@ -2047,7 +2048,7 @@ mod tests {
         }
 
         // Verify the proof is valid
-        let hasher = StandardHasher::new();
+        let hasher = StandardHasher::new(ForwardFold);
         let root = journal_root(&journal);
         assert!(verify_proof(
             &proof,
@@ -2141,7 +2142,7 @@ mod tests {
         let mut journal = create_journal_with_ops::<F>(context, "proof_historical", 50).await;
 
         // Capture root at historical state
-        let hasher = StandardHasher::new();
+        let hasher = StandardHasher::new(ForwardFold);
         let historical_root = journal_root(&journal);
         let historical_size = journal.size().await;
 

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -65,7 +65,7 @@
 //! # Example (MMR)
 //!
 //! ```ignore
-//! let hasher = StandardHasher::<Sha256>::new();
+//! let hasher = StandardHasher::<Sha256>::new(ForwardFold);
 //! let mut mmr = Mmr::new();
 //!
 //! // Fork two independent speculative chains from the same base.
@@ -594,7 +594,7 @@ impl<F: Family, D: Digest, S: Strategy> Readable for MerkleizedBatch<F, D, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::{hasher::Standard, mem::Mem};
+    use crate::merkle::{hasher::Standard, mem::Mem, Bagging::ForwardFold};
     use commonware_cryptography::{sha256, Sha256};
     use commonware_runtime::{deterministic, Runner as _};
 
@@ -626,7 +626,7 @@ mod tests {
     fn consistency_with_reference<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             for &n in &[1u64, 2, 10, 100, 199] {
                 let reference = build_reference::<F>(&hasher, n);
                 let base = Mem::<F, D>::new();
@@ -650,7 +650,7 @@ mod tests {
     fn lifecycle<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let base_root = mem_root(&base, &hasher);
             let mut batch = base.new_batch();
@@ -679,7 +679,7 @@ mod tests {
     fn apply_batch<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mut base = build_reference::<F>(&hasher, 50);
             let mut batch = base.new_batch();
             for i in 50u64..75 {
@@ -698,7 +698,7 @@ mod tests {
     fn multiple_forks<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let base_root = mem_root(&base, &hasher);
             let mut ba = base.new_batch();
@@ -725,7 +725,7 @@ mod tests {
     fn fork_of_fork_reads<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let mut ba = base.new_batch();
             for i in 50u64..60 {
@@ -765,7 +765,7 @@ mod tests {
     fn update_leaf_digest_roundtrip<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 100);
             let base_root = mem_root(&base, &hasher);
             let updated = Sha256::fill(0xFF);
@@ -789,7 +789,7 @@ mod tests {
     fn update_and_add<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let base_root = mem_root(&base, &hasher);
             let updated = Sha256::fill(0xAA);
@@ -811,7 +811,7 @@ mod tests {
     fn update_leaf_batched_roundtrip<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 100);
             let base_root = mem_root(&base, &hasher);
             let updated = Sha256::fill(0xBB);
@@ -843,7 +843,7 @@ mod tests {
     fn proof_verification<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let mut batch = base.new_batch();
             for i in 50u64..60 {
@@ -880,7 +880,7 @@ mod tests {
     fn empty_batch<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let base_root = mem_root(&base, &hasher);
             let m = base.new_batch().merkleize(&base, &hasher);
@@ -891,7 +891,7 @@ mod tests {
     fn batch_roundtrip<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let mut batch = base.new_batch();
             for i in 50u64..55 {
@@ -915,7 +915,7 @@ mod tests {
     fn sequential_apply_batch<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mut base = build_reference::<F>(&hasher, 50);
             let mut b1 = base.new_batch();
             for i in 50u64..60 {
@@ -939,7 +939,7 @@ mod tests {
     fn batch_on_pruned_base<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mut base = build_reference::<F>(&hasher, 100);
             base.prune(Location::new(27)).unwrap();
             let mut batch = base.new_batch();
@@ -966,7 +966,7 @@ mod tests {
     fn three_deep_stacking<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mut base = build_reference::<F>(&hasher, 100);
             let da = Sha256::fill(0xDD);
             let db = Sha256::fill(0xEE);
@@ -995,7 +995,7 @@ mod tests {
     fn overwrite_collision<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mut base = build_reference::<F>(&hasher, 100);
             let dx = Sha256::fill(0xAA);
             let dy = Sha256::fill(0xBB);
@@ -1020,7 +1020,7 @@ mod tests {
     fn update_appended_leaf<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let mut batch = base.new_batch();
             for i in 50u64..60 {
@@ -1051,7 +1051,7 @@ mod tests {
     fn update_leaf_element<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let base_root = mem_root(&base, &hasher);
             let element = b"updated-element";
@@ -1075,7 +1075,7 @@ mod tests {
     fn update_out_of_bounds<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let base = build_reference::<F>(&hasher, 50);
             let r1 = base
                 .new_batch()

--- a/storage/src/merkle/benches/append.rs
+++ b/storage/src/merkle/benches/append.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::{sha256, Sha256};
 use commonware_math::algebra::Random as _;
-use commonware_storage::merkle::{self, mem::Mem, Family};
+use commonware_storage::merkle::{self, mem::Mem, Bagging::ForwardFold, Family};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, SeedableRng};
@@ -24,7 +24,7 @@ fn bench_append_family<F: Family>(c: &mut Criterion, family: &str) {
         c.bench_function(&format!("{}/n={n} family={family}", module_path!()), |b| {
             b.iter(|| {
                 block_on(async {
-                    let h = StandardHasher::<Sha256>::new();
+                    let h = StandardHasher::<Sha256>::new(ForwardFold);
                     let mut mem = Mem::<F, _>::new();
                     let batch = {
                         let mut batch = mem.new_batch();

--- a/storage/src/merkle/benches/append_additional.rs
+++ b/storage/src/merkle/benches/append_additional.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::{sha256, Sha256};
 use commonware_math::algebra::Random as _;
-use commonware_storage::merkle::{self, mem::Mem, Family};
+use commonware_storage::merkle::{self, mem::Mem, Bagging::ForwardFold, Family};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, SeedableRng};
@@ -32,7 +32,7 @@ fn bench_append_additional_family<F: Family>(c: &mut Criterion, family: &str) {
                 |b| {
                     b.iter_batched(
                         || {
-                            let h = StandardHasher::<Sha256>::new();
+                            let h = StandardHasher::<Sha256>::new(ForwardFold);
                             let mut mem = Mem::<F, _>::new();
                             block_on(async {
                                 let batch = {
@@ -47,7 +47,7 @@ fn bench_append_additional_family<F: Family>(c: &mut Criterion, family: &str) {
                             mem
                         },
                         |mem| {
-                            let h = StandardHasher::<Sha256>::new();
+                            let h = StandardHasher::<Sha256>::new(ForwardFold);
                             block_on(async {
                                 let mut batch = mem.new_batch();
                                 for digest in &additional {

--- a/storage/src/merkle/benches/prove_many_elements.rs
+++ b/storage/src/merkle/benches/prove_many_elements.rs
@@ -1,6 +1,8 @@
 use commonware_cryptography::{sha256, Sha256};
 use commonware_math::algebra::Random as _;
-use commonware_storage::merkle::{self, mem::Mem, Family, Location, LocationRangeExt as _};
+use commonware_storage::merkle::{
+    self, mem::Mem, Bagging::ForwardFold, Family, Location, LocationRangeExt as _,
+};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -16,7 +18,7 @@ const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000]
 
 fn bench_prove_many_elements_family<F: Family>(c: &mut Criterion, family: &str) {
     for n in N_LEAVES {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut mem = Mem::<F, _>::new();
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
@@ -61,7 +63,7 @@ fn bench_prove_many_elements_family<F: Family>(c: &mut Criterion, family: &str) 
                             })
                         },
                         |samples| {
-                            let hasher = StandardHasher::<Sha256>::new();
+                            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
                             block_on(async {
                                 for range in samples {
                                     let proof = mem.range_proof(&hasher, range.clone(), 0).unwrap();

--- a/storage/src/merkle/benches/prove_single_element.rs
+++ b/storage/src/merkle/benches/prove_single_element.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::{sha256, Sha256};
 use commonware_math::algebra::Random as _;
-use commonware_storage::merkle::{self, mem::Mem, Family, Location};
+use commonware_storage::merkle::{self, mem::Mem, Bagging::ForwardFold, Family, Location};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -16,7 +16,7 @@ const N_LEAVES: [usize; 5] = [10_000, 100_000, 1_000_000, 5_000_000, 10_000_000]
 
 fn bench_prove_single_element_family<F: Family>(c: &mut Criterion, family: &str) {
     for n in N_LEAVES {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut mem = Mem::<F, _>::new();
         let mut elements = Vec::with_capacity(n);
         let mut sampler = StdRng::seed_from_u64(0);
@@ -51,7 +51,7 @@ fn bench_prove_single_element_family<F: Family>(c: &mut Criterion, family: &str)
                     },
                     |samples| {
                         block_on(async {
-                            let hasher = StandardHasher::<Sha256>::new();
+                            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
                             for (loc, element) in samples {
                                 let proof = mem.proof(&hasher, loc, 0).unwrap();
                                 assert!(

--- a/storage/src/merkle/benches/update.rs
+++ b/storage/src/merkle/benches/update.rs
@@ -5,7 +5,7 @@ use commonware_runtime::{
     tokio::Config,
     ThreadPooler,
 };
-use commonware_storage::merkle::{self, mem::Mem, Family, Location};
+use commonware_storage::merkle::{self, mem::Mem, Bagging::ForwardFold, Family, Location};
 use commonware_utils::NZUsize;
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -50,7 +50,7 @@ fn bench_update_family<F: Family>(c: &mut Criterion, runner: &tokio::Runner, fam
                             let mut elements = Vec::with_capacity(leaves);
                             let mut sampler = StdRng::seed_from_u64(0);
                             let mut leaf_locations = Vec::with_capacity(leaves);
-                            let h = StandardHasher::<Sha256>::new();
+                            let h = StandardHasher::<Sha256>::new(ForwardFold);
 
                             let mut mem = Mem::<F, _>::new();
                             let batch = {

--- a/storage/src/merkle/conformance.rs
+++ b/storage/src/merkle/conformance.rs
@@ -1,6 +1,6 @@
 //! Shared conformance test utilities and stability tests for Merkle-family structures.
 
-use crate::merkle::{hasher::Hasher, mem::Mem, Family};
+use crate::merkle::{hasher::Hasher, mem::Mem, Bagging::ForwardFold, Family};
 use commonware_conformance::{conformance_tests, Conformance};
 use commonware_cryptography::{sha256, Sha256};
 
@@ -55,7 +55,7 @@ struct MmrRootStability;
 
 impl Conformance for MmrRootStability {
     async fn commit(seed: u64) -> Vec<u8> {
-        let hasher = Standard::new();
+        let hasher = Standard::new(ForwardFold);
         let mmr = crate::mmr::mem::Mmr::new();
         build_test_mem(&hasher, mmr, seed)
             .root(&hasher, 0)
@@ -72,7 +72,7 @@ struct MmbRootStability;
 
 impl Conformance for MmbRootStability {
     async fn commit(seed: u64) -> Vec<u8> {
-        let hasher = Standard::new();
+        let hasher = Standard::new(ForwardFold);
         let mmb = crate::mmb::mem::Mmb::new();
         build_test_mem(&hasher, mmb, seed)
             .root(&hasher, 0)

--- a/storage/src/merkle/hasher.rs
+++ b/storage/src/merkle/hasher.rs
@@ -1,10 +1,6 @@
 //! Shared hasher trait and standard implementation for Merkle-family data structures.
 
-use crate::merkle::{
-    Bagging,
-    Bagging::{BackwardFold, ForwardFold},
-    Error, Family, Location, Position,
-};
+use crate::merkle::{Bagging, Error, Family, Location, Position};
 use alloc::vec::Vec;
 use commonware_cryptography::{Digest, Hasher as CHasher};
 use core::marker::PhantomData;
@@ -166,16 +162,6 @@ impl<H: CHasher> Standard<H> {
         }
     }
 
-    /// Creates a new [Standard] hasher with forward-fold bagging.
-    pub const fn forward() -> Self {
-        Self::new(ForwardFold)
-    }
-
-    /// Creates a new [Standard] hasher with backward-fold bagging.
-    pub const fn backward() -> Self {
-        Self::new(BackwardFold)
-    }
-
     /// Hash an arbitrary sequence of byte slices into a single digest.
     pub fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> H::Digest {
         let mut h = H::new();
@@ -220,7 +206,7 @@ mod tests {
     use super::*;
     use crate::merkle::{
         mmr::{Location, Position, StandardHasher as Standard},
-        Bagging::ForwardFold,
+        Bagging::{BackwardFold, ForwardFold},
     };
     use alloc::vec::Vec;
     use commonware_cryptography::{sha256, Hasher as CHasher, Sha256};
@@ -242,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_invalid_inactive_prefix_returns_err() {
-        let mmr_hasher: Standard<Sha256> = Standard::backward();
+        let mmr_hasher: Standard<Sha256> = Standard::new(BackwardFold);
         let d1 = test_digest::<Sha256>(1);
         let d2 = test_digest::<Sha256>(2);
         let digests = [d1, d2];

--- a/storage/src/merkle/hasher.rs
+++ b/storage/src/merkle/hasher.rs
@@ -1,6 +1,10 @@
 //! Shared hasher trait and standard implementation for Merkle-family data structures.
 
-use crate::merkle::{Bagging, Error, Family, Location, Position};
+use crate::merkle::{
+    Bagging,
+    Bagging::{BackwardFold, ForwardFold},
+    Error, Family, Location, Position,
+};
 use alloc::vec::Vec;
 use commonware_cryptography::{Digest, Hasher as CHasher};
 use core::marker::PhantomData;
@@ -154,27 +158,22 @@ pub struct Standard<H: CHasher> {
 }
 
 impl<H: CHasher> Standard<H> {
-    /// Creates a new [Standard] hasher with the default forward-fold bagging.
-    pub const fn new() -> Self {
-        Self::forward()
-    }
-
-    /// Creates a new [Standard] hasher with forward-fold bagging.
-    pub const fn forward() -> Self {
-        Self::with_bagging(Bagging::ForwardFold)
-    }
-
-    /// Creates a new [Standard] hasher with backward-fold bagging.
-    pub const fn backward() -> Self {
-        Self::with_bagging(Bagging::BackwardFold)
-    }
-
     /// Creates a new [Standard] hasher with the given bagging policy.
-    pub const fn with_bagging(bagging: Bagging) -> Self {
+    pub const fn new(bagging: Bagging) -> Self {
         Self {
             _hasher: PhantomData,
             bagging,
         }
+    }
+
+    /// Creates a new [Standard] hasher with forward-fold bagging.
+    pub const fn forward() -> Self {
+        Self::new(ForwardFold)
+    }
+
+    /// Creates a new [Standard] hasher with backward-fold bagging.
+    pub const fn backward() -> Self {
+        Self::new(BackwardFold)
     }
 
     /// Hash an arbitrary sequence of byte slices into a single digest.
@@ -189,12 +188,6 @@ impl<H: CHasher> Standard<H> {
     /// Compute the digest of a byte slice.
     pub fn digest(&self, data: &[u8]) -> H::Digest {
         self.hash(core::iter::once(data))
-    }
-}
-
-impl<H: CHasher> Default for Standard<H> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -225,7 +218,10 @@ impl<F: Family, T: Hasher<F>> Hasher<F> for &T {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::mmr::{Location, Position, StandardHasher as Standard};
+    use crate::merkle::{
+        mmr::{Location, Position, StandardHasher as Standard},
+        Bagging::ForwardFold,
+    };
     use alloc::vec::Vec;
     use commonware_cryptography::{sha256, Hasher as CHasher, Sha256};
 
@@ -292,7 +288,7 @@ mod tests {
     }
 
     fn test_leaf_digest<H: CHasher>() {
-        let mmr_hasher: Standard<H> = Standard::new();
+        let mmr_hasher: Standard<H> = Standard::new(ForwardFold);
         let digest1 = test_digest::<H>(1);
         let digest2 = test_digest::<H>(2);
 
@@ -310,7 +306,7 @@ mod tests {
     }
 
     fn test_node_digest<H: CHasher>() {
-        let mmr_hasher: Standard<H> = Standard::new();
+        let mmr_hasher: Standard<H> = Standard::new(ForwardFold);
 
         let d1 = test_digest::<H>(1);
         let d2 = test_digest::<H>(2);
@@ -345,7 +341,7 @@ mod tests {
     }
 
     fn test_root<H: CHasher>() {
-        let mmr_hasher: Standard<H> = Standard::new();
+        let mmr_hasher: Standard<H> = Standard::new(ForwardFold);
         let d1 = test_digest::<H>(1);
         let d2 = test_digest::<H>(2);
         let d3 = test_digest::<H>(3);

--- a/storage/src/merkle/hasher.rs
+++ b/storage/src/merkle/hasher.rs
@@ -162,6 +162,11 @@ impl<H: CHasher> Standard<H> {
         }
     }
 
+    /// Return the bagging policy used when folding peaks into a root.
+    pub const fn root_bagging(&self) -> Bagging {
+        self.bagging
+    }
+
     /// Hash an arbitrary sequence of byte slices into a single digest.
     pub fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> H::Digest {
         let mut h = H::new();
@@ -185,7 +190,7 @@ impl<F: Family, H: CHasher> Hasher<F> for Standard<H> {
     }
 
     fn root_bagging(&self) -> Bagging {
-        self.bagging
+        Self::root_bagging(self)
     }
 }
 

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -463,7 +463,9 @@ impl<F: Family, D: Digest> Readable for Mem<F, D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::{hasher::Standard, Bagging, Error, Location, Position};
+    use crate::merkle::{
+        hasher::Standard, Bagging, Bagging::ForwardFold, Error, Location, Position,
+    };
     use commonware_cryptography::{sha256, Sha256};
     use commonware_parallel::Sequential;
     use commonware_runtime::{deterministic, Runner as _, ThreadPooler};
@@ -513,7 +515,7 @@ mod tests {
     fn validity<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mut mem = Mem::<F, D>::new();
             for i in 0u64..256 {
                 assert!(
@@ -539,7 +541,7 @@ mod tests {
     fn prune_all_then_append<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mut mem = Mem::<F, D>::new();
             for i in 0u64..256 {
                 mem.prune_all();
@@ -556,7 +558,7 @@ mod tests {
     fn range_proof_out_of_bounds<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mem = Mem::<F, D>::new();
             assert!(matches!(
                 mem.range_proof(&hasher, Location::new(0)..Location::new(1), 0),
@@ -576,7 +578,7 @@ mod tests {
     fn proof_out_of_bounds<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mem = Mem::<F, D>::new();
             assert!(matches!(
                 mem.proof(&hasher, Location::new(0), 0),
@@ -594,7 +596,7 @@ mod tests {
     fn init_pinned_nodes_validation<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
 
             assert!(Mem::<F, D>::init(Config {
                 nodes: vec![],
@@ -636,7 +638,7 @@ mod tests {
     fn root_stable_under_pruning<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mut reference = Mem::<F, D>::new();
             let mut pruned = Mem::<F, D>::new();
             for i in 0u64..200 {
@@ -693,7 +695,7 @@ mod tests {
     fn batch_update_leaf<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mem = build::<F>(&hasher, 200);
             do_batch_update(&hasher, mem, Sequential);
         });
@@ -702,7 +704,7 @@ mod tests {
     fn batch_parallel_update_leaf<F: Family>() {
         let executor = commonware_runtime::tokio::Runner::default();
         executor.start(|ctx| async move {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mem = build::<F>(&hasher, 200);
             let strategy = ctx.create_strategy(NZUsize!(4)).unwrap();
             do_batch_update(&hasher, mem, strategy);
@@ -710,7 +712,7 @@ mod tests {
     }
 
     fn root_changes_with_each_append<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
         let mut prev_root = plain_root(&mem, &hasher);
         for i in 0u64..16 {
@@ -730,7 +732,7 @@ mod tests {
     }
 
     fn single_element_proof_roundtrip<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mem = build_raw::<F>(&hasher, 16);
         let root = plain_root(&mem, &hasher);
         for i in 0u64..16 {
@@ -746,7 +748,7 @@ mod tests {
 
     fn range_proof_roundtrip_exhaustive<F: Family>() {
         for n in 1u64..=24 {
-            let hasher: H = Standard::new();
+            let hasher: H = Standard::new(ForwardFold);
             let mem = build_raw::<F>(&hasher, n);
             let root = plain_root(&mem, &hasher);
 
@@ -768,7 +770,7 @@ mod tests {
     }
 
     fn root_with_repeated_pruning<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = build::<F>(&hasher, 32);
         let root = plain_root(&mem, &hasher);
 
@@ -801,7 +803,7 @@ mod tests {
     }
 
     fn append_after_partial_prune<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = build_raw::<F>(&hasher, 20);
         mem.prune(Location::new(7)).unwrap();
 
@@ -832,7 +834,7 @@ mod tests {
     }
 
     fn update_leaf<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = build_raw::<F>(&hasher, 11);
         let root_before = plain_root(&mem, &hasher);
 
@@ -889,7 +891,7 @@ mod tests {
 
     fn update_leaf_every_position<F: Family>() {
         let n = 20u64;
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = build::<F>(&hasher, n);
 
         for update_loc in 0..n {
@@ -916,7 +918,7 @@ mod tests {
     }
 
     fn update_leaf_errors<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = build::<F>(&hasher, 10);
 
         {
@@ -940,7 +942,7 @@ mod tests {
     }
 
     fn update_leaf_with_append<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = build::<F>(&hasher, 8);
 
         let batch = {
@@ -974,7 +976,7 @@ mod tests {
     }
 
     fn update_leaf_under_merge_parent<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = build::<F>(&hasher, 2);
         let batch = {
             let batch = mem.new_batch();
@@ -986,7 +988,7 @@ mod tests {
         };
         mem.apply_batch(&batch).unwrap();
 
-        let ref_hasher: H = Standard::new();
+        let ref_hasher: H = Standard::new(ForwardFold);
         let mut ref_mem = build::<F>(&ref_hasher, 2);
         let cs = {
             let batch = ref_mem.new_batch();
@@ -1026,7 +1028,7 @@ mod tests {
     /// nodes produced by `nodes_to_pin` under re-merkleization.
     fn update_leaf_after_prune<F: Family>() {
         let max_n = 20u64;
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         for n in 1..=max_n {
             for prune_to in 1..n {
                 let mut mem = build_raw::<F>(&hasher, n);
@@ -1062,7 +1064,7 @@ mod tests {
     /// Applying C (child of B, grandchild of A) after only A is applied
     /// must apply B's uncommitted data + C's data, skipping only A.
     fn apply_batch_skips_only_committed_ancestors<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
 
         // Chain: Mem -> A -> B -> C
@@ -1092,7 +1094,7 @@ mod tests {
     /// Dropping an uncommitted ancestor before merkleizing a descendant must
     /// be detected at apply time, not silently corrupt data.
     fn apply_batch_detects_dropped_ancestor<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
 
         let a = mem.new_batch().add(&hasher, b"a").merkleize(&mem, &hasher);
@@ -1109,7 +1111,7 @@ mod tests {
 
     /// Overwrite-only ancestor B must not be skipped when applying C after A.
     fn apply_batch_overwrite_only_ancestor<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let mut mem = build_raw::<F>(&hasher, 10);
 
         let pos0 = Position::<F>::try_from(Location::new(0)).unwrap();
@@ -1153,7 +1155,7 @@ mod tests {
     }
 
     fn split_root_matches_recompute<F: Family>() {
-        let hasher: H = Standard::new();
+        let hasher: H = Standard::new(ForwardFold);
         let plain = build::<F>(&hasher, 49);
         let inactive_peaks = 1;
         let peaks: Vec<_> = F::peaks(plain.size())

--- a/storage/src/merkle/mmb/mem.rs
+++ b/storage/src/merkle/mmb/mem.rs
@@ -12,6 +12,7 @@ mod tests {
     use crate::merkle::{
         hasher::{Hasher as _, Standard},
         mmb::{Error, Location, Position},
+        Bagging::ForwardFold,
     };
     use commonware_cryptography::Sha256;
 
@@ -19,7 +20,7 @@ mod tests {
     type H = Standard<Sha256>;
 
     fn build_mmb(n: u64) -> (H, Mmb<D>) {
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mmb = Mmb::new();
         let batch = {
             let mut batch = mmb.new_batch();
@@ -34,7 +35,7 @@ mod tests {
 
     #[test]
     fn test_append_and_size() {
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mmb = Mmb::new();
 
         for i in 0u64..8 {
@@ -161,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_init_size_validation() {
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
 
         assert!(Mmb::<D>::init(Config {
             nodes: vec![],

--- a/storage/src/merkle/mmb/mod.rs
+++ b/storage/src/merkle/mmb/mod.rs
@@ -392,7 +392,7 @@ impl Graftable for Family {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mmb::mem::Mmb;
+    use crate::{merkle::Bagging::ForwardFold, mmb::mem::Mmb};
     use commonware_cryptography::Sha256;
 
     /// Verify the MMB merge schedule via `Family::parent_heights`.
@@ -455,7 +455,7 @@ mod tests {
     fn test_leftmost_leaf() {
         // Verify leftmost_leaf is consistent with subtree_root_position:
         // subtree_root_position(leftmost_leaf(pos, h), h) == pos.
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut mmb = Mmb::new();
         let digest = [1u8; 32];
         for _ in 0..200 {
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn test_chunk_peaks() {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut mmb = Mmb::new();
         let digest = [1u8; 32];
 

--- a/storage/src/merkle/mmb/proof.rs
+++ b/storage/src/merkle/mmb/proof.rs
@@ -5,7 +5,10 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        merkle::{hasher::Standard, mmb::mem::Mmb, proof::Blueprint, Bagging, Family},
+        merkle::{
+            hasher::Standard, mmb::mem::Mmb, proof::Blueprint, Bagging, Bagging::ForwardFold,
+            Family,
+        },
         mmb::Location,
     };
     use commonware_cryptography::Sha256;
@@ -15,7 +18,7 @@ mod tests {
 
     /// Build an in-memory MMB with `n` elements (element i = i.to_be_bytes()).
     fn make_mmb(n: u64) -> (H, Mmb<D>) {
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mmb = Mmb::new();
         let batch = {
             let mut batch = mmb.new_batch();
@@ -58,7 +61,7 @@ mod tests {
     fn test_last_element_proof_size_is_two() {
         // An MMB property is that the most recent item always has a small proof
         // (at most 2 digests). Verify this holds as the tree grows.
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let (_, mut mmb) = make_mmb(1000);
         let mut n = 1000u64;
 

--- a/storage/src/merkle/mmr/full.rs
+++ b/storage/src/merkle/mmr/full.rs
@@ -26,7 +26,7 @@ pub type Mmr<E, D, S = Sequential> = crate::merkle::full::Merkle<Family, E, D, S
 mod tests {
     use super::*;
     use crate::{
-        merkle::{conformance::build_test_mmr, Family as _},
+        merkle::{conformance::build_test_mmr, Bagging::ForwardFold, Family as _},
         mmr::{mem, Error, Location, Position, StandardHasher as Standard},
     };
     use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
@@ -62,14 +62,14 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             const NUM_ELEMENTS: u64 = 199;
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let test_mmr = mem::Mmr::new();
             let test_mmr = build_test_mmr(&hasher, test_mmr, NUM_ELEMENTS);
             let expected_root = test_mmr.root(&hasher, 0).unwrap();
 
             let mut mmr = Mmr::init(
                 context.clone(),
-                &Standard::<Sha256>::new(),
+                &Standard::<Sha256>::new(ForwardFold),
                 test_config(&context),
             )
             .await
@@ -92,7 +92,7 @@ mod tests {
     fn test_full_mmr_peek_root_empty_journal() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let peek =
                 Mmr::<_, Digest>::peek_root(context.clone(), test_config(&context), &hasher, 0)
                     .await
@@ -109,7 +109,7 @@ mod tests {
         executor.start(|context| async move {
             const NUM_ELEMENTS: u64 = 200;
 
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let cfg = test_config(&context);
             let mut mmr = Mmr::init(context, &hasher, cfg).await.unwrap();
 
@@ -234,12 +234,12 @@ mod tests {
     fn test_full_mmr_batch_stacking() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
 
             // Build base full MMR with 10 elements.
             let mut mmr = Mmr::init(
                 context.clone(),
-                &Standard::<Sha256>::new(),
+                &Standard::<Sha256>::new(ForwardFold),
                 test_config(&context),
             )
             .await
@@ -297,7 +297,7 @@ mod tests {
     fn test_init_sync_fresh_start_updates_journal_size() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = Standard::<Sha256>::new();
+            let hasher = Standard::<Sha256>::new(ForwardFold);
 
             // Build an MMR with 5 leaves (size 8), sync, drop.
             let mut mmr =

--- a/storage/src/merkle/mmr/iterator.rs
+++ b/storage/src/merkle/mmr/iterator.rs
@@ -132,14 +132,17 @@ pub(crate) const fn pos_to_height(pos: Position) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::mmr::{mem::Mmr, Location, StandardHasher as Standard};
+    use crate::merkle::{
+        mmr::{mem::Mmr, Location, StandardHasher as Standard},
+        Bagging::ForwardFold,
+    };
     use commonware_cryptography::Sha256;
 
     #[test]
     fn test_leaf_loc_calculation() {
         // Build MMR with 1000 leaves and make sure we can correctly convert each leaf position to
         // its number and back again.
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Mmr::new();
         let digest = [1u8; 32];
         let (batch, loc_to_pos) = {
@@ -176,7 +179,7 @@ mod tests {
     #[test]
     fn test_to_nearest_size() {
         // Build an MMR incrementally and verify to_nearest_size for all intermediate values
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Mmr::new();
         let digest = [1u8; 32];
 

--- a/storage/src/merkle/mmr/mem.rs
+++ b/storage/src/merkle/mmr/mem.rs
@@ -10,7 +10,7 @@ pub type Config<D> = crate::merkle::mem::Config<super::Family, D>;
 mod tests {
     use super::*;
     use crate::{
-        merkle::{conformance::build_test_mmr, hasher::Hasher as _},
+        merkle::{conformance::build_test_mmr, hasher::Hasher as _, Bagging::ForwardFold},
         mmr::{Error, Location, Position, StandardHasher as Standard},
     };
     use commonware_cryptography::{sha256, Hasher, Sha256};
@@ -24,7 +24,7 @@ mod tests {
     fn test_mem_mmr_add_eleven_values() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let mut mmr = Mmr::new();
             let element = <Sha256 as Hasher>::Digest::from(*b"01234567012345670123456701234567");
             let mut leaves: Vec<Location> = Vec::new();
@@ -120,7 +120,7 @@ mod tests {
     fn test_mem_mmr_batched_root() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             const NUM_ELEMENTS: u64 = 199;
             let mut test_mmr = Mmr::new();
             test_mmr = build_test_mmr(&hasher, test_mmr, NUM_ELEMENTS);
@@ -151,14 +151,14 @@ mod tests {
     fn test_mem_mmr_batched_root_parallel() {
         let executor = tokio::Runner::default();
         executor.start(|context| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             const NUM_ELEMENTS: u64 = 199;
             let test_mmr = Mmr::new();
             let test_mmr = build_test_mmr(&hasher, test_mmr, NUM_ELEMENTS);
             let expected_root = test_mmr.root(&hasher, 0).unwrap();
 
             let strategy = context.create_strategy(NZUsize!(4)).unwrap();
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
 
             let mut mmr = Mmr::init(Config {
                 nodes: vec![],
@@ -188,7 +188,7 @@ mod tests {
     fn test_init_size_validation() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             assert!(Mmr::init(Config::<sha256::Digest> {
                 nodes: vec![],
                 pruning_boundary: Location::new(0),

--- a/storage/src/merkle/mmr/mod.rs
+++ b/storage/src/merkle/mmr/mod.rs
@@ -264,6 +264,7 @@ impl Graftable for Family {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::merkle::Bagging::ForwardFold;
     use commonware_cryptography::Sha256;
 
     const MAX_NODES: Position = <Family as crate::merkle::Family>::MAX_NODES;
@@ -397,7 +398,7 @@ mod tests {
     #[test]
     fn test_is_valid_size() {
         let mut size_to_check = Position::new(0);
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut mmr = mem::Mmr::new();
         let digest = [1u8; 32];
         for _i in 0..10000 {
@@ -710,7 +711,7 @@ mod tests {
 
     #[test]
     fn test_chunk_peaks() {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut mmr = mem::Mmr::new();
         let digest = [1u8; 32];
 
@@ -784,7 +785,7 @@ mod tests {
     fn test_leftmost_leaf() {
         // Verify leftmost_leaf is consistent with subtree_root_position:
         // `subtree_root_position(leftmost_leaf(pos, h), h) == pos`.
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut mmr = mem::Mmr::new();
         let digest = [1u8; 32];
         for _ in 0..200 {

--- a/storage/src/merkle/mmr/proof.rs
+++ b/storage/src/merkle/mmr/proof.rs
@@ -9,7 +9,9 @@ mod tests {
             StandardHasher as Standard,
         },
         proof::{nodes_required_for_multi_proof, Blueprint},
-        Bagging, Family as _, LocationRangeExt as _,
+        Bagging,
+        Bagging::ForwardFold,
+        Family as _, LocationRangeExt as _,
     };
     use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
 
@@ -20,7 +22,7 @@ mod tests {
     #[test]
     fn test_proving_digests_from_range() {
         // create a new MMR and add a non-trivial amount (49) of elements
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         let mut mmr = Mmr::new();
         let elements: Vec<_> = (0..49).map(test_digest).collect();
         let batch = {
@@ -297,7 +299,7 @@ mod tests {
     /// node at position 0 (L0) which is a sibling within the range peak, not a fold-prefix peak.
     #[test]
     fn test_verify_proof_and_pinned_nodes_sibling_case() {
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         let mut mmr = Mmr::new();
         let elements: Vec<Digest> = (0..3).map(test_digest).collect();
         let batch = {
@@ -361,7 +363,7 @@ mod tests {
     /// Test verify_proof_and_pinned_nodes when pinned nodes ARE fold-prefix peaks.
     #[test]
     fn test_verify_proof_and_pinned_nodes_fold_prefix_case() {
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         let mut mmr = Mmr::new();
         // 10-leaf MMR: peaks at positions covering [0-7] and [8-9].
         // start_loc=8 puts the first peak entirely in the fold prefix.

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -33,6 +33,8 @@ pub use position::Position;
 #[cfg(test)]
 pub(crate) use proof::build_range_proof;
 pub use proof::Proof;
+#[cfg(feature = "std")]
+pub(crate) use proof::{build_range_collection_proof, range_collection_nodes};
 pub use read::Readable;
 use thiserror::Error;
 

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -483,7 +483,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
 mod tests {
     use super::*;
     use crate::{
-        merkle::{hasher::Standard as StandardHasher, mmb, mmr},
+        merkle::{hasher::Standard as StandardHasher, mmb, mmr, Bagging::ForwardFold},
         metadata::{Config as MConfig, Metadata},
     };
     use commonware_cryptography::Sha256;
@@ -505,7 +505,7 @@ mod tests {
     }
 
     async fn append_and_sync<F: Family>(merkle: &mut TestMerkle<F>, values: &[&[u8]]) {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let batch = {
             let mut b = merkle.new_batch();
             for v in values {
@@ -521,7 +521,7 @@ mod tests {
         context: deterministic::Context,
         partition: &str,
     ) {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let cfg = Config {
             partition: partition.into(),
             strategy: Sequential,
@@ -572,7 +572,7 @@ mod tests {
         context: deterministic::Context,
         partition: &str,
     ) {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut merkle = open::<F>(context, partition).await;
 
         append_and_sync(&mut merkle, &[b"a", b"b"]).await;
@@ -626,7 +626,7 @@ mod tests {
     #[test]
     fn test_rewind_discards_uncommitted() {
         deterministic::Runner::default().start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let mut merkle = open::<mmr::Family>(context, "rewind-uncommitted").await;
 
             append_and_sync(&mut merkle, &[b"a"]).await;
@@ -655,7 +655,7 @@ mod tests {
     #[test]
     fn test_rewind_persists_across_reopen() {
         deterministic::Runner::default().start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let partition = "rewind-reopen";
             let cfg = Config {
                 partition: partition.into(),
@@ -696,7 +696,7 @@ mod tests {
     #[test]
     fn test_rewind_then_sync_then_rewind() {
         deterministic::Runner::default().start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new();
+            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let mut merkle = open::<mmr::Family>(context, "rewind-resumable").await;
 
             append_and_sync(&mut merkle, &[b"a"]).await;

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -1110,7 +1110,10 @@ mod tests {
     use super::*;
     use crate::{
         journal::contiguous::fixed::{Config as JConfig, Journal},
-        merkle::{hasher::Standard, mmb, mmr, Location, LocationRangeExt as _, Position, Proof},
+        merkle::{
+            hasher::Standard, mmb, mmr, Bagging::ForwardFold, Location, LocationRangeExt as _,
+            Position, Proof,
+        },
         metadata::{Config as MConfig, Metadata},
     };
     use commonware_cryptography::{
@@ -1144,7 +1147,7 @@ mod tests {
     }
 
     async fn full_empty_inner<F: Family>(context: deterministic::Context) {
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("first"),
             &hasher,
@@ -1182,7 +1185,7 @@ mod tests {
         assert_eq!(mmr.size(), 0);
 
         let empty_proof = Proof::<F, Digest>::default();
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         let root = mmr.root(&hasher, 0).unwrap();
         assert!(empty_proof.verify_range_inclusion(
             &hasher,
@@ -1231,7 +1234,7 @@ mod tests {
     async fn full_prune_out_of_bounds_returns_error_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("oob_prune"),
             &hasher,
@@ -1267,7 +1270,7 @@ mod tests {
     async fn full_rewind_error_leaves_valid_state_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
 
         // Case 1: rewind partially succeeds, then returns ElementPruned.
         let element_pruned_context = context.with_label("element_pruned_case");
@@ -1326,7 +1329,7 @@ mod tests {
     }
 
     async fn full_basic_inner<F: Family>(context: deterministic::Context) {
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         let cfg = test_config(&context);
         let mut mmr = Merkle::<F, _, Digest>::init(context, &hasher, cfg)
             .await
@@ -1397,7 +1400,7 @@ mod tests {
     async fn full_recovery_inner<F: Family>(context: deterministic::Context) {
         use crate::journal::contiguous::fixed::{Config as JConfig, Journal};
 
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("first"),
             &hasher,
@@ -1484,7 +1487,7 @@ mod tests {
     }
 
     async fn full_pruning_inner<F: Family>(context: deterministic::Context) {
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         // make sure pruning doesn't break root computation, adding of new nodes, etc.
         const LEAF_COUNT: usize = 2000;
         let cfg_pruned = test_config(&context);
@@ -1648,7 +1651,7 @@ mod tests {
     /// Simulate partial writes after pruning, making sure we recover to a valid state.
     async fn full_recovery_with_pruning_inner<F: Family>(context: deterministic::Context) {
         // Build structure with 2000 leaves.
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         const LEAF_COUNT: usize = 2000;
         let mut leaves = Vec::with_capacity(LEAF_COUNT);
         let mut mmr = Merkle::<F, _, Digest>::init(
@@ -1742,7 +1745,7 @@ mod tests {
 
     async fn full_historical_proof_basic_inner<F: Family>(context: deterministic::Context) {
         // Create structure with 10 elements
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let cfg = test_config(&context);
         let mut mmr = Merkle::<F, _, Digest>::init(context, &hasher, cfg)
             .await
@@ -1822,7 +1825,7 @@ mod tests {
     }
 
     async fn full_historical_proof_with_pruning_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("main"),
             &hasher,
@@ -1910,7 +1913,7 @@ mod tests {
     }
 
     async fn full_historical_proof_large_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("server"),
@@ -1996,7 +1999,7 @@ mod tests {
     }
 
     async fn full_historical_proof_singleton_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let cfg = test_config(&context);
         let mut mmr = Merkle::<F, _, Digest>::init(context, &hasher, cfg)
             .await
@@ -2043,7 +2046,7 @@ mod tests {
 
     // Test `init_sync` when there is no persisted data.
     async fn full_init_sync_empty_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Test fresh start scenario with completely new structure (no existing data)
         let sync_cfg = SyncConfig::<F, sha256::Digest> {
@@ -2088,7 +2091,7 @@ mod tests {
 
     // Test `init_sync` where the persisted structure's persisted nodes match the sync boundaries.
     async fn full_init_sync_nonempty_exact_match_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Create initial structure with elements.
         let mut mmr = Merkle::<F, _, Digest>::init(
@@ -2167,7 +2170,7 @@ mod tests {
     // Test `init_sync` where the persisted structure's data partially overlaps with the sync
     // boundaries.
     async fn full_init_sync_partial_overlap_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Create initial structure with elements.
         let mut mmr = Merkle::<F, _, Digest>::init(
@@ -2277,7 +2280,7 @@ mod tests {
     async fn full_init_stale_metadata_returns_error_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Create a structure with some data and prune it
         let mut mmr = Merkle::<F, _, Digest>::init(
@@ -2352,7 +2355,7 @@ mod tests {
     // of journal (crashed before journal prune completed). This should successfully
     // prune the journal to match metadata.
     async fn full_init_metadata_ahead_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Create a structure with some data
         let mut mmr = Merkle::<F, _, Digest>::init(
@@ -2417,7 +2420,7 @@ mod tests {
     async fn full_init_sync_computes_pinned_nodes_before_pruning_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Use small items_per_blob to create many sections and trigger pruning.
         let cfg = Config {
@@ -2484,7 +2487,7 @@ mod tests {
     async fn full_historical_proof_pruned_elements_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("init"),
@@ -2550,7 +2553,7 @@ mod tests {
     async fn full_append_while_historical_proof_is_available_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("init"),
             &hasher,
@@ -2606,7 +2609,7 @@ mod tests {
     async fn full_historical_proof_after_sync_reads_from_journal_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("init"),
             &hasher,
@@ -2652,7 +2655,7 @@ mod tests {
     }
 
     async fn full_historical_proof_after_pruning_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("init"),
             &hasher,
@@ -2695,7 +2698,7 @@ mod tests {
     }
 
     async fn full_historical_proof_edge_cases_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Case 1: Empty structure.
         let mmr = Merkle::<F, _, Digest>::init(
@@ -2797,7 +2800,7 @@ mod tests {
     }
 
     async fn full_historical_proof_out_of_bounds_inner<F: Family>(context: deterministic::Context) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr =
             Merkle::<F, _, Digest>::init(context.with_label("oob"), &hasher, test_config(&context))
                 .await
@@ -2837,7 +2840,7 @@ mod tests {
     async fn full_historical_proof_range_validation_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("range_validation"),
             &hasher,
@@ -2926,7 +2929,7 @@ mod tests {
     async fn full_historical_proof_non_size_prune_excludes_pruned_leaves_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.with_label("non_size_prune"),
             &hasher,
@@ -2991,7 +2994,7 @@ mod tests {
     async fn full_init_sync_recovers_from_invalid_journal_size_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Build a structure with 3 leaves, sync, and drop.
         let mut mmr = Merkle::<F, _, Digest>::init(
@@ -3062,10 +3065,10 @@ mod tests {
     }
 
     async fn full_stale_batch_inner<F: Family>(context: deterministic::Context) {
-        let hasher: Standard<Sha256> = Standard::new();
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(
             context.clone(),
-            &Standard::<Sha256>::new(),
+            &Standard::<Sha256>::new(ForwardFold),
             test_config(&context),
         )
         .await
@@ -3106,7 +3109,7 @@ mod tests {
     async fn full_new_batch_returns_append_only_wrapper_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mmr = Merkle::<F, _, Digest>::init(context.clone(), &hasher, test_config(&context))
             .await
             .unwrap();
@@ -3135,7 +3138,7 @@ mod tests {
     async fn full_update_leaf_after_sync_returns_pruned_inner<F: Family>(
         context: deterministic::Context,
     ) {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Merkle::<F, _, Digest>::init(context.clone(), &hasher, test_config(&context))
             .await
             .unwrap();

--- a/storage/src/merkle/position.rs
+++ b/storage/src/merkle/position.rs
@@ -356,7 +356,7 @@ impl<F: Family> commonware_codec::Read for Position<F> {
 mod tests {
     use super::{Location as GenericLocation, Position as GenericPosition};
     use crate::{
-        merkle::Family as _,
+        merkle::{Bagging::ForwardFold, Family as _},
         mmr::{self, mem::Mmr, StandardHasher as Standard},
     };
     use commonware_cryptography::Sha256;
@@ -534,7 +534,7 @@ mod tests {
         // Build an MMR one node at a time and check that the validity check is correct for all
         // sizes up to the current size.
         let mut size_to_check = Position::new(0);
-        let hasher = Standard::<Sha256>::new();
+        let hasher = Standard::<Sha256>::new(ForwardFold);
         let mut mmr = Mmr::new();
         let digest = [1u8; 32];
         for _i in 0..10000 {

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -592,6 +592,74 @@ impl<F: Family, D: Digest> Proof<F, D> {
             )
             .ok_or(ReconstructionError::InvalidProof)
     }
+
+    /// Authenticate the proven range without reconstructing the full generic Merkle root.
+    ///
+    /// This consumes only the sibling digests needed to rebuild the proven range peaks, then returns
+    /// those peak digests in `collected`. It deliberately does not consume peak-bagging witnesses
+    /// such as prefix peaks, after peaks, or backward-fold suffix accumulators.
+    ///
+    /// Current QMDB grafted proofs use this path because their final root is rebuilt by the wrapper
+    /// from the collected range peaks plus grafted prefix/suffix witnesses. Including generic
+    /// peak-bagging witnesses here would create proof bytes that the wrapper root ignores, making
+    /// those bytes malleable.
+    #[cfg(feature = "std")]
+    pub(crate) fn reconstruct_range_collecting<H, E>(
+        &self,
+        hasher: &H,
+        elements: &[E],
+        start_loc: Location<F>,
+        collected: &mut Vec<(Position<F>, D)>,
+    ) -> Result<(), ReconstructionError>
+    where
+        H: Hasher<F, Digest = D>,
+        E: AsRef<[u8]>,
+    {
+        if elements.is_empty() {
+            return Err(ReconstructionError::MissingElements);
+        }
+        if !start_loc.is_valid_index() {
+            return Err(ReconstructionError::InvalidStartLoc);
+        }
+        let end_loc = start_loc
+            .checked_add(elements.len() as u64)
+            .ok_or(ReconstructionError::InvalidEndLoc)?;
+        if end_loc > self.leaves {
+            return Err(ReconstructionError::InvalidEndLoc);
+        }
+
+        let range = start_loc..end_loc;
+        // Bagging only governs the prefix/suffix accumulator layout, which this method
+        // deliberately ignores; `range_peaks` and `fetch_nodes` are bagging-independent. Pass
+        // ForwardFold as a placeholder.
+        let bp = Blueprint::new(
+            self.leaves,
+            self.inactive_peaks,
+            Bagging::ForwardFold,
+            range,
+        )
+        .map_err(|_| ReconstructionError::InvalidSize)?;
+
+        let mut sibling_cursor = 0usize;
+        let mut elements_iter = elements.iter();
+        for peak in &bp.range_peaks {
+            let peak_digest = peak.reconstruct_digest(
+                hasher,
+                &bp.range,
+                &mut elements_iter,
+                &self.digests,
+                &mut sibling_cursor,
+                None,
+            )?;
+            collected.push((peak.pos, peak_digest));
+        }
+
+        if elements_iter.next().is_some() || sibling_cursor != self.digests.len() {
+            return Err(ReconstructionError::ExtraDigests);
+        }
+
+        Ok(())
+    }
 }
 
 /// A perfect binary subtree within a peak, identified by its root position, height,
@@ -1064,6 +1132,56 @@ where
         get_node,
         element_pruned,
     )
+}
+
+/// Return the node positions needed by [`build_range_collection_proof`].
+///
+/// Bagging only governs prefix/suffix accumulator layout, which this helper does not consult; the
+/// `range_peaks` siblings it collects are bagging-independent. ForwardFold is passed as a
+/// placeholder.
+#[cfg(feature = "std")]
+pub(crate) fn range_collection_nodes<F: Family>(
+    leaves: Location<F>,
+    inactive_peaks: usize,
+    range: Range<Location<F>>,
+) -> Result<Vec<Position<F>>, super::Error<F>> {
+    let bp = Blueprint::new(leaves, inactive_peaks, Bagging::ForwardFold, range)?;
+    let mut fetch_nodes = Vec::new();
+    for peak in &bp.range_peaks {
+        peak.collect_siblings(&bp.range, &mut fetch_nodes);
+    }
+    Ok(fetch_nodes)
+}
+
+/// Build a proof containing only the sibling digests needed to authenticate the requested range.
+///
+/// The resulting proof cannot reconstruct a complete generic Merkle root on its own. It is intended
+/// for wrappers that rebuild a custom root from separately supplied peak witnesses, such as current
+/// QMDB grafted proofs.
+#[cfg(feature = "std")]
+pub(crate) fn build_range_collection_proof<F, D, E>(
+    leaves: Location<F>,
+    inactive_peaks: usize,
+    range: Range<Location<F>>,
+    get_node: impl Fn(Position<F>) -> Option<D>,
+    element_pruned: impl Fn(Position<F>) -> E,
+) -> Result<Proof<F, D>, E>
+where
+    F: Family,
+    D: Digest,
+    E: From<super::Error<F>>,
+{
+    let fetch_nodes = range_collection_nodes(leaves, inactive_peaks, range)?;
+    let mut digests = Vec::with_capacity(fetch_nodes.len());
+    for pos in fetch_nodes {
+        digests.push(get_node(pos).ok_or_else(|| element_pruned(pos))?);
+    }
+
+    Ok(Proof {
+        leaves,
+        inactive_peaks,
+        digests,
+    })
 }
 
 /// Returns the positions of the minimal set of nodes whose digests are required to prove the

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -629,23 +629,15 @@ impl<F: Family, D: Digest> Proof<F, D> {
         }
 
         let range = start_loc..end_loc;
-        // Bagging only governs the prefix/suffix accumulator layout, which this method
-        // deliberately ignores; `range_peaks` and `fetch_nodes` are bagging-independent. Pass
-        // ForwardFold as a placeholder.
-        let bp = Blueprint::new(
-            self.leaves,
-            self.inactive_peaks,
-            Bagging::ForwardFold,
-            range,
-        )
-        .map_err(|_| ReconstructionError::InvalidSize)?;
+        let peaks = range_peaks(self.leaves, self.inactive_peaks, &range)
+            .map_err(|_| ReconstructionError::InvalidSize)?;
 
         let mut sibling_cursor = 0usize;
         let mut elements_iter = elements.iter();
-        for peak in &bp.range_peaks {
+        for peak in &peaks {
             let peak_digest = peak.reconstruct_digest(
                 hasher,
-                &bp.range,
+                &range,
                 &mut elements_iter,
                 &self.digests,
                 &mut sibling_cursor,
@@ -844,6 +836,25 @@ impl<F: Family> Subtree<F> {
 
         Ok(hasher.node_digest(self.pos, &left_d, &right_d))
     }
+}
+
+/// Return the peaks of a tree of `leaves` that overlap `range`, validating both the range and the
+/// declared `inactive_peaks` boundary.
+///
+/// The returned subtrees are bagging-independent: `Blueprint::new`'s prefix/suffix accumulator
+/// layout depends on bagging, but the per-peak partition of the proven range does not.
+///
+/// # Errors
+///
+/// See [`Blueprint::new`].
+pub(crate) fn range_peaks<F: Family>(
+    leaves: Location<F>,
+    inactive_peaks: usize,
+    range: &Range<Location<F>>,
+) -> Result<Vec<Subtree<F>>, super::Error<F>> {
+    // Bagging only affects `Blueprint`'s prefix/suffix bucketing; `range_peaks` is independent.
+    Blueprint::new(leaves, inactive_peaks, Bagging::ForwardFold, range.clone())
+        .map(|bp| bp.range_peaks)
 }
 
 /// Blueprint for a range proof, separating fold-prefix peaks from nodes that must be fetched.
@@ -1135,25 +1146,25 @@ where
 }
 
 /// Return the node positions needed by [`build_range_collection_proof`].
-///
-/// Bagging only governs prefix/suffix accumulator layout, which this helper does not consult; the
-/// `range_peaks` siblings it collects are bagging-independent. ForwardFold is passed as a
-/// placeholder.
 #[cfg(feature = "std")]
 pub(crate) fn range_collection_nodes<F: Family>(
     leaves: Location<F>,
     inactive_peaks: usize,
     range: Range<Location<F>>,
 ) -> Result<Vec<Position<F>>, super::Error<F>> {
-    let bp = Blueprint::new(leaves, inactive_peaks, Bagging::ForwardFold, range)?;
+    let peaks = range_peaks(leaves, inactive_peaks, &range)?;
     let mut fetch_nodes = Vec::new();
-    for peak in &bp.range_peaks {
-        peak.collect_siblings(&bp.range, &mut fetch_nodes);
+    for peak in &peaks {
+        peak.collect_siblings(&range, &mut fetch_nodes);
     }
     Ok(fetch_nodes)
 }
 
 /// Build a proof containing only the sibling digests needed to authenticate the requested range.
+///
+/// `fetch_nodes` must be the slice returned by [`range_collection_nodes`] for the same `leaves` and
+/// `inactive_peaks`; the caller passes it in so the Blueprint traversal isn't repeated when the
+/// positions are already known (e.g., to drive concurrent fetching).
 ///
 /// The resulting proof cannot reconstruct a complete generic Merkle root on its own. It is intended
 /// for wrappers that rebuild a custom root from separately supplied peak witnesses, such as current
@@ -1162,7 +1173,7 @@ pub(crate) fn range_collection_nodes<F: Family>(
 pub(crate) fn build_range_collection_proof<F, D, E>(
     leaves: Location<F>,
     inactive_peaks: usize,
-    range: Range<Location<F>>,
+    fetch_nodes: &[Position<F>],
     get_node: impl Fn(Position<F>) -> Option<D>,
     element_pruned: impl Fn(Position<F>) -> E,
 ) -> Result<Proof<F, D>, E>
@@ -1171,9 +1182,8 @@ where
     D: Digest,
     E: From<super::Error<F>>,
 {
-    let fetch_nodes = range_collection_nodes(leaves, inactive_peaks, range)?;
     let mut digests = Vec::with_capacity(fetch_nodes.len());
-    for pos in fetch_nodes {
+    for &pos in fetch_nodes {
         digests.push(get_node(pos).ok_or_else(|| element_pruned(pos))?);
     }
 

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -1243,6 +1243,7 @@ mod tests {
         mem::Mem,
         mmb, mmr,
         proof::{nodes_required_for_multi_proof, Blueprint, Proof},
+        Bagging::ForwardFold,
         Family, Location, LocationRangeExt as _,
     };
     use alloc::vec;
@@ -1297,7 +1298,7 @@ mod tests {
 
     /// Hasher tuned for `bagging` so callers can mix forward/backward and full/split policies.
     fn hasher_for_bagging(bagging: Bagging) -> H {
-        Standard::with_bagging(bagging)
+        Standard::new(bagging)
     }
 
     fn push_unique_shape(shapes: &mut Vec<(Bagging, usize)>, shape: (Bagging, usize)) {
@@ -1340,7 +1341,7 @@ mod tests {
     }
 
     fn range_proofs_verify_for_supported_root_shapes<F: Family>() {
-        let mem = build_raw::<F>(&H::new(), 123);
+        let mem = build_raw::<F>(&H::new(ForwardFold), 123);
         let leaves = mem.leaves();
 
         for (bagging, inactive_peaks) in supported_root_shapes::<F>(leaves) {
@@ -1387,7 +1388,7 @@ mod tests {
     }
 
     fn multi_proofs_verify_for_supported_root_shapes<F: Family>() {
-        let mem = build_raw::<F>(&H::new(), 123);
+        let mem = build_raw::<F>(&H::new(ForwardFold), 123);
         let leaves = mem.leaves();
 
         for (bagging, inactive_peaks) in supported_root_shapes::<F>(leaves) {
@@ -1554,7 +1555,7 @@ mod tests {
 
     fn empty_proof<F: Family>() {
         // Test that an empty proof authenticates an empty structure.
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mem = Mem::<F, D>::new();
         let root = plain_root(&mem, &hasher);
         let proof: Proof<F, D> = Proof::default();
@@ -1591,7 +1592,7 @@ mod tests {
     fn verify_element<F: Family>() {
         // Create an 11 element structure and test single-element inclusion proofs.
         let element = D::from(*b"01234567012345670123456701234567");
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
         let batch = {
             let mut batch = mem.new_batch();
@@ -1680,7 +1681,7 @@ mod tests {
 
     fn verify_range<F: Family>() {
         // Create a structure and add 49 elements.
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
         let elements: Vec<_> = (0..49).map(test_digest).collect();
         let batch = {
@@ -1795,7 +1796,7 @@ mod tests {
 
     fn retained_nodes_provable_after_pruning<F: Family>() {
         // Create a structure and add 49 elements.
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
         let elements: Vec<_> = (0..49).map(test_digest).collect();
         let batch = {
@@ -1833,7 +1834,7 @@ mod tests {
 
     fn ranges_provable_after_pruning<F: Family>() {
         // Create a structure and add 49 elements.
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
         let mut elements: Vec<_> = (0..49).map(test_digest).collect();
         let batch = {
@@ -1901,7 +1902,7 @@ mod tests {
 
     fn proof_serialization<F: Family>() {
         // Create a structure and add 25 elements.
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
         let elements: Vec<_> = (0..25).map(test_digest).collect();
         let batch = {
@@ -1968,7 +1969,7 @@ mod tests {
 
     fn multi_proof_generation_and_verify<F: Family>() {
         // Create a structure with 20 elements.
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
         let elements: Vec<_> = (0..20).map(test_digest).collect();
         let batch = {
@@ -2114,7 +2115,7 @@ mod tests {
         ));
 
         // Empty multi-proof.
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let empty_mem = Mem::<F, D>::new();
         let empty_root = plain_root(&empty_mem, &hasher);
         let empty_proof: Proof<F, D> = Proof::default();
@@ -2131,7 +2132,7 @@ mod tests {
     }
 
     fn multi_proof_deduplication<F: Family>() {
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
         let elements: Vec<_> = (0..30).map(test_digest).collect();
         let batch = {
@@ -2179,7 +2180,7 @@ mod tests {
     }
 
     fn proof_leaves_malleability<F: Family>() {
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mut mem = Mem::<F, D>::new();
 
         // 252 leaves. Leaf 240 sits in a peak preceded by prefix peaks.
@@ -2264,7 +2265,7 @@ mod tests {
 
     fn single_element_proof_reconstruction<F: Family>() {
         for n in 1u64..=64 {
-            let hasher = H::new();
+            let hasher = H::new(ForwardFold);
             let mem = build_raw::<F>(&hasher, n);
             let root = plain_root(&mem, &hasher);
 
@@ -2286,7 +2287,7 @@ mod tests {
 
     fn range_proof_reconstruction<F: Family>() {
         for n in 2u64..=32 {
-            let hasher = H::new();
+            let hasher = H::new(ForwardFold);
             let mem = build_raw::<F>(&hasher, n);
             let root = plain_root(&mem, &hasher);
 
@@ -2323,7 +2324,7 @@ mod tests {
 
     fn verify_element_inclusion<F: Family>() {
         for n in 1u64..=32 {
-            let hasher = H::new();
+            let hasher = H::new(ForwardFold);
             let mem = build_raw::<F>(&hasher, n);
             let root = plain_root(&mem, &hasher);
 
@@ -2352,7 +2353,7 @@ mod tests {
 
     fn full_range<F: Family>() {
         for n in 1u64..=32 {
-            let hasher = H::new();
+            let hasher = H::new(ForwardFold);
             let mem = build_raw::<F>(&hasher, n);
             let root = plain_root(&mem, &hasher);
 
@@ -2375,7 +2376,7 @@ mod tests {
     }
 
     fn empty_proof_verifies_empty_tree<F: Family>() {
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mem = Mem::<F, D>::new();
         let root = plain_root(&mem, &hasher);
         let proof = Proof::<F, D>::default();
@@ -2403,7 +2404,7 @@ mod tests {
 
     fn every_element_contributes_to_root<F: Family>() {
         for n in [8u64, 13, 20, 32] {
-            let hasher = H::new();
+            let hasher = H::new(ForwardFold);
             let mem = build_raw::<F>(&hasher, n);
             let root = plain_root(&mem, &hasher);
 
@@ -2433,7 +2434,7 @@ mod tests {
     }
 
     fn multi_proof_generation_and_verify_raw<F: Family>() {
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         let mem = build_raw::<F>(&hasher, 20);
         let root = plain_root(&mem, &hasher);
 
@@ -2497,7 +2498,7 @@ mod tests {
         ));
 
         // Empty multi-proof on empty tree.
-        let hasher2 = H::new();
+        let hasher2 = H::new(ForwardFold);
         let empty_mem = Mem::<F, D>::new();
         let empty_proof: Proof<F, D> = Proof::default();
         assert!(empty_proof.verify_multi_inclusion(
@@ -2521,7 +2522,7 @@ mod tests {
 
     fn tampered_proof_digests_rejected<F: Family>() {
         for n in [8u64, 13, 20, 32] {
-            let hasher = H::new();
+            let hasher = H::new(ForwardFold);
             let mem = build_raw::<F>(&hasher, n);
             let root = plain_root(&mem, &hasher);
 
@@ -2547,7 +2548,7 @@ mod tests {
     fn no_duplicate_positions<F: Family>() {
         use alloc::collections::BTreeSet;
         for n in 1u64..=64 {
-            let hasher = H::new();
+            let hasher = H::new(ForwardFold);
             let mem = build_raw::<F>(&hasher, n);
             let leaves = mem.leaves();
             for loc in 0..n {
@@ -2595,7 +2596,7 @@ mod tests {
             (2000, 500),
         ];
 
-        let hasher = H::new();
+        let hasher = H::new(ForwardFold);
         for &(n, start) in cases {
             let mem = build_raw::<F>(&hasher, n);
             let root = plain_root(&mem, &hasher);

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -1243,7 +1243,7 @@ mod tests {
         mem::Mem,
         mmb, mmr,
         proof::{nodes_required_for_multi_proof, Blueprint, Proof},
-        Bagging::ForwardFold,
+        Bagging::{BackwardFold, ForwardFold},
         Family, Location, LocationRangeExt as _,
     };
     use alloc::vec;
@@ -1292,7 +1292,7 @@ mod tests {
     }
 
     fn split_root<F: Family>(mem: &Mem<F, D>, inactive_peaks: usize) -> D {
-        let backward_hasher: H = Standard::backward();
+        let backward_hasher: H = Standard::new(BackwardFold);
         mem.root(&backward_hasher, inactive_peaks).unwrap()
     }
 
@@ -1435,7 +1435,7 @@ mod tests {
     }
 
     fn backward_fold_proof_optimization_inner(inactive_peaks: usize) {
-        let hasher: H = Standard::backward();
+        let hasher: H = Standard::new(BackwardFold);
         let mem = build_inactive_prefix::<mmb::Family>(&hasher, 123, inactive_peaks);
         let leaves = mem.leaves();
         let root = split_root(&mem, inactive_peaks);
@@ -1489,7 +1489,7 @@ mod tests {
 
     #[test]
     fn full_backward_root_proves_like_split_zero() {
-        let hasher: H = Standard::backward();
+        let hasher: H = Standard::new(BackwardFold);
         let mem = build_raw::<mmb::Family>(&hasher, 123);
         let range = Location::new(2)..Location::new(3);
 

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -847,6 +847,7 @@ impl<F: Family> Subtree<F> {
 /// # Errors
 ///
 /// See [`Blueprint::new`].
+#[cfg(feature = "std")]
 pub(crate) fn range_peaks<F: Family>(
     leaves: Location<F>,
     inactive_peaks: usize,

--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -399,7 +399,10 @@ pub async fn multi_proof<F: Family, D: Digest, S: Storage<F, Digest = D>>(
 mod tests {
     use super::*;
     use crate::{
-        merkle::{Bagging::ForwardFold, LocationRangeExt as _},
+        merkle::{
+            Bagging::{BackwardFold, ForwardFold},
+            LocationRangeExt as _,
+        },
         mmb::{mem::Mmb, Location as MmbLocation},
         mmr::{mem::Mmr, StandardHasher as Standard},
     };
@@ -587,7 +590,7 @@ mod tests {
                 batch.merkleize(&mmb, &hasher)
             };
             mmb.apply_batch(&batch).unwrap();
-            let hasher: Standard<Sha256> = Standard::backward();
+            let hasher: Standard<Sha256> = Standard::new(BackwardFold);
             let root = mmb.root(&hasher, inactive_peaks).unwrap();
 
             let range = MmbLocation::new(0)..MmbLocation::new(1);
@@ -645,7 +648,7 @@ mod tests {
             let total_leaves = *mmb.leaves();
             assert!(active_start > 0 && active_start < total_leaves);
 
-            let hasher: Standard<Sha256> = Standard::backward();
+            let hasher: Standard<Sha256> = Standard::new(BackwardFold);
             let root = mmb.root(&hasher, inactive_peaks).unwrap();
 
             let range = MmbLocation::new(active_start)..MmbLocation::new(total_leaves);
@@ -703,7 +706,7 @@ mod tests {
                 batch.merkleize(&mmb, &hasher)
             };
             mmb.apply_batch(&batch).unwrap();
-            let hasher: Standard<Sha256> = Standard::backward();
+            let hasher: Standard<Sha256> = Standard::new(BackwardFold);
             let inactive_peaks = 0usize;
             let root = mmb.root(&hasher, inactive_peaks).unwrap();
 

--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -399,7 +399,7 @@ pub async fn multi_proof<F: Family, D: Digest, S: Storage<F, Digest = D>>(
 mod tests {
     use super::*;
     use crate::{
-        merkle::LocationRangeExt as _,
+        merkle::{Bagging::ForwardFold, LocationRangeExt as _},
         mmb::{mem::Mmb, Location as MmbLocation},
         mmr::{mem::Mmr, StandardHasher as Standard},
     };
@@ -416,7 +416,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             // create a new MMR and add a non-trivial amount (49) of elements
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let mut mmr = Mmr::new();
             let elements: Vec<_> = (0..49).map(test_digest).collect();
             let batch = {
@@ -476,7 +476,7 @@ mod tests {
         executor.start(|_| async move {
             // Build MMR with 49 elements. Peaks cover locations 0-31, 32-47, 48.
             // A proof starting at location 32 puts the first peak entirely in the fold prefix.
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let mut mmr = Mmr::new();
             let elements: Vec<_> = (0..49).map(test_digest).collect();
             let batch = {
@@ -526,7 +526,7 @@ mod tests {
     fn test_verification_proof_store_with_fold_prefix_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let mut mmb = Mmb::new();
             let elements: Vec<_> = (0..8).map(test_digest).collect();
             let batch = {
@@ -575,7 +575,7 @@ mod tests {
     fn test_verification_proof_store_with_backward_fold_suffix_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let inactive_peaks = 0;
             let mut mmb = Mmb::new();
             let elements: Vec<_> = (0..123).map(test_digest).collect();
@@ -624,7 +624,7 @@ mod tests {
     fn test_verification_proof_store_with_backward_fold_inactive_prefix_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let mut mmb = Mmb::new();
             let elements: Vec<_> = (0..123).map(test_digest).collect();
             let batch = {
@@ -692,7 +692,7 @@ mod tests {
     fn test_verification_proof_store_multi_proof_backward_fold_suffix_peaks() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
-            let hasher: Standard<Sha256> = Standard::new();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let mut mmb = Mmb::new();
             let elements: Vec<_> = (0..123).map(test_digest).collect();
             let batch = {

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -79,9 +79,6 @@ pub struct Db<
     /// Cached operations root for this database.
     pub(crate) root: H::Digest,
 
-    /// Whether the operations root uses inactive-prefix split semantics.
-    pub(crate) split_root: bool,
-
     /// A location before which all operations are "inactive" (that is, operations before this point
     /// are over keys that have been updated by some operation at or after this point).
     pub(crate) inactivity_floor_loc: Location<F>,
@@ -161,16 +158,11 @@ where
     }
 
     /// Return the inactive_peaks count for the given leaf count and inactivity floor.
-    ///
-    /// Returns 0 when `split_root` is false (the boundary is not committed in that case).
     pub(crate) fn inactive_peaks(
         &self,
         leaves: Location<F>,
         inactivity_floor: Location<F>,
     ) -> usize {
-        if !self.split_root {
-            return 0;
-        }
         F::inactive_peaks(F::location_to_position(leaves), inactivity_floor)
     }
 
@@ -338,17 +330,14 @@ where
     ///
     /// # Contract
     ///
-    /// In split-root mode, `historical_size` must be a commit-boundary size: the operation at
-    /// `historical_size - 1` must itself be a commit op declaring the governing inactivity floor.
-    /// In plain-root mode, historical proof roots do not depend on the floor and any retained
-    /// `historical_size` works.
+    /// `historical_size` must be a commit-boundary size: the operation at `historical_size - 1`
+    /// must itself be a commit op declaring the governing inactivity floor.
     ///
     /// # Errors
     ///
-    /// Returns [`crate::qmdb::Error::HistoricalFloorPruned`] in split-root mode if
-    /// `historical_size - 1` is retained but is not a commit op, either because the caller
-    /// passed a non-commit-boundary size or because pruning removed the commit that would
-    /// have governed it.
+    /// Returns [`crate::qmdb::Error::HistoricalFloorPruned`] if `historical_size - 1` is retained
+    /// but is not a commit op, either because the caller passed a non-commit-boundary size or
+    /// because pruning removed the commit that would have governed it.
     pub async fn historical_proof(
         &self,
         historical_size: Location<F>,
@@ -361,14 +350,12 @@ where
             ));
         }
 
-        let inactivity_floor = if self.split_root {
+        let inactivity_floor = {
             let reader = self.log.reader().await;
             crate::qmdb::find_inactivity_floor_at::<F, _>(&reader, historical_size, |op| {
                 op.has_floor()
             })
             .await?
-        } else {
-            Location::new(0)
         };
         let inactive_peaks = self.inactive_peaks(historical_size, inactivity_floor);
         self.log
@@ -579,7 +566,6 @@ where
         mut index: I,
         log: AuthenticatedLog<F, E, C, H, S>,
         shared_bitmap: Option<Arc<Shared<N>>>,
-        split_root: bool,
     ) -> Result<Self, crate::qmdb::Error<F>> {
         let (last_commit_loc, inactivity_floor_loc, active_keys, bitmap) = {
             let reader = log.reader().await;
@@ -658,20 +644,15 @@ where
             ));
         }
 
-        let inactive_peaks = if split_root {
-            F::inactive_peaks(
-                F::location_to_position(log.merkle.leaves()),
-                inactivity_floor_loc,
-            )
-        } else {
-            0
-        };
+        let inactive_peaks = F::inactive_peaks(
+            F::location_to_position(log.merkle.leaves()),
+            inactivity_floor_loc,
+        );
         let root = log.root(inactive_peaks)?;
 
         Ok(Self {
             log,
             root,
-            split_root,
             inactivity_floor_loc,
             snapshot: index,
             last_commit_loc,

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -570,10 +570,19 @@ where
         let (last_commit_loc, inactivity_floor_loc, active_keys, bitmap) = {
             let reader = log.reader().await;
             let bounds = reader.bounds();
-            let last_commit_loc = bounds.end.checked_sub(1).expect("commit should exist");
-            let last_commit = reader.read(last_commit_loc).await?;
-            let inactivity_floor_loc = last_commit.has_floor().expect("should be a commit");
-            if *inactivity_floor_loc > last_commit_loc {
+            let last_commit_loc = Location::new(
+                bounds
+                    .end
+                    .checked_sub(1)
+                    .ok_or(Error::HistoricalFloorPruned(Location::new(bounds.end)))?,
+            );
+            let inactivity_floor_loc = crate::qmdb::find_inactivity_floor_at::<F, _>(
+                &reader,
+                Location::new(bounds.end),
+                |op| op.has_floor(),
+            )
+            .await?;
+            if inactivity_floor_loc > last_commit_loc {
                 return Err(crate::qmdb::Error::DataCorrupted(
                     "inactivity floor exceeds last commit",
                 ));
@@ -629,12 +638,7 @@ where
             // last_commit_loc)` for each CommitFloor op, so the per-op push above already
             // encodes this.
 
-            (
-                Location::new(last_commit_loc),
-                inactivity_floor_loc,
-                active_keys,
-                bitmap,
-            )
+            (last_commit_loc, inactivity_floor_loc, active_keys, bitmap)
         };
 
         // The bitmap must have exactly one bit per retained log location.

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -582,11 +582,6 @@ where
                 |op| op.has_floor(),
             )
             .await?;
-            if inactivity_floor_loc > last_commit_loc {
-                return Err(crate::qmdb::Error::DataCorrupted(
-                    "inactivity floor exceeds last commit",
-                ));
-            }
 
             // Seed the bitmap so its pruned prefix matches the retained log boundary. Bits in
             // [pruned_bits, bounds.start) correspond to pruned operations and remain 0; replay

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -117,8 +117,6 @@ pub type FixedConfig<T, S = Sequential> = Config<T, FConfig, S>;
 pub type VariableConfig<T, C, S = Sequential> = Config<T, VConfig<C>, S>;
 
 /// Initialize an `Any` authenticated db from the given config.
-///
-/// The operations root uses split-root mode with backward-fold active bagging.
 pub async fn init<F, E, U, H, T, I, J, S>(
     context: E,
     cfg: Config<T, J::Config, S>,
@@ -134,29 +132,15 @@ where
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
 {
-    init_with_bitmap::<F, E, U, H, T, I, J, S, BITMAP_CHUNK_BYTES>(
-        context,
-        cfg,
-        None,
-        true,
-        Bagging::BackwardFold,
-    )
-    .await
+    init_with_bitmap::<F, E, U, H, T, I, J, S, BITMAP_CHUNK_BYTES>(context, cfg, None).await
 }
 
 /// Like [`init`] but accepts a pre-allocated bitmap (used by `current::Db`, which sizes pruned
 /// chunks from grafted metadata). `bitmap = None` allocates internally.
-///
-/// `split_root` selects whether the operations root commits to the inactive-prefix split, and
-/// `ops_root_bagging` selects its bagging policy. Public `Any` initialization uses split roots
-/// with backward-fold active bagging; `current::Db` passes a plain `ForwardFold` operations root
-/// because activity is committed through the grafted root instead.
 pub(crate) async fn init_with_bitmap<F, E, U, H, T, I, J, S, const N: usize>(
     context: E,
     cfg: Config<T, J::Config, S>,
     bitmap: Option<Arc<Shared<N>>>,
-    split_root: bool,
-    ops_root_bagging: Bagging,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where
     F: Family,
@@ -174,7 +158,7 @@ where
         cfg.merkle_config,
         cfg.journal_config,
         Operation::is_commit,
-        ops_root_bagging,
+        Bagging::BackwardFold,
     )
     .await?;
 
@@ -186,7 +170,7 @@ where
     }
 
     let index = I::new(context.with_label("index"), cfg.translator);
-    db::Db::init_from_log(index, log, bitmap, split_root).await
+    db::Db::init_from_log(index, log, bitmap).await
 }
 
 #[cfg(test)]

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -179,7 +179,10 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
-        qmdb::any::{FixedConfig, MerkleConfig, VariableConfig},
+        qmdb::{
+            self,
+            any::{FixedConfig, MerkleConfig, VariableConfig},
+        },
         translator::OneCap,
     };
     use commonware_codec::{Codec, CodecShared};
@@ -258,7 +261,7 @@ pub(crate) mod test {
     use crate::{
         index::Unordered as UnorderedIndex,
         journal::contiguous::Mutable,
-        merkle::{self, mmr},
+        merkle::mmr,
         qmdb::any::{
             db::Db as AnyDb,
             operation::{update::Update as UpdateTrait, Operation as AnyOperation},
@@ -627,7 +630,7 @@ pub(crate) mod test {
         V: CodecShared + Clone + Eq + std::hash::Hash + std::fmt::Debug,
         <D as Provable<mmr::Family>>::Operation: Codec,
     {
-        use crate::{mmr::StandardHasher, qmdb::verify_proof};
+        use crate::qmdb::verify_proof;
 
         const ELEMENTS: u64 = 1000;
 
@@ -689,7 +692,7 @@ pub(crate) mod test {
             }
         }
 
-        let hasher = StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
         let bounds = db.bounds().await;
         let inactivity_floor = db.inactivity_floor_loc().await;
         for loc in *inactivity_floor..*bounds.end {
@@ -749,7 +752,7 @@ pub(crate) mod test {
         D: DbAny<mmr::Family, Key = Digest, Value = V, Digest = Digest> + Provable<mmr::Family>,
         <D as Provable<mmr::Family>>::Operation: Codec + PartialEq + std::fmt::Debug,
     {
-        use crate::{mmr::StandardHasher, qmdb::verify_proof};
+        use crate::qmdb::verify_proof;
         use commonware_utils::NZU64;
 
         // Add some operations
@@ -779,7 +782,7 @@ pub(crate) mod test {
         assert_eq!(historical_proof.leaves, regular_proof.leaves);
         assert_eq!(historical_proof.digests, regular_proof.digests);
         assert_eq!(historical_ops, regular_ops);
-        let hasher = StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
         assert!(verify_proof(
             &hasher,
             &historical_proof,
@@ -828,7 +831,7 @@ pub(crate) mod test {
         D: DbAny<mmr::Family, Key = Digest, Value = V, Digest = Digest> + Provable<mmr::Family>,
         <D as Provable<mmr::Family>>::Operation: Codec + PartialEq + std::fmt::Debug + Clone,
     {
-        use crate::{mmr::StandardHasher, qmdb::verify_proof};
+        use crate::qmdb::verify_proof;
         use commonware_utils::NZU64;
 
         // Apply two single-write batches and capture the commit-boundary size after the
@@ -858,7 +861,7 @@ pub(crate) mod test {
         assert_eq!(proof.leaves, historical_op_count);
         assert_eq!(ops.len(), expected_ops_len);
 
-        let hasher = StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
 
         // Changing the proof digests should cause verification to fail
         {

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -69,11 +69,12 @@ use crate::{
         authenticated::Inner,
         contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     },
-    merkle::{full::Config as MerkleConfig, Bagging, Family, Location},
+    merkle::{full::Config as MerkleConfig, Family, Location},
     qmdb::{
         any::operation::{Operation, Update},
         bitmap::Shared,
         operation::Committable,
+        ROOT_BAGGING,
     },
     translator::Translator,
     Context,
@@ -158,7 +159,7 @@ where
         cfg.merkle_config,
         cfg.journal_config,
         Operation::is_commit,
-        Bagging::BackwardFold,
+        ROOT_BAGGING,
     )
     .await?;
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -126,11 +126,11 @@ pub(crate) mod test {
     use crate::{
         index::Unordered as _,
         merkle::{
-            self,
-            mmr::{self, Location, StandardHasher as Standard},
+            mmr::{self, Location},
             Location as GenericLocation,
         },
         qmdb::{
+            self,
             any::{
                 ordered::{
                     test::{
@@ -367,7 +367,7 @@ pub(crate) mod test {
         // confirm that the end state of the db matches that of an identically updated hashmap.
         const ELEMENTS: u64 = 1000;
         executor.start(|context| async move {
-            let hasher = Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let mut db = open_db(context.with_label("first")).await;
 
             let mut map = HashMap::<Digest, Digest>::default();
@@ -676,7 +676,7 @@ pub(crate) mod test {
             let mut db = create_test_db(context.clone()).await;
             let ops = create_test_ops(20);
             apply_ops(&mut db, ops.clone()).await;
-            let hasher = Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let root_hash = db.root();
             let original_op_count = db.bounds().await.end;
 
@@ -730,7 +730,7 @@ pub(crate) mod test {
     fn test_ordered_any_fixed_db_historical_proof_edge_cases() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
 
             let mut db = create_test_db(context.with_label("first")).await;
             // Apply ops in multiple batches; each apply_ops ends in a commit, so the size
@@ -801,7 +801,7 @@ pub(crate) mod test {
             let ops = create_test_ops(100);
             apply_ops(&mut db, ops.clone()).await;
 
-            let hasher = Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let root = db.root();
 
             let start_loc = Location::new(20);

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -2,8 +2,7 @@
 //! Contains implementation of [crate::qmdb::sync::Database] for all [Db] variants
 //! (ordered/unordered, fixed/variable).
 //!
-//! Callers verifying `any` sync proofs directly should use the same Merkle hasher configuration as
-//! the sync engine.
+//! Callers verifying `any` sync proofs directly should use `qmdb::hasher`.
 
 use crate::{
     index::Factory as IndexFactory,
@@ -11,7 +10,7 @@ use crate::{
         authenticated,
         contiguous::{fixed, variable, Mutable, Reader as _},
     },
-    merkle::{self, full, hasher::Standard as StandardHasher, Location},
+    merkle::{self, full, Location},
     qmdb::{
         self,
         any::{
@@ -64,7 +63,6 @@ pub async fn has_local_target_state<F, E, H, S>(
     merkle_config: full::Config<S>,
     target: &qmdb::sync::Target<F, H::Digest>,
     inactive_peaks: usize,
-    bagging: merkle::Bagging,
 ) -> bool
 where
     F: merkle::Family,
@@ -72,7 +70,7 @@ where
     H: Hasher,
     S: Strategy,
 {
-    let hasher = StandardHasher::<H>::with_bagging(bagging);
+    let hasher = qmdb::hasher::<H>();
     let peek = full::Merkle::<F, _, _, S>::peek_root(
         context.with_label("local_target_probe"),
         merkle_config,
@@ -111,7 +109,7 @@ where
     S: Strategy,
     Operation<F, U>: Codec + Committable + CodecShared,
 {
-    let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+    let hasher = qmdb::hasher::<H>();
 
     let merkle = full::Merkle::<F, _, _, S>::init_sync(
         context.with_label("merkle"),
@@ -209,7 +207,6 @@ macro_rules! impl_sync_database {
                     config.merkle_config.clone(),
                     target,
                     inactive_peaks,
-                    merkle::Bagging::BackwardFold,
                 )
                 .await
             }

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -129,7 +129,7 @@ where
         apply_batch_size as u64,
     )
     .await?;
-    let db = Db::init_from_log(index, log, None, true).await?;
+    let db = Db::init_from_log(index, log, None).await?;
 
     Ok(db)
 }
@@ -158,7 +158,6 @@ macro_rules! impl_sync_database {
             type Config = $config;
             type Digest = H::Digest;
 
-            const ROOT_BAGGING: merkle::Bagging = merkle::Bagging::BackwardFold;
 
             async fn from_sync_result(
                 context: Self::Context,

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -158,7 +158,6 @@ macro_rules! impl_sync_database {
             type Config = $config;
             type Digest = H::Digest;
 
-
             async fn from_sync_result(
                 context: Self::Context,
                 config: Self::Config,

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -1,12 +1,15 @@
 //! Shared synchronization logic for [crate::qmdb::any] databases.
 //! Contains implementation of [crate::qmdb::sync::Database] for all [Db] variants
 //! (ordered/unordered, fixed/variable).
+//!
+//! Callers verifying `any` sync proofs directly should use the same Merkle hasher configuration as
+//! the sync engine.
 
 use crate::{
     index::Factory as IndexFactory,
     journal::{
         authenticated,
-        contiguous::{fixed, variable, Mutable},
+        contiguous::{fixed, variable, Mutable, Reader as _},
     },
     merkle::{self, full, hasher::Standard as StandardHasher, Location},
     qmdb::{
@@ -185,12 +188,24 @@ macro_rules! impl_sync_database {
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Family, Self::Digest>,
             ) -> bool {
+                let Ok(journal) = <$journal>::init(
+                    context.with_label("local_target_journal_probe"),
+                    config.journal_config.clone(),
+                )
+                .await
+                else {
+                    return false;
+                };
+                if Location::new(journal.reader().await.bounds().start) > target.range.start() {
+                    return false;
+                }
+
                 let inactive_peaks = F::inactive_peaks(
                     F::location_to_position(target.range.end()),
                     target.range.start(),
                 );
                 qmdb::any::sync::has_local_target_state::<F, _, H, S>(
-                    context,
+                    context.with_label("local_target_merkle_probe"),
                     config.merkle_config.clone(),
                     target,
                     inactive_peaks,

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -123,11 +123,11 @@ pub(crate) mod test {
     use crate::{
         index::Unordered as _,
         merkle::{
-            self,
-            mmr::{self, Location, StandardHasher},
+            mmr::{self, Location},
             Location as GenericLocation,
         },
         qmdb::{
+            self,
             any::{
                 test::fixed_db_config,
                 unordered::{fixed::Operation, Update},
@@ -592,7 +592,7 @@ pub(crate) mod test {
             assert_eq!(historical_proof.leaves, regular_proof.leaves);
             assert_eq!(historical_proof.digests, regular_proof.digests);
             assert_eq!(historical_ops, regular_ops);
-            let hasher = StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             assert!(verify_proof(
                 &hasher,
                 &historical_proof,
@@ -640,7 +640,7 @@ pub(crate) mod test {
     fn test_any_fixed_db_historical_proof_edge_cases() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
 
             let mut db = create_test_db(context.with_label("first")).await;
             // Apply ops in multiple batches; each apply_ops ends in a commit, so the size
@@ -708,7 +708,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ops = create_test_ops(100);
-            let hasher = StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let start_loc = Location::new(2);
             let max_ops = NZU64!(10);
 

--- a/storage/src/qmdb/compact_witness.rs
+++ b/storage/src/qmdb/compact_witness.rs
@@ -23,9 +23,9 @@
 //!    its proof on every serve.
 
 use crate::{
-    merkle::{self, compact, Family, Location, Proof},
+    merkle::{compact, Family, Location, Proof},
     metadata::Metadata,
-    qmdb::{sync::compact::Target, Error},
+    qmdb::{self, sync::compact::Target, Error},
     Context,
 };
 use commonware_codec::{Decode as _, Encode as _, FixedSize};
@@ -236,7 +236,7 @@ where
 
     let inactive_peaks =
         F::inactive_peaks(F::location_to_position(leaf_count), inactivity_floor_loc);
-    let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+    let hasher = qmdb::hasher::<H>();
     let root = merkle
         .root(&hasher, inactive_peaks)
         .map_err(|_| Error::DataCorrupted("failed to compute compact witness root"))?;
@@ -279,7 +279,7 @@ where
     H: Hasher,
     S: Strategy,
 {
-    let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+    let hasher = qmdb::hasher::<H>();
     let batch = {
         let batch = merkle.new_batch().add(&hasher, &commit_op_bytes);
         merkle.with_mem(|mem| batch.merkleize(mem, &hasher))
@@ -360,7 +360,7 @@ where
     H: Hasher,
     S: Strategy,
 {
-    let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+    let hasher = qmdb::hasher::<H>();
     let last_commit_loc = source.last_commit_loc();
     let inactivity_floor_loc = source.inactivity_floor_loc();
     let commit_op_bytes = source.encode_current_commit_op();

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -7,7 +7,8 @@ use crate::{
     journal::contiguous::{Contiguous, Mutable},
     merkle::{
         self, batch::MerkleizedBatch as GenericMerkleizedBatch, hasher::Standard as StandardHasher,
-        mem::Mem, storage::Storage as MerkleStorage, Graftable, Location, Position, Readable,
+        mem::Mem, storage::Storage as MerkleStorage, Bagging, Graftable, Location, Position,
+        Readable,
     },
     qmdb::{
         any::{
@@ -609,7 +610,7 @@ where
         (idx, chunk)
     });
 
-    let hasher = StandardHasher::<H>::new();
+    let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
     let new_leaves = compute_grafted_leaves::<F, H, S, N>(
         &hasher,
         &ops_tree_adapter,
@@ -669,6 +670,7 @@ where
         &bitmap_batch,
         &grafted_storage,
         partial,
+        inner.new_inactivity_floor_loc,
         &ops_root,
     )
     .await?;
@@ -937,12 +939,12 @@ mod trait_impls {
             Self::write(self, key, value)
         }
 
-        fn merkleize(
+        async fn merkleize(
             self,
             db: &CurrentDb<F, E, C, I, H, update::Unordered<K, V>, N, S>,
             metadata: Option<V::Value>,
-        ) -> impl Future<Output = Result<Self::Merkleized, crate::qmdb::Error<F>>> {
-            self.merkleize(db, metadata)
+        ) -> Result<Self::Merkleized, crate::qmdb::Error<F>> {
+            Self::merkleize(self, db, metadata).await
         }
     }
 
@@ -971,12 +973,12 @@ mod trait_impls {
             Self::write(self, key, value)
         }
 
-        fn merkleize(
+        async fn merkleize(
             self,
             db: &CurrentDb<F, E, C, I, H, update::Ordered<K, V>, N, S>,
             metadata: Option<V::Value>,
-        ) -> impl Future<Output = Result<Self::Merkleized, crate::qmdb::Error<F>>> {
-            self.merkleize(db, metadata)
+        ) -> Result<Self::Merkleized, crate::qmdb::Error<F>> {
+            Self::merkleize(self, db, metadata).await
         }
     }
 
@@ -1018,7 +1020,7 @@ mod trait_impls {
         type Batch = UnmerkleizedBatch<F, H, update::Unordered<K, V>, N, S>;
 
         fn new_batch(&self) -> Self::Batch {
-            self.new_batch()
+            Self::new_batch(self)
         }
 
         fn apply_batch(
@@ -1026,7 +1028,7 @@ mod trait_impls {
             batch: Self::Merkleized,
         ) -> impl Future<Output = Result<core::ops::Range<Location<F>>, crate::qmdb::Error<F>>>
         {
-            self.apply_batch(batch)
+            Self::apply_batch(self, batch)
         }
     }
 
@@ -1051,7 +1053,7 @@ mod trait_impls {
         type Batch = UnmerkleizedBatch<F, H, update::Ordered<K, V>, N, S>;
 
         fn new_batch(&self) -> Self::Batch {
-            self.new_batch()
+            Self::new_batch(self)
         }
 
         fn apply_batch(
@@ -1059,7 +1061,7 @@ mod trait_impls {
             batch: Self::Merkleized,
         ) -> impl Future<Output = Result<core::ops::Range<Location<F>>, crate::qmdb::Error<F>>>
         {
-            self.apply_batch(batch)
+            Self::apply_batch(self, batch)
         }
     }
 }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -6,11 +6,11 @@ use crate::{
     index::Unordered as UnorderedIndex,
     journal::contiguous::{Contiguous, Mutable},
     merkle::{
-        self, batch::MerkleizedBatch as GenericMerkleizedBatch, hasher::Standard as StandardHasher,
-        mem::Mem, storage::Storage as MerkleStorage, Bagging, Graftable, Location, Position,
-        Readable,
+        self, batch::MerkleizedBatch as GenericMerkleizedBatch, mem::Mem,
+        storage::Storage as MerkleStorage, Graftable, Location, Position, Readable,
     },
     qmdb::{
+        self,
         any::{
             self,
             batch::{lookup_sorted, DiffEntry},
@@ -610,7 +610,7 @@ where
         (idx, chunk)
     });
 
-    let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
+    let hasher = qmdb::hasher::<H>();
     let new_leaves = compute_grafted_leaves::<F, H, S, N>(
         &hasher,
         &ops_tree_adapter,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -944,7 +944,7 @@ mod trait_impls {
             db: &CurrentDb<F, E, C, I, H, update::Unordered<K, V>, N, S>,
             metadata: Option<V::Value>,
         ) -> Result<Self::Merkleized, crate::qmdb::Error<F>> {
-            Self::merkleize(self, db, metadata).await
+            self.merkleize(db, metadata).await
         }
     }
 
@@ -978,7 +978,7 @@ mod trait_impls {
             db: &CurrentDb<F, E, C, I, H, update::Ordered<K, V>, N, S>,
             metadata: Option<V::Value>,
         ) -> Result<Self::Merkleized, crate::qmdb::Error<F>> {
-            Self::merkleize(self, db, metadata).await
+            self.merkleize(db, metadata).await
         }
     }
 
@@ -1020,7 +1020,7 @@ mod trait_impls {
         type Batch = UnmerkleizedBatch<F, H, update::Unordered<K, V>, N, S>;
 
         fn new_batch(&self) -> Self::Batch {
-            Self::new_batch(self)
+            self.new_batch()
         }
 
         fn apply_batch(
@@ -1028,7 +1028,7 @@ mod trait_impls {
             batch: Self::Merkleized,
         ) -> impl Future<Output = Result<core::ops::Range<Location<F>>, crate::qmdb::Error<F>>>
         {
-            Self::apply_batch(self, batch)
+            self.apply_batch(batch)
         }
     }
 
@@ -1053,7 +1053,7 @@ mod trait_impls {
         type Batch = UnmerkleizedBatch<F, H, update::Ordered<K, V>, N, S>;
 
         fn new_batch(&self) -> Self::Batch {
-            Self::new_batch(self)
+            self.new_batch()
         }
 
         fn apply_batch(
@@ -1061,7 +1061,7 @@ mod trait_impls {
             batch: Self::Merkleized,
         ) -> impl Future<Output = Result<core::ops::Range<Location<F>>, crate::qmdb::Error<F>>>
         {
-            Self::apply_batch(self, batch)
+            self.apply_batch(batch)
         }
     }
 }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -291,7 +291,7 @@ where
     ///
     /// Unlike [`range_proof`](Self::range_proof) which returns grafted proofs incorporating the
     /// activity bitmap, this returns ops-tree Merkle proofs suitable for state sync. Direct
-    /// verifiers should use the same Merkle hasher configuration as QMDB sync.
+    /// verifiers should use [`crate::qmdb::hasher`].
     pub async fn ops_historical_proof(
         &self,
         historical_size: Location<F>,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     merkle::{
         self, hasher::Standard as StandardHasher, mem::Mem, storage::Storage as MerkleStorage,
-        Location, Position,
+        Bagging, Location, Position,
     },
     metadata::{Config as MConfig, Metadata},
     qmdb::{
@@ -153,7 +153,7 @@ where
             &self.grafted_tree,
             grafting::height::<N>(),
             &self.any.log.merkle,
-            StandardHasher::<H>::new(),
+            StandardHasher::<H>::with_bagging(Bagging::BackwardFold),
         )
     }
 
@@ -187,9 +187,13 @@ where
         hasher: &mut StandardHasher<H>,
     ) -> Result<OpsRootWitness<H::Digest>, Error<F>> {
         let storage = self.grafted_storage();
-        let grafted_root =
-            compute_grafted_root::<F, H, _, _, N>(hasher, self.any.bitmap.as_ref(), &storage)
-                .await?;
+        let grafted_root = compute_grafted_root::<F, H, _, _, N>(
+            hasher,
+            self.any.bitmap.as_ref(),
+            &storage,
+            self.any.inactivity_floor_loc,
+        )
+        .await?;
         let partial_chunk = partial_chunk::<_, N>(self.any.bitmap.as_ref())
             .map(|(chunk, next_bit)| (next_bit, hasher.digest(&chunk)));
         Ok(OpsRootWitness {
@@ -223,7 +227,15 @@ where
     ) -> Result<OperationProof<F, H::Digest, N>, Error<F>> {
         let storage = self.grafted_storage();
         let ops_root = self.any.root();
-        OperationProof::new(hasher, self.any.bitmap.as_ref(), &storage, loc, ops_root).await
+        OperationProof::new(
+            hasher,
+            self.any.bitmap.as_ref(),
+            &storage,
+            self.any.inactivity_floor_loc,
+            loc,
+            ops_root,
+        )
+        .await
     }
 
     /// Returns a proof that the specified range of operations are part of the database, along with
@@ -249,6 +261,7 @@ where
             hasher,
             self.any.bitmap.as_ref(),
             &storage,
+            self.any.inactivity_floor_loc,
             &self.any.log,
             start_loc,
             max_ops,
@@ -544,7 +557,7 @@ where
         // the caller; reads through them now return inconsistent data.
         self.any.rewind(size).await?;
 
-        let hasher = StandardHasher::<H>::new();
+        let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
         let grafted_tree = build_grafted_tree::<F, H, S, N>(
             &hasher,
             self.any.bitmap.as_ref(),
@@ -566,6 +579,7 @@ where
             self.any.bitmap.as_ref(),
             &storage,
             partial_chunk,
+            self.any.inactivity_floor_loc,
             &ops_root,
         )
         .await?;
@@ -746,9 +760,10 @@ pub(super) async fn compute_db_root<
     status: &B,
     storage: &S,
     partial_chunk: Option<([u8; N], u64)>,
+    inactivity_floor: Location<F>,
     ops_root: &H::Digest,
 ) -> Result<H::Digest, Error<F>> {
-    let grafted_root = compute_grafted_root(hasher, status, storage).await?;
+    let grafted_root = compute_grafted_root(hasher, status, storage, inactivity_floor).await?;
     let partial = partial_chunk.map(|(chunk, next_bit)| {
         let digest = hasher.digest(&chunk);
         (next_bit, digest)
@@ -767,9 +782,9 @@ pub(super) async fn compute_db_root<
 /// grafting over MMB (Merkle Mountain Belt) structures. In an MMB, the trailing operations at the
 /// right edge of the structure might not be numerous enough to form a complete subtree at the
 /// grafting height. Therefore, a single bitmap chunk may span across multiple smaller ops peaks.
-/// `grafting::grafted_root` intercepts the folding process to group these sub-grafting-height
-/// peaks, hash them together with their corresponding bitmap chunks, and then complete the final
-/// fold. For MMR, this produces the exact same result as `hasher.root()`.
+/// `grafting::grafted_root` intercepts the folding process to group these sub-grafting-height peaks,
+/// hash them together with their corresponding bitmap chunks, and then complete the final fold using
+/// the QMDB root spec. For MMR, this produces the exact same result as `hasher.root()`.
 pub(super) async fn compute_grafted_root<
     F: merkle::Graftable,
     H: Hasher,
@@ -780,6 +795,7 @@ pub(super) async fn compute_grafted_root<
     hasher: &StandardHasher<H>,
     status: &B,
     storage: &S,
+    inactivity_floor: Location<F>,
 ) -> Result<H::Digest, Error<F>> {
     let size = storage.size().await;
     let leaves = Location::try_from(size)?;
@@ -798,9 +814,13 @@ pub(super) async fn compute_grafted_root<
     let complete_chunks = status.complete_chunks() as u64;
     let pruned_chunks = status.pruned_chunks() as u64;
 
+    let inactive_peaks =
+        grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting_height)?;
+
     Ok(grafting::grafted_root(
         hasher,
         leaves,
+        inactive_peaks,
         &peaks,
         grafting_height,
         |chunk_idx| {
@@ -817,7 +837,7 @@ pub(super) async fn compute_grafted_root<
                 None
             }
         },
-    ))
+    )?)
 }
 
 /// Compute grafted leaf digests for the given bitmap chunks as `(chunk_idx, digest)` pairs.
@@ -1138,7 +1158,7 @@ mod tests {
                 next_idx += 1;
             }
 
-            let mut hasher = StandardHasher::<Sha256>::new();
+            let mut hasher = StandardHasher::<Sha256>::with_bagging(Bagging::BackwardFold);
             let witness = db.ops_root_witness(&mut hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
@@ -1170,7 +1190,8 @@ mod tests {
             .unwrap();
             populate_fixed_db::<mmb::Family, _>(&mut db, 0, 260).await;
 
-            let mut hasher = StandardHasher::<Sha256>::new();
+            let mut hasher =
+                StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
             let witness = db.ops_root_witness(&mut hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
@@ -1219,7 +1240,7 @@ mod tests {
                 "test requires at least one pruned chunk to exercise the zero-chunk path"
             );
 
-            let mut hasher = StandardHasher::<Sha256>::new();
+            let mut hasher = StandardHasher::<Sha256>::with_bagging(Bagging::BackwardFold);
             let witness = db.ops_root_witness(&mut hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
@@ -1246,7 +1267,7 @@ mod tests {
             .await
             .unwrap();
 
-            let mut hasher = StandardHasher::<Sha256>::new();
+            let mut hasher = StandardHasher::<Sha256>::with_bagging(Bagging::BackwardFold);
             let witness = db.ops_root_witness(&mut hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1029,7 +1029,7 @@ pub(super) async fn init_metadata<F: merkle::Graftable, E: Context, D: Digest>(
 mod tests {
     use super::*;
     use crate::{
-        merkle::{mmb, mmr},
+        merkle::{mmb, mmr, Bagging::ForwardFold},
         qmdb::{
             any::traits::{DbAny, UnmerkleizedBatch as _},
             current::{tests::fixed_config, unordered::fixed},
@@ -1079,7 +1079,7 @@ mod tests {
 
     #[test]
     fn combine_roots_deterministic() {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let ops = Sha256::hash(b"ops");
         let grafted = Sha256::hash(b"grafted");
         let r1 = combine_roots(&hasher, &ops, &grafted, None);
@@ -1089,7 +1089,7 @@ mod tests {
 
     #[test]
     fn combine_roots_with_partial_differs() {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let ops = Sha256::hash(b"ops");
         let grafted = Sha256::hash(b"grafted");
         let partial_digest = Sha256::hash(b"partial");
@@ -1101,7 +1101,7 @@ mod tests {
 
     #[test]
     fn combine_roots_different_ops_root() {
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let ops_a = Sha256::hash(b"ops_a");
         let ops_b = Sha256::hash(b"ops_b");
         let grafted = Sha256::hash(b"grafted");

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -784,7 +784,8 @@ pub(super) async fn compute_db_root<
 /// grafting height. Therefore, a single bitmap chunk may span across multiple smaller ops peaks.
 /// `grafting::grafted_root` intercepts the folding process to group these sub-grafting-height peaks,
 /// hash them together with their corresponding bitmap chunks, and then complete the final fold using
-/// the QMDB root spec. For MMR, this produces the exact same result as `hasher.root()`.
+/// the hasher's peak-bagging policy. For MMR, each complete chunk already appears as a single
+/// grafted peak, so no extra peak regrouping is needed.
 pub(super) async fn compute_grafted_root<
     F: merkle::Graftable,
     H: Hasher,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -10,10 +10,11 @@ use crate::{
     },
     merkle::{
         self, hasher::Standard as StandardHasher, mem::Mem, storage::Storage as MerkleStorage,
-        Bagging, Location, Position,
+        Location, Position,
     },
     metadata::{Config as MConfig, Metadata},
     qmdb::{
+        self,
         any::{
             self,
             operation::{update::Update, Operation},
@@ -153,7 +154,7 @@ where
             &self.grafted_tree,
             grafting::height::<N>(),
             &self.any.log.merkle,
-            StandardHasher::<H>::with_bagging(Bagging::BackwardFold),
+            qmdb::hasher::<H>(),
         )
     }
 
@@ -290,8 +291,7 @@ where
     ///
     /// Unlike [`range_proof`](Self::range_proof) which returns grafted proofs incorporating the
     /// activity bitmap, this returns ops-tree Merkle proofs suitable for state sync. Direct
-    /// verifiers should use the same Merkle hasher configuration as QMDB sync:
-    /// [`Bagging::BackwardFold`].
+    /// verifiers should use the same Merkle hasher configuration as QMDB sync.
     pub async fn ops_historical_proof(
         &self,
         historical_size: Location<F>,
@@ -562,7 +562,7 @@ where
         // the caller; reads through them now return inconsistent data.
         self.any.rewind(size).await?;
 
-        let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<H>();
         let grafted_tree = build_grafted_tree::<F, H, S, N>(
             &hasher,
             self.any.bitmap.as_ref(),
@@ -1164,7 +1164,7 @@ mod tests {
                 next_idx += 1;
             }
 
-            let mut hasher = StandardHasher::<Sha256>::with_bagging(Bagging::BackwardFold);
+            let mut hasher = qmdb::hasher::<Sha256>();
             let witness = db.ops_root_witness(&mut hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
@@ -1196,7 +1196,7 @@ mod tests {
             .unwrap();
             populate_fixed_db::<mmb::Family, _>(&mut db, 0, 260).await;
 
-            let mut hasher = StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let mut hasher = qmdb::hasher::<Sha256>();
             let witness = db.ops_root_witness(&mut hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
@@ -1245,7 +1245,7 @@ mod tests {
                 "test requires at least one pruned chunk to exercise the zero-chunk path"
             );
 
-            let mut hasher = StandardHasher::<Sha256>::with_bagging(Bagging::BackwardFold);
+            let mut hasher = qmdb::hasher::<Sha256>();
             let witness = db.ops_root_witness(&mut hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
@@ -1272,7 +1272,7 @@ mod tests {
             .await
             .unwrap();
 
-            let mut hasher = StandardHasher::<Sha256>::with_bagging(Bagging::BackwardFold);
+            let mut hasher = qmdb::hasher::<Sha256>();
             let witness = db.ops_root_witness(&mut hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -174,6 +174,9 @@ where
     /// sync target because the sync engine verifies batches against the ops root, not the canonical
     /// root.
     ///
+    /// External consumers that receive a trusted canonical `current` root should use
+    /// [`Self::ops_root_witness`] to authenticate this ops root against it.
+    ///
     /// See the [Root structure](super) section in the module documentation.
     pub const fn ops_root(&self) -> H::Digest {
         self.any.root()
@@ -286,7 +289,9 @@ where
     /// Returns an ops-level historical proof for the specified range.
     ///
     /// Unlike [`range_proof`](Self::range_proof) which returns grafted proofs incorporating the
-    /// activity bitmap, this returns standard range proofs suitable for state sync.
+    /// activity bitmap, this returns ops-tree Merkle proofs suitable for state sync. Direct
+    /// verifiers should use the same Merkle hasher configuration as QMDB sync:
+    /// [`Bagging::BackwardFold`].
     pub async fn ops_historical_proof(
         &self,
         historical_size: Location<F>,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1190,8 +1190,7 @@ mod tests {
             .unwrap();
             populate_fixed_db::<mmb::Family, _>(&mut db, 0, 260).await;
 
-            let mut hasher =
-                StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            let mut hasher = StandardHasher::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
             let witness = db.ops_root_witness(&mut hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -55,94 +55,185 @@ pub(crate) const fn height<const N: usize>() -> u32 {
     BitMap::<N>::CHUNK_SIZE_BITS.trailing_zeros()
 }
 
-/// Folds a sequence of topological peak digests from right to left, intelligently regrouping any
-/// small, disjoint MMB operational peaks into their corresponding bitmap chunks before continuing
-/// the final fold.
+/// Return the number of root peaks whose covered leaves end on or before `inactivity_floor`, while
+/// keeping the resulting boundary aligned to a complete bitmap chunk.
 ///
-/// In a standard Merkle structure, `hasher.root()` would systematically fold the `peaks` directly
-/// right-to-left. By introducing a grafting layer, however, any subset of small peaks at the right
-/// edge of the database that fall physically under a single `grafting_height` boundary must first
-/// be logically grouped and hashed into a single "chunk ops root", and then hashed with their
-/// corresponding bitmap chunk activity data.
-///
-/// `fold_grafted_peaks` intercepts the standard right-to-left peak fold. It buffers any
-/// sub-grafting-height peaks directly into a `pending_chunk` accumulator. Once the fold passes the
-/// left boundary of that chunk, it "flushes" the accumulator by hashing it with the returned
-/// activity bitmap from `get_chunk`. For any trailing ops peaks that do not yet have an active,
-/// complete bitmap chunk (e.g., the final `partial_chunk`), `get_chunk` returns `None` and they are
-/// securely folded mathematically straight into the root without a bitmap wrap.
-///
-/// - `start_leaf` is the leftmost leaf covered by the first peak in `peaks` (i.e. the right-most
-///   peak).
-/// - `initial_acc` contains any peaks that were already folded before `start_leaf`, useful when
-///   resuming a fold.
-pub(super) fn fold_grafted_peaks<
-    F: Family,
+/// Current grafted roots treat bitmap chunks as the atomic grafting unit. If the exact inactivity
+/// floor falls inside a root peak or inside a multi-peak chunk group, the partially covered chunk
+/// stays in the active region and the inactive peak count is rounded down to the latest chunk
+/// boundary expressible by whole root peaks.
+pub(super) fn chunk_aligned_inactive_peaks<F: Family>(
+    leaves: Location<F>,
+    inactivity_floor: Location<F>,
+    grafting_height: u32,
+) -> Result<usize, merkle::Error<F>> {
+    let size = F::location_to_position(leaves);
+    let chunk_size = 1u64 << grafting_height;
+    let floor = *inactivity_floor;
+    let mut leaf_end = 0u64;
+    let mut aligned_count = 0usize;
+
+    for (idx, (_pos, height)) in F::peaks(size).enumerate() {
+        let next_leaf_end = leaf_end + (1u64 << height);
+        if next_leaf_end > floor {
+            break;
+        }
+        leaf_end = next_leaf_end;
+        if leaf_end.is_multiple_of(chunk_size) {
+            aligned_count = idx + 1;
+        }
+    }
+
+    Ok(aligned_count)
+}
+
+/// Transform raw ops-tree peaks into grafted peak digests, preserving how many original peaks
+/// each transformed digest represents.
+pub(super) fn transform_peak_digests<
+    F: Graftable,
     D: Digest,
     H: HasherTrait<F, Digest = D>,
     C: AsRef<[u8]>,
 >(
     hasher: &H,
-    initial_acc: Option<D>,
-    start_leaf: u64,
     peaks: impl IntoIterator<Item = (u32, D)>,
+    start_leaf: u64,
     grafting_height: u32,
-    get_chunk: impl Fn(u64) -> Option<C>,
-) -> Option<D> {
+    mut get_chunk: impl FnMut(u64) -> Option<C>,
+) -> Vec<(D, usize)> {
     let chunk_size = 1u64 << grafting_height;
-    let mut acc = initial_acc;
     let mut leaf_cursor = start_leaf;
-    let mut pending_chunk: Option<(u64, D, C)> = None;
+    let mut out = Vec::new();
+    let mut pending_chunk: Option<(u64, D, C, usize)> = None;
 
-    let flush = |acc: &mut Option<D>, pending: &mut Option<(u64, D, C)>| {
-        if let Some((_, ops_digest, chunk)) = pending.take() {
+    let flush = |out: &mut Vec<(D, usize)>, pending: &mut Option<(u64, D, C, usize)>| {
+        if let Some((_idx, ops_digest, chunk, count)) = pending.take() {
             let grafted = if !chunk.as_ref().iter().all(|&b| b == 0) {
                 hasher.hash([chunk.as_ref(), ops_digest.as_ref()])
             } else {
                 ops_digest
             };
-            *acc = Some(acc.map_or(grafted, |a| hasher.fold(&a, &grafted)));
+            out.push((grafted, count));
         }
     };
 
-    for (peak_height, digest) in peaks {
+    for (height, digest) in peaks {
         let peak_start = leaf_cursor;
-        leaf_cursor += 1u64 << peak_height;
+        leaf_cursor += 1u64 << height;
 
-        if peak_height >= grafting_height {
-            flush(&mut acc, &mut pending_chunk);
-            acc = Some(acc.map_or(digest, |a| hasher.fold(&a, &digest)));
+        if height >= grafting_height {
+            flush(&mut out, &mut pending_chunk);
+            out.push((digest, 1));
             continue;
         }
 
         let chunk_idx = peak_start / chunk_size;
         match pending_chunk.take() {
-            Some((idx, ops_digest, chunk)) if idx == chunk_idx => {
-                pending_chunk = Some((idx, hasher.fold(&ops_digest, &digest), chunk));
+            Some((idx, ops_digest, chunk, count)) if idx == chunk_idx => {
+                pending_chunk = Some((idx, hasher.fold(&ops_digest, &digest), chunk, count + 1));
             }
             old_chunk => {
                 pending_chunk = old_chunk;
-                flush(&mut acc, &mut pending_chunk);
-
+                flush(&mut out, &mut pending_chunk);
                 if let Some(chunk) = get_chunk(chunk_idx) {
-                    pending_chunk = Some((chunk_idx, digest, chunk));
+                    pending_chunk = Some((chunk_idx, digest, chunk, 1));
                 } else {
-                    acc = Some(acc.map_or(digest, |a| hasher.fold(&a, &digest)));
+                    out.push((digest, 1));
                 }
             }
         }
     }
 
-    flush(&mut acc, &mut pending_chunk);
+    flush(&mut out, &mut pending_chunk);
+    out
+}
 
-    acc
+/// Return how many transformed grafted peaks represent the requested inactive prefix.
+pub(super) fn transformed_inactive_peaks<F: Family, D>(
+    transformed: &[(D, usize)],
+    inactive_peaks: usize,
+    total_peaks: usize,
+) -> Result<usize, merkle::Error<F>> {
+    if inactive_peaks > total_peaks {
+        return Err(merkle::Error::InvalidInactivePeaks {
+            requested: inactive_peaks,
+            peaks: total_peaks,
+        });
+    }
+    if inactive_peaks == 0 {
+        return Ok(0);
+    }
+
+    let mut seen = 0usize;
+    for (idx, (_, count)) in transformed.iter().enumerate() {
+        seen += *count;
+        if seen == inactive_peaks {
+            return Ok(idx + 1);
+        }
+        if seen > inactive_peaks {
+            return Err(merkle::Error::InvalidInactivePeaks {
+                requested: inactive_peaks,
+                peaks: total_peaks,
+            });
+        }
+    }
+
+    (seen == inactive_peaks).then_some(transformed.len()).ok_or(
+        merkle::Error::InvalidInactivePeaks {
+            requested: inactive_peaks,
+            peaks: total_peaks,
+        },
+    )
+}
+
+/// Compute a grafted root according to `spec`.
+///
+/// The grafting transform is applied before final peak bagging. Any inactive boundary must be
+/// representable by whole transformed grafted peaks; otherwise the request is rejected.
+pub(super) fn grafted_root<
+    F: Graftable,
+    D: Digest,
+    H: HasherTrait<F, Digest = D>,
+    C: AsRef<[u8]>,
+>(
+    hasher: &H,
+    leaves: merkle::Location<F>,
+    inactive_peaks: usize,
+    peak_digests: &[D],
+    grafting_height: u32,
+    get_chunk: impl Fn(u64) -> Option<C>,
+) -> Result<D, merkle::Error<F>> {
+    let total_peaks = F::peaks(F::location_to_position(leaves)).count();
+    if peak_digests.len() != total_peaks {
+        return Err(merkle::Error::InvalidProof);
+    }
+    let transformed = transform_peak_digests::<F, D, H, C>(
+        hasher,
+        F::peaks(F::location_to_position(leaves))
+            .map(|(_, h)| h)
+            .zip(peak_digests.iter().copied()),
+        0,
+        grafting_height,
+        get_chunk,
+    );
+    let inactive_to_fold =
+        transformed_inactive_peaks::<F, _>(&transformed, inactive_peaks, total_peaks)?;
+    let digests = transformed.iter().map(|(digest, _count)| digest);
+
+    hasher
+        .root_with_folded_peaks(leaves, inactive_to_fold, inactive_peaks, digests)
+        .ok_or(merkle::Error::InvalidInactivePeaks {
+            requested: inactive_peaks,
+            peaks: total_peaks,
+        })
 }
 
 /// Compute the grafted root by folding peak digests with multi-peak chunk grafting.
 ///
-/// For MMR this produces the same result as `hasher.root(leaves, 0, peaks).expect("zero inactive peaks is always valid")` because every chunk has a
-/// single peak at the grafting height. For MMB, chunks that span multiple sub-grafting-height peaks
-/// are folded together and combined with the bitmap chunk.
+/// For MMR this produces the same result as
+/// `hasher.root(leaves, 0, peaks).expect("zero inactive peaks is always valid")` because every
+/// chunk has a single peak at the grafting height. For MMB, chunks that span multiple
+/// sub-grafting-height peaks are folded together and combined with the bitmap chunk.
 ///
 /// This custom folding process is necessary to ensure every bit of activity state from the bitmap
 /// is cryptographically incorporated into the root. Because MMB structures can have "incomplete"
@@ -155,7 +246,8 @@ pub(super) fn fold_grafted_peaks<
 /// not graftable (e.g. the partial trailing chunk, or a chunk outside the scope). Any un-graftable
 /// partial chunks at the very end of the tree are deliberately bypassed here and folded directly,
 /// so they can be securely hashed into the final canonical root in a subsequent step.
-pub(super) fn grafted_root<
+#[cfg(test)]
+fn grafted_root_full_forward<
     F: Graftable,
     D: Digest,
     H: HasherTrait<F, Digest = D>,
@@ -167,25 +259,8 @@ pub(super) fn grafted_root<
     grafting_height: u32,
     get_chunk: impl Fn(u64) -> Option<C>,
 ) -> D {
-    let size = F::location_to_position(leaves);
-    let mut peak_iter = peak_digests.iter();
-    let acc = fold_grafted_peaks::<F, D, H, C>(
-        hasher,
-        None,
-        0,
-        F::peaks(size).map(|(_peak_pos, peak_height)| {
-            let digest = *peak_iter.next().expect("peak count mismatch");
-            (peak_height, digest)
-        }),
-        grafting_height,
-        get_chunk,
-    );
-
-    // Final root = hash(leaves || acc).
-    acc.map_or_else(
-        || hasher.digest(&(*leaves).to_be_bytes()),
-        |a| hasher.hash([(*leaves).to_be_bytes().as_slice(), a.as_ref()]),
-    )
+    grafted_root(hasher, leaves, 0, peak_digests, grafting_height, get_chunk)
+        .expect("zero inactive peaks is always valid")
 }
 
 // --- Coordinate conversion ---
@@ -312,16 +387,17 @@ pub(super) struct Verifier<'a, F: Graftable, H: CHasher> {
 }
 
 impl<'a, F: Graftable, H: CHasher> Verifier<'a, F, H> {
-    /// Create a new Verifier.
+    /// Create a new Verifier whose internal hasher uses the supplied bagging policy.
     ///
     /// `start_chunk_index` is the chunk index corresponding to `chunks[0]`.
     pub(super) const fn new(
         grafting_height: u32,
         start_chunk_index: u64,
         chunks: Vec<&'a [u8]>,
+        bagging: merkle::Bagging,
     ) -> Self {
         Self {
-            hasher: merkle::hasher::Standard::new(),
+            hasher: merkle::hasher::Standard::with_bagging(bagging),
             grafting_height,
             chunks,
             start_chunk_index,
@@ -843,8 +919,12 @@ mod tests {
                         .await
                         .unwrap();
 
-                    let verifier =
-                        Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![&c1]);
+                    let verifier = Verifier::<mmr::Family, Sha256>::new(
+                        GRAFTING_HEIGHT,
+                        0,
+                        vec![&c1],
+                        merkle::Bagging::ForwardFold,
+                    );
                     assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root));
 
                     let loc = Location::new(1);
@@ -857,8 +937,12 @@ mod tests {
                     let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
                         .await
                         .unwrap();
-                    let verifier =
-                        Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 1, vec![&c2]);
+                    let verifier = Verifier::<mmr::Family, Sha256>::new(
+                        GRAFTING_HEIGHT,
+                        1,
+                        vec![&c2],
+                        merkle::Bagging::ForwardFold,
+                    );
                     assert!(proof.verify_element_inclusion(&verifier, &b3, loc, &grafted_root));
 
                     let loc = Location::new(3);
@@ -874,8 +958,12 @@ mod tests {
                     let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
                         .await
                         .unwrap();
-                    let verifier =
-                        Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 1, vec![&c2]);
+                    let verifier = Verifier::<mmr::Family, Sha256>::new(
+                        GRAFTING_HEIGHT,
+                        1,
+                        vec![&c2],
+                        merkle::Bagging::ForwardFold,
+                    );
                     assert!(proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
 
                     // Wrong leaf element.
@@ -893,13 +981,21 @@ mod tests {
                     ));
 
                     // Wrong chunk element in the verifier.
-                    let verifier =
-                        Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![&c1]);
+                    let verifier = Verifier::<mmr::Family, Sha256>::new(
+                        GRAFTING_HEIGHT,
+                        0,
+                        vec![&c1],
+                        merkle::Bagging::ForwardFold,
+                    );
                     assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
 
                     // Wrong chunk index in the verifier.
-                    let verifier =
-                        Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 2, vec![&c2]);
+                    let verifier = Verifier::<mmr::Family, Sha256>::new(
+                        GRAFTING_HEIGHT,
+                        2,
+                        vec![&c2],
+                        merkle::Bagging::ForwardFold,
+                    );
                     assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
                 }
 
@@ -914,8 +1010,12 @@ mod tests {
                     .await
                     .unwrap();
                     let range = vec![&b1, &b2, &b3, &b4];
-                    let verifier =
-                        Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![&c1, &c2]);
+                    let verifier = Verifier::<mmr::Family, Sha256>::new(
+                        GRAFTING_HEIGHT,
+                        0,
+                        vec![&c1, &c2],
+                        merkle::Bagging::ForwardFold,
+                    );
                     assert!(proof.verify_range_inclusion(
                         &verifier,
                         &range,
@@ -924,8 +1024,12 @@ mod tests {
                     ));
 
                     // Fails with incomplete chunk elements.
-                    let verifier =
-                        Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![&c1]);
+                    let verifier = Verifier::<mmr::Family, Sha256>::new(
+                        GRAFTING_HEIGHT,
+                        0,
+                        vec![&c1],
+                        merkle::Bagging::ForwardFold,
+                    );
                     assert!(!proof.verify_range_inclusion(
                         &verifier,
                         &range,
@@ -973,10 +1077,20 @@ mod tests {
                 .await
                 .unwrap();
 
-            let verifier = Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![&c1]);
+            let verifier = Verifier::<mmr::Family, Sha256>::new(
+                GRAFTING_HEIGHT,
+                0,
+                vec![&c1],
+                merkle::Bagging::ForwardFold,
+            );
             assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root));
 
-            let verifier = Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![]);
+            let verifier = Verifier::<mmr::Family, Sha256>::new(
+                GRAFTING_HEIGHT,
+                0,
+                vec![],
+                merkle::Bagging::ForwardFold,
+            );
             let loc = Location::new(4);
             let proof = merkle::verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
                 .await
@@ -1091,7 +1205,7 @@ mod tests {
                     peaks.push(combined.get_node(pos).await.unwrap().unwrap());
                 }
 
-                let grafted_root = grafted_root::<F, _, _, _>(
+                let grafted_root = grafted_root_full_forward::<F, _, _, _>(
                     &hasher,
                     leaves,
                     &peaks,

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -230,11 +230,6 @@ pub(super) fn grafted_root<
 
 /// Compute the grafted root by folding peak digests with multi-peak chunk grafting.
 ///
-/// For MMR this produces the same result as
-/// `hasher.root(leaves, 0, peaks).expect("zero inactive peaks is always valid")` because every
-/// chunk has a single peak at the grafting height. For MMB, chunks that span multiple
-/// sub-grafting-height peaks are folded together and combined with the bitmap chunk.
-///
 /// This custom folding process is necessary to ensure every bit of activity state from the bitmap
 /// is cryptographically incorporated into the root. Because MMB structures can have "incomplete"
 /// right edges, a single complete bitmap chunk block might logically cover several smaller,

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -186,7 +186,7 @@ pub(super) fn transformed_inactive_peaks<F: Family, D>(
     )
 }
 
-/// Compute a grafted root according to `spec`.
+/// Compute a grafted root using the hasher's peak-bagging policy.
 ///
 /// The grafting transform is applied before final peak bagging. Any inactive boundary must be
 /// representable by whole transformed grafted peaks; otherwise the request is rejected.

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -392,7 +392,7 @@ impl<'a, F: Graftable, H: CHasher> Verifier<'a, F, H> {
         bagging: merkle::Bagging,
     ) -> Self {
         Self {
-            hasher: merkle::hasher::Standard::with_bagging(bagging),
+            hasher: merkle::hasher::Standard::new(bagging),
             grafting_height,
             chunks,
             start_chunk_index,
@@ -567,6 +567,7 @@ mod tests {
         merkle::{
             conformance::{build_test_mem, build_test_mmr},
             mem::Mem,
+            Bagging::ForwardFold,
         },
         mmb, mmr,
         mmr::{
@@ -607,7 +608,7 @@ mod tests {
         if !chunks.is_empty() {
             // Use a separate hasher for leaf digest computation to avoid borrow conflict
             // with grafted_hasher (which borrows standard via fork()).
-            let leaf_hasher = StandardHasher::<Sha256>::new();
+            let leaf_hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let batch = {
                 let mut batch = grafted_mmr.new_batch();
                 for (i, chunk) in chunks.iter().enumerate() {
@@ -639,7 +640,7 @@ mod tests {
 
         if !chunks.is_empty() {
             let ops_size = ops.size();
-            let leaf_hasher = StandardHasher::<Sha256>::new();
+            let leaf_hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let merkleized = {
                 let mut batch = grafted_tree.new_batch();
                 for (chunk_idx, chunk) in chunks.iter().enumerate() {
@@ -759,7 +760,7 @@ mod tests {
         executor.start(|_| async move {
             const NUM_ELEMENTS: u64 = 200;
 
-            let standard: StandardHasher<Sha256> = StandardHasher::new();
+            let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
             let mmr = Mmr::new();
             let ops_mmr = build_test_mmr(&standard, mmr, NUM_ELEMENTS);
 
@@ -802,7 +803,7 @@ mod tests {
 
     #[test_traced]
     fn test_merkleize_grafted() {
-        let standard: StandardHasher<Sha256> = StandardHasher::new();
+        let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
         let grafting_height = 1u32;
 
         // Build ops MMR with 4 leaves.
@@ -826,7 +827,7 @@ mod tests {
         let pos1 = chunk_idx_to_ops_pos(1, grafting_height);
 
         let batch = {
-            let leaf_hasher = StandardHasher::<Sha256>::new();
+            let leaf_hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let sub0 = ops_mmr.get_node(pos0).unwrap();
             let batch = grafted
                 .new_batch()
@@ -859,7 +860,7 @@ mod tests {
             let b2 = Sha256::fill(0x02);
             let b3 = Sha256::fill(0x03);
             let b4 = Sha256::fill(0x04);
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
 
             // Build an ops MMR with 4 leaves.
             let mut ops_mmr = Mmr::new();
@@ -918,7 +919,7 @@ mod tests {
                         GRAFTING_HEIGHT,
                         0,
                         vec![&c1],
-                        merkle::Bagging::ForwardFold,
+                        ForwardFold,
                     );
                     assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root));
 
@@ -936,7 +937,7 @@ mod tests {
                         GRAFTING_HEIGHT,
                         1,
                         vec![&c2],
-                        merkle::Bagging::ForwardFold,
+                        ForwardFold,
                     );
                     assert!(proof.verify_element_inclusion(&verifier, &b3, loc, &grafted_root));
 
@@ -957,7 +958,7 @@ mod tests {
                         GRAFTING_HEIGHT,
                         1,
                         vec![&c2],
-                        merkle::Bagging::ForwardFold,
+                        ForwardFold,
                     );
                     assert!(proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
 
@@ -980,7 +981,7 @@ mod tests {
                         GRAFTING_HEIGHT,
                         0,
                         vec![&c1],
-                        merkle::Bagging::ForwardFold,
+                        ForwardFold,
                     );
                     assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
 
@@ -989,7 +990,7 @@ mod tests {
                         GRAFTING_HEIGHT,
                         2,
                         vec![&c2],
-                        merkle::Bagging::ForwardFold,
+                        ForwardFold,
                     );
                     assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
                 }
@@ -1009,7 +1010,7 @@ mod tests {
                         GRAFTING_HEIGHT,
                         0,
                         vec![&c1, &c2],
-                        merkle::Bagging::ForwardFold,
+                        ForwardFold,
                     );
                     assert!(proof.verify_range_inclusion(
                         &verifier,
@@ -1023,7 +1024,7 @@ mod tests {
                         GRAFTING_HEIGHT,
                         0,
                         vec![&c1],
-                        merkle::Bagging::ForwardFold,
+                        ForwardFold,
                     );
                     assert!(!proof.verify_range_inclusion(
                         &verifier,
@@ -1072,20 +1073,12 @@ mod tests {
                 .await
                 .unwrap();
 
-            let verifier = Verifier::<mmr::Family, Sha256>::new(
-                GRAFTING_HEIGHT,
-                0,
-                vec![&c1],
-                merkle::Bagging::ForwardFold,
-            );
+            let verifier =
+                Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![&c1], ForwardFold);
             assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root));
 
-            let verifier = Verifier::<mmr::Family, Sha256>::new(
-                GRAFTING_HEIGHT,
-                0,
-                vec![],
-                merkle::Bagging::ForwardFold,
-            );
+            let verifier =
+                Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![], ForwardFold);
             let loc = Location::new(4);
             let proof = merkle::verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
                 .await
@@ -1097,7 +1090,7 @@ mod tests {
     #[test_traced]
     fn test_grafted_mmr_basic() {
         let grafting_height = 1u32;
-        let standard: StandardHasher<Sha256> = StandardHasher::new();
+        let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
 
         // Build a grafted MMR with 2 leaves.
         let d0 = Sha256::fill(0x01);
@@ -1131,7 +1124,7 @@ mod tests {
     #[test_traced]
     fn test_grafted_mmr_with_pruning() {
         let grafting_height = 1u32;
-        let standard: StandardHasher<Sha256> = StandardHasher::new();
+        let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
 
         // Simulate pruning 4 chunks. The pruned sub-MMR has 4 grafted leaves,
         // mmr_size(4) = 7, with one peak at grafted position 6.
@@ -1166,7 +1159,7 @@ mod tests {
         executor.start(|_| async move {
             type F = mmb::Family;
 
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
             let grafting_height = 2u32;
             let mut exercised = 0usize;
 
@@ -1229,7 +1222,7 @@ mod tests {
     fn test_grafted_leaf_digests_mmb_for_multi_peak_chunks() {
         type F = mmb::Family;
 
-        let hasher: StandardHasher<Sha256> = StandardHasher::new();
+        let hasher: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
         let grafting_height = 2u32;
         let mut exercised = 0usize;
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -241,9 +241,9 @@
 //! For state sync, the sync engine targets the ops root and verifies each batch against it. Callers
 //! verifying ops proofs directly should use the same Merkle hasher configuration as sync. After
 //! sync, the bitmap and grafted tree are reconstructed deterministically from the operations, and
-//! the canonical root is computed. [proof::OpsRootWitness] can be used to validate that a particular
-//! ops root is committed by a trusted canonical root; the sync engine does not perform this check
-//! itself.
+//! the canonical root is computed.
+//! [proof::OpsRootWitness] can be used to validate that a particular ops root is committed by a
+//! trusted canonical root; the sync engine does not perform this check itself.
 
 use crate::{
     index::Factory as IndexFactory,
@@ -251,9 +251,9 @@ use crate::{
         authenticated::Inner,
         contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     },
-    merkle::{self, full::Config as MerkleConfig, Bagging, Location},
-    mmr::StandardHasher,
+    merkle::{self, full::Config as MerkleConfig, Location},
     qmdb::{
+        self,
         any::{
             self,
             operation::{Operation, Update},
@@ -359,7 +359,7 @@ where
     let any = any::init_with_bitmap(context.with_label("any"), config.into(), Some(bitmap)).await?;
 
     // Build the grafted tree from the bitmap and ops tree.
-    let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
+    let hasher = qmdb::hasher::<H>();
     let grafted_tree = db::build_grafted_tree::<F, H, S, N>(
         &hasher,
         any.bitmap.as_ref(),
@@ -419,6 +419,7 @@ pub mod tests {
     use crate::{
         merkle::{self, mmb, mmr},
         qmdb::{
+            self,
             any::{
                 test::colliding_digest,
                 traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
@@ -3639,9 +3640,8 @@ pub mod tests {
         });
     }
 
-    /// Regression: a `current::Db` over `mmb::Family` bags its ops root with backward-fold, so
-    /// [`crate::qmdb::verify_proof`] must use a hasher with that bagging to accept proofs returned
-    /// by `ops_historical_proof`.
+    /// Regression: `ops_historical_proof` must verify with QMDB's ops-tree hasher configuration,
+    /// not the Merkle default.
     #[test_traced("INFO")]
     fn test_current_mmb_ops_historical_proof_verifies_with_backward_bagging() {
         use crate::{merkle::hasher::Standard, qmdb::verify_proof};
@@ -3669,8 +3669,8 @@ pub mod tests {
                 .await
                 .unwrap();
 
-            // Verifies under the backward-fold bagging the prover actually used.
-            let hasher = Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+            // Verifies under the QMDB ops-tree hasher configuration.
+            let hasher = qmdb::hasher::<Sha256>();
             assert!(verify_proof(
                 &hasher,
                 &proof,
@@ -3679,8 +3679,7 @@ pub mod tests {
                 &ops_root
             ));
 
-            // Sanity: the plain forward-fold hasher must not accept this proof, since the ops
-            // root is bagged with backward bagging.
+            // Sanity: the plain Merkle default must not accept this proof.
             let plain = Standard::<Sha256>::new();
             assert!(!verify_proof(
                 &plain,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -223,9 +223,10 @@
 //!
 //! This combines two (or three) components into a single hash:
 //!
-//! - **Ops root**: The root of the raw operations tree (the inner [crate::qmdb::any] database's
-//!   root). Used for state sync, where a client downloads operations and verifies each batch
-//!   against this root using standard Merkle range proofs.
+//! - **QMDB ops root**: The root of the operations tree computed using the QMDB root spec for
+//!   the Merkle family (the inner [crate::qmdb::any] database's root). Used for state sync,
+//!   where a client downloads operations and verifies each batch against this root using QMDB
+//!   range proofs.
 //!
 //! - **Grafted root**: The root of the grafted tree (overlaying bitmap chunks
 //!   with ops subtree roots). Used for proofs about operation values and their activity status.
@@ -235,10 +236,10 @@
 //!   usually incomplete. Its digest and bit count are folded into the canonical root hash.
 //!
 //! The canonical root is returned by [Db](db::Db)`::`[root()](db::Db::root).
-//! The ops root is returned by the `sync::Database` trait's `root()` method, since the sync engine
-//! verifies batches against the ops root, not the canonical root.
+//! The QMDB ops root is returned by the `sync::Database` trait's `root()` method, since the sync
+//! engine verifies batches against the ops root, not the canonical root.
 //!
-//! For state sync, the sync engine targets the ops root and verifies each batch against it.
+//! For state sync, the sync engine targets the QMDB ops root and verifies each batch against it.
 //! After sync, the bitmap and grafted tree are reconstructed deterministically from the
 //! operations, and the canonical root is computed. [proof::OpsRootWitness] can be used to validate
 //! that a particular ops root is committed by a trusted canonical root; the sync engine does not
@@ -258,7 +259,6 @@ use crate::{
             operation::{Operation, Update},
             Config as AnyConfig,
         },
-        bitmap::Shared,
         operation::Committable,
     },
     translator::Translator,
@@ -349,23 +349,24 @@ where
         db::init_metadata(context.with_label("metadata"), &metadata_partition).await?;
 
     // Pre-build the activity-status bitmap with the known pruned-chunk count from grafted
-    // metadata, then hand it to `any` which becomes the sole owner. `any::init_from_log`
+    // metadata, then hand it to `any` which becomes the sole owner. `any::init_with_bitmap`
     // populates it during snapshot rebuild.
     let bitmap = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
         .map_err(|_| crate::qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
-    let bitmap = Arc::new(Shared::<N>::new(bitmap));
+    let bitmap = Arc::new(crate::qmdb::bitmap::Shared::<N>::new(bitmap));
 
+    // `current` always uses split bagging at the underlying ops tree.
     let any = any::init_with_bitmap(
         context.with_label("any"),
         config.into(),
         Some(bitmap),
-        false,
-        Bagging::ForwardFold,
+        true,
+        Bagging::BackwardFold,
     )
     .await?;
 
     // Build the grafted tree from the bitmap and ops tree.
-    let hasher = StandardHasher::<H>::new();
+    let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
     let grafted_tree = db::build_grafted_tree::<F, H, S, N>(
         &hasher,
         any.bitmap.as_ref(),
@@ -389,6 +390,7 @@ where
         any.bitmap.as_ref(),
         &storage,
         partial_chunk,
+        any.inactivity_floor_loc,
         &ops_root,
     )
     .await?;
@@ -438,7 +440,7 @@ pub mod tests {
         deterministic::{self, Context},
         BufferPooler, Metrics as _, Runner as _,
     };
-    use commonware_utils::{NZUsize, NZU16, NZU64};
+    use commonware_utils::{bitmap::Readable, NZUsize, NZU16, NZU64};
     use core::future::Future;
     use rand::{rngs::StdRng, RngCore, SeedableRng};
     use std::{
@@ -1027,7 +1029,6 @@ pub mod tests {
     use crate::translator::OneCap;
     use commonware_cryptography::{sha256::Digest, Hasher as _, Sha256};
     use commonware_macros::{test_group, test_traced};
-    use commonware_utils::bitmap::Readable;
 
     type OrderedFixedDb =
         ordered::fixed::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 32>;
@@ -3049,9 +3050,8 @@ pub mod tests {
             // Sanity: c's pending write is still readable via the any-layer diff chain.
             assert_eq!(c.get(&key(250), &db).await.unwrap(), Some(val(99_999)));
 
-            // The actual prune-interaction test: apply c after prune. `any.apply_batch` writes
-            // diff entries directly into the (now more-pruned) bitmap; bits for locations below
-            // the pruning boundary cannot exist and are filtered by snapshot precedence.
+            // The actual prune-interaction test: apply c after prune. apply_batch skips overlay
+            // chunks below the current pruned boundary.
             db.apply_batch(c).await.unwrap();
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(10_000)));
             assert_eq!(db.get(&key(250)).await.unwrap(), Some(val(99_999)));
@@ -3646,9 +3646,11 @@ pub mod tests {
         });
     }
 
-    /// Regression: MMB current-db ops proofs verify against the full-forward ops root.
+    /// Regression: a `current::Db` over `mmb::Family` commits its ops root with the QMDB root spec,
+    /// so [`crate::qmdb::verify_proof`] must use that spec to accept proofs returned by
+    /// `ops_historical_proof`.
     #[test_traced("INFO")]
-    fn test_current_mmb_ops_historical_proof_verifies_with_full_forward_bagging() {
+    fn test_current_mmb_ops_historical_proof_verifies_with_qmdb_spec() {
         use crate::{merkle::hasher::Standard, qmdb::verify_proof};
         use commonware_utils::NZU64;
 
@@ -3662,6 +3664,7 @@ pub mod tests {
             .await
             .unwrap();
 
+            // Apply a batch and commit so an ops historical proof exists.
             let writes: Vec<(Digest, Option<Digest>)> =
                 (0u64..16).map(|i| (key(i), Some(val(i)))).collect();
             commit_writes(&mut db, writes).await.unwrap();
@@ -3673,9 +3676,8 @@ pub mod tests {
                 .await
                 .unwrap();
 
-            let hasher = Standard::<Sha256>::new();
-            let hasher_backward = Standard::<Sha256>::backward();
-
+            // Verifies under the backward-fold bagging the prover actually used.
+            let hasher = Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
             assert!(verify_proof(
                 &hasher,
                 &proof,
@@ -3684,8 +3686,11 @@ pub mod tests {
                 &ops_root
             ));
 
+            // Sanity: the plain forward-fold hasher must not accept this proof, since the ops
+            // root is bagged with backward bagging.
+            let plain = Standard::<Sha256>::new();
             assert!(!verify_proof(
-                &hasher_backward,
+                &plain,
                 &proof,
                 Location::new(0),
                 &ops,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -223,10 +223,9 @@
 //!
 //! This combines two (or three) components into a single hash:
 //!
-//! - **ops root**: The root of the operations tree computed using the QMDB root spec for
-//!   the Merkle family (the inner [crate::qmdb::any] database's root). Used for state sync,
-//!   where a client downloads operations and verifies each batch against this root using QMDB
-//!   range proofs.
+//! - **Ops root**: The root of the raw operations tree (the inner [crate::qmdb::any] database's
+//!   root). Used for state sync, where a client downloads operations and verifies each batch
+//!   against this root using standard Merkle range proofs.
 //!
 //! - **Grafted root**: The root of the grafted tree (overlaying bitmap chunks
 //!   with ops subtree roots). Used for proofs about operation values and their activity status.
@@ -236,8 +235,8 @@
 //!   usually incomplete. Its digest and bit count are folded into the canonical root hash.
 //!
 //! The canonical root is returned by [Db](db::Db)`::`[root()](db::Db::root).
-//! The ops root is returned by the `sync::Database` trait's `root()` method, since the sync
-//! engine verifies batches against the ops root, not the canonical root.
+//! The ops root is returned by the `sync::Database` trait's `root()` method, since the sync engine
+//! verifies batches against the ops root, not the canonical root.
 //!
 //! For state sync, the sync engine targets the ops root and verifies each batch against it.
 //! After sync, the bitmap and grafted tree are reconstructed deterministically from the
@@ -259,6 +258,7 @@ use crate::{
             operation::{Operation, Update},
             Config as AnyConfig,
         },
+        bitmap::Shared,
         operation::Committable,
     },
     translator::Translator,
@@ -353,7 +353,7 @@ where
     // populates it during snapshot rebuild.
     let bitmap = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
         .map_err(|_| crate::qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
-    let bitmap = Arc::new(crate::qmdb::bitmap::Shared::<N>::new(bitmap));
+    let bitmap = Arc::new(Shared::<N>::new(bitmap));
 
     let any = any::init_with_bitmap(context.with_label("any"), config.into(), Some(bitmap)).await?;
 
@@ -3638,11 +3638,11 @@ pub mod tests {
         });
     }
 
-    /// Regression: a `current::Db` over `mmb::Family` commits its ops root with the QMDB root spec,
-    /// so [`crate::qmdb::verify_proof`] must use that spec to accept proofs returned by
-    /// `ops_historical_proof`.
+    /// Regression: a `current::Db` over `mmb::Family` bags its ops root with backward-fold, so
+    /// [`crate::qmdb::verify_proof`] must use a hasher with that bagging to accept proofs returned
+    /// by `ops_historical_proof`.
     #[test_traced("INFO")]
-    fn test_current_mmb_ops_historical_proof_verifies_with_qmdb_spec() {
+    fn test_current_mmb_ops_historical_proof_verifies_with_backward_bagging() {
         use crate::{merkle::hasher::Standard, qmdb::verify_proof};
         use commonware_utils::NZU64;
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -239,9 +239,9 @@
 //! verifies batches against the ops root, not the canonical root.
 //!
 //! For state sync, the sync engine targets the ops root and verifies each batch against it. Callers
-//! verifying ops proofs directly should use the same Merkle hasher configuration as sync. After
-//! sync, the bitmap and grafted tree are reconstructed deterministically from the operations, and
-//! the canonical root is computed.
+//! verifying ops proofs directly should use [`crate::qmdb::hasher`]. After sync, the bitmap and
+//! grafted tree are reconstructed deterministically from the operations, and the canonical root is
+//! computed.
 //! [proof::OpsRootWitness] can be used to validate that a particular ops root is committed by a
 //! trusted canonical root; the sync engine does not perform this check itself.
 
@@ -3640,8 +3640,7 @@ pub mod tests {
         });
     }
 
-    /// Regression: `ops_historical_proof` must verify with QMDB's ops-tree hasher configuration,
-    /// not the Merkle default.
+    /// Regression: `ops_historical_proof` must verify with QMDB's ops-tree hasher configuration.
     #[test_traced("INFO")]
     fn test_current_mmb_ops_historical_proof_verifies_with_backward_bagging() {
         use crate::{merkle::hasher::Standard, qmdb::verify_proof};
@@ -3679,7 +3678,7 @@ pub mod tests {
                 &ops_root
             ));
 
-            // Sanity: the plain Merkle default must not accept this proof.
+            // Sanity: a different Merkle hasher configuration must not accept this proof.
             let plain = Standard::<Sha256>::new(ForwardFold);
             assert!(!verify_proof(
                 &plain,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -225,7 +225,7 @@
 //!
 //! - **Ops root**: The root of the raw operations tree (the inner [crate::qmdb::any] database's
 //!   root). Used for state sync, where a client downloads operations and verifies each batch
-//!   against this root using standard Merkle range proofs.
+//!   against this root using ops-tree range proofs.
 //!
 //! - **Grafted root**: The root of the grafted tree (overlaying bitmap chunks
 //!   with ops subtree roots). Used for proofs about operation values and their activity status.
@@ -238,11 +238,12 @@
 //! The ops root is returned by the `sync::Database` trait's `root()` method, since the sync engine
 //! verifies batches against the ops root, not the canonical root.
 //!
-//! For state sync, the sync engine targets the ops root and verifies each batch against it.
-//! After sync, the bitmap and grafted tree are reconstructed deterministically from the
-//! operations, and the canonical root is computed. [proof::OpsRootWitness] can be used to validate
-//! that a particular ops root is committed by a trusted canonical root; the sync engine does not
-//! perform this check itself.
+//! For state sync, the sync engine targets the ops root and verifies each batch against it. Callers
+//! verifying ops proofs directly should use the same Merkle hasher configuration as sync. After
+//! sync, the bitmap and grafted tree are reconstructed deterministically from the operations, and
+//! the canonical root is computed. [proof::OpsRootWitness] can be used to validate that a particular
+//! ops root is committed by a trusted canonical root; the sync engine does not perform this check
+//! itself.
 
 use crate::{
     index::Factory as IndexFactory,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -417,7 +417,7 @@ pub mod tests {
     pub use super::BitmapPrunedBits;
     use super::{ordered, unordered, FConfig, FixedConfig, MerkleConfig, VConfig, VariableConfig};
     use crate::{
-        merkle::{self, mmb, mmr},
+        merkle::{self, mmb, mmr, Bagging::ForwardFold},
         qmdb::{
             self,
             any::{
@@ -3680,7 +3680,7 @@ pub mod tests {
             ));
 
             // Sanity: the plain Merkle default must not accept this proof.
-            let plain = Standard::<Sha256>::new();
+            let plain = Standard::<Sha256>::new(ForwardFold);
             assert!(!verify_proof(
                 &plain,
                 &proof,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -355,15 +355,7 @@ where
         .map_err(|_| crate::qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
     let bitmap = Arc::new(crate::qmdb::bitmap::Shared::<N>::new(bitmap));
 
-    // `current` always uses split bagging at the underlying ops tree.
-    let any = any::init_with_bitmap(
-        context.with_label("any"),
-        config.into(),
-        Some(bitmap),
-        true,
-        Bagging::BackwardFold,
-    )
-    .await?;
+    let any = any::init_with_bitmap(context.with_label("any"), config.into(), Some(bitmap)).await?;
 
     // Build the grafted tree from the bitmap and ops tree.
     let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -223,7 +223,7 @@
 //!
 //! This combines two (or three) components into a single hash:
 //!
-//! - **QMDB ops root**: The root of the operations tree computed using the QMDB root spec for
+//! - **ops root**: The root of the operations tree computed using the QMDB root spec for
 //!   the Merkle family (the inner [crate::qmdb::any] database's root). Used for state sync,
 //!   where a client downloads operations and verifies each batch against this root using QMDB
 //!   range proofs.
@@ -236,10 +236,10 @@
 //!   usually incomplete. Its digest and bit count are folded into the canonical root hash.
 //!
 //! The canonical root is returned by [Db](db::Db)`::`[root()](db::Db::root).
-//! The QMDB ops root is returned by the `sync::Database` trait's `root()` method, since the sync
+//! The ops root is returned by the `sync::Database` trait's `root()` method, since the sync
 //! engine verifies batches against the ops root, not the canonical root.
 //!
-//! For state sync, the sync engine targets the QMDB ops root and verifies each batch against it.
+//! For state sync, the sync engine targets the ops root and verifies each batch against it.
 //! After sync, the bitmap and grafted tree are reconstructed deterministically from the
 //! operations, and the canonical root is computed. [proof::OpsRootWitness] can be used to validate
 //! that a particular ops root is committed by a trusted canonical root; the sync engine does not

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -392,8 +392,8 @@ pub mod tests {
             // Empty range proof should not crash or verify, since even an empty db has a single
             let proof = RangeProof {
                 proof: Proof::default(),
-                pre_prefix_acc: None,
                 unfolded_prefix_peaks: vec![],
+                unfolded_suffix_peaks: vec![],
                 partial_chunk_digest: None,
                 ops_root: Digest::EMPTY,
             };

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -925,7 +925,8 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> =
+                StandardHasher::with_bagging(Bagging::BackwardFold);
             let grafting_height = grafting::height::<N>();
 
             let leaf_count = (16..=64u64)
@@ -1260,7 +1261,8 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> =
+                StandardHasher::with_bagging(Bagging::BackwardFold);
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
 
@@ -1353,7 +1355,8 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> =
+                StandardHasher::with_bagging(Bagging::BackwardFold);
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
 
@@ -1517,7 +1520,8 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> =
+                StandardHasher::with_bagging(Bagging::BackwardFold);
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
             let leaf_count = chunk_bits;

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -11,7 +11,7 @@ use crate::{
         self,
         hasher::{Hasher, Standard as StandardHasher},
         storage::Storage,
-        Bagging, Family, Graftable, Location, Position, Proof,
+        Family, Graftable, Location, Position, Proof,
     },
     qmdb::{
         self,
@@ -801,7 +801,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             grafting_height,
             start_chunk,
             chunk_vec,
-            Bagging::BackwardFold,
+            qmdb::ROOT_BAGGING,
         );
 
         // For partial chunks, validate the last chunk digest from the proof.

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -14,6 +14,7 @@ use crate::{
         Bagging, Family, Graftable, Location, Position, Proof,
     },
     qmdb::{
+        self,
         current::{db::combine_roots, grafting},
         Error,
     },
@@ -615,7 +616,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         range: Range<Location<F>>,
         ops_root: D,
     ) -> Result<Self, Error<F>> {
-        let std_hasher = merkle::hasher::Standard::<H>::with_bagging(Bagging::BackwardFold);
+        let std_hasher = qmdb::hasher::<H>();
         let range_for_layout = range.clone();
         let complete_chunks = status.complete_chunks() as u64;
         let pruned_chunks = status.pruned_chunks() as u64;
@@ -983,7 +984,6 @@ mod tests {
     use crate::{
         merkle::{conformance::build_test_mem, mem::Mem},
         mmb,
-        mmr::StandardHasher,
         qmdb::current::{db, grafting},
     };
     use commonware_codec::{DecodeExt as _, Encode as _};
@@ -1018,8 +1018,7 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> =
-                StandardHasher::with_bagging(Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let grafting_height = grafting::height::<N>();
 
             let leaf_count = (16..=64u64)
@@ -1111,8 +1110,7 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> =
-                StandardHasher::with_bagging(Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let grafting_height = grafting::height::<N>();
 
             let (leaf_count, loc) = (17..=64u64)
@@ -1234,8 +1232,7 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> =
-                StandardHasher::with_bagging(Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
 
@@ -1354,8 +1351,7 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> =
-                StandardHasher::with_bagging(Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
 
@@ -1448,8 +1444,7 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> =
-                StandardHasher::with_bagging(Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
 
@@ -1613,8 +1608,7 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> =
-                StandardHasher::with_bagging(Bagging::BackwardFold);
+            let hasher = qmdb::hasher::<Sha256>();
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
             let leaf_count = chunk_bits;

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -444,8 +444,9 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let mut unfolded_prefix_peaks = Vec::new();
         let mut unfolded_suffix_peaks = Vec::new();
         let proof = if needs_grafted_peak_fold {
-            let mut positions =
+            let collection_positions =
                 merkle::range_collection_nodes(leaves, inactive_peaks, range.clone())?;
+            let mut positions = collection_positions.clone();
             positions.extend(layout.prefix.iter().map(|&(pos, _)| pos));
             positions.extend(layout.after.iter().map(|&(pos, _)| pos));
             positions.sort_unstable();
@@ -471,7 +472,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             let proof = merkle::build_range_collection_proof::<F, D, Error<F>>(
                 leaves,
                 inactive_peaks,
-                range.clone(),
+                &collection_positions,
                 |pos| fetched.get(&pos).copied(),
                 |pos| Error::from(merkle::Error::<F>::MissingNode(pos)),
             )?;

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -383,6 +383,196 @@ fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     verifier.root_with_folded_peaks(leaves, inactive_to_fold, inactive_peaks, digests)
 }
 
+struct GraftedProofParts<F: Family, D: Digest> {
+    proof: Proof<F, D>,
+    unfolded_prefix_peaks: Vec<D>,
+    unfolded_suffix_peaks: Vec<D>,
+}
+
+fn grafted_chunk<const N: usize>(
+    status: &impl BitmapReadable<N>,
+    complete_chunks: u64,
+    pruned_chunks: u64,
+    idx: u64,
+) -> Option<[u8; N]> {
+    if idx >= complete_chunks {
+        None
+    } else if idx < pruned_chunks {
+        Some([0u8; N])
+    } else {
+        Some(status.get_chunk(idx as usize))
+    }
+}
+
+fn peak_digests<F: Family, D: Digest>(
+    peaks: &[(Position<F>, u32)],
+    fetched: &BTreeMap<Position<F>, D>,
+) -> Result<Vec<D>, Error<F>> {
+    peaks
+        .iter()
+        .map(|&(pos, _)| {
+            fetched
+                .get(&pos)
+                .copied()
+                .ok_or_else(|| Error::from(merkle::Error::<F>::MissingNode(pos)))
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prefix_witness<F: Graftable, D: Digest, H: CHasher<Digest = D>, const N: usize>(
+    hasher: &StandardHasher<H>,
+    status: &impl BitmapReadable<N>,
+    peaks: &[(Position<F>, u32)],
+    raw_digests: &[D],
+    raw_start: usize,
+    grafting_height: u32,
+    complete_chunks: u64,
+    pruned_chunks: u64,
+) -> Vec<D> {
+    let mut witness = grafting::transform_peak_digests::<F, _, _, _>(
+        hasher,
+        peaks[..raw_start]
+            .iter()
+            .map(|(_, h)| *h)
+            .zip(raw_digests[..raw_start].iter().copied()),
+        0,
+        grafting_height,
+        |idx| grafted_chunk(status, complete_chunks, pruned_chunks, idx),
+    )
+    .into_iter()
+    .map(|(digest, _count)| digest)
+    .collect::<Vec<_>>();
+    witness.extend_from_slice(&raw_digests[raw_start..]);
+    witness
+}
+
+#[allow(clippy::too_many_arguments)]
+fn suffix_witness<F: Graftable, D: Digest, H: CHasher<Digest = D>, const N: usize>(
+    hasher: &StandardHasher<H>,
+    status: &impl BitmapReadable<N>,
+    peaks: &[(Position<F>, u32)],
+    raw_digests: &[D],
+    suffix_start: u64,
+    raw_end: usize,
+    grafting_height: u32,
+    complete_chunks: u64,
+    pruned_chunks: u64,
+) -> Vec<D> {
+    let mut witness = raw_digests[..raw_end].to_vec();
+    witness.extend(
+        grafting::transform_peak_digests::<F, _, _, _>(
+            hasher,
+            peaks[raw_end..]
+                .iter()
+                .map(|(_, h)| *h)
+                .zip(raw_digests[raw_end..].iter().copied()),
+            suffix_start + peaks_leaf_len(&peaks[..raw_end]),
+            grafting_height,
+            |idx| grafted_chunk(status, complete_chunks, pruned_chunks, idx),
+        )
+        .into_iter()
+        .map(|(digest, _count)| digest),
+    );
+    witness
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn build_grafted_range_proof<
+    F: Graftable,
+    D: Digest,
+    H: CHasher<Digest = D>,
+    S: Storage<F, Digest = D>,
+    const N: usize,
+>(
+    hasher: &StandardHasher<H>,
+    status: &impl BitmapReadable<N>,
+    storage: &S,
+    layout: &PeakLayout<F>,
+    leaves: Location<F>,
+    inactive_peaks: usize,
+    range: Range<Location<F>>,
+    grafting_height: u32,
+    complete_chunks: u64,
+    pruned_chunks: u64,
+) -> Result<GraftedProofParts<F, D>, Error<F>> {
+    let proof_start_chunk = *range.start >> grafting_height;
+    let proof_end_chunk = *range.end.checked_sub(1).ok_or(merkle::Error::Empty)? >> grafting_height;
+
+    let proof_positions = merkle::range_collection_nodes(leaves, inactive_peaks, range)?;
+    let mut fetch_positions = proof_positions.clone();
+    fetch_positions.extend(layout.prefix.iter().map(|&(pos, _)| pos));
+    fetch_positions.extend(layout.after.iter().map(|&(pos, _)| pos));
+    fetch_positions.sort_unstable();
+    debug_assert!(
+        fetch_positions
+            .windows(2)
+            .all(|window| window[0] != window[1]),
+        "grafted proof fetch positions should be unique"
+    );
+
+    let node_futures = fetch_positions
+        .into_iter()
+        .map(|pos| async move { storage.get_node(pos).await.map(|digest| (pos, digest)) })
+        .collect::<Vec<_>>();
+    let fetched: BTreeMap<Position<F>, D> = try_join_all(node_futures)
+        .await?
+        .into_iter()
+        .map(|(pos, digest)| {
+            digest
+                .ok_or_else(|| Error::from(merkle::Error::<F>::MissingNode(pos)))
+                .map(|d| (pos, d))
+        })
+        .collect::<Result<_, Error<F>>>()?;
+
+    let proof = merkle::build_range_collection_proof::<F, D, Error<F>>(
+        leaves,
+        inactive_peaks,
+        &proof_positions,
+        |pos| fetched.get(&pos).copied(),
+        |pos| Error::from(merkle::Error::<F>::MissingNode(pos)),
+    )?;
+
+    let prefix_raw = peak_digests(&layout.prefix, &fetched)?;
+    let prefix_raw_start = prefix_raw_start_idx(&layout.prefix, proof_start_chunk, grafting_height);
+    let unfolded_prefix_peaks = prefix_witness::<F, D, H, N>(
+        hasher,
+        status,
+        &layout.prefix,
+        &prefix_raw,
+        prefix_raw_start,
+        grafting_height,
+        complete_chunks,
+        pruned_chunks,
+    );
+
+    let suffix_raw = peak_digests(&layout.after, &fetched)?;
+    let suffix_start = peaks_leaf_len(&layout.prefix) + peaks_leaf_len(&layout.range);
+    let suffix_raw_end = after_raw_end_idx(
+        &layout.after,
+        suffix_start,
+        proof_end_chunk,
+        grafting_height,
+    );
+    let unfolded_suffix_peaks = suffix_witness::<F, D, H, N>(
+        hasher,
+        status,
+        &layout.after,
+        &suffix_raw,
+        suffix_start,
+        suffix_raw_end,
+        grafting_height,
+        complete_chunks,
+        pruned_chunks,
+    );
+
+    Ok(GraftedProofParts {
+        proof,
+        unfolded_prefix_peaks,
+        unfolded_suffix_peaks,
+    })
+}
+
 /// A proof that a range of operations exist in the database.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct RangeProof<F: Family, D: Digest> {
@@ -432,141 +622,43 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let leaves = Location::try_from(storage.size().await)?;
         let layout = peak_layout(leaves, range_for_layout)?;
         let grafting_height = grafting::height::<N>();
-        let proof_start_chunk = *range.start >> grafting_height;
-        let proof_end_chunk =
-            *range.end.checked_sub(1).ok_or(merkle::Error::Empty)? >> grafting_height;
         let inactive_peaks =
             grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting_height)?;
 
         let size = Position::<F>::try_from(leaves)?;
         let needs_grafted_peak_fold =
             proof_needs_grafted_peak_fold(&layout, size, grafting_height, complete_chunks);
-        let mut unfolded_prefix_peaks = Vec::new();
-        let mut unfolded_suffix_peaks = Vec::new();
-        let proof = if needs_grafted_peak_fold {
-            let collection_positions =
-                merkle::range_collection_nodes(leaves, inactive_peaks, range.clone())?;
-            let mut positions = collection_positions.clone();
-            positions.extend(layout.prefix.iter().map(|&(pos, _)| pos));
-            positions.extend(layout.after.iter().map(|&(pos, _)| pos));
-            positions.sort_unstable();
-            debug_assert!(
-                positions.windows(2).all(|window| window[0] != window[1]),
-                "grafted proof fetch positions should be unique"
-            );
-
-            let node_futures = positions
-                .into_iter()
-                .map(|pos| async move { storage.get_node(pos).await.map(|digest| (pos, digest)) })
-                .collect::<Vec<_>>();
-            let fetched: BTreeMap<Position<F>, D> = try_join_all(node_futures)
-                .await?
-                .into_iter()
-                .map(|(pos, digest)| {
-                    digest
-                        .ok_or_else(|| Error::from(merkle::Error::<F>::MissingNode(pos)))
-                        .map(|d| (pos, d))
-                })
-                .collect::<Result<_, Error<F>>>()?;
-
-            let proof = merkle::build_range_collection_proof::<F, D, Error<F>>(
-                leaves,
-                inactive_peaks,
-                &collection_positions,
-                |pos| fetched.get(&pos).copied(),
-                |pos| Error::from(merkle::Error::<F>::MissingNode(pos)),
-            )?;
-
-            let prefix_raw = layout
-                .prefix
-                .iter()
-                .map(|&(pos, _)| {
-                    fetched
-                        .get(&pos)
-                        .copied()
-                        .ok_or(merkle::Error::<F>::MissingNode(pos))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let prefix_raw_start =
-                prefix_raw_start_idx(&layout.prefix, proof_start_chunk, grafting_height);
-            unfolded_prefix_peaks = grafting::transform_peak_digests::<F, _, _, _>(
+        let GraftedProofParts {
+            proof,
+            unfolded_prefix_peaks,
+            unfolded_suffix_peaks,
+        } = if needs_grafted_peak_fold {
+            build_grafted_range_proof(
                 &std_hasher,
-                layout.prefix[..prefix_raw_start]
-                    .iter()
-                    .map(|(_, h)| *h)
-                    .zip(prefix_raw[..prefix_raw_start].iter().copied()),
-                0,
-                grafting_height,
-                |idx| {
-                    if idx < complete_chunks {
-                        if idx < pruned_chunks {
-                            Some([0u8; N])
-                        } else {
-                            Some(status.get_chunk(idx as usize))
-                        }
-                    } else {
-                        None
-                    }
-                },
-            )
-            .into_iter()
-            .map(|(digest, _count)| digest)
-            .collect();
-            unfolded_prefix_peaks.extend_from_slice(&prefix_raw[prefix_raw_start..]);
-
-            let suffix_digests = layout
-                .after
-                .iter()
-                .map(|&(pos, _)| {
-                    fetched
-                        .get(&pos)
-                        .copied()
-                        .ok_or(merkle::Error::<F>::MissingNode(pos))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let suffix_start = peaks_leaf_len(&layout.prefix) + peaks_leaf_len(&layout.range);
-            let suffix_raw_end = after_raw_end_idx(
-                &layout.after,
-                suffix_start,
-                proof_end_chunk,
-                grafting_height,
-            );
-            unfolded_suffix_peaks.extend_from_slice(&suffix_digests[..suffix_raw_end]);
-            unfolded_suffix_peaks.extend(
-                grafting::transform_peak_digests::<F, _, _, _>(
-                    &std_hasher,
-                    layout.after[suffix_raw_end..]
-                        .iter()
-                        .map(|(_, h)| *h)
-                        .zip(suffix_digests[suffix_raw_end..].iter().copied()),
-                    suffix_start + peaks_leaf_len(&layout.after[..suffix_raw_end]),
-                    grafting_height,
-                    |idx| {
-                        if idx < complete_chunks {
-                            if idx < pruned_chunks {
-                                Some([0u8; N])
-                            } else {
-                                Some(status.get_chunk(idx as usize))
-                            }
-                        } else {
-                            None
-                        }
-                    },
-                )
-                .into_iter()
-                .map(|(digest, _count)| digest),
-            );
-
-            proof
-        } else {
-            merkle::verification::historical_range_proof(
-                &std_hasher,
+                status,
                 storage,
+                &layout,
                 leaves,
-                range.clone(),
                 inactive_peaks,
+                range.clone(),
+                grafting_height,
+                complete_chunks,
+                pruned_chunks,
             )
             .await?
+        } else {
+            GraftedProofParts {
+                proof: merkle::verification::historical_range_proof(
+                    &std_hasher,
+                    storage,
+                    leaves,
+                    range.clone(),
+                    inactive_peaks,
+                )
+                .await?,
+                unfolded_prefix_peaks: Vec::new(),
+                unfolded_suffix_peaks: Vec::new(),
+            }
         };
 
         let (last_chunk, next_bit) = status.last_chunk();

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -11,7 +11,7 @@ use crate::{
         self,
         hasher::{Hasher, Standard as StandardHasher},
         storage::Storage,
-        Family, Graftable, Location, Position, Proof,
+        Bagging, Family, Graftable, Location, Position, Proof,
     },
     qmdb::{
         current::{db::combine_roots, grafting},
@@ -168,28 +168,6 @@ fn chunk_needs_grafted_fold<F: Graftable>(
             .is_some()
 }
 
-/// Finds the index in `prefix_peaks` where the standard prefix accumulation must stop.
-///
-/// During proof generation, prefix peaks are typically accumulated into a single digest
-/// (`pre_prefix_acc`). However, if a complete chunk spans some of these prefix peaks AND
-/// extends into the proven range, we must NOT fold those overlapping prefix peaks into the generic
-/// accumulator. Instead, we must expose them individually (`unfolded_prefix_peaks`) so the
-/// Verifier can correctly regroup them with the in-range peaks for grafted root reconstruction.
-/// Returns the slice index where unfolding must begin, or `None` if zero unfolding is needed.
-fn unfolding_start_idx<F: Graftable>(
-    prefix_peaks: &[(Position<F>, u32)],
-    grafting_height: u32,
-    start_chunk: u64,
-    complete_chunks: u64,
-) -> Option<usize> {
-    let mut leaf_cursor = 0;
-    prefix_peaks.iter().position(|&(_pos, height)| {
-        let chunk_idx = leaf_cursor / (1u64 << grafting_height);
-        leaf_cursor += 1u64 << height;
-        chunk_idx == start_chunk && chunk_idx < complete_chunks
-    })
-}
-
 /// Checks if the provided proof interacts with ANY multi-peak complete chunks.
 ///
 /// It scans all peaks dynamically bucketed by `layout` (prefix, active range, and suffix after).
@@ -217,82 +195,192 @@ fn proof_needs_grafted_peak_fold<F: Graftable>(
         })
 }
 
-/// Accumulates the absolute physical leaf count spanned by the slice of given prefix peaks.
-fn prefix_leaf_end<F: Family>(prefix_peaks: &[(Position<F>, u32)]) -> u64 {
-    prefix_peaks
+/// Return the number of leaves covered by `peaks`.
+fn peaks_leaf_len<F: Family>(peaks: &[(Position<F>, u32)]) -> u64 {
+    peaks
         .iter()
-        .fold(0u64, |acc, (_, height)| acc + (1u64 << *height))
+        .fold(0u64, |acc, (_pos, height)| acc + (1u64 << *height))
 }
 
-/// Safely extracts the computed digests for all active-range and after-range peaks.
-///
-/// Since standard verification sequentially computes and caches these intermediate node digests
-/// into the `collected` map, this function plucks them out linearly to pass into the grafted root
-/// reconstruction engine. Returns `None` if any structurally required peak is missing.
-fn collect_peak_digests<F: Family, D: Digest>(
-    layout: &PeakLayout<F>,
-    collected: &BTreeMap<Position<F>, D>,
-) -> Option<Vec<D>> {
-    let mut peak_digests = Vec::with_capacity(layout.range.len() + layout.after.len());
-    for (pos, _) in layout.range.iter().chain(layout.after.iter()) {
-        peak_digests.push(*collected.get(pos)?);
+/// Return the prefix index where peaks may need to regroup with caller-provided chunks.
+fn prefix_raw_start_idx<F: Family>(
+    peaks: &[(Position<F>, u32)],
+    start_chunk: u64,
+    grafting_height: u32,
+) -> usize {
+    let chunk_start = start_chunk << grafting_height;
+    let mut leaf_cursor = 0u64;
+    for (idx, (_pos, height)) in peaks.iter().enumerate() {
+        leaf_cursor += 1u64 << *height;
+        if leaf_cursor > chunk_start {
+            return idx;
+        }
     }
-    Some(peak_digests)
+    peaks.len()
+}
+
+/// Return the after-region index up to which peaks may need caller-provided chunks.
+fn after_raw_end_idx<F: Family>(
+    peaks: &[(Position<F>, u32)],
+    start_leaf: u64,
+    end_chunk: u64,
+    grafting_height: u32,
+) -> usize {
+    let chunk_end = (end_chunk + 1) << grafting_height;
+    let mut leaf_cursor = start_leaf;
+    for (idx, (_pos, height)) in peaks.iter().enumerate() {
+        if leaf_cursor >= chunk_end {
+            return idx;
+        }
+        leaf_cursor += 1u64 << *height;
+    }
+    peaks.len()
+}
+
+/// Return the transformed grafted witness shape for a peak slice.
+fn transformed_peak_counts<F: Graftable>(
+    peaks: &[(Position<F>, u32)],
+    start_leaf: u64,
+    grafting_height: u32,
+    has_chunk: impl Fn(u64) -> bool,
+) -> Vec<usize> {
+    let chunk_size = 1u64 << grafting_height;
+    let mut leaf_cursor = start_leaf;
+    let mut out = Vec::new();
+    let mut pending_chunk: Option<(u64, usize)> = None;
+
+    let flush = |out: &mut Vec<usize>, pending: &mut Option<(u64, usize)>| {
+        if let Some((_idx, count)) = pending.take() {
+            out.push(count);
+        }
+    };
+
+    for (_pos, height) in peaks {
+        let peak_start = leaf_cursor;
+        leaf_cursor += 1u64 << *height;
+
+        if *height >= grafting_height {
+            flush(&mut out, &mut pending_chunk);
+            out.push(1);
+            continue;
+        }
+
+        let chunk_idx = peak_start / chunk_size;
+        match pending_chunk.take() {
+            Some((idx, count)) if idx == chunk_idx => {
+                pending_chunk = Some((idx, count + 1));
+            }
+            old_chunk => {
+                pending_chunk = old_chunk;
+                flush(&mut out, &mut pending_chunk);
+                if has_chunk(chunk_idx) {
+                    pending_chunk = Some((chunk_idx, 1));
+                } else {
+                    out.push(1);
+                }
+            }
+        }
+    }
+    flush(&mut out, &mut pending_chunk);
+
+    out
 }
 
 // Reconstructs the canonical grafted root from the combination of generic proof boundaries,
-// the operation elements, and the prefix hashes provided by the prover.
+// operation elements, and grafted prefix/suffix witnesses provided by the prover.
+#[allow(clippy::too_many_arguments)]
 fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     verifier: &grafting::Verifier<'_, F, H>,
     proof: &RangeProof<F, H::Digest>,
     layout: &PeakLayout<F>,
     leaves: Location<F>,
+    range: Range<Location<F>>,
     collected: &BTreeMap<Position<F>, H::Digest>,
     grafting_height: u32,
     get_chunk: impl Fn(u64) -> Option<C>,
 ) -> Option<H::Digest> {
-    let suffix_peaks = collect_peak_digests(layout, collected)?;
+    let prefix_start = 0;
+    let range_start = peaks_leaf_len(&layout.prefix);
+    let after_start = range_start + peaks_leaf_len(&layout.range);
+    let chunk_available = |idx| idx < (*leaves >> grafting_height);
+    let start_chunk = *range.start >> grafting_height;
+    let end_chunk = *range.end.checked_sub(1)? >> grafting_height;
+    let prefix_raw_start = prefix_raw_start_idx(&layout.prefix, start_chunk, grafting_height);
+    let after_raw_end = after_raw_end_idx(&layout.after, after_start, end_chunk, grafting_height);
 
-    let (initial_acc, start_leaf, prefix_peaks) =
-        if proof.pre_prefix_acc.is_some() || !proof.unfolded_prefix_peaks.is_empty() {
-            let split_idx = layout
-                .prefix
-                .len()
-                .checked_sub(proof.unfolded_prefix_peaks.len())?;
-            (
-                proof.pre_prefix_acc,
-                prefix_leaf_end(&layout.prefix[..split_idx]),
-                layout.prefix[split_idx..]
-                    .iter()
-                    .zip(proof.unfolded_prefix_peaks.iter())
-                    .map(|((_, height), &digest)| (*height, digest))
-                    .collect::<Vec<_>>(),
-            )
-        } else {
-            (None, prefix_leaf_end(&layout.prefix), vec![])
-        };
-
-    let peaks = prefix_peaks.into_iter().chain(
-        layout
-            .range
-            .iter()
-            .chain(layout.after.iter())
-            .zip(suffix_peaks)
-            .map(|((_, height), digest)| (*height, digest)),
+    let prefix_counts = transformed_peak_counts(
+        &layout.prefix[..prefix_raw_start],
+        prefix_start,
+        grafting_height,
+        chunk_available,
     );
+    let suffix_counts = transformed_peak_counts(
+        &layout.after[after_raw_end..],
+        after_start + peaks_leaf_len(&layout.after[..after_raw_end]),
+        grafting_height,
+        chunk_available,
+    );
+    let prefix_witness_len = prefix_counts.len() + layout.prefix[prefix_raw_start..].len();
+    let suffix_witness_len = layout.after[..after_raw_end].len() + suffix_counts.len();
+    if proof.unfolded_prefix_peaks.len() != prefix_witness_len
+        || proof.unfolded_suffix_peaks.len() != suffix_witness_len
+    {
+        return None;
+    }
 
-    let acc = grafting::fold_grafted_peaks::<F, H::Digest, _, _>(
+    let mut transformed = Vec::with_capacity(
+        proof.unfolded_prefix_peaks.len() + layout.range.len() + proof.unfolded_suffix_peaks.len(),
+    );
+    let (prefix_transformed, prefix_raw) =
+        proof.unfolded_prefix_peaks.split_at(prefix_counts.len());
+    transformed.extend(prefix_transformed.iter().copied().zip(prefix_counts));
+    let mut range_digests = Vec::with_capacity(layout.range.len());
+    for (pos, _) in &layout.range {
+        range_digests.push(*collected.get(pos)?);
+    }
+    let (suffix_raw, suffix_transformed) = proof
+        .unfolded_suffix_peaks
+        .split_at(layout.after[..after_raw_end].len());
+
+    // The transformed list has three regions: entries before the range-adjacent chunks, the
+    // middle chunks that may combine raw prefix/range/suffix peaks, and entries after that middle
+    // region. `middle_peaks` covers exactly the chunk span from the first raw prefix peak through
+    // the last raw suffix peak that can share a grafted chunk with the proven range.
+    let middle_iter = layout.prefix[prefix_raw_start..]
+        .iter()
+        .map(|(_, h)| *h)
+        .zip(prefix_raw.iter().copied())
+        .chain(
+            layout
+                .range
+                .iter()
+                .map(|(_, h)| *h)
+                .zip(range_digests.iter().copied()),
+        )
+        .chain(
+            layout.after[..after_raw_end]
+                .iter()
+                .map(|(_, h)| *h)
+                .zip(suffix_raw.iter().copied()),
+        );
+    transformed.extend(grafting::transform_peak_digests::<F, _, _, _>(
         verifier,
-        initial_acc,
-        start_leaf,
-        peaks,
+        middle_iter,
+        range_start - peaks_leaf_len(&layout.prefix[prefix_raw_start..]),
         grafting_height,
         get_chunk,
-    );
-    Some(acc.map_or_else(
-        || verifier.digest(&(*leaves).to_be_bytes()),
-        |acc| verifier.hash([(*leaves).to_be_bytes().as_slice(), acc.as_ref()]),
-    ))
+    ));
+    transformed.extend(suffix_transformed.iter().copied().zip(suffix_counts));
+
+    let inactive_peaks = proof.proof.inactive_peaks;
+    let inactive_to_fold = grafting::transformed_inactive_peaks::<F, _>(
+        &transformed,
+        inactive_peaks,
+        layout.prefix.len() + layout.range.len() + layout.after.len(),
+    )
+    .ok()?;
+    let digests = transformed.iter().map(|(digest, _count)| digest);
+    verifier.root_with_folded_peaks(leaves, inactive_to_fold, inactive_peaks, digests)
 }
 
 /// A proof that a range of operations exist in the database.
@@ -301,13 +389,23 @@ pub struct RangeProof<F: Family, D: Digest> {
     /// The Merkle digest material required to verify the proof.
     pub proof: Proof<F, D>,
 
-    /// The single folded accumulator of all aligned prefix peaks that do not require unfolding.
-    pub pre_prefix_acc: Option<D>,
-
-    /// Individual fold-prefix peak digests, in peak order, when the generic proof's single
-    /// folded prefix accumulator would otherwise hide multi-peak chunk structure needed for
-    /// grafted-root reconstruction.
+    /// Extra prefix witnesses needed when generic proof collection would hide peaks behind a
+    /// prefix accumulator that grafted reconstruction must inspect.
+    ///
+    /// This vector is intentionally split by convention. It starts with already-transformed
+    /// grafted digests for the prefix region before the range-adjacent chunk span, then contains
+    /// raw peak digests that can regroup with the proven range. The verifier reconstructs the split
+    /// point from the peak layout.
     pub unfolded_prefix_peaks: Vec<D>,
+
+    /// Extra suffix witnesses needed when generic backward-bagged proofs hide peaks behind a
+    /// suffix accumulator that grafted reconstruction must inspect.
+    ///
+    /// This vector is intentionally split by convention. It starts with raw peak digests adjacent
+    /// to the proven range, because those peaks may share grafted chunks with in-range peaks. It
+    /// then contains already-transformed grafted digests for the remaining suffix region. The
+    /// verifier reconstructs the split point from the peak layout.
+    pub unfolded_suffix_peaks: Vec<D>,
 
     /// The partial chunk digest from the status bitmap at the time of proof generation, if any.
     pub partial_chunk_digest: Option<D>,
@@ -323,60 +421,127 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         hasher: &mut H,
         status: &impl BitmapReadable<N>,
         storage: &S,
+        inactivity_floor: Location<F>,
         range: Range<Location<F>>,
         ops_root: D,
     ) -> Result<Self, Error<F>> {
-        let std_hasher = merkle::hasher::Standard::<H>::new();
+        let std_hasher = merkle::hasher::Standard::<H>::with_bagging(Bagging::BackwardFold);
         let range_for_layout = range.clone();
-        let start_chunk = *range.start / BitMap::<N>::CHUNK_SIZE_BITS;
         let complete_chunks = status.complete_chunks() as u64;
         let pruned_chunks = status.pruned_chunks() as u64;
         let leaves = Location::try_from(storage.size().await)?;
         let layout = peak_layout(leaves, range_for_layout)?;
         let grafting_height = grafting::height::<N>();
+        let proof_start_chunk = *range.start >> grafting_height;
+        let proof_end_chunk =
+            *range.end.checked_sub(1).ok_or(merkle::Error::Empty)? >> grafting_height;
+        let inactive_peaks =
+            grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting_height)?;
 
         let size = Position::<F>::try_from(leaves)?;
         let needs_grafted_peak_fold =
             proof_needs_grafted_peak_fold(&layout, size, grafting_height, complete_chunks);
-        let proof =
-            merkle::verification::historical_range_proof(&std_hasher, storage, leaves, range, 0)
-                .await?;
-        let mut pre_prefix_acc: Option<D> = None;
         let mut unfolded_prefix_peaks = Vec::new();
-        if needs_grafted_peak_fold {
-            let split_idx_opt = unfolding_start_idx(
-                &layout.prefix,
-                grafting_height,
-                start_chunk,
-                complete_chunks,
+        let mut unfolded_suffix_peaks = Vec::new();
+        let proof = if needs_grafted_peak_fold {
+            let mut positions =
+                merkle::range_collection_nodes(leaves, inactive_peaks, range.clone())?;
+            positions.extend(layout.prefix.iter().map(|&(pos, _)| pos));
+            positions.extend(layout.after.iter().map(|&(pos, _)| pos));
+            positions.sort_unstable();
+            debug_assert!(
+                positions.windows(2).all(|window| window[0] != window[1]),
+                "grafted proof fetch positions should be unique"
             );
-            let split_idx = split_idx_opt.unwrap_or(layout.prefix.len());
 
-            let prefix_futures = layout.prefix.iter().map(|&(pos, _)| storage.get_node(pos));
-            let prefix_digests = try_join_all(prefix_futures)
+            let node_futures = positions
+                .into_iter()
+                .map(|pos| async move { storage.get_node(pos).await.map(|digest| (pos, digest)) })
+                .collect::<Vec<_>>();
+            let fetched: BTreeMap<Position<F>, D> = try_join_all(node_futures)
                 .await?
                 .into_iter()
-                .zip(layout.prefix.iter())
-                .map(|(result, &(pos, height))| {
-                    result
+                .map(|(pos, digest)| {
+                    digest
+                        .ok_or_else(|| Error::from(merkle::Error::<F>::MissingNode(pos)))
+                        .map(|d| (pos, d))
+                })
+                .collect::<Result<_, Error<F>>>()?;
+
+            let proof = merkle::build_range_collection_proof::<F, D, Error<F>>(
+                leaves,
+                inactive_peaks,
+                range.clone(),
+                |pos| fetched.get(&pos).copied(),
+                |pos| Error::from(merkle::Error::<F>::MissingNode(pos)),
+            )?;
+
+            let prefix_raw = layout
+                .prefix
+                .iter()
+                .map(|&(pos, _)| {
+                    fetched
+                        .get(&pos)
+                        .copied()
                         .ok_or(merkle::Error::<F>::MissingNode(pos))
-                        .map(|d| (height, d))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
+            let prefix_raw_start =
+                prefix_raw_start_idx(&layout.prefix, proof_start_chunk, grafting_height);
+            unfolded_prefix_peaks = grafting::transform_peak_digests::<F, _, _, _>(
+                &std_hasher,
+                layout.prefix[..prefix_raw_start]
+                    .iter()
+                    .map(|(_, h)| *h)
+                    .zip(prefix_raw[..prefix_raw_start].iter().copied()),
+                0,
+                grafting_height,
+                |idx| {
+                    if idx < complete_chunks {
+                        if idx < pruned_chunks {
+                            Some([0u8; N])
+                        } else {
+                            Some(status.get_chunk(idx as usize))
+                        }
+                    } else {
+                        None
+                    }
+                },
+            )
+            .into_iter()
+            .map(|(digest, _count)| digest)
+            .collect();
+            unfolded_prefix_peaks.extend_from_slice(&prefix_raw[prefix_raw_start..]);
 
-            if split_idx > 0 {
-                let prefix_peaks = prefix_digests[..split_idx].to_vec();
-                pre_prefix_acc = grafting::fold_grafted_peaks::<F, D, _, _>(
+            let suffix_digests = layout
+                .after
+                .iter()
+                .map(|&(pos, _)| {
+                    fetched
+                        .get(&pos)
+                        .copied()
+                        .ok_or(merkle::Error::<F>::MissingNode(pos))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let suffix_start = peaks_leaf_len(&layout.prefix) + peaks_leaf_len(&layout.range);
+            let suffix_raw_end = after_raw_end_idx(
+                &layout.after,
+                suffix_start,
+                proof_end_chunk,
+                grafting_height,
+            );
+            unfolded_suffix_peaks.extend_from_slice(&suffix_digests[..suffix_raw_end]);
+            unfolded_suffix_peaks.extend(
+                grafting::transform_peak_digests::<F, _, _, _>(
                     &std_hasher,
-                    None,
-                    0,
-                    prefix_peaks,
+                    layout.after[suffix_raw_end..]
+                        .iter()
+                        .map(|(_, h)| *h)
+                        .zip(suffix_digests[suffix_raw_end..].iter().copied()),
+                    suffix_start + peaks_leaf_len(&layout.after[..suffix_raw_end]),
                     grafting_height,
                     |idx| {
                         if idx < complete_chunks {
-                            // Pruned chunks are guaranteed all-zero (only chunks with no active
-                            // operations are prunable), so a synthetic zero chunk produces the
-                            // correct grafted digest via the zero-chunk identity shortcut.
                             if idx < pruned_chunks {
                                 Some([0u8; N])
                             } else {
@@ -386,15 +551,22 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
                             None
                         }
                     },
-                );
-            }
-            if split_idx < layout.prefix.len() {
-                unfolded_prefix_peaks.reserve(layout.prefix.len() - split_idx);
-                for (_, digest) in &prefix_digests[split_idx..] {
-                    unfolded_prefix_peaks.push(*digest);
-                }
-            }
-        }
+                )
+                .into_iter()
+                .map(|(digest, _count)| digest),
+            );
+
+            proof
+        } else {
+            merkle::verification::historical_range_proof(
+                &std_hasher,
+                storage,
+                leaves,
+                range.clone(),
+                inactive_peaks,
+            )
+            .await?
+        };
 
         let (last_chunk, next_bit) = status.last_chunk();
         let partial_chunk_digest = if next_bit != BitMap::<N>::CHUNK_SIZE_BITS {
@@ -408,8 +580,8 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
 
         Ok(Self {
             proof,
-            pre_prefix_acc,
             unfolded_prefix_peaks,
+            unfolded_suffix_peaks,
             partial_chunk_digest,
             ops_root,
         })
@@ -434,6 +606,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         hasher: &mut H,
         status: &impl BitmapReadable<N>,
         storage: &S,
+        inactivity_floor: Location<F>,
         log: &C,
         start_loc: Location<F>,
         max_ops: NonZeroU64,
@@ -456,7 +629,15 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let end_loc = core::cmp::min(max_loc, leaves);
 
         // Generate the proof from the grafted storage.
-        let proof = Self::new(hasher, status, storage, start_loc..end_loc, ops_root).await?;
+        let proof = Self::new(
+            hasher,
+            status,
+            storage,
+            inactivity_floor,
+            start_loc..end_loc,
+            ops_root,
+        )
+        .await?;
 
         // Collect the operations necessary to verify the proof.
         let reader = log.reader().await;
@@ -488,10 +669,6 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
     ) -> bool {
         if ops.is_empty() || chunks.is_empty() {
             debug!("verification failed, empty input");
-            return false;
-        }
-        if self.proof.inactive_peaks != 0 {
-            debug!("verification failed, current proofs must use full-forward ops roots");
             return false;
         }
         // Compute the (non-inclusive) end location of the range.
@@ -526,7 +703,12 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let elements = ops.iter().map(|op| op.encode()).collect::<Vec<_>>();
         let chunk_vec = chunks.iter().map(|c| c.as_ref()).collect::<Vec<_>>();
         let grafting_height = grafting::height::<N>();
-        let verifier = grafting::Verifier::<F, H>::new(grafting_height, start_chunk, chunk_vec);
+        let verifier = grafting::Verifier::<F, H>::new(
+            grafting_height,
+            start_chunk,
+            chunk_vec,
+            Bagging::BackwardFold,
+        );
 
         // For partial chunks, validate the last chunk digest from the proof.
         if has_partial_chunk {
@@ -566,8 +748,8 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let needs_grafted_peak_fold =
             proof_needs_grafted_peak_fold(&layout, size, grafting_height, complete_chunks);
         let merkle_root = if !needs_grafted_peak_fold {
-            if self.pre_prefix_acc.is_some() || !self.unfolded_prefix_peaks.is_empty() {
-                debug!("verification failed, unexpected grafted prefix metadata");
+            if !self.unfolded_prefix_peaks.is_empty() || !self.unfolded_suffix_peaks.is_empty() {
+                debug!("verification failed, unexpected grafted metadata");
                 return false;
             }
             match self.proof.reconstruct_root(&verifier, &elements, start_loc) {
@@ -579,11 +761,11 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             }
         } else {
             let mut collected = Vec::new();
-            if let Err(error) = self.proof.reconstruct_root_inner(
+            if let Err(error) = self.proof.reconstruct_range_collecting(
                 &verifier,
                 &elements,
                 start_loc,
-                Some(&mut collected),
+                &mut collected,
             ) {
                 debug!(?error, "invalid proof input");
                 return false;
@@ -604,6 +786,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
                 self,
                 &layout,
                 leaves,
+                start_loc..end_loc,
                 &collected,
                 grafting_height,
                 get_chunk,
@@ -651,6 +834,7 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
         hasher: &mut H,
         status: &impl BitmapReadable<N>,
         storage: &S,
+        inactivity_floor: Location<F>,
         loc: Location<F>,
         ops_root: D,
     ) -> Result<Self, Error<F>> {
@@ -658,7 +842,15 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
         if BitMap::<N>::to_chunk_index(*loc) < status.pruned_chunks() {
             return Err(Error::OperationPruned(loc));
         }
-        let range_proof = RangeProof::new(hasher, status, storage, loc..loc + 1, ops_root).await?;
+        let range_proof = RangeProof::new(
+            hasher,
+            status,
+            storage,
+            inactivity_floor,
+            loc..loc + 1,
+            ops_root,
+        )
+        .await?;
         let chunk = status.get_chunk(BitMap::<N>::to_chunk_index(*loc));
         Ok(Self {
             loc,
@@ -783,17 +975,28 @@ mod tests {
 
             let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
             let root = db::compute_db_root::<F, Sha256, _, _, N>(
-                &hasher, &status, &storage, None, &ops_root,
+                &hasher,
+                &status,
+                &storage,
+                None,
+                Location::new(0),
+                &ops_root,
             )
             .await
             .unwrap();
 
             let loc = mmb::Location::new(BitMap::<N>::CHUNK_SIZE_BITS + 4);
             let mut proof_hasher = Sha256::new();
-            let proof =
-                RangeProof::new(&mut proof_hasher, &status, &storage, loc..loc + 1, ops_root)
-                    .await
-                    .unwrap();
+            let proof = RangeProof::new(
+                &mut proof_hasher,
+                &status,
+                &storage,
+                Location::new(0),
+                loc..loc + 1,
+                ops_root,
+            )
+            .await
+            .unwrap();
 
             let element = hasher.digest(&(*loc).to_be_bytes());
             let mut verify_hasher = Sha256::new();
@@ -814,7 +1017,8 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> =
+                StandardHasher::with_bagging(Bagging::BackwardFold);
             let grafting_height = grafting::height::<N>();
 
             let (leaf_count, loc) = (17..=64u64)
@@ -892,16 +1096,27 @@ mod tests {
                 Some((*chunk, next_bit))
             };
             let root = db::compute_db_root::<F, Sha256, _, _, N>(
-                &hasher, &status, &storage, partial, &ops_root,
+                &hasher,
+                &status,
+                &storage,
+                partial,
+                Location::new(0),
+                &ops_root,
             )
             .await
             .unwrap();
 
             let mut proof_hasher = Sha256::new();
-            let proof =
-                RangeProof::new(&mut proof_hasher, &status, &storage, loc..loc + 1, ops_root)
-                    .await
-                    .unwrap();
+            let proof = RangeProof::new(
+                &mut proof_hasher,
+                &status,
+                &storage,
+                Location::new(0),
+                loc..loc + 1,
+                ops_root,
+            )
+            .await
+            .unwrap();
 
             let element = hasher.digest(&(*loc).to_be_bytes());
             let chunk_idx = (*loc / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
@@ -925,7 +1140,8 @@ mod tests {
             type F = mmb::Family;
             const N: usize = 1;
 
-            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let hasher: StandardHasher<Sha256> =
+                StandardHasher::with_bagging(Bagging::BackwardFold);
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
 
@@ -1001,7 +1217,12 @@ mod tests {
                 Some((*chunk, next_bit))
             };
             let root = db::compute_db_root::<F, Sha256, _, _, N>(
-                &hasher, &status, &storage, partial, &ops_root,
+                &hasher,
+                &status,
+                &storage,
+                partial,
+                Location::new(0),
+                &ops_root,
             )
             .await
             .unwrap();
@@ -1012,6 +1233,7 @@ mod tests {
                 &mut proof_hasher,
                 &status,
                 &storage,
+                Location::new(0),
                 start_loc..leaves_loc,
                 ops_root,
             )
@@ -1083,25 +1305,31 @@ mod tests {
 
             let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
             let root = db::compute_db_root::<F, Sha256, _, _, N>(
-                &hasher, &status, &storage, None, &ops_root,
+                &hasher,
+                &status,
+                &storage,
+                None,
+                Location::new(0),
+                &ops_root,
             )
             .await
             .unwrap();
 
             let loc = mmb::Location::new(0);
             let mut proof_hasher = Sha256::new();
-            let mut proof =
-                RangeProof::new(&mut proof_hasher, &status, &storage, loc..loc + 1, ops_root)
-                    .await
-                    .unwrap();
+            let mut proof = RangeProof::new(
+                &mut proof_hasher,
+                &status,
+                &storage,
+                Location::new(0),
+                loc..loc + 1,
+                ops_root,
+            )
+            .await
+            .unwrap();
 
             let element = hasher.digest(&(*loc).to_be_bytes());
             let chunk = <BitMap<N> as BitmapReadable<N>>::get_chunk(&status, 0);
-
-            let mut tampered = proof.clone();
-            tampered.pre_prefix_acc = Some(hasher.digest(b"fake prefix"));
-            let mut verify_hasher = Sha256::new();
-            assert!(!tampered.verify(&mut verify_hasher, loc, &[element], &[chunk], &root,));
 
             let mut tampered = proof.clone();
             tampered
@@ -1119,7 +1347,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_range_proof_uses_canonical_mmb_prefix_unfolding() {
+    fn test_range_proof_unfolds_mmb_peaks_for_grafted_reconstruction() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             type F = mmb::Family;
@@ -1129,31 +1357,25 @@ mod tests {
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
 
-            let (leaf_count, loc, layout, split_idx, _complete_chunks) = (chunk_bits * 3..=128u64)
+            let (leaf_count, loc, layout) = (chunk_bits * 3..=128u64)
                 .filter(|leaves| leaves % chunk_bits == 0)
                 .find_map(|leaves| {
                     let leaves_loc = mmb::Location::new(leaves);
                     let complete_chunks = leaves / chunk_bits;
                     (0..leaves).find_map(|idx| {
                         let loc = mmb::Location::new(idx);
-                        let start_chunk = *loc / chunk_bits;
                         let layout = peak_layout(leaves_loc, loc..loc + 1).ok()?;
-                        let split_idx = unfolding_start_idx(
-                            &layout.prefix,
+                        let size = F::location_to_position(leaves_loc);
+                        proof_needs_grafted_peak_fold(
+                            &layout,
+                            size,
                             grafting_height,
-                            start_chunk,
                             complete_chunks,
-                        )?;
-                        (split_idx > 0 && split_idx < layout.prefix.len()).then_some((
-                            leaves,
-                            loc,
-                            layout,
-                            split_idx,
-                            complete_chunks,
-                        ))
+                        )
+                        .then_some((leaves, loc, layout))
                     })
                 })
-                .expect("expected an MMB proof with a partially unfolded prefix");
+                .expect("expected an MMB proof requiring grafted peak folding");
 
             let mut status = BitMap::<N>::new();
             for _ in 0..leaf_count {
@@ -1195,25 +1417,43 @@ mod tests {
 
             let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
             let root = db::compute_db_root::<F, Sha256, _, _, N>(
-                &hasher, &status, &storage, None, &ops_root,
+                &hasher,
+                &status,
+                &storage,
+                None,
+                Location::new(0),
+                &ops_root,
             )
             .await
             .unwrap();
 
             let mut proof_hasher = Sha256::new();
-            let proof =
-                RangeProof::new(&mut proof_hasher, &status, &storage, loc..loc + 1, ops_root)
-                    .await
-                    .unwrap();
+            let proof = RangeProof::new(
+                &mut proof_hasher,
+                &status,
+                &storage,
+                Location::new(0),
+                loc..loc + 1,
+                ops_root,
+            )
+            .await
+            .unwrap();
 
-            // Under `current`'s ForwardFold bagging, the prefix peaks before the multi-peak
-            // chunk that straddles the range are folded into `pre_prefix_acc`. Only the
-            // straddling chunk's prefix peaks ship individually as `unfolded_prefix_peaks` so the
-            // verifier can re-graft.
-            let expected_unfolded_len = layout.prefix[split_idx..].len();
-            assert_eq!(proof.unfolded_prefix_peaks.len(), expected_unfolded_len);
-            assert!(!proof.unfolded_prefix_peaks.is_empty());
-            assert!(proof.pre_prefix_acc.is_some());
+            // Grafted reconstruction needs the individual prefix/suffix peaks that generic
+            // backward proofs may otherwise hide behind fold accumulators. These witnesses are
+            // already grouped by grafted chunk, so their counts can be smaller than raw peak
+            // counts.
+            let prefix_counts =
+                transformed_peak_counts(&layout.prefix, 0, grafting_height, |idx| {
+                    idx < leaf_count / chunk_bits
+                });
+            let suffix_start = peaks_leaf_len(&layout.prefix) + peaks_leaf_len(&layout.range);
+            let suffix_counts =
+                transformed_peak_counts(&layout.after, suffix_start, grafting_height, |idx| {
+                    idx < leaf_count / chunk_bits
+                });
+            assert_eq!(proof.unfolded_prefix_peaks.len(), prefix_counts.len());
+            assert_eq!(proof.unfolded_suffix_peaks.len(), suffix_counts.len());
 
             let element = hasher.digest(&(*loc).to_be_bytes());
             let chunk_idx = (*loc / chunk_bits) as usize;
@@ -1253,6 +1493,118 @@ mod tests {
                 )],
                 &root,
             ));
+
+            let mut tampered = proof.clone();
+            assert!(!tampered.proof.digests.is_empty());
+            tampered.proof.digests[0] = hasher.digest(b"fake generic sibling");
+            let mut verify_hasher = Sha256::new();
+            assert!(!tampered.verify(
+                &mut verify_hasher,
+                loc,
+                &[element],
+                &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
+                    &status, chunk_idx
+                )],
+                &root,
+            ));
+        });
+    }
+
+    #[test_traced]
+    fn test_range_proof_allows_ops_and_grafted_inactive_counts_to_differ() {
+        let executor = deterministic::Runner::default();
+        executor.start(|_| async move {
+            type F = mmb::Family;
+            const N: usize = 1;
+
+            let hasher: StandardHasher<Sha256> = StandardHasher::new();
+            let grafting_height = grafting::height::<N>();
+            let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
+            let leaf_count = chunk_bits;
+            let leaves = mmb::Location::new(leaf_count);
+            let inactivity_floor = mmb::Location::new(chunk_bits - 2);
+
+            let raw_inactive = F::inactive_peaks(F::location_to_position(leaves), inactivity_floor);
+            let aligned_inactive = grafting::chunk_aligned_inactive_peaks::<F>(
+                leaves,
+                inactivity_floor,
+                grafting_height,
+            )
+            .unwrap();
+            assert_ne!(raw_inactive, aligned_inactive);
+
+            let mut status = BitMap::<N>::new();
+            for _ in 0..leaf_count {
+                status.push(true);
+            }
+            let ops = build_test_mem(&hasher, mmb::mem::Mmb::new(), leaf_count);
+
+            // The ops root is the inner QMDB log root and commits the raw inactive peak count.
+            // The grafted bitmap root commits the chunk-aligned count, since grafted chunks are
+            // the atomic inactive-prefix boundary for the current root.
+            let ops_root = ops.root(&hasher, raw_inactive).unwrap();
+
+            let chunk_inputs: Vec<_> =
+                (0..<BitMap<N> as BitmapReadable<N>>::complete_chunks(&status))
+                    .map(|chunk_idx| {
+                        (
+                            chunk_idx,
+                            <BitMap<N> as BitmapReadable<N>>::get_chunk(&status, chunk_idx),
+                        )
+                    })
+                    .collect();
+            let mut leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
+                &hasher,
+                &ops,
+                chunk_inputs,
+                &Sequential,
+            )
+            .await
+            .unwrap();
+            leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
+
+            let grafted_hasher =
+                grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+            let mut grafted = Mem::<F, sha256::Digest>::new();
+            let merkleized = {
+                let mut batch = grafted.new_batch();
+                for (_, digest) in leaf_digests {
+                    batch = batch.add_leaf_digest(digest);
+                }
+                batch.merkleize(&grafted, &grafted_hasher)
+            };
+            grafted.apply_batch(&merkleized).unwrap();
+
+            let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+            let root = db::compute_db_root::<F, Sha256, _, _, N>(
+                &hasher,
+                &status,
+                &storage,
+                None,
+                inactivity_floor,
+                &ops_root,
+            )
+            .await
+            .unwrap();
+
+            let loc = mmb::Location::new(chunk_bits - 1);
+            let mut proof_hasher = Sha256::new();
+            let proof = RangeProof::new(
+                &mut proof_hasher,
+                &status,
+                &storage,
+                inactivity_floor,
+                loc..loc + 1,
+                ops_root,
+            )
+            .await
+            .unwrap();
+            assert_eq!(proof.proof.inactive_peaks, aligned_inactive);
+
+            let element = hasher.digest(&(*loc).to_be_bytes());
+            let chunk = <BitMap<N> as BitmapReadable<N>>::get_chunk(&status, 0);
+            let mut verify_hasher = Sha256::new();
+            assert!(proof.verify(&mut verify_hasher, loc, &[element], &[chunk], &root));
         });
     }
 }

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -305,13 +305,12 @@ macro_rules! impl_current_sync_database {
                 if Location::new(bounds.start) > target.range.start() {
                     return false;
                 }
-                let Some(last_loc) = bounds.end.checked_sub(1) else {
-                    return false;
-                };
-                let Ok(last_op) = reader.read(last_loc).await else {
-                    return false;
-                };
-                let Some(inactivity_floor) = last_op.has_floor() else {
+                let Ok(inactivity_floor) =
+                    qmdb::find_inactivity_floor_at::<F, _>(&reader, target.range.end(), |op| {
+                        op.has_floor()
+                    })
+                    .await
+                else {
                     return false;
                 };
 

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -3,21 +3,20 @@
 //! Contains implementation of [crate::qmdb::sync::Database] for all [Db](crate::qmdb::current::db::Db)
 //! variants (ordered/unordered, fixed/variable).
 //!
-//! The canonical root of a `current` database combines the QMDB ops root, grafted tree root, and
+//! The canonical root of a `current` database combines the ops root, grafted tree root, and
 //! optional partial chunk into a single hash (see the [Root structure](super) section in the
-//! module documentation). The sync engine operates on the **QMDB ops root**, not the canonical
-//! root: it downloads operations and verifies each batch against the QMDB ops-root spec for the
-//! Merkle family.
-//! [crate::qmdb::current::proof::OpsRootWitness] can be used by callers that need to authenticate
-//! the synced ops root against a trusted canonical root; the sync engine does not perform this
-//! check itself.
+//! module documentation). The sync engine operates on the **ops root**, not the canonical root:
+//! it downloads operations and verifies each batch against the ops root using standard merkle
+//! range proofs (identical to `any` sync). [crate::qmdb::current::proof::OpsRootWitness] can be
+//! used by callers that need to authenticate the synced ops root against a trusted canonical root;
+//! the sync engine does not perform this check itself.
 //!
 //! After all operations are synced, the bitmap and grafted tree are reconstructed
 //! deterministically from the operations. The canonical root is then computed from the
-//! QMDB ops root, the reconstructed grafted tree root, and any partial chunk.
+//! ops root, the reconstructed grafted tree root, and any partial chunk.
 //!
 //! The [Database]`::`[root()](crate::qmdb::sync::Database::root)
-//! implementation returns the **QMDB ops root** (not the canonical root) because that is what the
+//! implementation returns the **ops root** (not the canonical root) because that is what the
 //! sync engine verifies against.
 //!
 //! For pruned databases (`range.start > 0`), grafted pinned nodes for the pruned region are
@@ -52,6 +51,7 @@ use crate::{
             },
             FixedValue, VariableValue,
         },
+        bitmap::Shared,
         current::{
             db, grafting,
             ordered::{
@@ -137,17 +137,19 @@ where
     )
     .await?;
 
-    // Pre-build the activity-status bitmap with the pruned-chunk count derived from the sync
-    // range, then hand it to `any::Db::init_from_log` which becomes the sole owner. Floor
-    // division is intentional: chunks entirely below range.start are pruned. If range.start
-    // is not chunk-aligned, the partial leading chunk is reconstructed by `init_from_log`,
-    // which pads the gap between `pruned_chunks * CHUNK_SIZE_BITS` and the journal's
-    // inactivity floor with inactive (false) bits.
+    // Initialize bitmap with pruned chunks.
+    //
+    // Floor division is intentional: chunks entirely below range.start are pruned.
+    // If range.start is not chunk-aligned, the partial leading chunk is reconstructed by
+    // init_from_log, which pads the gap between `pruned_chunks * CHUNK_SIZE_BITS` and the
+    // journal's inactivity floor with inactive (false) bits.
     let pruned_chunks = (*range.start() / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
     let bitmap = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
         .map_err(|_| qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
-    let bitmap = Arc::new(qmdb::bitmap::Shared::<N>::new(bitmap));
+    let bitmap = Arc::new(Shared::<N>::new(bitmap));
 
+    // Build any::Db, handing it the pre-allocated bitmap. `init_from_log` populates the bitmap
+    // during replay.
     let any: AnyDb<F, E, J, I, H, U, N, S> = AnyDb::init_from_log(index, log, Some(bitmap)).await?;
 
     // Fetch grafted pinned nodes from the ops tree. For each position the grafted family
@@ -333,7 +335,7 @@ macro_rules! impl_current_sync_database {
                 true
             }
 
-            /// Returns the QMDB ops root (not the canonical root), since the sync engine verifies
+            /// Returns the ops root (not the canonical root), since the sync engine verifies
             /// batches against the ops tree.
             fn root(&self) -> Self::Digest {
                 self.any.root()
@@ -373,7 +375,7 @@ impl_current_sync_database!(
 // --- Resolver implementations ---
 //
 // The resolver for `current` databases serves ops-level proofs (not grafted proofs) from
-// the inner `any` db. The sync engine verifies each batch against the QMDB ops root.
+// the inner `any` db. The sync engine verifies each batch against the ops root.
 
 macro_rules! impl_current_resolver {
     ($db:ident, $op:ident, $val_bound:ident, $key_bound:path $(; $($where_extra:tt)+)?) => {

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -148,9 +148,7 @@ where
         .map_err(|_| qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
     let bitmap = Arc::new(qmdb::bitmap::Shared::<N>::new(bitmap));
 
-    // `current` always uses split bagging at the underlying ops tree.
-    let any: AnyDb<F, E, J, I, H, U, N, S> =
-        AnyDb::init_from_log(index, log, Some(bitmap), true).await?;
+    let any: AnyDb<F, E, J, I, H, U, N, S> = AnyDb::init_from_log(index, log, Some(bitmap)).await?;
 
     // Fetch grafted pinned nodes from the ops tree. For each position the grafted family
     // needs at its pruning boundary, source the digest from the ops tree via the zero-chunk
@@ -261,7 +259,6 @@ macro_rules! impl_current_sync_database {
             type Config = $config;
             type Digest = H::Digest;
 
-            const ROOT_BAGGING: Bagging = Bagging::BackwardFold;
 
             async fn from_sync_result(
                 context: Self::Context,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -3,20 +3,21 @@
 //! Contains implementation of [crate::qmdb::sync::Database] for all [Db](crate::qmdb::current::db::Db)
 //! variants (ordered/unordered, fixed/variable).
 //!
-//! The canonical root of a `current` database combines the ops root, grafted tree root, and
+//! The canonical root of a `current` database combines the QMDB ops root, grafted tree root, and
 //! optional partial chunk into a single hash (see the [Root structure](super) section in the
-//! module documentation). The sync engine operates on the **ops root**, not the canonical root:
-//! it downloads operations and verifies each batch against the ops root using standard merkle
-//! range proofs (identical to `any` sync). [crate::qmdb::current::proof::OpsRootWitness] can be
-//! used by callers that need to authenticate the synced ops root against a trusted canonical root;
-//! the sync engine does not perform this check itself.
+//! module documentation). The sync engine operates on the **QMDB ops root**, not the canonical
+//! root: it downloads operations and verifies each batch against the QMDB ops-root spec for the
+//! Merkle family.
+//! [crate::qmdb::current::proof::OpsRootWitness] can be used by callers that need to authenticate
+//! the synced ops root against a trusted canonical root; the sync engine does not perform this
+//! check itself.
 //!
 //! After all operations are synced, the bitmap and grafted tree are reconstructed
 //! deterministically from the operations. The canonical root is then computed from the
-//! ops root, the reconstructed grafted tree root, and any partial chunk.
+//! QMDB ops root, the reconstructed grafted tree root, and any partial chunk.
 //!
 //! The [Database]`::`[root()](crate::qmdb::sync::Database::root)
-//! implementation returns the **ops root** (not the canonical root) because that is what the
+//! implementation returns the **QMDB ops root** (not the canonical root) because that is what the
 //! sync engine verifies against.
 //!
 //! For pruned databases (`range.start > 0`), grafted pinned nodes for the pruned region are
@@ -51,7 +52,6 @@ use crate::{
             },
             FixedValue, VariableValue,
         },
-        bitmap::Shared,
         current::{
             db, grafting,
             ordered::{
@@ -62,7 +62,7 @@ use crate::{
             },
             FixedConfig, VariableConfig,
         },
-        operation::{Committable, Key},
+        operation::{Committable, Key, Operation as _},
         sync::{Database, DatabaseConfig as Config},
     },
     translator::Translator,
@@ -118,7 +118,7 @@ where
     Operation<F, U>: Codec + Committable + CodecShared,
 {
     // Build authenticated log.
-    let hasher = StandardHasher::<H>::new();
+    let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
     let merkle = Merkle::<F, _, _, S>::init_sync(
         context.with_label("merkle"),
         full::SyncConfig {
@@ -137,21 +137,20 @@ where
     )
     .await?;
 
-    // Initialize bitmap with pruned chunks.
-    //
-    // Floor division is intentional: chunks entirely below range.start are pruned.
-    // If range.start is not chunk-aligned, the partial leading chunk is reconstructed by
-    // init_from_log, which pads the gap between `pruned_chunks * CHUNK_SIZE_BITS` and the
-    // journal's inactivity floor with inactive (false) bits.
+    // Pre-build the activity-status bitmap with the pruned-chunk count derived from the sync
+    // range, then hand it to `any::Db::init_from_log` which becomes the sole owner. Floor
+    // division is intentional: chunks entirely below range.start are pruned. If range.start
+    // is not chunk-aligned, the partial leading chunk is reconstructed by `init_from_log`,
+    // which pads the gap between `pruned_chunks * CHUNK_SIZE_BITS` and the journal's
+    // inactivity floor with inactive (false) bits.
     let pruned_chunks = (*range.start() / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
     let bitmap = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
         .map_err(|_| qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
-    let bitmap = Arc::new(Shared::<N>::new(bitmap));
+    let bitmap = Arc::new(qmdb::bitmap::Shared::<N>::new(bitmap));
 
-    // Build any::Db, handing it the pre-allocated bitmap. `init_from_log` populates the bitmap
-    // during replay.
+    // `current` always uses split bagging at the underlying ops tree.
     let any: AnyDb<F, E, J, I, H, U, N, S> =
-        AnyDb::init_from_log(index, log, Some(bitmap), false).await?;
+        AnyDb::init_from_log(index, log, Some(bitmap), true).await?;
 
     // Fetch grafted pinned nodes from the ops tree. For each position the grafted family
     // needs at its pruning boundary, source the digest from the ops tree via the zero-chunk
@@ -178,7 +177,7 @@ where
     };
 
     // Build grafted tree.
-    let hasher = StandardHasher::<H>::new();
+    let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
     let grafted_tree = db::build_grafted_tree::<F, H, S, N>(
         &hasher,
         any.bitmap.as_ref(),
@@ -198,7 +197,13 @@ where
         hasher.clone(),
     );
     let partial = db::partial_chunk(any.bitmap.as_ref());
-    let grafted_root = db::compute_grafted_root(&hasher, any.bitmap.as_ref(), &storage).await?;
+    let grafted_root = db::compute_grafted_root(
+        &hasher,
+        any.bitmap.as_ref(),
+        &storage,
+        any.inactivity_floor_loc,
+    )
+    .await?;
     let ops_root = any.root();
     let partial_digest = partial.map(|(chunk, next_bit)| {
         let digest = hasher.digest(&chunk);
@@ -256,7 +261,7 @@ macro_rules! impl_current_sync_database {
             type Config = $config;
             type Digest = H::Digest;
 
-            const ROOT_BAGGING: Bagging = Bagging::ForwardFold;
+            const ROOT_BAGGING: Bagging = Bagging::BackwardFold;
 
             async fn from_sync_result(
                 context: Self::Context,
@@ -289,18 +294,6 @@ macro_rules! impl_current_sync_database {
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Family, Self::Digest>,
             ) -> bool {
-                if !qmdb::any::sync::has_local_target_state::<F, _, H, S>(
-                    context.with_label("local_target_merkle_probe"),
-                    config.merkle_config.clone(),
-                    target,
-                    0,
-                    Bagging::ForwardFold,
-                )
-                .await
-                {
-                    return false;
-                }
-
                 let Ok(journal) = <$journal>::init(
                     context.with_label("local_target_journal_probe"),
                     config.journal_config(),
@@ -309,12 +302,41 @@ macro_rules! impl_current_sync_database {
                 else {
                     return false;
                 };
-                let bounds = journal.reader().await.bounds();
+                let reader = journal.reader().await;
+                let bounds = reader.bounds();
+                if Location::new(bounds.start) > target.range.start() {
+                    return false;
+                }
+                let Some(last_loc) = bounds.end.checked_sub(1) else {
+                    return false;
+                };
+                let Ok(last_op) = reader.read(last_loc).await else {
+                    return false;
+                };
+                let Some(inactivity_floor) = last_op.has_floor() else {
+                    return false;
+                };
 
-                Location::new(bounds.start) <= target.range.start()
+                let inactive_peaks = F::inactive_peaks(
+                    F::location_to_position(target.range.end()),
+                    inactivity_floor,
+                );
+                if !qmdb::any::sync::has_local_target_state::<F, _, H, S>(
+                    context.with_label("local_target_merkle_probe"),
+                    config.merkle_config.clone(),
+                    target,
+                    inactive_peaks,
+                    Bagging::BackwardFold,
+                )
+                .await
+                {
+                    return false;
+                }
+
+                true
             }
 
-            /// Returns the ops root (not the canonical root), since the sync engine verifies
+            /// Returns the QMDB ops root (not the canonical root), since the sync engine verifies
             /// batches against the ops tree.
             fn root(&self) -> Self::Digest {
                 self.any.root()
@@ -354,7 +376,7 @@ impl_current_sync_database!(
 // --- Resolver implementations ---
 //
 // The resolver for `current` databases serves ops-level proofs (not grafted proofs) from
-// the inner `any` db. The sync engine verifies each batch against the ops root.
+// the inner `any` db. The sync engine verifies each batch against the QMDB ops root.
 
 macro_rules! impl_current_resolver {
     ($db:ident, $op:ident, $val_bound:ident, $key_bound:path $(; $($where_extra:tt)+)?) => {

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -7,9 +7,10 @@
 //! optional partial chunk into a single hash (see the [Root structure](super) section in the
 //! module documentation). The sync engine operates on the **ops root**, not the canonical root:
 //! it downloads operations and verifies each batch against the ops root using standard merkle
-//! range proofs (identical to `any` sync). [crate::qmdb::current::proof::OpsRootWitness] can be
-//! used by callers that need to authenticate the synced ops root against a trusted canonical root;
-//! the sync engine does not perform this check itself.
+//! range proofs (identical to `any` sync). Callers that verify current ops proofs directly should
+//! use the same Merkle hasher configuration as sync. [crate::qmdb::current::proof::OpsRootWitness]
+//! can be used by callers that need to authenticate the synced ops root against a trusted canonical
+//! root; the sync engine does not perform this check itself.
 //!
 //! After all operations are synced, the bitmap and grafted tree are reconstructed
 //! deterministically from the operations. The canonical root is then computed from the

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -261,7 +261,6 @@ macro_rules! impl_current_sync_database {
             type Config = $config;
             type Digest = H::Digest;
 
-
             async fn from_sync_result(
                 context: Self::Context,
                 config: Self::Config,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -6,11 +6,11 @@
 //! The canonical root of a `current` database combines the ops root, grafted tree root, and
 //! optional partial chunk into a single hash (see the [Root structure](super) section in the
 //! module documentation). The sync engine operates on the **ops root**, not the canonical root:
-//! it downloads operations and verifies each batch against the ops root using standard merkle
-//! range proofs (identical to `any` sync). Callers that verify current ops proofs directly should
-//! use the same Merkle hasher configuration as sync. [crate::qmdb::current::proof::OpsRootWitness]
-//! can be used by callers that need to authenticate the synced ops root against a trusted canonical
-//! root; the sync engine does not perform this check itself.
+//! it downloads operations and verifies each batch against the ops root using ops-tree range proofs
+//! (identical to `any` sync). Callers that verify current ops proofs directly should
+//! use `qmdb::hasher`. [crate::qmdb::current::proof::OpsRootWitness] can be
+//! used by callers that need to authenticate the synced ops root against a trusted canonical root;
+//! the sync engine does not perform this check itself.
 //!
 //! After all operations are synced, the bitmap and grafted tree are reconstructed
 //! deterministically from the operations. The canonical root is then computed from the
@@ -34,8 +34,7 @@ use crate::{
     },
     merkle::{
         full::{self, Merkle},
-        hasher::Standard as StandardHasher,
-        Bagging, Graftable, Location,
+        Graftable, Location,
     },
     qmdb::{
         self,
@@ -119,7 +118,7 @@ where
     Operation<F, U>: Codec + Committable + CodecShared,
 {
     // Build authenticated log.
-    let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
+    let hasher = qmdb::hasher::<H>();
     let merkle = Merkle::<F, _, _, S>::init_sync(
         context.with_label("merkle"),
         full::SyncConfig {
@@ -178,7 +177,7 @@ where
     };
 
     // Build grafted tree.
-    let hasher = StandardHasher::<H>::with_bagging(Bagging::BackwardFold);
+    let hasher = qmdb::hasher::<H>();
     let grafted_tree = db::build_grafted_tree::<F, H, S, N>(
         &hasher,
         any.bitmap.as_ref(),
@@ -324,7 +323,6 @@ macro_rules! impl_current_sync_database {
                     config.merkle_config.clone(),
                     target,
                     inactive_peaks,
-                    Bagging::BackwardFold,
                 )
                 .await
                 {

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -348,8 +348,8 @@ pub mod tests {
             // commit op.
             let proof = RangeProof {
                 proof: Proof::default(),
-                pre_prefix_acc: None,
                 unfolded_prefix_peaks: vec![],
+                unfolded_suffix_peaks: vec![],
                 partial_chunk_digest: None,
                 ops_root: Digest::EMPTY,
             };

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -22,8 +22,9 @@
 
 use super::operation::Operation;
 use crate::{
-    merkle::{self, batch, compact as compact_merkle, Family, Location, Proof},
+    merkle::{batch, compact as compact_merkle, Family, Location, Proof},
     qmdb::{
+        self,
         any::value::ValueEncoding,
         compact_witness::{self, CachedServeState, WitnessSource},
         operation::Key,
@@ -201,7 +202,7 @@ where
         C: Clone + Send + Sync + 'static,
         Operation<F, K, V>: Read<Cfg = C>,
     {
-        let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<H>();
         let mut ops: Vec<Operation<F, K, V>> = Vec::with_capacity(self.mutations.len() + 1);
         for (key, value) in self.mutations {
             ops.push(Operation::Set(key, value));
@@ -400,7 +401,7 @@ where
     where
         F: Family,
     {
-        let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<H>();
         let inactive_peaks = F::inactive_peaks(
             F::location_to_position(Location::new(*self.last_commit_loc + 1)),
             self.inactivity_floor_loc,

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -8,10 +8,10 @@ use crate::{
         authenticated,
         contiguous::fixed::{self, Config as JournalConfig},
     },
-    merkle::{self, Family},
+    merkle::Family,
     qmdb::{
         any::{value::FixedEncoding, FixedValue},
-        Error,
+        Error, ROOT_BAGGING,
     },
     translator::Translator,
 };
@@ -58,7 +58,7 @@ impl<
             cfg.merkle_config,
             cfg.log,
             Operation::<F, K, V>::is_commit,
-            merkle::Bagging::BackwardFold,
+            ROOT_BAGGING,
         )
         .await?;
         Self::init_from_journal(journal, context, cfg.translator).await

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -693,8 +693,8 @@ where
 pub(super) mod test {
     use super::*;
     use crate::{
-        merkle::{self, Family, Location},
-        qmdb::verify_proof,
+        merkle::{Family, Location},
+        qmdb::{self, verify_proof},
         translator::TwoCap,
     };
     use commonware_codec::EncodeShared;
@@ -853,8 +853,7 @@ pub(super) mod test {
 
         let (proof, ops) = db.proof(Location::new(0), NZU64!(100)).await.unwrap();
         let root = db.root();
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
         assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root));
 
         db.destroy().await.unwrap();
@@ -964,8 +963,7 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         // Build a db with `ELEMENTS` key/value pairs and prove ranges over them.
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
         let mut db = open_db(context.with_label("first")).await;
 
         let mut batch = db.new_batch();
@@ -1741,8 +1739,7 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.with_label("db")).await;
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
 
         const BATCHES: u64 = 20;
         const KEYS_PER_BATCH: u64 = 5;
@@ -1885,8 +1882,7 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.with_label("db")).await;
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
 
         const N: u64 = 500;
         let mut kvs: Vec<(Digest, Digest)> = Vec::new();

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -6,11 +6,11 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
-        self,
         full::{self, Merkle},
         Family, Location,
     },
     qmdb::{
+        self,
         any::ValueEncoding,
         build_snapshot_from_log, compact_witness,
         immutable::{self, CompactDb, Operation},
@@ -73,7 +73,7 @@ where
         range: NonEmptyRange<Location<F>>,
         apply_batch_size: usize,
     ) -> Result<Self, Error<F>> {
-        let hasher = merkle::hasher::Standard::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<H>();
 
         // Initialize Merkle structure for sync
         let merkle = Merkle::<F, _, _, S>::init_sync(
@@ -186,7 +186,7 @@ where
             Operation::<F, K, V>::Commit(last_commit_metadata.clone(), inactivity_floor_loc)
                 .encode()
                 .to_vec();
-        let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<H>();
         let merkle = crate::merkle::compact::Merkle::init_from_compact_state(
             context.with_label("merkle"),
             config.merkle,

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -49,8 +49,6 @@ where
     type Digest = H::Digest;
     type Context = E;
 
-    const ROOT_BAGGING: merkle::Bagging = merkle::Bagging::BackwardFold;
-
     /// Returns an [Immutable](immutable::Immutable) initialized from data collected in the sync process.
     ///
     /// # Behavior
@@ -163,8 +161,6 @@ where
     type Digest = H::Digest;
     type Context = E;
     type Hasher = H;
-
-    const ROOT_BAGGING: merkle::Bagging = merkle::Bagging::BackwardFold;
 
     async fn from_compact_state(
         context: Self::Context,

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -100,14 +100,18 @@ where
         let (last_commit_loc, inactivity_floor_loc) = {
             let reader = journal.journal.reader().await;
             let bounds = reader.bounds();
-            let last_commit_loc =
-                Location::<F>::new(bounds.end.checked_sub(1).expect("commit should exist"));
-
-            // Read the floor from the last commit operation.
-            let last_op = reader.read(*last_commit_loc).await?;
-            let inactivity_floor_loc = last_op
-                .has_floor()
-                .expect("last operation should be a commit with floor");
+            let last_commit_loc = Location::<F>::new(
+                bounds
+                    .end
+                    .checked_sub(1)
+                    .ok_or(Error::HistoricalFloorPruned(Location::new(bounds.end)))?,
+            );
+            let inactivity_floor_loc = crate::qmdb::find_inactivity_floor_at::<F, _>(
+                &reader,
+                Location::new(bounds.end),
+                |op| op.has_floor(),
+            )
+            .await?;
 
             // Replay the log from the inactivity floor to build the snapshot.
             build_snapshot_from_log::<F, _, _, _>(

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -8,11 +8,11 @@ use crate::{
         authenticated,
         contiguous::variable::{self, Config as JournalConfig},
     },
-    merkle::{self, Family},
+    merkle::Family,
     qmdb::{
         any::{value::VariableEncoding, VariableValue},
         operation::Key,
-        Error,
+        Error, ROOT_BAGGING,
     },
     translator::Translator,
 };
@@ -62,7 +62,7 @@ impl<
             cfg.merkle_config,
             cfg.log,
             Operation::<F, K, V>::is_commit,
-            merkle::Bagging::BackwardFold,
+            ROOT_BAGGING,
         )
         .await?;
         Self::init_from_journal(journal, context, cfg.translator).await

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -22,8 +22,9 @@
 
 use super::operation::Operation;
 use crate::{
-    merkle::{self, batch, compact as compact_merkle, Family, Location, Proof},
+    merkle::{batch, compact as compact_merkle, Family, Location, Proof},
     qmdb::{
+        self,
         any::value::ValueEncoding,
         compact_witness::{self, CachedServeState, WitnessSource},
         sync::compact as compact_sync,
@@ -192,7 +193,7 @@ where
         C: Clone + Send + Sync + 'static,
         Operation<F, V>: Read<Cfg = C>,
     {
-        let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<H>();
         let mut ops: Vec<Operation<F, V>> = Vec::with_capacity(self.appends.len() + 1);
         for value in self.appends {
             ops.push(Operation::Append(value));
@@ -331,8 +332,8 @@ where
         };
 
         Ok(Self {
-            last_commit_loc,
             merkle,
+            last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
@@ -389,7 +390,7 @@ where
     where
         F: Family,
     {
-        let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<H>();
         let inactive_peaks = F::inactive_peaks(
             F::location_to_position(Location::new(*self.last_commit_loc + 1)),
             self.inactivity_floor_loc,

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -7,12 +7,12 @@ use crate::{
         authenticated,
         contiguous::fixed::{self, Config as JournalConfig},
     },
-    merkle::{self, Family},
+    merkle::Family,
     qmdb::{
         any::value::{FixedEncoding, FixedValue},
         keyless::operation::Operation as BaseOperation,
         operation::Committable,
-        Error,
+        Error, ROOT_BAGGING,
     },
 };
 use commonware_cryptography::Hasher;
@@ -49,7 +49,7 @@ impl<F: Family, E: Storage + Clock + Metrics, V: FixedValue, H: Hasher, S: Strat
             cfg.merkle,
             cfg.log,
             Operation::<F, V>::is_commit,
-            merkle::Bagging::BackwardFold,
+            ROOT_BAGGING,
         )
         .await?;
         Self::init_from_journal(journal).await

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -528,8 +528,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::{
         journal::{contiguous::Mutable, Error as JournalError},
-        merkle,
-        qmdb::verify_proof,
+        qmdb::{self, verify_proof},
         Persistable,
     };
     use commonware_cryptography::Sha256;
@@ -742,8 +741,7 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
         const ELEMENTS: u64 = 50;
 
         {
@@ -1303,8 +1301,7 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
 
         // Build a db with some values.
         const ELEMENTS: u64 = 100;
@@ -1380,8 +1377,7 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
 
         const ELEMENTS: u64 = 100;
         {
@@ -1655,8 +1651,7 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
 
         const BATCHES: u64 = 20;
         const APPENDS_PER_BATCH: u64 = 5;
@@ -1766,8 +1761,7 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher =
-            merkle::hasher::Standard::<Sha256>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<Sha256>();
         const N: u64 = 500;
         let mut values = Vec::new();
         let mut locs = Vec::new();

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -89,15 +89,18 @@ where
 
         let (last_commit_loc, inactivity_floor_loc) = {
             let reader = journal.reader().await;
-            let loc = reader
-                .bounds()
+            let bounds = reader.bounds();
+            let loc = bounds
                 .end
                 .checked_sub(1)
-                .expect("journal should not be empty");
-            let op = reader.read(loc).await?;
-            let floor = op
-                .has_floor()
-                .expect("last operation should be a commit with floor");
+                .ok_or(qmdb::Error::HistoricalFloorPruned(Location::new(
+                    bounds.end,
+                )))?;
+            let floor =
+                qmdb::find_inactivity_floor_at::<F, _>(&reader, Location::new(bounds.end), |op| {
+                    op.has_floor()
+                })
+                .await?;
             (Location::new(loc), floor)
         };
         let inactive_peaks = F::inactive_peaks(

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     merkle::{
         self,
         full::{self, Merkle},
-        Bagging, Family, Location,
+        Family, Location,
     },
     qmdb::{
         self,
@@ -43,8 +43,6 @@ where
     type Config = super::Config<C::Config, S>;
     type Digest = H::Digest;
     type Context = E;
-
-    const ROOT_BAGGING: Bagging = merkle::Bagging::BackwardFold;
 
     /// Returns a [Keyless] db initialized from data collected in the sync process.
     ///
@@ -141,8 +139,6 @@ where
     type Digest = H::Digest;
     type Context = E;
     type Hasher = H;
-
-    const ROOT_BAGGING: Bagging = merkle::Bagging::BackwardFold;
 
     async fn from_compact_state(
         context: Self::Context,

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -5,7 +5,6 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
-        self,
         full::{self, Merkle},
         Family, Location,
     },
@@ -67,7 +66,7 @@ where
         range: NonEmptyRange<Location<F>>,
         apply_batch_size: usize,
     ) -> Result<Self, qmdb::Error<F>> {
-        let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<H>();
 
         let merkle = Merkle::<F, _, _, S>::init_sync(
             context.with_label("merkle"),
@@ -163,7 +162,7 @@ where
             Operation::<F, V>::Commit(last_commit_metadata.clone(), inactivity_floor_loc)
                 .encode()
                 .to_vec();
-        let hasher = merkle::hasher::Standard::<H>::with_bagging(merkle::Bagging::BackwardFold);
+        let hasher = qmdb::hasher::<H>();
         let merkle = crate::merkle::compact::Merkle::init_from_compact_state(
             context.with_label("merkle"),
             config.merkle,

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -7,12 +7,12 @@ use crate::{
         authenticated,
         contiguous::variable::{self, Config as JournalConfig},
     },
-    merkle::{self, Family},
+    merkle::Family,
     qmdb::{
         any::value::{VariableEncoding, VariableValue},
         keyless::operation::Operation as BaseOperation,
         operation::Committable,
-        Error,
+        Error, ROOT_BAGGING,
     },
 };
 use commonware_codec::Read;
@@ -54,7 +54,7 @@ impl<F: Family, E: Storage + Clock + Metrics, V: VariableValue, H: Hasher, S: St
             cfg.merkle,
             cfg.log,
             Operation::<F, V>::is_commit,
-            merkle::Bagging::BackwardFold,
+            ROOT_BAGGING,
         )
         .await?;
         Self::init_from_journal(journal).await

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -75,9 +75,12 @@ pub use verify::{
     verify_proof_and_extract_digests, verify_proof_and_pinned_nodes,
 };
 
+/// Merkle peak bagging policy used by QMDB operation roots.
+pub(crate) const ROOT_BAGGING: Bagging = Bagging::BackwardFold;
+
 /// Return the Merkle hasher configuration used by QMDB operation roots and proofs.
 pub const fn hasher<H: CryptoHasher>() -> StandardHasher<H> {
-    StandardHasher::with_bagging(Bagging::BackwardFold)
+    StandardHasher::with_bagging(ROOT_BAGGING)
 }
 
 /// Look up the inactivity floor declared at the commit immediately preceding `op_count`.

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -48,9 +48,10 @@ use crate::{
         contiguous::{Mutable, Reader},
         Error as JournalError,
     },
-    merkle::{Family, Location},
+    merkle::{hasher::Standard as StandardHasher, Bagging, Family, Location},
     qmdb::operation::Operation,
 };
+use commonware_cryptography::Hasher as CryptoHasher;
 use commonware_utils::NZUsize;
 use core::num::NonZeroUsize;
 use futures::{pin_mut, StreamExt as _};
@@ -73,6 +74,11 @@ pub use verify::{
     create_multi_proof, create_proof_store, verify_multi_proof, verify_proof,
     verify_proof_and_extract_digests, verify_proof_and_pinned_nodes,
 };
+
+/// Return the Merkle hasher configuration used by QMDB operation roots and proofs.
+pub const fn hasher<H: CryptoHasher>() -> StandardHasher<H> {
+    StandardHasher::with_bagging(Bagging::BackwardFold)
+}
 
 /// Look up the inactivity floor declared at the commit immediately preceding `op_count`.
 ///

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -80,7 +80,7 @@ pub(crate) const ROOT_BAGGING: Bagging = Bagging::BackwardFold;
 
 /// Return the Merkle hasher configuration used by QMDB operation roots and proofs.
 pub const fn hasher<H: CryptoHasher>() -> StandardHasher<H> {
-    StandardHasher::with_bagging(ROOT_BAGGING)
+    StandardHasher::new(ROOT_BAGGING)
 }
 
 /// Look up the inactivity floor declared at the commit immediately preceding `op_count`.

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -249,9 +249,6 @@ pub trait Database: Sized + Send {
     type Context: Storage + Clock + Metrics;
     type Hasher: Hasher<Digest = Self::Digest>;
 
-    /// Bagging policy used by this database when computing roots.
-    const ROOT_BAGGING: merkle::Bagging;
-
     /// Build a database from authenticated state in memory.
     ///
     /// The caller has already verified `last_commit_proof` against the requested target root, but
@@ -327,7 +324,7 @@ where
         }));
     }
 
-    let hasher = StandardHasher::<DB::Hasher>::with_bagging(DB::ROOT_BAGGING);
+    let hasher = StandardHasher::<DB::Hasher>::with_bagging(merkle::Bagging::BackwardFold);
     let last_commit_loc = Location::new(*state.leaf_count - 1);
     if !verify_proof(
         &hasher,

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -47,7 +47,7 @@
 //! with `DataCorrupted` rather than silently serving or restoring mismatched state.
 
 use crate::{
-    merkle::{self, hasher::Standard as StandardHasher, Family, Location, Proof},
+    merkle::{Family, Location, Proof},
     qmdb::{
         self,
         any::{value::ValueEncoding, FixedValue, VariableValue},
@@ -324,7 +324,7 @@ where
         }));
     }
 
-    let hasher = StandardHasher::<DB::Hasher>::with_bagging(merkle::Bagging::BackwardFold);
+    let hasher = qmdb::hasher::<DB::Hasher>();
     let last_commit_loc = Location::new(*state.leaf_count - 1);
     if !verify_proof(
         &hasher,

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -1,5 +1,5 @@
 use crate::{
-    merkle::{Bagging, Family, Location},
+    merkle::{Family, Location},
     qmdb::sync::Journal,
     translator::Translator,
 };
@@ -47,9 +47,6 @@ pub trait Database: Sized + Send {
         + commonware_runtime::Clock
         + commonware_runtime::Metrics;
     type Hasher: commonware_cryptography::Hasher<Digest = Self::Digest>;
-
-    /// Bagging policy used by this database when computing roots/proofs.
-    const ROOT_BAGGING: Bagging;
 
     /// Build a database from the journal and pinned nodes populated by the sync engine.
     fn from_sync_result(

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -1,6 +1,6 @@
 //! Core sync engine components that are shared across sync clients.
 use crate::{
-    merkle::{hasher::Standard as StandardHasher, Family, Location},
+    merkle::{self, hasher::Standard as StandardHasher, Family, Location},
     qmdb::{
         self,
         sync::{
@@ -332,7 +332,7 @@ where
             apply_batch_size: config.apply_batch_size,
             journal,
             resolver: config.resolver.clone(),
-            hasher: StandardHasher::<DB::Hasher>::with_bagging(DB::ROOT_BAGGING),
+            hasher: StandardHasher::<DB::Hasher>::with_bagging(merkle::Bagging::BackwardFold),
             context: config.context,
             config: config.db_config,
             update_rx: config.update_rx,

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -1,6 +1,6 @@
 //! Core sync engine components that are shared across sync clients.
 use crate::{
-    merkle::{self, hasher::Standard as StandardHasher, Family, Location},
+    merkle::{hasher::Standard as StandardHasher, Family, Location},
     qmdb::{
         self,
         sync::{
@@ -332,7 +332,7 @@ where
             apply_batch_size: config.apply_batch_size,
             journal,
             resolver: config.resolver.clone(),
-            hasher: StandardHasher::<DB::Hasher>::with_bagging(merkle::Bagging::BackwardFold),
+            hasher: qmdb::hasher::<DB::Hasher>(),
             context: config.context,
             config: config.db_config,
             update_rx: config.update_rx,

--- a/storage/src/qmdb/verify.rs
+++ b/storage/src/qmdb/verify.rs
@@ -123,7 +123,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        merkle::{build_range_proof, mem::Mem, LocationRangeExt as _},
+        merkle::{build_range_proof, mem::Mem, Bagging::ForwardFold, LocationRangeExt as _},
         mmb, mmr,
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
@@ -136,7 +136,7 @@ mod tests {
     }
 
     fn test_hasher() -> Standard<Sha256> {
-        Standard::new()
+        Standard::new(ForwardFold)
     }
 
     fn qmdb_range_proof<F: Family>(


### PR DESCRIPTION
## Summary

- Switch QMDB operation roots to pyramid bagging (split + backwards-fold active region).
- Update Current grafted root and range-proof reconstruction so MMR/MMB proofs handle inactive prefixes, grafted peak regrouping, and partial chunks consistently.
- Align Current sync, compact sync verification, conformance fixtures, and fuzz tampering coverage with the new root semantics.
